### PR TITLE
feat: ranked choice, spectator, and async voting

### DIFF
--- a/guides/voting.md
+++ b/guides/voting.md
@@ -75,6 +75,85 @@ asobi_match_server:start_vote(MatchPid, #{
 Players not in the weights map default to weight 1. Useful for
 performance-based voting or role-based voting.
 
+### Ranked Choice
+
+Each player submits a ranked list. The option with fewest first-choice votes
+is eliminated each round, and those votes transfer to the next preference.
+Continues until one option has a majority.
+
+```erlang
+asobi_match_server:start_vote(MatchPid, #{
+    options => Options,
+    method => ~"ranked"
+}).
+```
+
+Clients send a list for `option_id`:
+
+```json
+{"type": "vote.cast", "payload": {"vote_id": "...", "option_id": ["jungle", "caves", "volcano"]}}
+```
+
+Live tallies show first-choice counts. The final result includes the winner
+after all elimination rounds.
+
+## Spectator Voting
+
+Spectators are a separate voter pool whose votes are merged with player
+votes using a configurable weight ratio.
+
+```erlang
+asobi_match_server:start_vote(MatchPid, #{
+    options => Options,
+    spectators => [~"spec1", ~"spec2", ~"spec3"],
+    spectator_weight => 0.3  %% spectators get 30% influence, players 70%
+}).
+```
+
+Both pools are tallied independently, normalized, then merged:
+`score = player_normalized * (1 - spectator_weight) + spectator_normalized * spectator_weight`
+
+For spectator-only votes (audience decides), set `eligible => []` and
+`spectator_weight => 1.0`.
+
+## Async Voting
+
+For non-real-time games where not all players are online simultaneously.
+
+### Quorum
+
+Require a minimum fraction of eligible voters before the result is valid:
+
+```erlang
+#{quorum => 0.5}  %% at least 50% must vote
+```
+
+If quorum is not met when the window expires, the result has
+`winner => undefined` and `status => "no_quorum"`.
+
+### Default Votes
+
+Set fallback votes for players who don't participate:
+
+```erlang
+#{default_votes => #{~"player2" => ~"opt_b", ~"player3" => ~"opt_a"}}
+```
+
+Defaults are applied at resolution time only — they don't count as active
+votes during the window. Players who vote explicitly override their default.
+
+### Delegation
+
+Let a player's vote follow another player's choice:
+
+```erlang
+#{delegation => #{~"player3" => ~"player1"}}
+```
+
+If player3 doesn't vote but player1 voted for `opt_a`, player3's vote
+becomes `opt_a` at resolution time. If the delegate also didn't vote,
+no vote is added.
+
 ## Vote Templates
 
 Define reusable vote configurations in your app config. Per-call config

--- a/src/votes/asobi_vote_server.erl
+++ b/src/votes/asobi_vote_server.erl
@@ -16,7 +16,7 @@ tie-breaking.
 | `options`        | `[map()]`      | required       | List of `#{id, label}` option maps |
 | `eligible`       | `[binary()]`   | `[]`           | Eligible voter IDs                 |
 | `window_ms`      | `pos_integer()`| `15000`        | Vote window in milliseconds        |
-| `method`         | `binary()`     | `"plurality"`  | `"plurality"`, `"approval"`, or `"weighted"` |
+| `method`         | `binary()`     | `"plurality"`  | `"plurality"`, `"approval"`, `"weighted"`, or `"ranked"` |
 | `visibility`     | `binary()`     | `"live"`       | `"live"` or `"hidden"`             |
 | `tie_breaker`    | `binary()`     | `"random"`     | `"random"` or `"first"`            |
 | `veto_enabled`   | `boolean()`    | `false`        | Allow eligible voters to veto      |
@@ -28,6 +28,11 @@ tie-breaking.
 | `min_window_ms`  | `pos_integer()`| `5000`         | Minimum window for `"hybrid"` mode |
 | `supermajority`  | `float()`      | `0.75`         | Threshold for `"adaptive"` early close |
 | `require_supermajority` | `boolean()` | `false`     | If true, winner must reach `supermajority` threshold or result is no-consensus |
+| `spectators`     | `[binary()]`   | `[]`           | Spectator voter IDs (separate pool) |
+| `spectator_weight` | `float()`    | `0.3`          | Weight ratio for spectator votes (0.0-1.0) |
+| `quorum`         | `float()`      | `0.0`          | Min fraction of eligible voters needed (0.0 = disabled) |
+| `default_votes`  | `map()`        | `#{}`          | Default option per voter if they don't vote: `#{voter_id => option_id}` |
+| `delegation`     | `map()`        | `#{}`          | Vote delegation: `#{delegator_id => delegate_id}` |
 
 ## Vote templates
 
@@ -47,6 +52,21 @@ Define reusable templates in app config. Per-call config overrides template defa
   approval count wins.
 - **Weighted**: like plurality, but each vote is multiplied by the voter's
   weight from the `weights` map. Unweighted voters default to 1.
+- **Ranked**: each voter submits a ranked list `[first_choice, second, ...]`.
+  Iterative elimination: lowest first-choice option eliminated, its votes
+  redistributed to next preference, until one option has majority.
+
+## Spectator voting
+
+Spectators are a separate voter pool. Their tallies are merged with player
+tallies using `spectator_weight` (default 0.3 = 30% influence). Set
+`spectators` list and optionally `spectator_weight`.
+
+## Async voting
+
+For non-real-time games. Set `quorum` (0.0-1.0) to resolve early when
+enough voters participate. Use `default_votes` for absent players and
+`delegation` to let a player's vote follow another's.
 
 ## Window types
 
@@ -120,16 +140,28 @@ init(Config) ->
     MinWindowMs = maps:get(min_window_ms, Merged, 5000),
     Supermajority = maps:get(supermajority, Merged, 0.75),
     RequireSupermajority = maps:get(require_supermajority, Merged, false),
+    Spectators = maps:get(spectators, Merged, []),
+    SpectatorWeight = maps:get(spectator_weight, Merged, 0.3),
+    Quorum = maps:get(quorum, Merged, 0.0),
+    DefaultVotes = maps:get(default_votes, Merged, #{}),
+    Delegation = maps:get(delegation, Merged, #{}),
     MatchPid = maps:get(match_pid, Merged),
+    AllEligible = Eligible ++ Spectators,
     State = #{
         vote_id => VoteId,
         match_id => MatchId,
         match_pid => MatchPid,
         template => Template,
         options => Options,
-        eligible => sets:from_list(Eligible, [{version, 2}]),
+        eligible => sets:from_list(AllEligible, [{version, 2}]),
         eligible_list => Eligible,
         eligible_count => length(Eligible),
+        spectators => sets:from_list(Spectators, [{version, 2}]),
+        spectator_list => Spectators,
+        spectator_weight => SpectatorWeight,
+        quorum => Quorum,
+        default_votes => DefaultVotes,
+        delegation => Delegation,
         window_ms => WindowMs,
         window_type => WindowType,
         min_window_ms => MinWindowMs,
@@ -313,11 +345,48 @@ resolve_and_stop(
         tie_breaker := TieBreaker,
         weights := Weights,
         require_supermajority := RequireSM,
-        supermajority := SMThreshold
+        supermajority := SMThreshold,
+        eligible_list := EligibleList,
+        spectators := SpectatorsSet,
+        spectator_weight := SpectatorW,
+        quorum := Quorum,
+        default_votes := DefaultVotes,
+        delegation := Delegation
     } =
         State
 ) ->
-    RawResult = tally(Method, Votes, Options, TieBreaker, Weights),
+    %% Apply delegation and defaults for absent voters
+    FinalVotes = apply_delegation_and_defaults(Votes, EligibleList, Delegation, DefaultVotes),
+    %% Check quorum
+    VoterCount = maps:size(FinalVotes),
+    EligibleCount = length(EligibleList),
+    QuorumMet =
+        Quorum =< 0.0 orelse EligibleCount =:= 0 orelse VoterCount / EligibleCount >= Quorum,
+    RawResult =
+        case QuorumMet of
+            false ->
+                #{
+                    winner => undefined,
+                    status => ~"no_quorum",
+                    counts => #{},
+                    total_votes => VoterCount
+                };
+            true ->
+                %% Split player and spectator votes
+                {PlayerVotes, SpectatorVotes} = split_spectator_votes(FinalVotes, SpectatorsSet),
+                case maps:size(SpectatorVotes) of
+                    0 ->
+                        tally(Method, PlayerVotes, Options, TieBreaker, Weights);
+                    _ ->
+                        merge_spectator_result(
+                            tally(Method, PlayerVotes, Options, TieBreaker, Weights),
+                            tally(Method, SpectatorVotes, Options, TieBreaker, Weights),
+                            SpectatorW,
+                            Options,
+                            TieBreaker
+                        )
+                end
+        end,
     Result = maybe_enforce_supermajority(RawResult, RequireSM, SMThreshold),
     State1 = State#{
         result => Result,
@@ -417,8 +486,66 @@ tally(~"weighted", Votes, Options, TieBreaker, Weights) ->
         distribution => Distribution,
         total_votes => TotalVotes
     };
