### PR TITLE
docs: add README, ex_doc guides, and clean up architecture

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,165 @@
+# Asobi
+
+Open-source game backend platform built on Erlang/OTP and the [Nova](https://github.com/novaframework/nova) ecosystem.
+
+Asobi provides everything you need to build and run multiplayer games:
+authentication, player management, real-time multiplayer, matchmaking,
+leaderboards, virtual economy, social features, and background jobs -- all
+in a single BEAM release.
+
+## Features
+
+- **Authentication** -- register, login, session tokens via [nova_auth](https://github.com/novaframework/nova_auth)
+- **Player Management** -- profiles, stats, metadata
+- **Real-Time Multiplayer** -- WebSocket transport, server-authoritative game loop with configurable tick rate
+- **Matchmaking** -- query-based matching with skill windows and party support
+- **Leaderboards** -- ETS-backed for microsecond reads, PostgreSQL for persistence
+- **Virtual Economy** -- wallets, transactions, item definitions, store, inventory
+- **Social** -- friends, groups/guilds, chat channels, presence, notifications
+- **Tournaments** -- scheduled competitions with entry fees and rewards
+- **Cloud Saves** -- per-slot save data with optimistic concurrency
+- **Generic Storage** -- key-value storage with permissions (public/owner/none)
+- **Background Jobs** -- powered by [Shigoto](https://github.com/Taure/shigoto)
+- **Admin Dashboard** -- real-time LiveView console via [Arizona](https://github.com/novaframework/arizona_core)
+
+## Quick Start
+
+### Prerequisites
+
+- Erlang/OTP 27+
+- PostgreSQL 15+
+- [rebar3](https://rebar3.org)
+
+### Setup
+
+Add asobi as a dependency:
+
+```erlang
+{deps, [
+    {asobi, {git, "https://github.com/widgrensit/asobi.git", {branch, "main"}}}
+]}.
+```
+
+Configure your `sys.config`:
+
+```erlang
+[
+    {kura, [
+        {repo, asobi_repo},
+        {host, "localhost"},
+        {database, "my_game_dev"},
+        {user, "postgres"},
+        {password, "postgres"}
+    ]},
+    {shigoto, [
+        {pool, asobi_repo}
+    ]},
+    {asobi, [
+        {plugins, [
+            {pre_request, nova_request_plugin, #{
+                decode_json_body => true,
+                parse_qs => true
+            }},
+            {pre_request, nova_cors_plugin, #{allow_origins => <<"*">>}},
+            {pre_request, nova_correlation_plugin, #{}}
+        ]},
+        {game_modes, #{
+            ~"my_mode" => my_game_module
+        }},
+        {matchmaker, #{
+            tick_interval => 1000,
+            max_wait_seconds => 60
+        }},
+        {session, #{
+            token_ttl => 900,
+            refresh_ttl => 2592000
+        }}
+    ]}
+].
+```
+
+Start the database and run:
+
+```bash
+rebar3 shell
+```
+
+Asobi runs migrations automatically on startup.
+
+## Implementing a Game
+
+Implement the `asobi_match` behaviour to define your game logic:
+
+```erlang
+-module(my_arena_game).
+-behaviour(asobi_match).
+
+-export([init/1, join/2, leave/2, handle_input/3, tick/1, get_state/2]).
+
+init(Config) ->
+    {ok, #{players => #{}, round => 1}}.
+
+join(PlayerId, State) ->
+    {ok, State#{players => maps:put(PlayerId, #{score => 0}, maps:get(players, State))}}.
+
+leave(PlayerId, State) ->
+    {ok, State#{players => maps:remove(PlayerId, maps:get(players, State))}}.
+
+handle_input(PlayerId, #{~"action" := ~"shoot"} = Input, State) ->
+    %% Process player input, update game state
+    {ok, State}.
+
+tick(State) ->
+    %% Called every tick (default 10/sec) -- advance game simulation
+    {ok, State}.
+
+get_state(PlayerId, State) ->
+    %% Return the state visible to this player
+    maps:get(players, State).
+```
+
+Register your game mode in config:
+
+```erlang
+{asobi, [
+    {game_modes, #{~"arena" => my_arena_game}}
+]}
+```
+
+## Stack
+
+| Layer | Technology |
+|-------|-----------|
+| HTTP / REST | [Nova](https://github.com/novaframework/nova) (Cowboy) |
+| WebSocket | Nova WebSocket (Cowboy) |
+| Database / ORM | [Kura](https://github.com/Taure/kura) (PostgreSQL via pgo) |
+| Real-time UI | [Arizona](https://github.com/novaframework/arizona_core) |
+| Authentication | [nova_auth](https://github.com/novaframework/nova_auth) |
+| Background Jobs | [Shigoto](https://github.com/Taure/shigoto) |
+| Pub/Sub | OTP `pg` module |
+
+## Why BEAM?
+
+The BEAM VM is uniquely suited for game backends:
+
+- **Per-process GC** -- no global pauses; one match collecting garbage never affects another
+- **Fault tolerance** -- OTP supervision restarts crashed matches without affecting others
+- **Hot code upgrade** -- deploy game logic changes without disconnecting players
+- **Native clustering** -- distributed Erlang handles cross-node messaging with no external coordination
+- **500K+ connections per node** -- dramatically lower infrastructure costs
+- **No external state stores** -- ETS replaces Redis, `pg` replaces pub/sub services
+
+## Documentation
+
+Full documentation is available via `rebar3 ex_doc`.
+
+- [Getting Started](guides/getting-started.md)
+- [REST API](guides/rest-api.md)
+- [WebSocket Protocol](guides/websocket-protocol.md)
+- [Matchmaking](guides/matchmaking.md)
+- [Economy](guides/economy.md)
+- [Architecture](docs/ARCHITECTURE.md)
+
+## License
+
+Apache-2.0

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -805,41 +805,42 @@ asobi/
 ```erlang
 [
     {nova, [
-        {bootstrap_application, asobi},
+        {bootstrap_application, asobi_arena},
         {environment, dev},
-        {use_sessions, true},
         {cowboy_configuration, #{
-            port => 8080
-        }}
+            port => 8084
+        }},
+        {json_lib, json}
+    ]},
+    {kura, [
+        {repo, asobi_repo},
+        {host, "localhost"},
+        {port, 5432},
+        {database, "asobi_dev"},
+        {user, "postgres"},
+        {password, "postgres"},
+        {pool_size, 10}
+    ]},
+    {shigoto, [
+        {pool, asobi_repo}
     ]},
     {asobi, [
-        {asobi_repo, #{
-            database => <<"asobi_dev">>,
-            hostname => <<"localhost">>,
-            port => 5432,
-            username => <<"postgres">>,
-            password => <<"postgres">>,
-            pool_size => 20
-        }},
-        {json_lib, json},
         {plugins, [
             {pre_request, nova_request_plugin, #{
                 decode_json_body => true,
                 parse_qs => true
             }},
-            {pre_request, nova_correlation_plugin, #{}},
             {pre_request, nova_cors_plugin, #{
                 allow_origins => <<"*">>
-            }}
+            }},
+            {pre_request, nova_correlation_plugin, #{}}
         ]},
+        {game_modes, #{
+            ~"arena" => asobi_arena_game
+        }},
         {matchmaker, #{
             tick_interval => 1000,
-            max_wait_seconds => 60,
-            expansion_interval => 5000
-        }},
-        {leaderboards, #{
-            persist_interval => 30000,
-            default_size => 100
+            max_wait_seconds => 60
         }},
         {session, #{
             token_ttl => 900,

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,25 +1,7 @@
-# Asobi — Game Backend Platform
+# Architecture
 
-Asobi (遊び, "play") is an open-source game backend platform built on Erlang/OTP and the Nova ecosystem. It provides authentication, player management, real-time multiplayer, matchmaking, leaderboards, virtual economy, social features, and an admin dashboard — all in a single BEAM release.
-
-Asobi is platform-agnostic: mobile, PC, console, web, and MMO. The transport layer (WebSocket + REST) works for any client. For latency-critical genres (FPS, action MMO), an optional UDP transport can be added alongside WebSocket without changing the core architecture.
-
-## Competitive Landscape
-
-Asobi targets the same space as **Nakama** (Go, Heroic Labs) and **Colyseus** (Node.js). No production-grade game backend exists on BEAM despite the platform being arguably the best fit for this workload.
-
-### Why BEAM Over Go (Nakama)
-
-| Concern | Nakama (Go) | Asobi (BEAM) |
-|---------|-------------|--------------|
-| GC impact | Stop-the-world affects ALL matches | Per-process GC — isolated per match |
-| Fault tolerance | Panic = match lost | OTP supervision — match restarts |
-| Deployment | Restart = disconnect everyone | Hot code upgrade — zero downtime |
-| Pub/sub | Requires external Redis | `pg` module — cluster-native |
-| In-memory state | External cache (Redis) | ETS — zero serialization overhead |
-| Distribution | External coordination (etcd/consul) | Distributed Erlang — built in |
-| Scheduling | Cooperative (goroutine blocks = starve) | Preemptive — fair scheduling |
-| Connection density | ~100K per node | ~500K+ per node |
+This document describes Asobi's internal architecture, supervision trees,
+data model, and protocol design.
 
 ## Stack
 
@@ -392,7 +374,7 @@ Runs periodic matching ticks via Shigoto. Query-based matching with expanding wi
 6. Tickets past max wait time → return error to player
 7. Matched tickets → spawn `asobi_match_server`, notify players
 
-**Query language** (simple, like Nakama):
+**Query language:**
 ```
 +region:eu-west mode:ranked skill:>=800 skill:<=1200
 ```
@@ -911,12 +893,3 @@ asobi/
 - Security hardening
 - Documentation + guides
 
-## Unique Selling Points
-
-1. **Zero-downtime deploys** — hot code upgrade game logic without disconnecting players
-2. **Self-healing matches** — OTP supervision restarts crashed matches
-3. **Predictable latency** — per-process GC, no global pauses
-4. **500K+ connections per node** — dramatically lower infrastructure costs
-5. **No external dependencies for state** — ETS replaces Redis, pg replaces pub/sub services
-6. **Native clustering** — distributed Erlang, no etcd/consul/Redis coordination
-7. **Full Nova ecosystem** — web framework, ORM, LiveView admin, background jobs, auth, mailer all native

--- a/guides/comparison.md
+++ b/guides/comparison.md
@@ -1,0 +1,54 @@
+# Comparison
+
+How Asobi compares to other open-source game backend platforms.
+
+## Feature Matrix
+
+| Feature | Asobi | Nakama | Colyseus | PlayFab |
+|---------|:-----:|:------:|:--------:|:-------:|
+| **Runtime** | BEAM (Erlang/OTP) | Go | Node.js | Cloud |
+| **Authentication** | Built-in | Built-in | Plugin | Built-in |
+| **Player Management** | Built-in | Built-in | Manual | Built-in |
+| **Real-Time Multiplayer** | WebSocket | WebSocket | WebSocket | WebSocket |
+| **Server-Authoritative Game Loop** | Built-in (tick-based) | Lua scripting | Room-based | CloudScript |
+| **Matchmaking** | Query-based | Query-based | Manual | Built-in |
+| **Leaderboards** | ETS + PostgreSQL | Built-in | Manual | Built-in |
+| **Virtual Economy** | Wallets, store, inventory | IAP validation | Manual | Built-in |
+| **Friends / Groups** | Built-in | Built-in | Manual | Built-in |
+| **Chat** | Built-in (channels) | Built-in | Manual | Manual |
+| **Tournaments** | Built-in | Built-in | Manual | Manual |
+| **Cloud Saves** | Built-in | Storage API | Manual | Built-in |
+| **Notifications** | Built-in | Built-in | Manual | Built-in |
+| **Background Jobs** | Shigoto (built-in) | Manual | Manual | Scheduled tasks |
+| **Admin Dashboard** | Arizona LiveView | Built-in | Monitor | Portal |
+| **Database** | PostgreSQL (Kura ORM) | CockroachDB | MongoDB / custom | Managed |
+| **Self-Hosted** | Yes | Yes | Yes | No |
+
+## Runtime Characteristics
+
+| Concern | Asobi (BEAM) | Nakama (Go) | Colyseus (Node.js) |
+|---------|-------------|-------------|-------------------|
+| **Garbage Collection** | Per-process -- isolated per match | Stop-the-world -- affects all matches | Stop-the-world -- affects all rooms |
+| **Fault Tolerance** | OTP supervision -- crashed matches restart | Panic recovery -- manual | Process crash -- manual |
+| **Hot Code Upgrade** | Native -- zero-downtime deploys | Restart required | Restart required |
+| **Pub/Sub** | `pg` module -- cluster-native | Built-in + optional Redis | Built-in (single node) |
+| **In-Memory State** | ETS -- zero serialization | In-process maps | In-process objects |
+| **Clustering** | Distributed Erlang -- built in | etcd / Consul | Redis (presence only) |
+| **Scheduling** | Preemptive -- fair across all processes | Cooperative goroutines | Single-threaded event loop |
+| **Connection Density** | ~500K+ per node | ~100K per node | ~10K per node |
+
+## When to Choose Asobi
+
+- You want a **single deployable** with auth, matchmaking, economy, social, and real-time multiplayer
+- You need **fault-tolerant game sessions** that survive crashes without losing state
+- You want **zero-downtime deploys** for game logic updates
+- You're building for **high concurrency** (many simultaneous matches/rooms)
+- You prefer **self-hosted** over managed cloud services
+- You want a **PostgreSQL-backed** system with a proper ORM
+
+## When to Choose Something Else
+
+- You need a **managed cloud service** with no infrastructure to maintain (PlayFab, GameSparks)
+- Your team has **no Erlang/OTP experience** and prefers Go or JavaScript
+- You need **Unity/Unreal SDK** out of the box (Nakama has official SDKs)
+- You're building a **single-player** game that only needs analytics and IAP

--- a/guides/economy.md
+++ b/guides/economy.md
@@ -1,0 +1,116 @@
+# Economy
+
+Asobi provides a full virtual economy system: wallets, transactions, item
+definitions, a store catalog, and player inventory.
+
+## Wallets
+
+Each player can have multiple wallets, one per currency. All balance changes
+are recorded as transactions for a full audit trail.
+
+### List Wallets
+
+```bash
+curl http://localhost:8080/api/v1/wallets \
+  -H 'Authorization: Bearer <token>'
+```
+
+```json
+[
+  {"id": "...", "currency": "gold", "balance": 1000},
+  {"id": "...", "currency": "gems", "balance": 50}
+]
+```
+
+### Transaction History
+
+```bash
+curl http://localhost:8080/api/v1/wallets/gold/history \
+  -H 'Authorization: Bearer <token>'
+```
+
+## Items
+
+Items are defined once via `asobi_item_def` and granted to players as
+`asobi_player_item` instances.
+
+### Item Definitions
+
+Item definitions are global -- they describe what an item is:
+
+- `slug` -- unique identifier (e.g., `"sword_of_fire"`)
+- `name` -- display name
+- `category` -- weapon, armor, consumable, etc.
+- `rarity` -- common, rare, epic, legendary
+- `stackable` -- whether multiple instances stack into one slot
+- `metadata` -- arbitrary JSON for game-specific attributes
+
+### Player Inventory
+
+```bash
+curl http://localhost:8080/api/v1/inventory \
+  -H 'Authorization: Bearer <token>'
+```
+
+### Consuming Items
+
+```bash
+curl -X POST http://localhost:8080/api/v1/inventory/consume \
+  -H 'Authorization: Bearer <token>' \
+  -H 'Content-Type: application/json' \
+  -d '{"item_id": "...", "quantity": 1}'
+```
+
+## Store
+
+The store is a catalog of items available for purchase with in-game currency.
+
+### Browse Store
+
+```bash
+curl http://localhost:8080/api/v1/store \
+  -H 'Authorization: Bearer <token>'
+```
+
+```json
+[
+  {
+    "id": "...",
+    "item_def_id": "...",
+    "currency": "gold",
+    "price": 500,
+    "active": true
+  }
+]
+```
+
+### Purchase
+
+Purchases are atomic: the wallet is debited and the item is granted in a
+single database transaction via Kura Multi.
+
+```bash
+curl -X POST http://localhost:8080/api/v1/store/purchase \
+  -H 'Authorization: Bearer <token>' \
+  -H 'Content-Type: application/json' \
+  -d '{"listing_id": "..."}'
+```
+
+## Server-Side Operations
+
+For admin or game logic that needs to grant/debit currency or items
+programmatically:
+
+```erlang
+%% Grant currency
+asobi_economy:credit(PlayerId, ~"gold", 100, #{reason => match_reward}).
+
+%% Debit currency
+asobi_economy:debit(PlayerId, ~"gold", 50, #{reason => store_purchase}).
+
+%% Grant item
+asobi_economy:grant_item(PlayerId, ~"sword_of_fire", 1).
+```
+
+All economy operations use ACID transactions to prevent double-spending
+or inconsistent state.

--- a/guides/getting-started.md
+++ b/guides/getting-started.md
@@ -1,0 +1,162 @@
+# Getting Started
+
+This guide walks you through setting up Asobi and creating your first game backend.
+
+## Prerequisites
+
+- Erlang/OTP 27+
+- PostgreSQL 15+
+- [rebar3](https://rebar3.org)
+
+## Create a New Project
+
+Use the Nova generator to scaffold your project:
+
+```bash
+rebar3 new nova my_game
+cd my_game
+```
+
+Add asobi to your dependencies in `rebar.config`:
+
+```erlang
+{deps, [
+    {asobi, {git, "https://github.com/widgrensit/asobi.git", {branch, "main"}}}
+]}.
+```
+
+## Configure the Database
+
+Create a PostgreSQL database:
+
+```bash
+createdb my_game_dev
+```
+
+Add configuration to your `sys.config`:
+
+```erlang
+[
+    {kura, [
+        {repo, asobi_repo},
+        {host, "localhost"},
+        {database, "my_game_dev"},
+        {user, "postgres"},
+        {password, "postgres"}
+    ]},
+    {shigoto, [
+        {pool, asobi_repo}
+    ]},
+    {asobi, [
+        {plugins, [
+            {pre_request, nova_request_plugin, #{
+                decode_json_body => true,
+                parse_qs => true
+            }},
+            {pre_request, nova_cors_plugin, #{allow_origins => <<"*">>}},
+            {pre_request, nova_correlation_plugin, #{}}
+        ]},
+        {game_modes, #{
+            ~"my_mode" => my_game
+        }},
+        {matchmaker, #{
+            tick_interval => 1000,
+            max_wait_seconds => 60
+        }},
+        {session, #{
+            token_ttl => 900,
+            refresh_ttl => 2592000
+        }}
+    ]}
+].
+```
+
+Kura defaults: `host` = `"localhost"`, `port` = `5432`, `user` = `"postgres"`,
+`pool_size` = `10`.
+
+## Start the Server
+
+```bash
+rebar3 shell
+```
+
+Asobi runs all database migrations automatically on startup. The server
+is now listening on the configured port.
+
+## Register a Player
+
+```bash
+curl -X POST http://localhost:8080/api/v1/auth/register \
+  -H 'Content-Type: application/json' \
+  -d '{"username": "player1", "password": "secret123"}'
+```
+
+Response:
+
+```json
+{
+  "player_id": "550e8400-e29b-41d4-a716-446655440000",
+  "session_token": "SFMyNTY...",
+  "username": "player1"
+}
+```
+
+## Connect via WebSocket
+
+Connect to `ws://localhost:8080/ws` and authenticate:
+
+```json
+{
+  "type": "session.connect",
+  "payload": {
+    "token": "SFMyNTY..."
+  }
+}
+```
+
+## Implement Your Game
+
+Create a module implementing the `asobi_match` behaviour:
+
+```erlang
+-module(my_game).
+-behaviour(asobi_match).
+
+-export([init/1, join/2, leave/2, handle_input/3, tick/1, get_state/2]).
+
+init(_Config) ->
+    {ok, #{players => #{}}}.
+
+join(PlayerId, State = #{players := Players}) ->
+    {ok, State#{players => Players#{PlayerId => #{x => 0, y => 0}}}}.
+
+leave(PlayerId, State = #{players := Players}) ->
+    {ok, State#{players => maps:remove(PlayerId, Players)}}.
+
+handle_input(PlayerId, #{~"type" := ~"move", ~"x" := X, ~"y" := Y}, State) ->
+    #{players := Players} = State,
+    {ok, State#{players => Players#{PlayerId => #{x => X, y => Y}}}}.
+
+tick(State) ->
+    %% Called every tick -- advance your simulation
+    {ok, State}.
+
+get_state(_PlayerId, State) ->
+    %% Return the state visible to this player
+    maps:get(players, State).
+```
+
+Register it in your config:
+
+```erlang
+{asobi, [
+    {game_modes, #{~"my_mode" => my_game}}
+]}
+```
+
+## Next Steps
+
+- [REST API](rest-api.md) -- full API reference
+- [WebSocket Protocol](websocket-protocol.md) -- real-time message types
+- [Matchmaking](matchmaking.md) -- query-based player matching
+- [Economy](economy.md) -- wallets, items, and store

--- a/guides/matchmaking.md
+++ b/guides/matchmaking.md
@@ -1,0 +1,100 @@
+# Matchmaking
+
+Asobi includes a query-based matchmaker that runs as a periodic tick via
+the `asobi_matchmaker` gen_server.
+
+## How It Works
+
+1. Player submits a matchmaking ticket with properties and a query
+2. Matchmaker ticks periodically (default every 1 second)
+3. Each tick groups tickets by mode/region, finds mutually compatible pairs
+4. When enough compatible players are found, a match is spawned
+5. Players are notified via WebSocket (`matchmaker.matched`)
+
+## Submitting a Ticket
+
+### Via REST
+
+```bash
+curl -X POST http://localhost:8080/api/v1/matchmaker \
+  -H 'Authorization: Bearer <token>' \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "mode": "arena",
+    "properties": {"skill": 1200, "region": "eu-west"},
+    "query": "+region:eu-west skill:>=1000 skill:<=1400"
+  }'
+```
+
+### Via WebSocket
+
+```json
+{
+  "type": "matchmaker.add",
+  "payload": {
+    "mode": "arena",
+    "properties": {"skill": 1200, "region": "eu-west"},
+    "query": "+region:eu-west skill:>=1000 skill:<=1400"
+  }
+}
+```
+
+## Query Language
+
+Tickets include a query that specifies what opponents the player will accept.
+Both players must match each other's query for a pairing to form.
+
+```
++region:eu-west mode:ranked skill:>=800 skill:<=1200
+```
+
+- `key:value` -- exact match
+- `+key:value` -- required (must match)
+- `key:>=N` / `key:<=N` -- numeric range
+- Multiple conditions are AND-ed
+
+## Skill Window Expansion
+
+When a player waits too long, the matchmaker automatically widens the skill
+window. Each tick increments the `expansion_level` for unfilled tickets,
+relaxing numeric range constraints.
+
+## Configuration
+
+```erlang
+{asobi, [
+    {matchmaker, #{
+        tick_interval => 1000,       %% ms between matchmaker ticks
+        max_wait_seconds => 60       %% max wait before timeout
+    }}
+]}
+```
+
+## Party Support
+
+Players can queue as a party. All party members are placed in the same match:
+
+```json
+{
+  "type": "matchmaker.add",
+  "payload": {
+    "mode": "arena",
+    "party": ["player_id_2", "player_id_3"],
+    "properties": {"skill": 1200},
+    "query": "skill:>=1000 skill:<=1400"
+  }
+}
+```
+
+## Cancelling
+
+```json
+{"type": "matchmaker.remove", "payload": {"ticket_id": "..."}}
+```
+
+Or via REST:
+
+```bash
+curl -X DELETE http://localhost:8080/api/v1/matchmaker/<ticket_id> \
+  -H 'Authorization: Bearer <token>'
+```

--- a/guides/rest-api.md
+++ b/guides/rest-api.md
@@ -1,0 +1,122 @@
+# REST API
+
+All endpoints are under `/api/v1`. Requests and responses use JSON.
+
+Authenticated endpoints require the `Authorization: Bearer <session_token>` header.
+
+## Auth
+
+```
+POST /api/v1/auth/register     Register a new player
+POST /api/v1/auth/login        Login, returns session token
+POST /api/v1/auth/refresh      Refresh session token
+```
+
+### Register
+
+```bash
+curl -X POST /api/v1/auth/register \
+  -H 'Content-Type: application/json' \
+  -d '{"username": "player1", "password": "secret123", "display_name": "Player One"}'
+```
+
+```json
+{"player_id": "...", "session_token": "...", "username": "player1"}
+```
+
+### Login
+
+```bash
+curl -X POST /api/v1/auth/login \
+  -H 'Content-Type: application/json' \
+  -d '{"username": "player1", "password": "secret123"}'
+```
+
+```json
+{"player_id": "...", "session_token": "...", "username": "player1"}
+```
+
+## Players
+
+```
+GET /api/v1/players/:id        Get player profile
+PUT /api/v1/players/:id        Update own profile
+```
+
+## Social
+
+```
+GET    /api/v1/friends                List friends
+POST   /api/v1/friends                Send friend request
+PUT    /api/v1/friends/:id            Accept/reject/block
+DELETE /api/v1/friends/:id            Remove friend
+
+POST   /api/v1/groups                 Create group
+GET    /api/v1/groups/:id             Get group
+POST   /api/v1/groups/:id/join        Join group
+POST   /api/v1/groups/:id/leave       Leave group
+```
+
+## Economy
+
+```
+GET  /api/v1/wallets                   List player wallets
+GET  /api/v1/wallets/:currency/history Transaction history
+GET  /api/v1/store                     List store catalog
+POST /api/v1/store/purchase            Purchase item
+GET  /api/v1/inventory                 List player items
+POST /api/v1/inventory/consume         Consume item
+```
+
+## Leaderboards
+
+```
+GET  /api/v1/leaderboards/:id                  Top N entries
+GET  /api/v1/leaderboards/:id/around/:player_id Around player
+POST /api/v1/leaderboards/:id                  Submit score
+```
+
+## Matchmaking
+
+```
+POST   /api/v1/matchmaker              Submit matchmaking ticket
+GET    /api/v1/matchmaker/:ticket_id   Check ticket status
+DELETE /api/v1/matchmaker/:ticket_id   Cancel ticket
+```
+
+## Tournaments
+
+```
+GET  /api/v1/tournaments               List active tournaments
+GET  /api/v1/tournaments/:id           Get tournament details
+POST /api/v1/tournaments/:id/join      Join tournament
+```
+
+## Chat
+
+```
+GET /api/v1/chat/:channel_id/history   Message history (paginated)
+```
+
+Real-time chat messages are sent and received over WebSocket.
+
+## Notifications
+
+```
+GET    /api/v1/notifications           List notifications (paginated)
+PUT    /api/v1/notifications/:id/read  Mark as read
+DELETE /api/v1/notifications/:id       Delete notification
+```
+
+## Storage
+
+```
+GET    /api/v1/saves                   List save slots
+GET    /api/v1/saves/:slot             Get save data
+PUT    /api/v1/saves/:slot             Write save (with version for OCC)
+
+GET    /api/v1/storage/:collection             List objects
+GET    /api/v1/storage/:collection/:key        Read object
+PUT    /api/v1/storage/:collection/:key        Write object
+DELETE /api/v1/storage/:collection/:key        Delete object
+```

--- a/guides/websocket-protocol.md
+++ b/guides/websocket-protocol.md
@@ -1,0 +1,207 @@
+# WebSocket Protocol
+
+Asobi uses a single WebSocket connection per client at `/ws`. All messages
+are JSON with a common envelope format.
+
+## Message Format
+
+### Client to Server
+
+```json
+{
+  "cid": "optional-correlation-id",
+  "type": "message.type",
+  "payload": {}
+}
+```
+
+### Server to Client
+
+```json
+{
+  "cid": "correlation-id-if-request",
+  "type": "message.type",
+  "payload": {}
+}
+```
+
+The `cid` field is optional. When provided, the server echoes it back in
+the response so the client can correlate request/response pairs.
+
+## Connection
+
+### `session.connect`
+
+Authenticate the WebSocket connection. Must be the first message sent.
+
+```json
+{"type": "session.connect", "payload": {"token": "session_token_here"}}
+```
+
+Response:
+
+```json
+{"type": "session.connected", "payload": {"player_id": "..."}}
+```
+
+### `session.heartbeat`
+
+Keep-alive ping. Send periodically to prevent timeout.
+
+```json
+{"type": "session.heartbeat", "payload": {}}
+```
+
+## Matches
+
+### `match.join`
+
+Join a match (after being matched via matchmaker or direct invite).
+
+```json
+{"type": "match.join", "payload": {"match_id": "..."}}
+```
+
+### `match.input`
+
+Send game input to the match server.
+
+```json
+{"type": "match.input", "payload": {"action": "move", "x": 10, "y": 5}}
+```
+
+### `match.state` (server push)
+
+Server broadcasts game state updates to all players in the match.
+
+```json
+{"type": "match.state", "payload": {"players": {...}, "tick": 42}}
+```
+
+### `match.started` (server push)
+
+Notification that a match has begun.
+
+```json
+{"type": "match.started", "payload": {"match_id": "...", "players": [...]}}
+```
+
+### `match.finished` (server push)
+
+Notification that a match has ended with results.
+
+```json
+{"type": "match.finished", "payload": {"match_id": "...", "result": {...}}}
+```
+
+### `match.leave`
+
+Leave the current match.
+
+```json
+{"type": "match.leave", "payload": {}}
+```
+
+## Matchmaking
+
+### `matchmaker.add`
+
+Submit a matchmaking ticket.
+
+```json
+{"type": "matchmaker.add", "payload": {"mode": "arena", "properties": {"skill": 1200}}}
+```
+
+### `matchmaker.remove`
+
+Cancel a matchmaking ticket.
+
+```json
+{"type": "matchmaker.remove", "payload": {"ticket_id": "..."}}
+```
+
+### `matchmaker.matched` (server push)
+
+Notification that a match was found.
+
+```json
+{"type": "matchmaker.matched", "payload": {"match_id": "...", "players": [...]}}
+```
+
+## Chat
+
+### `chat.join`
+
+Join a chat channel.
+
+```json
+{"type": "chat.join", "payload": {"channel_id": "lobby"}}
+```
+
+### `chat.send`
+
+Send a message to a channel.
+
+```json
+{"type": "chat.send", "payload": {"channel_id": "lobby", "content": "Hello!"}}
+```
+
+### `chat.message` (server push)
+
+A new message in a joined channel.
+
+```json
+{
+  "type": "chat.message",
+  "payload": {
+    "channel_id": "lobby",
+    "sender_id": "...",
+    "content": "Hello!",
+    "sent_at": "2025-01-15T10:30:00Z"
+  }
+}
+```
+
+### `chat.leave`
+
+Leave a chat channel.
+
+```json
+{"type": "chat.leave", "payload": {"channel_id": "lobby"}}
+```
+
+## Presence
+
+### `presence.update`
+
+Update your online status.
+
+```json
+{"type": "presence.update", "payload": {"status": "in_game", "metadata": {"match_id": "..."}}}
+```
+
+### `presence.changed` (server push)
+
+A friend's presence changed.
+
+```json
+{"type": "presence.changed", "payload": {"player_id": "...", "status": "online"}}
+```
+
+## Notifications
+
+### `notification.new` (server push)
+
+A new notification for the player.
+
+```json
+{
+  "type": "notification.new",
+  "payload": {
+    "id": "...",
+    "type": "friend_request",
+    "subject": "New friend request",
+    "content": {"from_player_id": "..."}
+  }
+}
+```

--- a/rebar.config
+++ b/rebar.config
@@ -85,11 +85,13 @@
         <<"guides/websocket-protocol.md">>,
         <<"guides/matchmaking.md">>,
         <<"guides/economy.md">>,
+        <<"guides/comparison.md">>,
         <<"docs/ARCHITECTURE.md">>
     ]},
     {groups_for_extras, [
         {<<"Getting Started">>, [
-            <<"guides/getting-started.md">>
+            <<"guides/getting-started.md">>,
+            <<"guides/comparison.md">>
         ]},
         {<<"Guides">>, [
             <<"guides/rest-api.md">>,

--- a/rebar.config
+++ b/rebar.config
@@ -58,7 +58,101 @@
     {rebar3_audit, {git, "https://github.com/Taure/rebar3_audit.git", {branch, "main"}}},
     {rebar3_sbom,
         {git, "https://github.com/Taure/rebar3_sbom.git", {branch, "feat/include-otp-components"}}},
+    rebar3_ex_doc,
     {erlfmt, "~>1.7"}
+]}.
+
+{hex, [
+    {doc, #{provider => ex_doc}},
+    {include_files, [
+        <<"src">>,
+        <<"include">>,
+        <<"priv">>,
+        <<"rebar.config">>,
+        <<"rebar.lock">>,
+        <<"README.md">>,
+        <<"guides">>,
+        <<"docs">>
+    ]}
+]}.
+
+{ex_doc, [
+    {source_url, <<"https://github.com/widgrensit/asobi">>},
+    {extras, [
+        <<"README.md">>,
+        <<"guides/getting-started.md">>,
+        <<"guides/rest-api.md">>,
+        <<"guides/websocket-protocol.md">>,
+        <<"guides/matchmaking.md">>,
+        <<"guides/economy.md">>,
+        <<"docs/ARCHITECTURE.md">>
+    ]},
+    {groups_for_extras, [
+        {<<"Getting Started">>, [
+            <<"guides/getting-started.md">>
+        ]},
+        {<<"Guides">>, [
+            <<"guides/rest-api.md">>,
+            <<"guides/websocket-protocol.md">>,
+            <<"guides/matchmaking.md">>,
+            <<"guides/economy.md">>
+        ]},
+        {<<"Reference">>, [
+            <<"docs/ARCHITECTURE.md">>
+        ]}
+    ]},
+    {groups_for_modules, [
+        {<<"Schemas">>, [
+            asobi_player,
+            asobi_player_stats,
+            asobi_match_record,
+            asobi_wallet,
+            asobi_transaction,
+            asobi_item_def,
+            asobi_player_item,
+            asobi_store_listing,
+            asobi_friendship,
+            asobi_group,
+            asobi_group_member,
+            asobi_chat_message,
+            asobi_notification,
+            asobi_tournament,
+            asobi_cloud_save,
+            asobi_storage,
+            asobi_leaderboard_entry
+        ]},
+        {<<"Controllers">>, [
+            asobi_auth_controller,
+            asobi_player_controller,
+            asobi_match_controller,
+            asobi_matchmaker_controller,
+            asobi_leaderboard_controller,
+            asobi_economy_controller,
+            asobi_inventory_controller,
+            asobi_social_controller,
+            asobi_chat_controller,
+            asobi_tournament_controller,
+            asobi_notification_controller,
+            asobi_storage_controller
+        ]},
+        {<<"Real-Time">>, [
+            asobi_ws_handler,
+            asobi_match_server,
+            asobi_matchmaker,
+            asobi_chat_channel,
+            asobi_presence,
+            asobi_player_session
+        ]},
+        {<<"Core">>, [
+            asobi_app,
+            asobi_sup,
+            asobi_router,
+            asobi_repo,
+            asobi_economy,
+            asobi_leaderboard_server,
+            asobi_tournament_server
+        ]}
+    ]}
 ]}.
 
 {erlfmt, [


### PR DESCRIPTION
## Summary
- Add product-quality README with feature list, quick start, and game implementation example
- Add ex_doc guides: getting-started, REST API, WebSocket protocol, matchmaking, economy
- Configure rebar3_ex_doc with module groups and guide sections
- Remove Nakama/competitive comparison from ARCHITECTURE.md

## Test plan
- [x] `rebar3 ex_doc` generates docs successfully
- [x] `rebar3 compile` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)