### PR TITLE
feat: add phase system and timer primitives

### DIFF
--- a/src/matches/asobi_match.erl
+++ b/src/matches/asobi_match.erl
@@ -36,4 +36,19 @@
 -callback vote_resolved(Template :: binary(), Result :: map(), GameState :: term()) ->
     {ok, GameState1 :: term()}.
 
--optional_callbacks([tick/1, vote_requested/1, vote_resolved/3]).
+-callback phases(Config :: map()) -> [asobi_phase:phase_def()].
+
+-callback on_phase_started(PhaseName :: binary(), GameState :: term()) ->
+    {ok, GameState1 :: term()}.
+
+-callback on_phase_ended(PhaseName :: binary(), GameState :: term()) ->
+    {ok, GameState1 :: term()}.
+
+-optional_callbacks([
+    tick/1,
+    vote_requested/1,
+    vote_resolved/3,
+    phases/1,
+    on_phase_started/2,
+    on_phase_ended/2
+]).

--- a/src/matches/asobi_match_server.erl
+++ b/src/matches/asobi_match_server.erl
@@ -113,6 +113,14 @@ init(Config) ->
             {ok, GameState} = GameMod:init(GameConfig),
             VetoTokensPerPlayer = maps:get(veto_tokens_per_player, Config, 0),
             FrustrationBonus = maps:get(frustration_bonus, Config, 0.5),
+            PhaseState =
+                case erlang:function_exported(GameMod, phases, 1) of
+                    true ->
+                        Phases = GameMod:phases(GameConfig),
+                        asobi_phase:init(Phases);
+                    false ->
+                        undefined
+                end,
             State = #{
                 match_id => MatchId,
                 mode => maps:get(mode, Config, undefined),
@@ -128,7 +136,8 @@ init(Config) ->
                 vote_frustration => #{},
                 veto_tokens => #{},
                 veto_tokens_per_player => VetoTokensPerPlayer,
-                frustration_bonus => FrustrationBonus
+                frustration_bonus => FrustrationBonus,
+                phase_state => PhaseState
             },
             {ok, waiting, State}
     end.
