### PR TITLE
feat: majority tyranny mitigations

### DIFF
--- a/guides/voting.md
+++ b/guides/voting.md
@@ -304,6 +304,71 @@ When `veto_enabled` is true, any eligible voter can veto the vote. This
 immediately cancels it and notifies all players. Use sparingly — typically
 as a limited-use resource managed by the game mode.
 
+## Majority Tyranny Mitigations
+
+When the same majority always outvotes a minority, voting becomes
+frustrating. Asobi provides three configurable mitigations.
+
+### Frustration Accumulator
+
+Players who vote for the losing option accumulate frustration. On the
+next vote, their weight is boosted: `1 + frustration_count * frustration_bonus`.
+When they finally win, their frustration resets to 0.
+
+Configure at match level:
+
+```erlang
+asobi_match_sup:start_match(#{
+    game_module => MyGame,
+    frustration_bonus => 0.5  %% default 0.5, set 0 to disable
+}).
+```
+
+A player who lost 3 consecutive votes gets weight `1 + 3 * 0.5 = 2.5`,
+making their vote count 2.5x. This only applies to weighted voting or
+when frustration weights are merged (which happens automatically when
+starting votes via the match server).
+
+### Supermajority Requirement
+
+Force high-stakes votes to require a supermajority. If no option reaches
+the threshold, the result has `winner => undefined` and
+`status => "no_consensus"`.
+
+```erlang
+asobi_match_server:start_vote(MatchPid, #{
+    options => Options,
+    require_supermajority => true,
+    supermajority => 0.75  %% 75% required
+}).
+```
+
+The game mode's `vote_resolved/3` callback receives the no-consensus
+result and can decide what to do (random pick, re-vote, default option).
+
+### Veto Tokens
+
+Give players a limited number of vetoes per match. When used, the current
+vote is immediately cancelled. The game mode decides what happens next.
+
+Configure at match level:
+
+```erlang
+asobi_match_sup:start_match(#{
+    game_module => MyGame,
+    veto_tokens_per_player => 2  %% default 0 (disabled)
+}).
+```
+
+Clients use veto tokens via WebSocket:
+
+```json
+{"type": "vote.veto", "payload": {"vote_id": "..."}}
+```
+
+The match server checks token availability before forwarding to the vote
+server. Returns `{error, no_veto_tokens}` when exhausted.
+
 ## Grace Period
 
 Votes arriving within 500ms after the window closes are still accepted to

