### PR TITLE
chore: switch all deps to Hex

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -12,12 +12,10 @@
 
 {deps, [
     nova,
-    {kura, "~> 1.14"},
-    %% Switch to Hex versions once published
-    {nova_auth, {git, "https://github.com/novaframework/nova_auth.git", {branch, "main"}}},
-    {nova_resilience,
-        {git, "https://github.com/novaframework/nova_resilience.git", {branch, "main"}}},
-    {shigoto, "~> 1.0"}
+    {kura, "~> 1.17"},
+    {nova_auth, "~> 0.1"},
+    {nova_resilience, "~> 1.0"},
+    {shigoto, "~> 1.2"}
 ]}.
 
 {relx, [


### PR DESCRIPTION
All dependencies now on Hex. Ready for `rebar3 hex publish`.