### PR TITLE
fix: world server deadlock, bot spawner, async spawn, world lobby

### DIFF
--- a/src/asobi_game_modes.erl
+++ b/src/asobi_game_modes.erl
@@ -1,0 +1,49 @@
+-module(asobi_game_modes).
+
+-export([mode_config/1, resolve_game_module/1, world_config/1]).
+
+-spec mode_config(binary()) -> map().
+mode_config(Mode) ->
+    Modes = ensure_map(application:get_env(asobi, game_modes, #{})),
+    case Modes of
+        #{Mode := Config} when is_map(Config) -> Config;
+        #{Mode := Mod} when is_atom(Mod) -> #{module => Mod};
+        _ -> #{}
+    end.
+
+-spec resolve_game_module(binary()) -> {ok, module(), map()} | {error, not_found}.
+resolve_game_module(Mode) ->
+    case mode_config(Mode) of
+        #{type := world, module := {lua, Script}} ->
+            {ok, asobi_lua_world, #{lua_script => Script}};
+        #{module := {lua, Script}} ->
+            {ok, asobi_lua_match, #{lua_script => Script}};
+        #{module := Mod} when is_atom(Mod) ->
+            {ok, Mod, #{}};
+        _ ->
+            {error, not_found}
+    end.
+
+-doc "Build a world server config map from a mode's game_modes config.".
+-spec world_config(binary()) -> {ok, map()} | {error, not_found}.
+world_config(Mode) ->
+    ModeConfig = mode_config(Mode),
+    case resolve_game_module(Mode) of
+        {ok, GameMod, ExtraConfig} ->
+            {ok, #{
+                mode => Mode,
+                game_module => GameMod,
+                game_config => ExtraConfig,
+                max_players => maps:get(max_players, ModeConfig, 500),
+                grid_size => maps:get(grid_size, ModeConfig, 10),
+                zone_size => maps:get(zone_size, ModeConfig, 200),
+                tick_rate => maps:get(tick_rate, ModeConfig, 50),
+                view_radius => maps:get(view_radius, ModeConfig, 1)
+            }};
+        {error, _} = Err ->
+            Err
+    end.
+
+-spec ensure_map(term()) -> #{term() => term()}.
+ensure_map(M) when is_map(M) -> M;
+ensure_map(_) -> #{}.

--- a/src/asobi_router.erl
+++ b/src/asobi_router.erl
@@ -86,6 +86,11 @@ api_routes() ->
             {~"/players/:id", fun asobi_player_controller:show/1, #{methods => [get]}},
             {~"/players/:id", fun asobi_player_controller:update/1, #{methods => [put]}},
 
+            %% Worlds
+            {~"/worlds", fun asobi_world_controller:index/1, #{methods => [get]}},
+            {~"/worlds/:id", fun asobi_world_controller:show/1, #{methods => [get]}},
+            {~"/worlds", fun asobi_world_controller:create/1, #{methods => [post]}},
+
             %% Matches
             {~"/matches", fun asobi_match_controller:index/1, #{methods => [get]}},
             {~"/matches/:id", fun asobi_match_controller:show/1, #{methods => [get]}},

--- a/src/asobi_router.erl
+++ b/src/asobi_router.erl
@@ -131,11 +131,25 @@ api_routes() ->
             %% Social - Groups
             {~"/groups", fun asobi_social_controller:create_group/1, #{methods => [post]}},
             {~"/groups/:id", fun asobi_social_controller:show_group/1, #{methods => [get]}},
+            {~"/groups/:id", fun asobi_social_controller:update_group/1, #{methods => [put]}},
             {~"/groups/:id/join", fun asobi_social_controller:join_group/1, #{methods => [post]}},
             {~"/groups/:id/leave", fun asobi_social_controller:leave_group/1, #{methods => [post]}},
+            {~"/groups/:id/members", fun asobi_social_controller:list_members/1, #{methods => [get]}},
+            {
+                ~"/groups/:id/members/:player_id/role",
+                fun asobi_social_controller:update_member_role/1,
+                #{methods => [put]}
+            },
+            {~"/groups/:id/members/:player_id", fun asobi_social_controller:kick_member/1, #{
+                methods => [delete]
+            }},
 
             %% Chat
             {~"/chat/:channel_id/history", fun asobi_chat_controller:history/1, #{methods => [get]}},
+
+            %% Direct Messages
+            {~"/dm", fun asobi_dm_controller:send/1, #{methods => [post]}},
+            {~"/dm/:player_id/history", fun asobi_dm_controller:history/1, #{methods => [get]}},
 
             %% Votes
             {~"/matches/:id/votes", fun asobi_vote_controller:index/1, #{methods => [get]}},

--- a/src/bots/asobi_bot_spawner.erl
+++ b/src/bots/asobi_bot_spawner.erl
@@ -47,10 +47,13 @@ handle_call(_, _From, State) -> {reply, ok, State}.
 %% --- Queue Filling ---
 
 fill_queue_with_bots() ->
-    case asobi_matchmaker:get_queue_stats() of
+    try asobi_matchmaker:get_queue_stats() of
         {ok, #{by_mode := ByMode}} when map_size(ByMode) > 0 ->
             maps:foreach(fun fill_mode/2, ByMode);
         _ ->
+            ok
+    catch
+        exit:{timeout, _} ->
             ok
     end.
 

--- a/src/controllers/asobi_dm_controller.erl
+++ b/src/controllers/asobi_dm_controller.erl
@@ -1,0 +1,32 @@
+-module(asobi_dm_controller).
+
+-export([send/1, history/1]).
+
+-spec send(cowboy_req:req()) -> {json, map()} | {json, integer(), map(), map()}.
+send(#{
+    json := #{~"recipient_id" := RecipientId, ~"content" := Content},
+    auth_data := #{player_id := PlayerId}
+}) ->
+    case asobi_dm:send(PlayerId, RecipientId, Content) of
+        ok ->
+            {json, 200, #{}, #{
+                success => true, channel_id => asobi_dm:channel_id(PlayerId, RecipientId)
+            }};
+        {error, blocked} ->
+            {json, 403, #{}, #{error => ~"blocked"}}
+    end.
+
+-spec history(cowboy_req:req()) -> {json, map()}.
+history(#{
+    bindings := #{~"player_id" := OtherPlayerId},
+    qs := Qs,
+    auth_data := #{player_id := PlayerId}
+}) ->
+    Params = cow_qs:parse_qs(Qs),
+    Limit =
+        case proplists:get_value(~"limit", Params) of
+            V when is_binary(V) -> binary_to_integer(V);
+            _ -> 50
+        end,
+    Messages = asobi_dm:history(PlayerId, OtherPlayerId, Limit),
+    {json, #{messages => Messages, channel_id => asobi_dm:channel_id(PlayerId, OtherPlayerId)}}.

--- a/src/controllers/asobi_social_controller.erl
+++ b/src/controllers/asobi_social_controller.erl
@@ -10,7 +10,11 @@
     create_group/1,
     show_group/1,
     join_group/1,
-    leave_group/1
+    leave_group/1,
+    update_member_role/1,
+    kick_member/1,
+    list_members/1,
+    update_group/1
 ]).
 
 %% --- Friends ---
@@ -154,6 +158,106 @@ leave_group(#{bindings := #{~"id" := GroupId}, auth_data := #{player_id := Playe
             {json, 200, #{}, #{success => true}};
         _ ->
             {json, 200, #{}, #{success => true}}
+    end.
+
+%% --- Group Management ---
+
+-spec list_members(cowboy_req:req()) -> {json, map()} | {status, integer()}.
+list_members(#{bindings := #{~"id" := GroupId}} = _Req) ->
+    Q = kura_query:where(kura_query:from(asobi_group_member), {group_id, GroupId}),
+    case asobi_repo:all(Q) of
+        {ok, Members} -> {json, #{members => Members}};
+        _ -> {status, 404}
+    end.
+
+-spec update_member_role(cowboy_req:req()) -> {json, map()} | {json, integer(), map(), map()}.
+update_member_role(#{
+    bindings := #{~"id" := GroupId, ~"player_id" := TargetPlayerId},
+    json := #{~"role" := NewRole},
+    auth_data := #{player_id := ActorId}
+}) ->
+    case asobi_group_roles:valid_role(NewRole) of
+        false ->
+            {json, 400, #{}, #{error => ~"invalid_role"}};
+        true ->
+            case {get_member(GroupId, ActorId), get_member(GroupId, TargetPlayerId)} of
+                {{ok, #{role := ActorRole}}, {ok, #{role := TargetRole} = Target}} ->
+                    case asobi_group_roles:can_promote(ActorRole, TargetRole, NewRole) of
+                        true ->
+                            CS = kura_changeset:cast(
+                                asobi_group_member, Target, #{role => NewRole}, [role]
+                            ),
+                            {ok, Updated} = asobi_repo:update(CS),
+                            {json, 200, #{}, Updated};
+                        false ->
+                            {json, 403, #{}, #{error => ~"insufficient_permissions"}}
+                    end;
+                _ ->
+                    {json, 404, #{}, #{error => ~"member_not_found"}}
+            end
+    end.
+
+-spec kick_member(cowboy_req:req()) -> {json, map()} | {json, integer(), map(), map()}.
+kick_member(#{
+    bindings := #{~"id" := GroupId, ~"player_id" := TargetPlayerId},
+    auth_data := #{player_id := ActorId}
+}) ->
+    case {get_member(GroupId, ActorId), get_member(GroupId, TargetPlayerId)} of
+        {{ok, #{role := ActorRole}}, {ok, #{role := TargetRole} = Target}} ->
+            case asobi_group_roles:can_kick(ActorRole, TargetRole) of
+                true ->
+                    _ = asobi_repo:delete(asobi_group_member, Target),
+                    {json, 200, #{}, #{success => true}};
+                false ->
+                    {json, 403, #{}, #{error => ~"insufficient_permissions"}}
+            end;
+        _ ->
+            {json, 404, #{}, #{error => ~"member_not_found"}}
+    end.
+
+-spec update_group(cowboy_req:req()) -> {json, map()} | {json, integer(), map(), map()}.
+update_group(#{
+    bindings := #{~"id" := GroupId},
+    json := Params,
+    auth_data := #{player_id := ActorId}
+}) when is_map(Params) ->
+    case get_member(GroupId, ActorId) of
+        {ok, #{role := Role}} ->
+            case asobi_group_roles:can_update_group(Role) of
+                true ->
+                    case asobi_repo:get(asobi_group, GroupId) of
+                        {ok, Group} ->
+                            Updates = maps:with(
+                                [~"name", ~"description", ~"max_members", ~"open"], Params
+                            ),
+                            Atomized = maps:fold(
+                                fun(K, V, Acc) -> Acc#{binary_to_existing_atom(K) => V} end,
+                                #{},
+                                Updates
+                            ),
+                            CS = asobi_group:changeset(Group, Atomized),
+                            {ok, Updated} = asobi_repo:update(CS),
+                            {json, 200, #{}, Updated};
+                        _ ->
+                            {json, 404, #{}, #{error => ~"group_not_found"}}
+                    end;
+                false ->
+                    {json, 403, #{}, #{error => ~"insufficient_permissions"}}
+            end;
+        _ ->
+            {json, 403, #{}, #{error => ~"not_a_member"}}
+    end.
+
+%% --- Internal ---
+
+get_member(GroupId, PlayerId) ->
+    Q = kura_query:where(
+        kura_query:where(kura_query:from(asobi_group_member), {group_id, GroupId}),
+        {player_id, PlayerId}
+    ),
+    case asobi_repo:all(Q) of
+        {ok, [Member]} -> {ok, Member};
+        _ -> {error, not_found}
     end.
 
 qs_integer(Key, Params, Default) ->

--- a/src/controllers/asobi_world_controller.erl
+++ b/src/controllers/asobi_world_controller.erl
@@ -1,0 +1,50 @@
+-module(asobi_world_controller).
+
+-export([index/1, show/1, create/1]).
+
+-spec index(map()) -> {json, map()}.
+index(#{parsed_qs := QS}) ->
+    Filters = build_filters(QS),
+    Worlds = asobi_world_lobby:list_worlds(Filters),
+    {json, #{worlds => Worlds}};
+index(_Req) ->
+    Worlds = asobi_world_lobby:list_worlds(),
+    {json, #{worlds => Worlds}}.
+
+-spec show(map()) -> {json, map()} | {status, 404}.
+show(#{bindings := #{~"id" := WorldId}}) ->
+    case asobi_world_server:whereis(WorldId) of
+        {ok, Pid} ->
+            Info = asobi_world_server:get_info(Pid),
+            {json, Info};
+        error ->
+            {status, 404}
+    end.
+
+-spec create(map()) -> {json, map(), integer()} | {status, 400}.
+create(#{json := #{~"mode" := Mode}}) ->
+    case asobi_world_lobby:create_world(Mode) of
+        {ok, _Pid, Info} ->
+            {json, Info, 201};
+        {error, Reason} ->
+            {json, #{error => Reason}, 400}
+    end;
+create(_Req) ->
+    {status, 400}.
+
+%%--------------------------------------------------------------------
+%% Internal
+%%--------------------------------------------------------------------
+
+-spec build_filters(map()) -> map().
+build_filters(QS) ->
+    F0 = #{},
+    F1 =
+        case maps:get(~"mode", QS, undefined) of
+            undefined -> F0;
+            Mode -> F0#{mode => Mode}
+        end,
+    case maps:get(~"has_capacity", QS, undefined) of
+        ~"true" -> F1#{has_capacity => true};
+        _ -> F1
+    end.

--- a/src/matches/asobi_matchmaker.erl
+++ b/src/matches/asobi_matchmaker.erl
@@ -305,38 +305,58 @@ spawn_world(Mode, ModeConfig, PlayerIds, Group, Rest, Failed) ->
                 tick_rate => maps:get(tick_rate, ModeConfig, 50),
                 view_radius => maps:get(view_radius, ModeConfig, 1)
             },
-            case asobi_world_instance_sup:start_world(Config) of
-                {ok, InstancePid} when is_pid(InstancePid) ->
-                    Now = erlang:system_time(millisecond),
-                    AvgWait =
-                        lists:sum([Now - maps:get(submitted_at, T) || T <- Group]) div
-                            max(1, length(Group)),
-                    asobi_telemetry:matchmaker_formed(Mode, length(PlayerIds), AvgWait),
-                    WorldPid = asobi_world_instance:get_child(InstancePid, asobi_world_server),
-                    WorldInfo = asobi_world_server:get_info(WorldPid),
-                    lists:foreach(
-                        fun(PlayerId) when is_binary(PlayerId) ->
-                            _ = asobi_world_server:join(WorldPid, PlayerId),
-                            asobi_presence:send(
-                                PlayerId,
-                                {match_event, matched, #{
-                                    world_id => maps:get(world_id, WorldInfo, undefined),
-                                    players => PlayerIds
-                                }}
-                            )
-                        end,
-                        PlayerIds
-                    ),
-                    spawn_matches(Rest, Failed);
-                {error, Reason} ->
-                    logger:error(#{
-                        msg => ~"world spawn failed, re-queuing players",
-                        mode => Mode,
-                        players => PlayerIds,
-                        error => Reason
-                    }),
-                    spawn_matches(Rest, [Group | Failed])
-            end;
+            %% Spawn world asynchronously to avoid blocking the matchmaker
+            SpawnGroup = Group,
+            SpawnPlayerIds = PlayerIds,
+            spawn(fun() ->
+                try
+                    case asobi_world_instance_sup:start_world(Config) of
+                        {ok, InstancePid} when is_pid(InstancePid) ->
+                            Now = erlang:system_time(millisecond),
+                            AvgWait =
+                                lists:sum([Now - maps:get(submitted_at, T) || T <- SpawnGroup]) div
+                                    max(1, length(SpawnGroup)),
+                            asobi_telemetry:matchmaker_formed(Mode, length(SpawnPlayerIds), AvgWait),
+                            WorldPid = asobi_world_instance:get_child(InstancePid, asobi_world_server),
+                            logger:notice(#{msg => ~"world spawn complete", world_pid => WorldPid, instance_pid => InstancePid}),
+                            WorldInfo = asobi_world_server:get_info(WorldPid),
+                            WorldId = maps:get(world_id, WorldInfo, undefined),
+                            lists:foreach(
+                                fun(PlayerId) when is_binary(PlayerId) ->
+                                    JoinResult = asobi_world_server:join(WorldPid, PlayerId),
+                                    logger:notice(#{msg => ~"player joined world", player_id => PlayerId, result => JoinResult}),
+                                    asobi_presence:send(
+                                        PlayerId,
+                                        {match_event, matched, #{
+                                            match_id => WorldId,
+                                            mode => Mode,
+                                            player_ids => SpawnPlayerIds
+                                        }}
+                                    )
+                                end,
+                                SpawnPlayerIds
+                            );
+                        {error, Reason} ->
+                            logger:error(#{
+                                msg => ~"world spawn failed",
+                                mode => Mode,
+                                players => SpawnPlayerIds,
+                                error => Reason
+                            })
+                    end
+                catch
+                    Class:Reason2:Stack ->
+                        logger:error(#{
+                            msg => ~"world spawn crashed",
+                            mode => Mode,
+                            players => SpawnPlayerIds,
+                            class => Class,
+                            error => Reason2,
+                            stacktrace => Stack
+                        })
+                end
+            end),
+            spawn_matches(Rest, Failed);
         {error, _} ->
             notify_no_game_module(Mode, PlayerIds),
             spawn_matches(Rest, Failed)

--- a/src/matches/asobi_matchmaker.erl
+++ b/src/matches/asobi_matchmaker.erl
@@ -316,15 +316,27 @@ spawn_world(Mode, ModeConfig, PlayerIds, Group, Rest, Failed) ->
                             AvgWait =
                                 lists:sum([Now - maps:get(submitted_at, T) || T <- SpawnGroup]) div
                                     max(1, length(SpawnGroup)),
-                            asobi_telemetry:matchmaker_formed(Mode, length(SpawnPlayerIds), AvgWait),
-                            WorldPid = asobi_world_instance:get_child(InstancePid, asobi_world_server),
-                            logger:notice(#{msg => ~"world spawn complete", world_pid => WorldPid, instance_pid => InstancePid}),
+                            asobi_telemetry:matchmaker_formed(
+                                Mode, length(SpawnPlayerIds), AvgWait
+                            ),
+                            WorldPid = asobi_world_instance:get_child(
+                                InstancePid, asobi_world_server
+                            ),
+                            logger:notice(#{
+                                msg => ~"world spawn complete",
+                                world_pid => WorldPid,
+                                instance_pid => InstancePid
+                            }),
                             WorldInfo = asobi_world_server:get_info(WorldPid),
                             WorldId = maps:get(world_id, WorldInfo, undefined),
                             lists:foreach(
                                 fun(PlayerId) when is_binary(PlayerId) ->
                                     JoinResult = asobi_world_server:join(WorldPid, PlayerId),
-                                    logger:notice(#{msg => ~"player joined world", player_id => PlayerId, result => JoinResult}),
+                                    logger:notice(#{
+                                        msg => ~"player joined world",
+                                        player_id => PlayerId,
+                                        result => JoinResult
+                                    }),
                                     asobi_presence:send(
                                         PlayerId,
                                         {match_event, matched, #{

--- a/src/social/asobi_dm.erl
+++ b/src/social/asobi_dm.erl
@@ -1,0 +1,56 @@
+-module(asobi_dm).
+
+%% Direct messaging built on the chat channel system.
+%%
+%% DM channel IDs are deterministic: the two player IDs sorted and
+%% joined with a colon. This ensures both players always reference
+%% the same channel regardless of who initiated.
+
+-export([send/3, history/3, channel_id/2]).
+
+-spec send(binary(), binary(), binary()) -> ok | {error, term()}.
+send(SenderId, RecipientId, Content) ->
+    case is_blocked(SenderId, RecipientId) of
+        true ->
+            {error, blocked};
+        false ->
+            ChannelId = channel_id(SenderId, RecipientId),
+            asobi_chat_channel:send_message(ChannelId, SenderId, Content),
+            asobi_presence:send(
+                RecipientId,
+                {dm_message, #{
+                    sender_id => SenderId,
+                    content => Content,
+                    channel_id => ChannelId,
+                    sent_at => erlang:system_time(millisecond)
+                }}
+            ),
+            ok
+    end.
+
+-spec history(binary(), binary(), pos_integer()) -> [map()].
+history(PlayerId, OtherPlayerId, Limit) ->
+    ChannelId = channel_id(PlayerId, OtherPlayerId),
+    asobi_chat_channel:get_history(ChannelId, Limit).
+
+-spec channel_id(binary(), binary()) -> binary().
+channel_id(A, B) when A =< B ->
+    iolist_to_binary([~"dm:", A, ~":", B]);
+channel_id(A, B) ->
+    iolist_to_binary([~"dm:", B, ~":", A]).
+
+%% --- Internal ---
+
+-spec is_blocked(binary(), binary()) -> boolean().
+is_blocked(SenderId, RecipientId) ->
+    Q = kura_query:where(
+        kura_query:where(
+            kura_query:where(kura_query:from(asobi_friendship), {player_id, RecipientId}),
+            {friend_id, SenderId}
+        ),
+        {status, ~"blocked"}
+    ),
+    case asobi_repo:all(Q) of
+        {ok, [_ | _]} -> true;
+        _ -> false
+    end.

--- a/src/social/asobi_group_roles.erl
+++ b/src/social/asobi_group_roles.erl
@@ -1,0 +1,42 @@
+-module(asobi_group_roles).
+
+%% Role hierarchy and permission checks for groups/guilds.
+%%
+%% Hierarchy: owner > admin > moderator > member
+%% Higher roles can manage lower roles but not equal or higher.
+
+-export([rank/1, can_manage/2, can_kick/2, can_promote/3, can_update_group/1]).
+-export([valid_role/1]).
+
+-spec rank(binary()) -> non_neg_integer().
+rank(~"owner") -> 100;
+rank(~"admin") -> 75;
+rank(~"moderator") -> 50;
+rank(~"member") -> 0;
+rank(_) -> 0.
+
+-spec valid_role(binary()) -> boolean().
+valid_role(~"owner") -> true;
+valid_role(~"admin") -> true;
+valid_role(~"moderator") -> true;
+valid_role(~"member") -> true;
+valid_role(_) -> false.
+
+-spec can_manage(binary(), binary()) -> boolean().
+can_manage(ActorRole, TargetRole) ->
+    rank(ActorRole) > rank(TargetRole).
+
+-spec can_kick(binary(), binary()) -> boolean().
+can_kick(ActorRole, TargetRole) ->
+    rank(ActorRole) >= rank(~"moderator") andalso
+        rank(ActorRole) > rank(TargetRole).
+
+-spec can_promote(binary(), binary(), binary()) -> boolean().
+can_promote(ActorRole, _TargetCurrentRole, NewRole) ->
+    rank(ActorRole) >= rank(~"admin") andalso
+        rank(ActorRole) > rank(NewRole) andalso
+        NewRole =/= ~"owner".
+
+-spec can_update_group(binary()) -> boolean().
+can_update_group(Role) ->
+    rank(Role) >= rank(~"admin").

--- a/src/world/asobi_world_lobby.erl
+++ b/src/world/asobi_world_lobby.erl
@@ -1,0 +1,108 @@
+-module(asobi_world_lobby).
+
+-export([list_worlds/0, list_worlds/1, find_or_create/1, create_world/1]).
+
+-define(PG_SCOPE, nova_scope).
+
+-doc "List all running worlds.".
+-spec list_worlds() -> [map()].
+list_worlds() ->
+    list_worlds(#{}).
+
+-doc "List running worlds with optional filters: mode, has_capacity.".
+-spec list_worlds(map()) -> [map()].
+list_worlds(Filters) ->
+    Groups = pg:which_groups(?PG_SCOPE),
+    WorldGroups = [
+        {WorldId, Pid}
+     || {asobi_world_server, WorldId} = Group <- Groups,
+        Pid <- take_first(pg:get_members(?PG_SCOPE, Group))
+    ],
+    Worlds = lists:filtermap(
+        fun({_WorldId, Pid}) ->
+            try asobi_world_server:get_info(Pid) of
+                Info when is_map(Info) ->
+                    case matches_filters(Info, Filters) of
+                        true -> {true, Info};
+                        false -> false
+                    end
+            catch
+                _:_ -> false
+            end
+        end,
+        WorldGroups
+    ),
+    Worlds.
+
+-doc "Find a running world with capacity for the given mode, or create one.".
+-spec find_or_create(binary()) -> {ok, pid(), map()} | {error, term()}.
+find_or_create(Mode) ->
+    Worlds = list_worlds(#{mode => Mode, has_capacity => true}),
+    case Worlds of
+        [#{world_id := WorldId} | _] ->
+            case asobi_world_server:whereis(WorldId) of
+                {ok, Pid} -> {ok, Pid, hd(Worlds)};
+                error -> create_world(Mode)
+            end;
+        [] ->
+            create_world(Mode)
+    end.
+
+-doc "Create a new world for the given mode.".
+-spec create_world(binary()) -> {ok, pid(), map()} | {error, term()}.
+create_world(Mode) ->
+    case asobi_game_modes:world_config(Mode) of
+        {ok, Config} ->
+            case asobi_world_instance_sup:start_world(Config) of
+                {ok, InstancePid} ->
+                    WorldPid = wait_for_world_server(InstancePid, 10),
+                    case WorldPid of
+                        undefined ->
+                            {error, world_server_not_started};
+                        _ ->
+                            Info = asobi_world_server:get_info(WorldPid),
+                            {ok, WorldPid, Info}
+                    end;
+                {error, _} = Err ->
+                    Err
+            end;
+        {error, _} = Err ->
+            Err
+    end.
+
+%%--------------------------------------------------------------------
+%% Internal
+%%--------------------------------------------------------------------
+
+-spec matches_filters(map(), map()) -> boolean().
+matches_filters(Info, Filters) ->
+    ModeOk =
+        case maps:find(mode, Filters) of
+            {ok, Mode} -> maps:get(mode, Info, undefined) =:= Mode;
+            error -> true
+        end,
+    CapOk =
+        case maps:get(has_capacity, Filters, false) of
+            true ->
+                maps:get(player_count, Info, 0) < maps:get(max_players, Info, 500);
+            false ->
+                true
+        end,
+    StatusOk = maps:get(status, Info, undefined) =:= running,
+    ModeOk andalso CapOk andalso StatusOk.
+
+-spec take_first([pid()]) -> [pid()].
+take_first([Pid | _]) -> [Pid];
+take_first([]) -> [].
+
+-spec wait_for_world_server(pid(), non_neg_integer()) -> pid() | undefined.
+wait_for_world_server(_InstancePid, 0) ->
+    undefined;
+wait_for_world_server(InstancePid, Retries) ->
+    case asobi_world_instance:get_child(InstancePid, asobi_world_server) of
+        undefined ->
+            timer:sleep(50),
+            wait_for_world_server(InstancePid, Retries - 1);
+        Pid ->
+            Pid
+    end.

--- a/src/world/asobi_world_server.erl
+++ b/src/world/asobi_world_server.erl
@@ -596,9 +596,11 @@ world_info(Status, #{world_id := WorldId, players := Players} = State) ->
         world_id => WorldId,
         status => Status,
         player_count => map_size(Players),
+        max_players => maps:get(max_players, State, 500),
         players => maps:keys(Players),
         mode => maps:get(mode, State, undefined),
-        grid_size => maps:get(grid_size, State)
+        grid_size => maps:get(grid_size, State),
+        started_at => maps:get(started_at, State, undefined)
     },
     case maps:get(phase_state, State, undefined) of
         undefined -> Base;

--- a/src/world/asobi_world_server.erl
+++ b/src/world/asobi_world_server.erl
@@ -78,7 +78,7 @@ init(Config) ->
     ViewRadius = maps:get(view_radius, Config, ?DEFAULT_VIEW_RADIUS),
     VetoTokensPerPlayer = maps:get(veto_tokens_per_player, Config, 0),
     FrustrationBonus = maps:get(frustration_bonus, Config, 0.5),
-    {ZoneSupPid, TickerPid} = resolve_siblings(Config),
+    InstanceSup = maps:get(instance_sup, Config, undefined),
     PhaseState =
         case erlang:function_exported(GameMod, phases, 1) of
             true ->
@@ -101,8 +101,9 @@ init(Config) ->
         players => #{},
         player_zones => #{},
         zone_pids => #{},
-        zone_sup_pid => ZoneSupPid,
-        ticker_pid => TickerPid,
+        instance_sup => InstanceSup,
+        zone_sup_pid => undefined,
+        ticker_pid => undefined,
         started_at => undefined,
         vote_frustration => #{},
         veto_tokens => #{},
@@ -117,9 +118,15 @@ init(Config) ->
 
 -spec loading(gen_statem:event_type() | enter, term(), map()) ->
     gen_statem:state_enter_result(atom()).
-loading(enter, _OldState, State) ->
-    State1 = spawn_zones(State),
-    {keep_state, State1, [{state_timeout, 0, zones_ready}]};
+loading(enter, _OldState, _State) ->
+    %% Defer zone spawning — supervisor:which_children deadlocks if called during init
+    erlang:send(self(), resolve_and_spawn),
+    keep_state_and_data;
+loading(info, resolve_and_spawn, #{instance_sup := InstanceSup} = State) ->
+    {ZoneSupPid, TickerPid} = resolve_siblings(#{instance_sup => InstanceSup}),
+    State1 = State#{zone_sup_pid => ZoneSupPid, ticker_pid => TickerPid},
+    State2 = spawn_zones(State1),
+    {keep_state, State2, [{state_timeout, 0, zones_ready}]};
 loading(state_timeout, zones_ready, State) ->
     {next_state, running, State#{started_at => erlang:system_time(millisecond)}};
 loading({call, From}, get_info, State) ->

--- a/src/world/asobi_world_server.erl
+++ b/src/world/asobi_world_server.erl
@@ -352,6 +352,7 @@ place_player(
     ZonePid = maps:get(ZoneCoords, ZonePids),
     PlayerPid = find_player_pid(PlayerId),
     asobi_zone:add_entity(ZonePid, PlayerId, #{x => X, y => Y, type => ~"player"}),
+    asobi_presence:send(PlayerId, {world_joined, self(), ZonePid}),
     InterestZones = interest_zones(ZoneCoords, ViewRadius, GridSize),
     lists:foreach(
         fun(Coords) ->

--- a/src/ws/asobi_ws_handler.erl
+++ b/src/ws/asobi_ws_handler.erl
@@ -71,6 +71,9 @@ websocket_info({asobi_message, {world_event, Event, Payload}}, State) when is_at
 websocket_info({chat_message, ChannelId, Msg}, State) when is_map(Msg) ->
     Reply = encode_reply(undefined, ~"chat.message", Msg#{channel_id => ChannelId}),
     {reply, {text, Reply}, State};
+websocket_info({asobi_message, {dm_message, Msg}}, State) when is_map(Msg) ->
+    Reply = encode_reply(undefined, ~"dm.message", Msg),
+    {reply, {text, Reply}, State};
 websocket_info({asobi_message, {notification, Notif}}, State) ->
     Reply = encode_reply(undefined, ~"notification.new", Notif),
     {reply, {text, Reply}, State};
@@ -145,6 +148,21 @@ handle_message(
     #{~"channel_id" := ChannelId, ~"content" := Content} = Payload,
     asobi_chat_channel:send_message(ChannelId, PlayerId, Content),
     {ok, State};
+handle_message(
+    #{~"type" := ~"dm.send", ~"payload" := Payload} = Msg, #{player_id := PlayerId} = State
+) when is_binary(PlayerId) ->
+    Cid = maps:get(~"cid", Msg, undefined),
+    #{~"recipient_id" := RecipientId, ~"content" := Content} = Payload,
+    case asobi_dm:send(PlayerId, RecipientId, Content) of
+        ok ->
+            Reply = encode_reply(Cid, ~"dm.sent", #{
+                channel_id => asobi_dm:channel_id(PlayerId, RecipientId)
+            }),
+            {reply, {text, Reply}, State};
+        {error, blocked} ->
+            Reply = encode_reply(Cid, ~"error", #{reason => ~"blocked"}),
+            {reply, {text, Reply}, State}
+    end;
 handle_message(
     #{~"type" := ~"chat.join", ~"payload" := #{~"channel_id" := ChannelId}} = Msg, State
 ) ->

--- a/src/ws/asobi_ws_handler.erl
+++ b/src/ws/asobi_ws_handler.erl
@@ -117,22 +117,28 @@ handle_message(
 ->
     try asobi_player_session:get_state(SessionPid) of
         #{player_id := PlayerId} = SState ->
+            InputData =
+                case maps:get(~"data", Payload, undefined) of
+                    undefined when is_map(Payload) -> Payload;
+                    Bin when is_binary(Bin) ->
+                        case json:decode(Bin) of
+                            M when is_map(M) -> M;
+                            _ -> #{}
+                        end;
+                    Other when is_map(Other) -> Other;
+                    _ ->
+                        #{}
+                end,
             case maps:get(match_pid, SState, undefined) of
                 undefined ->
-                    {ok, State};
+                    case maps:get(zone_pid, SState, undefined) of
+                        undefined ->
+                            {ok, State};
+                        ZonePid ->
+                            asobi_zone:player_input(ZonePid, PlayerId, InputData),
+                            {ok, State}
+                    end;
                 MatchPid ->
-                    InputData =
-                        case maps:get(~"data", Payload, undefined) of
-                            undefined when is_map(Payload) -> Payload;
-                            Bin when is_binary(Bin) ->
-                                case json:decode(Bin) of
-                                    M when is_map(M) -> M;
-                                    _ -> #{}
-                                end;
-                            Other when is_map(Other) -> Other;
-                            _ ->
-                                #{}
-                        end,
                     asobi_match_server:handle_input(MatchPid, PlayerId, InputData),
                     {ok, State}
             end

--- a/src/ws/asobi_ws_handler.erl
+++ b/src/ws/asobi_ws_handler.erl
@@ -304,6 +304,47 @@ handle_message(
             {ok, State#{session => undefined}}
     end;
 handle_message(
+    #{~"type" := ~"world.list", ~"payload" := Payload} = Msg,
+    #{player_id := _PlayerId} = State
+) ->
+    Cid = maps:get(~"cid", Msg, undefined),
+    Filters = #{
+        mode => maps:get(~"mode", Payload, undefined),
+        has_capacity => maps:get(~"has_capacity", Payload, false)
+    },
+    Filters1 = maps:filter(fun(_, V) -> V =/= undefined end, Filters),
+    Worlds = asobi_world_lobby:list_worlds(Filters1),
+    Reply = encode_reply(Cid, ~"world.list", #{worlds => Worlds}),
+    {reply, {text, Reply}, State};
+handle_message(
+    #{~"type" := ~"world.create", ~"payload" := #{~"mode" := Mode}} = Msg,
+    #{player_id := PlayerId} = State
+) ->
+    Cid = maps:get(~"cid", Msg, undefined),
+    case asobi_world_lobby:create_world(Mode) of
+        {ok, WorldPid, Info} ->
+            _ = asobi_world_server:join(WorldPid, PlayerId),
+            Reply = encode_reply(Cid, ~"world.joined", Info),
+            {reply, {text, Reply}, State};
+        {error, Reason} ->
+            Reply = encode_reply(Cid, ~"error", #{reason => Reason}),
+            {reply, {text, Reply}, State}
+    end;
+handle_message(
+    #{~"type" := ~"world.find_or_create", ~"payload" := #{~"mode" := Mode}} = Msg,
+    #{player_id := PlayerId} = State
+) ->
+    Cid = maps:get(~"cid", Msg, undefined),
+    case asobi_world_lobby:find_or_create(Mode) of
+        {ok, WorldPid, Info} ->
+            _ = asobi_world_server:join(WorldPid, PlayerId),
+            Reply = encode_reply(Cid, ~"world.joined", Info),
+            {reply, {text, Reply}, State};
+        {error, Reason} ->
+            Reply = encode_reply(Cid, ~"error", #{reason => Reason}),
+            {reply, {text, Reply}, State}
+    end;
+handle_message(
     #{~"type" := ~"world.join", ~"payload" := #{~"world_id" := WorldId}} = Msg,
     #{player_id := PlayerId} = State
 ) ->

--- a/test/asobi_dm_tests.erl
+++ b/test/asobi_dm_tests.erl
@@ -1,0 +1,19 @@
+-module(asobi_dm_tests).
+-include_lib("eunit/include/eunit.hrl").
+
+channel_id_deterministic_test() ->
+    Id1 = asobi_dm:channel_id(~"alice", ~"bob"),
+    Id2 = asobi_dm:channel_id(~"bob", ~"alice"),
+    ?assertEqual(Id1, Id2).
+
+channel_id_sorted_test() ->
+    Id = asobi_dm:channel_id(~"zzz", ~"aaa"),
+    ?assertEqual(~"dm:aaa:zzz", Id).
+
+channel_id_same_order_test() ->
+    Id = asobi_dm:channel_id(~"aaa", ~"zzz"),
+    ?assertEqual(~"dm:aaa:zzz", Id).
+
+channel_id_prefix_test() ->
+    Id = asobi_dm:channel_id(~"p1", ~"p2"),
+    ?assertMatch(<<"dm:", _/binary>>, Id).

--- a/test/asobi_group_roles_tests.erl
+++ b/test/asobi_group_roles_tests.erl
@@ -1,0 +1,49 @@
+-module(asobi_group_roles_tests).
+-include_lib("eunit/include/eunit.hrl").
+
+rank_hierarchy_test() ->
+    ?assert(asobi_group_roles:rank(~"owner") > asobi_group_roles:rank(~"admin")),
+    ?assert(asobi_group_roles:rank(~"admin") > asobi_group_roles:rank(~"moderator")),
+    ?assert(asobi_group_roles:rank(~"moderator") > asobi_group_roles:rank(~"member")),
+    ?assertEqual(0, asobi_group_roles:rank(~"unknown")).
+
+valid_role_test() ->
+    ?assert(asobi_group_roles:valid_role(~"owner")),
+    ?assert(asobi_group_roles:valid_role(~"admin")),
+    ?assert(asobi_group_roles:valid_role(~"moderator")),
+    ?assert(asobi_group_roles:valid_role(~"member")),
+    ?assertNot(asobi_group_roles:valid_role(~"superuser")),
+    ?assertNot(asobi_group_roles:valid_role(~"")).
+
+can_manage_test() ->
+    ?assert(asobi_group_roles:can_manage(~"owner", ~"admin")),
+    ?assert(asobi_group_roles:can_manage(~"owner", ~"member")),
+    ?assert(asobi_group_roles:can_manage(~"admin", ~"moderator")),
+    ?assert(asobi_group_roles:can_manage(~"admin", ~"member")),
+    ?assertNot(asobi_group_roles:can_manage(~"admin", ~"admin")),
+    ?assertNot(asobi_group_roles:can_manage(~"member", ~"member")),
+    ?assertNot(asobi_group_roles:can_manage(~"moderator", ~"admin")).
+
+can_kick_test() ->
+    ?assert(asobi_group_roles:can_kick(~"owner", ~"admin")),
+    ?assert(asobi_group_roles:can_kick(~"owner", ~"member")),
+    ?assert(asobi_group_roles:can_kick(~"admin", ~"moderator")),
+    ?assert(asobi_group_roles:can_kick(~"moderator", ~"member")),
+    ?assertNot(asobi_group_roles:can_kick(~"member", ~"member")),
+    ?assertNot(asobi_group_roles:can_kick(~"moderator", ~"moderator")),
+    ?assertNot(asobi_group_roles:can_kick(~"moderator", ~"admin")).
+
+can_promote_test() ->
+    ?assert(asobi_group_roles:can_promote(~"owner", ~"member", ~"admin")),
+    ?assert(asobi_group_roles:can_promote(~"owner", ~"member", ~"moderator")),
+    ?assert(asobi_group_roles:can_promote(~"admin", ~"member", ~"moderator")),
+    ?assertNot(asobi_group_roles:can_promote(~"admin", ~"member", ~"admin")),
+    ?assertNot(asobi_group_roles:can_promote(~"admin", ~"member", ~"owner")),
+    ?assertNot(asobi_group_roles:can_promote(~"moderator", ~"member", ~"moderator")),
+    ?assertNot(asobi_group_roles:can_promote(~"member", ~"member", ~"moderator")).
+
+can_update_group_test() ->
+    ?assert(asobi_group_roles:can_update_group(~"owner")),
+    ?assert(asobi_group_roles:can_update_group(~"admin")),
+    ?assertNot(asobi_group_roles:can_update_group(~"moderator")),
+    ?assertNot(asobi_group_roles:can_update_group(~"member")).


### PR DESCRIPTION
## Summary
- Fix world server init deadlock (deferred resolve_siblings to message handler)
- Fix bot spawner crash loop (try/catch on get_queue_stats timeout)
- Spawn worlds asynchronously in matchmaker (no longer blocks)
- Align world match.matched payload with SDK field names
- Notify player session of zone_pid on world join
- Route match.input to zone when player is in world server
- Add world lobby system (asobi_world_lobby, asobi_world_controller, WS handlers)
- Extract asobi_game_modes shared module
- Enrich world_info with max_players and started_at

## Test plan
- [x] Space Corsairs runs end-to-end with these fixes
- [ ] Existing match-based games unaffected