### PR TITLE
perf: reduce PBKDF2 iterations for faster registration

### DIFF
--- a/config/dev_sys.config.src
+++ b/config/dev_sys.config.src
@@ -10,6 +10,9 @@
             }}
         ]}
     ]},
+    {nova_auth, [
+        {pbkdf2_iterations, 100000}
+    ]},
     {nova, [
         {use_stacktrace, true},
         {environment, dev},

--- a/config/prod_sys.config.src
+++ b/config/prod_sys.config.src
@@ -10,6 +10,9 @@
             }}
         ]}
     ]},
+    {nova_auth, [
+        {pbkdf2_iterations, 100000}
+    ]},
     {nova, [
         {use_stacktrace, false},
         {environment, prod},


### PR DESCRIPTION
## Summary
- Configure PBKDF2 iterations to 100k (down from 600k default)
- Registration: 167ms → 31ms (5.4x faster)
- Depends on novaframework/nova_auth#2 (merged)

## Test plan
- [x] All 66 tests pass
- [x] Benchmarked: 23ms hash, 31ms full HTTP registration