### PR TITLE
feat: add roguelike voting system

### DIFF
--- a/guides/rest-api.md
+++ b/guides/rest-api.md
@@ -92,6 +92,15 @@ GET  /api/v1/tournaments/:id           Get tournament details
 POST /api/v1/tournaments/:id/join      Join tournament
 ```
 
+## Votes
+
+```
+GET /api/v1/matches/:match_id/votes    List votes for a match (newest first, max 50)
+GET /api/v1/votes/:id                  Get a single vote with full results
+```
+
+Voting itself happens over WebSocket. See the [Voting guide](voting.md).
+
 ## Chat
 
 ```

--- a/guides/voting.md
+++ b/guides/voting.md
@@ -1,0 +1,219 @@
+# Voting
+
+Asobi includes an in-match voting system for roguelike-style group decisions
+such as path selection, item picks, event choices, and run modifiers.
+
+## How It Works
+
+1. Game mode (or match server) starts a vote with options and a timed window
+2. Eligible players receive a `match.vote_start` event via WebSocket
+3. Players cast votes during the window
+4. When the window expires, votes are tallied and the result is broadcast
+5. The game mode receives the result via the `vote_resolved/3` callback
+
+## Starting a Vote
+
+Votes are started from a game mode callback or via the match server API:
+
+```erlang
+%% From inside a game module callback
+asobi_match_server:start_vote(MatchPid, #{
+    template => ~"path_choice",
+    options => [
+        #{id => ~"jungle", label => ~"Jungle Path"},
+        #{id => ~"volcano", label => ~"Volcano Path"},
+        #{id => ~"caves", label => ~"Ice Caves"}
+    ],
+    window_ms => 15000,
+    method => ~"plurality",
+    visibility => ~"live"
+}).
+```
+
+### Config Options
+
+| Key            | Type           | Default        | Description                        |
+|----------------|----------------|----------------|------------------------------------|
+| `options`      | `[map()]`      | required       | List of `#{id, label}` option maps |
+| `template`     | `binary()`     | `"default"`    | Template name (for analytics)      |
+| `window_ms`    | `pos_integer()`| `15000`        | Vote window in milliseconds        |
+| `method`       | `binary()`     | `"plurality"`  | `"plurality"` or `"approval"`      |
+| `visibility`   | `binary()`     | `"live"`       | `"live"` or `"hidden"`             |
+| `tie_breaker`  | `binary()`     | `"random"`     | `"random"` or `"first"`            |
+| `veto_enabled` | `boolean()`    | `false`        | Allow players to veto              |
+
+The match server automatically fills in `match_id`, `match_pid`, and
+`eligible` (all current players) when starting the vote.
+
+## Voting Methods
+
+### Plurality
+
+Each player picks exactly one option. The option with the most votes wins.
+Ties are broken by the configured `tie_breaker` strategy.
+
+### Approval
+
+Each player submits a list of all options they approve of. The option with
+the highest total approval count wins. Good for "avoid the worst option"
+scenarios.
+
+## Game Mode Integration
+
+Implement the optional `asobi_match` callbacks to react to vote results:
+
+```erlang
+-module(my_roguelike).
+-behaviour(asobi_match).
+
+%% ... init/1, join/2, leave/2, handle_input/3, get_state/2 ...
+
+vote_resolved(~"path_choice", #{winner := WinnerId}, GameState) ->
+    %% Apply the voted path to game state
+    {ok, GameState#{current_path => WinnerId}};
+vote_resolved(~"item_pick", #{winner := ItemId}, GameState) ->
+    {ok, add_item(ItemId, GameState)}.
+```
+
+Both callbacks are optional. If `vote_resolved/3` is not implemented, the
+vote still runs and broadcasts results to clients — the game mode just
+doesn't react server-side.
+
+## WebSocket Protocol
+
+### Casting a Vote (client to server)
+
+```json
+{
+  "type": "vote.cast",
+  "cid": "v1",
+  "payload": {
+    "vote_id": "...",
+    "option_id": "jungle"
+  }
+}
+```
+
+For approval voting, `option_id` is a list:
+
+```json
+{"option_id": ["jungle", "caves"]}
+```
+
+Response:
+
+```json
+{"type": "vote.cast_ok", "cid": "v1", "payload": {"success": true}}
+```
+
+Players can change their vote by sending another `vote.cast` during the
+window. The new vote replaces the previous one.
+
+### Server Push Events
+
+All vote events are broadcast to match players as `match.*` events:
+
+#### `match.vote_start`
+
+A new vote has started.
+
+```json
+{
+  "type": "match.vote_start",
+  "payload": {
+    "vote_id": "...",
+    "options": [
+      {"id": "jungle", "label": "Jungle Path"},
+      {"id": "volcano", "label": "Volcano Path"},
+      {"id": "caves", "label": "Ice Caves"}
+    ],
+    "window_ms": 15000,
+    "method": "plurality"
+  }
+}
+```
+
+#### `match.vote_tally`
+
+Running tally update (only with `"live"` visibility). Sent each time a vote
+is cast.
+
+```json
+{
+  "type": "match.vote_tally",
+  "payload": {
+    "vote_id": "...",
+    "tallies": {"jungle": 2, "volcano": 1, "caves": 0},
+    "time_remaining_ms": 8432,
+    "total_votes": 3
+  }
+}
+```
+
+#### `match.vote_result`
+
+Vote has closed and the winner is determined.
+
+```json
+{
+  "type": "match.vote_result",
+  "payload": {
+    "vote_id": "...",
+    "winner": "jungle",
+    "counts": {"jungle": 2, "volcano": 1, "caves": 0},
+    "distribution": {"jungle": 0.666, "volcano": 0.333, "caves": 0.0},
+    "total_votes": 3,
+    "turnout": 1.0
+  }
+}
+```
+
+#### `match.vote_vetoed`
+
+A player has vetoed the vote (when `veto_enabled` is true).
+
+```json
+{
+  "type": "match.vote_vetoed",
+  "payload": {
+    "vote_id": "...",
+    "vetoed_by": "player_id"
+  }
+}
+```
+
+## REST API
+
+### List votes for a match
+
+```bash
+curl http://localhost:8082/api/v1/matches/<match_id>/votes \
+  -H 'Authorization: Bearer <token>'
+```
+
+Returns the most recent 50 votes for the match, ordered by newest first.
+
+### Get a single vote
+
+```bash
+curl http://localhost:8082/api/v1/votes/<vote_id> \
+  -H 'Authorization: Bearer <token>'
+```
+
+## Visibility Modes
+
+- **`"live"`**: Running tallies are broadcast after each vote and included in
+  state queries. Creates excitement and enables strategic voting.
+- **`"hidden"`**: Tallies are not shown until the vote closes. Prevents
+  bandwagon effects. Only total vote count is visible during the window.
+
+## Veto
+
+When `veto_enabled` is true, any eligible voter can veto the vote. This
+immediately cancels it and notifies all players. Use sparingly — typically
+as a limited-use resource managed by the game mode.
+
+## Grace Period
+
+Votes arriving within 500ms after the window closes are still accepted to
+compensate for network latency.

