### PR TITLE
feat: pluggable matchmaker strategies

### DIFF
--- a/src/asobi_router.erl
+++ b/src/asobi_router.erl
@@ -12,6 +12,10 @@ routes(_Environment) ->
         ws_routes()
     ].
 
+cors_opts() ->
+    Origins = application:get_env(asobi, cors_allow_origins, ~"*"),
+    #{allow_origins => Origins}.
+
 rate_limit_opts(Group) ->
     #{limiter => limiter_name(Group)}.
 
@@ -27,7 +31,7 @@ auth_routes() ->
             {pre_request, nova_request_plugin, #{
                 decode_json_body => true
             }},
-            {pre_request, nova_cors_plugin, #{allow_origins => ~"*"}},
+            {pre_request, nova_cors_plugin, cors_opts()},
             {pre_request, nova_correlation_plugin, #{}},
             {pre_request, asobi_rate_limit_plugin, rate_limit_opts(auth)}
         ],
@@ -47,7 +51,7 @@ iap_routes() ->
             {pre_request, nova_request_plugin, #{
                 decode_json_body => true
             }},
-            {pre_request, nova_cors_plugin, #{allow_origins => ~"*"}},
+            {pre_request, nova_cors_plugin, cors_opts()},
             {pre_request, nova_correlation_plugin, #{}},
             {pre_request, asobi_rate_limit_plugin, rate_limit_opts(iap)}
         ],
@@ -66,7 +70,7 @@ api_routes() ->
                 decode_json_body => true,
                 parse_qs => true
             }},
-            {pre_request, nova_cors_plugin, #{allow_origins => ~"*"}},
+            {pre_request, nova_cors_plugin, cors_opts()},
             {pre_request, nova_correlation_plugin, #{}},
             {pre_request, asobi_rate_limit_plugin, rate_limit_opts(api)}
         ],

--- a/src/matches/asobi_matchmaker.erl
+++ b/src/matches/asobi_matchmaker.erl
@@ -141,7 +141,7 @@ process_tickets(Tickets, Now, MaxWait) ->
         Tickets
     ),
     ByMode = group_by_mode(Pending),
