### PR TITLE
fix: encode game state for Lua bot AI and deep decode match state

### DIFF
--- a/src/bots/asobi_bot.erl
+++ b/src/bots/asobi_bot.erl
@@ -111,10 +111,13 @@ send_input(#{lua_state := undefined, bot_id := BotId, match_pid := MatchPid, gam
     Input = default_ai(BotId, GS),
     asobi_match_server:handle_input(MatchPid, BotId, Input);
 send_input(#{lua_state := LuaSt, bot_id := BotId, match_pid := MatchPid, game_state := GS}) ->
+    {EncGS, LuaSt1} = luerl:encode(GS, LuaSt),
     Input =
-        case asobi_lua_loader:call(think, [BotId, GS], LuaSt, 50) of
-            {ok, [Result | _], _} when is_map(Result) -> Result;
-            _ -> default_ai(BotId, GS)
+        case asobi_lua_loader:call(think, [BotId, EncGS], LuaSt1, 50) of
+            {ok, [Result | _], LuaSt2} ->
+                decode_result(Result, LuaSt2);
+            _ ->
+                default_ai(BotId, GS)
         end,
     asobi_match_server:handle_input(MatchPid, BotId, Input).
 
@@ -226,6 +229,18 @@ pick_random_option(Options) ->
     Idx = rand:uniform(length(Options)),
     Opt = lists:nth(Idx, Options),
     maps:get(id, Opt, maps:get(~"id", Opt, undefined)).
+
+decode_result(Result, _LuaSt) when is_map(Result) ->
+    Result;
+decode_result(Result, LuaSt) ->
+    case luerl:decode(Result, LuaSt) of
+        [{K, _} | _] = PropList when is_binary(K) ->
+            maps:from_list(PropList);
+        M when is_map(M) ->
+            M;
+        _ ->
+            #{}
+    end.
 
 %% --- Helpers ---
 

--- a/src/lua/asobi_lua_match.erl
+++ b/src/lua/asobi_lua_match.erl
@@ -165,11 +165,15 @@ is_finished(GS, LuaSt) ->
     end.
 
 decode_to_map(Term, LuaSt) ->
-    case luerl:decode(Term, LuaSt) of
-        [{K, _} | _] = PropList when is_binary(K) ->
-            maps:from_list(PropList);
-        M when is_map(M) ->
-            M;
-        _ ->
-            #{}
-    end.
+    deep_decode(luerl:decode(Term, LuaSt)).
+
+deep_decode([{K, _} | _] = PropList) when is_binary(K) ->
+    maps:from_list([{Key, deep_decode(Val)} || {Key, Val} <- PropList]);
+deep_decode([{N, _} | _] = NumList) when is_integer(N) ->
+    [deep_decode(Val) || {_, Val} <- lists:sort(NumList)];
+deep_decode(M) when is_map(M) ->
+    maps:map(fun(_, V) -> deep_decode(V) end, M);
+deep_decode(L) when is_list(L) ->
+    [deep_decode(E) || E <- L];
+deep_decode(V) ->
+    V.


### PR DESCRIPTION
## Summary
- Fix bot AI crash: encode Erlang maps to Luerl table refs before passing to Lua `think()` function
- Fix shallow decode in `asobi_lua_match`: `decode_to_map` now recursively converts nested proplists to maps
- Fix bot `think()` result decoding: Luerl table refs are decoded back to Erlang maps

Without these fixes, Lua bot processes crash on first `think()` call (raw Erlang maps can't be indexed in Luerl), their `terminate` callback calls `leave`, and all bots disappear from matches. The shallow decode caused nested player data to serialize as JSON arrays instead of objects.

## Test plan
- [ ] Start a Lua-scripted match with bots enabled
- [ ] Verify bots stay alive and move/shoot correctly
- [ ] Verify `get_state` returns properly nested maps (not proplists)
- [ ] Verify client receives correct JSON structure for players, standings, boon offers