### PR TITLE
feat: add configuration-driven chat channels for world server

### DIFF
--- a/guides/world-server.md
+++ b/guides/world-server.md
@@ -383,6 +383,70 @@ When you send `world.input`, the message is routed to the zone process
 that currently owns your player entity. You don't need to specify which
 zone -- the server tracks your position and routes automatically.
 
+## Chat Channels
+
+World chat is configuration-driven. Enable the channel types you need per
+game mode:
+
+```erlang
+{asobi, [
+    {game_modes, #{
+        ~"galaxy" => #{
+            type => world,
+            module => my_game,
+            chat => #{
+                world => true,       %% global channel for everyone in the world
+                zone => true,        %% auto-join/leave as players move between zones
+                proximity => 2       %% chat with players within N zones of you
+            }
+        }
+    }}
+]}
+```
+
+Lua equivalent:
+
+```lua
+-- In your world script globals
+chat_world     = true
+chat_zone      = true
+chat_proximity = 2
+```
+
+### Channel Types
+
+| Type | Scope | Lifecycle |
+|------|-------|-----------|
+| **World** | All players in the world instance | Join on world join, leave on world leave |
+| **Zone** | Players in the same zone cell | Auto-swap when crossing zone boundaries |
+| **Proximity** | Players within N zones | Follows your interest radius, updates on zone change |
+| **Federation** | Federation members only | Managed by the social system (works automatically) |
+
+### How It Works
+
+Chat channels use the existing `asobi_chat_channel` system. The world
+server automatically manages subscriptions:
+
+- **On join**: player is added to world chat and their spawn zone's chat
+- **On zone change**: old zone chat is left, new zone chat is joined.
+  Proximity channels diff the old and new interest areas so only the
+  delta is updated
+- **On leave**: all world/zone/proximity channels are cleaned up
+
+No extra client code needed. Chat messages arrive via the same WebSocket
+as `chat.message` events. Clients just need to know the channel IDs,
+which follow a predictable format:
+
+- World: `world:{world_id}`
+- Zone: `zone:{world_id}:{x},{y}`
+- Proximity: `prox:{world_id}:{x},{y}`
+
+### No Chat Config
+
+If you omit the `chat` key entirely, no chat channels are created. The
+world server runs without any chat overhead. Add channels later by
+updating your mode config.
+
 ## Clustering
 
 Zones are regular Erlang processes. In a multi-node cluster, they