--- a/guides/websocket-protocol.md
+++ b/guides/websocket-protocol.md
@@ -170,6 +170,80 @@ Leave a chat channel.
 {"type": "chat.leave", "payload": {"channel_id": "lobby"}}
 ```
 
+## Voting
+
+### `vote.cast`
+
+Cast a vote in an active match vote.
+
+```json
+{"type": "vote.cast", "cid": "v1", "payload": {"vote_id": "...", "option_id": "jungle"}}
+```
+
+For approval voting, `option_id` is a list:
+
+```json
+{"type": "vote.cast", "payload": {"vote_id": "...", "option_id": ["jungle", "caves"]}}
+```
+
+### `match.vote_start` (server push)
+
+A new vote has started.
+
+```json
+{
+  "type": "match.vote_start",
+  "payload": {
+    "vote_id": "...",
+    "options": [{"id": "jungle", "label": "Jungle Path"}, {"id": "volcano", "label": "Volcano Path"}],
+    "window_ms": 15000,
+    "method": "plurality"
+  }
+}
+```
+
+### `match.vote_tally` (server push)
+
+Running tally update (only with `"live"` visibility).
+
+```json
+{
+  "type": "match.vote_tally",
+  "payload": {
+    "vote_id": "...",
+    "tallies": {"jungle": 2, "volcano": 1},
+    "time_remaining_ms": 8432,
+    "total_votes": 3
+  }
+}
+```
+
+### `match.vote_result` (server push)
+
+Vote closed, winner determined.
+
+```json
+{
+  "type": "match.vote_result",
+  "payload": {
+    "vote_id": "...",
+    "winner": "jungle",
+    "counts": {"jungle": 2, "volcano": 1},
+    "distribution": {"jungle": 0.666, "volcano": 0.333},
+    "total_votes": 3,
+    "turnout": 1.0
+  }
+}
+```
+
+### `match.vote_vetoed` (server push)
+
+A player vetoed the vote.
+
+```json
+{"type": "match.vote_vetoed", "payload": {"vote_id": "...", "vetoed_by": "player_id"}}
+```
+
 ## Presence
 
 ### `presence.update`

--- a/rebar.config
+++ b/rebar.config
@@ -90,7 +90,8 @@
         <<"guides/clustering.md">>,
         <<"docs/ARCHITECTURE.md">>,
         <<"guides/authentication.md">>,
-        <<"guides/iap.md">>
+        <<"guides/iap.md">>,
+        <<"guides/voting.md">>
     ]},
     {groups_for_extras, [
         {<<"Getting Started">>, [
@@ -104,7 +105,8 @@
             <<"guides/economy.md">>,
             <<"guides/clustering.md">>,
             <<"guides/authentication.md">>,
-            <<"guides/iap.md">>
+            <<"guides/iap.md">>,
+            <<"guides/voting.md">>
         ]},
         {<<"Reference">>, [
             <<"docs/ARCHITECTURE.md">>
@@ -129,7 +131,8 @@
             asobi_cloud_save,
             asobi_storage,
             asobi_leaderboard_entry,
-            asobi_player_identity
+            asobi_player_identity,
+            asobi_vote
         ]},
         {<<"Controllers">>, [
             asobi_auth_controller,
@@ -145,7 +148,8 @@
             asobi_chat_controller,
             asobi_tournament_controller,
             asobi_notification_controller,
-            asobi_storage_controller
+            asobi_storage_controller,
+            asobi_vote_controller
         ]},
         {<<"Real-Time">>, [
             asobi_ws_handler,
@@ -153,7 +157,8 @@
             asobi_matchmaker,
             asobi_chat_channel,
             asobi_presence,
-            asobi_player_session
+            asobi_player_session,
+            asobi_vote_server
         ]},
         {<<"Auth">>, [
             asobi_oidc_config,

--- a/src/asobi_router.erl
+++ b/src/asobi_router.erl
@@ -120,6 +120,10 @@ api_routes() ->
             %% Chat
             {~"/chat/:channel_id/history", fun asobi_chat_controller:history/1, #{methods => [get]}},
 
+            %% Votes
+            {~"/matches/:match_id/votes", fun asobi_vote_controller:index/1, #{methods => [get]}},
+            {~"/votes/:id", fun asobi_vote_controller:show/1, #{methods => [get]}},
+
             %% Tournaments
             {~"/tournaments", fun asobi_tournament_controller:index/1, #{methods => [get]}},
             {~"/tournaments/:id", fun asobi_tournament_controller:show/1, #{methods => [get]}},

--- a/src/asobi_sup.erl
+++ b/src/asobi_sup.erl
@@ -20,6 +20,7 @@ init([]) ->
         cluster_spec(),
         player_session_sup(),
         match_sup(),
+        vote_sup(),
         matchmaker_spec(),
         leaderboard_sup(),
         chat_sup(),
@@ -53,6 +54,13 @@ chat_sup() ->
     #{
         id => asobi_chat_sup,
         start => {asobi_chat_sup, start_link, []},
+        type => supervisor
+    }.
+
+vote_sup() ->
+    #{
+        id => asobi_vote_sup,
+        start => {asobi_vote_sup, start_link, []},
         type => supervisor
     }.
 

--- a/src/matches/asobi_match.erl
+++ b/src/matches/asobi_match.erl
@@ -30,4 +30,10 @@
 -callback get_state(PlayerId :: binary(), GameState :: term()) ->
     StateForPlayer :: map().
 
--optional_callbacks([tick/1]).
+-callback vote_requested(GameState :: term()) ->
+    {ok, VoteConfig :: map()} | none.
+
+-callback vote_resolved(Template :: binary(), Result :: map(), GameState :: term()) ->
+    {ok, GameState1 :: term()}.
+
+-optional_callbacks([tick/1, vote_requested/1, vote_resolved/3]).

--- a/src/matches/asobi_match_server.erl
+++ b/src/matches/asobi_match_server.erl
@@ -2,6 +2,7 @@
 -behaviour(gen_statem).
 
 -export([start_link/1, join/2, leave/2, handle_input/3, get_info/1, pause/1, resume/1, cancel/1]).
+-export([start_vote/2, cast_vote/4, broadcast_event/3]).
 -export([callback_mode/0, init/1, terminate/3]).
 -export([waiting/3, running/3, paused/3, finished/3]).
 
@@ -44,6 +45,18 @@ resume(Pid) ->
 -spec cancel(pid()) -> ok.
 cancel(Pid) ->
     gen_statem:cast(Pid, cancel).
+
+-spec start_vote(pid(), map()) -> {ok, pid()} | {error, term()}.
+start_vote(Pid, VoteConfig) ->
+    gen_statem:call(Pid, {start_vote, VoteConfig}).
+
+-spec cast_vote(pid(), binary(), binary(), binary()) -> ok | {error, term()}.
+cast_vote(Pid, PlayerId, VoteId, OptionId) ->
+    gen_statem:call(Pid, {cast_vote, PlayerId, VoteId, OptionId}).
+
+-spec broadcast_event(pid(), atom(), map()) -> ok.
+broadcast_event(Pid, Event, Payload) ->
+    gen_statem:cast(Pid, {broadcast_event, Event, Payload}).
 
 %% --- gen_statem callbacks ---
 
@@ -120,7 +133,47 @@ running({call, From}, resume, _State) ->
 running({call, From}, get_info, State) ->
     {keep_state_and_data, [{reply, From, match_info(running, State)}]};
 running({call, From}, {join, PlayerId}, State) ->
-    handle_join(From, PlayerId, State).
+    handle_join(From, PlayerId, State);
+running({call, From}, {start_vote, VoteConfig}, #{match_id := MatchId, players := Players} = State) ->
+    VoteId = maps:get(vote_id, VoteConfig, asobi_id:generate()),
+    FullConfig = VoteConfig#{
+        vote_id => VoteId,
+        match_id => MatchId,
+        match_pid => self(),
+        eligible => maps:keys(Players)
+    },
+    {ok, VotePid} = asobi_vote_sup:start_vote(FullConfig),
+    Active = maps:get(active_votes, State, #{}),
+    {keep_state, State#{active_votes => Active#{VoteId => VotePid}}, [
+        {reply, From, {ok, VotePid}}
+    ]};
+running({call, From}, {cast_vote, PlayerId, VoteId, OptionId}, State) ->
+    Active = maps:get(active_votes, State, #{}),
+    case maps:get(VoteId, Active, undefined) of
+        undefined ->
+            {keep_state_and_data, [{reply, From, {error, vote_not_found}}]};
+        VotePid ->
+            Result = asobi_vote_server:cast_vote(VotePid, PlayerId, OptionId),
+            {keep_state_and_data, [{reply, From, Result}]}
+    end;
+running(cast, {broadcast_event, Event, Payload}, State) ->
+    broadcast_match_event(Event, Payload, State),
+    keep_state_and_data;
+running(
+    info, {vote_resolved, VoteId, Template, Result}, #{game_module := Mod, game_state := GS} = State
+) ->
+    Active = maps:remove(VoteId, maps:get(active_votes, State, #{})),
+    State1 = State#{active_votes => Active},
+    case erlang:function_exported(Mod, vote_resolved, 3) of
+        true ->
+            {ok, GS1} = Mod:vote_resolved(Template, Result, GS),
+            {keep_state, State1#{game_state => GS1}};
+        false ->
+            {keep_state, State1}
+    end;
+running(info, {vote_vetoed, VoteId, _Template}, State) ->
+    Active = maps:remove(VoteId, maps:get(active_votes, State, #{})),
+    {keep_state, State#{active_votes => Active}}.
 
 %% --- paused state ---
 
@@ -137,6 +190,24 @@ paused(cast, {leave, PlayerId}, State) ->
     handle_leave(PlayerId, State);
 paused({call, From}, get_info, State) ->
     {keep_state_and_data, [{reply, From, match_info(paused, State)}]};
+paused(cast, {broadcast_event, Event, Payload}, State) ->
+    broadcast_match_event(Event, Payload, State),
+    keep_state_and_data;
+paused(
+    info, {vote_resolved, VoteId, Template, Result}, #{game_module := Mod, game_state := GS} = State
+) ->
+    Active = maps:remove(VoteId, maps:get(active_votes, State, #{})),
+    State1 = State#{active_votes => Active},
+    case erlang:function_exported(Mod, vote_resolved, 3) of
+        true ->
+            {ok, GS1} = Mod:vote_resolved(Template, Result, GS),
+            {keep_state, State1#{game_state => GS1}};
+        false ->
+            {keep_state, State1}
+    end;
+paused(info, {vote_vetoed, VoteId, _Template}, State) ->
+    Active = maps:remove(VoteId, maps:get(active_votes, State, #{})),
+    {keep_state, State#{active_votes => Active}};
 paused(_EventType, _Event, _State) ->
     keep_state_and_data.
 
@@ -219,6 +290,14 @@ apply_inputs(Mod, [{PlayerId, Input} | Rest], GS) ->
             }),
             apply_inputs(Mod, Rest, GS)
     end.
+
+broadcast_match_event(Event, Payload, #{players := Players}) ->
+    maps:foreach(
+        fun(PlayerId, _Meta) ->
+            asobi_presence:send(PlayerId, {match_event, Event, Payload})
+        end,
+        Players
+    ).
 
 broadcast_state(#{players := Players, game_module := Mod, game_state := GS}) ->
     maps:foreach(

--- a/src/migrations/m20260401094412_create_votes.erl
+++ b/src/migrations/m20260401094412_create_votes.erl
@@ -1,0 +1,28 @@
+-module(m20260401094412_create_votes).
+-moduledoc false.
+-behaviour(kura_migration).
+-include_lib("kura/include/kura.hrl").
+-export([up/0, down/0]).
+
+-spec up() -> [kura_migration:operation()].
+up() ->
+    [{create_table, <<"votes">>, [
+        #kura_column{name = id, type = uuid, primary_key = true, nullable = false},
+        #kura_column{name = match_id, type = uuid, nullable = false},
+        #kura_column{name = template, type = string, nullable = false},
+        #kura_column{name = method, type = string, nullable = false},
+        #kura_column{name = options, type = jsonb, nullable = false, default = []},
+        #kura_column{name = votes_cast, type = jsonb, default = #{}},
+        #kura_column{name = result, type = jsonb, default = #{}},
+        #kura_column{name = distribution, type = jsonb, default = #{}},
+        #kura_column{name = turnout, type = float, default = 0.0},
+        #kura_column{name = eligible_count, type = integer, default = 0},
+        #kura_column{name = window_ms, type = integer, nullable = false},
+        #kura_column{name = opened_at, type = utc_datetime},
+        #kura_column{name = closed_at, type = utc_datetime},
+        #kura_column{name = inserted_at, type = utc_datetime, nullable = false}
+    ]}].
+
+-spec down() -> [kura_migration:operation()].
+down() ->
+    [{drop_table, <<"votes">>}].

--- a/src/migrations/m20260401094412_create_votes.erl
+++ b/src/migrations/m20260401094412_create_votes.erl
@@ -6,22 +6,24 @@
 
 -spec up() -> [kura_migration:operation()].
 up() ->
-    [{create_table, <<"votes">>, [
-        #kura_column{name = id, type = uuid, primary_key = true, nullable = false},
-        #kura_column{name = match_id, type = uuid, nullable = false},
-        #kura_column{name = template, type = string, nullable = false},
-        #kura_column{name = method, type = string, nullable = false},
-        #kura_column{name = options, type = jsonb, nullable = false, default = []},
-        #kura_column{name = votes_cast, type = jsonb, default = #{}},
-        #kura_column{name = result, type = jsonb, default = #{}},
-        #kura_column{name = distribution, type = jsonb, default = #{}},
-        #kura_column{name = turnout, type = float, default = 0.0},
-        #kura_column{name = eligible_count, type = integer, default = 0},
-        #kura_column{name = window_ms, type = integer, nullable = false},
-        #kura_column{name = opened_at, type = utc_datetime},
-        #kura_column{name = closed_at, type = utc_datetime},
-        #kura_column{name = inserted_at, type = utc_datetime, nullable = false}
-    ]}].
+    [
+        {create_table, <<"votes">>, [
+            #kura_column{name = id, type = uuid, primary_key = true, nullable = false},
+            #kura_column{name = match_id, type = uuid, nullable = false},
+            #kura_column{name = template, type = string, nullable = false},
+            #kura_column{name = method, type = string, nullable = false},
+            #kura_column{name = options, type = jsonb, nullable = false, default = []},
+            #kura_column{name = votes_cast, type = jsonb, default = #{}},
+            #kura_column{name = result, type = jsonb, default = #{}},
+            #kura_column{name = distribution, type = jsonb, default = #{}},
+            #kura_column{name = turnout, type = float, default = 0.0},
+            #kura_column{name = eligible_count, type = integer, default = 0},
+            #kura_column{name = window_ms, type = integer, nullable = false},
+            #kura_column{name = opened_at, type = utc_datetime},
+            #kura_column{name = closed_at, type = utc_datetime},
+            #kura_column{name = inserted_at, type = utc_datetime, nullable = false}
+        ]}
+    ].
 
 -spec down() -> [kura_migration:operation()].
 down() ->

--- a/src/votes/asobi_vote.erl
+++ b/src/votes/asobi_vote.erl
@@ -1,0 +1,37 @@
+-module(asobi_vote).
+-behaviour(kura_schema).
+-include_lib("kura/include/kura.hrl").
+
+-export([table/0, fields/0, associations/0, indexes/0]).
+
+-spec table() -> binary().
+table() -> ~"votes".
+
+-spec fields() -> [#kura_field{}].
+fields() ->
+    [
+        #kura_field{name = id, type = uuid, primary_key = true, nullable = false},
+        #kura_field{name = match_id, type = uuid, nullable = false},
+        #kura_field{name = template, type = string, nullable = false},
+        #kura_field{name = method, type = string, nullable = false},
+        #kura_field{name = options, type = jsonb, nullable = false, default = []},
+        #kura_field{name = votes_cast, type = jsonb, default = #{}},
+        #kura_field{name = result, type = jsonb, default = #{}},
+        #kura_field{name = distribution, type = jsonb, default = #{}},
+        #kura_field{name = turnout, type = float, default = 0.0},
+        #kura_field{name = eligible_count, type = integer, default = 0},
+        #kura_field{name = window_ms, type = integer, nullable = false},
+        #kura_field{name = opened_at, type = utc_datetime},
+        #kura_field{name = closed_at, type = utc_datetime},
+        #kura_field{name = inserted_at, type = utc_datetime, nullable = false}
+    ].
+
+-spec associations() -> [#kura_assoc{}].
+associations() -> [].
+
+-spec indexes() -> [{[atom()], map()}].
+indexes() ->
+    [
+        {[match_id], #{}},
+        {[template], #{}}
+    ].

--- a/src/votes/asobi_vote.erl
+++ b/src/votes/asobi_vote.erl
@@ -1,4 +1,10 @@
 -module(asobi_vote).
+-moduledoc """
+Kura schema for persisted vote results.
+
+Each record represents a completed vote within a match, including the options
+presented, votes cast, tallied result, and turnout statistics.
+""".
 -behaviour(kura_schema).
 -include_lib("kura/include/kura.hrl").
 

--- a/src/votes/asobi_vote_controller.erl
+++ b/src/votes/asobi_vote_controller.erl
@@ -1,0 +1,25 @@
+-module(asobi_vote_controller).
+
+-export([index/1, show/1]).
+
+-spec index(cowboy_req:req()) -> {json, map()} | {status, integer()}.
+index(#{bindings := #{~"match_id" := MatchId}, auth_data := #{player_id := _PlayerId}} = _Req) ->
+    Q0 = kura_query:from(asobi_vote),
+    Q1 = kura_query:where(Q0, {match_id, MatchId}),
+    Q2 = kura_query:order_by(Q1, [{inserted_at, desc}]),
+    Q3 = kura_query:limit(Q2, 50),
+    case asobi_repo:all(Q3) of
+        {ok, Votes} ->
+            {json, #{votes => Votes}};
+        {error, _} ->
+            {status, 500}
+    end.
+
+-spec show(cowboy_req:req()) -> {json, map()} | {status, integer()}.
+show(#{bindings := #{~"id" := VoteId}, auth_data := #{player_id := _PlayerId}} = _Req) ->
+    case asobi_repo:get(asobi_vote, VoteId) of
+        {ok, Vote} ->
+            {json, Vote};
+        {error, not_found} ->
+            {status, 404}
+    end.

--- a/src/votes/asobi_vote_controller.erl
+++ b/src/votes/asobi_vote_controller.erl
@@ -1,4 +1,5 @@
 -module(asobi_vote_controller).
+-moduledoc "REST controller for vote history queries.".
 
 -export([index/1, show/1]).
 

--- a/src/votes/asobi_vote_server.erl
+++ b/src/votes/asobi_vote_server.erl
@@ -1,0 +1,406 @@
+-module(asobi_vote_server).
+-behaviour(gen_statem).
+
+-export([start_link/1, cast_vote/3, cast_veto/2, get_state/1]).
+-export([callback_mode/0, init/1, terminate/3]).
+-export([open/3, closed/3]).
+
+-define(GRACE_MS, 500).
+
+%% --- Public API ---
+
+-spec start_link(map()) -> {ok, pid()}.
+start_link(Config) ->
+    gen_statem:start_link(?MODULE, Config, []).
+
+-spec cast_vote(pid(), binary(), binary()) -> ok | {error, term()}.
+cast_vote(Pid, VoterId, OptionId) ->
+    gen_statem:call(Pid, {cast_vote, VoterId, OptionId}).
+
+-spec cast_veto(pid(), binary()) -> ok | {error, term()}.
+cast_veto(Pid, VoterId) ->
+    gen_statem:call(Pid, {veto, VoterId}).
+
+-spec get_state(pid()) -> map().
+get_state(Pid) ->
+    gen_statem:call(Pid, get_state).
+
+%% --- gen_statem callbacks ---
+
+-spec callback_mode() -> [atom()].
+callback_mode() -> [state_functions, state_enter].
+
+-spec init(map()) -> {ok, open, map()}.
+init(Config) ->
+    VoteId = maps:get(vote_id, Config, asobi_id:generate()),
+    MatchId = maps:get(match_id, Config),
+    Template = maps:get(template, Config, ~"default"),
+    Options = maps:get(options, Config),
+    Eligible = maps:get(eligible, Config, []),
+    WindowMs = maps:get(window_ms, Config, 15000),
+    Method = maps:get(method, Config, ~"plurality"),
+    Visibility = maps:get(visibility, Config, ~"live"),
+    TieBreaker = maps:get(tie_breaker, Config, ~"random"),
+    VetoEnabled = maps:get(veto_enabled, Config, false),
+    MatchPid = maps:get(match_pid, Config),
+    State = #{
+        vote_id => VoteId,
+        match_id => MatchId,
+        match_pid => MatchPid,
+        template => Template,
+        options => Options,
+        eligible => sets:from_list(Eligible, [{version, 2}]),
+        eligible_list => Eligible,
+        window_ms => WindowMs,
+        method => Method,
+        visibility => Visibility,
+        tie_breaker => TieBreaker,
+        veto_enabled => VetoEnabled,
+        votes => #{},
+        vetoed => false,
+        opened_at => erlang:system_time(millisecond)
+    },
+    broadcast_vote_start(State),
+    {ok, open, State}.
+
+%% --- open state ---
+
+-spec open(gen_statem:event_type(), term(), map()) -> gen_statem:state_enter_result(atom()).
+open(enter, _OldState, #{window_ms := WindowMs}) ->
+    {keep_state_and_data, [{state_timeout, WindowMs, window_expired}]};
+open({call, From}, {cast_vote, VoterId, OptionId}, State) ->
+    handle_cast_vote(From, VoterId, OptionId, State);
+open({call, From}, {veto, VoterId}, #{veto_enabled := true} = State) ->
+    handle_veto(From, VoterId, State);
+open({call, From}, {veto, _VoterId}, _State) ->
+    {keep_state_and_data, [{reply, From, {error, veto_disabled}}]};
+open({call, From}, get_state, State) ->
+    {keep_state_and_data, [{reply, From, external_state(open, State)}]};
+open(state_timeout, window_expired, State) ->
+    {next_state, closed, State}.
+
+%% --- closed state ---
+
+-spec closed(gen_statem:event_type(), term(), map()) -> gen_statem:state_enter_result(atom()).
+closed(enter, _OldState, State) ->
+    resolve_and_stop(State);
+closed({call, From}, {cast_vote, VoterId, OptionId}, State) ->
+    %% Grace period: accept if within GRACE_MS of window close
+    Now = erlang:system_time(millisecond),
+    OpenedAt = maps:get(opened_at, State),
+    WindowMs = maps:get(window_ms, State),
+    case Now - (OpenedAt + WindowMs) =< ?GRACE_MS of
+        true -> handle_cast_vote(From, VoterId, OptionId, State);
+        false -> {keep_state_and_data, [{reply, From, {error, vote_closed}}]}
+    end;
+closed({call, From}, get_state, State) ->
+    {keep_state_and_data, [{reply, From, external_state(closed, State)}]};
+closed({call, From}, _, _State) ->
+    {keep_state_and_data, [{reply, From, {error, vote_closed}}]}.
+
+-spec terminate(term(), atom(), map()) -> ok.
+terminate(_Reason, _StateName, _State) ->
+    ok.
+
+%% --- Internal ---
+
+handle_cast_vote(
+    From, VoterId, OptionId, #{eligible := Eligible, options := Options, votes := Votes} = State
+) ->
+    IsEligible = sets:is_element(VoterId, Eligible),
+    ValidOption = validate_option(OptionId, Options),
+    case {IsEligible, ValidOption} of
+        {false, _} ->
+            {keep_state_and_data, [{reply, From, {error, not_eligible}}]};
+        {_, false} ->
+            {keep_state_and_data, [{reply, From, {error, invalid_option}}]};
+        {true, true} ->
+            Votes1 = Votes#{VoterId => OptionId},
+            State1 = State#{votes => Votes1},
+            maybe_broadcast_tally(State1),
+            {keep_state, State1, [{reply, From, ok}]}
+    end.
+
+validate_option(OptionIds, Options) when is_list(OptionIds) ->
+    OptionSet = sets:from_list([Id || #{id := Id} <- Options], [{version, 2}]),
+    lists:all(fun(Id) -> sets:is_element(Id, OptionSet) end, OptionIds);
+validate_option(OptionId, Options) ->
+    lists:any(fun(#{id := Id}) -> Id =:= OptionId end, Options).
+
+handle_veto(From, VoterId, #{eligible := Eligible} = State) ->
+    case sets:is_element(VoterId, Eligible) of
+        false ->
+            {keep_state_and_data, [{reply, From, {error, not_eligible}}]};
+        true ->
+            State1 = State#{vetoed => true, vetoed_by => VoterId},
+            broadcast_vote_vetoed(State1),
+            _ = notify_match(vetoed, State1),
+            {stop_and_reply, normal, [{reply, From, ok}], State1}
+    end.
+
+resolve_and_stop(
+    #{votes := Votes, options := Options, method := Method, tie_breaker := TieBreaker} = State
+) ->
+    Result = tally(Method, Votes, Options, TieBreaker),
+    State1 = State#{
+        result => Result,
+        closed_at => erlang:system_time(millisecond)
+    },
+    broadcast_vote_result(State1),
+    persist_vote(State1),
+    _ = notify_match(resolved, State1),
+    {stop, normal, State1}.
+
+tally(~"plurality", Votes, Options, TieBreaker) ->
+    Counts = lists:foldl(
+        fun(#{id := Id}, Acc) -> Acc#{Id => 0} end,
+        #{},
+        Options
+    ),
+    Counts1 = maps:fold(
+        fun(_VoterId, OptionId, Acc) ->
+            Acc#{OptionId => maps:get(OptionId, Acc, 0) + 1}
+        end,
+        Counts,
+        Votes
+    ),
+    TotalVotes = maps:size(Votes),
+    Distribution = maps:map(
+        fun(_Id, Count) ->
+            case TotalVotes of
+                0 -> 0.0;
+                _ -> Count / TotalVotes
+            end
+        end,
+        Counts1
+    ),
+    MaxCount = lists:max([0 | maps:values(Counts1)]),
+    Winners = maps:keys(maps:filter(fun(_Id, C) -> C =:= MaxCount end, Counts1)),
+    Winner = break_tie(Winners, TieBreaker),
+    #{
+        winner => Winner,
+        counts => Counts1,
+        distribution => Distribution,
+        total_votes => TotalVotes
+    };
+tally(~"approval", Votes, Options, TieBreaker) ->
+    %% In approval voting, each vote value is a list of approved option IDs
+    Counts = lists:foldl(
+        fun(#{id := Id}, Acc) -> Acc#{Id => 0} end,
+        #{},
+        Options
+    ),
+    Counts1 = maps:fold(
+        fun
+            (_VoterId, Approved, Acc) when is_list(Approved) ->
+                lists:foldl(
+                    fun(OptId, InnerAcc) ->
+                        InnerAcc#{OptId => maps:get(OptId, InnerAcc, 0) + 1}
+                    end,
+                    Acc,
+                    Approved
+                );
+            (_VoterId, OptionId, Acc) ->
+                Acc#{OptionId => maps:get(OptionId, Acc, 0) + 1}
+        end,
+        Counts,
+        Votes
+    ),
+    TotalVotes = maps:size(Votes),
+    MaxCount = lists:max([0 | maps:values(Counts1)]),
+    Winners = maps:keys(maps:filter(fun(_Id, C) -> C =:= MaxCount end, Counts1)),
+    Winner = break_tie(Winners, TieBreaker),
+    #{
+        winner => Winner,
+        counts => Counts1,
+        total_votes => TotalVotes
+    };
+tally(_Method, Votes, Options, TieBreaker) ->
+    %% Fallback to plurality
+    tally(~"plurality", Votes, Options, TieBreaker).
+
+break_tie([Single], _TieBreaker) ->
+    Single;
+break_tie([], _TieBreaker) ->
+    undefined;
+break_tie(Winners, ~"random") ->
+    lists:nth(rand:uniform(length(Winners)), Winners);
+break_tie([First | _], ~"first") ->
+    First;
+break_tie(Winners, _) ->
+    lists:nth(rand:uniform(length(Winners)), Winners).
+
+maybe_broadcast_tally(#{visibility := ~"live"} = State) ->
+    broadcast_vote_tally(State);
+maybe_broadcast_tally(_State) ->
+    ok.
+
+broadcast_vote_start(#{
+    match_pid := MatchPid,
+    vote_id := VoteId,
+    options := Options,
+    window_ms := WindowMs,
+    method := Method
+}) ->
+    Payload = #{
+        vote_id => VoteId,
+        options => Options,
+        window_ms => WindowMs,
+        method => Method
+    },
+    asobi_match_server:broadcast_event(MatchPid, vote_start, Payload).
+
+broadcast_vote_tally(#{
+    match_pid := MatchPid,
+    vote_id := VoteId,
+    votes := Votes,
+    options := Options,
+    opened_at := OpenedAt,
+    window_ms := WindowMs
+}) ->
+    Now = erlang:system_time(millisecond),
+    Remaining = max(0, (OpenedAt + WindowMs) - Now),
+    Counts = maps:fold(
+        fun(_VoterId, OptionId, Acc) ->
+            Acc#{OptionId => maps:get(OptionId, Acc, 0) + 1}
+        end,
+        lists:foldl(fun(#{id := Id}, Acc) -> Acc#{Id => 0} end, #{}, Options),
+        Votes
+    ),
+    Payload = #{
+        vote_id => VoteId,
+        tallies => Counts,
+        time_remaining_ms => Remaining,
+        total_votes => maps:size(Votes)
+    },
+    asobi_match_server:broadcast_event(MatchPid, vote_tally, Payload).
+
+broadcast_vote_result(#{
+    match_pid := MatchPid,
+    vote_id := VoteId,
+    result := Result,
+    eligible_list := Eligible,
+    votes := Votes
+}) ->
+    EligibleCount = length(Eligible),
+    VoteCount = maps:size(Votes),
+    Turnout =
+        case EligibleCount of
+            0 -> 0.0;
+            _ -> VoteCount / EligibleCount
+        end,
+    Payload = #{
+        vote_id => VoteId,
+        winner => maps:get(winner, Result),
+        distribution => maps:get(distribution, Result, #{}),
+        counts => maps:get(counts, Result),
+        total_votes => VoteCount,
+        turnout => Turnout
+    },
+    asobi_match_server:broadcast_event(MatchPid, vote_result, Payload).
+
+broadcast_vote_vetoed(#{match_pid := MatchPid, vote_id := VoteId, vetoed_by := VetoedBy}) ->
+    Payload = #{vote_id => VoteId, vetoed_by => VetoedBy},
+    asobi_match_server:broadcast_event(MatchPid, vote_vetoed, Payload).
+
+notify_match(resolved, #{
+    match_pid := MatchPid, vote_id := VoteId, template := Template, result := Result
+}) ->
+    MatchPid ! {vote_resolved, VoteId, Template, Result};
+notify_match(vetoed, #{match_pid := MatchPid, vote_id := VoteId, template := Template}) ->
+    MatchPid ! {vote_vetoed, VoteId, Template}.
+
+persist_vote(#{
+    vote_id := VoteId,
+    match_id := MatchId,
+    template := Template,
+    method := Method,
+    options := Options,
+    votes := Votes,
+    result := Result,
+    eligible_list := Eligible,
+    window_ms := WindowMs,
+    opened_at := OpenedAt,
+    closed_at := ClosedAt
+}) ->
+    EligibleCount = length(Eligible),
+    VoteCount = maps:size(Votes),
+    Turnout =
+        case EligibleCount of
+            0 -> 0.0;
+            _ -> VoteCount / EligibleCount
+        end,
+    CS = kura_changeset:cast(
+        asobi_vote,
+        #{},
+        #{
+            id => VoteId,
+            match_id => MatchId,
+            template => Template,
+            method => Method,
+            options => Options,
+            votes_cast => Votes,
+            result => Result,
+            distribution => maps:get(distribution, Result, #{}),
+            turnout => Turnout,
+            eligible_count => EligibleCount,
+            window_ms => WindowMs,
+            opened_at => OpenedAt,
+            closed_at => ClosedAt
+        },
+        [
+            id,
+            match_id,
+            template,
+            method,
+            options,
+            votes_cast,
+            result,
+            distribution,
+            turnout,
+            eligible_count,
+            window_ms,
+            opened_at,
+            closed_at
+        ]
+    ),
+    case asobi_repo:insert(CS) of
+        {ok, _} ->
+            ok;
+        {error, Reason} ->
+            logger:warning(#{msg => ~"failed to persist vote", vote_id => VoteId, reason => Reason}),
+            ok
+    end.
+
+external_state(Status, #{
+    vote_id := VoteId,
+    options := Options,
+    method := Method,
+    visibility := Visibility,
+    votes := Votes,
+    opened_at := OpenedAt,
+    window_ms := WindowMs
+}) ->
+    Now = erlang:system_time(millisecond),
+    Remaining = max(0, (OpenedAt + WindowMs) - Now),
+    Base = #{
+        vote_id => VoteId,
+        status => Status,
+        options => Options,
+        method => Method,
+        total_votes => maps:size(Votes),
+        time_remaining_ms => Remaining
+    },
+    case Visibility of
+        ~"live" ->
+            Counts = maps:fold(
+                fun(_VoterId, OptionId, Acc) ->
+                    Acc#{OptionId => maps:get(OptionId, Acc, 0) + 1}
+                end,
+                lists:foldl(fun(#{id := Id}, Acc) -> Acc#{Id => 0} end, #{}, Options),
+                Votes
+            ),
+            Base#{tallies => Counts};
+        _ ->
+            Base
+    end.

--- a/src/votes/asobi_vote_server.erl
+++ b/src/votes/asobi_vote_server.erl
@@ -1,4 +1,39 @@
 -module(asobi_vote_server).
+-moduledoc """
+Vote lifecycle state machine.
+
+Manages a single vote instance within a match. States flow `open` -> `closed`
+(with automatic resolution on close). Supports plurality and approval voting
+methods, configurable timed windows, live or hidden tallies, veto, and
+tie-breaking.
+
+## Config keys
+
+| Key            | Type           | Default        | Description                        |
+|----------------|----------------|----------------|------------------------------------|
+| `match_id`     | `binary()`     | required       | Parent match ID                    |
+| `match_pid`    | `pid()`        | required       | Match server process               |
+| `options`      | `[map()]`      | required       | List of `#{id, label}` option maps |
+| `eligible`     | `[binary()]`   | `[]`           | Eligible voter IDs                 |
+| `window_ms`    | `pos_integer()`| `15000`        | Vote window in milliseconds        |
+| `method`       | `binary()`     | `"plurality"`  | `"plurality"` or `"approval"`      |
+| `visibility`   | `binary()`     | `"live"`       | `"live"` or `"hidden"`             |
+| `tie_breaker`  | `binary()`     | `"random"`     | `"random"` or `"first"`            |
+| `veto_enabled` | `boolean()`    | `false`        | Allow eligible voters to veto      |
+| `template`     | `binary()`     | `"default"`    | Template name for analytics        |
+| `vote_id`      | `binary()`     | auto-generated | Override vote ID                   |
+
+## Vote methods
+
+- **Plurality**: each voter picks one option, highest count wins.
+- **Approval**: each voter submits a list of approved option IDs, highest
+  approval count wins.
+
+## Grace period
+
+Late votes arriving within 500ms after the window closes are still accepted
+to compensate for network latency.
+""".
 -behaviour(gen_statem).
 
 -export([start_link/1, cast_vote/3, cast_veto/2, get_state/1]).
@@ -9,18 +44,22 @@
 
 %% --- Public API ---
 
+-doc "Start a vote server with the given config. See moduledoc for config keys.".
 -spec start_link(map()) -> {ok, pid()}.
 start_link(Config) ->
     gen_statem:start_link(?MODULE, Config, []).
 
+-doc "Cast a vote. Replaces any previous vote by the same voter during the window.".
 -spec cast_vote(pid(), binary(), binary()) -> ok | {error, term()}.
 cast_vote(Pid, VoterId, OptionId) ->
     gen_statem:call(Pid, {cast_vote, VoterId, OptionId}).
 
+-doc "Veto the vote (immediately cancels it). Only works if `veto_enabled` is true.".
 -spec cast_veto(pid(), binary()) -> ok | {error, term()}.
 cast_veto(Pid, VoterId) ->
     gen_statem:call(Pid, {veto, VoterId}).
 
+-doc "Return the current vote state including status, options, tallies (if live), and time remaining.".
 -spec get_state(pid()) -> map().
 get_state(Pid) ->
     gen_statem:call(Pid, get_state).

--- a/src/votes/asobi_vote_sup.erl
+++ b/src/votes/asobi_vote_sup.erl
@@ -1,0 +1,27 @@
+-module(asobi_vote_sup).
+-behaviour(supervisor).
+
+-export([start_link/0, start_vote/1]).
+-export([init/1]).
+
+-spec start_link() -> {ok, pid()}.
+start_link() ->
+    supervisor:start_link({local, ?MODULE}, ?MODULE, []).
+
+-spec start_vote(map()) -> {ok, pid()}.
+start_vote(Config) ->
+    supervisor:start_child(?MODULE, [Config]).
+
+-spec init([]) -> {ok, {supervisor:sup_flags(), [supervisor:child_spec()]}}.
+init([]) ->
+    SupFlags = #{
+        strategy => simple_one_for_one,
+        intensity => 10,
+        period => 60
+    },
+    ChildSpec = #{
+        id => asobi_vote_server,
+        start => {asobi_vote_server, start_link, []},
+        restart => temporary
+    },
+    {ok, {SupFlags, [ChildSpec]}}.

--- a/src/votes/asobi_vote_sup.erl
+++ b/src/votes/asobi_vote_sup.erl
@@ -1,4 +1,5 @@
 -module(asobi_vote_sup).
+-moduledoc "Dynamic supervisor for `asobi_vote_server` processes.".
 -behaviour(supervisor).
 
 -export([start_link/0, start_vote/1]).

--- a/src/ws/asobi_ws_handler.erl
+++ b/src/ws/asobi_ws_handler.erl
@@ -182,6 +182,33 @@ handle_message(
             Reply = encode_reply(Cid, ~"match.left", #{success => true}),
             {reply, {text, Reply}, State}
     end;
+handle_message(
+    #{~"type" := ~"vote.cast", ~"payload" := Payload} = Msg,
+    #{session := SessionPid} = State
+) when SessionPid =/= undefined ->
+    Cid = maps:get(~"cid", Msg, undefined),
+    try asobi_player_session:get_state(SessionPid) of
+        #{player_id := PlayerId} = SState ->
+            case maps:get(match_pid, SState, undefined) of
+                undefined ->
+                    Reply = encode_reply(Cid, ~"error", #{reason => ~"not_in_match"}),
+                    {reply, {text, Reply}, State};
+                MatchPid ->
+                    VoteId = maps:get(~"vote_id", Payload),
+                    OptionId = maps:get(~"option_id", Payload),
+                    case asobi_match_server:cast_vote(MatchPid, PlayerId, VoteId, OptionId) of
+                        ok ->
+                            Reply = encode_reply(Cid, ~"vote.cast_ok", #{success => true}),
+                            {reply, {text, Reply}, State};
+                        {error, Reason} ->
+                            Reply = encode_reply(Cid, ~"error", #{reason => Reason}),
+                            {reply, {text, Reply}, State}
+                    end
+            end
+    catch
+        exit:{noproc, _} ->
+            {ok, State#{session => undefined}}
+    end;
 handle_message(#{~"type" := Type} = Msg, State) ->
     Cid = maps:get(~"cid", Msg, undefined),
     Reply = encode_reply(Cid, ~"error", #{reason => ~"unknown_type", type => Type}),

--- a/test/asobi_vote_SUITE.erl
+++ b/test/asobi_vote_SUITE.erl
@@ -1,0 +1,299 @@
+-module(asobi_vote_SUITE).
+
+-include_lib("stdlib/include/assert.hrl").
+
+-export([all/0, init_per_suite/1, end_per_suite/1]).
+-export([
+    vote_lifecycle_plurality/1,
+    vote_tie_random/1,
+    vote_window_expires/1,
+    vote_ineligible_voter/1,
+    vote_invalid_option/1,
+    vote_change_during_window/1,
+    vote_veto/1,
+    vote_veto_disabled/1,
+    vote_approval_method/1,
+    vote_via_match_server/1,
+    vote_hidden_visibility/1,
+    vote_no_votes_cast/1
+]).
+
+all() ->
+    [
+        vote_lifecycle_plurality,
+        vote_tie_random,
+        vote_window_expires,
+        vote_ineligible_voter,
+        vote_invalid_option,
+        vote_change_during_window,
+        vote_veto,
+        vote_veto_disabled,
+        vote_approval_method,
+        vote_via_match_server,
+        vote_hidden_visibility,
+        vote_no_votes_cast
+    ].
+
+init_per_suite(Config) ->
+    {ok, _} = application:ensure_all_started(asobi),
+    Config.
+
+end_per_suite(Config) ->
+    Config.
+
+%% --- Tests ---
+
+vote_lifecycle_plurality(_Config) ->
+    Options = [
+        #{id => ~"opt_a", label => ~"Path A"},
+        #{id => ~"opt_b", label => ~"Path B"},
+        #{id => ~"opt_c", label => ~"Path C"}
+    ],
+    {ok, MatchPid} = start_test_match(),
+    {ok, VotePid} = asobi_vote_sup:start_vote(#{
+        match_id => asobi_id:generate(),
+        match_pid => MatchPid,
+        options => Options,
+        eligible => [~"p1", ~"p2", ~"p3"],
+        window_ms => 5000,
+        method => ~"plurality",
+        visibility => ~"live"
+    }),
+    ?assert(is_pid(VotePid)),
+    ok = asobi_vote_server:cast_vote(VotePid, ~"p1", ~"opt_a"),
+    ok = asobi_vote_server:cast_vote(VotePid, ~"p2", ~"opt_a"),
+    ok = asobi_vote_server:cast_vote(VotePid, ~"p3", ~"opt_b"),
+    Info = asobi_vote_server:get_state(VotePid),
+    ?assertMatch(#{status := open, total_votes := 3}, Info),
+    ?assertMatch(#{tallies := #{~"opt_a" := 2, ~"opt_b" := 1, ~"opt_c" := 0}}, Info).
+
+vote_tie_random(_Config) ->
+    Options = [
+        #{id => ~"opt_a", label => ~"A"},
+        #{id => ~"opt_b", label => ~"B"}
+    ],
+    {ok, MatchPid} = start_test_match(),
+    {ok, VotePid} = asobi_vote_sup:start_vote(#{
+        match_id => asobi_id:generate(),
+        match_pid => MatchPid,
+        options => Options,
+        eligible => [~"p1", ~"p2"],
+        window_ms => 200,
+        method => ~"plurality",
+        tie_breaker => ~"random"
+    }),
+    ok = asobi_vote_server:cast_vote(VotePid, ~"p1", ~"opt_a"),
+    ok = asobi_vote_server:cast_vote(VotePid, ~"p2", ~"opt_b"),
+    Ref = monitor(process, VotePid),
+    receive
+        {'DOWN', Ref, process, VotePid, normal} -> ok
+    after 2000 ->
+        error(vote_did_not_resolve)
+    end,
+    %% Vote resolved — winner is one of the tied options
+    %% We can't check directly since the process is dead, but it didn't crash
+    ok.
+
+vote_window_expires(_Config) ->
+    Options = [#{id => ~"opt_a", label => ~"A"}],
+    {ok, MatchPid} = start_test_match(),
+    {ok, VotePid} = asobi_vote_sup:start_vote(#{
+        match_id => asobi_id:generate(),
+        match_pid => MatchPid,
+        options => Options,
+        eligible => [~"p1"],
+        window_ms => 100
+    }),
+    Ref = monitor(process, VotePid),
+    receive
+        {'DOWN', Ref, process, VotePid, normal} -> ok
+    after 2000 ->
+        error(vote_did_not_expire)
+    end.
+
+vote_ineligible_voter(_Config) ->
+    Options = [#{id => ~"opt_a", label => ~"A"}],
+    {ok, MatchPid} = start_test_match(),
+    {ok, VotePid} = asobi_vote_sup:start_vote(#{
+        match_id => asobi_id:generate(),
+        match_pid => MatchPid,
+        options => Options,
+        eligible => [~"p1"],
+        window_ms => 5000
+    }),
+    ?assertMatch(
+        {error, not_eligible}, asobi_vote_server:cast_vote(VotePid, ~"outsider", ~"opt_a")
+    ).
+
+vote_invalid_option(_Config) ->
+    Options = [#{id => ~"opt_a", label => ~"A"}],
+    {ok, MatchPid} = start_test_match(),
+    {ok, VotePid} = asobi_vote_sup:start_vote(#{
+        match_id => asobi_id:generate(),
+        match_pid => MatchPid,
+        options => Options,
+        eligible => [~"p1"],
+        window_ms => 5000
+    }),
+    ?assertMatch(
+        {error, invalid_option}, asobi_vote_server:cast_vote(VotePid, ~"p1", ~"nonexistent")
+    ).
+
+vote_change_during_window(_Config) ->
+    Options = [
+        #{id => ~"opt_a", label => ~"A"},
+        #{id => ~"opt_b", label => ~"B"}
+    ],
+    {ok, MatchPid} = start_test_match(),
+    {ok, VotePid} = asobi_vote_sup:start_vote(#{
+        match_id => asobi_id:generate(),
+        match_pid => MatchPid,
+        options => Options,
+        eligible => [~"p1"],
+        window_ms => 5000,
+        visibility => ~"live"
+    }),
+    ok = asobi_vote_server:cast_vote(VotePid, ~"p1", ~"opt_a"),
+    Info1 = asobi_vote_server:get_state(VotePid),
+    ?assertMatch(#{tallies := #{~"opt_a" := 1, ~"opt_b" := 0}}, Info1),
+    %% Change vote
+    ok = asobi_vote_server:cast_vote(VotePid, ~"p1", ~"opt_b"),
+    Info2 = asobi_vote_server:get_state(VotePid),
+    ?assertMatch(#{tallies := #{~"opt_a" := 0, ~"opt_b" := 1}}, Info2).
+
+vote_veto(_Config) ->
+    Options = [#{id => ~"opt_a", label => ~"A"}],
+    {ok, MatchPid} = start_test_match(),
+    {ok, VotePid} = asobi_vote_sup:start_vote(#{
+        match_id => asobi_id:generate(),
+        match_pid => MatchPid,
+        options => Options,
+        eligible => [~"p1", ~"p2"],
+        window_ms => 5000,
+        veto_enabled => true
+    }),
+    Ref = monitor(process, VotePid),
+    ok = asobi_vote_server:cast_veto(VotePid, ~"p1"),
+    receive
+        {'DOWN', Ref, process, VotePid, normal} -> ok
+    after 1000 ->
+        error(veto_did_not_stop)
+    end.
+
+vote_veto_disabled(_Config) ->
+    Options = [#{id => ~"opt_a", label => ~"A"}],
+    {ok, MatchPid} = start_test_match(),
+    {ok, VotePid} = asobi_vote_sup:start_vote(#{
+        match_id => asobi_id:generate(),
+        match_pid => MatchPid,
+        options => Options,
+        eligible => [~"p1"],
+        window_ms => 5000,
+        veto_enabled => false
+    }),
+    ?assertMatch({error, veto_disabled}, asobi_vote_server:cast_veto(VotePid, ~"p1")).
+
+vote_approval_method(_Config) ->
+    Options = [
+        #{id => ~"opt_a", label => ~"A"},
+        #{id => ~"opt_b", label => ~"B"},
+        #{id => ~"opt_c", label => ~"C"}
+    ],
+    {ok, MatchPid} = start_test_match(),
+    {ok, VotePid} = asobi_vote_sup:start_vote(#{
+        match_id => asobi_id:generate(),
+        match_pid => MatchPid,
+        options => Options,
+        eligible => [~"p1", ~"p2"],
+        window_ms => 200,
+        method => ~"approval"
+    }),
+    %% Approval voting: vote value is a list of approved options
+    ok = asobi_vote_server:cast_vote(VotePid, ~"p1", [~"opt_a", ~"opt_b"]),
+    ok = asobi_vote_server:cast_vote(VotePid, ~"p2", [~"opt_b", ~"opt_c"]),
+    Ref = monitor(process, VotePid),
+    receive
+        {'DOWN', Ref, process, VotePid, normal} -> ok
+    after 2000 ->
+        error(vote_did_not_resolve)
+    end.
+
+vote_via_match_server(_Config) ->
+    Options = [
+        #{id => ~"opt_a", label => ~"A"},
+        #{id => ~"opt_b", label => ~"B"}
+    ],
+    {ok, MatchPid} = asobi_match_sup:start_match(#{
+        game_module => asobi_test_game,
+        min_players => 2,
+        max_players => 4,
+        tick_rate => 50
+    }),
+    ok = asobi_match_server:join(MatchPid, ~"p1"),
+    ok = asobi_match_server:join(MatchPid, ~"p2"),
+    timer:sleep(100),
+    VoteId = asobi_id:generate(),
+    {ok, _VotePid} = asobi_match_server:start_vote(MatchPid, #{
+        vote_id => VoteId,
+        options => Options,
+        window_ms => 500,
+        template => ~"path_choice"
+    }),
+    ok = asobi_match_server:cast_vote(MatchPid, ~"p1", VoteId, ~"opt_a"),
+    ok = asobi_match_server:cast_vote(MatchPid, ~"p2", VoteId, ~"opt_a"),
+    %% Wait for vote to resolve
+    timer:sleep(700),
+    %% Match should still be running
+    Info = asobi_match_server:get_info(MatchPid),
+    ?assertMatch(#{status := running}, Info).
+
+vote_hidden_visibility(_Config) ->
+    Options = [
+        #{id => ~"opt_a", label => ~"A"},
+        #{id => ~"opt_b", label => ~"B"}
+    ],
+    {ok, MatchPid} = start_test_match(),
+    {ok, VotePid} = asobi_vote_sup:start_vote(#{
+        match_id => asobi_id:generate(),
+        match_pid => MatchPid,
+        options => Options,
+        eligible => [~"p1"],
+        window_ms => 5000,
+        visibility => ~"hidden"
+    }),
+    ok = asobi_vote_server:cast_vote(VotePid, ~"p1", ~"opt_a"),
+    Info = asobi_vote_server:get_state(VotePid),
+    %% Hidden visibility should not include tallies
+    ?assertNot(maps:is_key(tallies, Info)),
+    ?assertMatch(#{total_votes := 1}, Info).
+
+vote_no_votes_cast(_Config) ->
+    Options = [
+        #{id => ~"opt_a", label => ~"A"},
+        #{id => ~"opt_b", label => ~"B"}
+    ],
+    {ok, MatchPid} = start_test_match(),
+    {ok, VotePid} = asobi_vote_sup:start_vote(#{
+        match_id => asobi_id:generate(),
+        match_pid => MatchPid,
+        options => Options,
+        eligible => [~"p1"],
+        window_ms => 100
+    }),
+    Ref = monitor(process, VotePid),
+    %% Don't cast any votes, let it expire
+    receive
+        {'DOWN', Ref, process, VotePid, normal} -> ok
+    after 2000 ->
+        error(vote_did_not_expire)
+    end.
+
+%% --- Helpers ---
+
+start_test_match() ->
+    asobi_match_sup:start_match(#{
+        game_module => asobi_test_game,
+        min_players => 1,
+        max_players => 4,
+        tick_rate => 50
+    }).


### PR DESCRIPTION
## Summary
- Add in-match voting system with gen_statem lifecycle (open → closed → resolved)
- Support plurality and approval voting methods, configurable windows, live/hidden tallies, veto, tie-breaking
- Game modes integrate via optional `vote_requested/1` and `vote_resolved/3` callbacks on `asobi_match` behaviour
- Votes persist to PostgreSQL and broadcast over WebSocket (vote.start/tally/result/vetoed)
- REST API for vote history (`GET /matches/:match_id/votes`, `GET /votes/:id`)

## New modules
- `asobi_vote` — Kura schema
- `asobi_vote_server` — gen_statem vote lifecycle
- `asobi_vote_sup` — dynamic supervisor
- `asobi_vote_controller` — REST endpoints

## Test plan
- [x] 12 CT test cases covering plurality, approval, tie-breaking, window expiry, eligibility, vote changing, veto, match integration, hidden visibility, empty votes
- [x] `rebar3 compile` clean
- [x] `rebar3 fmt --check` clean
- [x] `rebar3 xref` clean
- [x] `rebar3 dialyzer` clean
- [x] All 12 vote tests pass