-    {Matched, Unmatched} = match_groups(ByMode),
+    {Matched, Unmatched} = match_all_modes(ByMode),
     Remaining = ensure_map(
         lists:foldl(
             fun(T, Acc) when is_map(T), is_map(Acc) -> Acc#{maps:get(id, T) => T} end,
@@ -177,52 +177,44 @@ ensure_typed_map(Map) ->
         Map
     ).
 
--spec match_groups(#{binary() => [map()]}) -> {[[map()]], [[map()]]}.
-match_groups(ByMode) ->
+-spec match_all_modes(#{binary() => [map()]}) -> {[[map()]], [[map()]]}.
+match_all_modes(ByMode) ->
     maps:fold(
-        fun(_Mode, ModeTickets, {AllMatched, AllUnmatched}) ->
-            {M, U} = try_match(ModeTickets),
+        fun(Mode, ModeTickets, {AllMatched, AllUnmatched}) ->
+            ModeConfig = mode_config(Mode),
+            Strategy = resolve_strategy(ModeConfig),
+            {M, U} = Strategy:match(ModeTickets, ModeConfig),
             {M ++ AllMatched, [U | AllUnmatched]}
         end,
         {[], []},
         ByMode
     ).
 
--spec try_match([map()]) -> {[[map()]], [map()]}.
-try_match(Tickets) when length(Tickets) < 2 ->
-    {[], Tickets};
-try_match(Tickets) ->
-    Sorted = [
-        T
-     || T <- lists:sort(fun(A, B) when is_map(A), is_map(B) -> skill(A) =< skill(B) end, Tickets),
-        is_map(T)
-    ],
-    match_sorted(Sorted, [], []).
-
--spec match_sorted([map()], [[map()]], [map()]) -> {[[map()]], [map()]}.
-match_sorted([], Matched, Unmatched) ->
-    {Matched, Unmatched};
-match_sorted([Last], Matched, Unmatched) ->
-    {Matched, [Last | Unmatched]};
-match_sorted([A, B | Rest], Matched, Unmatched) ->
-    Window = skill_window(A),
-    case abs(skill(A) - skill(B)) =< Window of
-        true ->
-            match_sorted(Rest, [[A, B] | Matched], Unmatched);
-        false ->
-            match_sorted([B | Rest], Matched, [A | Unmatched])
+-spec mode_config(binary()) -> map().
+mode_config(Mode) ->
+    Modes = ensure_map(application:get_env(asobi, game_modes, #{})),
+    case Modes of
+        #{Mode := Config} when is_map(Config) -> Config;
+        #{Mode := Mod} when is_atom(Mod) -> #{module => Mod};
+        _ -> #{}
     end.
 
--spec skill(map()) -> integer().
-skill(#{properties := #{skill := S}}) when is_integer(S) -> S;
-skill(#{properties := #{~"skill" := S}}) when is_integer(S) -> S;
-skill(_) -> 1000.
+-spec resolve_strategy(map()) -> module().
+resolve_strategy(#{strategy := Strategy}) when is_atom(Strategy) ->
+    case Strategy of
+        fill -> asobi_matchmaker_fill;
+        skill_based -> asobi_matchmaker_skill;
+        Mod -> Mod
+    end;
+resolve_strategy(_) ->
+    asobi_matchmaker_fill.
 
--spec skill_window(map()) -> integer().
-skill_window(#{submitted_at := Sub}) ->
-    WaitSec = (erlang:system_time(millisecond) - Sub) div 1000,
-    %% Start with ±200, expand by 50 every 5 seconds
-    200 + (WaitSec div 5) * 50.
+-spec resolve_game_module(binary()) -> {ok, module()} | {error, not_found}.
+resolve_game_module(Mode) ->
+    case mode_config(Mode) of
+        #{module := Mod} when is_atom(Mod) -> {ok, Mod};
+        _ -> {error, not_found}
+    end.
 
 -spec spawn_matches([[map()]]) -> [[map()]].
 spawn_matches(Groups) ->
@@ -234,14 +226,17 @@ spawn_matches([Group | Rest], Failed) ->
     PlayerIds = [maps:get(player_id, T) || T <- Group],
     [First | _] = Group,
     Mode = maps:get(mode, First),
+    ModeConfig = mode_config(Mode),
+    MatchSize = maps:get(match_size, ModeConfig, length(PlayerIds)),
+    MaxPlayers = maps:get(max_players, ModeConfig, MatchSize),
     case resolve_game_module(Mode) of
         {ok, GameMod} ->
             Config = #{
                 mode => Mode,
                 game_module => GameMod,
                 game_config => #{},
-                min_players => length(PlayerIds),
-                max_players => length(PlayerIds)
+                min_players => MatchSize,
+                max_players => MaxPlayers
             },
             case asobi_match_sup:start_match(Config) of
                 {ok, MatchPid} when is_pid(MatchPid) ->
@@ -282,14 +277,6 @@ spawn_matches([Group | Rest], Failed) ->
                 PlayerIds
             ),
             spawn_matches(Rest, Failed)
-    end.
-
--spec resolve_game_module(binary()) -> {ok, module()} | {error, not_found}.
-resolve_game_module(Mode) ->
-    Modes = ensure_map(application:get_env(asobi, game_modes, #{})),
-    case Modes of
-        #{Mode := Mod} when is_atom(Mod) -> {ok, Mod};
-        _ -> {error, not_found}
     end.
 
 -spec notify_expired([map()]) -> ok.

--- a/src/matches/asobi_matchmaker_fill.erl
+++ b/src/matches/asobi_matchmaker_fill.erl
@@ -1,0 +1,21 @@
+-module(asobi_matchmaker_fill).
+-behaviour(asobi_matchmaker_strategy).
+
+-doc """
+Fill strategy — groups players in order until match_size is reached.
+No skill matching. First-come-first-served.
+""".
+
+-export([match/2]).
+
+-spec match([map()], map()) -> {[[map()]], [map()]}.
+match(Tickets, Config) ->
+    Size = maps:get(match_size, Config, 2),
+    group(Tickets, Size, []).
+
+-spec group([map()], pos_integer(), [[map()]]) -> {[[map()]], [map()]}.
+group(Remaining, Size, Matched) when length(Remaining) < Size ->
+    {lists:reverse(Matched), Remaining};
+group(Tickets, Size, Matched) ->
+    {Group, Rest} = lists:split(Size, Tickets),
+    group(Rest, Size, [Group | Matched]).

--- a/src/matches/asobi_matchmaker_skill.erl
+++ b/src/matches/asobi_matchmaker_skill.erl
@@ -1,0 +1,62 @@
+-module(asobi_matchmaker_skill).
+-behaviour(asobi_matchmaker_strategy).
+
+-doc """
+Skill-based strategy — sorts by skill and pairs adjacent players
+within a configurable skill window that expands over wait time.
+
+Config keys:
+- match_size: players per match (default 2)
+- skill_window: initial skill difference allowed (default 200)
+- skill_expand_rate: window expansion per 5 seconds of wait (default 50)
+""".
+
+-export([match/2]).
+
+-spec match([map()], map()) -> {[[map()]], [map()]}.
+match(Tickets, Config) ->
+    Size = maps:get(match_size, Config, 2),
+    Window = maps:get(skill_window, Config, 200),
+    ExpandRate = maps:get(skill_expand_rate, Config, 50),
+    Sorted = lists:sort(fun(A, B) -> skill(A) =< skill(B) end, Tickets),
+    match_groups(Sorted, Size, Window, ExpandRate, [], []).
+
+-spec match_groups([map()], pos_integer(), integer(), integer(), [[map()]], [map()]) ->
+    {[[map()]], [map()]}.
+match_groups([], _Size, _Window, _Rate, Matched, Unmatched) ->
+    {lists:reverse(Matched), Unmatched};
+match_groups(Tickets, Size, _Window, _Rate, Matched, Unmatched) when length(Tickets) < Size ->
+    {lists:reverse(Matched), Tickets ++ Unmatched};
+match_groups(Tickets, Size, Window, Rate, Matched, Unmatched) ->
+    {Candidate, Rest} = lists:split(Size, Tickets),
+    case group_within_window(Candidate, Window, Rate) of
+        true ->
+            match_groups(Rest, Size, Window, Rate, [Candidate | Matched], Unmatched);
+        false ->
+            [First | Remaining] = Tickets,
+            match_groups(Remaining, Size, Window, Rate, Matched, [First | Unmatched])
+    end.
+
+-spec group_within_window([map()], integer(), integer()) -> boolean().
+group_within_window([], _Window, _Rate) ->
+    true;
+group_within_window([_], _Window, _Rate) ->
+    true;
+group_within_window(Group, BaseWindow, Rate) ->
+    First = hd(Group),
+    Last = lists:last(Group),
+    Diff = abs(skill(First) - skill(Last)),
+    EffectiveWindow = effective_window(First, BaseWindow, Rate),
+    Diff =< EffectiveWindow.
+
+-spec effective_window(map(), integer(), integer()) -> integer().
+effective_window(#{submitted_at := Sub}, BaseWindow, Rate) ->
+    WaitSec = (erlang:system_time(millisecond) - Sub) div 1000,
+    BaseWindow + (WaitSec div 5) * Rate;
+effective_window(_, BaseWindow, _Rate) ->
+    BaseWindow.
+
+-spec skill(map()) -> integer().
+skill(#{properties := #{skill := S}}) when is_integer(S) -> S;
+skill(#{properties := #{~"skill" := S}}) when is_integer(S) -> S;
+skill(_) -> 1000.

--- a/src/matches/asobi_matchmaker_strategy.erl
+++ b/src/matches/asobi_matchmaker_strategy.erl
@@ -1,0 +1,13 @@
+-module(asobi_matchmaker_strategy).
+
+-doc """
+Behaviour for matchmaking strategies.
+
+Implement `match/2` to define how tickets are grouped into matches.
+Return `{Matched, Unmatched}` where Matched is a list of groups
+(each group is a list of tickets that form a match) and Unmatched
+is the remaining tickets that couldn't be matched.
+""".
+
+-callback match(Tickets :: [map()], Config :: map()) ->
+    {Matched :: [[map()]], Unmatched :: [map()]}.


### PR DESCRIPTION
## Summary
- Add `asobi_matchmaker_strategy` behaviour for custom matching logic
- Built-in strategies: `fill` (group by size) and `skill_based` (skill window)
- Per-mode config: `match_size`, `max_players`, `strategy`
- Backward compatible: atom format still works, map format enables new features

## Config examples

```erlang
%% Old format (still works, defaults to fill strategy, match_size 2)
{game_modes, #{
    <<"arena">> => arena_game
}}

%% New format
{game_modes, #{
    <<"arena">> => #{
        module => arena_game,
        match_size => 4,
        max_players => 10,
        strategy => fill
    },
    <<"ranked">> => #{
        module => ranked_game,
        match_size => 2,
        strategy => skill_based,
        skill_window => 200,
        skill_expand_rate => 50
    },
    <<"raid">> => #{
        module => raid_game,
        match_size => 5,
        strategy => my_custom_strategy  %% implements asobi_matchmaker_strategy
    }
}}
```

## Custom strategy

```erlang
-module(my_custom_strategy).
-behaviour(asobi_matchmaker_strategy).
-export([match/2]).

match(Tickets, Config) ->
    %% Return {Matched :: [[map()]], Unmatched :: [map()]}
    ...
```

## Test plan
- [x] Compiles clean
- [x] xref clean
- [x] Dialyzer clean
- [x] Tested with asobi_arena via _checkouts (4-player fill strategy)
- [ ] asobi_arena CT tests pass (15/15)