--- a/src/world/asobi_world_chat.erl
+++ b/src/world/asobi_world_chat.erl
@@ -1,0 +1,170 @@
+-module(asobi_world_chat).
+
+%% Manages chat channel lifecycle for world instances.
+%%
+%% Chat channels are configured per game mode:
+%%
+%% ```erlang
+%% {game_modes, #{
+%%     ~"galaxy" => #{
+%%         type => world,
+%%         chat => #{
+%%             world => true,       %% global channel for all players in the world
+%%             zone => true,        %% auto-join/leave as players move between zones
+%%             proximity => 2       %% chat with players within N zones (uses interest radius)
+%%         }
+%%     }
+%% }}
+%% ```
+%%
+%% Federation chat is handled separately by the social system.
+
+-export([init/2]).
+-export([player_joined/3, player_left/3, player_zone_changed/5]).
+-export([channel_id/3]).
+
+-spec init(binary(), map()) -> map().
+init(WorldId, Config) ->
+    ChatConfig = maps:get(chat, Config, #{}),
+    #{
+        world_id => WorldId,
+        chat_config => ChatConfig
+    }.
+
+-spec player_joined(binary(), {integer(), integer()}, map()) -> ok.
+player_joined(PlayerId, ZoneCoords, #{world_id := WorldId, chat_config := ChatConfig}) ->
+    PlayerPid = find_player_pid(PlayerId),
+    case maps:get(world, ChatConfig, false) of
+        true ->
+            ChannelId = channel_id(WorldId, world, undefined),
+            asobi_chat_channel:join(ChannelId, PlayerPid);
+        false ->
+            ok
+    end,
+    join_zone_chats(PlayerId, PlayerPid, WorldId, ZoneCoords, ChatConfig),
+    ok.
+
+-spec player_left(binary(), {integer(), integer()}, map()) -> ok.
+player_left(PlayerId, ZoneCoords, #{world_id := WorldId, chat_config := ChatConfig}) ->
+    PlayerPid = find_player_pid(PlayerId),
+    case maps:get(world, ChatConfig, false) of
+        true ->
+            ChannelId = channel_id(WorldId, world, undefined),
+            asobi_chat_channel:leave(ChannelId, PlayerPid);
+        false ->
+            ok
+    end,
+    leave_zone_chats(PlayerId, PlayerPid, WorldId, ZoneCoords, ChatConfig),
+    ok.
+
+-spec player_zone_changed(
+    binary(), {integer(), integer()}, {integer(), integer()}, non_neg_integer(), map()
+) -> ok.
+player_zone_changed(
+    PlayerId, OldZoneCoords, NewZoneCoords, GridSize, #{
+        world_id := WorldId, chat_config := ChatConfig
+    }
+) ->
+    PlayerPid = find_player_pid(PlayerId),
+    case maps:get(zone, ChatConfig, false) of
+        true ->
+            OldChannelId = channel_id(WorldId, zone, OldZoneCoords),
+            NewChannelId = channel_id(WorldId, zone, NewZoneCoords),
+            asobi_chat_channel:leave(OldChannelId, PlayerPid),
+            asobi_chat_channel:join(NewChannelId, PlayerPid);
+        false ->
+            ok
+    end,
+    case maps:get(proximity, ChatConfig, false) of
+        false ->
+            ok;
+        Radius when is_integer(Radius) ->
+            OldProx = proximity_zones(OldZoneCoords, Radius, GridSize),
+            NewProx = proximity_zones(NewZoneCoords, Radius, GridSize),
+            LeaveProx = OldProx -- NewProx,
+            JoinProx = NewProx -- OldProx,
+            lists:foreach(
+                fun(Coords) ->
+                    asobi_chat_channel:leave(channel_id(WorldId, proximity, Coords), PlayerPid)
+                end,
+                LeaveProx
+            ),
+            lists:foreach(
+                fun(Coords) ->
+                    asobi_chat_channel:join(channel_id(WorldId, proximity, Coords), PlayerPid)
+                end,
+                JoinProx
+            )
+    end,
+    ok.
+
+%% --- Channel ID generation ---
+
+-spec channel_id(binary(), atom(), term()) -> binary().
+channel_id(WorldId, world, _) ->
+    iolist_to_binary([~"world:", WorldId]);
+channel_id(WorldId, zone, {X, Y}) ->
+    iolist_to_binary([~"zone:", WorldId, ~":", integer_to_binary(X), ~",", integer_to_binary(Y)]);
+channel_id(WorldId, proximity, {X, Y}) ->
+    iolist_to_binary([~"prox:", WorldId, ~":", integer_to_binary(X), ~",", integer_to_binary(Y)]).
+
+%% --- Internal ---
+
+join_zone_chats(PlayerId, PlayerPid, WorldId, ZoneCoords, ChatConfig) ->
+    case maps:get(zone, ChatConfig, false) of
+        true ->
+            asobi_chat_channel:join(channel_id(WorldId, zone, ZoneCoords), PlayerPid);
+        false ->
+            ok
+    end,
+    case maps:get(proximity, ChatConfig, false) of
+        false ->
+            ok;
+        Radius when is_integer(Radius) ->
+            GridSize = maps:get(grid_size, ChatConfig, 10),
+            Zones = proximity_zones(ZoneCoords, Radius, GridSize),
+            lists:foreach(
+                fun(Coords) ->
+                    asobi_chat_channel:join(channel_id(WorldId, proximity, Coords), PlayerPid)
+                end,
+                Zones
+            )
+    end,
+    ignore_result(PlayerId).
+
+leave_zone_chats(PlayerId, PlayerPid, WorldId, ZoneCoords, ChatConfig) ->
+    case maps:get(zone, ChatConfig, false) of
+        true ->
+            asobi_chat_channel:leave(channel_id(WorldId, zone, ZoneCoords), PlayerPid);
+        false ->
+            ok
+    end,
+    case maps:get(proximity, ChatConfig, false) of
+        false ->
+            ok;
+        Radius when is_integer(Radius) ->
+            GridSize = maps:get(grid_size, ChatConfig, 10),
+            Zones = proximity_zones(ZoneCoords, Radius, GridSize),
+            lists:foreach(
+                fun(Coords) ->
+                    asobi_chat_channel:leave(channel_id(WorldId, proximity, Coords), PlayerPid)
+                end,
+                Zones
+            )
+    end,
+    ignore_result(PlayerId).
+
+proximity_zones({ZX, ZY}, Radius, GridSize) ->
+    [
+        {X, Y}
+     || X <- lists:seq(max(0, ZX - Radius), min(GridSize - 1, ZX + Radius)),
+        Y <- lists:seq(max(0, ZY - Radius), min(GridSize - 1, ZY + Radius))
+    ].
+
+find_player_pid(PlayerId) ->
+    case pg:get_members(nova_scope, {player, PlayerId}) of
+        [Pid | _] -> Pid;
+        [] -> self()
+    end.
+
+ignore_result(_) -> ok.

--- a/src/world/asobi_world_server.erl
+++ b/src/world/asobi_world_server.erl
@@ -1,7 +1,7 @@
 -module(asobi_world_server).
 -behaviour(gen_statem).
 
--export([start_link/1, join/2, leave/2, post_tick/2, get_info/1, cancel/1]).
+-export([start_link/1, join/2, leave/2, move_player/3, post_tick/2, get_info/1, cancel/1]).
 -export([start_vote/2, cast_vote/4, use_veto/3]).
 -export([whereis/1]).
 -export([callback_mode/0, init/1, terminate/3]).
@@ -27,6 +27,10 @@ join(Pid, PlayerId) ->
 -spec leave(pid(), binary()) -> ok.
 leave(Pid, PlayerId) ->
     gen_statem:cast(Pid, {leave, PlayerId}).
+
+-spec move_player(pid(), binary(), {number(), number()}) -> ok.
+move_player(Pid, PlayerId, NewPos) ->
+    gen_statem:cast(Pid, {move_player, PlayerId, NewPos}).
 
 -spec post_tick(pid(), non_neg_integer()) -> ok.
 post_tick(Pid, TickN) ->
@@ -87,6 +91,9 @@ init(Config) ->
             false ->
                 undefined
         end,
+    ChatConfig0 = maps:get(chat, Config, #{}),
+    ChatConfig = ChatConfig0#{grid_size => GridSize},
+    ChatState = asobi_world_chat:init(WorldId, Config#{chat => ChatConfig}),
     State = #{
         world_id => WorldId,
         mode => maps:get(mode, Config, undefined),
@@ -109,6 +116,7 @@ init(Config) ->
         veto_tokens_per_player => VetoTokensPerPlayer,
         frustration_bonus => FrustrationBonus,
         active_votes => #{},
+        chat_state => ChatState,
         phase_state => PhaseState
     },
     {ok, loading, State}.
@@ -148,6 +156,8 @@ running({call, From}, {join, PlayerId}, State) ->
     handle_join(From, PlayerId, State);
 running(cast, {leave, PlayerId}, State) ->
     handle_leave(PlayerId, State);
+running(cast, {move_player, PlayerId, NewPos}, State) ->
+    handle_move(PlayerId, NewPos, State);
 running(
     cast,
     {post_tick, TickN},
@@ -298,6 +308,10 @@ handle_join(
                         veto_tokens => VetoTokens#{PlayerId => VetoCount}
                     },
                     asobi_telemetry:world_player_joined(WorldId, PlayerId),
+                    ZoneCoords = pos_to_zone(SpawnPos, maps:get(zone_size, State3)),
+                    asobi_world_chat:player_joined(
+                        PlayerId, ZoneCoords, maps:get(chat_state, State3)
+                    ),
                     State4 = notify_phase_player_joined(State3),
                     {keep_state, State4, [{reply, From, ok}]};
                 {error, Reason} ->
@@ -319,6 +333,7 @@ handle_leave(
         true ->
             asobi_telemetry:world_player_left(maps:get(world_id, State), PlayerId),
             {ok, GS1} = Mod:leave(PlayerId, GS),
+            leave_chat(PlayerId, State),
             State1 = remove_player_from_zones(PlayerId, State),
             Players1 = maps:remove(PlayerId, Players),
             case map_size(Players1) of
@@ -383,6 +398,69 @@ remove_player_from_zones(
                 InterestZones
             ),
             State#{player_zones => maps:remove(PlayerId, PlayerZones)}
+    end.
+
+handle_move(
+    PlayerId,
+    {X, Y} = NewPos,
+    #{
+        players := Players,
+        player_zones := PlayerZones,
+        zone_pids := ZonePids,
+        zone_size := ZoneSize,
+        view_radius := ViewRadius,
+        grid_size := GridSize,
+        chat_state := ChatState
+    } = State
+) ->
+    case maps:get(PlayerId, PlayerZones, undefined) of
+        undefined ->
+            keep_state_and_data;
+        #{zone := OldZoneCoords} ->
+            NewZoneCoords = pos_to_zone(NewPos, ZoneSize),
+            case OldZoneCoords =:= NewZoneCoords of
+                true ->
+                    %% Same zone — just update entity position
+                    ZonePid = maps:get(OldZoneCoords, ZonePids),
+                    asobi_zone:add_entity(ZonePid, PlayerId, #{x => X, y => Y, type => ~"player"}),
+                    Players1 = maps:update_with(
+                        PlayerId,
+                        fun(Meta) -> Meta#{position => NewPos} end,
+                        Players
+                    ),
+                    {keep_state, State#{players => Players1}};
+                false ->
+                    %% Zone crossing — full handoff
+                    State1 = remove_player_from_zones(PlayerId, State),
+                    State2 = place_player(PlayerId, NewPos, State1),
+                    asobi_world_chat:player_zone_changed(
+                        PlayerId, OldZoneCoords, NewZoneCoords, GridSize, ChatState
+                    ),
+                    Players1 = maps:update_with(
+                        PlayerId,
+                        fun(Meta) -> Meta#{position => NewPos} end,
+                        maps:get(players, State2)
+                    ),
+                    PlayerPid = find_player_pid(PlayerId),
+                    ZonePid = maps:get(NewZoneCoords, ZonePids),
+                    PlayerPid ! {asobi_message, {world_zone_changed, ZonePid}},
+                    NewInterest = interest_zones(NewZoneCoords, ViewRadius, GridSize),
+                    PZ = maps:get(player_zones, State2),
+                    {keep_state, State2#{
+                        players => Players1,
+                        player_zones => PZ#{
+                            PlayerId => #{zone => NewZoneCoords, interest => NewInterest}
+                        }
+                    }}
+            end
+    end.
+
+leave_chat(PlayerId, #{player_zones := PlayerZones, chat_state := ChatState}) ->
+    case maps:get(PlayerId, PlayerZones, undefined) of
+        undefined ->
+            ok;
+        #{zone := ZoneCoords} ->
+            asobi_world_chat:player_left(PlayerId, ZoneCoords, ChatState)
     end.
 
 %% --- Internal: Spatial ---

--- a/test/asobi_world_chat_tests.erl
+++ b/test/asobi_world_chat_tests.erl
@@ -1,0 +1,139 @@
+-module(asobi_world_chat_tests).
+-include_lib("eunit/include/eunit.hrl").
+
+channel_id_test_() ->
+    [
+        {"world channel id", fun() ->
+            ?assertEqual(
+                ~"world:w1",
+                asobi_world_chat:channel_id(~"w1", world, undefined)
+            )
+        end},
+        {"zone channel id", fun() ->
+            ?assertEqual(
+                ~"zone:w1:3,5",
+                asobi_world_chat:channel_id(~"w1", zone, {3, 5})
+            )
+        end},
+        {"proximity channel id", fun() ->
+            ?assertEqual(
+                ~"prox:w1:0,0",
+                asobi_world_chat:channel_id(~"w1", proximity, {0, 0})
+            )
+        end}
+    ].
+
+init_test_() ->
+    [
+        {"init returns chat state with config", fun() ->
+            Config = #{chat => #{world => true, zone => true}},
+            State = asobi_world_chat:init(~"w1", Config),
+            ?assertEqual(~"w1", maps:get(world_id, State)),
+            ChatConfig = maps:get(chat_config, State),
+            ?assertEqual(true, maps:get(world, ChatConfig)),
+            ?assertEqual(true, maps:get(zone, ChatConfig))
+        end},
+        {"init with empty config", fun() ->
+            State = asobi_world_chat:init(~"w1", #{}),
+            ?assertEqual(#{}, maps:get(chat_config, State))
+        end}
+    ].
+
+integration_test_() ->
+    {setup, fun setup/0, fun cleanup/1, [
+        {"player join creates world chat channel", fun join_world_chat/0},
+        {"player join creates zone chat channel", fun join_zone_chat/0},
+        {"player leave cleans up channels", fun leave_cleans_up/0},
+        {"zone change swaps zone chat", fun zone_change_swaps_chat/0},
+        {"proximity chat subscribes to nearby zones", fun proximity_chat/0},
+        {"no chat config means no channels", fun no_chat_config/0}
+    ]}.
+
+setup() ->
+    case whereis(nova_scope) of
+        undefined -> pg:start_link(nova_scope);
+        _ -> ok
+    end,
+    case whereis(asobi_chat_sup) of
+        undefined ->
+            {ok, Pid} = asobi_chat_sup:start_link(),
+            unlink(Pid);
+        _ ->
+            ok
+    end,
+    meck:new(asobi_repo, [no_link]),
+    meck:expect(asobi_repo, insert, fun(_CS) -> {ok, #{}} end),
+    ok.
+
+cleanup(_) ->
+    meck:unload(asobi_repo),
+    ok.
+
+register_player() ->
+    pg:join(nova_scope, {player, ~"p1"}, self()).
+
+unregister_player() ->
+    pg:leave(nova_scope, {player, ~"p1"}, self()).
+
+join_world_chat() ->
+    register_player(),
+    ChatState = asobi_world_chat:init(~"wc1", #{chat => #{world => true}}),
+    asobi_world_chat:player_joined(~"p1", {0, 0}, ChatState),
+    ChannelId = asobi_world_chat:channel_id(~"wc1", world, undefined),
+    Members = pg:get_members(nova_scope, {chat, ChannelId}),
+    ?assert(lists:member(self(), Members)),
+    unregister_player().
+
+join_zone_chat() ->
+    register_player(),
+    ChatState = asobi_world_chat:init(~"wc2", #{chat => #{zone => true}}),
+    asobi_world_chat:player_joined(~"p1", {2, 3}, ChatState),
+    ChannelId = asobi_world_chat:channel_id(~"wc2", zone, {2, 3}),
+    Members = pg:get_members(nova_scope, {chat, ChannelId}),
+    ?assert(lists:member(self(), Members)),
+    unregister_player().
+
+leave_cleans_up() ->
+    register_player(),
+    ChatState = asobi_world_chat:init(~"wc3", #{chat => #{world => true, zone => true}}),
+    asobi_world_chat:player_joined(~"p1", {1, 1}, ChatState),
+    asobi_world_chat:player_left(~"p1", {1, 1}, ChatState),
+    WorldChannel = asobi_world_chat:channel_id(~"wc3", world, undefined),
+    ZoneChannel = asobi_world_chat:channel_id(~"wc3", zone, {1, 1}),
+    ?assertNot(lists:member(self(), pg:get_members(nova_scope, {chat, WorldChannel}))),
+    ?assertNot(lists:member(self(), pg:get_members(nova_scope, {chat, ZoneChannel}))),
+    unregister_player().
+
+zone_change_swaps_chat() ->
+    register_player(),
+    ChatState = asobi_world_chat:init(~"wc4", #{chat => #{zone => true, grid_size => 10}}),
+    asobi_world_chat:player_joined(~"p1", {1, 1}, ChatState),
+    OldChannel = asobi_world_chat:channel_id(~"wc4", zone, {1, 1}),
+    ?assert(lists:member(self(), pg:get_members(nova_scope, {chat, OldChannel}))),
+    asobi_world_chat:player_zone_changed(~"p1", {1, 1}, {2, 2}, 10, ChatState),
+    NewChannel = asobi_world_chat:channel_id(~"wc4", zone, {2, 2}),
+    ?assertNot(lists:member(self(), pg:get_members(nova_scope, {chat, OldChannel}))),
+    ?assert(lists:member(self(), pg:get_members(nova_scope, {chat, NewChannel}))),
+    unregister_player().
+
+proximity_chat() ->
+    register_player(),
+    ChatState = asobi_world_chat:init(~"wc5", #{chat => #{proximity => 1, grid_size => 5}}),
+    asobi_world_chat:player_joined(~"p1", {2, 2}, ChatState),
+    Center = asobi_world_chat:channel_id(~"wc5", proximity, {2, 2}),
+    Corner = asobi_world_chat:channel_id(~"wc5", proximity, {1, 1}),
+    Far = asobi_world_chat:channel_id(~"wc5", proximity, {4, 4}),
+    ?assert(lists:member(self(), pg:get_members(nova_scope, {chat, Center}))),
+    ?assert(lists:member(self(), pg:get_members(nova_scope, {chat, Corner}))),
+    ?assertNot(lists:member(self(), pg:get_members(nova_scope, {chat, Far}))),
+    unregister_player().
+
+no_chat_config() ->
+    register_player(),
+    ChatState = asobi_world_chat:init(~"wc6", #{}),
+    asobi_world_chat:player_joined(~"p1", {0, 0}, ChatState),
+    WorldChannel = asobi_world_chat:channel_id(~"wc6", world, undefined),
+    ZoneChannel = asobi_world_chat:channel_id(~"wc6", zone, {0, 0}),
+    ?assertNot(lists:member(self(), pg:get_members(nova_scope, {chat, WorldChannel}))),
+    ?assertNot(lists:member(self(), pg:get_members(nova_scope, {chat, ZoneChannel}))),
+    unregister_player().


### PR DESCRIPTION
## Summary

- Adds `asobi_world_chat` module for automatic chat channel lifecycle in world instances
- Three channel types: world (global), zone (per-cell, auto-swap on movement), proximity (nearby zones within configurable radius)
- Configuration-driven via `chat` key in game mode config — no chat overhead when omitted
- `move_player/3` API on world server handles zone transitions with entity handoff + chat swap
- Guide updated with full chat configuration docs

## Configuration

```erlang
{game_modes, #{
    ~"galaxy" => #{
        type => world,
        chat => #{
            world => true,
            zone => true,
            proximity => 2
        }
    }
}}
```

## Test plan

- [x] Channel ID generation (world, zone, proximity formats)
- [x] Init with and without chat config
- [x] Player join creates world and zone chat channels
- [x] Player leave cleans up all channels
- [x] Zone change swaps zone chat (leave old, join new)
- [x] Proximity chat subscribes to correct nearby zones
- [x] No chat config means no channels created
- [x] All 105 tests passing (94 existing + 11 new)
- [x] Dialyzer, xref, ELP lint, erlfmt all clean