### PR TITLE
fix: consistent leaderboard response shape

### DIFF
--- a/src/controllers/asobi_leaderboard_controller.erl
+++ b/src/controllers/asobi_leaderboard_controller.erl
@@ -7,30 +7,56 @@ top(#{bindings := #{~"id" := BoardId}, qs := Qs} = _Req) ->
     Params = cow_qs:parse_qs(Qs),
     Limit = binary_to_integer(proplists:get_value(~"limit", Params, ~"100")),
     Entries = asobi_leaderboard_server:top(BoardId, Limit),
-    {json, #{leaderboard_id => BoardId, entries => format_entries(Entries)}}.
+    {json, #{entries => format_entries(BoardId, Entries)}}.
 
 -spec around(cowboy_req:req()) -> {json, map()}.
 around(#{bindings := #{~"id" := BoardId, ~"player_id" := PlayerId}, qs := Qs} = _Req) ->
     Params = cow_qs:parse_qs(Qs),
     Range = binary_to_integer(proplists:get_value(~"range", Params, ~"5")),
     Entries = asobi_leaderboard_server:around(BoardId, PlayerId, Range),
-    {json, #{leaderboard_id => BoardId, entries => format_entries(Entries)}}.
+    {json, #{entries => format_entries(BoardId, Entries)}}.
 
 -spec submit(cowboy_req:req()) -> {json, map()}.
 submit(
     #{bindings := #{~"id" := BoardId}, json := Params, auth_data := #{player_id := PlayerId}} = _Req
 ) ->
     Score = maps:get(~"score", Params),
+    SubScore = maps:get(~"sub_score", Params, 0),
     asobi_leaderboard_server:submit(BoardId, PlayerId, Score),
-    case asobi_leaderboard_server:rank(BoardId, PlayerId) of
-        {ok, Rank} ->
-            {json, #{leaderboard_id => BoardId, rank => Rank, score => Score}};
-        {error, not_found} ->
-            {json, #{leaderboard_id => BoardId, score => Score}}
-    end.
+    Rank =
+        case asobi_leaderboard_server:rank(BoardId, PlayerId) of
+            {ok, R} -> R;
+            {error, not_found} -> null
+        end,
+    {json, #{
+        leaderboard_id => BoardId,
+        player_id => PlayerId,
+        score => Score,
+        sub_score => SubScore,
+        rank => Rank,
+        updated_at => format_timestamp(erlang:system_time(millisecond))
+    }}.
 
 %% --- Internal ---
 
--spec format_entries([{binary(), integer(), pos_integer()}]) -> [map()].
-format_entries(Entries) ->
-    [#{player_id => P, score => S, rank => R} || {P, S, R} <- Entries].
+-spec format_entries(binary(), [{binary(), integer(), pos_integer()}]) -> [map()].
+format_entries(BoardId, Entries) ->
+    [#{
+        leaderboard_id => BoardId,
+        player_id => P,
+        score => S,
+        sub_score => 0,
+        rank => R,
+        updated_at => null
+    } || {P, S, R} <- Entries].
+
+-spec format_timestamp(integer()) -> binary().
+format_timestamp(Ms) ->
+    Seconds = Ms div 1000,
+    {{Y, Mo, D}, {H, Mi, S}} = calendar:system_time_to_universal_time(Seconds, second),
+    iolist_to_binary(
+        io_lib:format(
+            ~"~4..0B-~2..0B-~2..0BT~2..0B:~2..0B:~2..0BZ",
+            [Y, Mo, D, H, Mi, S]
+        )
+    ).

--- a/src/controllers/asobi_leaderboard_controller.erl
+++ b/src/controllers/asobi_leaderboard_controller.erl
@@ -41,14 +41,17 @@ submit(
 
 -spec format_entries(binary(), [{binary(), integer(), pos_integer()}]) -> [map()].
 format_entries(BoardId, Entries) ->
-    [#{
-        leaderboard_id => BoardId,
-        player_id => P,
-        score => S,
-        sub_score => 0,
-        rank => R,
-        updated_at => null
-    } || {P, S, R} <- Entries].
+    [
+        #{
+            leaderboard_id => BoardId,
+            player_id => P,
+            score => S,
+            sub_score => 0,
+            rank => R,
+            updated_at => null
+        }
+     || {P, S, R} <- Entries
+    ].
 
 -spec format_timestamp(integer()) -> binary().
 format_timestamp(Ms) ->


### PR DESCRIPTION
## Summary
All leaderboard endpoints now return the same entry shape with all fields present:
- `leaderboard_id`, `player_id`, `score`, `sub_score`, `rank`, `updated_at`

Previously submit returned only `leaderboard_id/rank/score` and top/around entries
were missing `leaderboard_id/sub_score/updated_at`. This caused SDK model parsing
failures (Dart SDK crashed on null cast).

## Test plan
- [ ] Submit score, verify response has all 6 fields
- [ ] Get top, verify each entry has all 6 fields
- [ ] Get around, verify each entry has all 6 fields
- [ ] Flame demo shows leaderboard correctly