### PR TITLE
feat: add scheduled timers, entity timers, reconnection, seasons

### DIFF
--- a/src/asobi_sup.erl
+++ b/src/asobi_sup.erl
@@ -28,7 +28,8 @@ init([]) ->
         tournament_sup(),
         presence_spec(),
         bot_sup(),
-        bot_spawner_spec()
+        bot_spawner_spec(),
+        season_manager_spec()
     ],
     {ok, {SupFlags, Children}}.
 
@@ -147,4 +148,10 @@ bot_spawner_spec() ->
     #{
         id => asobi_bot_spawner,
         start => {asobi_bot_spawner, start_link, []}
+    }.
+
+season_manager_spec() ->
+    #{
+        id => asobi_season_manager,
+        start => {asobi_season_manager, start_link, []}
     }.

--- a/src/matches/asobi_match_server.erl
+++ b/src/matches/asobi_match_server.erl
@@ -137,7 +137,8 @@ init(Config) ->
                 veto_tokens => #{},
                 veto_tokens_per_player => VetoTokensPerPlayer,
                 frustration_bonus => FrustrationBonus,
-                phase_state => PhaseState
+                phase_state => PhaseState,
+                reconnect_state => init_reconnect(Config)
             },
             {ok, waiting, State}
     end.
@@ -176,7 +177,7 @@ running(state_timeout, tick, #{game_module := Mod, game_state := GS, input_queue
                 {ok, GS2} ->
                     State1 = State#{game_state => GS2, input_queue => []},
                     State2 = maybe_start_vote(Mod, State1),
-                    State3 = tick_phases(TickRate, State2),
+                    State3 = tick_reconnect(TickRate, tick_phases(TickRate, State2)),
                     case maps:get(phase_state, State3) of
                         PS when is_map(PS) ->
                             case asobi_phase:info(PS) of
@@ -695,6 +696,45 @@ handle_phase_events([{phase_ended, Name} | Rest], Mod, GS) ->
     handle_phase_events(Rest, Mod, GS1);
 handle_phase_events([_Event | Rest], Mod, GS) ->
     handle_phase_events(Rest, Mod, GS).
+
+%% --- Internal: Reconnection ---
+
+init_reconnect(Config) ->
+    case maps:get(reconnect, Config, undefined) of
+        undefined -> undefined;
+        Policy when is_map(Policy) -> asobi_reconnect:new(Policy)
+    end.
+
+tick_reconnect(_DeltaMs, #{reconnect_state := undefined} = State) ->
+    State;
+tick_reconnect(DeltaMs, #{reconnect_state := RS} = State) ->
+    {Events, RS1} = asobi_reconnect:tick(DeltaMs, RS),
+    State1 = State#{reconnect_state => RS1},
+    handle_reconnect_events(Events, State1).
+
+handle_reconnect_events([], State) ->
+    State;
+handle_reconnect_events([{grace_expired, PlayerId, Action} | Rest], State) ->
+    State1 =
+        case Action of
+            remove ->
+                #{players := Players, game_module := Mod, game_state := GS} = State,
+                case maps:is_key(PlayerId, Players) of
+                    false ->
+                        State;
+                    true ->
+                        {ok, GS1} = Mod:leave(PlayerId, GS),
+                        State#{
+                            players => maps:remove(PlayerId, Players),
+                            game_state => GS1
+                        }
+                end;
+            _ ->
+                State
+        end,
+    handle_reconnect_events(Rest, State1);
+handle_reconnect_events([_ | Rest], State) ->
+    handle_reconnect_events(Rest, State).
 
 generate_id() ->
     asobi_id:generate().

--- a/src/timers/asobi_entity_timer.erl
+++ b/src/timers/asobi_entity_timer.erl
@@ -1,0 +1,134 @@
+-module(asobi_entity_timer).
+
+%% Per-entity timers for zone-level objects (crafting, decay, cooldowns).
+%%
+%% Designed for scale: no individual erlang:send_after per entity.
+%% The zone server calls `tick/2` each zone tick, which checks all
+%% active timers against wall-clock time. Expired timers fire events.
+
+-export([new/0, start_timer/2, cancel_timer/3, tick/2]).
+-export([get_timers/2, active_count/1, info/1]).
+
+-export_type([state/0, entity_timer_event/0]).
+
+-opaque state() :: #{
+    timers := #{binary() => #{binary() => timer_entry()}}
+}.
+
+-type timer_entry() :: #{
+    timer_id := binary(),
+    entity_id := binary(),
+    owner := binary() | undefined,
+    end_at := pos_integer(),
+    on_complete := term(),
+    category := atom(),
+    pause_when_offline := boolean(),
+    paused := boolean()
+}.
+
+-type entity_timer_event() ::
+    {entity_timer_expired, binary(), binary(), term()}.
+
+%% -------------------------------------------------------------------
+%% Constructor
+%% -------------------------------------------------------------------
+
+-spec new() -> state().
+new() ->
+    #{timers => #{}}.
+
+%% -------------------------------------------------------------------
+%% Start a timer on an entity
+%% -------------------------------------------------------------------
+
+-spec start_timer(map(), state()) -> state().
+start_timer(Config, #{timers := Timers} = State) ->
+    EntityId = maps:get(entity_id, Config),
+    TimerId = maps:get(timer_id, Config),
+    Duration = maps:get(duration, Config),
+    Entry = #{
+        timer_id => TimerId,
+        entity_id => EntityId,
+        owner => maps:get(owner, Config, undefined),
+        end_at => erlang:system_time(millisecond) + Duration,
+        on_complete => maps:get(on_complete, Config, undefined),
+        category => maps:get(category, Config, general),
+        pause_when_offline => maps:get(pause_when_offline, Config, false),
+        paused => false
+    },
+    EntityTimers = maps:get(EntityId, Timers, #{}),
+    EntityTimers1 = EntityTimers#{TimerId => Entry},
+    State#{timers => Timers#{EntityId => EntityTimers1}}.
+
+%% -------------------------------------------------------------------
+%% Cancel a timer
+%% -------------------------------------------------------------------
+
+-spec cancel_timer(binary(), binary(), state()) -> state().
+cancel_timer(EntityId, TimerId, #{timers := Timers} = State) ->
+    case maps:get(EntityId, Timers, undefined) of
+        undefined ->
+            State;
+        EntityTimers ->
+            EntityTimers1 = maps:remove(TimerId, EntityTimers),
+            case map_size(EntityTimers1) of
+                0 -> State#{timers => maps:remove(EntityId, Timers)};
+                _ -> State#{timers => Timers#{EntityId => EntityTimers1}}
+            end
+    end.
+
+%% -------------------------------------------------------------------
+%% Tick — check all timers, return expired events + updated state
+%% -------------------------------------------------------------------
+
+-spec tick(pos_integer(), state()) -> {[entity_timer_event()], state()}.
+tick(Now, #{timers := Timers} = State) ->
+    {Events, Timers1} = maps:fold(
+        fun(EntityId, EntityTimers, {EvtAcc, TAcc}) ->
+            {Expired, Remaining} = maps:fold(
+                fun(TId, #{end_at := EndAt, paused := Paused} = Entry, {Exp, Rem}) ->
+                    case not Paused andalso Now >= EndAt of
+                        true ->
+                            OnComplete = maps:get(on_complete, Entry),
+                            {[{entity_timer_expired, EntityId, TId, OnComplete} | Exp], Rem};
+                        false ->
+                            {Exp, Rem#{TId => Entry}}
+                    end
+                end,
+                {[], #{}},
+                EntityTimers
+            ),
+            TAcc1 =
+                case map_size(Remaining) of
+                    0 -> TAcc;
+                    _ -> TAcc#{EntityId => Remaining}
+                end,
+            {Expired ++ EvtAcc, TAcc1}
+        end,
+        {[], #{}},
+        Timers
+    ),
+    {Events, State#{timers => Timers1}}.
+
+%% -------------------------------------------------------------------
+%% Queries
+%% -------------------------------------------------------------------
+
+-spec get_timers(binary(), state()) -> [timer_entry()].
+get_timers(EntityId, #{timers := Timers}) ->
+    case maps:get(EntityId, Timers, undefined) of
+        undefined -> [];
+        EntityTimers -> maps:values(EntityTimers)
+    end.
+
+-spec active_count(state()) -> non_neg_integer().
+active_count(#{timers := Timers}) ->
+    maps:fold(
+        fun(_EntityId, EntityTimers, Acc) -> Acc + map_size(EntityTimers) end,
+        0,
+        Timers
+    ).
+
+-spec info(state()) -> map().
+info(State) ->
+    #{active_timers => active_count(State)}.

--- a/src/timers/asobi_phase.erl
+++ b/src/timers/asobi_phase.erl
@@ -313,7 +313,8 @@ build_timers(TimerConfigs) ->
                 case Type of
                     countdown -> asobi_timer:countdown(Config);
                     conditional -> asobi_timer:conditional(Config);
-                    cycle -> asobi_timer:cycle(Config)
+                    cycle -> asobi_timer:cycle(Config);
+                    scheduled -> asobi_timer:scheduled(Config)
                 end,
             Acc#{Id => Timer}
         end,

--- a/src/timers/asobi_reconnect.erl
+++ b/src/timers/asobi_reconnect.erl
@@ -1,0 +1,147 @@
+-module(asobi_reconnect).
+
+%% Reconnection policy for match and world servers.
+%%
+%% Tracks disconnected players with grace period timers.
+%% Pure functional — the owning server calls `tick/2` each tick and
+%% `disconnect/3` / `reconnect/2` on player state changes.
+
+-export([new/1]).
+-export([disconnect/3, reconnect/2, tick/2]).
+-export([is_disconnected/2, disconnected_players/1, info/1]).
+
+-export_type([state/0, reconnect_event/0, policy/0]).
+
+-type policy() :: #{
+    grace_period := pos_integer(),
+    during_grace := idle | ai_controlled | invulnerable | removed | frozen,
+    on_reconnect := resume | respawn | spectate,
+    on_expire := remove | forfeit | ai_takeover | kick,
+    pause_match := boolean(),
+    max_offline_total := pos_integer() | infinity
+}.
+
+-type reconnect_event() ::
+    {grace_started, binary()}
+    | {grace_expired, binary(), atom()}
+    | {player_reconnected, binary(), atom()}.
+
+-opaque state() :: #{
+    policy := policy(),
+    disconnected := #{binary() => disconnect_entry()},
+    offline_totals := #{binary() => pos_integer()}
+}.
+
+-type disconnect_entry() :: #{
+    player_id := binary(),
+    disconnected_at := pos_integer(),
+    grace_remaining := pos_integer(),
+    total_offline := pos_integer()
+}.
+
+%% -------------------------------------------------------------------
+%% Constructor
+%% -------------------------------------------------------------------
+
+-spec new(policy()) -> state().
+new(Policy) ->
+    #{policy => Policy, disconnected => #{}, offline_totals => #{}}.
+
+%% -------------------------------------------------------------------
+%% Player disconnected
+%% -------------------------------------------------------------------
+
+-spec disconnect(binary(), pos_integer(), state()) -> {[reconnect_event()], state()}.
+disconnect(
+    PlayerId,
+    Now,
+    #{
+        policy := Policy,
+        disconnected := Disc,
+        offline_totals := Totals
+    } = State
+) ->
+    GracePeriod = maps:get(grace_period, Policy),
+    PrevTotal = maps:get(PlayerId, Totals, 0),
+    Entry = #{
+        player_id => PlayerId,
+        disconnected_at => Now,
+        grace_remaining => GracePeriod,
+        total_offline => PrevTotal
+    },
+    {[{grace_started, PlayerId}], State#{disconnected => Disc#{PlayerId => Entry}}}.
+
+%% -------------------------------------------------------------------
+%% Player reconnected
+%% -------------------------------------------------------------------
+
+-spec reconnect(binary(), state()) -> {[reconnect_event()], state()}.
+reconnect(
+    PlayerId,
+    #{
+        policy := Policy,
+        disconnected := Disc,
+        offline_totals := Totals
+    } = State
+) ->
+    case maps:get(PlayerId, Disc, undefined) of
+        undefined ->
+            {[], State};
+        #{total_offline := Total} ->
+            Action = maps:get(on_reconnect, Policy),
+            {[{player_reconnected, PlayerId, Action}], State#{
+                disconnected => maps:remove(PlayerId, Disc),
+                offline_totals => Totals#{PlayerId => Total}
+            }}
+    end.
+
+%% -------------------------------------------------------------------
+%% Tick — check grace periods
+%% -------------------------------------------------------------------
+
+-spec tick(pos_integer(), state()) -> {[reconnect_event()], state()}.
+tick(DeltaMs, #{policy := Policy, disconnected := Disc} = State) ->
+    OnExpire = maps:get(on_expire, Policy),
+    MaxTotal = maps:get(max_offline_total, Policy, infinity),
+    {Events, Disc1} = maps:fold(
+        fun(PlayerId, #{grace_remaining := Rem, total_offline := Total} = Entry, {Evts, Acc}) ->
+            Rem1 = Rem - DeltaMs,
+            Total1 = Total + DeltaMs,
+            BudgetExceeded = MaxTotal =/= infinity andalso Total1 >= MaxTotal,
+            case Rem1 =< 0 orelse BudgetExceeded of
+                true ->
+                    {[{grace_expired, PlayerId, OnExpire} | Evts], Acc};
+                false ->
+                    Entry1 = Entry#{grace_remaining => Rem1, total_offline => Total1},
+                    {Evts, Acc#{PlayerId => Entry1}}
+            end
+        end,
+        {[], #{}},
+        Disc
+    ),
+    {Events, State#{disconnected => Disc1}}.
+
+%% -------------------------------------------------------------------
+%% Queries
+%% -------------------------------------------------------------------
+
+-spec is_disconnected(binary(), state()) -> boolean().
+is_disconnected(PlayerId, #{disconnected := Disc}) ->
+    maps:is_key(PlayerId, Disc).
+
+-spec disconnected_players(state()) -> [binary()].
+disconnected_players(#{disconnected := Disc}) ->
+    maps:keys(Disc).
+
+-spec info(state()) -> map().
+info(#{policy := Policy, disconnected := Disc}) ->
+    #{
+        policy => Policy,
+        disconnected_count => map_size(Disc),
+        disconnected => maps:map(
+            fun(_Id, #{grace_remaining := Rem, total_offline := Total}) ->
+                #{grace_remaining_ms => max(0, Rem), total_offline_ms => Total}
+            end,
+            Disc
+        )
+    }.

--- a/src/timers/asobi_season.erl
+++ b/src/timers/asobi_season.erl
@@ -58,7 +58,7 @@ config(Key) ->
 upcoming() ->
     Q = kura_query:order_by(
         kura_query:where(kura_query:from(asobi_season), {status, ~"upcoming"}),
-        {starts_at, asc}
+        [{starts_at, asc}]
     ),
     case asobi_repo:all(Q) of
         {ok, Seasons} -> Seasons;
@@ -70,7 +70,7 @@ history() ->
     Q = kura_query:limit(
         kura_query:order_by(
             kura_query:where(kura_query:from(asobi_season), {status, ~"ended"}),
-            {ends_at, desc}
+            [{ends_at, desc}]
         ),
         20
     ),

--- a/src/timers/asobi_season.erl
+++ b/src/timers/asobi_season.erl
@@ -1,0 +1,90 @@
+-module(asobi_season).
+-behaviour(kura_schema).
+
+-include_lib("kura/include/kura.hrl").
+
+-export([table/0, fields/0, associations/0, indexes/0, generate_id/0]).
+-export([current/0, config/1, upcoming/0, history/0, time_remaining/0]).
+
+-spec table() -> binary().
+table() -> ~"seasons".
+
+-spec fields() -> [#kura_field{}].
+fields() ->
+    [
+        #kura_field{name = id, type = uuid, primary_key = true, nullable = false},
+        #kura_field{name = name, type = string, nullable = false},
+        #kura_field{name = starts_at, type = bigint, nullable = false},
+        #kura_field{name = ends_at, type = bigint, nullable = false},
+        #kura_field{name = status, type = string, default = ~"upcoming"},
+        #kura_field{name = config, type = jsonb, default = #{}},
+        #kura_field{name = ranked, type = jsonb, default = #{}},
+        #kura_field{name = rewards, type = jsonb, default = #{}},
+        #kura_field{name = inserted_at, type = utc_datetime, nullable = false}
+    ].
+
+-spec generate_id() -> binary().
+generate_id() -> asobi_id:generate().
+
+-spec associations() -> [#kura_assoc{}].
+associations() -> [].
+
+-spec indexes() -> [{[atom()], map()}].
+indexes() ->
+    [
+        {[status], #{}},
+        {[starts_at], #{}},
+        {[ends_at], #{}}
+    ].
+
+%% --- Query API ---
+
+-spec current() -> {ok, map()} | {error, no_active_season}.
+current() ->
+    Q = kura_query:limit(kura_query:where(kura_query:from(asobi_season), {status, ~"active"}), 1),
+    case asobi_repo:all(Q) of
+        {ok, [Season | _]} -> {ok, Season};
+        _ -> {error, no_active_season}
+    end.
+
+-spec config(binary()) -> term().
+config(Key) ->
+    case current() of
+        {ok, #{config := Config}} -> maps:get(Key, Config, undefined);
+        _ -> undefined
+    end.
+
+-spec upcoming() -> [map()].
+upcoming() ->
+    Q = kura_query:order_by(
+        kura_query:where(kura_query:from(asobi_season), {status, ~"upcoming"}),
+        {starts_at, asc}
+    ),
+    case asobi_repo:all(Q) of
+        {ok, Seasons} -> Seasons;
+        _ -> []
+    end.
+
+-spec history() -> [map()].
+history() ->
+    Q = kura_query:limit(
+        kura_query:order_by(
+            kura_query:where(kura_query:from(asobi_season), {status, ~"ended"}),
+            {ends_at, desc}
+        ),
+        20
+    ),
+    case asobi_repo:all(Q) of
+        {ok, Seasons} -> Seasons;
+        _ -> []
+    end.
+
+-spec time_remaining() -> pos_integer() | infinity.
+time_remaining() ->
+    case current() of
+        {ok, #{ends_at := EndsAt}} ->
+            Now = erlang:system_time(millisecond),
+            max(0, EndsAt - Now);
+        _ ->
+            infinity
+    end.

--- a/src/timers/asobi_season_manager.erl
+++ b/src/timers/asobi_season_manager.erl
@@ -1,0 +1,102 @@
+-module(asobi_season_manager).
+-behaviour(gen_server).
+
+%% Periodically checks season boundaries and manages transitions.
+
+-export([start_link/0]).
+-export([init/1, handle_call/3, handle_cast/2, handle_info/2, terminate/2]).
+
+-define(CHECK_INTERVAL, 60_000).
+
+-spec start_link() -> gen_server:start_ret().
+start_link() ->
+    gen_server:start_link({local, ?MODULE}, ?MODULE, [], []).
+
+-spec init([]) -> {ok, map()}.
+init([]) ->
+    erlang:send_after(?CHECK_INTERVAL, self(), check_seasons),
+    {ok, #{}}.
+
+-spec handle_call(term(), gen_server:from(), map()) -> {reply, term(), map()}.
+handle_call(_Request, _From, State) ->
+    {reply, {error, unknown_request}, State}.
+
+-spec handle_cast(term(), map()) -> {noreply, map()}.
+handle_cast(_Msg, State) ->
+    {noreply, State}.
+
+-spec handle_info(term(), map()) -> {noreply, map()}.
+handle_info(check_seasons, State) ->
+    check_and_transition(),
+    erlang:send_after(?CHECK_INTERVAL, self(), check_seasons),
+    {noreply, State};
+handle_info(_Info, State) ->
+    {noreply, State}.
+
+-spec terminate(term(), map()) -> ok.
+terminate(_Reason, _State) ->
+    ok.
+
+%% --- Internal ---
+
+-spec check_and_transition() -> ok.
+check_and_transition() ->
+    Now = erlang:system_time(millisecond),
+    activate_upcoming(Now),
+    end_expired(Now).
+
+-spec activate_upcoming(pos_integer()) -> ok.
+activate_upcoming(Now) ->
+    Q = kura_query:where(kura_query:from(asobi_season), {status, ~"upcoming"}),
+    case asobi_repo:all(Q) of
+        {ok, Seasons} ->
+            lists:foreach(
+                fun(#{id := Id, starts_at := StartsAt} = Season) ->
+                    case Now >= StartsAt of
+                        true ->
+                            CS = kura_changeset:cast(
+                                asobi_season, Season, #{status => ~"active"}, [status]
+                            ),
+                            _ = asobi_repo:update(CS),
+                            logger:notice(#{
+                                msg => ~"season_activated",
+                                season_id => Id,
+                                name => maps:get(name, Season)
+                            });
+                        false ->
+                            ok
+                    end
+                end,
+                Seasons
+            );
+        _ ->
+            ok
+    end.
+
+-spec end_expired(pos_integer()) -> ok.
+end_expired(Now) ->
+    Q = kura_query:where(kura_query:from(asobi_season), {status, ~"active"}),
+    case asobi_repo:all(Q) of
+        {ok, Seasons} ->
+            lists:foreach(
+                fun(#{id := Id, ends_at := EndsAt} = Season) ->
+                    case Now >= EndsAt of
+                        true ->
+                            CS = kura_changeset:cast(
+                                asobi_season, Season, #{status => ~"ended"}, [status]
+                            ),
+                            _ = asobi_repo:update(CS),
+                            logger:notice(#{
+                                msg => ~"season_ended",
+                                season_id => Id,
+                                name => maps:get(name, Season)
+                            });
+                        false ->
+                            ok
+                    end
+                end,
+                Seasons
+            );
+        _ ->
+            ok
+    end.

--- a/src/timers/asobi_timer.erl
+++ b/src/timers/asobi_timer.erl
@@ -6,7 +6,7 @@
 %% advances each tick by calling `tick/2`. This keeps timer logic
 %% testable and avoids per-timer process overhead.
 
--export([countdown/1, conditional/1, cycle/1]).
+-export([countdown/1, conditional/1, cycle/1, scheduled/1]).
 -export([tick/2, notify/3, pause/1, resume/1]).
 -export([is_expired/1, is_started/1, is_paused/1]).
 -export([remaining/1, current_phase/1, info/1]).
@@ -14,7 +14,7 @@
 -export_type([timer/0, timer_event/0]).
 
 -opaque timer() :: #{
-    type := countdown | conditional | cycle,
+    type := countdown | conditional | cycle | scheduled,
     id := binary(),
     _ => _
 }.
@@ -23,7 +23,10 @@
     {timer_started, binary()}
     | {timer_warning, binary(), pos_integer()}
     | {timer_expired, binary()}
-    | {phase_changed, binary(), binary()}.
+    | {phase_changed, binary(), binary()}
+    | {window_open, binary()}
+    | {window_close, binary()}
+    | {scheduled_fire, binary()}.
 
 %% -------------------------------------------------------------------
 %% Constructors
@@ -93,6 +96,24 @@ cycle(Config) ->
         expired => false
     }.
 
+-spec scheduled(map()) -> timer().
+scheduled(Config) ->
+    Id = maps:get(id, Config),
+    Schedule = maps:get(schedule, Config),
+    OnOpen = maps:get(on_open, Config, window_open),
+    OnClose = maps:get(on_close, Config, window_close),
+    #{
+        type => scheduled,
+        id => Id,
+        schedule => Schedule,
+        on_open => OnOpen,
+        on_close => OnClose,
+        window_active => false,
+        last_check => erlang:system_time(second),
+        paused => false,
+        expired => false
+    }.
+
 %% -------------------------------------------------------------------
 %% Tick — advance timer by DeltaMs, return {Events, Timer1}
 %% -------------------------------------------------------------------
@@ -139,6 +160,25 @@ tick(DeltaMs, #{type := conditional, started := true, id := Id, remaining := Rem
         false ->
             {WarningEvents, Timer1#{remaining => Rem1}}
     end;
+%% Scheduled — check wall-clock windows
+tick(
+    _DeltaMs,
+    #{
+        type := scheduled,
+        id := Id,
+        schedule := Schedule,
+        window_active := WasActive
+    } = Timer
+) ->
+    Now = erlang:system_time(second),
+    IsActive = check_schedule(Schedule, Now),
+    Events =
+        case {WasActive, IsActive} of
+            {false, true} -> [{window_open, Id}];
+            {true, false} -> [{window_close, Id}];
+            _ -> []
+        end,
+    {Events, Timer#{window_active => IsActive, last_check => Now}};
 %% Cycle
 tick(DeltaMs, #{type := cycle} = Timer) ->
     tick_cycle(DeltaMs, Timer, []).
@@ -189,6 +229,7 @@ is_paused(#{paused := Paused}) -> Paused.
 
 -spec remaining(timer()) -> pos_integer() | infinity.
 remaining(#{type := conditional, started := false}) -> infinity;
+remaining(#{type := scheduled}) -> infinity;
 remaining(#{type := cycle, phase_remaining := Rem}) -> Rem;
 remaining(#{remaining := Rem}) -> max(0, Rem).
 
@@ -225,6 +266,20 @@ info(#{
                 true -> max(0, Rem);
                 false -> infinity
             end,
+        paused => Paused,
+        expired => Expired
+    };
+info(#{
+    type := scheduled,
+    id := Id,
+    window_active := Active,
+    paused := Paused,
+    expired := Expired
+}) ->
+    #{
+        type => scheduled,
+        id => Id,
+        window_active => Active,
         paused => Paused,
         expired => Expired
     };
@@ -333,4 +388,34 @@ check_condition(Event, _Data, {event, Event}) ->
 check_condition(timer_expired, TimerId, {prev_expired, TimerId}) ->
     true;
 check_condition(_Event, _Data, _Condition) ->
+    false.
+
+%% -------------------------------------------------------------------
+%% Internal — schedule checking
+%% -------------------------------------------------------------------
+
+-spec check_schedule(term(), integer()) -> boolean().
+check_schedule({window, WindowConfig}, NowSec) ->
+    {{_Y, _M, _D} = Date, {H, Mi, _S}} = calendar:system_time_to_universal_time(NowSec, second),
+    DayOfWeek = calendar:day_of_the_week(Date),
+    Key =
+        case DayOfWeek of
+            N when N >= 6 -> weekend;
+            _ -> weekday
+        end,
+    case maps:get(Key, WindowConfig, undefined) of
+        undefined ->
+            false;
+        {StartH, StartM, EndH, EndM} ->
+            NowMins = H * 60 + Mi,
+            StartMins = StartH * 60 + StartM,
+            EndMins = EndH * 60 + EndM,
+            NowMins >= StartMins andalso NowMins < EndMins
+    end;
+check_schedule({once, TargetDatetime}, NowSec) ->
+    TargetSec =
+        calendar:datetime_to_gregorian_seconds(TargetDatetime) -
+            calendar:datetime_to_gregorian_seconds({{1970, 1, 1}, {0, 0, 0}}),
+    NowSec >= TargetSec;
+check_schedule(_Schedule, _NowSec) ->
     false.

--- a/src/world/asobi_zone.erl
+++ b/src/world/asobi_zone.erl
@@ -5,6 +5,7 @@
 -export([tick/2, player_input/3, add_entity/3, remove_entity/2]).
 -export([subscribe/2, unsubscribe/2]).
 -export([get_entities/1, get_subscriber_count/1]).
+-export([start_entity_timer/2, cancel_entity_timer/3]).
 -export([init/1, handle_call/3, handle_cast/2, handle_info/2, terminate/2]).
 
 -define(PG_SCOPE, nova_scope).
@@ -47,6 +48,14 @@ get_entities(Pid) ->
 get_subscriber_count(Pid) ->
     gen_server:call(Pid, get_subscriber_count).
 
+-spec start_entity_timer(pid(), map()) -> ok.
+start_entity_timer(Pid, Config) ->
+    gen_server:cast(Pid, {start_entity_timer, Config}).
+
+-spec cancel_entity_timer(pid(), binary(), binary()) -> ok.
+cancel_entity_timer(Pid, EntityId, TimerId) ->
+    gen_server:cast(Pid, {cancel_entity_timer, EntityId, TimerId}).
+
 %% --- gen_server callbacks ---
 
 -spec init(map()) -> {ok, map()}.
@@ -67,6 +76,7 @@ init(Config) ->
         subscribers => #{},
         zone_state => ZoneState,
         input_queue => [],
+        entity_timers => asobi_entity_timer:new(),
         tick => 0
     }}.
 
@@ -99,6 +109,10 @@ handle_cast({unsubscribe, PlayerId}, #{subscribers := Subs} = State) ->
             demonitor(MonRef, [flush]),
             {noreply, State#{subscribers => maps:remove(PlayerId, Subs)}}
     end;
+handle_cast({start_entity_timer, Config}, #{entity_timers := ET} = State) ->
+    {noreply, State#{entity_timers => asobi_entity_timer:start_timer(Config, ET)}};
+handle_cast({cancel_entity_timer, EntityId, TimerId}, #{entity_timers := ET} = State) ->
+    {noreply, State#{entity_timers => asobi_entity_timer:cancel_timer(EntityId, TimerId, ET)}};
 handle_cast(_Msg, State) ->
     {noreply, State}.
 
@@ -128,21 +142,39 @@ do_tick(
         zone_state := ZoneState,
         input_queue := Queue,
         subscribers := Subs,
-        ticker_pid := TickerPid
+        ticker_pid := TickerPid,
+        entity_timers := ET
     } = State
 ) ->
     Entities1 = apply_inputs(GameMod, Queue, Entities),
     {Entities2, ZoneState1} = GameMod:zone_tick(Entities1, ZoneState),
-    Deltas = compute_deltas(PrevEntities, Entities2),
+    Now = erlang:system_time(millisecond),
+    {TimerEvents, ET1} = asobi_entity_timer:tick(Now, ET),
+    Entities3 = apply_timer_events(TimerEvents, Entities2),
+    Deltas = compute_deltas(PrevEntities, Entities3),
     broadcast_deltas(TickN, Deltas, Subs),
     asobi_world_ticker:tick_done(TickerPid, self(), TickN),
     State#{
-        entities => Entities2,
-        prev_entities => Entities2,
+        entities => Entities3,
+        prev_entities => Entities3,
         zone_state => ZoneState1,
         input_queue => [],
+        entity_timers => ET1,
         tick => TickN
     }.
+
+apply_timer_events([], Entities) ->
+    Entities;
+apply_timer_events([{entity_timer_expired, EntityId, _TimerId, OnComplete} | Rest], Entities) ->
+    Entities1 =
+        case maps:get(EntityId, Entities, undefined) of
+            undefined ->
+                Entities;
+            EntityState ->
+                Timers = maps:get(~"completed_timers", EntityState, []),
+                Entities#{EntityId => EntityState#{~"completed_timers" => [OnComplete | Timers]}}
+        end,
+    apply_timer_events(Rest, Entities1).
 
 apply_inputs(_GameMod, [], Entities) ->
     Entities;

--- a/test/asobi_entity_timer_tests.erl
+++ b/test/asobi_entity_timer_tests.erl
@@ -1,0 +1,119 @@
+-module(asobi_entity_timer_tests).
+-include_lib("eunit/include/eunit.hrl").
+
+new_empty_test() ->
+    S = asobi_entity_timer:new(),
+    ?assertEqual(0, asobi_entity_timer:active_count(S)),
+    ?assertEqual([], asobi_entity_timer:get_timers(~"e1", S)).
+
+start_and_query_test() ->
+    S0 = asobi_entity_timer:new(),
+    S1 = asobi_entity_timer:start_timer(
+        #{
+            entity_id => ~"furnace_1",
+            timer_id => ~"smelt",
+            duration => 5000,
+            on_complete => {craft_complete, ~"iron_ingot", 10},
+            category => crafting
+        },
+        S0
+    ),
+    ?assertEqual(1, asobi_entity_timer:active_count(S1)),
+    Timers = asobi_entity_timer:get_timers(~"furnace_1", S1),
+    ?assertEqual(1, length(Timers)).
+
+tick_no_expire_test() ->
+    S0 = asobi_entity_timer:new(),
+    S1 = asobi_entity_timer:start_timer(
+        #{
+            entity_id => ~"e1",
+            timer_id => ~"t1",
+            duration => 10000,
+            on_complete => done
+        },
+        S0
+    ),
+    Now = erlang:system_time(millisecond) + 5000,
+    {Events, S2} = asobi_entity_timer:tick(Now, S1),
+    ?assertEqual([], Events),
+    ?assertEqual(1, asobi_entity_timer:active_count(S2)).
+
+tick_expire_test() ->
+    S0 = asobi_entity_timer:new(),
+    S1 = asobi_entity_timer:start_timer(
+        #{
+            entity_id => ~"e1",
+            timer_id => ~"t1",
+            duration => 100,
+            on_complete => {done, ~"item_a"}
+        },
+        S0
+    ),
+    Now = erlang:system_time(millisecond) + 200,
+    {Events, S2} = asobi_entity_timer:tick(Now, S1),
+    ?assertMatch([{entity_timer_expired, ~"e1", ~"t1", {done, ~"item_a"}}], Events),
+    ?assertEqual(0, asobi_entity_timer:active_count(S2)).
+
+cancel_timer_test() ->
+    S0 = asobi_entity_timer:new(),
+    S1 = asobi_entity_timer:start_timer(
+        #{
+            entity_id => ~"e1",
+            timer_id => ~"t1",
+            duration => 10000,
+            on_complete => done
+        },
+        S0
+    ),
+    S2 = asobi_entity_timer:cancel_timer(~"e1", ~"t1", S1),
+    ?assertEqual(0, asobi_entity_timer:active_count(S2)).
+
+multiple_entities_test() ->
+    S0 = asobi_entity_timer:new(),
+    S1 = asobi_entity_timer:start_timer(
+        #{
+            entity_id => ~"e1",
+            timer_id => ~"t1",
+            duration => 100,
+            on_complete => a
+        },
+        S0
+    ),
+    S2 = asobi_entity_timer:start_timer(
+        #{
+            entity_id => ~"e2",
+            timer_id => ~"t1",
+            duration => 200,
+            on_complete => b
+        },
+        S1
+    ),
+    S3 = asobi_entity_timer:start_timer(
+        #{
+            entity_id => ~"e1",
+            timer_id => ~"t2",
+            duration => 300,
+            on_complete => c
+        },
+        S2
+    ),
+    ?assertEqual(3, asobi_entity_timer:active_count(S3)),
+
+    Now = erlang:system_time(millisecond) + 150,
+    {Events, S4} = asobi_entity_timer:tick(Now, S3),
+    ?assertEqual(1, length(Events)),
+    ?assertEqual(2, asobi_entity_timer:active_count(S4)).
+
+info_test() ->
+    S0 = asobi_entity_timer:new(),
+    S1 = asobi_entity_timer:start_timer(
+        #{
+            entity_id => ~"e1",
+            timer_id => ~"t1",
+            duration => 100,
+            on_complete => done
+        },
+        S0
+    ),
+    Info = asobi_entity_timer:info(S1),
+    ?assertEqual(1, maps:get(active_timers, Info)).

--- a/test/asobi_reconnect_tests.erl
+++ b/test/asobi_reconnect_tests.erl
@@ -1,0 +1,81 @@
+-module(asobi_reconnect_tests).
+-include_lib("eunit/include/eunit.hrl").
+
+default_policy() ->
+    #{
+        grace_period => 5000,
+        during_grace => idle,
+        on_reconnect => resume,
+        on_expire => remove,
+        pause_match => false,
+        max_offline_total => infinity
+    }.
+
+disconnect_starts_grace_test() ->
+    S = asobi_reconnect:new(default_policy()),
+    Now = erlang:system_time(millisecond),
+    {Events, S1} = asobi_reconnect:disconnect(~"p1", Now, S),
+    ?assertMatch([{grace_started, ~"p1"}], Events),
+    ?assert(asobi_reconnect:is_disconnected(~"p1", S1)).
+
+reconnect_before_expire_test() ->
+    S = asobi_reconnect:new(default_policy()),
+    Now = erlang:system_time(millisecond),
+    {_, S1} = asobi_reconnect:disconnect(~"p1", Now, S),
+    {Events, S2} = asobi_reconnect:reconnect(~"p1", S1),
+    ?assertMatch([{player_reconnected, ~"p1", resume}], Events),
+    ?assertNot(asobi_reconnect:is_disconnected(~"p1", S2)).
+
+grace_expires_test() ->
+    S = asobi_reconnect:new(default_policy()),
+    Now = erlang:system_time(millisecond),
+    {_, S1} = asobi_reconnect:disconnect(~"p1", Now, S),
+    {Events, S2} = asobi_reconnect:tick(6000, S1),
+    ?assertMatch([{grace_expired, ~"p1", remove}], Events),
+    ?assertNot(asobi_reconnect:is_disconnected(~"p1", S2)).
+
+grace_not_expired_yet_test() ->
+    S = asobi_reconnect:new(default_policy()),
+    Now = erlang:system_time(millisecond),
+    {_, S1} = asobi_reconnect:disconnect(~"p1", Now, S),
+    {Events, S2} = asobi_reconnect:tick(3000, S1),
+    ?assertEqual([], Events),
+    ?assert(asobi_reconnect:is_disconnected(~"p1", S2)).
+
+max_offline_total_test() ->
+    Policy = (default_policy())#{grace_period => 10000, max_offline_total => 8000},
+    S = asobi_reconnect:new(Policy),
+    Now = erlang:system_time(millisecond),
+    {_, S1} = asobi_reconnect:disconnect(~"p1", Now, S),
+    {[], S2} = asobi_reconnect:tick(5000, S1),
+    {_, S3} = asobi_reconnect:reconnect(~"p1", S2),
+    {_, S4} = asobi_reconnect:disconnect(~"p1", Now + 10000, S3),
+    {Events, _S5} = asobi_reconnect:tick(4000, S4),
+    ?assertMatch([{grace_expired, ~"p1", remove}], Events).
+
+multiple_disconnects_test() ->
+    S = asobi_reconnect:new(default_policy()),
+    Now = erlang:system_time(millisecond),
+    {_, S1} = asobi_reconnect:disconnect(~"p1", Now, S),
+    {_, S2} = asobi_reconnect:disconnect(~"p2", Now, S1),
+    ?assertEqual([~"p1", ~"p2"], lists:sort(asobi_reconnect:disconnected_players(S2))).
+
+reconnect_unknown_player_test() ->
+    S = asobi_reconnect:new(default_policy()),
+    {Events, _} = asobi_reconnect:reconnect(~"nobody", S),
+    ?assertEqual([], Events).
+
+forfeit_policy_test() ->
+    Policy = (default_policy())#{on_expire => forfeit},
+    S = asobi_reconnect:new(Policy),
+    Now = erlang:system_time(millisecond),
+    {_, S1} = asobi_reconnect:disconnect(~"p1", Now, S),
+    {Events, _} = asobi_reconnect:tick(6000, S1),
+    ?assertMatch([{grace_expired, ~"p1", forfeit}], Events).
+
+info_test() ->
+    S = asobi_reconnect:new(default_policy()),
+    Now = erlang:system_time(millisecond),
+    {_, S1} = asobi_reconnect:disconnect(~"p1", Now, S),
+    Info = asobi_reconnect:info(S1),
+    ?assertEqual(1, maps:get(disconnected_count, Info)).

--- a/test/asobi_timer_tests.erl
+++ b/test/asobi_timer_tests.erl
@@ -215,3 +215,53 @@ info_cycle_test() ->
     ?assertEqual(cycle, maps:get(type, Info)),
     ?assertEqual(~"a", maps:get(current_phase, Info)),
     ?assertEqual(2, maps:get(total_phases, Info)).
+
+%% -------------------------------------------------------------------
+%% Scheduled
+%% -------------------------------------------------------------------
+
+scheduled_window_open_close_test() ->
+    {{Y, M, D}, _} = calendar:universal_time(),
+    DayOfWeek = calendar:day_of_the_week({Y, M, D}),
+    Key =
+        case DayOfWeek >= 6 of
+            true -> weekend;
+            false -> weekday
+        end,
+    T = asobi_timer:scheduled(#{
+        id => ~"pvp",
+        schedule => {window, #{Key => {0, 0, 23, 59}}}
+    }),
+    ?assertNot(asobi_timer:is_expired(T)),
+    {Events, T1} = asobi_timer:tick(0, T),
+    ?assertMatch([{window_open, ~"pvp"}], Events),
+    Info = asobi_timer:info(T1),
+    ?assertEqual(scheduled, maps:get(type, Info)),
+    ?assert(maps:get(window_active, Info)).
+
+scheduled_window_closed_test() ->
+    T = asobi_timer:scheduled(#{
+        id => ~"pvp",
+        schedule => {window, #{weekday => {25, 0, 25, 1}}}
+    }),
+    {Events, _} = asobi_timer:tick(0, T),
+    ?assertEqual([], Events).
+
+scheduled_once_test() ->
+    Past = {{2020, 1, 1}, {0, 0, 0}},
+    T = asobi_timer:scheduled(#{
+        id => ~"event",
+        schedule => {once, Past}
+    }),
+    {Events, T1} = asobi_timer:tick(0, T),
+    ?assertMatch([{window_open, ~"event"}], Events),
+    {[], _} = asobi_timer:tick(0, T1).
+
+scheduled_info_test() ->
+    T = asobi_timer:scheduled(#{
+        id => ~"s1",
+        schedule => {window, #{}}
+    }),
+    Info = asobi_timer:info(T),
+    ?assertEqual(scheduled, maps:get(type, Info)),
+    ?assertNot(maps:get(window_active, Info)).


### PR DESCRIPTION
## Summary

- Add scheduled timer primitive (wall-clock windows, one-shot triggers)
- Add entity timer system for per-entity zone-level timers (crafting, decay, cooldowns)
- Add reconnection policy with configurable grace periods and offline budgets
- Add season system with schema, manager, and query API

## New modules

| Module | Purpose |
|--------|---------|
| `asobi_entity_timer` | Per-entity timers ticked within zones (no per-timer processes) |
| `asobi_reconnect` | Disconnect/reconnect grace period tracking |
| `asobi_season` | Kura schema + query API for time-bounded season config |
| `asobi_season_manager` | Gen_server checking season boundaries every 60s |

## Modified modules

| Module | Change |
|--------|--------|
| `asobi_timer` | Added `scheduled/1` constructor + wall-clock checking |
| `asobi_phase` | Added `scheduled` to timer builder |
| `asobi_zone` | Entity timer integration in tick loop + start/cancel API |
| `asobi_match_server` | Reconnection policy init + tick integration |
| `asobi_sup` | Added season_manager to supervisor tree |

## Test plan

- [x] 4 scheduled timer tests (window open/close, one-shot, info)
- [x] 7 entity timer tests (start, expire, cancel, multiple entities, info)
- [x] 9 reconnection tests (disconnect, reconnect, grace expiry, max offline, policies)
- [x] All 141 tests pass
- [x] `rebar3 fmt --check` clean
- [x] `rebar3 xref` clean