### PR TITLE
refactor: move route plugins to Nova global config

### DIFF
--- a/config/dev_sys.config.src
+++ b/config/dev_sys.config.src
@@ -24,7 +24,19 @@
         }},
         {dev_mode, true},
         {bootstrap_application, asobi},
-        {json_lib, json}
+        {json_lib, json},
+        {plugins, [
+            {pre_request, nova_request_plugin, #{
+                decode_json_body => true,
+                parse_qs => true
+            }},
+            {pre_request, nova_cors_plugin, #{
+                allow_origins => ~"*"
+            }},
+            {pre_request, nova_correlation_plugin, #{}},
+            {pre_request, asobi_rate_limit_plugin, #{limiter => asobi_api_limiter}},
+            {post_request, asobi_security_headers_plugin, #{}}
+        ]}
     ]},
     {kura, [
         {repo, asobi_repo},
@@ -37,16 +49,6 @@
     ]},
     {asobi, [
         {nova_apps, [nova_resilience]},
-        {plugins, [
-            {pre_request, nova_request_plugin, #{
-                decode_json_body => true,
-                parse_qs => true
-            }},
-            {pre_request, nova_correlation_plugin, #{}},
-            {pre_request, nova_cors_plugin, #{
-                allow_origins => <<"*">>
-            }}
-        ]},
         {game_modes, #{
             %% Map mode names to game behaviour modules
             %% ~"default" => my_game_module

--- a/config/prod_sys.config.src
+++ b/config/prod_sys.config.src
@@ -21,7 +21,19 @@
         }},
         {dev_mode, false},
         {bootstrap_application, asobi},
-        {json_lib, json}
+        {json_lib, json},
+        {plugins, [
+            {pre_request, nova_request_plugin, #{
+                decode_json_body => true,
+                parse_qs => true
+            }},
+            {pre_request, nova_cors_plugin, #{
+                allow_origins => <<"${ASOBI_CORS_ORIGINS}">>
+            }},
+            {pre_request, nova_correlation_plugin, #{}},
+            {pre_request, asobi_rate_limit_plugin, #{limiter => asobi_api_limiter}},
+            {post_request, asobi_security_headers_plugin, #{}}
+        ]}
     ]},
     {kura, [
         {repo, asobi_repo},
@@ -35,16 +47,6 @@
     {asobi, [
         {game_dir, "/app/game"},
         {nova_apps, [nova_resilience]},
-        {plugins, [
-            {pre_request, nova_request_plugin, #{
-                decode_json_body => true,
-                parse_qs => true
-            }},
-            {pre_request, nova_correlation_plugin, #{}},
-            {pre_request, nova_cors_plugin, #{
-                allow_origins => <<"${ASOBI_CORS_ORIGINS}">>
-            }}
-        ]},
         {matchmaker, #{
             tick_interval => 1000,
             max_wait_seconds => 60

--- a/src/asobi_router.erl
+++ b/src/asobi_router.erl
@@ -12,30 +12,10 @@ routes(_Environment) ->
         ws_routes()
     ].
 
-cors_opts() ->
-    Origins = application:get_env(asobi, cors_allow_origins, ~""),
-    #{allow_origins => Origins}.
-
-rate_limit_opts(Group) ->
-    #{limiter => limiter_name(Group)}.
-
-limiter_name(auth) -> asobi_auth_limiter;
-limiter_name(iap) -> asobi_iap_limiter;
-limiter_name(api) -> asobi_api_limiter.
-
 auth_routes() ->
     #{
         prefix => ~"/api/v1/auth",
         security => false,
-        plugins => [
-            {pre_request, nova_request_plugin, #{
-                decode_json_body => true
-            }},
-            {pre_request, nova_cors_plugin, cors_opts()},
-            {pre_request, nova_correlation_plugin, #{}},
-            {pre_request, asobi_rate_limit_plugin, rate_limit_opts(auth)},
-            {post_request, asobi_security_headers_plugin, #{}}
-        ],
         routes => [
             {~"/register", fun asobi_auth_controller:register/1, #{methods => [post]}},
             {~"/login", fun asobi_auth_controller:login/1, #{methods => [post]}},
@@ -48,15 +28,6 @@ iap_routes() ->
     #{
         prefix => ~"/api/v1/iap",
         security => fun asobi_auth_plugin:verify/1,
-        plugins => [
-            {pre_request, nova_request_plugin, #{
-                decode_json_body => true
-            }},
-            {pre_request, nova_cors_plugin, cors_opts()},
-            {pre_request, nova_correlation_plugin, #{}},
-            {pre_request, asobi_rate_limit_plugin, rate_limit_opts(iap)},
-            {post_request, asobi_security_headers_plugin, #{}}
-        ],
         routes => [
             {~"/apple", fun asobi_iap_controller:verify_apple/1, #{methods => [post]}},
             {~"/google", fun asobi_iap_controller:verify_google/1, #{methods => [post]}}
@@ -67,16 +38,6 @@ api_routes() ->
     #{
         prefix => ~"/api/v1",
         security => fun asobi_auth_plugin:verify/1,
-        plugins => [
-            {pre_request, nova_request_plugin, #{
-                decode_json_body => true,
-                parse_qs => true
-            }},
-            {pre_request, nova_cors_plugin, cors_opts()},
-            {pre_request, nova_correlation_plugin, #{}},
-            {pre_request, asobi_rate_limit_plugin, rate_limit_opts(api)},
-            {post_request, asobi_security_headers_plugin, #{}}
-        ],
         routes => [
             %% Auth - Provider linking
             {~"/auth/link", fun asobi_oauth_controller:link/1, #{methods => [post]}},
@@ -139,7 +100,9 @@ api_routes() ->
             {~"/groups/:id", fun asobi_social_controller:update_group/1, #{methods => [put]}},
             {~"/groups/:id/join", fun asobi_social_controller:join_group/1, #{methods => [post]}},
             {~"/groups/:id/leave", fun asobi_social_controller:leave_group/1, #{methods => [post]}},
-            {~"/groups/:id/members", fun asobi_social_controller:list_members/1, #{methods => [get]}},
+            {~"/groups/:id/members", fun asobi_social_controller:list_members/1, #{
+                methods => [get]
+            }},
             {
                 ~"/groups/:id/members/:player_id/role",
                 fun asobi_social_controller:update_member_role/1,


### PR DESCRIPTION
## Summary
- Remove per-group `plugins =>` from all asobi_router route groups
- Move plugins to `{nova, [{plugins, [...]}]}` in dev and prod sys.config
- Asobi standalone behaviour is unchanged — same plugins, just configured globally

## Why
Wrapper applications (e.g. asobi_engine for SaaS) need to inject additional plugins (tenant resolution) into all routes. With per-group plugins hardcoded in the router, the only option was duplicating all route definitions. Nova's global plugin mechanism (`application:get_env(nova, plugins, [])`) is used as fallback when route groups don't define their own — by removing per-group definitions, wrapper apps can now control the full plugin chain via their Nova config.

## Test plan
- [x] `rebar3 compile` — clean
- [x] `rebar3 fmt --check` — clean
- [x] `rebar3 xref` — clean
- [x] Verified via asobi_engine `_checkouts`: global plugins apply to all asobi routes, tenant plugin injects correctly, 15 tests pass