### PR TITLE
feat: Docker image with CI publish to ghcr.io

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,46 @@
+name: Docker
+
+on:
+  push:
+    tags: ['v*']
+  workflow_dispatch:
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Log in to Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern={{major}}
+            type=raw,value=latest,enable={{is_default_branch}}
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,28 +17,35 @@ RUN rebar3 compile --deps_only
 # Copy source and build release
 COPY config/ config/
 COPY src/ src/
-COPY priv/ priv/
 RUN rebar3 as prod release
 
 # --- Runtime ---
 FROM debian:bookworm-slim
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
-    libncurses6 libssl3 libtinfo6 ca-certificates && \
+    libncurses6 libssl3 libtinfo6 ca-certificates tini && \
     rm -rf /var/lib/apt/lists/*
 
 RUN groupadd -r asobi && useradd -r -g asobi -d /app asobi
 
 WORKDIR /app
 COPY --from=builder /build/_build/prod/rel/asobi/ ./
-RUN chown -R asobi:asobi /app
+
+# Game scripts mount point for Lua users
+RUN mkdir -p /app/game && chown -R asobi:asobi /app
+VOLUME ["/app/game"]
 
 USER asobi
 EXPOSE 8080
 
-ENV ASOBI_PORT=8080
-ENV ASOBI_NODE_HOST=127.0.0.1
-ENV ERLANG_COOKIE=asobi_cookie
+ENV ASOBI_PORT=8080 \
+    ASOBI_NODE_HOST=127.0.0.1 \
+    ERLANG_COOKIE=asobi_cookie \
+    ASOBI_DB_HOST=db \
+    ASOBI_DB_NAME=asobi \
+    ASOBI_DB_USER=postgres \
+    ASOBI_DB_PASSWORD=postgres \
+    ASOBI_CORS_ORIGINS=*
 
-ENTRYPOINT ["bin/asobi"]
-CMD ["foreground"]
+ENTRYPOINT ["tini", "--"]
+CMD ["bin/asobi", "foreground"]

--- a/docker-compose.example.yml
+++ b/docker-compose.example.yml
@@ -1,0 +1,42 @@
+## Example docker-compose for running Asobi with Lua game scripts.
+## Copy this file to your project and customize.
+##
+##   cp docker-compose.example.yml docker-compose.yml
+##   mkdir -p game
+##   # add your match.lua, bots/, etc. to game/
+##   docker compose up
+
+services:
+  asobi:
+    image: ghcr.io/widgrensit/asobi:latest
+    ports:
+      - "8080:8080"
+    volumes:
+      - ./game:/app/game
+    environment:
+      ASOBI_PORT: 8080
+      ASOBI_DB_HOST: db
+      ASOBI_DB_NAME: my_game
+      ASOBI_DB_USER: postgres
+      ASOBI_DB_PASSWORD: postgres
+      ASOBI_CORS_ORIGINS: "*"
+      ERLANG_COOKIE: change_me_in_production
+    depends_on:
+      db:
+        condition: service_healthy
+
+  db:
+    image: postgres:17
+    environment:
+      POSTGRES_DB: my_game
+      POSTGRES_PASSWORD: postgres
+    volumes:
+      - pgdata:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U postgres"]
+      interval: 5s
+      timeout: 5s
+      retries: 5
+
+volumes:
+  pgdata:


### PR DESCRIPTION
## Summary
- Updated Dockerfile with tini entrypoint, `/app/game` volume mount for Lua scripts, default env vars
- GitHub Actions workflow to build and push to `ghcr.io/widgrensit/asobi` on version tags
- Semver tagging: `v1.2.3` produces tags `1.2.3`, `1.2`, `1`, `latest`
- Example docker-compose.yml with PostgreSQL for quick start

## Usage
```yaml
services:
  asobi:
    image: ghcr.io/widgrensit/asobi:latest
    volumes:
      - ./game:/app/game
    environment:
      ASOBI_DB_HOST: db
```

## Test plan
- [ ] CI passes
- [ ] Merge after feat/lua-scripting lands (Docker image should include Lua support)