--- a/guides/websocket-protocol.md
+++ b/guides/websocket-protocol.md
@@ -186,6 +186,15 @@ For approval voting, `option_id` is a list:
 {"type": "vote.cast", "payload": {"vote_id": "...", "option_id": ["jungle", "caves"]}}
 ```
 
+### `vote.veto`
+
+Use a veto token to cancel the current vote. Requires `veto_tokens_per_player > 0`
+in match config and `veto_enabled` on the vote.
+
+```json
+{"type": "vote.veto", "payload": {"vote_id": "..."}}
+```
+
 ### `match.vote_start` (server push)
 
 A new vote has started.

--- a/src/matches/asobi_match_server.erl
+++ b/src/matches/asobi_match_server.erl
@@ -2,7 +2,7 @@
 -behaviour(gen_statem).
 
 -export([start_link/1, join/2, leave/2, handle_input/3, get_info/1, pause/1, resume/1, cancel/1]).
--export([start_vote/2, cast_vote/4, broadcast_event/3]).
+-export([start_vote/2, cast_vote/4, use_veto/3, broadcast_event/3]).
 -export([callback_mode/0, init/1, terminate/3]).
 -export([waiting/3, running/3, paused/3, finished/3]).
 
@@ -54,6 +54,10 @@ start_vote(Pid, VoteConfig) ->
 cast_vote(Pid, PlayerId, VoteId, OptionId) ->
     gen_statem:call(Pid, {cast_vote, PlayerId, VoteId, OptionId}).
 
+-spec use_veto(pid(), binary(), binary()) -> ok | {error, term()}.
+use_veto(Pid, PlayerId, VoteId) ->
+    gen_statem:call(Pid, {use_veto, PlayerId, VoteId}).
+
 -spec broadcast_event(pid(), atom(), map()) -> ok.
 broadcast_event(Pid, Event, Payload) ->
     gen_statem:cast(Pid, {broadcast_event, Event, Payload}).
@@ -69,6 +73,8 @@ init(Config) ->
     GameMod = maps:get(game_module, Config),
     GameConfig = maps:get(game_config, Config, #{}),
     {ok, GameState} = GameMod:init(GameConfig),
+    VetoTokensPerPlayer = maps:get(veto_tokens_per_player, Config, 0),
+    FrustrationBonus = maps:get(frustration_bonus, Config, 0.5),
     State = #{
         match_id => MatchId,
         game_module => GameMod,
@@ -78,7 +84,11 @@ init(Config) ->
         tick_rate => maps:get(tick_rate, Config, ?DEFAULT_TICK_RATE),
         min_players => maps:get(min_players, Config, ?DEFAULT_MIN_PLAYERS),
         max_players => maps:get(max_players, Config, ?DEFAULT_MAX_PLAYERS),
-        started_at => undefined
+        started_at => undefined,
+        vote_frustration => #{},
+        veto_tokens => #{},
+        veto_tokens_per_player => VetoTokensPerPlayer,
+        frustration_bonus => FrustrationBonus
     },
     {ok, waiting, State}.
 
@@ -134,13 +144,30 @@ running({call, From}, get_info, State) ->
     {keep_state_and_data, [{reply, From, match_info(running, State)}]};
 running({call, From}, {join, PlayerId}, State) ->
     handle_join(From, PlayerId, State);
-running({call, From}, {start_vote, VoteConfig}, #{match_id := MatchId, players := Players} = State) ->
+running(
+    {call, From},
+    {start_vote, VoteConfig},
+    #{
+        match_id := MatchId,
+        players := Players,
+        vote_frustration := Frustration,
+        frustration_bonus := FBonus
+    } = State
+) ->
     VoteId = maps:get(vote_id, VoteConfig, asobi_id:generate()),
+    PlayerIds = maps:keys(Players),
+    FrustrationWeights = maps:from_list([
+        {PId, 1 + maps:get(PId, Frustration, 0) * FBonus}
+     || PId <- PlayerIds
+    ]),
+    BaseWeights = maps:get(weights, VoteConfig, #{}),
+    MergedWeights = maps:merge(FrustrationWeights, BaseWeights),
     FullConfig = VoteConfig#{
         vote_id => VoteId,
         match_id => MatchId,
         match_pid => self(),
-        eligible => maps:keys(Players)
+        eligible => PlayerIds,
+        weights => MergedWeights
     },
     {ok, VotePid} = asobi_vote_sup:start_vote(FullConfig),
     Active = maps:get(active_votes, State, #{}),
@@ -156,6 +183,23 @@ running({call, From}, {cast_vote, PlayerId, VoteId, OptionId}, State) ->
             Result = asobi_vote_server:cast_vote(VotePid, PlayerId, OptionId),
             {keep_state_and_data, [{reply, From, Result}]}
     end;
+running({call, From}, {use_veto, PlayerId, VoteId}, #{veto_tokens := Tokens} = State) ->
+    Active = maps:get(active_votes, State, #{}),
+    Remaining = maps:get(PlayerId, Tokens, 0),
+    case {maps:get(VoteId, Active, undefined), Remaining} of
+        {undefined, _} ->
+            {keep_state_and_data, [{reply, From, {error, vote_not_found}}]};
+        {_, 0} ->
+            {keep_state_and_data, [{reply, From, {error, no_veto_tokens}}]};
+        {VotePid, N} ->
+            case asobi_vote_server:cast_veto(VotePid, PlayerId) of
+                ok ->
+                    Tokens1 = Tokens#{PlayerId => N - 1},
+                    {keep_state, State#{veto_tokens => Tokens1}, [{reply, From, ok}]};
+                {error, _} = Err ->
+                    {keep_state_and_data, [{reply, From, Err}]}
+            end
+    end;
 running(cast, {broadcast_event, Event, Payload}, State) ->
     broadcast_match_event(Event, Payload, State),
     keep_state_and_data;
@@ -163,7 +207,7 @@ running(
     info, {vote_resolved, VoteId, Template, Result}, #{game_module := Mod, game_state := GS} = State
 ) ->
     Active = maps:remove(VoteId, maps:get(active_votes, State, #{})),
-    State1 = State#{active_votes => Active},
+    State1 = update_frustration(Result, State#{active_votes => Active}),
     case erlang:function_exported(Mod, vote_resolved, 3) of
         true ->
             {ok, GS1} = Mod:vote_resolved(Template, Result, GS),
@@ -245,7 +289,12 @@ handle_join(
                     Players1 = Players#{
                         PlayerId => #{joined_at => erlang:system_time(millisecond)}
                     },
-                    State1 = State#{players => Players1, game_state => GS1},
+                    VetoTokens = maps:get(veto_tokens, State),
+                    VetoCount = maps:get(veto_tokens_per_player, State),
+                    VetoTokens1 = VetoTokens#{PlayerId => VetoCount},
+                    State1 = State#{
+                        players => Players1, game_state => GS1, veto_tokens => VetoTokens1
+                    },
                     maybe_start(From, PlayerId, State1);
                 {error, Reason} ->
                     {keep_state_and_data, [{reply, From, {error, Reason}}]}
@@ -345,6 +394,25 @@ match_info(Status, #{match_id := MatchId, players := Players}) ->
         player_count => map_size(Players),
         players => maps:keys(Players)
     }.
+
+update_frustration(#{winner := undefined}, State) ->
+    State;
+update_frustration(
+    #{winner := Winner, votes_cast := VotesCast}, #{vote_frustration := Frustration} = State
+) ->
+    Frustration1 = maps:fold(
+        fun(PlayerId, Vote, Acc) ->
+            case Vote =:= Winner of
+                true -> maps:remove(PlayerId, Acc);
+                false -> Acc#{PlayerId => maps:get(PlayerId, Acc, 0) + 1}
+            end
+        end,
+        Frustration,
+        VotesCast
+    ),
+    State#{vote_frustration => Frustration1};
+update_frustration(_Result, State) ->
+    State.
 
 generate_id() ->
     asobi_id:generate().

--- a/src/votes/asobi_vote_server.erl
+++ b/src/votes/asobi_vote_server.erl
@@ -27,6 +27,7 @@ tie-breaking.
 | `window_type`    | `binary()`     | `"fixed"`      | `"fixed"`, `"ready_up"`, `"hybrid"`, or `"adaptive"` |
 | `min_window_ms`  | `pos_integer()`| `5000`         | Minimum window for `"hybrid"` mode |
 | `supermajority`  | `float()`      | `0.75`         | Threshold for `"adaptive"` early close |
+| `require_supermajority` | `boolean()` | `false`     | If true, winner must reach `supermajority` threshold or result is no-consensus |
 
 ## Vote templates
 
@@ -118,6 +119,7 @@ init(Config) ->
     WindowType = maps:get(window_type, Merged, ~"fixed"),
     MinWindowMs = maps:get(min_window_ms, Merged, 5000),
     Supermajority = maps:get(supermajority, Merged, 0.75),
+    RequireSupermajority = maps:get(require_supermajority, Merged, false),
     MatchPid = maps:get(match_pid, Merged),
     State = #{
         vote_id => VoteId,
@@ -132,6 +134,7 @@ init(Config) ->
         window_type => WindowType,
         min_window_ms => MinWindowMs,
         supermajority => Supermajority,
+        require_supermajority => RequireSupermajority,
         method => Method,
         visibility => Visibility,
         tie_breaker => TieBreaker,
@@ -308,11 +311,14 @@ resolve_and_stop(
         options := Options,
         method := Method,
         tie_breaker := TieBreaker,
-        weights := Weights
+        weights := Weights,
+        require_supermajority := RequireSM,
+        supermajority := SMThreshold
     } =
         State
 ) ->
-    Result = tally(Method, Votes, Options, TieBreaker, Weights),
+    RawResult = tally(Method, Votes, Options, TieBreaker, Weights),
+    Result = maybe_enforce_supermajority(RawResult, RequireSM, SMThreshold),
     State1 = State#{
         result => Result,
         closed_at => erlang:system_time(millisecond)
@@ -414,6 +420,21 @@ tally(~"weighted", Votes, Options, TieBreaker, Weights) ->
 tally(_Method, Votes, Options, TieBreaker, Weights) ->
     tally(~"plurality", Votes, Options, TieBreaker, Weights).
 
+maybe_enforce_supermajority(Result, false, _Threshold) ->
+    Result;
+maybe_enforce_supermajority(#{winner := undefined} = Result, true, _Threshold) ->
+    Result;
+maybe_enforce_supermajority(
+    #{winner := Winner, counts := Counts, total_votes := TotalVotes} = Result, true, Threshold
+) ->
+    WinnerCount = maps:get(Winner, Counts, 0),
+    case TotalVotes > 0 andalso WinnerCount / TotalVotes >= Threshold of
+        true ->
+            Result;
+        false ->
+            Result#{winner => undefined, status => ~"no_consensus"}
+    end.
+
 init_counts(Options) ->
     lists:foldl(fun(#{id := Id}, Acc) -> Acc#{Id => 0} end, #{}, Options).
 
@@ -508,9 +529,9 @@ broadcast_vote_vetoed(#{match_pid := MatchPid, vote_id := VoteId, vetoed_by := V
     asobi_match_server:broadcast_event(MatchPid, vote_vetoed, Payload).
 
 notify_match(resolved, #{
-    match_pid := MatchPid, vote_id := VoteId, template := Template, result := Result
+    match_pid := MatchPid, vote_id := VoteId, template := Template, result := Result, votes := Votes
 }) ->
-    MatchPid ! {vote_resolved, VoteId, Template, Result};
+    MatchPid ! {vote_resolved, VoteId, Template, Result#{votes_cast => Votes}};
 notify_match(vetoed, #{match_pid := MatchPid, vote_id := VoteId, template := Template}) ->
     MatchPid ! {vote_vetoed, VoteId, Template}.
 

--- a/src/ws/asobi_ws_handler.erl
+++ b/src/ws/asobi_ws_handler.erl
@@ -209,6 +209,32 @@ handle_message(
         exit:{noproc, _} ->
             {ok, State#{session => undefined}}
     end;
+handle_message(
+    #{~"type" := ~"vote.veto", ~"payload" := Payload} = Msg,
+    #{session := SessionPid} = State
+) when SessionPid =/= undefined ->
+    Cid = maps:get(~"cid", Msg, undefined),
+    try asobi_player_session:get_state(SessionPid) of
+        #{player_id := PlayerId} = SState ->
+            case maps:get(match_pid, SState, undefined) of
+                undefined ->
+                    Reply = encode_reply(Cid, ~"error", #{reason => ~"not_in_match"}),
+                    {reply, {text, Reply}, State};
+                MatchPid ->
+                    VoteId = maps:get(~"vote_id", Payload),
+                    case asobi_match_server:use_veto(MatchPid, PlayerId, VoteId) of
+                        ok ->
+                            Reply = encode_reply(Cid, ~"vote.veto_ok", #{success => true}),
+                            {reply, {text, Reply}, State};
+                        {error, Reason} ->
+                            Reply = encode_reply(Cid, ~"error", #{reason => Reason}),
+                            {reply, {text, Reply}, State}
+                    end
+            end
+    catch
+        exit:{noproc, _} ->
+            {ok, State#{session => undefined}}
+    end;
 handle_message(#{~"type" := Type} = Msg, State) ->
     Cid = maps:get(~"cid", Msg, undefined),
     Reply = encode_reply(Cid, ~"error", #{reason => ~"unknown_type", type => Type}),

--- a/test/asobi_vote_SUITE.erl
+++ b/test/asobi_vote_SUITE.erl
@@ -25,7 +25,12 @@
     vote_window_ready_up_timeout/1,
     vote_window_hybrid/1,
     vote_window_hybrid_min_enforced/1,
-    vote_window_adaptive/1
+    vote_window_adaptive/1,
+    vote_supermajority_met/1,
+    vote_supermajority_not_met/1,
+    vote_frustration_accumulator/1,
+    vote_veto_tokens/1,
+    vote_veto_tokens_exhausted/1
 ]).
 
 all() ->
@@ -51,7 +56,12 @@ all() ->
         vote_window_ready_up_timeout,
         vote_window_hybrid,
         vote_window_hybrid_min_enforced,
-        vote_window_adaptive
+        vote_window_adaptive,
+        vote_supermajority_met,
+        vote_supermajority_not_met,
+        vote_frustration_accumulator,
+        vote_veto_tokens,
+        vote_veto_tokens_exhausted
     ].
 
 init_per_suite(Config) ->
@@ -550,6 +560,170 @@ vote_window_adaptive(_Config) ->
     after 5000 ->
         error(adaptive_did_not_shrink)
     end.
+
+vote_supermajority_met(_Config) ->
+    Options = [
+        #{id => ~"opt_a", label => ~"A"},
+        #{id => ~"opt_b", label => ~"B"}
+    ],
+    {ok, MatchPid} = start_test_match(),
+    {ok, VotePid} = asobi_vote_sup:start_vote(#{
+        match_id => asobi_id:generate(),
+        match_pid => MatchPid,
+        options => Options,
+        eligible => [~"p1", ~"p2", ~"p3", ~"p4"],
+        window_ms => 200,
+        require_supermajority => true,
+        supermajority => 0.75
+    }),
+    %% 3 out of 4 = 75%, meets threshold
+    ok = asobi_vote_server:cast_vote(VotePid, ~"p1", ~"opt_a"),
+    ok = asobi_vote_server:cast_vote(VotePid, ~"p2", ~"opt_a"),
+    ok = asobi_vote_server:cast_vote(VotePid, ~"p3", ~"opt_a"),
+    ok = asobi_vote_server:cast_vote(VotePid, ~"p4", ~"opt_b"),
+    Ref = monitor(process, VotePid),
+    receive
+        {'DOWN', Ref, process, VotePid, normal} -> ok
+    after 2000 ->
+        error(vote_did_not_resolve)
+    end.
+
+vote_supermajority_not_met(_Config) ->
+    Options = [
+        #{id => ~"opt_a", label => ~"A"},
+        #{id => ~"opt_b", label => ~"B"}
+    ],
+    {ok, MatchPid} = start_test_match(),
+    {ok, VotePid} = asobi_vote_sup:start_vote(#{
+        match_id => asobi_id:generate(),
+        match_pid => MatchPid,
+        options => Options,
+        eligible => [~"p1", ~"p2", ~"p3", ~"p4"],
+        window_ms => 200,
+        require_supermajority => true,
+        supermajority => 0.75
+    }),
+    %% 2 out of 4 = 50%, below threshold
+    ok = asobi_vote_server:cast_vote(VotePid, ~"p1", ~"opt_a"),
+    ok = asobi_vote_server:cast_vote(VotePid, ~"p2", ~"opt_a"),
+    ok = asobi_vote_server:cast_vote(VotePid, ~"p3", ~"opt_b"),
+    ok = asobi_vote_server:cast_vote(VotePid, ~"p4", ~"opt_b"),
+    Ref = monitor(process, VotePid),
+    receive
+        {'DOWN', Ref, process, VotePid, normal} -> ok
+    after 2000 ->
+        error(vote_did_not_resolve)
+    end.
+
+vote_frustration_accumulator(_Config) ->
+    Options = [
+        #{id => ~"opt_a", label => ~"A"},
+        #{id => ~"opt_b", label => ~"B"}
+    ],
+    {ok, MatchPid} = asobi_match_sup:start_match(#{
+        game_module => asobi_test_game,
+        min_players => 2,
+        max_players => 4,
+        tick_rate => 50,
+        frustration_bonus => 1.0
+    }),
+    ok = asobi_match_server:join(MatchPid, ~"p1"),
+    ok = asobi_match_server:join(MatchPid, ~"p2"),
+    ok = asobi_match_server:join(MatchPid, ~"p3"),
+    timer:sleep(100),
+    %% Vote 1: p1 loses (votes B, A wins)
+    VoteId1 = asobi_id:generate(),
+    {ok, _} = asobi_match_server:start_vote(MatchPid, #{
+        vote_id => VoteId1,
+        options => Options,
+        window_ms => 200,
+        method => ~"weighted"
+    }),
+    ok = asobi_match_server:cast_vote(MatchPid, ~"p1", VoteId1, ~"opt_b"),
+    ok = asobi_match_server:cast_vote(MatchPid, ~"p2", VoteId1, ~"opt_a"),
+    ok = asobi_match_server:cast_vote(MatchPid, ~"p3", VoteId1, ~"opt_a"),
+    timer:sleep(400),
+    %% Vote 2: p1 should now have frustration bonus weight
+    VoteId2 = asobi_id:generate(),
+    {ok, VotePid2} = asobi_match_server:start_vote(MatchPid, #{
+        vote_id => VoteId2,
+        options => Options,
+        window_ms => 5000,
+        method => ~"weighted",
+        visibility => ~"live"
+    }),
+    %% p1 has frustration=1, bonus=1.0, so weight=2.0
+    %% p2 and p3 won last time, frustration=0, weight=1.0
+    ok = asobi_match_server:cast_vote(MatchPid, ~"p1", VoteId2, ~"opt_b"),
+    ok = asobi_match_server:cast_vote(MatchPid, ~"p2", VoteId2, ~"opt_a"),
+    Info = asobi_vote_server:get_state(VotePid2),
+    %% p1 weight=2.0 for opt_b, p2 weight=1.0 for opt_a
+    ?assertMatch(#{tallies := #{~"opt_b" := 2.0, ~"opt_a" := 1.0}}, Info).
+
+vote_veto_tokens(_Config) ->
+    Options = [#{id => ~"opt_a", label => ~"A"}],
+    {ok, MatchPid} = asobi_match_sup:start_match(#{
+        game_module => asobi_test_game,
+        min_players => 2,
+        max_players => 4,
+        tick_rate => 50,
+        veto_tokens_per_player => 2
+    }),
+    ok = asobi_match_server:join(MatchPid, ~"p1"),
+    ok = asobi_match_server:join(MatchPid, ~"p2"),
+    timer:sleep(100),
+    VoteId = asobi_id:generate(),
+    {ok, _} = asobi_match_server:start_vote(MatchPid, #{
+        vote_id => VoteId,
+        options => Options,
+        window_ms => 5000,
+        veto_enabled => true
+    }),
+    %% p1 uses a veto token
+    ok = asobi_match_server:use_veto(MatchPid, ~"p1", VoteId),
+    %% Vote should be dead
+    timer:sleep(100),
+    %% Start another vote, p1 uses another token
+    VoteId2 = asobi_id:generate(),
+    {ok, _} = asobi_match_server:start_vote(MatchPid, #{
+        vote_id => VoteId2,
+        options => Options,
+        window_ms => 5000,
+        veto_enabled => true
+    }),
+    ok = asobi_match_server:use_veto(MatchPid, ~"p1", VoteId2).
+
+vote_veto_tokens_exhausted(_Config) ->
+    Options = [#{id => ~"opt_a", label => ~"A"}],
+    {ok, MatchPid} = asobi_match_sup:start_match(#{
+        game_module => asobi_test_game,
+        min_players => 2,
+        max_players => 4,
+        tick_rate => 50,
+        veto_tokens_per_player => 1
+    }),
+    ok = asobi_match_server:join(MatchPid, ~"p1"),
+    ok = asobi_match_server:join(MatchPid, ~"p2"),
+    timer:sleep(100),
+    %% Use the one token
+    VoteId1 = asobi_id:generate(),
+    {ok, _} = asobi_match_server:start_vote(MatchPid, #{
+        vote_id => VoteId1,
+        options => Options,
+        window_ms => 5000,
+        veto_enabled => true
+    }),
+    ok = asobi_match_server:use_veto(MatchPid, ~"p1", VoteId1),
+    timer:sleep(100),
+    %% Second veto should fail — no tokens left
+    VoteId2 = asobi_id:generate(),
+    {ok, _} = asobi_match_server:start_vote(MatchPid, #{
+        vote_id => VoteId2,
+        options => Options,
+        window_ms => 5000,
+        veto_enabled => true
+    }),
+    ?assertMatch({error, no_veto_tokens}, asobi_match_server:use_veto(MatchPid, ~"p1", VoteId2)).
 
 %% --- Helpers ---
 


### PR DESCRIPTION
## Summary
- **Frustration accumulator**: minority voters gain weight bonus on next vote (resets on win)
- **Supermajority requirement**: configurable threshold, returns `no_consensus` if unmet
- **Veto tokens**: limited-use per-match vetoes with `vote.veto` WebSocket message

## Test plan
- [x] 27 CT tests (5 new: supermajority met/not met, frustration accumulator, veto tokens, tokens exhausted)
- [x] `rebar3 fmt --check` clean
- [x] `rebar3 xref` clean
- [x] `rebar3 dialyzer` clean
- [x] All tests pass