### PR TITLE
feat: validate API keys against Asobi SaaS control plane

### DIFF
--- a/config/dev_sys.config.src
+++ b/config/dev_sys.config.src
@@ -35,6 +35,7 @@
             }},
             {pre_request, nova_correlation_plugin, #{}},
             {pre_request, asobi_rate_limit_plugin, #{limiter => asobi_api_limiter}},
+            {pre_request, asobi_saas_key_plugin, #{}},
             {post_request, asobi_security_headers_plugin, #{}}
         ]}
     ]},

--- a/config/prod_sys.config.src
+++ b/config/prod_sys.config.src
@@ -32,6 +32,7 @@
             }},
             {pre_request, nova_correlation_plugin, #{}},
             {pre_request, asobi_rate_limit_plugin, #{limiter => asobi_api_limiter}},
+            {pre_request, asobi_saas_key_plugin, #{}},
             {post_request, asobi_security_headers_plugin, #{}}
         ]}
     ]},
@@ -47,6 +48,9 @@
     {asobi, [
         {game_dir, "/app/game"},
         {nova_apps, [nova_resilience]},
+        {saas_internal_url, <<"${ASOBI_SAAS_URL}">>},
+        {saas_internal_token, <<"${ASOBI_SAAS_INTERNAL_TOKEN}">>},
+        {environment_name, <<"${ASOBI_ENVIRONMENT_NAME}">>},
         {matchmaker, #{
             tick_interval => 1000,
             max_wait_seconds => 60

--- a/src/plugins/asobi_saas_key_plugin.erl
+++ b/src/plugins/asobi_saas_key_plugin.erl
@@ -1,0 +1,197 @@
+-module(asobi_saas_key_plugin).
+-behaviour(nova_plugin).
+
+-export([pre_request/4, post_request/4, plugin_info/0]).
+
+-define(HEADER, ~"x-asobi-key").
+-define(CACHE_TABLE, asobi_saas_key_cache).
+-define(CACHE_TTL_MS, 300_000).
+
+-spec pre_request(cowboy_req:req(), map(), map(), term()) ->
+    {ok, cowboy_req:req(), term()} | {break, cowboy_req:req(), term()}.
+pre_request(Req, _Env, _Options, State) ->
+    case application:get_env(asobi, saas_internal_url) of
+        undefined ->
+            {ok, Req, State};
+        {ok, Url} when is_binary(Url); is_list(Url) ->
+            maybe_validate(Req, to_binary(Url), State)
+    end.
+
+-spec post_request(cowboy_req:req(), map(), map(), term()) ->
+    {ok, cowboy_req:req(), term()}.
+post_request(Req, _Env, _Options, State) ->
+    {ok, Req, State}.
+
+-spec plugin_info() -> map().
+plugin_info() ->
+    #{
+        title => ~"Asobi SaaS Key Plugin",
+        version => ~"0.1.0",
+        url => ~"https://github.com/widgrensit/asobi",
+        authors => [~"widgrensit"],
+        description => ~"Validates API keys against the Asobi SaaS control plane."
+    }.
+
+%% --- Internal ---
+
+-spec maybe_validate(cowboy_req:req(), binary(), term()) ->
+    {ok, cowboy_req:req(), term()} | {break, cowboy_req:req(), term()}.
+maybe_validate(Req, SaasUrl, State) ->
+    case is_protected(cowboy_req:path(Req)) of
+        false ->
+            {ok, Req, State};
+        true ->
+            case cowboy_req:header(?HEADER, Req) of
+                undefined ->
+                    reject(Req, State, 401, ~"missing_api_key");
+                <<>> ->
+                    reject(Req, State, 401, ~"missing_api_key");
+                RawKey ->
+                    validate(Req, SaasUrl, RawKey, State)
+            end
+    end.
+
+-spec is_protected(binary()) -> boolean().
+is_protected(Path) ->
+    binary:match(Path, ~"/api/v1/") =/= nomatch.
+
+-spec validate(cowboy_req:req(), binary(), binary(), term()) ->
+    {ok, cowboy_req:req(), term()} | {break, cowboy_req:req(), term()}.
+validate(Req, SaasUrl, RawKey, State) ->
+    case lookup_cache(RawKey) of
+        {ok, Ctx} ->
+            apply_context(Req, Ctx, State);
+        miss ->
+            fetch_and_validate(Req, SaasUrl, RawKey, State)
+    end.
+
+-spec fetch_and_validate(cowboy_req:req(), binary(), binary(), term()) ->
+    {ok, cowboy_req:req(), term()} | {break, cowboy_req:req(), term()}.
+fetch_and_validate(Req, SaasUrl, RawKey, State) ->
+    case call_saas(SaasUrl, RawKey) of
+        {ok, #{~"environment_id" := _} = Body} ->
+            case env_matches(Body) of
+                true ->
+                    Ctx = to_context(Body),
+                    store_cache(RawKey, Ctx),
+                    apply_context(Req, Ctx, State);
+                false ->
+                    reject(Req, State, 403, ~"environment_mismatch")
+            end;
+        {ok, _} ->
+            reject(Req, State, 401, ~"invalid_key");
+        {error, {Status, _Body}} when Status >= 400, Status < 500 ->
+            reject(Req, State, 401, ~"invalid_key");
+        {error, _Other} ->
+            reject(Req, State, 503, ~"saas_unavailable")
+    end.
+
+-spec call_saas(binary(), binary()) ->
+    {ok, map()} | {error, term()}.
+call_saas(SaasUrl, RawKey) ->
+    QS = iolist_to_binary(cow_qs:qs([{~"key", RawKey}])),
+    Url = binary_to_list(<<SaasUrl/binary, "/internal/validate?", QS/binary>>),
+    Headers = [
+        {"accept", "application/json"},
+        {"x-asobi-internal-token", internal_token()}
+    ],
+    case httpc:request(get, {Url, Headers}, [{timeout, 5000}], [{body_format, binary}]) of
+        {ok, {{_, 200, _}, _, Body}} when is_binary(Body) ->
+            decode_json(Body);
+        {ok, {{_, Status, _}, _, _Body}} when is_integer(Status) ->
+            {error, {Status, invalid}};
+        {error, Reason} ->
+            {error, Reason}
+    end.
+
+-spec decode_json(binary()) -> {ok, map()} | {error, term()}.
+decode_json(Body) ->
+    try json:decode(Body) of
+        Map when is_map(Map) -> {ok, Map};
+        _ -> {error, invalid_json}
+    catch
+        _:_ -> {error, invalid_json}
+    end.
+
+-spec internal_token() -> string().
+internal_token() ->
+    case application:get_env(asobi, saas_internal_token) of
+        {ok, T} when is_binary(T) -> binary_to_list(T);
+        _ -> ""
+    end.
+
+-spec env_matches(map()) -> boolean().
+env_matches(Body) ->
+    case application:get_env(asobi, environment_name) of
+        {ok, Expected} when is_binary(Expected) ->
+            maps:get(~"env_name", Body, undefined) =:= Expected;
+        _ ->
+            true
+    end.
+
+-spec to_context(map()) -> map().
+to_context(Body) ->
+    #{
+        tenant_id => maps:get(~"tenant_id", Body),
+        game_id => maps:get(~"game_id", Body),
+        environment_id => maps:get(~"environment_id", Body),
+        env_name => maps:get(~"env_name", Body, nil),
+        plan => maps:get(~"plan", Body, nil),
+        scopes => maps:get(~"scopes", Body, [])
+    }.
+
+-spec apply_context(cowboy_req:req(), map(), term()) ->
+    {ok, cowboy_req:req(), term()}.
+apply_context(Req, Ctx, State) ->
+    Req1 = Req#{asobi_tenant => Ctx},
+    {ok, Req1, State}.
+
+-spec reject(cowboy_req:req(), term(), pos_integer(), binary()) ->
+    {break, cowboy_req:req(), term()}.
+reject(Req, State, Status, Error) ->
+    Body = json:encode(#{~"error" => Error}),
+    Req1 = cowboy_req:reply(
+        Status,
+        #{~"content-type" => ~"application/json"},
+        Body,
+        Req
+    ),
+    {break, Req1, State}.
+
+%% --- Cache ---
+
+-spec lookup_cache(binary()) -> {ok, map()} | miss.
+lookup_cache(RawKey) ->
+    ensure_table(),
+    Now = erlang:monotonic_time(millisecond),
+    case ets:lookup(?CACHE_TABLE, RawKey) of
+        [{_, Ctx, ExpiresAt}] when ExpiresAt > Now -> {ok, Ctx};
+        _ -> miss
+    end.
+
+-spec store_cache(binary(), map()) -> ok.
+store_cache(RawKey, Ctx) ->
+    ensure_table(),
+    ExpiresAt = erlang:monotonic_time(millisecond) + ?CACHE_TTL_MS,
+    ets:insert(?CACHE_TABLE, {RawKey, Ctx, ExpiresAt}),
+    ok.
+
+-spec ensure_table() -> ok.
+ensure_table() ->
+    case ets:whereis(?CACHE_TABLE) of
+        undefined ->
+            try
+                _ = ets:new(?CACHE_TABLE, [
+                    named_table, public, set, {read_concurrency, true}
+                ]),
+                ok
+            catch
+                error:badarg -> ok
+            end;
+        _ ->
+            ok
+    end.
+
+-spec to_binary(binary() | list()) -> binary().
+to_binary(B) when is_binary(B) -> B;
+to_binary(L) when is_list(L) -> list_to_binary(L).

--- a/test/asobi_saas_key_plugin_SUITE.erl
+++ b/test/asobi_saas_key_plugin_SUITE.erl
@@ -1,0 +1,193 @@
+-module(asobi_saas_key_plugin_SUITE).
+
+-include_lib("common_test/include/ct.hrl").
+-include_lib("stdlib/include/assert.hrl").
+
+-export([all/0, init_per_suite/1, end_per_suite/1, init_per_testcase/2, end_per_testcase/2]).
+-export([
+    passthrough_when_unconfigured/1,
+    skips_non_api_paths/1,
+    rejects_missing_key/1,
+    rejects_invalid_key/1,
+    rejects_env_mismatch/1,
+    allows_valid_key/1,
+    caches_valid_key/1,
+    unavailable_saas_returns_503/1
+]).
+
+%% Mock saas handler
+-export([init/2]).
+
+-define(SAAS_URL, <<"http://localhost:4099">>).
+
+all() ->
+    [
+        passthrough_when_unconfigured,
+        skips_non_api_paths,
+        rejects_missing_key,
+        rejects_invalid_key,
+        rejects_env_mismatch,
+        allows_valid_key,
+        caches_valid_key,
+        unavailable_saas_returns_503
+    ].
+
+init_per_suite(Config) ->
+    application:ensure_all_started(cowboy),
+    application:ensure_all_started(inets),
+    Dispatch = cowboy_router:compile([
+        {'_', [{"/internal/validate", ?MODULE, []}]}
+    ]),
+    {ok, _} = cowboy:start_clear(
+        saas_mock_listener,
+        [{port, 4099}],
+        #{env => #{dispatch => Dispatch}}
+    ),
+    Config.
+
+end_per_suite(_Config) ->
+    cowboy:stop_listener(saas_mock_listener),
+    ok.
+
+init_per_testcase(_Case, Config) ->
+    meck:new(cowboy_req, [unstick, passthrough]),
+    meck:expect(cowboy_req, reply, fun
+        (Status, Headers, Body, #{fake := true} = Req) ->
+            Req#{reply => {Status, Headers, Body}};
+        (Status, Headers, Body, Req) ->
+            meck:passthrough([Status, Headers, Body, Req])
+    end),
+    meck:expect(cowboy_req, header, fun
+        (Name, #{fake := true} = Req) ->
+            maps:get(Name, maps:get(headers, Req, #{}), undefined);
+        (Name, Req) ->
+            meck:passthrough([Name, Req])
+    end),
+    meck:expect(cowboy_req, path, fun
+        (#{fake := true} = Req) -> maps:get(path, Req, ~"/");
+        (Req) -> meck:passthrough([Req])
+    end),
+    reset_env(),
+    clear_cache(),
+    set_mock_response({ok, 200, valid_body(~"dev")}),
+    Config.
+
+end_per_testcase(_Case, _Config) ->
+    meck:unload(cowboy_req),
+    reset_env(),
+    clear_cache(),
+    ok.
+
+%% --- Tests ---
+
+passthrough_when_unconfigured(_) ->
+    Req = req(~"/api/v1/players/abc", #{~"x-asobi-key" => ~"ak_whatever"}),
+    Result = asobi_saas_key_plugin:pre_request(Req, #{}, #{}, state),
+    ?assertMatch({ok, _, state}, Result),
+    {ok, Req1, state} = Result,
+    ?assertEqual(Req, Req1).
+
+skips_non_api_paths(_) ->
+    set_url(),
+    Req = req(~"/ws", #{}),
+    {ok, _, state} = asobi_saas_key_plugin:pre_request(Req, #{}, #{}, state).
+
+rejects_missing_key(_) ->
+    set_url(),
+    Req = req(~"/api/v1/players/abc", #{}),
+    {break, Req1, state} = asobi_saas_key_plugin:pre_request(Req, #{}, #{}, state),
+    ?assertMatch({401, _, _}, maps:get(reply, Req1)).
+
+rejects_invalid_key(_) ->
+    set_url(),
+    set_mock_response({ok, 401, #{~"error" => ~"invalid_key"}}),
+    Req = req(~"/api/v1/players/abc", #{~"x-asobi-key" => ~"ak_bad"}),
+    {break, Req1, state} = asobi_saas_key_plugin:pre_request(Req, #{}, #{}, state),
+    ?assertMatch({401, _, _}, maps:get(reply, Req1)).
+
+rejects_env_mismatch(_) ->
+    set_url(),
+    set_env_name(~"live"),
+    set_mock_response({ok, 200, valid_body(~"dev")}),
+    Req = req(~"/api/v1/players/abc", #{~"x-asobi-key" => ~"ak_devkey"}),
+    {break, Req1, state} = asobi_saas_key_plugin:pre_request(Req, #{}, #{}, state),
+    ?assertMatch({403, _, _}, maps:get(reply, Req1)).
+
+allows_valid_key(_) ->
+    set_url(),
+    set_env_name(~"dev"),
+    set_mock_response({ok, 200, valid_body(~"dev")}),
+    Req = req(~"/api/v1/players/abc", #{~"x-asobi-key" => ~"ak_devkey"}),
+    {ok, Req1, state} = asobi_saas_key_plugin:pre_request(Req, #{}, #{}, state),
+    Ctx = maps:get(asobi_tenant, Req1),
+    ?assertMatch(#{tenant_id := _, game_id := _, environment_id := _}, Ctx),
+    ?assertEqual(~"dev", maps:get(env_name, Ctx)).
+
+caches_valid_key(_) ->
+    set_url(),
+    set_env_name(~"dev"),
+    set_mock_response({ok, 200, valid_body(~"dev")}),
+    Req = req(~"/api/v1/players/abc", #{~"x-asobi-key" => ~"ak_cached"}),
+    {ok, _, state} = asobi_saas_key_plugin:pre_request(Req, #{}, #{}, state),
+    %% Break saas — subsequent call should use cache
+    set_mock_response({ok, 503, #{~"error" => ~"down"}}),
+    {ok, _, state} = asobi_saas_key_plugin:pre_request(Req, #{}, #{}, state).
+
+unavailable_saas_returns_503(_) ->
+    application:set_env(asobi, saas_internal_url, <<"http://localhost:1">>),
+    Req = req(~"/api/v1/players/abc", #{~"x-asobi-key" => ~"ak_any"}),
+    {break, Req1, state} = asobi_saas_key_plugin:pre_request(Req, #{}, #{}, state),
+    ?assertMatch({503, _, _}, maps:get(reply, Req1)).
+
+%% --- Mock saas cowboy handler ---
+
+init(Req0, State) ->
+    {Status, BodyJson} =
+        case application:get_env(asobi, test_saas_response, undefined) of
+            {S, B} when is_integer(S), is_binary(B) -> {S, B};
+            _ -> {500, <<"{}">>}
+        end,
+    Resp = cowboy_req:reply(
+        Status,
+        #{<<"content-type">> => <<"application/json">>},
+        BodyJson,
+        Req0
+    ),
+    {ok, Resp, State}.
+
+%% --- Helpers ---
+
+req(Path, Headers) ->
+    #{fake => true, path => Path, headers => Headers}.
+
+valid_body(EnvName) ->
+    #{
+        ~"tenant_id" => ~"tenant-1",
+        ~"game_id" => ~"game-1",
+        ~"environment_id" => ~"env-1",
+        ~"env_name" => EnvName,
+        ~"plan" => ~"free",
+        ~"scopes" => [~"game"]
+    }.
+
+set_url() ->
+    application:set_env(asobi, saas_internal_url, ?SAAS_URL).
+
+set_env_name(Name) ->
+    application:set_env(asobi, environment_name, Name).
+
+set_mock_response({ok, Status, Body}) ->
+    Json = iolist_to_binary(json:encode(Body)),
+    application:set_env(asobi, test_saas_response, {Status, Json}).
+
+reset_env() ->
+    application:unset_env(asobi, saas_internal_url),
+    application:unset_env(asobi, environment_name),
+    application:unset_env(asobi, saas_internal_token),
+    application:unset_env(asobi, test_saas_response).
+
+clear_cache() ->
+    case ets:whereis(asobi_saas_key_cache) of
+        undefined -> ok;
+        _ -> ets:delete_all_objects(asobi_saas_key_cache)
+    end.


### PR DESCRIPTION
## Summary
- New \`asobi_saas_key_plugin\` (Nova pre_request) that reads the \`x-asobi-key\` header, validates against saas \`/internal/validate\`, and stashes the resolved tenant/game/environment context on the request.
- 5-minute ETS cache keyed on the raw key; short-circuits the HTTP roundtrip on hot paths.
- Deployment-level environment enforcement: when \`asobi.environment_name\` is set (e.g. \"dev\" or \"live\"), responses whose \`env_name\` doesn't match are rejected with 403. So two engine deployments pointing at the same saas (api-dev.asobi.dev / api.asobi.dev) each only accept keys scoped to their own env.
- Passthrough when \`saas_internal_url\` is unset — local dev and existing CT suites keep working without a running saas.
- Prod config threads \`ASOBI_SAAS_URL\`, \`ASOBI_SAAS_INTERNAL_TOKEN\`, \`ASOBI_ENVIRONMENT_NAME\` through \`prod_sys.config.src\`.

## Test plan
- [x] \`asobi_saas_key_plugin_SUITE\` — 8 cases covering passthrough, path skip, missing/invalid/mismatched/valid/cached/unreachable. Driven through a mini cowboy mock saas so real httpc + URL encoding paths are exercised.
- [x] rebar3 ct (164/164)
- [x] rebar3 xref
- [x] rebar3 fmt --check
- [x] rebar3 dialyzer
- [x] elp eqwalize-all — no new errors introduced (116 pre-existing to tackle separately)