### PR TITLE
fix: resolve multiplayer match issues for Unity demo

### DIFF
--- a/src/leaderboards/asobi_leaderboard_server.erl
+++ b/src/leaderboards/asobi_leaderboard_server.erl
@@ -10,19 +10,33 @@ start_link(BoardId) ->
 
 -spec submit(binary(), binary(), integer()) -> ok.
 submit(BoardId, PlayerId, Score) ->
+    ensure_started(BoardId),
     gen_server:cast({global, {?MODULE, BoardId}}, {submit, PlayerId, Score}).
 
 -spec top(binary(), pos_integer()) -> [{binary(), integer(), pos_integer()}].
 top(BoardId, N) ->
+    ensure_started(BoardId),
     gen_server:call({global, {?MODULE, BoardId}}, {top, N}).
 
 -spec rank(binary(), binary()) -> {ok, pos_integer()} | {error, not_found}.
 rank(BoardId, PlayerId) ->
+    ensure_started(BoardId),
     gen_server:call({global, {?MODULE, BoardId}}, {rank, PlayerId}).
 
 -spec around(binary(), binary(), pos_integer()) -> [{binary(), integer(), pos_integer()}].
 around(BoardId, PlayerId, N) ->
+    ensure_started(BoardId),
     gen_server:call({global, {?MODULE, BoardId}}, {around, PlayerId, N}).
+
+-spec ensure_started(binary()) -> ok.
+ensure_started(BoardId) ->
+    case global:whereis_name({?MODULE, BoardId}) of
+        undefined ->
+            _ = asobi_leaderboard_sup:start_board(BoardId),
+            ok;
+        _Pid ->
+            ok
+    end.
 
 -spec init(binary()) -> {ok, map()}.
 init(BoardId) ->

--- a/src/matches/asobi_matchmaker.erl
+++ b/src/matches/asobi_matchmaker.erl
@@ -183,6 +183,7 @@ spawn_matches([Group | Rest], Failed) ->
                     lists:foreach(
                         fun(PlayerId) ->
                             _ = asobi_match_server:join(MatchPid, PlayerId),
+                            asobi_presence:send(PlayerId, {match_joined, MatchPid}),
                             asobi_presence:send(
                                 PlayerId,
                                 {match_event, matched, #{

--- a/src/players/asobi_player_session.erl
+++ b/src/players/asobi_player_session.erl
@@ -53,6 +53,8 @@ handle_cast(_Msg, State) ->
 -spec handle_info(term(), map()) -> {noreply, map()} | {stop, normal, map()}.
 handle_info({'DOWN', _Ref, process, WsPid, _Reason}, #{ws_pid := WsPid} = State) ->
     {stop, normal, State};
+handle_info({asobi_message, {match_joined, MatchPid}}, State) ->
+    {noreply, State#{match_pid => MatchPid}};
 handle_info({asobi_message, _} = Msg, #{ws_pid := WsPid} = State) ->
     WsPid ! Msg,
     {noreply, State};

--- a/src/ws/asobi_ws_handler.erl
+++ b/src/ws/asobi_ws_handler.erl
@@ -77,7 +77,13 @@ handle_message(
                 undefined ->
                     {ok, State};
                 MatchPid ->
-                    asobi_match_server:handle_input(MatchPid, PlayerId, Payload),
+                    InputData =
+                        case maps:get(~"data", Payload, undefined) of
+                            undefined -> Payload;
+                            Bin when is_binary(Bin) -> json:decode(Bin);
+                            Other -> Other
+                        end,
+                    asobi_match_server:handle_input(MatchPid, PlayerId, InputData),
                     {ok, State}
             end
     catch


### PR DESCRIPTION
## Summary
- Store match_pid in player session when matchmaker joins players to a match
- Decode nested JSON `data` field in match.input WS handler
- Auto-start leaderboard server on first access to prevent noproc crashes

## Test plan
- [x] Tested with Unity arena demo — players can move, shoot, and matches complete
- [x] Leaderboard queries no longer crash on first access

🤖 Generated with [Claude Code](https://claude.com/claude-code)