### PR TITLE
feat: add direct messages and guild role hierarchy

### DIFF
--- a/src/asobi_router.erl
+++ b/src/asobi_router.erl
@@ -131,11 +131,25 @@ api_routes() ->
             %% Social - Groups
             {~"/groups", fun asobi_social_controller:create_group/1, #{methods => [post]}},
             {~"/groups/:id", fun asobi_social_controller:show_group/1, #{methods => [get]}},
+            {~"/groups/:id", fun asobi_social_controller:update_group/1, #{methods => [put]}},
             {~"/groups/:id/join", fun asobi_social_controller:join_group/1, #{methods => [post]}},
             {~"/groups/:id/leave", fun asobi_social_controller:leave_group/1, #{methods => [post]}},
+            {~"/groups/:id/members", fun asobi_social_controller:list_members/1, #{methods => [get]}},
+            {
+                ~"/groups/:id/members/:player_id/role",
+                fun asobi_social_controller:update_member_role/1,
+                #{methods => [put]}
+            },
+            {~"/groups/:id/members/:player_id", fun asobi_social_controller:kick_member/1, #{
+                methods => [delete]
+            }},
 
             %% Chat
             {~"/chat/:channel_id/history", fun asobi_chat_controller:history/1, #{methods => [get]}},
+
+            %% Direct Messages
+            {~"/dm", fun asobi_dm_controller:send/1, #{methods => [post]}},
+            {~"/dm/:player_id/history", fun asobi_dm_controller:history/1, #{methods => [get]}},
 
             %% Votes
             {~"/matches/:id/votes", fun asobi_vote_controller:index/1, #{methods => [get]}},

--- a/src/controllers/asobi_dm_controller.erl
+++ b/src/controllers/asobi_dm_controller.erl
@@ -1,0 +1,32 @@
+-module(asobi_dm_controller).
+
+-export([send/1, history/1]).
+
+-spec send(cowboy_req:req()) -> {json, map()} | {json, integer(), map(), map()}.
+send(#{
+    json := #{~"recipient_id" := RecipientId, ~"content" := Content},
+    auth_data := #{player_id := PlayerId}
+}) ->
+    case asobi_dm:send(PlayerId, RecipientId, Content) of
+        ok ->
+            {json, 200, #{}, #{
+                success => true, channel_id => asobi_dm:channel_id(PlayerId, RecipientId)
+            }};
+        {error, blocked} ->
+            {json, 403, #{}, #{error => ~"blocked"}}
+    end.
+
+-spec history(cowboy_req:req()) -> {json, map()}.
+history(#{
+    bindings := #{~"player_id" := OtherPlayerId},
+    qs := Qs,
+    auth_data := #{player_id := PlayerId}
+}) ->
+    Params = cow_qs:parse_qs(Qs),
+    Limit =
+        case proplists:get_value(~"limit", Params) of
+            V when is_binary(V) -> binary_to_integer(V);
+            _ -> 50
+        end,
+    Messages = asobi_dm:history(PlayerId, OtherPlayerId, Limit),
+    {json, #{messages => Messages, channel_id => asobi_dm:channel_id(PlayerId, OtherPlayerId)}}.

--- a/src/controllers/asobi_social_controller.erl
+++ b/src/controllers/asobi_social_controller.erl
@@ -10,7 +10,11 @@
     create_group/1,
     show_group/1,
     join_group/1,
-    leave_group/1
+    leave_group/1,
+    update_member_role/1,
+    kick_member/1,
+    list_members/1,
+    update_group/1
 ]).
 
 %% --- Friends ---
@@ -154,6 +158,106 @@ leave_group(#{bindings := #{~"id" := GroupId}, auth_data := #{player_id := Playe
             {json, 200, #{}, #{success => true}};
         _ ->
             {json, 200, #{}, #{success => true}}
+    end.
+
+%% --- Group Management ---
+
+-spec list_members(cowboy_req:req()) -> {json, map()} | {status, integer()}.
+list_members(#{bindings := #{~"id" := GroupId}} = _Req) ->
+    Q = kura_query:where(kura_query:from(asobi_group_member), {group_id, GroupId}),
+    case asobi_repo:all(Q) of
+        {ok, Members} -> {json, #{members => Members}};
+        _ -> {status, 404}
+    end.
+
+-spec update_member_role(cowboy_req:req()) -> {json, map()} | {json, integer(), map(), map()}.
+update_member_role(#{
+    bindings := #{~"id" := GroupId, ~"player_id" := TargetPlayerId},
+    json := #{~"role" := NewRole},
+    auth_data := #{player_id := ActorId}
+}) ->
+    case asobi_group_roles:valid_role(NewRole) of
+        false ->
+            {json, 400, #{}, #{error => ~"invalid_role"}};
+        true ->
+            case {get_member(GroupId, ActorId), get_member(GroupId, TargetPlayerId)} of
+                {{ok, #{role := ActorRole}}, {ok, #{role := TargetRole} = Target}} ->
+                    case asobi_group_roles:can_promote(ActorRole, TargetRole, NewRole) of
+                        true ->
+                            CS = kura_changeset:cast(
+                                asobi_group_member, Target, #{role => NewRole}, [role]
+                            ),
+                            {ok, Updated} = asobi_repo:update(CS),
+                            {json, 200, #{}, Updated};
+                        false ->
+                            {json, 403, #{}, #{error => ~"insufficient_permissions"}}
+                    end;
+                _ ->
+                    {json, 404, #{}, #{error => ~"member_not_found"}}
+            end
+    end.
+
+-spec kick_member(cowboy_req:req()) -> {json, map()} | {json, integer(), map(), map()}.
+kick_member(#{
+    bindings := #{~"id" := GroupId, ~"player_id" := TargetPlayerId},
+    auth_data := #{player_id := ActorId}
+}) ->
+    case {get_member(GroupId, ActorId), get_member(GroupId, TargetPlayerId)} of
+        {{ok, #{role := ActorRole}}, {ok, #{role := TargetRole} = Target}} ->
+            case asobi_group_roles:can_kick(ActorRole, TargetRole) of
+                true ->
+                    _ = asobi_repo:delete(asobi_group_member, Target),
+                    {json, 200, #{}, #{success => true}};
+                false ->
+                    {json, 403, #{}, #{error => ~"insufficient_permissions"}}
+            end;
+        _ ->
+            {json, 404, #{}, #{error => ~"member_not_found"}}
+    end.
+
+-spec update_group(cowboy_req:req()) -> {json, map()} | {json, integer(), map(), map()}.
+update_group(#{
+    bindings := #{~"id" := GroupId},
+    json := Params,
+    auth_data := #{player_id := ActorId}
+}) when is_map(Params) ->
+    case get_member(GroupId, ActorId) of
+        {ok, #{role := Role}} ->
+            case asobi_group_roles:can_update_group(Role) of
+                true ->
+                    case asobi_repo:get(asobi_group, GroupId) of
+                        {ok, Group} ->
+                            Updates = maps:with(
+                                [~"name", ~"description", ~"max_members", ~"open"], Params
+                            ),
+                            Atomized = maps:fold(
+                                fun(K, V, Acc) -> Acc#{binary_to_existing_atom(K) => V} end,
+                                #{},
+                                Updates
+                            ),
+                            CS = asobi_group:changeset(Group, Atomized),
+                            {ok, Updated} = asobi_repo:update(CS),
+                            {json, 200, #{}, Updated};
+                        _ ->
+                            {json, 404, #{}, #{error => ~"group_not_found"}}
+                    end;
+                false ->
+                    {json, 403, #{}, #{error => ~"insufficient_permissions"}}
+            end;
+        _ ->
+            {json, 403, #{}, #{error => ~"not_a_member"}}
+    end.
+
+%% --- Internal ---
+
+get_member(GroupId, PlayerId) ->
+    Q = kura_query:where(
+        kura_query:where(kura_query:from(asobi_group_member), {group_id, GroupId}),
+        {player_id, PlayerId}
+    ),
+    case asobi_repo:all(Q) of
+        {ok, [Member]} -> {ok, Member};
+        _ -> {error, not_found}
     end.
 
 qs_integer(Key, Params, Default) ->

--- a/src/social/asobi_dm.erl
+++ b/src/social/asobi_dm.erl
@@ -1,0 +1,56 @@
+-module(asobi_dm).
+
+%% Direct messaging built on the chat channel system.
+%%
+%% DM channel IDs are deterministic: the two player IDs sorted and
+%% joined with a colon. This ensures both players always reference
+%% the same channel regardless of who initiated.
+
+-export([send/3, history/3, channel_id/2]).
+
+-spec send(binary(), binary(), binary()) -> ok | {error, term()}.
+send(SenderId, RecipientId, Content) ->
+    case is_blocked(SenderId, RecipientId) of
+        true ->
+            {error, blocked};
+        false ->
+            ChannelId = channel_id(SenderId, RecipientId),
+            asobi_chat_channel:send_message(ChannelId, SenderId, Content),
+            asobi_presence:send(
+                RecipientId,
+                {dm_message, #{
+                    sender_id => SenderId,
+                    content => Content,
+                    channel_id => ChannelId,
+                    sent_at => erlang:system_time(millisecond)
+                }}
+            ),
+            ok
+    end.
+
+-spec history(binary(), binary(), pos_integer()) -> [map()].
+history(PlayerId, OtherPlayerId, Limit) ->
+    ChannelId = channel_id(PlayerId, OtherPlayerId),
+    asobi_chat_channel:get_history(ChannelId, Limit).
+
+-spec channel_id(binary(), binary()) -> binary().
+channel_id(A, B) when A =< B ->
+    iolist_to_binary([~"dm:", A, ~":", B]);
+channel_id(A, B) ->
+    iolist_to_binary([~"dm:", B, ~":", A]).
+
+%% --- Internal ---
+
+-spec is_blocked(binary(), binary()) -> boolean().
+is_blocked(SenderId, RecipientId) ->
+    Q = kura_query:where(
+        kura_query:where(
+            kura_query:where(kura_query:from(asobi_friendship), {player_id, RecipientId}),
+            {friend_id, SenderId}
+        ),
+        {status, ~"blocked"}
+    ),
+    case asobi_repo:all(Q) of
+        {ok, [_ | _]} -> true;
+        _ -> false
+    end.

--- a/src/social/asobi_group_roles.erl
+++ b/src/social/asobi_group_roles.erl
@@ -1,0 +1,42 @@
+-module(asobi_group_roles).
+
+%% Role hierarchy and permission checks for groups/guilds.
+%%
+%% Hierarchy: owner > admin > moderator > member
+%% Higher roles can manage lower roles but not equal or higher.
+
+-export([rank/1, can_manage/2, can_kick/2, can_promote/3, can_update_group/1]).
+-export([valid_role/1]).
+
+-spec rank(binary()) -> non_neg_integer().
+rank(~"owner") -> 100;
+rank(~"admin") -> 75;
+rank(~"moderator") -> 50;
+rank(~"member") -> 0;
+rank(_) -> 0.
+
+-spec valid_role(binary()) -> boolean().
+valid_role(~"owner") -> true;
+valid_role(~"admin") -> true;
+valid_role(~"moderator") -> true;
+valid_role(~"member") -> true;
+valid_role(_) -> false.
+
+-spec can_manage(binary(), binary()) -> boolean().
+can_manage(ActorRole, TargetRole) ->
+    rank(ActorRole) > rank(TargetRole).
+
+-spec can_kick(binary(), binary()) -> boolean().
+can_kick(ActorRole, TargetRole) ->
+    rank(ActorRole) >= rank(~"moderator") andalso
+        rank(ActorRole) > rank(TargetRole).
+
+-spec can_promote(binary(), binary(), binary()) -> boolean().
+can_promote(ActorRole, _TargetCurrentRole, NewRole) ->
+    rank(ActorRole) >= rank(~"admin") andalso
+        rank(ActorRole) > rank(NewRole) andalso
+        NewRole =/= ~"owner".
+
+-spec can_update_group(binary()) -> boolean().
+can_update_group(Role) ->
+    rank(Role) >= rank(~"admin").

--- a/src/ws/asobi_ws_handler.erl
+++ b/src/ws/asobi_ws_handler.erl
@@ -71,6 +71,9 @@ websocket_info({asobi_message, {world_event, Event, Payload}}, State) when is_at
 websocket_info({chat_message, ChannelId, Msg}, State) when is_map(Msg) ->
     Reply = encode_reply(undefined, ~"chat.message", Msg#{channel_id => ChannelId}),
     {reply, {text, Reply}, State};
+websocket_info({asobi_message, {dm_message, Msg}}, State) when is_map(Msg) ->
+    Reply = encode_reply(undefined, ~"dm.message", Msg),
+    {reply, {text, Reply}, State};
 websocket_info({asobi_message, {notification, Notif}}, State) ->
     Reply = encode_reply(undefined, ~"notification.new", Notif),
     {reply, {text, Reply}, State};
@@ -145,6 +148,21 @@ handle_message(
     #{~"channel_id" := ChannelId, ~"content" := Content} = Payload,
     asobi_chat_channel:send_message(ChannelId, PlayerId, Content),
     {ok, State};
+handle_message(
+    #{~"type" := ~"dm.send", ~"payload" := Payload} = Msg, #{player_id := PlayerId} = State
+) when is_binary(PlayerId) ->
+    Cid = maps:get(~"cid", Msg, undefined),
+    #{~"recipient_id" := RecipientId, ~"content" := Content} = Payload,
+    case asobi_dm:send(PlayerId, RecipientId, Content) of
+        ok ->
+            Reply = encode_reply(Cid, ~"dm.sent", #{
+                channel_id => asobi_dm:channel_id(PlayerId, RecipientId)
+            }),
+            {reply, {text, Reply}, State};
+        {error, blocked} ->
+            Reply = encode_reply(Cid, ~"error", #{reason => ~"blocked"}),
+            {reply, {text, Reply}, State}
+    end;
 handle_message(
     #{~"type" := ~"chat.join", ~"payload" := #{~"channel_id" := ChannelId}} = Msg, State
 ) ->

--- a/test/asobi_dm_tests.erl
+++ b/test/asobi_dm_tests.erl
@@ -1,0 +1,19 @@
+-module(asobi_dm_tests).
+-include_lib("eunit/include/eunit.hrl").
+
+channel_id_deterministic_test() ->
+    Id1 = asobi_dm:channel_id(~"alice", ~"bob"),
+    Id2 = asobi_dm:channel_id(~"bob", ~"alice"),
+    ?assertEqual(Id1, Id2).
+
+channel_id_sorted_test() ->
+    Id = asobi_dm:channel_id(~"zzz", ~"aaa"),
+    ?assertEqual(~"dm:aaa:zzz", Id).
+
+channel_id_same_order_test() ->
+    Id = asobi_dm:channel_id(~"aaa", ~"zzz"),
+    ?assertEqual(~"dm:aaa:zzz", Id).
+
+channel_id_prefix_test() ->
+    Id = asobi_dm:channel_id(~"p1", ~"p2"),
+    ?assertMatch(<<"dm:", _/binary>>, Id).

--- a/test/asobi_group_roles_tests.erl
+++ b/test/asobi_group_roles_tests.erl
@@ -1,0 +1,49 @@
+-module(asobi_group_roles_tests).
+-include_lib("eunit/include/eunit.hrl").
+
+rank_hierarchy_test() ->
+    ?assert(asobi_group_roles:rank(~"owner") > asobi_group_roles:rank(~"admin")),
+    ?assert(asobi_group_roles:rank(~"admin") > asobi_group_roles:rank(~"moderator")),
+    ?assert(asobi_group_roles:rank(~"moderator") > asobi_group_roles:rank(~"member")),
+    ?assertEqual(0, asobi_group_roles:rank(~"unknown")).
+
+valid_role_test() ->
+    ?assert(asobi_group_roles:valid_role(~"owner")),
+    ?assert(asobi_group_roles:valid_role(~"admin")),
+    ?assert(asobi_group_roles:valid_role(~"moderator")),
+    ?assert(asobi_group_roles:valid_role(~"member")),
+    ?assertNot(asobi_group_roles:valid_role(~"superuser")),
+    ?assertNot(asobi_group_roles:valid_role(~"")).
+
+can_manage_test() ->
+    ?assert(asobi_group_roles:can_manage(~"owner", ~"admin")),
+    ?assert(asobi_group_roles:can_manage(~"owner", ~"member")),
+    ?assert(asobi_group_roles:can_manage(~"admin", ~"moderator")),
+    ?assert(asobi_group_roles:can_manage(~"admin", ~"member")),
+    ?assertNot(asobi_group_roles:can_manage(~"admin", ~"admin")),
+    ?assertNot(asobi_group_roles:can_manage(~"member", ~"member")),
+    ?assertNot(asobi_group_roles:can_manage(~"moderator", ~"admin")).
+
+can_kick_test() ->
+    ?assert(asobi_group_roles:can_kick(~"owner", ~"admin")),
+    ?assert(asobi_group_roles:can_kick(~"owner", ~"member")),
+    ?assert(asobi_group_roles:can_kick(~"admin", ~"moderator")),
+    ?assert(asobi_group_roles:can_kick(~"moderator", ~"member")),
+    ?assertNot(asobi_group_roles:can_kick(~"member", ~"member")),
+    ?assertNot(asobi_group_roles:can_kick(~"moderator", ~"moderator")),
+    ?assertNot(asobi_group_roles:can_kick(~"moderator", ~"admin")).
+
+can_promote_test() ->
+    ?assert(asobi_group_roles:can_promote(~"owner", ~"member", ~"admin")),
+    ?assert(asobi_group_roles:can_promote(~"owner", ~"member", ~"moderator")),
+    ?assert(asobi_group_roles:can_promote(~"admin", ~"member", ~"moderator")),
+    ?assertNot(asobi_group_roles:can_promote(~"admin", ~"member", ~"admin")),
+    ?assertNot(asobi_group_roles:can_promote(~"admin", ~"member", ~"owner")),
+    ?assertNot(asobi_group_roles:can_promote(~"moderator", ~"member", ~"moderator")),
+    ?assertNot(asobi_group_roles:can_promote(~"member", ~"member", ~"moderator")).
+
+can_update_group_test() ->
+    ?assert(asobi_group_roles:can_update_group(~"owner")),
+    ?assert(asobi_group_roles:can_update_group(~"admin")),
+    ?assertNot(asobi_group_roles:can_update_group(~"moderator")),
+    ?assertNot(asobi_group_roles:can_update_group(~"member")).


### PR DESCRIPTION
## Summary

- Add direct messaging system with block checking and real-time delivery
- Add guild role hierarchy (owner > admin > moderator > member) with permission checks
- New REST endpoints for DMs and group management

## Direct Messages

| Endpoint | Description |
|----------|-------------|
| `POST /api/v1/dm` | Send DM (checks blocks) |
| `GET /api/v1/dm/:player_id/history` | Get DM history |
| `dm.send` (WS) | Send DM via WebSocket |
| `dm.message` (WS) | Receive DM in real-time |

## Guild Roles

| Role | Rank | Can kick | Can promote | Can update group |
|------|------|----------|-------------|-----------------|
| owner | 100 | Anyone below | Up to admin | Yes |
| admin | 75 | Moderator, member | Up to moderator | Yes |
| moderator | 50 | Member only | No | No |
| member | 0 | No | No | No |

## New Group Endpoints

| Endpoint | Description |
|----------|-------------|
| `GET /groups/:id/members` | List members with roles |
| `PUT /groups/:id/members/:player_id/role` | Change member role |
| `DELETE /groups/:id/members/:player_id` | Kick member |
| `PUT /groups/:id` | Update group settings (admin+) |

## Test plan

- [x] 4 DM tests (deterministic IDs, sorting, prefix)
- [x] 6 guild role tests (hierarchy, kick, promote, manage, update permissions)
- [x] All 151 tests pass
- [x] `rebar3 xref` clean
- [x] `rebar3 fmt --check` clean