### PR TITLE
fix: trigger Docker build on tag push

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,8 +1,8 @@
 name: Docker
 
 on:
-  release:
-    types: [published]
+  push:
+    tags: ['v*']
   workflow_dispatch:
 
 env:


### PR DESCRIPTION
## Summary

- Change Docker workflow trigger from `release: [published]` to `push: tags: ['v*']`

The release workflow creates releases using `GITHUB_TOKEN` which does not trigger other workflows (GitHub limitation to prevent loops). Tag push events fire regardless of who created the tag.

## Test plan

- [ ] Merge, verify next release triggers Docker build