### PR TITLE
feat: poll vote_requested after each tick

### DIFF
--- a/guides/lua-scripting.md
+++ b/guides/lua-scripting.md
@@ -292,7 +292,9 @@ end
 ### `vote_requested(state)` (optional)
 
 Called after each tick. Return a vote configuration table to start a player
-vote, or `nil` to skip.
+vote, or `nil` to skip. Votes can be triggered at any point during gameplay -
+between rounds, after a boss kill, when a player levels up, or any other
+game event.
 
 ```lua
 function vote_requested(state)
@@ -311,6 +313,35 @@ function vote_requested(state)
     return nil
 end
 ```
+
+Mid-game example (roguelike ability choice):
+
+```lua
+function vote_requested(state)
+    if state.pending_vote then
+        local vote = state.pending_vote
+        state.pending_vote = nil
+        return vote
+    end
+    return nil
+end
+
+function tick(state)
+    -- Trigger a vote when party reaches XP threshold
+    if state.party_xp >= state.next_level_xp and not state.pending_vote then
+        state.pending_vote = {
+            template = "choose_ability",
+            options = random_abilities(3),
+            method = "plurality",
+            window_ms = 15000
+        }
+    end
+    return state
+end
+```
+
+The game keeps running while a vote is active. Multiple votes can run
+simultaneously.
 
 ### `vote_resolved(template, result, state)` (optional)
 

--- a/guides/voting.md
+++ b/guides/voting.md
@@ -13,7 +13,36 @@ such as path selection, item picks, event choices, and run modifiers.
 
 ## Starting a Vote
 