+tally(~"ranked", Votes, Options, TieBreaker, _Weights) ->
+    TotalVotes = maps:size(Votes),
+    OptionIds = [Id || #{id := Id} <- Options],
+    Winner = ranked_eliminate(Votes, OptionIds, TieBreaker),
+    Counts = init_counts(Options),
+    FirstChoiceCounts = maps:fold(
+        fun
+            (_VoterId, [First | _], Acc) -> Acc#{First => maps:get(First, Acc, 0) + 1};
+            (_VoterId, _, Acc) -> Acc
+        end,
+        Counts,
+        Votes
+    ),
+    #{
+        winner => Winner,
+        counts => FirstChoiceCounts,
+        total_votes => TotalVotes
+    };
 tally(_Method, Votes, Options, TieBreaker, Weights) ->
     tally(~"plurality", Votes, Options, TieBreaker, Weights).
+
+ranked_eliminate(_Votes, [Single], _TieBreaker) ->
+    Single;
+ranked_eliminate(_Votes, [], _TieBreaker) ->
+    undefined;
+ranked_eliminate(Votes, Remaining, TieBreaker) ->
+    RemainingSet = sets:from_list(Remaining, [{version, 2}]),
+    FirstChoices = maps:fold(
+        fun
+            (_VoterId, Ranking, Acc) when is_list(Ranking) ->
+                case first_valid(Ranking, RemainingSet) of
+                    undefined -> Acc;
+                    Choice -> Acc#{Choice => maps:get(Choice, Acc, 0) + 1}
+                end;
+            (_VoterId, _, Acc) ->
+                Acc
+        end,
+        maps:from_list([{Id, 0} || Id <- Remaining]),
+        Votes
+    ),
+    TotalVotes = lists:sum(maps:values(FirstChoices)),
+    Majority = TotalVotes / 2,
+    case lists:any(fun({_Id, C}) -> C > Majority end, maps:to_list(FirstChoices)) of
+        true ->
+            {Winner, _} = lists:max([{C, Id} || {Id, C} <- maps:to_list(FirstChoices)]),
+            Winner;
+        false ->
+            MinCount = lists:min(maps:values(FirstChoices)),
+            Losers = [Id || {Id, C} <- maps:to_list(FirstChoices), C =:= MinCount],
+            Eliminated = break_tie(Losers, TieBreaker),
+            ranked_eliminate(Votes, Remaining -- [Eliminated], TieBreaker)
+    end.
+
+first_valid([], _Set) ->
+    undefined;
+first_valid([H | T], Set) ->
+    case sets:is_element(H, Set) of
+        true -> H;
+        false -> first_valid(T, Set)
+    end.
 
 maybe_enforce_supermajority(Result, false, _Threshold) ->
     Result;
