### PR TITLE
chore: switch deps to Hex versions

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -11,12 +11,13 @@
 {shell, [{config, "./config/dev_sys.config.src"}]}.
 
 {deps, [
-    {nova, {git, "https://github.com/novaframework/nova.git", {branch, "master"}}},
-    {kura, {git, "https://github.com/Taure/kura.git", {branch, "main"}}},
+    nova,
+    {kura, "~> 1.14"},
+    %% Switch to Hex versions once published
     {nova_auth, {git, "https://github.com/novaframework/nova_auth.git", {branch, "main"}}},
     {nova_resilience,
         {git, "https://github.com/novaframework/nova_resilience.git", {branch, "main"}}},
-    {shigoto, {git, "https://github.com/Taure/shigoto.git", {branch, "main"}}}
+    {shigoto, "~> 1.0"}
 ]}.
 
 {relx, [


### PR DESCRIPTION
## Summary
- Switch nova, kura, and shigoto from git to Hex versions
- nova_auth and nova_resilience remain as git deps until published to Hex (PRs pending: novaframework/nova_auth#5, novaframework/nova_resilience#3)

## Test plan
- [x] `rebar3 compile` passes with mixed Hex/git deps
- [ ] CI passes