-Votes are started from a game mode callback or via the match server API:
+There are two ways to start a vote:
+
+### Automatic (via `vote_requested` callback)
+
+The match server polls the `vote_requested/1` callback after every tick. Return
+a vote config to start a vote, or `none`/`nil` to skip. This is the simplest
+approach and works for both Erlang and Lua game modules. Votes can be triggered
+at any point during gameplay - not just between rounds.
+
+```erlang
+vote_requested(#{phase := vote_pending} = _GameState) ->
+    {ok, #{
+        template => ~"path_choice",
+        options => [
+            #{id => ~"jungle", label => ~"Jungle Path"},
+            #{id => ~"volcano", label => ~"Volcano Path"}
+        ],
+        window_ms => 15000,
+        method => ~"plurality"
+    }};
+vote_requested(_) ->
+    none.
+```
+
+When a vote starts this way, the optional `vote_started/1` callback is called
+to let the game module update its state (e.g. change phase).
+
+### Manual (via match server API)
+
+Votes can also be started explicitly from a game mode callback:
 
 ```erlang
 %% From inside a game module callback

--- a/src/matches/asobi_match_server.erl
+++ b/src/matches/asobi_match_server.erl
@@ -493,7 +493,9 @@ maybe_start_vote(Mod, #{game_state := GS} = State) ->
             end
     end.
 
-do_start_vote(Mod, VoteConfig, #{match_id := MatchId, players := Players, game_state := GS} = State) ->
+do_start_vote(
+    Mod, VoteConfig, #{match_id := MatchId, players := Players, game_state := GS} = State
+) ->
     FullConfig = build_vote_config(VoteConfig, MatchId, Players, State),
     case asobi_vote_sup:start_vote(FullConfig) of
         {ok, VotePid} ->
@@ -522,19 +524,21 @@ merge_vote_weights(VoteConfig, PlayerIds, State) ->
     FBonus = maps:get(frustration_bonus, State, 0),
     FWeights = lists:foldl(
         fun(PId, Acc) ->
-            FVal = case maps:get(PId, Frustration, 0) of
-                N when is_number(N) -> N;
-                _ -> 0
-            end,
+            FVal =
+                case maps:get(PId, Frustration, 0) of
+                    N when is_number(N) -> N;
+                    _ -> 0
+                end,
             Acc#{PId => 1 + FVal * FBonus}
         end,
         #{},
         PlayerIds
     ),
-    BaseWeights = case maps:get(weights, VoteConfig, #{}) of
-        BW when is_map(BW) -> BW;
-        _ -> #{}
-    end,
+    BaseWeights =
+        case maps:get(weights, VoteConfig, #{}) of
+            BW when is_map(BW) -> BW;
+            _ -> #{}
+        end,
     maps:merge(FWeights, BaseWeights).
 
 notify_vote_started(Mod, GS, State) ->

--- a/src/matches/asobi_match_server.erl
+++ b/src/matches/asobi_match_server.erl
@@ -163,17 +163,21 @@ running(state_timeout, tick, #{game_module := Mod, game_state := GS, input_queue
         true ->
             case Mod:tick(GS1) of
                 {ok, GS2} ->
-                    broadcast_state(State#{game_state => GS2}),
-                    {keep_state, State#{game_state => GS2, input_queue => []}, [
-                        {state_timeout, maps:get(tick_rate, State), tick}
+                    State1 = State#{game_state => GS2, input_queue => []},
+                    State2 = maybe_start_vote(Mod, State1),
+                    broadcast_state(State2),
+                    {keep_state, State2, [
+                        {state_timeout, maps:get(tick_rate, State2), tick}
                     ]};
                 {finished, Result, GS2} ->
                     {next_state, finished, State#{game_state => GS2, result => Result}}
             end;
         false ->
-            broadcast_state(State#{game_state => GS1}),
-            {keep_state, State#{game_state => GS1, input_queue => []}, [
-                {state_timeout, maps:get(tick_rate, State), tick}
+            State1 = State#{game_state => GS1, input_queue => []},
+            State2 = maybe_start_vote(Mod, State1),
+            broadcast_state(State2),
+            {keep_state, State2, [
+                {state_timeout, maps:get(tick_rate, State2), tick}
             ]}
     end;
 running(cast, {input, PlayerId, Input}, #{input_queue := Queue} = State) ->
@@ -475,6 +479,69 @@ match_info(Status, #{match_id := MatchId, players := Players} = State) ->
         players => maps:keys(Players),
         mode => maps:get(mode, State, undefined)
     }.
+
+maybe_start_vote(Mod, #{game_state := GS} = State) ->
+    case erlang:function_exported(Mod, vote_requested, 1) of
+        false ->
+            State;
+        true ->
+            case Mod:vote_requested(GS) of
+                {ok, VoteConfig} when is_map(VoteConfig) ->
+                    do_start_vote(Mod, VoteConfig, State);
+                _ ->
+                    State
+            end
+    end.
+
+do_start_vote(Mod, VoteConfig, #{match_id := MatchId, players := Players, game_state := GS} = State) ->
+    FullConfig = build_vote_config(VoteConfig, MatchId, Players, State),
+    case asobi_vote_sup:start_vote(FullConfig) of
+        {ok, VotePid} ->
+            VoteId = maps:get(vote_id, FullConfig),
+            Active = maps:get(active_votes, State, #{}),
+            State1 = State#{active_votes => Active#{VoteId => VotePid}},
+            notify_vote_started(Mod, GS, State1);
+        {error, _} ->
+            State
+    end.
+
+build_vote_config(VoteConfig, MatchId, Players, State) ->
+    VoteId = maps:get(vote_id, VoteConfig, asobi_id:generate()),
+    PlayerIds = maps:keys(Players),
+    Weights = merge_vote_weights(VoteConfig, PlayerIds, State),
+    VoteConfig#{
+        vote_id => VoteId,
+        match_id => MatchId,
+        match_pid => self(),
+        eligible => PlayerIds,
+        weights => Weights
+    }.
+
+merge_vote_weights(VoteConfig, PlayerIds, State) ->
+    Frustration = maps:get(vote_frustration, State, #{}),
+    FBonus = maps:get(frustration_bonus, State, 0),
+    FWeights = lists:foldl(
+        fun(PId, Acc) ->
+            FVal = case maps:get(PId, Frustration, 0) of
+                N when is_number(N) -> N;
+                _ -> 0
+            end,
+            Acc#{PId => 1 + FVal * FBonus}
+        end,
+        #{},
+        PlayerIds
+    ),
+    BaseWeights = case maps:get(weights, VoteConfig, #{}) of
+        BW when is_map(BW) -> BW;
+        _ -> #{}
+    end,
+    maps:merge(FWeights, BaseWeights).
+
+notify_vote_started(Mod, GS, State) ->
+    case erlang:function_exported(Mod, vote_started, 1) of
+        true -> State#{game_state => Mod:vote_started(GS)};
+        false -> State
+    end.
 
 update_frustration(#{winner := undefined}, State) ->
     State;


### PR DESCRIPTION
## Summary
- Match server now polls `vote_requested/1` after every tick, starting votes automatically
- Refactored vote setup into `do_start_vote`, `build_vote_config`, `merge_vote_weights`, `notify_vote_started`
- Updated lua-scripting.md with mid-game vote example (roguelike ability choice)
- Updated voting.md with automatic vs manual vote starting docs

Previously `vote_requested` was defined on the `asobi_match` behaviour but never called by the match server. Votes could only be started manually via `start_vote/2`.

## Test plan
- [ ] Lua match with `vote_requested` returning a config triggers a vote
- [ ] Vote result delivered to `vote_resolved` callback
- [ ] `vote_started` callback updates game state when present
- [ ] Returning `nil`/`none` from `vote_requested` does not start a vote
- [ ] Multiple votes can run simultaneously
- [ ] Existing arena demo still works (boon pick -> vote flow)