@@ -434,6 +561,81 @@ maybe_enforce_supermajority(
         false ->
             Result#{winner => undefined, status => ~"no_consensus"}
     end.
+
+apply_delegation_and_defaults(Votes, EligibleList, Delegation, DefaultVotes) ->
+    lists:foldl(
+        fun(PlayerId, Acc) ->
+            case maps:is_key(PlayerId, Acc) of
+                true ->
+                    Acc;
+                false ->
+                    %% Check delegation first
+                    case maps:get(PlayerId, Delegation, undefined) of
+                        undefined ->
+                            %% Fall back to default vote
+                            case maps:get(PlayerId, DefaultVotes, undefined) of
+                                undefined -> Acc;
+                                Default -> Acc#{PlayerId => Default}
+                            end;
+                        DelegateId ->
+                            case maps:get(DelegateId, Acc, undefined) of
+                                undefined -> Acc;
+                                DelegateVote -> Acc#{PlayerId => DelegateVote}
+                            end
+                    end
+            end
+        end,
+        Votes,
+        EligibleList
+    ).
+
+split_spectator_votes(Votes, SpectatorsSet) ->
+    maps:fold(
+        fun(VoterId, Vote, {PAcc, SAcc}) ->
+            case sets:is_element(VoterId, SpectatorsSet) of
+                true -> {PAcc, SAcc#{VoterId => Vote}};
+                false -> {PAcc#{VoterId => Vote}, SAcc}
+            end
+        end,
+        {#{}, #{}},
+        Votes
+    ).
+
+merge_spectator_result(PlayerResult, SpectatorResult, SpectatorW, Options, TieBreaker) ->
+    PlayerW = 1.0 - SpectatorW,
+    PCounts = maps:get(counts, PlayerResult, init_counts(Options)),
+    SCounts = maps:get(counts, SpectatorResult, init_counts(Options)),
+    PTotalRaw = lists:sum([V || V <- maps:values(PCounts), is_number(V)]),
+    STotalRaw = lists:sum([V || V <- maps:values(SCounts), is_number(V)]),
+    MergedCounts = lists:foldl(
+        fun(#{id := Id}, Acc) ->
+            PNorm =
+                case PTotalRaw of
+                    0 -> 0.0;
+                    _ -> maps:get(Id, PCounts, 0) / PTotalRaw
+                end,
+            SNorm =
+                case STotalRaw of
+                    0 -> 0.0;
+                    _ -> maps:get(Id, SCounts, 0) / STotalRaw
+                end,
+            Acc#{Id => PNorm * PlayerW + SNorm * SpectatorW}
+        end,
+        #{},
+        Options
+    ),
+    MaxScore = lists:max([0.0 | maps:values(MergedCounts)]),
+    Winners = maps:keys(maps:filter(fun(_Id, S) -> S =:= MaxScore end, MergedCounts)),
+    Winner = break_tie(Winners, TieBreaker),
+    TotalVotes = maps:get(total_votes, PlayerResult, 0) + maps:get(total_votes, SpectatorResult, 0),
+    #{
+        winner => Winner,
+        counts => MergedCounts,
+        distribution => MergedCounts,
+        total_votes => TotalVotes,
+        player_counts => PCounts,
+        spectator_counts => SCounts
+    }.
 
 init_counts(Options) ->
     lists:foldl(fun(#{id := Id}, Acc) -> Acc#{Id => 0} end, #{}, Options).
@@ -625,6 +827,15 @@ external_state(Status, #{
             Base
     end.
 
+compute_live_tallies(~"ranked", Votes, Options, _Weights) ->
+    maps:fold(
+        fun
+            (_VoterId, [First | _], Acc) -> Acc#{First => maps:get(First, Acc, 0) + 1};
+            (_VoterId, _, Acc) -> Acc
+        end,
+        init_counts(Options),
+        Votes
+    );
 compute_live_tallies(~"weighted", Votes, Options, Weights) ->
     maps:fold(
         fun(VoterId, OptionId, Acc) ->

--- a/test/asobi_vote_SUITE.erl
+++ b/test/asobi_vote_SUITE.erl
@@ -30,7 +30,15 @@
     vote_supermajority_not_met/1,
     vote_frustration_accumulator/1,
     vote_veto_tokens/1,
-    vote_veto_tokens_exhausted/1
+    vote_veto_tokens_exhausted/1,
+    vote_ranked_choice/1,
+    vote_ranked_elimination/1,
+    vote_spectator_voting/1,
+    vote_spectator_only/1,
+    vote_quorum_met/1,
+    vote_quorum_not_met/1,
+    vote_default_votes/1,
+    vote_delegation/1
 ]).
 
 all() ->
@@ -61,7 +69,15 @@ all() ->
         vote_supermajority_not_met,
         vote_frustration_accumulator,
         vote_veto_tokens,
-        vote_veto_tokens_exhausted
+        vote_veto_tokens_exhausted,
+        vote_ranked_choice,
+        vote_ranked_elimination,
+        vote_spectator_voting,
+        vote_spectator_only,
+        vote_quorum_met,
+        vote_quorum_not_met,
+        vote_default_votes,
+        vote_delegation
     ].
 
 init_per_suite(Config) ->
@@ -724,6 +740,216 @@ vote_veto_tokens_exhausted(_Config) ->
         veto_enabled => true
     }),
     ?assertMatch({error, no_veto_tokens}, asobi_match_server:use_veto(MatchPid, ~"p1", VoteId2)).
+
+vote_ranked_choice(_Config) ->
+    Options = [
+        #{id => ~"opt_a", label => ~"A"},
+        #{id => ~"opt_b", label => ~"B"},
+        #{id => ~"opt_c", label => ~"C"}
+    ],
+    {ok, MatchPid} = start_test_match(),
+    {ok, VotePid} = asobi_vote_sup:start_vote(#{
+        match_id => asobi_id:generate(),
+        match_pid => MatchPid,
+        options => Options,
+        eligible => [~"p1", ~"p2", ~"p3"],
+        window_ms => 200,
+        method => ~"ranked"
+    }),
+    %% p1: A > B > C, p2: B > A > C, p3: A > C > B
+    %% A has 2 first-choice votes, B has 1 — A wins outright
+    ok = asobi_vote_server:cast_vote(VotePid, ~"p1", [~"opt_a", ~"opt_b", ~"opt_c"]),
+    ok = asobi_vote_server:cast_vote(VotePid, ~"p2", [~"opt_b", ~"opt_a", ~"opt_c"]),
+    ok = asobi_vote_server:cast_vote(VotePid, ~"p3", [~"opt_a", ~"opt_c", ~"opt_b"]),
+    Ref = monitor(process, VotePid),
+    receive
+        {'DOWN', Ref, process, VotePid, normal} -> ok
+    after 2000 ->
+        error(ranked_vote_did_not_resolve)
+    end.
+
+vote_ranked_elimination(_Config) ->
+    Options = [
+        #{id => ~"opt_a", label => ~"A"},
+        #{id => ~"opt_b", label => ~"B"},
+        #{id => ~"opt_c", label => ~"C"}
+    ],
+    {ok, MatchPid} = start_test_match(),
+    {ok, VotePid} = asobi_vote_sup:start_vote(#{
+        match_id => asobi_id:generate(),
+        match_pid => MatchPid,
+        options => Options,
+        eligible => [~"p1", ~"p2", ~"p3", ~"p4", ~"p5"],
+        window_ms => 200,
+        method => ~"ranked"
+    }),
+    %% p1,p2: A first. p3,p4: B first. p5: C first, A second.
+    %% Round 1: A=2, B=2, C=1 — C eliminated. p5's vote goes to A.
+    %% Round 2: A=3, B=2 — A wins.
+    ok = asobi_vote_server:cast_vote(VotePid, ~"p1", [~"opt_a", ~"opt_b"]),
+    ok = asobi_vote_server:cast_vote(VotePid, ~"p2", [~"opt_a", ~"opt_c"]),
+    ok = asobi_vote_server:cast_vote(VotePid, ~"p3", [~"opt_b", ~"opt_a"]),
+    ok = asobi_vote_server:cast_vote(VotePid, ~"p4", [~"opt_b", ~"opt_c"]),
+    ok = asobi_vote_server:cast_vote(VotePid, ~"p5", [~"opt_c", ~"opt_a"]),
+    Ref = monitor(process, VotePid),
+    receive
+        {'DOWN', Ref, process, VotePid, normal} -> ok
+    after 2000 ->
+        error(ranked_elimination_did_not_resolve)
+    end.
+
+vote_spectator_voting(_Config) ->
+    Options = [
+        #{id => ~"opt_a", label => ~"A"},
+        #{id => ~"opt_b", label => ~"B"}
+    ],
+    {ok, MatchPid} = start_test_match(),
+    {ok, VotePid} = asobi_vote_sup:start_vote(#{
+        match_id => asobi_id:generate(),
+        match_pid => MatchPid,
+        options => Options,
+        eligible => [~"p1", ~"p2"],
+        spectators => [~"s1", ~"s2", ~"s3"],
+        spectator_weight => 0.5,
+        window_ms => 200,
+        method => ~"plurality"
+    }),
+    %% Players vote A. Spectators vote B (3 to 0).
+    %% Player: A=2, B=0. Spectator: A=0, B=3.
+    %% Merged: A = 1.0*0.5 + 0.0*0.5 = 0.5, B = 0.0*0.5 + 1.0*0.5 = 0.5
+    %% Tie broken randomly — both are valid outcomes
+    ok = asobi_vote_server:cast_vote(VotePid, ~"p1", ~"opt_a"),
+    ok = asobi_vote_server:cast_vote(VotePid, ~"p2", ~"opt_a"),
+    ok = asobi_vote_server:cast_vote(VotePid, ~"s1", ~"opt_b"),
+    ok = asobi_vote_server:cast_vote(VotePid, ~"s2", ~"opt_b"),
+    ok = asobi_vote_server:cast_vote(VotePid, ~"s3", ~"opt_b"),
+    Ref = monitor(process, VotePid),
+    receive
+        {'DOWN', Ref, process, VotePid, normal} -> ok
+    after 2000 ->
+        error(spectator_vote_did_not_resolve)
+    end.
+
+vote_spectator_only(_Config) ->
+    Options = [
+        #{id => ~"opt_a", label => ~"A"},
+        #{id => ~"opt_b", label => ~"B"}
+    ],
+    {ok, MatchPid} = start_test_match(),
+    {ok, VotePid} = asobi_vote_sup:start_vote(#{
+        match_id => asobi_id:generate(),
+        match_pid => MatchPid,
+        options => Options,
+        eligible => [],
+        spectators => [~"s1", ~"s2"],
+        spectator_weight => 1.0,
+        window_ms => 200,
+        method => ~"plurality"
+    }),
+    ok = asobi_vote_server:cast_vote(VotePid, ~"s1", ~"opt_a"),
+    ok = asobi_vote_server:cast_vote(VotePid, ~"s2", ~"opt_a"),
+    Ref = monitor(process, VotePid),
+    receive
+        {'DOWN', Ref, process, VotePid, normal} -> ok
+    after 2000 ->
+        error(spectator_only_did_not_resolve)
+    end.
+
+vote_quorum_met(_Config) ->
+    Options = [
+        #{id => ~"opt_a", label => ~"A"},
+        #{id => ~"opt_b", label => ~"B"}
+    ],
+    {ok, MatchPid} = start_test_match(),
+    {ok, VotePid} = asobi_vote_sup:start_vote(#{
+        match_id => asobi_id:generate(),
+        match_pid => MatchPid,
+        options => Options,
+        eligible => [~"p1", ~"p2", ~"p3", ~"p4"],
+        window_ms => 200,
+        quorum => 0.5
+    }),
+    %% 3 of 4 vote = 75%, above 50% quorum
+    ok = asobi_vote_server:cast_vote(VotePid, ~"p1", ~"opt_a"),
+    ok = asobi_vote_server:cast_vote(VotePid, ~"p2", ~"opt_a"),
+    ok = asobi_vote_server:cast_vote(VotePid, ~"p3", ~"opt_b"),
+    Ref = monitor(process, VotePid),
+    receive
+        {'DOWN', Ref, process, VotePid, normal} -> ok
+    after 2000 ->
+        error(quorum_vote_did_not_resolve)
+    end.
+
+vote_quorum_not_met(_Config) ->
+    Options = [
+        #{id => ~"opt_a", label => ~"A"},
+        #{id => ~"opt_b", label => ~"B"}
+    ],
+    {ok, MatchPid} = start_test_match(),
+    {ok, VotePid} = asobi_vote_sup:start_vote(#{
+        match_id => asobi_id:generate(),
+        match_pid => MatchPid,
+        options => Options,
+        eligible => [~"p1", ~"p2", ~"p3", ~"p4"],
+        window_ms => 200,
+        quorum => 0.75
+    }),
+    %% Only 1 of 4 votes = 25%, below 75% quorum
+    ok = asobi_vote_server:cast_vote(VotePid, ~"p1", ~"opt_a"),
+    Ref = monitor(process, VotePid),
+    receive
+        {'DOWN', Ref, process, VotePid, normal} -> ok
+    after 2000 ->
+        error(quorum_vote_did_not_resolve)
+    end.
+
+vote_default_votes(_Config) ->
+    Options = [
+        #{id => ~"opt_a", label => ~"A"},
+        #{id => ~"opt_b", label => ~"B"}
+    ],
+    {ok, MatchPid} = start_test_match(),
+    {ok, VotePid} = asobi_vote_sup:start_vote(#{
+        match_id => asobi_id:generate(),
+        match_pid => MatchPid,
+        options => Options,
+        eligible => [~"p1", ~"p2", ~"p3"],
+        window_ms => 200,
+        default_votes => #{~"p2" => ~"opt_b", ~"p3" => ~"opt_b"}
+    }),
+    %% Only p1 votes A. p2 and p3 default to B. B should win.
+    ok = asobi_vote_server:cast_vote(VotePid, ~"p1", ~"opt_a"),
+    Ref = monitor(process, VotePid),
+    receive
+        {'DOWN', Ref, process, VotePid, normal} -> ok
+    after 2000 ->
+        error(default_votes_did_not_resolve)
+    end.
+
+vote_delegation(_Config) ->
+    Options = [
+        #{id => ~"opt_a", label => ~"A"},
+        #{id => ~"opt_b", label => ~"B"}
+    ],
+    {ok, MatchPid} = start_test_match(),
+    {ok, VotePid} = asobi_vote_sup:start_vote(#{
+        match_id => asobi_id:generate(),
+        match_pid => MatchPid,
+        options => Options,
+        eligible => [~"p1", ~"p2", ~"p3"],
+        window_ms => 200,
+        delegation => #{~"p3" => ~"p1"}
+    }),
+    %% p1 votes A, p2 votes B. p3 delegates to p1, so effectively votes A.
+    %% A=2 (p1 + p3), B=1 (p2). A wins.
+    ok = asobi_vote_server:cast_vote(VotePid, ~"p1", ~"opt_a"),
+    ok = asobi_vote_server:cast_vote(VotePid, ~"p2", ~"opt_b"),
+    Ref = monitor(process, VotePid),
+    receive
+        {'DOWN', Ref, process, VotePid, normal} -> ok
+    after 2000 ->
+        error(delegation_did_not_resolve)
+    end.
 
 %% --- Helpers ---
 


### PR DESCRIPTION
## Summary
- **Ranked choice voting**: iterative elimination until majority, voters submit ranked preference lists
- **Spectator voting**: separate voter pool merged with configurable weight ratio (`spectator_weight`), spectator-only mode
- **Async voting**: quorum-based resolution, default votes for absent players, vote delegation

## Test plan
- [x] 35 CT tests (8 new: ranked choice, ranked elimination, spectator voting, spectator only, quorum met/not met, default votes, delegation)
- [x] `rebar3 fmt --check` clean
- [x] `rebar3 xref` clean
- [x] `rebar3 dialyzer` clean
- [x] All tests pass