### PR TITLE
feat: session revocation via Shigoto fanout broadcast

### DIFF
--- a/config/dev_sys.config.src
+++ b/config/dev_sys.config.src
@@ -58,7 +58,14 @@
         }}
     ]},
     {shigoto, [
-        {pool, asobi_repo}
+        {pool, asobi_repo},
+        {poll_interval, 500},
+        {queues, [
+            {~"default", 10}
+        ]},
+        {fanout_queues, [
+            {~"broadcast", 5, #{window => 120}}
+        ]}
     ]},
     {nova_resilience, [
         {dependencies, [

--- a/config/prod_sys.config.src
+++ b/config/prod_sys.config.src
@@ -72,5 +72,15 @@
         {shutdown_delay, 5000},
         {shutdown_drain_timeout, 15000}
     ]},
+    {shigoto, [
+        {pool, asobi_repo},
+        {poll_interval, 200},
+        {queues, [
+            {~"default", 10}
+        ]},
+        {fanout_queues, [
+            {~"broadcast", 5, #{window => 120}}
+        ]}
+    ]},
     {pg, [{scope, [nova_scope, asobi_presence, asobi_chat]}]}
 ].

--- a/guides/architecture.md
+++ b/guides/architecture.md
@@ -1,0 +1,336 @@
+# Architecture
+
+## Overview
+
+Asobi is an Erlang/OTP game backend built on Nova. This document covers the
+runtime architecture, session lifecycle, how services communicate, and the
+trade-offs for single-node, distributed Erlang, and cloud-native deployments.
+
+## Supervision Tree
+
+```
+asobi_sup (one_for_one)
+├── asobi_rate_limit_server     — per-node ETS rate limiter
+├── asobi_cluster               — node discovery (DNS/EPMD)
+├── asobi_player_session_sup    — dynamic simple_one_for_one
+│   └── asobi_player_session    — one per connected player
+├── asobi_match_sup             — dynamic simple_one_for_one
+│   └── asobi_match_server      — one per active match (gen_statem)
+├── asobi_matchmaker            — matching algorithm, tick-based
+├── asobi_leaderboard_sup       — one child per leaderboard
+│   └── asobi_leaderboard_server — in-memory buffer, periodic DB flush
+├── asobi_chat_sup              — chat channel processes
+├── asobi_tournament_sup        — tournament processes
+└── asobi_presence              — tracks online players via pg
+```
+
+## Session Lifecycle
+
+```
+Client                    WS Handler              Session              Presence (pg)
+  │                          │                       │                      │
+  │── WS connect ───────────►│                       │                      │
+  │── session.connect ──────►│                       │                      │
+  │                          │── authenticate(token) │                      │
+  │                          │   (DB lookup)         │                      │
+  │                          │── start_session ─────►│                      │
+  │                          │                       │── track(id, self) ──►│
+  │                          │                       │   pg:join(player,id) │
+  │◄── session.connected ───│                       │                      │
+  │                          │                       │                      │
+  │   ... gameplay ...       │                       │                      │
+  │                          │                       │                      │
+  │── disconnect ───────────►│                       │                      │
+  │                          │── stop(session) ─────►│                      │
+  │                          │                       │── untrack(id) ──────►│
+  │                          │                       │   pg:leave           │
+```
+
+**Key points:**
+- Token is validated **once** at `session.connect` via DB lookup
+- After authentication, `player_id` lives in process state — no further DB checks
+- The session process monitors the WS process; if WS dies, session cleans up
+- WS terminate calls `session:stop/1` for the reverse direction
+
+## Session Revocation
+
+When a player is banned, deleted, or their token is revoked:
+
+```erlang
+asobi_presence:revoke_session(PlayerId, ~"banned").
+```
+
+**Flow:**
+1. `revoke_session/2` enqueues a job on the `broadcast` fanout queue via Shigoto
+2. All nodes poll the fanout queue and pick up the job
+3. Each node calls `asobi_presence:disconnect/2` locally
+4. `disconnect/2` looks up session processes in the local `pg` group
+5. Sends `{session_revoked, Reason}` to each session process
+6. Session forwards to WS process, then stops
+7. WS handler logs and returns `{stop, State}`
+
+This uses Shigoto's fanout queue mode — every node processes every broadcast
+job. Jobs are ephemeral (120s window, auto-pruned). Workers are idempotent.
+The source of truth is always the database.
+
+**Two-layer API:**
+- `asobi_presence:revoke_session/2` — public API, enqueues broadcast job (cross-node)
+- `asobi_presence:disconnect/2` — local delivery mechanism, called by the broadcast worker
+
+## Match Lifecycle
+
+```
+Matchmaker              Match Sup            Match Server          Players (via pg)
+  │                        │                      │                     │
+  │── start_match(Config)─►│                      │                     │
+  │                        │── start_link ────────►│ (waiting state)     │
+  │                        │                      │                     │
+  │── join(Pid, Player1) ─────────────────────────►│                     │
+  │── join(Pid, Player2) ─────────────────────────►│ (min_players met)   │
+  │                        │                      │── enter running ───►│
+  │                        │                      │                     │
+  │                        │                      │◄── {input, ...} ────│
+  │                        │                      │── tick ──────────── │
+  │                        │                      │── broadcast_state ─►│
+  │                        │                      │   (10 Hz loop)      │
+  │                        │                      │                     │
+  │                        │                      │── enter finished    │
+  │                        │                      │── persist_result ──►DB
+  │                        │                      │── notify_players ──►│
+  │                        │                      │── cleanup (5s) ────►stop
+```
+
+**Match states:** `waiting → running → finished` (also `paused`)
+
+**Server-authoritative:** The match process owns all game state. Clients send
+inputs, the server applies them each tick, and broadcasts the resulting state.
+The game module (`asobi_match` behaviour) provides `init/1`, `join/2`,
+`handle_input/3`, `tick/1`, and `get_state/2`.
+
+## Database & Migrations
+
+Each node runs its own PGO connection pool. Migrations run automatically at
+application startup via `kura_migrator:migrate(asobi_repo)`.
+
+**Migration rules:**
+- The initial schema uses `create_table` operations
+- Kura topologically sorts tables by FK dependencies — order in the migration
+  file doesn't matter
+- All operations run in a single PostgreSQL transaction with an advisory lock
+- **Never delete or modify an applied migration** — add new `alter_table`
+  migrations instead
+- If migration fails, the app logs the error and continues starting (by design,
+  to allow the app to serve health checks even with a stale schema)
+
+**Multi-node consideration:** The advisory lock ensures only one node runs
+migrations at a time. Other nodes wait. This is safe for rolling deploys.
+
+## Deployment Models
+
+### Single Node (Current)
+
+Everything runs on one BEAM node. All process communication is local.
+This is the simplest model and works for small-to-medium scale.
+
+```
+┌─────────────────────────────────┐
+│           BEAM Node             │
+│  ┌──────────┐  ┌─────────────┐ │
+│  │ WS/HTTP  │  │ Matchmaker  │ │
+│  │ Handlers │  │ (local)     │ │
+│  └──────────┘  └─────────────┘ │
+│  ┌──────────┐  ┌─────────────┐ │
+│  │ Sessions │  │ Matches     │ │
+│  │ (local)  │  │ (local)     │ │
+│  └──────────┘  └─────────────┘ │
+│  ┌──────────────────────────┐  │
+│  │ pg (presence, chat)      │  │
+│  └──────────────────────────┘  │
+└──────────────┬──────────────────┘
+               │
+         ┌─────▼─────┐
+         │ PostgreSQL │
+         └───────────┘
+```
+
+**Migrations:** Always run at startup. One node, no contention.
+
+**Scale limit:** A single BEAM node can handle tens of thousands of concurrent
+WebSocket connections and hundreds of active matches. The bottleneck is usually
+the game tick loop CPU cost, not connection count.
+
+### Distributed Erlang (Multi-Node)
+
+Multiple BEAM nodes connected via distributed Erlang. The `pg` module
+automatically replicates group membership across all connected nodes.
+
+```
+┌──────────────┐    ┌──────────────┐    ┌──────────────┐
+│    Node A     │    │    Node B     │    │    Node C     │
+│  WS/HTTP     │    │  WS/HTTP     │    │  WS/HTTP     │
+│  Sessions    │◄──►│  Sessions    │◄──►│  Sessions    │
+│  Matches     │    │  Matches     │    │  Matches     │
+│  Matchmaker  │    │  Matchmaker  │    │  Matchmaker  │
+│  pg (shared) │    │  pg (shared) │    │  pg (shared) │
+└──────┬───────┘    └──────┬───────┘    └──────┬───────┘
+       │                   │                   │
+       └───────────────────┼───────────────────┘
+                     ┌─────▼─────┐
+                     │ PostgreSQL │
+                     └───────────┘
+```
+
+**What works across nodes today:**
+- **Presence** — `pg:get_members(nova_scope, {player, Id})` returns pids on all
+  nodes. Sending messages to those pids works transparently.
+- **Session revocation** — `asobi_presence:disconnect/2` reaches sessions on any
+  node.
+- **Chat** — `nova_pubsub` uses `pg` underneath, so chat messages cross nodes.
+- **Match state broadcasts** — `broadcast_state` uses `asobi_presence:send/2`
+  which goes through `pg`, so a match process on Node A can send state to a
+  player session on Node B.
+
+**What does NOT work today:**
+- **Matchmaker** — Each node runs its own `asobi_matchmaker` (local registration).
+  A player on Node A and a player on Node B won't be matched together.
+- **Match lookup by ID** — `global:whereis_name({asobi_match_server, MatchId})`
+  fails because matches don't register globally.
+- **Rate limiting** — Per-node ETS, not shared.
+
+**Migrations:** The Kura advisory lock ensures only one node migrates at a
+time. Safe for rolling deploys, but you should NOT run migrations on every node
+simultaneously — let the first node apply, others will see the version already
+recorded and skip.
+
+**When to use:** Small clusters (2-5 nodes) on the same network. Full mesh
+topology. Good for HA and moderate scale. Not suitable for large clusters or
+multi-region.
+
+### Cloud-Native (No Distributed Erlang)
+
+In Kubernetes, Fly.io, or similar platforms, distributed Erlang is often
+impractical:
+- Dynamic IPs and pod churn make node discovery fragile
+- Full mesh doesn't scale beyond ~50 nodes
+- The distribution protocol has a large security surface
+- Stateless horizontal scaling is the expected model
+
+In this model, each BEAM node is independent. Cross-node communication goes
+through PostgreSQL (which you already have) and Shigoto (which you already have).
+No Redis, no NATS, no additional infrastructure.
+
+#### The Shigoto Broadcast Pattern
+
+The core idea: **every cross-node event is a Shigoto fanout job**. All nodes
+consume the fanout queue. When a node picks up a job, it broadcasts locally
+via `pg` to the affected sessions, which push to clients via WebSocket.
+
+```
+Producer Node                 PostgreSQL              All Consumer Nodes
+     │                            │                         │
+     │── shigoto:insert(...)────►│                         │
+     │   (broadcast queue)        │                         │
+     │                            │── fanout poll ─────────►│
+     │                            │   (no locking,          │── local pg lookup
+     │                            │    time-window)         │── broadcast to sessions
+     │                            │                         │── WS push to clients
+```
+
+Fanout jobs are ephemeral — they live in the database for a configurable
+window (default 120s), then are automatically pruned. Workers must be
+idempotent. If a node misses a broadcast (e.g. during restart), the client
+catches up from the database on reconnect. The database is always the
+source of truth; fanout is best-effort push.
+
+#### Architecture Diagram
+
+```
+┌──────────────────┐  ┌──────────────────┐  ┌──────────────────┐
+│      Pod A       │  │      Pod B       │  │      Pod C       │
+│  WS/HTTP         │  │  WS/HTTP         │  │  WS/HTTP         │
+│  Sessions (pg)   │  │  Sessions (pg)   │  │  Sessions (pg)   │
+│  Matches (local) │  │  Matches (local) │  │  Matches (local) │
+│  Shigoto worker  │  │  Shigoto worker  │  │  Shigoto worker  │
+└────────┬─────────┘  └────────┬─────────┘  └────────┬─────────┘
+         │                     │                     │
+         └─────────────────────┼─────────────────────┘
+                               │
+                    ┌──────────▼──────────┐
+                    │     PostgreSQL      │
+                    │  ┌───────────────┐  │
+                    │  │ shigoto_jobs  │  │  ← shared job queue
+                    │  │ asobi tables  │  │  ← application state
+                    │  └───────────────┘  │
+                    └─────────────────────┘
+```
+
+No Redis. No NATS. No distributed Erlang. Just PostgreSQL.
+
+#### What Goes Through the Fanout Queue
+
+| Event | Producer | Consumer Behavior |
+|-------|----------|-------------------|
+| Session revocation (ban/delete) | Admin action | All nodes: `asobi_presence:disconnect/2` locally |
+| Chat message (cross-pod) | Sender's pod | All nodes: deliver to local `pg` chat group members |
+| Notification | Any service | All nodes: push to player's local session if connected |
+| Presence update | Any pod | All nodes: update local presence state |
+| Matchmaker ticket | Player's pod | One node (matchmaker leader): process ticket |
+
+#### What Does NOT Go Through the Fanout Queue
+
+| Event | Why | Mechanism |
+|-------|-----|-----------|
+| Match state (10 Hz) | Too fast, must be local | Local `pg` on same pod (sticky placement) |
+| Match input | Same pod as match | Direct `gen_statem:cast` |
+| Leaderboard flush | Already DB-backed | Local buffer → periodic `asobi_repo:insert` |
+
+#### Sticky Match Placement
+
+The matchmaker assigns a pod for each match. All matched players connect (or
+get routed) to that pod. The match process, player sessions, and game tick
+loop stay local — no cross-pod communication at 10 Hz.
+
+The load balancer routes by match ID or a session cookie set during the
+matchmaker flow.
+
+#### Migrations
+
+Run as a separate Kubernetes Job or init container before the deployment rolls
+out. Do not race migrations across pods — use a single job with Kura's
+advisory lock as a safety net.
+
+## Match Placement: Same Node vs Distributed
+
+**Should all players in a match be on the same node?**
+
+Yes, for real-time games. The match server ticks at 10 Hz and broadcasts state
+to all players. If players are on different nodes:
+
+- **Distributed Erlang:** Works, but adds ~0.1-1ms per message hop. At 10 Hz
+  with 10 players on 3 nodes, that's 100 cross-node messages/second. Tolerable
+  for small clusters, but adds jitter.
+- **Cloud-native:** Unacceptable without distributed Erlang. You'd need to
+  serialize state to Redis/NATS per tick, which adds latency and complexity.
+
+**Recommendation:** Use sticky match placement. The matchmaker assigns a node,
+all matched players connect (or get routed) to that node for the duration of the
+match. This keeps the tight game loop local.
+
+**For non-real-time features** (leaderboards, chat, social, inventory): these
+are request/response or low-frequency pub/sub. Cross-node or cross-pod
+communication via the Shigoto fanout queue is fine.
+
+## Summary: Which Model When
+
+| Scale | Model | Notes |
+|-------|-------|-------|
+| Dev / small prod | Single node | Simplest. Up to ~10K concurrent connections. |
+| Medium (HA needed) | Distributed Erlang, 2-5 nodes | Add global matchmaker, global match registration. Sticky match placement. |
+| Large / cloud-native | Independent pods + Shigoto/PG | Cross-pod events via Shigoto fanout queue. Sticky match placement. No Redis/NATS needed. Migration via job. |
+
+The current codebase is designed for single-node. Moving to distributed Erlang
+requires making the matchmaker cluster-aware (global registration or a shared
+queue via `pg`). Moving to cloud-native requires only PostgreSQL — Shigoto
+provides the durable fanout queue for cross-pod broadcast, and `pg` handles
+local-node session routing. No additional infrastructure beyond what you
+already have.

--- a/src/players/asobi_player_session.erl
+++ b/src/players/asobi_player_session.erl
@@ -53,6 +53,9 @@ handle_cast(_Msg, State) ->
 -spec handle_info(term(), map()) -> {noreply, map()} | {stop, normal, map()}.
 handle_info({'DOWN', _Ref, process, WsPid, _Reason}, #{ws_pid := WsPid} = State) ->
     {stop, normal, State};
+handle_info({session_revoked, Reason}, #{ws_pid := WsPid} = State) ->
+    WsPid ! {session_revoked, Reason},
+    {stop, {shutdown, session_revoked}, State};
 handle_info({asobi_message, {match_joined, MatchPid}}, State) ->
     {noreply, State#{match_pid => MatchPid}};
 handle_info({asobi_message, _} = Msg, #{ws_pid := WsPid} = State) ->

--- a/src/social/asobi_presence.erl
+++ b/src/social/asobi_presence.erl
@@ -45,7 +45,7 @@ send(PlayerId, Message) ->
 
 -spec revoke_session(binary(), binary()) -> ok.
 revoke_session(PlayerId, Reason) ->
-    asobi_broadcast_worker:enqueue(~"session_revoked", #{
+    _ = asobi_broadcast_worker:enqueue(~"session_revoked", #{
         player_id => PlayerId,
         reason => Reason
     }),

--- a/src/social/asobi_presence.erl
+++ b/src/social/asobi_presence.erl
@@ -3,6 +3,7 @@
 
 -export([start_link/0]).
 -export([track/2, untrack/1, update/2, get_status/1, send/2, online_count/0]).
+-export([disconnect/2, revoke_session/2]).
 -export([init/1, handle_call/3, handle_cast/2, handle_info/2]).
 
 -define(PRESENCE_GROUP, asobi_online).
@@ -40,6 +41,20 @@ get_status(PlayerId) ->
 send(PlayerId, Message) ->
     Members = pg:get_members(?PG_SCOPE, {player, PlayerId}),
     lists:foreach(fun(Pid) -> Pid ! {asobi_message, Message} end, Members),
+    ok.
+
+-spec revoke_session(binary(), binary()) -> ok.
+revoke_session(PlayerId, Reason) ->
+    asobi_broadcast_worker:enqueue(~"session_revoked", #{
+        player_id => PlayerId,
+        reason => Reason
+    }),
+    ok.
+
+-spec disconnect(binary(), binary()) -> ok.
+disconnect(PlayerId, Reason) ->
+    Members = pg:get_members(?PG_SCOPE, {player, PlayerId}),
+    lists:foreach(fun(Pid) -> Pid ! {session_revoked, Reason} end, Members),
     ok.
 
 -spec online_count() -> non_neg_integer().

--- a/src/workers/asobi_broadcast_worker.erl
+++ b/src/workers/asobi_broadcast_worker.erl
@@ -1,0 +1,33 @@
+-module(asobi_broadcast_worker).
+-behaviour(shigoto_worker).
+
+-export([perform/1, queue/0, priority/0, max_attempts/1]).
+-export([enqueue/2]).
+
+-spec queue() -> binary().
+queue() -> ~"broadcast".
+
+-spec priority() -> integer().
+priority() -> 100.
+
+-spec max_attempts(map()) -> pos_integer().
+max_attempts(_Args) -> 1.
+
+-spec enqueue(binary(), map()) -> {ok, term()} | {error, term()}.
+enqueue(Type, Payload) ->
+    shigoto:insert(#{
+        worker => ?MODULE,
+        args => Payload#{type => Type}
+    }).
+
+-spec perform(map()) -> ok.
+perform(#{type := ~"session_revoked", player_id := PlayerId, reason := Reason}) ->
+    asobi_presence:disconnect(PlayerId, Reason);
+perform(#{type := ~"notification", player_id := PlayerId} = Payload) ->
+    Notif = maps:without([type, player_id], Payload),
+    asobi_presence:send(PlayerId, {notification, Notif});
+perform(#{type := ~"chat", channel_id := ChannelId, sender_id := SenderId, content := Content}) ->
+    asobi_chat_channel:send_message(ChannelId, SenderId, Content);
+perform(#{type := Type}) ->
+    logger:warning(#{msg => ~"unknown_broadcast_type", type => Type}),
+    ok.

--- a/src/ws/asobi_ws_handler.erl
+++ b/src/ws/asobi_ws_handler.erl
@@ -39,6 +39,9 @@ websocket_info({chat_message, ChannelId, Msg}, State) ->
 websocket_info({asobi_message, {notification, Notif}}, State) ->
     Reply = encode_reply(undefined, ~"notification.new", Notif),
     {reply, {text, Reply}, State};
+websocket_info({session_revoked, Reason}, State) ->
+    logger:notice(#{msg => ~"session_revoked", reason => Reason}),
+    {stop, State#{session => undefined}};
 websocket_info(_Info, State) ->
     {ok, State}.
 


### PR DESCRIPTION
## Summary
- Event-driven session revocation that works across nodes without distributed Erlang
- New `asobi_broadcast_worker` on Shigoto fanout queue for cross-node events
- `asobi_presence:revoke_session/2` as the public API for banning/revoking players
- Architecture guide documenting single-node, distributed Erlang, and cloud-native deployment models
- Shigoto fanout queue configured (broadcast, 5 workers, 120s window, 500ms poll dev / 200ms prod)

## Flow
```
asobi_presence:revoke_session(PlayerId, "banned")
  → Shigoto fanout job (broadcast queue)
    → All nodes poll and process
      → asobi_presence:disconnect/2 (local pg)
        → session_revoked → WS close
```

## Test plan
- [ ] Ban a player via shell: `asobi_presence:revoke_session(Id, ~"banned")`
- [ ] Verify WebSocket disconnects within poll interval
- [ ] Verify player cannot reconnect (token invalid)
- [ ] Verify job appears and is pruned from shigoto_jobs table
- [ ] Review architecture guide for accuracy