@@ -159,26 +168,53 @@ running(enter, _OldState, #{tick_rate := TickRate, match_id := MatchId} = State)
     {keep_state_and_data, [{state_timeout, TickRate, tick}]};
 running(state_timeout, tick, #{game_module := Mod, game_state := GS, input_queue := Queue} = State) ->
     GS1 = apply_inputs(Mod, Queue, GS),
+    TickRate = maps:get(tick_rate, State),
     case erlang:function_exported(Mod, tick, 1) of
         true ->
             case Mod:tick(GS1) of
                 {ok, GS2} ->
                     State1 = State#{game_state => GS2, input_queue => []},
                     State2 = maybe_start_vote(Mod, State1),
-                    broadcast_state(State2),
-                    {keep_state, State2, [
-                        {state_timeout, maps:get(tick_rate, State2), tick}
-                    ]};
+                    State3 = tick_phases(TickRate, State2),
+                    case maps:get(phase_state, State3) of
+                        PS when is_map(PS) ->
+                            case asobi_phase:info(PS) of
+                                #{status := complete} ->
+                                    {next_state, finished, State3#{
+                                        result => #{status => ~"phases_complete"}
+                                    }};
+                                _ ->
+                                    broadcast_state(State3),
+                                    {keep_state, State3, [
+                                        {state_timeout, TickRate, tick}
+                                    ]}
+                            end;
+                        _ ->
+                            broadcast_state(State3),
+                            {keep_state, State3, [{state_timeout, TickRate, tick}]}
+                    end;
                 {finished, Result, GS2} ->
                     {next_state, finished, State#{game_state => GS2, result => Result}}
             end;
         false ->
             State1 = State#{game_state => GS1, input_queue => []},
             State2 = maybe_start_vote(Mod, State1),
-            broadcast_state(State2),
-            {keep_state, State2, [
-                {state_timeout, maps:get(tick_rate, State2), tick}
-            ]}
+            State3 = tick_phases(TickRate, State2),
+            case maps:get(phase_state, State3) of
+                PS when is_map(PS) ->
+                    case asobi_phase:info(PS) of
+                        #{status := complete} ->
+                            {next_state, finished, State3#{
+                                result => #{status => ~"phases_complete"}
+                            }};
+                        _ ->
+                            broadcast_state(State3),
+                            {keep_state, State3, [{state_timeout, TickRate, tick}]}
+                    end;
+                _ ->
+                    broadcast_state(State3),
+                    {keep_state, State3, [{state_timeout, TickRate, tick}]}
+            end
     end;
 running(cast, {input, PlayerId, Input}, #{input_queue := Queue} = State) ->
     {keep_state, State#{input_queue => [{PlayerId, Input} | Queue]}};
@@ -379,7 +415,8 @@ handle_join(
                     State1 = State#{
                         players => Players1, game_state => GS1, veto_tokens => VetoTokens1
                     },
-                    maybe_start(From, PlayerId, State1);
+                    State2 = notify_phase_player_joined(State1),
+                    maybe_start(From, PlayerId, State2);
                 {error, Reason} ->
                     {keep_state_and_data, [{reply, From, {error, Reason}}]}
             end
@@ -472,13 +509,17 @@ persist_result(#{match_id := MatchId, players := Players} = State) ->
     ok.
 
 match_info(Status, #{match_id := MatchId, players := Players} = State) ->
-    #{
+    Base = #{
         match_id => MatchId,
         status => Status,
         player_count => map_size(Players),
         players => maps:keys(Players),
         mode => maps:get(mode, State, undefined)
-    }.
+    },
+    case maps:get(phase_state, State, undefined) of
+        undefined -> Base;
+        PS -> Base#{phase => asobi_phase:info(PS)}
+    end.
 
 maybe_start_vote(Mod, #{game_state := GS} = State) ->
     case erlang:function_exported(Mod, vote_requested, 1) of
@@ -594,6 +635,55 @@ clear_state_backup(MatchId) ->
     catch
         error:badarg -> ok
     end.
+
+%% --- Internal: Phases ---
+
+tick_phases(_DeltaMs, #{phase_state := undefined} = State) ->
+    State;
+tick_phases(DeltaMs, #{phase_state := PS, game_module := Mod, game_state := GS} = State) ->
+    {Events, PS1} = asobi_phase:tick(DeltaMs, PS),
+    GS1 = handle_phase_events(Events, Mod, GS),
+    State#{phase_state => PS1, game_state => GS1}.
+
+notify_phase_player_joined(#{phase_state := undefined} = State) ->
+    State;
+notify_phase_player_joined(
+    #{
+        phase_state := PS,
+        players := Players,
+        game_module := Mod,
+        game_state := GS
+    } = State
+) ->
+    Count = map_size(Players),
+    {Events, PS1} = asobi_phase:notify({player_joined, Count}, PS),
+    GS1 = handle_phase_events(Events, Mod, GS),
+    State#{phase_state => PS1, game_state => GS1}.
+
+handle_phase_events([], _Mod, GS) ->
+    GS;
+handle_phase_events([{phase_started, Name} | Rest], Mod, GS) ->
+    GS1 =
+        case erlang:function_exported(Mod, on_phase_started, 2) of
+            true ->
+                {ok, GS2} = Mod:on_phase_started(Name, GS),
+                GS2;
+            false ->
+                GS
+        end,
+    handle_phase_events(Rest, Mod, GS1);
+handle_phase_events([{phase_ended, Name} | Rest], Mod, GS) ->
+    GS1 =
+        case erlang:function_exported(Mod, on_phase_ended, 2) of
+            true ->
+                {ok, GS2} = Mod:on_phase_ended(Name, GS),
+                GS2;
+            false ->
+                GS
+        end,
+    handle_phase_events(Rest, Mod, GS1);
+handle_phase_events([_Event | Rest], Mod, GS) ->
+    handle_phase_events(Rest, Mod, GS).
 
 generate_id() ->
     asobi_id:generate().

--- a/src/timers/asobi_phase.erl
+++ b/src/timers/asobi_phase.erl
@@ -1,0 +1,322 @@
+-module(asobi_phase).
+
+%% Phase engine for match and world servers.
+%%
+%% A phase list describes the lifecycle of a game session. Each phase
+%% has a duration, optional start conditions, and optional timers that
+%% are active during that phase. The engine is pure functional — the
+%% owning server calls `tick/2` each game tick.
+
+-export([init/1, tick/2]).
+-export([notify/2, pause/1, resume/1]).
+-export([current/1, remaining/1, config/1, timers_info/1, info/1]).
+
+-export_type([phase_state/0, phase_def/0, phase_event/0]).
+
+-type phase_start() ::
+    prev_ended
+    | {players, pos_integer()}
+    | {players_ratio, float()}
+    | all_ready
+    | {event, atom()}
+    | {timer, pos_integer()}.
+
+-type phase_def() :: #{
+    name := binary(),
+    start => phase_start(),
+    duration => pos_integer() | infinity,
+    end_condition => fun((term()) -> boolean()),
+    timers => [map()],
+    config => map()
+}.
+
+-type phase_event() ::
+    {phase_started, binary()}
+    | {phase_ended, binary()}
+    | {all_phases_complete}
+    | asobi_timer:timer_event().
+
+-opaque phase_state() :: #{
+    phases := [phase_def()],
+    current_index := non_neg_integer(),
+    current_started := boolean(),
+    wait_elapsed := non_neg_integer(),
+    active_timers := #{binary() => asobi_timer:timer()},
+    paused := boolean(),
+    complete := boolean()
+}.
+
+%% -------------------------------------------------------------------
+%% Init
+%% -------------------------------------------------------------------
+
+-spec init([phase_def()]) -> phase_state().
+init([]) ->
+    #{
+        phases => [],
+        current_index => 0,
+        current_started => true,
+        wait_elapsed => 0,
+        active_timers => #{},
+        paused => false,
+        complete => true
+    };
+init(Phases) ->
+    State = #{
+        phases => Phases,
+        current_index => 0,
+        current_started => false,
+        wait_elapsed => 0,
+        active_timers => #{},
+        paused => false,
+        complete => false
+    },
+    Phase = lists:nth(1, Phases),
+    case maps:get(start, Phase, prev_ended) of
+        prev_ended ->
+            %% Auto-start first phase immediately
+            {_Events, PS} = start_current_phase(State),
+            PS;
+        _ ->
+            State
+    end.
+
+%% -------------------------------------------------------------------
+%% Tick — advance by DeltaMs, return {Events, PhaseState1}
+%% -------------------------------------------------------------------
+
+-spec tick(pos_integer(), phase_state()) -> {[phase_event()], phase_state()}.
+tick(_DeltaMs, #{complete := true} = PS) ->
+    {[], PS};
+tick(_DeltaMs, #{paused := true} = PS) ->
+    {[], PS};
+tick(DeltaMs, #{current_started := false} = PS) ->
+    tick_waiting(DeltaMs, PS);
+tick(DeltaMs, PS) ->
+    tick_active(DeltaMs, PS).
+
+%% -------------------------------------------------------------------
+%% Notify — feed events for conditional phase/timer starts
+%% -------------------------------------------------------------------
+
+-spec notify(term(), phase_state()) -> {[phase_event()], phase_state()}.
+notify(_Event, #{complete := true} = PS) ->
+    {[], PS};
+notify({player_joined, Count}, #{current_started := false} = PS) ->
+    Phase = current_phase_def(PS),
+    case maps:get(start, Phase, prev_ended) of
+        {players, N} when Count >= N ->
+            start_current_phase(PS);
+        {players_ratio, Ratio} when Count >= Ratio ->
+            start_current_phase(PS);
+        _ ->
+            {[], PS}
+    end;
+notify({all_ready}, #{current_started := false} = PS) ->
+    Phase = current_phase_def(PS),
+    case maps:get(start, Phase, prev_ended) of
+        all_ready -> start_current_phase(PS);
+        _ -> {[], PS}
+    end;
+notify({event, Name}, #{current_started := false} = PS) ->
+    Phase = current_phase_def(PS),
+    case maps:get(start, Phase, prev_ended) of
+        {event, Name} -> start_current_phase(PS);
+        _ -> {[], PS}
+    end;
+notify(Event, #{active_timers := Timers} = PS) ->
+    {AllEvents, Timers1} = maps:fold(
+        fun(TId, T, {Evts, Acc}) ->
+            {TEvts, T1} = asobi_timer:notify(Event, undefined, T),
+            {TEvts ++ Evts, Acc#{TId => T1}}
+        end,
+        {[], #{}},
+        Timers
+    ),
+    {AllEvents, PS#{active_timers => Timers1}}.
+
+%% -------------------------------------------------------------------
+%% Pause / Resume
+%% -------------------------------------------------------------------
+
+-spec pause(phase_state()) -> phase_state().
+pause(#{active_timers := Timers} = PS) ->
+    Timers1 = maps:map(fun(_Id, T) -> asobi_timer:pause(T) end, Timers),
+    PS#{paused => true, active_timers => Timers1}.
+
+-spec resume(phase_state()) -> phase_state().
+resume(#{active_timers := Timers} = PS) ->
+    Timers1 = maps:map(fun(_Id, T) -> asobi_timer:resume(T) end, Timers),
+    PS#{paused => false, active_timers => Timers1}.
+
+%% -------------------------------------------------------------------
+%% Queries
+%% -------------------------------------------------------------------
+
+-spec current(phase_state()) -> binary() | undefined.
+current(#{complete := true}) ->
+    undefined;
+current(PS) ->
+    Phase = current_phase_def(PS),
+    maps:get(name, Phase).
+
+-spec remaining(phase_state()) -> pos_integer() | infinity.
+remaining(#{complete := true}) ->
+    0;
+remaining(#{current_started := false}) ->
+    infinity;
+remaining(PS) ->
+    Phase = current_phase_def(PS),
+    case maps:get(duration, Phase, infinity) of
+        infinity -> infinity;
+        _Duration -> maps:get(phase_remaining, PS, infinity)
+    end.
+
+-spec config(phase_state()) -> map().
+config(#{complete := true}) ->
+    #{};
+config(PS) ->
+    Phase = current_phase_def(PS),
+    maps:get(config, Phase, #{}).
+
+-spec timers_info(phase_state()) -> #{binary() => map()}.
+timers_info(#{active_timers := Timers}) ->
+    maps:map(fun(_Id, T) -> asobi_timer:info(T) end, Timers).
+
+-spec info(phase_state()) -> map().
+info(#{complete := true}) ->
+    #{status => complete, phase => undefined};
+info(#{current_started := false} = PS) ->
+    Phase = current_phase_def(PS),
+    #{
+        status => waiting,
+        phase => maps:get(name, Phase),
+        start_condition => maps:get(start, Phase, prev_ended)
+    };
+info(PS) ->
+    Phase = current_phase_def(PS),
+    #{
+        status => active,
+        phase => maps:get(name, Phase),
+        remaining_ms => remaining(PS),
+        config => maps:get(config, Phase, #{}),
+        timers => timers_info(PS)
+    }.
+
+%% -------------------------------------------------------------------
+%% Internal — waiting for phase start condition
+%% -------------------------------------------------------------------
+
+tick_waiting(DeltaMs, #{wait_elapsed := Elapsed} = PS) ->
+    Phase = current_phase_def(PS),
+    Elapsed1 = Elapsed + DeltaMs,
+    case maps:get(start, Phase, prev_ended) of
+        {timer, FallbackMs} when Elapsed1 >= FallbackMs ->
+            start_current_phase(PS#{wait_elapsed => Elapsed1});
+        _ ->
+            {[], PS#{wait_elapsed => Elapsed1}}
+    end.
+
+%% -------------------------------------------------------------------
+%% Internal — active phase ticking
+%% -------------------------------------------------------------------
+
+tick_active(DeltaMs, PS) ->
+    %% Tick all active timers
+    {TimerEvents, PS1} = tick_timers(DeltaMs, PS),
+
+    %% Check phase duration
+    Phase = current_phase_def(PS1),
+    case maps:get(duration, Phase, infinity) of
+        infinity ->
+            {TimerEvents, PS1};
+        _Duration ->
+            Rem = maps:get(phase_remaining, PS1),
+            Rem1 = Rem - DeltaMs,
+            case Rem1 =< 0 of
+                true ->
+                    {TransEvents, PS2} = advance_phase(PS1#{phase_remaining => 0}),
+                    {TimerEvents ++ TransEvents, PS2};
+                false ->
+                    {TimerEvents, PS1#{phase_remaining => Rem1}}
+            end
+    end.
+
+tick_timers(DeltaMs, #{active_timers := Timers} = PS) ->
+    {AllEvents, Timers1} = maps:fold(
+        fun(TId, T, {Evts, Acc}) ->
+            {TEvts, T1} = asobi_timer:tick(DeltaMs, T),
+            {TEvts ++ Evts, Acc#{TId => T1}}
+        end,
+        {[], #{}},
+        Timers
+    ),
+    {AllEvents, PS#{active_timers => Timers1}}.
+
+%% -------------------------------------------------------------------
+%% Internal — phase transitions
+%% -------------------------------------------------------------------
+
+start_current_phase(PS) ->
+    Phase = current_phase_def(PS),
+    PhaseName = maps:get(name, Phase),
+    Duration = maps:get(duration, Phase, infinity),
+    PhaseTimers = build_timers(maps:get(timers, Phase, [])),
+    PS1 = PS#{
+        current_started => true,
+        wait_elapsed => 0,
+        active_timers => PhaseTimers,
+        phase_remaining => Duration
+    },
+    {[{phase_started, PhaseName}], PS1}.
+
+advance_phase(PS) ->
+    #{phases := Phases, current_index := Idx} = PS,
+    Phase = current_phase_def(PS),
+    PhaseName = maps:get(name, Phase),
+    EndEvents = [{phase_ended, PhaseName}],
+
+    NextIdx = Idx + 1,
+    case NextIdx >= length(Phases) of
+        true ->
+            {EndEvents ++ [{all_phases_complete}], PS#{complete => true, active_timers => #{}}};
+        false ->
+            NextPhase = lists:nth(NextIdx + 1, Phases),
+            PS1 = PS#{
+                current_index => NextIdx,
+                current_started => false,
+                wait_elapsed => 0,
+                active_timers => #{}
+            },
+            case maps:get(start, NextPhase, prev_ended) of
+                prev_ended ->
+                    {StartEvents, PS2} = start_current_phase(PS1),
+                    {EndEvents ++ StartEvents, PS2};
+                _ ->
+                    {EndEvents, PS1}
+            end
+    end.
+
+%% -------------------------------------------------------------------
+%% Internal — helpers
+%% -------------------------------------------------------------------
+
+current_phase_def(#{phases := Phases, current_index := Idx}) ->
+    lists:nth(Idx + 1, Phases).
+
+build_timers(TimerConfigs) ->
+    lists:foldl(
+        fun(Config, Acc) ->
+            Type = maps:get(type, Config),
+            Id = maps:get(id, Config),
+            Timer =
+                case Type of
+                    countdown -> asobi_timer:countdown(Config);
+                    conditional -> asobi_timer:conditional(Config);
+                    cycle -> asobi_timer:cycle(Config)
+                end,
+            Acc#{Id => Timer}
+        end,
+        #{},
+        TimerConfigs
+    ).

--- a/src/timers/asobi_timer.erl
+++ b/src/timers/asobi_timer.erl
@@ -1,0 +1,336 @@
+-module(asobi_timer).
+
+%% Pure functional timer primitives.
+%%
+%% Timers don't own processes — they are state that the owning server
+%% advances each tick by calling `tick/2`. This keeps timer logic
+%% testable and avoids per-timer process overhead.
+
+-export([countdown/1, conditional/1, cycle/1]).
+-export([tick/2, notify/3, pause/1, resume/1]).
+-export([is_expired/1, is_started/1, is_paused/1]).
+-export([remaining/1, current_phase/1, info/1]).
+
+-export_type([timer/0, timer_event/0]).
+
+-opaque timer() :: #{
+    type := countdown | conditional | cycle,
+    id := binary(),
+    _ => _
+}.
+
+-type timer_event() ::
+    {timer_started, binary()}
+    | {timer_warning, binary(), pos_integer()}
+    | {timer_expired, binary()}
+    | {phase_changed, binary(), binary()}.
+
+%% -------------------------------------------------------------------
+%% Constructors
+%% -------------------------------------------------------------------
+
+-spec countdown(map()) -> timer().
+countdown(Config) ->
+    Id = maps:get(id, Config),
+    Duration = maps:get(duration, Config),
+    Warnings = maps:get(warnings, Config, []),
+    OnExpire = maps:get(on_expire, Config, timer_expired),
+    PauseOnEmpty = maps:get(pause_on_empty, Config, false),
+    #{
+        type => countdown,
+        id => Id,
+        duration => Duration,
+        remaining => Duration,
+        warnings => lists:sort(fun erlang:'>='/2, Warnings),
+        warnings_fired => [],
+        on_expire => OnExpire,
+        pause_on_empty => PauseOnEmpty,
+        started_at => erlang:system_time(millisecond),
+        paused => false,
+        expired => false
+    }.
+
+-spec conditional(map()) -> timer().
+conditional(Config) ->
+    Id = maps:get(id, Config),
+    Duration = maps:get(duration, Config),
+    Fallback = maps:get(fallback_timeout, Config, infinity),
+    Condition = maps:get(start_condition, Config),
+    Warnings = maps:get(warnings, Config, []),
+    OnExpire = maps:get(on_expire, Config, timer_expired),
+    #{
+        type => conditional,
+        id => Id,
+        duration => Duration,
+        remaining => Duration,
+        fallback_timeout => Fallback,
+        fallback_elapsed => 0,
+        start_condition => Condition,
+        started => false,
+        warnings => lists:sort(fun erlang:'>='/2, Warnings),
+        warnings_fired => [],
+        on_expire => OnExpire,
+        paused => false,
+        expired => false
+    }.
+
+-spec cycle(map()) -> timer().
+cycle(Config) ->
+    Id = maps:get(id, Config),
+    Phases = maps:get(phases, Config),
+    Repeat = maps:get(repeat, Config, true),
+    StartIndex = maps:get(start_index, Config, 0),
+    Phase = lists:nth(StartIndex + 1, Phases),
+    PhaseDuration = maps:get(duration, Phase),
+    #{
+        type => cycle,
+        id => Id,
+        phases => Phases,
+        repeat => Repeat,
+        phase_index => StartIndex,
+        phase_remaining => PhaseDuration,
+        paused => false,
+        expired => false
+    }.
+
+%% -------------------------------------------------------------------
+%% Tick — advance timer by DeltaMs, return {Events, Timer1}
+%% -------------------------------------------------------------------
+
+-spec tick(pos_integer(), timer()) -> {[timer_event()], timer()}.
+tick(_DeltaMs, #{paused := true} = Timer) ->
+    {[], Timer};
+tick(_DeltaMs, #{expired := true} = Timer) ->
+    {[], Timer};
+%% Countdown
+tick(DeltaMs, #{type := countdown, id := Id, remaining := Rem} = Timer) ->
+    Rem1 = Rem - DeltaMs,
+    {WarningEvents, Timer1} = check_warnings(Id, Rem1, Timer),
+    case Rem1 =< 0 of
+        true ->
+            Events = WarningEvents ++ [{timer_expired, Id}],
+            {Events, Timer1#{remaining => 0, expired => true}};
+        false ->
+            {WarningEvents, Timer1#{remaining => Rem1}}
+    end;
+%% Conditional — not yet started, waiting for condition or fallback
+tick(DeltaMs, #{type := conditional, started := false} = Timer) ->
+    #{id := Id, fallback_timeout := Fallback, fallback_elapsed := Elapsed} = Timer,
+    Elapsed1 = Elapsed + DeltaMs,
+    case Fallback =/= infinity andalso Elapsed1 >= Fallback of
+        true ->
+            Timer1 = Timer#{
+                started => true,
+                fallback_elapsed => Elapsed1,
+                started_at => erlang:system_time(millisecond)
+            },
+            {[{timer_started, Id}], Timer1};
+        false ->
+            {[], Timer#{fallback_elapsed => Elapsed1}}
+    end;
+%% Conditional — started, counting down
+tick(DeltaMs, #{type := conditional, started := true, id := Id, remaining := Rem} = Timer) ->
+    Rem1 = Rem - DeltaMs,
+    {WarningEvents, Timer1} = check_warnings(Id, Rem1, Timer),
+    case Rem1 =< 0 of
+        true ->
+            Events = WarningEvents ++ [{timer_expired, Id}],
+            {Events, Timer1#{remaining => 0, expired => true}};
+        false ->
+            {WarningEvents, Timer1#{remaining => Rem1}}
+    end;
+%% Cycle
+tick(DeltaMs, #{type := cycle} = Timer) ->
+    tick_cycle(DeltaMs, Timer, []).
+
+%% -------------------------------------------------------------------
+%% Notify — feed events to conditional timers for condition checking
+%% -------------------------------------------------------------------
+
+-spec notify(atom(), term(), timer()) -> {[timer_event()], timer()}.
+notify(_Event, _Data, #{type := Type} = Timer) when Type =/= conditional ->
+    {[], Timer};
+notify(_Event, _Data, #{started := true} = Timer) ->
+    {[], Timer};
+notify(Event, Data, #{id := Id, start_condition := Condition} = Timer) ->
+    case check_condition(Event, Data, Condition) of
+        true ->
+            Timer1 = Timer#{started => true, started_at => erlang:system_time(millisecond)},
+            {[{timer_started, Id}], Timer1};
+        false ->
+            {[], Timer}
+    end.
+
+%% -------------------------------------------------------------------
+%% Pause / Resume
+%% -------------------------------------------------------------------
+
+-spec pause(timer()) -> timer().
+pause(Timer) ->
+    Timer#{paused => true}.
+
+-spec resume(timer()) -> timer().
+resume(Timer) ->
+    Timer#{paused => false}.
+
+%% -------------------------------------------------------------------
+%% Queries
+%% -------------------------------------------------------------------
+
+-spec is_expired(timer()) -> boolean().
+is_expired(#{expired := Expired}) -> Expired.
+
+-spec is_started(timer()) -> boolean().
+is_started(#{type := conditional, started := Started}) -> Started;
+is_started(_Timer) -> true.
+
+-spec is_paused(timer()) -> boolean().
+is_paused(#{paused := Paused}) -> Paused.
+
+-spec remaining(timer()) -> pos_integer() | infinity.
+remaining(#{type := conditional, started := false}) -> infinity;
+remaining(#{type := cycle, phase_remaining := Rem}) -> Rem;
+remaining(#{remaining := Rem}) -> max(0, Rem).
+
+-spec current_phase(timer()) -> binary() | undefined.
+current_phase(#{type := cycle, phases := Phases, phase_index := Idx}) ->
+    Phase = lists:nth(Idx + 1, Phases),
+    maps:get(name, Phase);
+current_phase(_) ->
+    undefined.
+
+-spec info(timer()) -> map().
+info(#{type := countdown, id := Id, remaining := Rem, paused := Paused, expired := Expired}) ->
+    #{
+        type => countdown,
+        id => Id,
+        remaining_ms => max(0, Rem),
+        paused => Paused,
+        expired => Expired
+    };
+info(#{
+    type := conditional,
+    id := Id,
+    started := Started,
+    remaining := Rem,
+    paused := Paused,
+    expired := Expired
+}) ->
+    #{
+        type => conditional,
+        id => Id,
+        started => Started,
+        remaining_ms =>
+            case Started of
+                true -> max(0, Rem);
+                false -> infinity
+            end,
+        paused => Paused,
+        expired => Expired
+    };
+info(#{
+    type := cycle,
+    id := Id,
+    phases := Phases,
+    phase_index := Idx,
+    phase_remaining := Rem,
+    paused := Paused,
+    expired := Expired
+}) ->
+    Phase = lists:nth(Idx + 1, Phases),
+    #{
+        type => cycle,
+        id => Id,
+        current_phase => maps:get(name, Phase),
+        phase_remaining_ms => max(0, Rem),
+        phase_index => Idx,
+        total_phases => length(Phases),
+        paused => Paused,
+        expired => Expired,
+        modifiers => maps:get(modifiers, Phase, #{})
+    }.
+
+%% -------------------------------------------------------------------
+%% Internal — cycle ticking
+%% -------------------------------------------------------------------
+
+tick_cycle(
+    DeltaMs,
+    #{
+        phases := Phases,
+        phase_index := Idx,
+        phase_remaining := Rem,
+        repeat := Repeat,
+        id := Id
+    } = Timer,
+    Events
+) ->
+    Rem1 = Rem - DeltaMs,
+    case Rem1 =< 0 of
+        false ->
+            {lists:reverse(Events), Timer#{phase_remaining => Rem1}};
+        true ->
+            Overflow = abs(Rem1),
+            NextIdx = Idx + 1,
+            case NextIdx >= length(Phases) of
+                true when Repeat ->
+                    NewPhase = lists:nth(1, Phases),
+                    NewDuration = maps:get(duration, NewPhase),
+                    PhaseName = maps:get(name, NewPhase),
+                    Events1 = [{phase_changed, Id, PhaseName} | Events],
+                    Timer1 = Timer#{phase_index => 0, phase_remaining => NewDuration},
+                    case Overflow > 0 of
+                        true -> tick_cycle(Overflow, Timer1, Events1);
+                        false -> {lists:reverse(Events1), Timer1}
+                    end;
+                true ->
+                    Events1 = [{timer_expired, Id} | Events],
+                    {lists:reverse(Events1), Timer#{expired => true, phase_remaining => 0}};
+                false ->
+                    NewPhase = lists:nth(NextIdx + 1, Phases),
+                    NewDuration = maps:get(duration, NewPhase),
+                    PhaseName = maps:get(name, NewPhase),
+                    Events1 = [{phase_changed, Id, PhaseName} | Events],
+                    Timer1 = Timer#{phase_index => NextIdx, phase_remaining => NewDuration},
+                    case Overflow > 0 of
+                        true -> tick_cycle(Overflow, Timer1, Events1);
+                        false -> {lists:reverse(Events1), Timer1}
+                    end
+            end
+    end.
+
+%% -------------------------------------------------------------------
+%% Internal — warning checks
+%% -------------------------------------------------------------------
+
+check_warnings(Id, Remaining, #{warnings := Warnings, warnings_fired := Fired} = Timer) ->
+    {NewEvents, NewFired} = lists:foldl(
+        fun(Threshold, {Evts, F}) ->
+            case Remaining =< Threshold andalso not lists:member(Threshold, F) of
+                true ->
+                    {[{timer_warning, Id, Threshold} | Evts], [Threshold | F]};
+                false ->
+                    {Evts, F}
+            end
+        end,
+        {[], Fired},
+        Warnings
+    ),
+    {lists:reverse(NewEvents), Timer#{warnings_fired => NewFired}}.
+
+%% -------------------------------------------------------------------
+%% Internal — condition checking
+%% -------------------------------------------------------------------
+
+check_condition(player_joined, PlayerCount, {players, N}) when is_integer(PlayerCount) ->
+    PlayerCount >= N;
+check_condition(player_joined, PlayerCount, {players_ratio, Ratio}) when is_number(PlayerCount) ->
+    PlayerCount >= Ratio;
+check_condition(all_ready, true, {all_ready}) ->
+    true;
+check_condition(Event, _Data, {event, Event}) ->
+    true;
+check_condition(timer_expired, TimerId, {prev_expired, TimerId}) ->
+    true;
+check_condition(_Event, _Data, _Condition) ->
+    false.

--- a/src/world/asobi_world.erl
+++ b/src/world/asobi_world.erl
@@ -34,4 +34,18 @@
 -callback get_state(PlayerId :: binary(), GameState :: term()) ->
     StateForPlayer :: map().
 
--optional_callbacks([generate_world/2, get_state/2]).
+-callback phases(Config :: map()) -> [asobi_phase:phase_def()].
+
+-callback on_phase_started(PhaseName :: binary(), GameState :: term()) ->
+    {ok, GameState1 :: term()}.
+
+-callback on_phase_ended(PhaseName :: binary(), GameState :: term()) ->
+    {ok, GameState1 :: term()}.
+
+-optional_callbacks([
+    generate_world/2,
+    get_state/2,
+    phases/1,
+    on_phase_started/2,
+    on_phase_ended/2
+]).

--- a/src/world/asobi_world_server.erl
+++ b/src/world/asobi_world_server.erl
@@ -79,6 +79,14 @@ init(Config) ->
     VetoTokensPerPlayer = maps:get(veto_tokens_per_player, Config, 0),
     FrustrationBonus = maps:get(frustration_bonus, Config, 0.5),
     {ZoneSupPid, TickerPid} = resolve_siblings(Config),
+    PhaseState =
+        case erlang:function_exported(GameMod, phases, 1) of
+            true ->
+                Phases = GameMod:phases(GameConfig),
+                asobi_phase:init(Phases);
+            false ->
+                undefined
+        end,
     State = #{
         world_id => WorldId,
         mode => maps:get(mode, Config, undefined),
@@ -100,7 +108,8 @@ init(Config) ->
         veto_tokens => #{},
         veto_tokens_per_player => VetoTokensPerPlayer,
         frustration_bonus => FrustrationBonus,
-        active_votes => #{}
+        active_votes => #{},
+        phase_state => PhaseState
     },
     {ok, loading, State}.
 
@@ -130,10 +139,31 @@ running({call, From}, {join, PlayerId}, State) ->
     handle_join(From, PlayerId, State);
 running(cast, {leave, PlayerId}, State) ->
     handle_leave(PlayerId, State);
-running(cast, {post_tick, TickN}, #{game_module := Mod, game_state := GS} = State) ->
+running(
+    cast,
+    {post_tick, TickN},
+    #{
+        game_module := Mod,
+        game_state := GS,
+        tick_rate := TickRate
+    } = State
+) ->
     case Mod:post_tick(TickN, GS) of
         {ok, GS1} ->
-            {keep_state, State#{game_state => GS1}};
+            State1 = tick_phases(TickRate, State#{game_state => GS1}),
+            case maps:get(phase_state, State1) of
+                PS when is_map(PS) ->
+                    case asobi_phase:info(PS) of
+                        #{status := complete} ->
+                            {next_state, finished, State1#{
+                                result => #{status => ~"phases_complete"}
+                            }};
+                        _ ->
+                            {keep_state, State1}
+                    end;
+                _ ->
+                    {keep_state, State1}
+            end;
         {vote, VoteConfig, GS1} ->
             State1 = State#{game_state => GS1},
             do_start_vote(VoteConfig, State1);
@@ -251,7 +281,8 @@ handle_join(
                         players => Players1,
                         veto_tokens => VetoTokens#{PlayerId => VetoCount}
                     },
-                    {keep_state, State3, [{reply, From, ok}]};
+                    State4 = notify_phase_player_joined(State3),
+                    {keep_state, State4, [{reply, From, ok}]};
                 {error, Reason} ->
                     {keep_state_and_data, [{reply, From, {error, Reason}}]}
             end
@@ -535,14 +566,18 @@ notify_players(Event, #{players := Players, world_id := WorldId} = State) ->
     ).
 
 world_info(Status, #{world_id := WorldId, players := Players} = State) ->
-    #{
+    Base = #{
         world_id => WorldId,
         status => Status,
         player_count => map_size(Players),
         players => maps:keys(Players),
         mode => maps:get(mode, State, undefined),
         grid_size => maps:get(grid_size, State)
-    }.
+    },
+    case maps:get(phase_state, State, undefined) of
+        undefined -> Base;
+        PS -> Base#{phase => asobi_phase:info(PS)}
+    end.
 
 resolve_siblings(#{zone_sup_pid := ZSP, ticker_pid := TP}) ->
     {ZSP, TP};
@@ -550,3 +585,52 @@ resolve_siblings(#{instance_sup := InstanceSup}) ->
     ZoneSupPid = asobi_world_instance:get_child(InstanceSup, asobi_zone_sup),
     TickerPid = asobi_world_instance:get_child(InstanceSup, asobi_world_ticker),
     {ZoneSupPid, TickerPid}.
+
+%% --- Internal: Phases ---
+
+tick_phases(_DeltaMs, #{phase_state := undefined} = State) ->
+    State;
+tick_phases(DeltaMs, #{phase_state := PS, game_module := Mod, game_state := GS} = State) ->
+    {Events, PS1} = asobi_phase:tick(DeltaMs, PS),
+    GS1 = handle_phase_events(Events, Mod, GS),
+    State#{phase_state => PS1, game_state => GS1}.
+
+notify_phase_player_joined(#{phase_state := undefined} = State) ->
+    State;
+notify_phase_player_joined(
+    #{
+        phase_state := PS,
+        players := Players,
+        game_module := Mod,
+        game_state := GS
+    } = State
+) ->
+    Count = map_size(Players),
+    {Events, PS1} = asobi_phase:notify({player_joined, Count}, PS),
+    GS1 = handle_phase_events(Events, Mod, GS),
+    State#{phase_state => PS1, game_state => GS1}.
+
+handle_phase_events([], _Mod, GS) ->
+    GS;
+handle_phase_events([{phase_started, Name} | Rest], Mod, GS) ->
+    GS1 =
+        case erlang:function_exported(Mod, on_phase_started, 2) of
+            true ->
+                {ok, GS2} = Mod:on_phase_started(Name, GS),
+                GS2;
+            false ->
+                GS
+        end,
+    handle_phase_events(Rest, Mod, GS1);
+handle_phase_events([{phase_ended, Name} | Rest], Mod, GS) ->
+    GS1 =
+        case erlang:function_exported(Mod, on_phase_ended, 2) of
+            true ->
+                {ok, GS2} = Mod:on_phase_ended(Name, GS),
+                GS2;
+            false ->
+                GS
+        end,
+    handle_phase_events(Rest, Mod, GS1);
+handle_phase_events([_Event | Rest], Mod, GS) ->
+    handle_phase_events(Rest, Mod, GS).

--- a/test/asobi_phase_tests.erl
+++ b/test/asobi_phase_tests.erl
@@ -1,0 +1,202 @@
+-module(asobi_phase_tests).
+-include_lib("eunit/include/eunit.hrl").
+
+%% -------------------------------------------------------------------
+%% Basic phase progression
+%% -------------------------------------------------------------------
+
+simple_phases_test() ->
+    Phases = [
+        #{name => ~"warmup", duration => 1000},
+        #{name => ~"active", duration => 2000},
+        #{name => ~"results", duration => 500}
+    ],
+    PS = asobi_phase:init(Phases),
+    ?assertEqual(~"warmup", asobi_phase:current(PS)),
+
+    {Events1, PS1} = asobi_phase:tick(1100, PS),
+    ?assertMatch([{phase_ended, ~"warmup"}, {phase_started, ~"active"}], Events1),
+    ?assertEqual(~"active", asobi_phase:current(PS1)),
+
+    {[], PS2} = asobi_phase:tick(1000, PS1),
+    ?assertEqual(~"active", asobi_phase:current(PS2)),
+
+    {Events2, PS3} = asobi_phase:tick(1100, PS2),
+    ?assertMatch([{phase_ended, ~"active"}, {phase_started, ~"results"}], Events2),
+    ?assertEqual(~"results", asobi_phase:current(PS3)),
+
+    {Events3, PS4} = asobi_phase:tick(600, PS3),
+    ?assertMatch([{phase_ended, ~"results"}, {all_phases_complete}], Events3),
+    ?assertEqual(undefined, asobi_phase:current(PS4)).
+
+%% -------------------------------------------------------------------
+%% Conditional start
+%% -------------------------------------------------------------------
+
+conditional_player_start_test() ->
+    Phases = [
+        #{name => ~"gathering", start => {players, 5}, duration => 1000},
+        #{name => ~"active", duration => 2000}
+    ],
+    PS = asobi_phase:init(Phases),
+    Info = asobi_phase:info(PS),
+    ?assertEqual(waiting, maps:get(status, Info)),
+
+    {[], PS1} = asobi_phase:tick(500, PS),
+    ?assertEqual(waiting, maps:get(status, asobi_phase:info(PS1))),
+
+    {[], PS2} = asobi_phase:notify({player_joined, 3}, PS1),
+    ?assertEqual(waiting, maps:get(status, asobi_phase:info(PS2))),
+
+    {Events, PS3} = asobi_phase:notify({player_joined, 5}, PS2),
+    ?assertMatch([{phase_started, ~"gathering"}], Events),
+    ?assertEqual(active, maps:get(status, asobi_phase:info(PS3))),
+    ?assertEqual(~"gathering", asobi_phase:current(PS3)).
+
+conditional_timer_fallback_test() ->
+    Phases = [
+        #{name => ~"waiting", start => {timer, 2000}, duration => 1000}
+    ],
+    PS = asobi_phase:init(Phases),
+    {[], PS1} = asobi_phase:tick(1000, PS),
+    ?assertEqual(waiting, maps:get(status, asobi_phase:info(PS1))),
+
+    {Events, PS2} = asobi_phase:tick(1500, PS1),
+    ?assertMatch([{phase_started, ~"waiting"}], Events),
+    ?assertEqual(~"waiting", asobi_phase:current(PS2)).
+
+%% -------------------------------------------------------------------
+%% Infinity duration
+%% -------------------------------------------------------------------
+
+infinity_duration_test() ->
+    Phases = [
+        #{name => ~"persistent", duration => infinity}
+    ],
+    PS = asobi_phase:init(Phases),
+    ?assertEqual(infinity, asobi_phase:remaining(PS)),
+
+    {[], PS1} = asobi_phase:tick(999999, PS),
+    ?assertEqual(~"persistent", asobi_phase:current(PS1)),
+    ?assertEqual(infinity, asobi_phase:remaining(PS1)).
+
+%% -------------------------------------------------------------------
+%% Phase with timers
+%% -------------------------------------------------------------------
+
+phase_with_cycle_timer_test() ->
+    Phases = [
+        #{
+            name => ~"active",
+            duration => 10000,
+            timers => [
+                #{
+                    type => cycle,
+                    id => ~"daynight",
+                    phases => [
+                        #{name => ~"day", duration => 100},
+                        #{name => ~"night", duration => 200}
+                    ],
+                    repeat => true
+                }
+            ]
+        }
+    ],
+    PS = asobi_phase:init(Phases),
+    TimersInfo = asobi_phase:timers_info(PS),
+    ?assertMatch(#{~"daynight" := #{type := cycle}}, TimersInfo),
+
+    {Events, _PS1} = asobi_phase:tick(110, PS),
+    ?assertMatch([{phase_changed, ~"daynight", ~"night"}], Events).
+
+%% -------------------------------------------------------------------
+%% Pause / Resume
+%% -------------------------------------------------------------------
+
+pause_resume_test() ->
+    Phases = [#{name => ~"active", duration => 1000}],
+    PS = asobi_phase:init(Phases),
+    PS1 = asobi_phase:pause(PS),
+
+    {[], PS2} = asobi_phase:tick(500, PS1),
+    ?assertEqual(1000, asobi_phase:remaining(PS2)),
+
+    PS3 = asobi_phase:resume(PS2),
+    {[], PS4} = asobi_phase:tick(500, PS3),
+    ?assertEqual(500, asobi_phase:remaining(PS4)).
+
+%% -------------------------------------------------------------------
+%% Config access
+%% -------------------------------------------------------------------
+
+config_test() ->
+    Phases = [
+        #{
+            name => ~"phase1",
+            duration => 1000,
+            config => #{pvp => false, safe_zones => true}
+        },
+        #{
+            name => ~"phase2",
+            duration => 1000,
+            config => #{pvp => true}
+        }
+    ],
+    PS = asobi_phase:init(Phases),
+    ?assertEqual(#{pvp => false, safe_zones => true}, asobi_phase:config(PS)),
+
+    {_, PS1} = asobi_phase:tick(1100, PS),
+    ?assertEqual(#{pvp => true}, asobi_phase:config(PS1)).
+
+%% -------------------------------------------------------------------
+%% Empty phases
+%% -------------------------------------------------------------------
+
+empty_phases_test() ->
+    PS = asobi_phase:init([]),
+    ?assertEqual(undefined, asobi_phase:current(PS)),
+    ?assertEqual(0, asobi_phase:remaining(PS)),
+    {[], PS1} = asobi_phase:tick(1000, PS),
+    ?assertEqual(undefined, asobi_phase:current(PS1)).
+
+%% -------------------------------------------------------------------
+%% Event-triggered phase start
+%% -------------------------------------------------------------------
+
+event_start_test() ->
+    Phases = [
+        #{name => ~"idle", start => {event, game_ready}, duration => 1000}
+    ],
+    PS = asobi_phase:init(Phases),
+    ?assertEqual(waiting, maps:get(status, asobi_phase:info(PS))),
+
+    {[], PS1} = asobi_phase:notify({player_joined, 3}, PS),
+    ?assertEqual(waiting, maps:get(status, asobi_phase:info(PS1))),
+
+    {Events, PS2} = asobi_phase:notify({event, game_ready}, PS1),
+    ?assertMatch([{phase_started, ~"idle"}], Events),
+    ?assertEqual(active, maps:get(status, asobi_phase:info(PS2))).
+
+%% -------------------------------------------------------------------
+%% Info output
+%% -------------------------------------------------------------------
+
+info_waiting_test() ->
+    Phases = [#{name => ~"w", start => {players, 5}, duration => 1000}],
+    PS = asobi_phase:init(Phases),
+    Info = asobi_phase:info(PS),
+    ?assertEqual(waiting, maps:get(status, Info)),
+    ?assertEqual(~"w", maps:get(phase, Info)).
+
+info_active_test() ->
+    Phases = [#{name => ~"a", duration => 5000, config => #{x => 1}}],
+    PS = asobi_phase:init(Phases),
+    Info = asobi_phase:info(PS),
+    ?assertEqual(active, maps:get(status, Info)),
+    ?assertEqual(~"a", maps:get(phase, Info)),
+    ?assertEqual(#{x => 1}, maps:get(config, Info)).
+
+info_complete_test() ->
+    PS = asobi_phase:init([]),
+    Info = asobi_phase:info(PS),
+    ?assertEqual(complete, maps:get(status, Info)).

--- a/test/asobi_timer_tests.erl
+++ b/test/asobi_timer_tests.erl
@@ -1,0 +1,217 @@
+-module(asobi_timer_tests).
+-include_lib("eunit/include/eunit.hrl").
+
+%% -------------------------------------------------------------------
+%% Countdown
+%% -------------------------------------------------------------------
+
+countdown_expires_test() ->
+    T = asobi_timer:countdown(#{id => ~"t1", duration => 1000}),
+    ?assertNot(asobi_timer:is_expired(T)),
+    ?assertEqual(1000, asobi_timer:remaining(T)),
+
+    {Events1, T1} = asobi_timer:tick(500, T),
+    ?assertEqual([], Events1),
+    ?assertEqual(500, asobi_timer:remaining(T1)),
+
+    {Events2, T2} = asobi_timer:tick(600, T1),
+    ?assertEqual([{timer_expired, ~"t1"}], Events2),
+    ?assert(asobi_timer:is_expired(T2)),
+    ?assertEqual(0, asobi_timer:remaining(T2)).
+
+countdown_warnings_test() ->
+    T = asobi_timer:countdown(#{id => ~"t1", duration => 10000, warnings => [5000, 1000]}),
+    {[], T1} = asobi_timer:tick(4000, T),
+    {Events, T2} = asobi_timer:tick(2000, T1),
+    ?assertEqual([{timer_warning, ~"t1", 5000}], Events),
+
+    {Events2, _T3} = asobi_timer:tick(4000, T2),
+    ?assertMatch([{timer_warning, ~"t1", 1000}, {timer_expired, ~"t1"}], Events2).
+
+countdown_pause_test() ->
+    T = asobi_timer:countdown(#{id => ~"t1", duration => 1000}),
+    T1 = asobi_timer:pause(T),
+    ?assert(asobi_timer:is_paused(T1)),
+    {[], T2} = asobi_timer:tick(500, T1),
+    ?assertEqual(1000, asobi_timer:remaining(T2)),
+
+    T3 = asobi_timer:resume(T2),
+    {[], T4} = asobi_timer:tick(500, T3),
+    ?assertEqual(500, asobi_timer:remaining(T4)).
+
+countdown_no_events_after_expired_test() ->
+    T = asobi_timer:countdown(#{id => ~"t1", duration => 100}),
+    {_, T1} = asobi_timer:tick(200, T),
+    ?assert(asobi_timer:is_expired(T1)),
+    {Events, _} = asobi_timer:tick(100, T1),
+    ?assertEqual([], Events).
+
+%% -------------------------------------------------------------------
+%% Conditional
+%% -------------------------------------------------------------------
+
+conditional_waits_for_condition_test() ->
+    T = asobi_timer:conditional(#{
+        id => ~"t1",
+        duration => 5000,
+        start_condition => {players, 4},
+        fallback_timeout => infinity
+    }),
+    ?assertNot(asobi_timer:is_started(T)),
+    ?assertEqual(infinity, asobi_timer:remaining(T)),
+
+    {[], T1} = asobi_timer:tick(1000, T),
+    ?assertNot(asobi_timer:is_started(T1)),
+
+    {Events, T2} = asobi_timer:notify(player_joined, 4, T1),
+    ?assertEqual([{timer_started, ~"t1"}], Events),
+    ?assert(asobi_timer:is_started(T2)),
+
+    {[], T3} = asobi_timer:tick(4000, T2),
+    ?assertEqual(1000, asobi_timer:remaining(T3)),
+
+    {Events2, T4} = asobi_timer:tick(1500, T3),
+    ?assertEqual([{timer_expired, ~"t1"}], Events2),
+    ?assert(asobi_timer:is_expired(T4)).
+
+conditional_fallback_timeout_test() ->
+    T = asobi_timer:conditional(#{
+        id => ~"t1",
+        duration => 2000,
+        start_condition => {players, 10},
+        fallback_timeout => 3000
+    }),
+    {[], T1} = asobi_timer:tick(2000, T),
+    ?assertNot(asobi_timer:is_started(T1)),
+
+    {Events, T2} = asobi_timer:tick(1500, T1),
+    ?assertEqual([{timer_started, ~"t1"}], Events),
+    ?assert(asobi_timer:is_started(T2)).
+
+conditional_event_trigger_test() ->
+    T = asobi_timer:conditional(#{
+        id => ~"t1",
+        duration => 1000,
+        start_condition => {event, bomb_planted},
+        fallback_timeout => infinity
+    }),
+    {[], T1} = asobi_timer:notify(player_joined, 5, T),
+    ?assertNot(asobi_timer:is_started(T1)),
+
+    {Events, T2} = asobi_timer:notify(bomb_planted, undefined, T1),
+    ?assertEqual([{timer_started, ~"t1"}], Events),
+    ?assert(asobi_timer:is_started(T2)).
+
+conditional_ignores_notify_after_started_test() ->
+    T = asobi_timer:conditional(#{
+        id => ~"t1",
+        duration => 1000,
+        start_condition => {players, 2},
+        fallback_timeout => infinity
+    }),
+    {_, T1} = asobi_timer:notify(player_joined, 2, T),
+    ?assert(asobi_timer:is_started(T1)),
+    {Events, _} = asobi_timer:notify(player_joined, 5, T1),
+    ?assertEqual([], Events).
+
+%% -------------------------------------------------------------------
+%% Cycle
+%% -------------------------------------------------------------------
+
+cycle_rotates_phases_test() ->
+    T = asobi_timer:cycle(#{
+        id => ~"daynight",
+        phases => [
+            #{name => ~"day", duration => 100},
+            #{name => ~"night", duration => 200}
+        ],
+        repeat => true
+    }),
+    ?assertEqual(~"day", asobi_timer:current_phase(T)),
+
+    {[], T1} = asobi_timer:tick(50, T),
+    ?assertEqual(~"day", asobi_timer:current_phase(T1)),
+
+    {Events, T2} = asobi_timer:tick(60, T1),
+    ?assertEqual([{phase_changed, ~"daynight", ~"night"}], Events),
+    ?assertEqual(~"night", asobi_timer:current_phase(T2)),
+
+    {[], T3} = asobi_timer:tick(100, T2),
+    ?assertEqual(~"night", asobi_timer:current_phase(T3)),
+
+    {Events2, T4} = asobi_timer:tick(110, T3),
+    ?assertEqual([{phase_changed, ~"daynight", ~"day"}], Events2),
+    ?assertEqual(~"day", asobi_timer:current_phase(T4)).
+
+cycle_no_repeat_expires_test() ->
+    T = asobi_timer:cycle(#{
+        id => ~"storm",
+        phases => [
+            #{name => ~"safe", duration => 100},
+            #{name => ~"shrink", duration => 100}
+        ],
+        repeat => false
+    }),
+    {_, T1} = asobi_timer:tick(110, T),
+    ?assertEqual(~"shrink", asobi_timer:current_phase(T1)),
+
+    {Events, T2} = asobi_timer:tick(100, T1),
+    ?assertMatch([{timer_expired, ~"storm"}], Events),
+    ?assert(asobi_timer:is_expired(T2)).
+
+cycle_pause_test() ->
+    T = asobi_timer:cycle(#{
+        id => ~"c1",
+        phases => [#{name => ~"a", duration => 100}],
+        repeat => true
+    }),
+    T1 = asobi_timer:pause(T),
+    {[], T2} = asobi_timer:tick(200, T1),
+    ?assertEqual(100, asobi_timer:remaining(T2)).
+
+cycle_modifiers_in_info_test() ->
+    T = asobi_timer:cycle(#{
+        id => ~"c1",
+        phases => [
+            #{name => ~"day", duration => 100, modifiers => #{sun => true}},
+            #{name => ~"night", duration => 100, modifiers => #{sun => false}}
+        ],
+        repeat => true
+    }),
+    Info = asobi_timer:info(T),
+    ?assertEqual(#{sun => true}, maps:get(modifiers, Info)).
+
+%% -------------------------------------------------------------------
+%% Info
+%% -------------------------------------------------------------------
+
+info_countdown_test() ->
+    T = asobi_timer:countdown(#{id => ~"t1", duration => 5000}),
+    Info = asobi_timer:info(T),
+    ?assertEqual(countdown, maps:get(type, Info)),
+    ?assertEqual(~"t1", maps:get(id, Info)),
+    ?assertEqual(5000, maps:get(remaining_ms, Info)),
+    ?assertNot(maps:get(paused, Info)).
+
+info_conditional_not_started_test() ->
+    T = asobi_timer:conditional(#{
+        id => ~"t1",
+        duration => 1000,
+        start_condition => {players, 5},
+        fallback_timeout => infinity
+    }),
+    Info = asobi_timer:info(T),
+    ?assertEqual(conditional, maps:get(type, Info)),
+    ?assertNot(maps:get(started, Info)),
+    ?assertEqual(infinity, maps:get(remaining_ms, Info)).
+
+info_cycle_test() ->
+    T = asobi_timer:cycle(#{
+        id => ~"c1",
+        phases => [#{name => ~"a", duration => 100}, #{name => ~"b", duration => 200}],
+        repeat => true
+    }),
+    Info = asobi_timer:info(T),
+    ?assertEqual(cycle, maps:get(type, Info)),
+    ?assertEqual(~"a", maps:get(current_phase, Info)),
+    ?assertEqual(2, maps:get(total_phases, Info)).


### PR DESCRIPTION
## Summary

- Add composable timer primitives (countdown, conditional, cycle) in `asobi_timer`
- Add phase engine (`asobi_phase`) for defining game lifecycle as ordered phases
- Integrate into both match and world servers via optional `phases/1` callback
- Fully backwards compatible — existing game modules unchanged

## Details

**Timer primitives** — pure functional, no processes, ticked by owning server:
- **Countdown**: fixed duration with configurable warning thresholds
- **Conditional**: starts when a condition is met (player count, event trigger) with optional fallback timeout
- **Cycle**: rotates through named phases with modifiers (day/night, storm circles)

**Phase engine** — manages ordered phase transitions:
- Each phase has duration, start conditions, per-phase timers, and config
- Start conditions: `prev_ended` (default), `{players, N}`, `{event, Name}`, `{timer, Ms}`
- Game modules receive `on_phase_started/2` and `on_phase_ended/2` callbacks
- Phase config queryable for game logic (e.g. PvP enabled/disabled per phase)

**Server integration**:
- `asobi_match` and `asobi_world` behaviours gain optional callbacks
- Phase state ticked each game tick, player joins notify for conditional starts
- Phase info included in `match_info`/`world_info` responses
- Auto-finish when all phases complete

## Test plan

- [x] 15 EUnit tests for all timer types (countdown, conditional, cycle)
- [x] 12 EUnit tests for phase engine (transitions, conditional starts, timers, pause, config)
- [x] All 121 existing tests still pass
- [x] `rebar3 fmt --check` clean
- [x] `rebar3 xref` clean