### PR TITLE
feat: Lua config loader for Docker game deployments

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,17 +33,93 @@ in a single BEAM release.
 - **Background Jobs** -- powered by [Shigoto](https://github.com/Taure/shigoto)
 - **Admin Dashboard** -- real-time LiveView console via [Arizona](https://github.com/novaframework/arizona_core)
 
-## Quick Start
+## Quick Start with Lua (Docker)
 
-### Prerequisites
+No Erlang needed. Just Lua scripts and Docker.
 
-- Erlang/OTP 27+
-- PostgreSQL 15+
-- [rebar3](https://rebar3.org)
+```bash
+mkdir my_game && cd my_game
+mkdir -p lua/bots
+```
 
-### Setup
+Write your game logic in Lua:
 
-Add asobi as a dependency:
+```lua
+-- lua/match.lua
+match_size = 2
+max_players = 4
+strategy = "fill"
+
+function init(config)
+    return { players = {} }
+end
+
+function join(player_id, state)
+    state.players[player_id] = { x = 400, y = 300, hp = 100 }
+    return state
+end
+
+function leave(player_id, state)
+    state.players[player_id] = nil
+    return state
+end
+
+function handle_input(player_id, input, state)
+    local p = state.players[player_id]
+    if not p then return state end
+    if input.right then p.x = p.x + 5 end
+    if input.left  then p.x = p.x - 5 end
+    return state
+end
+
+function tick(state)
+    return state
+end
+
+function get_state(player_id, state)
+    return { players = state.players }
+end
+```
+
+Add a `docker-compose.yml`:
+
+```yaml
+services:
+  postgres:
+    image: postgres:16
+    environment:
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: postgres
+      POSTGRES_DB: my_game_dev
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U postgres"]
+      interval: 5s
+      timeout: 5s
+      retries: 5
+
+  asobi:
+    image: ghcr.io/widgrensit/asobi:latest
+    depends_on:
+      postgres: { condition: service_healthy }
+    ports:
+      - "8080:8080"
+    volumes:
+      - ./lua:/app/game:ro
+    environment:
+      ASOBI_DB_HOST: postgres
+      ASOBI_DB_NAME: my_game_dev
+```
+
+```bash
+docker compose up -d
+```
+
+That's it. Your game backend is running with authentication, matchmaking,
+WebSocket transport, and everything else handled by Asobi.
+
+## Quick Start with Erlang
+
+For Erlang/OTP developers who want full control, add asobi as a dependency:
 
 ```erlang
 {deps, [
@@ -51,55 +127,7 @@ Add asobi as a dependency:
 ]}.
 ```
 
-Configure your `sys.config`:
-
-```erlang
-[
-    {kura, [
-        {repo, asobi_repo},
-        {host, "localhost"},
-        {database, "my_game_dev"},
-        {user, "postgres"},
-        {password, "postgres"}
-    ]},
-    {shigoto, [
-        {pool, asobi_repo}
-    ]},
-    {asobi, [
-        {plugins, [
-            {pre_request, nova_request_plugin, #{
-                decode_json_body => true,
-                parse_qs => true
-            }},
-            {pre_request, nova_cors_plugin, #{allow_origins => <<"*">>}},
-            {pre_request, nova_correlation_plugin, #{}}
-        ]},
-        {game_modes, #{
-            ~"my_mode" => my_game_module
-        }},
-        {matchmaker, #{
-            tick_interval => 1000,
-            max_wait_seconds => 60
-        }},
-        {session, #{
-            token_ttl => 900,
-            refresh_ttl => 2592000
-        }}
-    ]}
-].
-```
-
-Start the database and run:
-
-```bash
-rebar3 shell
-```
-
-Asobi runs migrations automatically on startup.
-
-## Implementing a Game
-
-Implement the `asobi_match` behaviour to define your game logic:
+Implement the `asobi_match` behaviour:
 
 ```erlang
 -module(my_arena_game).
@@ -107,35 +135,27 @@ Implement the `asobi_match` behaviour to define your game logic:
 
 -export([init/1, join/2, leave/2, handle_input/3, tick/1, get_state/2]).
 
-init(Config) ->
-    {ok, #{players => #{}, round => 1}}.
+init(_Config) ->
+    {ok, #{players => #{}}}.
 
-join(PlayerId, State) ->
-    {ok, State#{players => maps:put(PlayerId, #{score => 0}, maps:get(players, State))}}.
+join(PlayerId, #{players := Players} = State) ->
+    {ok, State#{players => Players#{PlayerId => #{x => 0, y => 0}}}}.
 
-leave(PlayerId, State) ->
-    {ok, State#{players => maps:remove(PlayerId, maps:get(players, State))}}.
+leave(PlayerId, #{players := Players} = State) ->
+    {ok, State#{players => maps:remove(PlayerId, Players)}}.
 
-handle_input(PlayerId, #{~"action" := ~"shoot"} = Input, State) ->
-    %% Process player input, update game state
+handle_input(_PlayerId, _Input, State) ->
     {ok, State}.
 
 tick(State) ->
-    %% Called every tick (default 10/sec) -- advance game simulation
     {ok, State}.
 
-get_state(PlayerId, State) ->
-    %% Return the state visible to this player
-    maps:get(players, State).
+get_state(_PlayerId, #{players := Players}) ->
+    Players.
 ```
 
-Register your game mode in config:
-
-```erlang
-{asobi, [
-    {game_modes, #{~"arena" => my_arena_game}}
-]}
-```
+Register it in `sys.config` and start with `rebar3 shell`.
+See the [Getting Started](guides/getting-started.md) guide for the full walkthrough.
 
 ## Stack
 
@@ -164,12 +184,15 @@ The BEAM VM is uniquely suited for game backends:
 
 Full documentation is available on [HexDocs](https://hexdocs.pm/asobi).
 
-- [Getting Started](guides/getting-started.md)
-- [REST API](guides/rest-api.md)
-- [WebSocket Protocol](guides/websocket-protocol.md)
-- [Matchmaking](guides/matchmaking.md)
-- [Economy](guides/economy.md)
-- [Architecture](docs/ARCHITECTURE.md)
+- [Getting Started](guides/getting-started.md) -- Lua (Docker) or Erlang setup
+- [Lua Scripting](guides/lua-scripting.md) -- write game logic in Lua
+- [Bots](guides/lua-bots.md) -- add AI-controlled players
+- [Configuration](guides/configuration.md) -- all configuration options
+- [REST API](guides/rest-api.md) -- full API reference
+- [WebSocket Protocol](guides/websocket-protocol.md) -- real-time message types
+- [Matchmaking](guides/matchmaking.md) -- query-based player matching
+- [Economy](guides/economy.md) -- wallets, items, and store
+- [Architecture](docs/ARCHITECTURE.md) -- system design
 
 ## License
 

--- a/config/prod_sys.config.src
+++ b/config/prod_sys.config.src
@@ -33,6 +33,7 @@
         {pool_size, 20}
     ]},
     {asobi, [
+        {game_dir, "/app/game"},
         {nova_apps, [nova_resilience]},
         {plugins, [
             {pre_request, nova_request_plugin, #{

--- a/guides/configuration.md
+++ b/guides/configuration.md
@@ -1,12 +1,64 @@
 # Configuration
 
-All Asobi configuration lives in your `sys.config` file under the `{asobi, [...]}` key.
+Asobi supports two configuration paths depending on how you use it.
 
-## Game Modes
+## Lua (Docker)
 
-Define one or more game modes. Each mode maps a name to a module and match settings.
+For Lua game developers using the Docker image, configuration lives in
+your Lua scripts. No Erlang syntax needed.
 
-### Erlang Module
+### Game Mode Config
+
+Declare settings as globals at the top of your match script:
+
+```lua
+-- match.lua
+match_size = 4
+max_players = 10
+strategy = "fill"
+bots = { script = "bots/arena_bot.lua" }
+```
+
+| Global | Required | Default | Description |
+|--------|----------|---------|-------------|
+| `match_size` | yes | -- | Minimum players to start a match |
+| `max_players` | no | `match_size` | Maximum players per match |
+| `strategy` | no | `"fill"` | `"fill"`, `"skill_based"`, or custom |
+| `bots` | no | none | `{ script = "path/to/bot.lua" }` |
+
+### Multiple Game Modes
+
+Add a `config.lua` manifest mapping mode names to scripts:
+
+```lua
+-- config.lua
+return {
+    arena = "arena/match.lua",
+    ctf   = "ctf/match.lua"
+}
+```
+
+### Infrastructure Config
+
+Infrastructure settings come from environment variables:
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `ASOBI_PORT` | `8080` | HTTP/WebSocket port |
+| `ASOBI_DB_HOST` | `db` | PostgreSQL host |
+| `ASOBI_DB_NAME` | `asobi` | Database name |
+| `ASOBI_DB_USER` | `postgres` | Database user |
+| `ASOBI_DB_PASSWORD` | `postgres` | Database password |
+| `ASOBI_CORS_ORIGINS` | `*` | Allowed CORS origins |
+| `ASOBI_NODE_HOST` | `127.0.0.1` | Erlang node hostname |
+| `ERLANG_COOKIE` | `asobi_cookie` | Erlang distribution cookie |
+
+## Erlang (sys.config)
+
+For Erlang OTP projects that add asobi as a dependency, all configuration
+lives in `sys.config` under the `{asobi, [...]}` key.
+
+### Game Modes
 
 ```erlang
 {game_modes, #{
@@ -19,7 +71,7 @@ Define one or more game modes. Each mode maps a name to a module and match setti
 }}
 ```
 
-### Lua Script
+Lua scripts work too:
 
 ```erlang
 {game_modes, #{
@@ -32,7 +84,7 @@ Define one or more game modes. Each mode maps a name to a module and match setti
 }}
 ```
 
-### Shorthand (Erlang only)
+Shorthand (Erlang module only):
 
 ```erlang
 {game_modes, #{
@@ -197,7 +249,7 @@ Database configuration is under the `kura` application key:
 ]}
 ```
 
-## Full Example
+## Full Example (Erlang sys.config)
 
 ```erlang
 [
@@ -236,11 +288,63 @@ Database configuration is under the `kura` application key:
                     enabled => true,
                     fill_after_ms => 8000,
                     min_players => 4,
-                    script => "game/bots/chaser.lua",
-                    names => [~"Spark", ~"Blitz", ~"Volt", ~"Neon"]
+                    script => <<"game/bots/chaser.lua">>
                 }
             }
         }}
     ]}
 ].
+```
+
+## Full Example (Lua Docker)
+
+```yaml
+# docker-compose.yml
+services:
+  postgres:
+    image: postgres:16
+    environment:
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: postgres
+      POSTGRES_DB: my_game_dev
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U postgres"]
+      interval: 5s
+      timeout: 5s
+      retries: 5
+
+  asobi:
+    image: ghcr.io/widgrensit/asobi:latest
+    depends_on:
+      postgres: { condition: service_healthy }
+    ports:
+      - "8080:8080"
+    volumes:
+      - ./lua:/app/game:ro
+    environment:
+      ASOBI_DB_HOST: postgres
+      ASOBI_DB_NAME: my_game_dev
+```
+
+```lua
+-- lua/match.lua
+match_size = 4
+max_players = 8
+strategy = "fill"
+bots = { script = "bots/chaser.lua" }
+
+function init(config)
+    return { players = {} }
+end
+
+-- ... rest of callbacks
+```
+
+```lua
+-- lua/bots/chaser.lua
+names = {"Spark", "Blitz", "Volt", "Neon"}
+
+function think(bot_id, state)
+    -- AI logic
+end
 ```

--- a/guides/getting-started.md
+++ b/guides/getting-started.md
@@ -2,15 +2,141 @@
 
 This guide walks you through setting up Asobi and creating your first game backend.
 
-## Prerequisites
+Choose your path:
+
+- **[Lua + Docker](#lua--docker)** -- write game logic in Lua, no Erlang needed
+- **[Erlang OTP](#erlang-otp)** -- add asobi as a dependency to your Erlang project
+
+## Lua + Docker
+
+The fastest way to start. You need [Docker](https://docs.docker.com/get-docker/) and nothing else.
+
+### 1. Create your project
+
+```bash
+mkdir my_game && cd my_game
+mkdir -p lua/bots
+```
+
+### 2. Write your match logic
+
+```lua
+-- lua/match.lua
+
+match_size = 2
+max_players = 4
+strategy = "fill"
+bots = { script = "bots/wanderer.lua" }
+
+function init(config)
+    return { players = {} }
+end
+
+function join(player_id, state)
+    state.players[player_id] = { x = 400, y = 300, hp = 100 }
+    return state
+end
+
+function leave(player_id, state)
+    state.players[player_id] = nil
+    return state
+end
+
+function handle_input(player_id, input, state)
+    local p = state.players[player_id]
+    if not p then return state end
+    if input.right then p.x = p.x + 5 end
+    if input.left  then p.x = p.x - 5 end
+    if input.down  then p.y = p.y + 5 end
+    if input.up    then p.y = p.y - 5 end
+    return state
+end
+
+function tick(state)
+    return state
+end
+
+function get_state(player_id, state)
+    return { players = state.players }
+end
+```
+
+### 3. Add a bot (optional)
+
+```lua
+-- lua/bots/wanderer.lua
+
+names = {"Spark", "Blitz", "Volt"}
+
+function think(bot_id, state)
+    return {
+        right = math.random(2) == 1,
+        left  = math.random(2) == 1,
+        down  = math.random(2) == 1,
+        up    = math.random(2) == 1,
+        shoot = false
+    }
+end
+```
+
+### 4. Create docker-compose.yml
+
+```yaml
+services:
+  postgres:
+    image: postgres:16
+    environment:
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: postgres
+      POSTGRES_DB: my_game_dev
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U postgres"]
+      interval: 5s
+      timeout: 5s
+      retries: 5
+
+  asobi:
+    image: ghcr.io/widgrensit/asobi:latest
+    depends_on:
+      postgres: { condition: service_healthy }
+    ports:
+      - "8080:8080"
+    volumes:
+      - ./lua:/app/game:ro
+    environment:
+      ASOBI_DB_HOST: postgres
+      ASOBI_DB_NAME: my_game_dev
+```
+
+### 5. Start it
+
+```bash
+docker compose up -d
+```
+
+Your game backend is running. Asobi reads your Lua scripts, sets up the
+database, and starts listening for WebSocket connections on port 8080.
+
+Edit your Lua files and restart to pick up changes:
+
+```bash
+docker compose restart asobi
+```
+
+See the [Lua Scripting](lua-scripting.md) guide for the full callback
+reference and advanced patterns.
+
+## Erlang OTP
+
+For Erlang developers who want full control.
+
+### Prerequisites
 
 - Erlang/OTP 27+
 - PostgreSQL 15+
 - [rebar3](https://rebar3.org)
 
-## Create a New Project
-
-Use the Nova generator to scaffold your project:
+### 1. Create a New Project
 
 ```bash
 rebar3 new nova my_game
@@ -25,7 +151,7 @@ Add asobi to your dependencies in `rebar.config`:
 ]}.
 ```
 
-## Configure the Database
+### 2. Configure the Database
 
 Create a PostgreSQL database:
 
@@ -71,10 +197,7 @@ Add configuration to your `sys.config`:
 ].
 ```
 
-Kura defaults: `host` = `"localhost"`, `port` = `5432`, `user` = `"postgres"`,
-`pool_size` = `10`.
-
-## Start the Server
+### 3. Start the Server
 
 ```bash
 rebar3 shell
@@ -154,22 +277,9 @@ Register it in your config:
 ]}
 ```
 
-## Write Game Logic in Lua
-
-Don't want to write Erlang? Use Lua instead. Create `game/match.lua` and
-configure your game mode:
-
-```erlang
-{game_modes, #{
-    ~"my_mode" => #{module => {lua, "game/match.lua"}, match_size => 2}
-}}
-```
-
-See the [Lua Scripting](lua-scripting.md) guide for the full walkthrough.
-
 ## Next Steps
 
-- [Lua Scripting](lua-scripting.md) -- write game logic in Lua
+- [Lua Scripting](lua-scripting.md) -- write game logic in Lua (Docker or Erlang)
 - [Bots](lua-bots.md) -- add AI-controlled players
 - [Configuration](configuration.md) -- all configuration options
 - [REST API](rest-api.md) -- full API reference

--- a/guides/lua-bots.md
+++ b/guides/lua-bots.md
@@ -14,34 +14,59 @@ AI logic runs in the same tick loop as the game.
 
 ## Configuration
 
-Enable bots per game mode in your `sys.config`:
+### Lua (Docker)
 
-```erlang
-{asobi, [
-    {game_modes, #{
-        ~"arena" => #{
-            module => {lua, "game/match.lua"},
-            match_size => 4,
-            max_players => 8,
-            bots => #{
-                enabled => true,
-                fill_after_ms => 8000,
-                min_players => 4,
-                script => "game/bots/chaser.lua",
-                names => [~"Spark", ~"Blitz", ~"Volt", ~"Neon", ~"Pulse"]
-            }
-        }
-    }}
-]}
+Enable bots by adding `bots` to your match script globals and a `names`
+list to your bot script:
+
+```lua
+-- match.lua
+match_size = 4
+max_players = 8
+strategy = "fill"
+bots = { script = "bots/chaser.lua" }
 ```
 
-| Option | Default | Description |
-|--------|---------|-------------|
-| `enabled` | `false` | Enable bot filling for this mode |
-| `fill_after_ms` | `8000` | Wait time before adding bots to queue |
-| `min_players` | `4` | Fill up to this many players with bots |
-| `script` | `undefined` | Path to Lua bot AI script |
-| `names` | `["Spark", ...]` | Display names for bots (prefixed with `bot_`) |
+```lua
+-- bots/chaser.lua
+names = {"Spark", "Blitz", "Volt", "Neon", "Pulse"}
+
+function think(bot_id, state)
+    -- AI logic here
+end
+```
+
+The platform reads `names` from your bot script at runtime. Bot names are
+prefixed with `bot_` (e.g., `bot_Spark`).
+
+Platform-level bot tuning is controlled via environment variables:
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `ASOBI_BOT_FILL_AFTER` | `8000` | Milliseconds before bots fill queue |
+| `ASOBI_BOT_MIN_PLAYERS` | `match_size` | Fill up to this many players |
+
+### Erlang (sys.config)
+
+For Erlang OTP projects, configure bots in `sys.config`:
+
+```erlang
+{game_modes, #{
+    ~"arena" => #{
+        module => {lua, "game/match.lua"},
+        match_size => 4,
+        bots => #{
+            enabled => true,
+            fill_after_ms => 8000,
+            min_players => 4,
+            script => <<"game/bots/chaser.lua">>
+        }
+    }
+}}
+```
+
+Bot names are read from the bot script's `names` global. If not defined,
+defaults to `["Spark", "Blitz", "Volt", "Neon", "Pulse"]`.
 
 ## Writing a Bot AI Script
 

--- a/guides/lua-scripting.md
+++ b/guides/lua-scripting.md
@@ -5,23 +5,26 @@ inside the BEAM via [Luerl](https://github.com/rvirding/luerl), giving you
 the fault tolerance and concurrency of OTP with a language game developers
 already know.
 
-## Quick Start
+No Erlang knowledge required. No compilation step. Just Lua files and Docker.
 
-Create a `game/` directory with your match script:
+## Quick Start with Docker
 
-```
-my_game/
-├── game/
-│   └── match.lua
-├── rebar.config
-└── config/
-    └── dev_sys.config.src
+The fastest way to get started -- no Erlang toolchain needed:
+
+```bash
+mkdir my_game && cd my_game
+mkdir -p lua/bots
 ```
 
-Write your match logic:
+Create your match script:
 
 ```lua
--- game/match.lua
+-- lua/match.lua
+
+-- Game mode config
+match_size = 2
+max_players = 8
+strategy = "fill"
 
 function init(config)
     return {
@@ -68,7 +71,96 @@ function get_state(player_id, state)
 end
 ```
 
-Configure your game mode to use the Lua script:
+Create a `docker-compose.yml`:
+
+```yaml
+services:
+  postgres:
+    image: postgres:16
+    environment:
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: postgres
+      POSTGRES_DB: my_game_dev
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U postgres"]
+      interval: 5s
+      timeout: 5s
+      retries: 5
+
+  asobi:
+    image: ghcr.io/widgrensit/asobi:latest
+    depends_on:
+      postgres: { condition: service_healthy }
+    ports:
+      - "8080:8080"
+    volumes:
+      - ./lua:/app/game:ro
+    environment:
+      ASOBI_DB_HOST: postgres
+      ASOBI_DB_NAME: my_game_dev
+```
+
+Start it:
+
+```bash
+docker compose up -d
+```
+
+That's it. Your game is running. Asobi reads your Lua scripts from the
+mounted volume, discovers the game mode from `match.lua`, and handles
+everything else -- database, authentication, matchmaking, WebSockets.
+
+### Multiple Game Modes
+
+For games with more than one mode, add a `config.lua` manifest:
+
+```lua
+-- lua/config.lua
+return {
+    arena = "arena/match.lua",
+    ctf   = "ctf/match.lua"
+}
+```
+
+```
+my_game/
+├── lua/
+│   ├── config.lua
+│   ├── arena/
+│   │   └── match.lua
+│   └── ctf/
+│       └── match.lua
+└── docker-compose.yml
+```
+
+Each match script declares its own config as globals. When `config.lua`
+exists, Asobi reads it instead of looking for a top-level `match.lua`.
+When there is no `config.lua`, a single `match.lua` is loaded as the
+`"default"` game mode.
+
+## Match Script Globals
+
+Declare your game mode settings as globals at the top of your match script.
+Asobi reads these at startup before calling any callbacks.
+
+```lua
+match_size   = 4                          -- required: min players to start
+max_players  = 10                         -- optional: max per match (defaults to match_size)
+strategy     = "fill"                     -- optional: "fill" or "skill_based"
+bots         = { script = "bots/ai.lua" } -- optional: enable bot filling
+```
+
+| Global | Required | Default | Description |
+|--------|----------|---------|-------------|
+| `match_size` | yes | -- | Minimum players needed to start a match |
+| `max_players` | no | `match_size` | Maximum players per match |
+| `strategy` | no | `"fill"` | Matchmaking strategy |
+| `bots` | no | none | Bot configuration (see [Bots](lua-bots.md)) |
+
+## Using with Erlang Projects
+
+If you're building an Erlang OTP application that depends on asobi,
+configure Lua game modes in your `sys.config` instead:
 
 ```erlang
 {asobi, [
@@ -82,7 +174,8 @@ Configure your game mode to use the Lua script:
 ]}
 ```
 
-Start the server and your Lua match logic runs inside the BEAM.
+The Lua config loader only runs when a game directory with scripts exists.
+Erlang projects with their own `sys.config` are completely unaffected.
 
 ## Callbacks
 

--- a/src/asobi_app.erl
+++ b/src/asobi_app.erl
@@ -11,6 +11,13 @@ start(_StartType, _StartArgs) ->
         {error, MigErr} ->
             logger:error(#{msg => ~"migration_failed", error => MigErr})
     end,
+    case asobi_config:maybe_load_game_config() of
+        ok ->
+            ok;
+        {error, ConfigErr} ->
+            logger:error(#{msg => ~"game_config_failed", error => ConfigErr}),
+            error({game_config_failed, ConfigErr})
+    end,
     case asobi_sup:start_link() of
         {ok, Pid} -> {ok, Pid};
         ignore -> {error, supervisor_ignored};

--- a/src/asobi_config.erl
+++ b/src/asobi_config.erl
@@ -1,0 +1,263 @@
+-module(asobi_config).
+-moduledoc """
+Loads game configuration from Lua files in the game directory.
+
+Supports two modes:
+
+1. **Single mode** — a `match.lua` in the game directory. The script declares
+   its config as globals (`match_size`, `max_players`, `strategy`, `bots`).
+   The mode name defaults to `"default"`.
+
+2. **Multi-mode** — a `config.lua` that returns a table mapping mode names to
+   script paths:
+
+   ```lua
+   return {
+       arena = "arena/match.lua",
+       ctf   = "ctf/match.lua"
+   }
+   ```
+
+   Each match script declares its own config as globals.
+
+If neither file exists, the loader is a no-op (Erlang OTP projects that
+configure via `sys.config` are unaffected).
+
+## Match script globals
+
+```lua
+match_size   = 4                          -- required, positive integer
+max_players  = 10                         -- optional, defaults to match_size
+strategy     = "fill"                     -- optional, "fill" | "skill_based"
+bots         = { script = "bots/ai.lua" } -- optional
+```
+
+Bot scripts can export a `names` list that the platform reads after loading:
+
+```lua
+names = {"Spark", "Blitz", "Volt"}
+```
+""".
+
+-export([maybe_load_game_config/0]).
+
+-spec maybe_load_game_config() -> ok | {error, term()}.
+maybe_load_game_config() ->
+    GameDir = application:get_env(asobi, game_dir, ~"/app/game"),
+    GameDirStr = to_string(GameDir),
+    ConfigPath = filename:join(GameDirStr, "config.lua"),
+    MatchPath = filename:join(GameDirStr, "match.lua"),
+    case {filelib:is_regular(ConfigPath), filelib:is_regular(MatchPath)} of
+        {true, _} ->
+            load_multi_mode(GameDirStr, ConfigPath);
+        {false, true} ->
+            load_single_mode(GameDirStr, MatchPath);
+        {false, false} ->
+            ok
+    end.
+
+%% --- Multi-mode: config.lua maps mode names to script paths ---
+
+load_multi_mode(GameDir, ConfigPath) ->
+    St0 = luerl:init(),
+    case do_file(ConfigPath, St0) of
+        {ok, [Table | _], St1} ->
+            Decoded = luerl:decode(Table, St1),
+            case build_modes_from_manifest(GameDir, Decoded) of
+                {ok, Modes} ->
+                    apply_game_modes(Modes);
+                {error, _} = Err ->
+                    Err
+            end;
+        {ok, [], _} ->
+            {error, {config_error, ~"config.lua must return a table"}};
+        {error, Reason} ->
+            {error, {config_error, Reason}}
+    end.
+
+build_modes_from_manifest(GameDir, PropList) when is_list(PropList) ->
+    Results = lists:map(
+        fun
+            ({ModeName, ScriptRel}) when is_binary(ModeName), is_binary(ScriptRel) ->
+                ScriptAbs = filename:join(GameDir, binary_to_list(ScriptRel)),
+                case load_match_config(ScriptAbs) of
+                    {ok, ModeConfig} ->
+                        {ok, {ModeName, ModeConfig}};
+                    {error, Reason} ->
+                        {error, {ModeName, Reason}}
+                end;
+            ({ModeName, _}) ->
+                {error, {ModeName, ~"value must be a script path string"}}
+        end,
+        PropList
+    ),
+    case collect_results(Results) of
+        {ok, Pairs} ->
+            {ok, maps:from_list(Pairs)};
+        {error, _} = Err ->
+            Err
+    end;
+build_modes_from_manifest(_, _) ->
+    {error, {config_error, ~"config.lua must return a table of mode_name = \"script.lua\""}}.
+
+%% --- Single-mode: just match.lua in the game dir ---
+
+load_single_mode(_GameDir, MatchPath) ->
+    case load_match_config(MatchPath) of
+        {ok, ModeConfig} ->
+            Modes = #{~"default" => ModeConfig},
+            apply_game_modes(Modes);
+        {error, _} = Err ->
+            Err
+    end.
+
+%% --- Load a match script and read its config globals ---
+
+load_match_config(ScriptPath) ->
+    case asobi_lua_loader:new(ScriptPath) of
+        {ok, St} ->
+            read_match_globals(ScriptPath, St);
+        {error, Reason} ->
+            {error, {script_load_failed, ScriptPath, Reason}}
+    end.
+
+read_match_globals(ScriptPath, St) ->
+    MatchSize = read_global_int(~"match_size", St),
+    MaxPlayers = read_global_int(~"max_players", St),
+    Strategy = read_global_string(~"strategy", St),
+    Bots = read_global_table(~"bots", St),
+    case MatchSize of
+        undefined ->
+            {error, {ScriptPath, ~"match_size global is required"}};
+        N when is_integer(N), N > 0 ->
+            Config0 = #{
+                module => {lua, ScriptPath},
+                match_size => N,
+                max_players =>
+                    case MaxPlayers of
+                        MP when is_integer(MP), MP > 0 -> MP;
+                        _ -> N
+                    end
+            },
+            Config1 = maybe_add_strategy(Config0, Strategy),
+            Config2 = maybe_add_bots(Config1, Bots, ScriptPath),
+            {ok, Config2};
+        _ ->
+            {error, {ScriptPath, ~"match_size must be a positive integer"}}
+    end.
+
+maybe_add_strategy(Config, undefined) ->
+    Config;
+maybe_add_strategy(Config, Strategy) ->
+    case Strategy of
+        ~"fill" -> Config#{strategy => fill};
+        ~"skill_based" -> Config#{strategy => skill_based};
+        Other -> Config#{strategy => Other}
+    end.
+
+maybe_add_bots(Config, undefined, _ScriptPath) ->
+    Config;
+maybe_add_bots(Config, BotProps, ScriptPath) when is_list(BotProps) ->
+    BaseDir = filename:dirname(to_string(ScriptPath)),
+    case proplists:get_value(~"script", BotProps) of
+        undefined ->
+            Config;
+        BotScript when is_binary(BotScript) ->
+            AbsBot = filename:join(BaseDir, binary_to_list(BotScript)),
+            Config#{
+                bots => #{
+                    enabled => true,
+                    script => unicode:characters_to_binary(AbsBot)
+                }
+            }
+    end;
+maybe_add_bots(Config, _, _) ->
+    Config.
+
+%% --- Apply to app env ---
+
+apply_game_modes(Modes) ->
+    Existing =
+        case application:get_env(asobi, game_modes, #{}) of
+            M when is_map(M) -> M;
+            _ -> #{}
+        end,
+    Merged = maps:merge(Existing, Modes),
+    application:set_env(asobi, game_modes, Merged),
+    logger:notice(#{
+        msg => ~"lua game config loaded",
+        modes => maps:keys(Merged)
+    }),
+    ok.
+
+%% --- Lua helpers ---
+
+do_file(Path, St) ->
+    case file:read_file(Path) of
+        {ok, Code} ->
+            CodeStr = binary_to_list(Code),
+            try luerl:do(CodeStr, St) of
+                {ok, Results, St1} -> {ok, Results, St1};
+                {error, Errors, _St1} -> {error, {lua_error, Errors}};
+                {lua_error, Reason, _St1} -> {error, {lua_error, Reason}}
+            catch
+                error:{lua_error, Reason, _} -> {error, {lua_error, Reason}};
+                error:Reason -> {error, Reason}
+            end;
+        {error, Reason} ->
+            {error, {file_error, Path, Reason}}
+    end.
+
+read_global_int(Name, St) ->
+    case luerl:get_table_keys([Name], St) of
+        {ok, Val, _} when is_number(Val) -> trunc(Val);
+        _ -> undefined
+    end.
+
+read_global_string(Name, St) ->
+    case luerl:get_table_keys([Name], St) of
+        {ok, Val, _} when is_binary(Val) -> Val;
+        _ -> undefined
+    end.
+
+read_global_table(Name, St) ->
+    case luerl:get_table_keys([Name], St) of
+        {ok, Val, St1} when Val =/= nil, Val =/= false ->
+            case luerl:decode(Val, St1) of
+                Props when is_list(Props) -> Props;
+                _ -> undefined
+            end;
+        _ ->
+            undefined
+    end.
+
+%% --- Utilities ---
+
+collect_results(Results) ->
+    {Oks, Errs} = lists:partition(
+        fun
+            ({ok, _}) -> true;
+            (_) -> false
+        end,
+        Results
+    ),
+    case Errs of
+        [] ->
+            {ok, [V || {ok, V} <- Oks]};
+        _ ->
+            ErrDetails = [{N, R} || {error, {N, R}} <- Errs],
+            lists:foreach(
+                fun({Name, Reason}) ->
+                    logger:error(#{
+                        msg => ~"game mode config error",
+                        mode => Name,
+                        reason => Reason
+                    })
+                end,
+                ErrDetails
+            ),
+            {error, {config_errors, ErrDetails}}
+    end.
+
+to_string(B) when is_binary(B) -> binary_to_list(B);
+to_string(L) when is_list(L) -> L.

--- a/src/bots/asobi_bot_spawner.erl
+++ b/src/bots/asobi_bot_spawner.erl
@@ -3,21 +3,8 @@
 Watches the matchmaker queue and fills with bots when players are waiting.
 Also starts bot AI processes when bots join matches.
 
-Configuration per game mode:
-```erlang
-#{
-    ~"arena" => #{
-        module => {lua, "priv/lua/match.lua"},
-        bots => #{
-            enabled => true,
-            fill_after_ms => 8000,
-            min_players => 4,
-            script => "priv/lua/bots/chaser.lua",
-            names => [~"Spark", ~"Blitz", ~"Volt", ~"Neon", ~"Pulse"]
-        }
-    }
-}
-```
+Bot names are read from the bot script's `names` global. If not defined,
+falls back to default generated names.
 """.
 
 -behaviour(gen_server).
@@ -74,7 +61,7 @@ fill_mode(Mode, Count) when is_binary(Mode), Count > 0 ->
             MinPlayers = maps:get(min_players, BotConfig, 4),
             case Count < MinPlayers of
                 true ->
-                    Names = maps:get(names, BotConfig, default_names()),
+                    Names = load_bot_names(BotConfig),
                     BotsNeeded = MinPlayers - Count,
                     lists:foreach(
                         fun(N) ->
@@ -141,6 +128,28 @@ start_bots_for_match(MatchId) ->
     end.
 
 %% --- Config Helpers ---
+
+load_bot_names(#{names := Names}) when is_list(Names) ->
+    Names;
+load_bot_names(#{script := Script}) when is_binary(Script); is_list(Script) ->
+    case asobi_lua_loader:new(Script) of
+        {ok, St} ->
+            case luerl:get_table_keys([~"names"], St) of
+                {ok, Val, St1} when Val =/= nil, Val =/= false ->
+                    case luerl:decode(Val, St1) of
+                        Props when is_list(Props) ->
+                            [V || {_, V} <- Props, is_binary(V)];
+                        _ ->
+                            default_names()
+                    end;
+                _ ->
+                    default_names()
+            end;
+        {error, _} ->
+            default_names()
+    end;
+load_bot_names(_) ->
+    default_names().
 
 bot_config(Mode) ->
     Modes =

--- a/test/asobi_config_tests.erl
+++ b/test/asobi_config_tests.erl
@@ -1,0 +1,123 @@
+-module(asobi_config_tests).
+-include_lib("eunit/include/eunit.hrl").
+
+fixture(Name) ->
+    filename:absname(
+        filename:join([code:lib_dir(asobi), "test", "fixtures", "lua", Name])
+    ).
+
+fixture_dir() ->
+    filename:absname(
+        filename:join([code:lib_dir(asobi), "test", "fixtures", "lua"])
+    ).
+
+%% --- Tests ---
+
+config_test_() ->
+    {foreach, fun() -> application:set_env(asobi, game_modes, #{}) end,
+        fun(_) -> application:set_env(asobi, game_modes, #{}) end, [
+            {"single mode: loads match.lua globals", fun single_mode_loads_globals/0},
+            {"single mode: minimal config (only match_size)", fun single_mode_minimal/0},
+            {"single mode: missing match_size fails", fun single_mode_missing_size/0},
+            {"multi mode: loads config.lua manifest", fun multi_mode_manifest/0},
+            {"no config files: no-op", fun no_config_noop/0},
+            {"bot names: reads from bot script", fun bot_names_from_script/0},
+            {"bot names: falls back to defaults", fun bot_names_fallback/0}
+        ]}.
+
+single_mode_loads_globals() ->
+    application:set_env(asobi, game_dir, fixture_dir()),
+    %% Rename config_match.lua content expectations:
+    %% match_size=4, max_players=10, strategy=fill, bots with script
+    ok = asobi_config:maybe_load_game_config(),
+    {ok, Modes} = application:get_env(asobi, game_modes),
+    ?assert(is_map_key(~"default", Modes)),
+    Mode = maps:get(~"default", Modes),
+    ?assertMatch(#{module := {lua, _}, match_size := 4, max_players := 10, strategy := fill}, Mode),
+    #{bots := #{enabled := true, script := BotScript}} = Mode,
+    ?assert(is_binary(BotScript)).
+
+single_mode_minimal() ->
+    %% Point game_dir to a temp dir with only config_minimal.lua renamed to match.lua
+    TmpDir = make_temp_dir(),
+    {ok, Content} = file:read_file(fixture("config_minimal.lua")),
+    ok = file:write_file(filename:join(TmpDir, "match.lua"), Content),
+    application:set_env(asobi, game_dir, TmpDir),
+    ok = asobi_config:maybe_load_game_config(),
+    {ok, Modes} = application:get_env(asobi, game_modes),
+    Mode = maps:get(~"default", Modes),
+    ?assertEqual(2, maps:get(match_size, Mode)),
+    ?assertEqual(2, maps:get(max_players, Mode)),
+    cleanup_temp_dir(TmpDir).
+
+single_mode_missing_size() ->
+    TmpDir = make_temp_dir(),
+    {ok, Content} = file:read_file(fixture("config_no_size.lua")),
+    ok = file:write_file(filename:join(TmpDir, "match.lua"), Content),
+    application:set_env(asobi, game_dir, TmpDir),
+    {error, _} = asobi_config:maybe_load_game_config(),
+    cleanup_temp_dir(TmpDir).
+
+multi_mode_manifest() ->
+    TmpDir = make_temp_dir(),
+    %% Copy config.lua manifest and the match scripts it references
+    {ok, Manifest} = file:read_file(fixture("config_manifest.lua")),
+    ok = file:write_file(filename:join(TmpDir, "config.lua"), Manifest),
+    {ok, Match} = file:read_file(fixture("config_match.lua")),
+    ok = file:write_file(filename:join(TmpDir, "config_match.lua"), Match),
+    {ok, Minimal} = file:read_file(fixture("config_minimal.lua")),
+    ok = file:write_file(filename:join(TmpDir, "config_minimal.lua"), Minimal),
+    %% Copy boons.lua (required by config_match.lua)
+    {ok, Boons} = file:read_file(fixture("boons.lua")),
+    ok = file:write_file(filename:join(TmpDir, "boons.lua"), Boons),
+    %% Copy bots dir
+    ok = file:make_dir(filename:join(TmpDir, "bots")),
+    {ok, Chaser} = file:read_file(fixture("bots/chaser.lua")),
+    ok = file:write_file(filename:join(TmpDir, "bots/chaser.lua"), Chaser),
+
+    application:set_env(asobi, game_dir, TmpDir),
+    ok = asobi_config:maybe_load_game_config(),
+    {ok, Modes} = application:get_env(asobi, game_modes),
+    ?assert(is_map_key(~"arena", Modes)),
+    ?assert(is_map_key(~"minimal", Modes)),
+    Arena = maps:get(~"arena", Modes),
+    ?assertEqual(4, maps:get(match_size, Arena)),
+    ?assertEqual(10, maps:get(max_players, Arena)),
+    Minimal2 = maps:get(~"minimal", Modes),
+    ?assertEqual(2, maps:get(match_size, Minimal2)),
+    cleanup_temp_dir(TmpDir).
+
+no_config_noop() ->
+    TmpDir = make_temp_dir(),
+    application:set_env(asobi, game_dir, TmpDir),
+    application:set_env(asobi, game_modes, #{~"existing" => #{module => my_mod}}),
+    ok = asobi_config:maybe_load_game_config(),
+    {ok, Modes} = application:get_env(asobi, game_modes),
+    ?assert(is_map_key(~"existing", Modes)),
+    cleanup_temp_dir(TmpDir).
+
+bot_names_from_script() ->
+    {ok, St} = asobi_lua_loader:new(fixture("bots/named_bot.lua")),
+    {ok, Val, St1} = luerl:get_table_keys([~"names"], St),
+    Names = luerl:decode(Val, St1),
+    NameList = [V || {_, V} <- Names, is_binary(V)],
+    ?assertEqual([~"Spark", ~"Blitz", ~"Volt", ~"Neon", ~"Pulse"], NameList).
+
+bot_names_fallback() ->
+    {ok, St} = asobi_lua_loader:new(fixture("bots/chaser.lua")),
+    case luerl:get_table_keys([~"names"], St) of
+        {ok, nil, _} -> ok;
+        {ok, false, _} -> ok;
+        _ -> ?assert(false)
+    end.
+
+%% --- Helpers ---
+
+make_temp_dir() ->
+    TmpDir = "/tmp/asobi_config_test_" ++ integer_to_list(erlang:unique_integer([positive])),
+    ok = filelib:ensure_dir(filename:join(TmpDir, "dummy")),
+    TmpDir.
+
+cleanup_temp_dir(Dir) ->
+    os:cmd("rm -rf " ++ Dir),
+    ok.

--- a/test/fixtures/lua/bots/named_bot.lua
+++ b/test/fixtures/lua/bots/named_bot.lua
@@ -1,0 +1,8 @@
+names = {"Spark", "Blitz", "Volt", "Neon", "Pulse"}
+
+function think(bot_id, state)
+    return {
+        right = true,
+        shoot = false
+    }
+end

--- a/test/fixtures/lua/config_manifest.lua
+++ b/test/fixtures/lua/config_manifest.lua
@@ -1,0 +1,4 @@
+return {
+    arena = "config_match.lua",
+    minimal = "config_minimal.lua"
+}

--- a/test/fixtures/lua/config_match.lua
+++ b/test/fixtures/lua/config_match.lua
@@ -1,0 +1,37 @@
+-- Match script with config globals for asobi_config tests
+local boons = require("boons")
+
+match_size = 4
+max_players = 10
+strategy = "fill"
+bots = { script = "bots/chaser.lua" }
+
+function init(config)
+    return {
+        players = {},
+        tick_count = 0
+    }
+end
+
+function join(player_id, state)
+    state.players[player_id] = { x = 100, y = 100, hp = 100 }
+    return state
+end
+
+function leave(player_id, state)
+    state.players[player_id] = nil
+    return state
+end
+
+function handle_input(player_id, input, state)
+    return state
+end
+
+function tick(state)
+    state.tick_count = (state.tick_count or 0) + 1
+    return state
+end
+
+function get_state(player_id, state)
+    return state
+end

--- a/test/fixtures/lua/config_minimal.lua
+++ b/test/fixtures/lua/config_minimal.lua
@@ -1,0 +1,9 @@
+-- Minimal match script with only required globals
+match_size = 2
+
+function init(config) return { players = {} } end
+function join(player_id, state) return state end
+function leave(player_id, state) return state end
+function handle_input(player_id, input, state) return state end
+function tick(state) return state end
+function get_state(player_id, state) return state end

--- a/test/fixtures/lua/config_no_size.lua
+++ b/test/fixtures/lua/config_no_size.lua
@@ -1,0 +1,9 @@
+-- Match script missing required match_size global
+strategy = "fill"
+
+function init(config) return {} end
+function join(player_id, state) return state end
+function leave(player_id, state) return state end
+function handle_input(player_id, input, state) return state end
+function tick(state) return state end
+function get_state(player_id, state) return state end

--- a/test/fixtures/lua/match.lua
+++ b/test/fixtures/lua/match.lua
@@ -1,0 +1,37 @@
+-- Default match.lua for single-mode config tests
+local boons = require("boons")
+
+match_size = 4
+max_players = 10
+strategy = "fill"
+bots = { script = "bots/chaser.lua" }
+
+function init(config)
+    return {
+        players = {},
+        tick_count = 0
+    }
+end
+
+function join(player_id, state)
+    state.players[player_id] = { x = 100, y = 100, hp = 100 }
+    return state
+end
+
+function leave(player_id, state)
+    state.players[player_id] = nil
+    return state
+end
+
+function handle_input(player_id, input, state)
+    return state
+end
+
+function tick(state)
+    state.tick_count = (state.tick_count or 0) + 1
+    return state
+end
+
+function get_state(player_id, state)
+    return state
+end


### PR DESCRIPTION
## Summary

- Add `asobi_config` module that loads game configuration from Lua scripts at startup
- Match scripts declare config as globals (`match_size`, `max_players`, `strategy`, `bots`)
- Bot scripts export their own `names` list
- Supports single-mode (`match.lua`) and multi-mode (`config.lua` manifest)
- No-op when no game directory exists — Erlang OTP projects unaffected
- Rewrite docs: Lua/Docker as the primary getting-started path

Lua game developers no longer need to write or understand Erlang `sys.config` syntax. They mount a `lua/` directory into the Docker container and everything is configured in Lua.

### Changes

- **New**: `src/asobi_config.erl` — Lua config loader, transformer, validator
- **Modified**: `src/asobi_app.erl` — call config loader before supervisor start
- **Modified**: `src/bots/asobi_bot_spawner.erl` — read bot names from Luerl state
- **Modified**: `config/prod_sys.config.src` — add `game_dir` setting
- **New**: `test/asobi_config_tests.erl` — 7 EUnit tests
- **Docs**: getting-started, lua-scripting, lua-bots, configuration, README

## Test plan

- [x] `rebar3 eunit` — 78 tests, 0 failures
- [x] `rebar3 fmt --check` — clean
- [x] `rebar3 xref` — clean
- [x] `rebar3 dialyzer` — clean
- [x] Docker image build + `asobi_arena_lua` integration test — matches start from Lua config