### PR TITLE
chore: add release workflow and changelog config

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,11 @@
+name: Release
+
+on:
+  push:
+    branches: [main]
+
+jobs:
+  release:
+    uses: Taure/erlang-ci/.github/workflows/release.yml@main
+    permissions:
+      contents: write

--- a/cliff.toml
+++ b/cliff.toml
@@ -1,0 +1,38 @@
+[changelog]
+header = """
+# Changelog\n
+All notable changes to this project will be documented in this file.\n
+"""
+body = """
+{% if version %}\
+    ## [{{ version | trim_start_matches(pat="v") }}] - {{ timestamp | date(format="%Y-%m-%d") }}
+{% else %}\
+    ## [unreleased]
+{% endif %}\
+{% for group, commits in commits | group_by(attribute="group") %}
+    ### {{ group | striptags | trim | upper_first }}
+    {% for commit in commits %}
+        - {% if commit.scope %}*({{ commit.scope }})* {% endif %}\
+            {{ commit.message | upper_first }}\
+    {% endfor %}
+{% endfor %}\n
+"""
+trim = true
+
+[git]
+conventional_commits = true
+filter_unconventional = true
+split_commits = false
+commit_parsers = [
+    { message = "^feat", group = "Features" },
+    { message = "^fix", group = "Bug Fixes" },
+    { message = "^docs", group = "Documentation" },
+    { message = "^refactor", group = "Refactor" },
+    { message = "^test", group = "Testing" },
+    { message = "^chore\\(release\\)", skip = true },
+    { message = "^chore", group = "Miscellaneous" },
+    { message = "^ci", skip = true },
+]
+protect_breaking_commits = false
+tag_pattern = "v[0-9].*"
+sort_commits = "oldest"


### PR DESCRIPTION
## Summary
- Add erlang-ci release workflow (triggers on push to main, auto-tags with git-cliff)
- Add cliff.toml for conventional commit changelog generation
- First release will be v0.1.0, subsequent releases auto-bump based on commit prefixes

## Test plan
- [ ] CI passes
- [ ] After merge, release workflow creates v0.1.0 tag and GitHub release
- [ ] Discord webhook fires on release