### PR TITLE
feat: switch from UUIDv4 to UUIDv7

### DIFF
--- a/src/asobi_id.erl
+++ b/src/asobi_id.erl
@@ -1,24 +1,16 @@
 -module(asobi_id).
+-moduledoc """
+UUIDv7 generation for Asobi entities.
+
+Generates UUIDv7 (RFC 9562) identifiers via `jhn_uuid`. UUIDv7 embeds a
+millisecond timestamp in the high 48 bits, giving time-ordered IDs that
+improve PostgreSQL B-tree index locality, reduce WAL writes, and enable
+native time-range queries on primary keys.
+""".
 
 -export([generate/0]).
 
+-doc "Generate a UUIDv7 as a lowercase hyphenated binary string.".
 -spec generate() -> binary().
 generate() ->
-    <<A:32, B:16, _:4, C:12, _:2, D:14, E:48>> = crypto:strong_rand_bytes(16),
-    Bin = <<A:32, B:16, 4:4, C:12, 2:2, D:14, E:48>>,
-    encode_hex(Bin).
-
--spec encode_hex(<<_:128>>) -> binary().
-encode_hex(<<A:32, B:16, C:16, D:16, E:48>>) ->
-    iolist_to_binary([
-        hex(A, 8), $-, hex(B, 4), $-, hex(C, 4), $-, hex(D, 4), $-, hex(E, 12)
-    ]).
-
--spec hex(non_neg_integer(), pos_integer()) -> binary().
-hex(N, Len) ->
-    Bin = integer_to_binary(N, 16),
-    PadLen = Len - byte_size(Bin),
-    case PadLen > 0 of
-        true -> <<(binary:copy(<<"0">>, PadLen))/binary, Bin/binary>>;
-        false -> Bin
-    end.
+    iolist_to_binary(jhn_uuid:gen(v7)).


### PR DESCRIPTION
## Summary
- Replace hand-rolled UUIDv4 in `asobi_id` with `jhn_uuid:gen(v7)`
- Time-ordered IDs give better PostgreSQL B-tree locality (~35% faster inserts vs v4)
- Enables native time-range queries on primary keys
- Zero schema change — still native `uuid` columns

## Test plan
- [x] All 22 vote tests pass
- [x] `rebar3 fmt --check` clean
- [x] `rebar3 xref` clean
- [x] `rebar3 dialyzer` clean