### PR TITLE
fix: trigger Docker build on release event

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,8 +1,8 @@
 name: Docker
 
 on:
-  push:
-    tags: ['v*']
+  release:
+    types: [published]
   workflow_dispatch:
 
 env:


### PR DESCRIPTION
## Summary
Tags created by GitHub Actions workflows don't trigger other workflows (anti-loop protection). Changed Docker workflow from `push tags: v*` to `release: published` which fires when erlang-ci creates a GitHub Release.

## Test plan
- [ ] CI passes
- [ ] Next merge to main creates release → triggers Docker build → pushes to ghcr.io