### PR TITLE
feat: zone entity persistence, dynamic spawning, and spatial queries

### DIFF
--- a/src/migrations/m20260412172429_update_schema.erl
+++ b/src/migrations/m20260412172429_update_schema.erl
@@ -1,0 +1,40 @@
+-module(m20260412172429_update_schema).
+-moduledoc false.
+-behaviour(kura_migration).
+-include_lib("kura/include/kura.hrl").
+-export([up/0, down/0]).
+
+-spec up() -> [kura_migration:operation()].
+up() ->
+    [
+        {create_table, <<"seasons">>, [
+            #kura_column{name = id, type = uuid, primary_key = true, nullable = false},
+            #kura_column{name = name, type = string, nullable = false},
+            #kura_column{name = starts_at, type = bigint, nullable = false},
+            #kura_column{name = ends_at, type = bigint, nullable = false},
+            #kura_column{name = status, type = string, default = <<"upcoming">>},
+            #kura_column{name = config, type = jsonb, default = #{}},
+            #kura_column{name = ranked, type = jsonb, default = #{}},
+            #kura_column{name = rewards, type = jsonb, default = #{}},
+            #kura_column{name = inserted_at, type = utc_datetime, nullable = false}
+        ]},
+        {create_table, <<"zone_snapshots">>, [
+            #kura_column{name = id, type = uuid, primary_key = true, nullable = false},
+            #kura_column{name = world_id, type = uuid, nullable = false},
+            #kura_column{name = zone_x, type = integer, nullable = false},
+            #kura_column{name = zone_y, type = integer, nullable = false},
+            #kura_column{name = entities, type = jsonb, nullable = false, default = #{}},
+            #kura_column{name = zone_state, type = jsonb, default = #{}},
+            #kura_column{name = entity_timers, type = jsonb, default = #{}},
+            #kura_column{name = spawner_state, type = jsonb, default = #{}},
+            #kura_column{name = tick, type = bigint, nullable = false, default = 0},
+            #kura_column{name = snapshot_at, type = utc_datetime, nullable = false}
+        ]}
+    ].
+
+-spec down() -> [kura_migration:operation()].
+down() ->
+    [
+        {drop_table, <<"seasons">>},
+        {drop_table, <<"zone_snapshots">>}
+    ].

--- a/src/world/asobi_spatial.erl
+++ b/src/world/asobi_spatial.erl
@@ -1,0 +1,204 @@
+-module(asobi_spatial).
+
+%% Spatial query primitives for zone entities.
+%% Pure functional — no process, no state. Operates on entity maps.
+
+-export([query_radius/3, query_radius/4]).
+-export([query_rect/3, query_rect/4]).
+-export([nearest/3, nearest/4]).
+-export([in_range/3, distance/2, distance_pos/2]).
+
+-export_type([query_opts/0]).
+
+-type query_opts() :: #{
+    type => binary() | [binary()],
+    exclude => binary() | [binary()],
+    max_results => pos_integer(),
+    sort => nearest | farthest | none,
+    filter => fun((binary(), map()) -> boolean())
+}.
+
+%% -------------------------------------------------------------------
+%% Radius queries
+%% -------------------------------------------------------------------
+
+-spec query_radius(map(), {number(), number()}, number()) ->
+    [{binary(), map(), float()}].
+query_radius(Entities, Center, Radius) ->
+    query_radius(Entities, Center, Radius, #{}).
+
+-spec query_radius(map(), {number(), number()}, number(), query_opts()) ->
+    [{binary(), map(), float()}].
+query_radius(Entities, {CX, CY}, Radius, Opts) ->
+    R2 = Radius * Radius,
+    TypeFilter = type_filter(Opts),
+    Exclude = exclude_set(Opts),
+    CustomFilter = maps:get(filter, Opts, fun(_, _) -> true end),
+    Results = maps:fold(
+        fun
+            (Id, #{x := X, y := Y} = Entity, Acc) ->
+                D2 = (X - CX) * (X - CX) + (Y - CY) * (Y - CY),
+                case
+                    D2 =< R2 andalso
+                        TypeFilter(Entity) andalso
+                        not maps:is_key(Id, Exclude) andalso
+                        CustomFilter(Id, Entity)
+                of
+                    true -> [{Id, Entity, math:sqrt(D2)} | Acc];
+                    false -> Acc
+                end;
+            (_Id, _Entity, Acc) ->
+                Acc
+        end,
+        [],
+        Entities
+    ),
+    sort_and_limit(Results, Opts).
+
+%% -------------------------------------------------------------------
+%% Rectangle queries
+%% -------------------------------------------------------------------
+
+-spec query_rect(map(), {number(), number()}, {number(), number()}) ->
+    [{binary(), map()}].
+query_rect(Entities, TopLeft, BottomRight) ->
+    query_rect(Entities, TopLeft, BottomRight, #{}).
+
+-spec query_rect(map(), {number(), number()}, {number(), number()}, query_opts()) ->
+    [{binary(), map()}].
+query_rect(Entities, {MinX, MinY}, {MaxX, MaxY}, Opts) ->
+    TypeFilter = type_filter(Opts),
+    Exclude = exclude_set(Opts),
+    CustomFilter = maps:get(filter, Opts, fun(_, _) -> true end),
+    Results = maps:fold(
+        fun
+            (Id, #{x := X, y := Y} = Entity, Acc) ->
+                case
+                    X >= MinX andalso X =< MaxX andalso
+                        Y >= MinY andalso Y =< MaxY andalso
+                        TypeFilter(Entity) andalso
+                        not maps:is_key(Id, Exclude) andalso
+                        CustomFilter(Id, Entity)
+                of
+                    true -> [{Id, Entity} | Acc];
+                    false -> Acc
+                end;
+            (_Id, _Entity, Acc) ->
+                Acc
+        end,
+        [],
+        Entities
+    ),
+    maybe_limit(Results, Opts).
+
+%% -------------------------------------------------------------------
+%% Nearest-N queries
+%% -------------------------------------------------------------------
+
+-spec nearest(map(), {number(), number()}, pos_integer()) ->
+    [{binary(), map(), float()}].
+nearest(Entities, Center, N) ->
+    nearest(Entities, Center, N, #{}).
+
+-spec nearest(map(), {number(), number()}, pos_integer(), query_opts()) ->
+    [{binary(), map(), float()}].
+nearest(Entities, {CX, CY}, N, Opts) ->
+    TypeFilter = type_filter(Opts),
+    Exclude = exclude_set(Opts),
+    CustomFilter = maps:get(filter, Opts, fun(_, _) -> true end),
+    All = collect_with_distance(
+        maps:to_list(Entities), CX, CY, TypeFilter, Exclude, CustomFilter, []
+    ),
+    Sorted = lists:sort(fun({D1, _, _}, {D2, _, _}) -> D1 =< D2 end, All),
+    format_nearest(lists:sublist(Sorted, N), []).
+
+-spec collect_with_distance(
+    [{binary(), map()}],
+    number(),
+    number(),
+    fun((map()) -> boolean()),
+    map(),
+    fun((binary(), map()) -> boolean()),
+    [{float(), binary(), map()}]
+) -> [{float(), binary(), map()}].
+collect_with_distance([], _, _, _, _, _, Acc) ->
+    Acc;
+collect_with_distance([{Id, #{x := X, y := Y} = Entity} | Rest], CX, CY, TF, Excl, CF, Acc) ->
+    case TF(Entity) andalso not maps:is_key(Id, Excl) andalso CF(Id, Entity) of
+        true ->
+            D2 = (X - CX) * (X - CX) + (Y - CY) * (Y - CY),
+            collect_with_distance(Rest, CX, CY, TF, Excl, CF, [{D2, Id, Entity} | Acc]);
+        false ->
+            collect_with_distance(Rest, CX, CY, TF, Excl, CF, Acc)
+    end;
+collect_with_distance([_ | Rest], CX, CY, TF, Excl, CF, Acc) ->
+    collect_with_distance(Rest, CX, CY, TF, Excl, CF, Acc).
+
+-spec format_nearest([{float(), binary(), map()}], [{binary(), map(), float()}]) ->
+    [{binary(), map(), float()}].
+format_nearest([], Acc) ->
+    lists:reverse(Acc);
+format_nearest([{D2, Id, E} | Rest], Acc) ->
+    format_nearest(Rest, [{Id, E, math:sqrt(D2)} | Acc]).
+
+%% -------------------------------------------------------------------
+%% Point utilities
+%% -------------------------------------------------------------------
+
+-spec in_range(map(), map(), number()) -> boolean().
+in_range(#{x := X1, y := Y1}, #{x := X2, y := Y2}, Range) ->
+    DX = X2 - X1,
+    DY = Y2 - Y1,
+    DX * DX + DY * DY =< Range * Range.
+
+-spec distance(map(), map()) -> float().
+distance(#{x := X1, y := Y1}, #{x := X2, y := Y2}) ->
+    distance_pos({X1, Y1}, {X2, Y2}).
+
+-spec distance_pos({number(), number()}, {number(), number()}) -> float().
+distance_pos({X1, Y1}, {X2, Y2}) ->
+    DX = X2 - X1,
+    DY = Y2 - Y1,
+    math:sqrt(DX * DX + DY * DY).
+
+%% -------------------------------------------------------------------
+%% Internal
+%% -------------------------------------------------------------------
+
+type_filter(#{type := Types}) when is_list(Types) ->
+    Set = maps:from_keys(Types, true),
+    fun
+        (#{type := T}) -> maps:is_key(T, Set);
+        (_) -> false
+    end;
+type_filter(#{type := Type}) ->
+    fun
+        (#{type := T}) -> T =:= Type;
+        (_) -> false
+    end;
+type_filter(_) ->
+    fun(_) -> true end.
+
+exclude_set(#{exclude := Ids}) when is_list(Ids) ->
+    maps:from_keys(Ids, true);
+exclude_set(#{exclude := Id}) when is_binary(Id) ->
+    #{Id => true};
+exclude_set(_) ->
+    #{}.
+
+sort_and_limit(Results, Opts) ->
+    Sorted =
+        case maps:get(sort, Opts, none) of
+            nearest -> lists:sort(fun({_, _, D1}, {_, _, D2}) -> D1 =< D2 end, Results);
+            farthest -> lists:sort(fun({_, _, D1}, {_, _, D2}) -> D1 >= D2 end, Results);
+            none -> Results
+        end,
+    case maps:get(max_results, Opts, infinity) of
+        infinity -> Sorted;
+        Max -> lists:sublist(Sorted, Max)
+    end.
+
+maybe_limit(Results, #{max_results := Max}) ->
+    lists:sublist(Results, Max);
+maybe_limit(Results, _) ->
+    Results.

--- a/src/world/asobi_world.erl
+++ b/src/world/asobi_world.erl
@@ -42,10 +42,18 @@
 -callback on_phase_ended(PhaseName :: binary(), GameState :: term()) ->
     {ok, GameState1 :: term()}.
 
+-callback on_world_recovered(Snapshots :: map(), GameState :: term()) ->
+    {ok, GameState1 :: term()}.
+
+-callback spawn_templates(Config :: map()) ->
+    #{binary() => asobi_zone_spawner:spawn_template()}.
+
 -optional_callbacks([
     generate_world/2,
     get_state/2,
     phases/1,
     on_phase_started/2,
-    on_phase_ended/2
+    on_phase_ended/2,
+    on_world_recovered/2,
+    spawn_templates/1
 ]).

--- a/src/world/asobi_world_server.erl
+++ b/src/world/asobi_world_server.erl
@@ -2,6 +2,7 @@
 -behaviour(gen_statem).
 
 -export([start_link/1, join/2, leave/2, move_player/3, post_tick/2, get_info/1, cancel/1]).
+-export([spawn_at/3, spawn_at/4]).
 -export([reconnect/2]).
 -export([start_vote/2, cast_vote/4, use_veto/3]).
 -export([whereis/1]).
@@ -48,6 +49,14 @@ reconnect(Pid, PlayerId) ->
 -spec cancel(pid()) -> ok.
 cancel(Pid) ->
     gen_statem:cast(Pid, cancel).
+
+-spec spawn_at(pid(), binary(), {number(), number()}) -> ok.
+spawn_at(Pid, TemplateId, Pos) ->
+    spawn_at(Pid, TemplateId, Pos, #{}).
+
+-spec spawn_at(pid(), binary(), {number(), number()}, map()) -> ok.
+spawn_at(Pid, TemplateId, Pos, Overrides) ->
+    gen_statem:cast(Pid, {spawn_at, TemplateId, Pos, Overrides}).
 
 -spec start_vote(pid(), map()) -> {ok, pid()} | {error, term()}.
 start_vote(Pid, VoteConfig) ->
@@ -214,6 +223,19 @@ running({call, From}, {cast_vote, PlayerId, VoteId, OptionId}, State) ->
     handle_cast_vote(From, PlayerId, VoteId, OptionId, State);
 running({call, From}, {use_veto, PlayerId, VoteId}, State) ->
     handle_use_veto(From, PlayerId, VoteId, State);
+running(
+    cast,
+    {spawn_at, TemplateId, {_X, _Y} = Pos, Overrides},
+    #{zone_pids := ZP, zone_size := ZS} = _State
+) ->
+    Coords = pos_to_zone(Pos, ZS),
+    case maps:get(Coords, ZP, undefined) of
+        undefined ->
+            keep_state_and_data;
+        ZonePid ->
+            asobi_zone:spawn_entity(ZonePid, TemplateId, Pos, Overrides),
+            keep_state_and_data
+    end;
 running(cast, cancel, State) ->
     {next_state, finished, State#{result => #{status => ~"cancelled"}}};
 running(info, {vote_resolved, VoteId, Template, Result}, State) ->
@@ -287,7 +309,7 @@ running({call, From}, {reconnect, PlayerId}, State) ->
 
 -spec finished(gen_statem:event_type() | enter, term(), map()) ->
     gen_statem:state_enter_result(atom()).
-finished(enter, _OldState, #{world_id := WorldId} = State) ->
+finished(enter, _OldState, #{world_id := WorldId, config := Config} = State) ->
     DurationMs =
         case maps:get(started_at, State, undefined) of
             undefined -> 0;
@@ -295,6 +317,11 @@ finished(enter, _OldState, #{world_id := WorldId} = State) ->
         end,
     asobi_telemetry:world_finished(WorldId, DurationMs, maps:get(result, State, #{})),
     persist_result(State),
+    %% Clean up snapshots unless world is persistent (will be restarted)
+    case maps:get(persistent, Config, false) of
+        false -> asobi_zone_snapshotter:delete_world(WorldId);
+        true -> ok
+    end,
     notify_players(finished, State),
     {keep_state_and_data, [{state_timeout, 5000, cleanup}]};
 finished(state_timeout, cleanup, State) ->
@@ -318,37 +345,84 @@ spawn_zones(
         config := Config,
         zone_sup_pid := ZoneSupPid,
         ticker_pid := TickerPid,
-        world_id := WorldId
+        world_id := WorldId,
+        game_state := GS
     } = State
 ) ->
-    Seed = maps:get(seed, Config, erlang:system_time(millisecond)),
-    ZoneStates = generate_zone_states(GameMod, Seed, Config, GridSize),
+    Persistence = maps:get(persistence, Config, false),
+    Templates = get_spawn_templates(GameMod, Config),
     AllCoords = [{X, Y} || X <- lists:seq(0, GridSize - 1), Y <- lists:seq(0, GridSize - 1)],
+    %% Check for existing snapshots when persistence is enabled
+    {ZoneStates, Entities, SpawnerStates, GS1} =
+        case Persistence of
+            true ->
+                case asobi_zone_snapshotter:load_snapshots(WorldId) of
+                    {ok, Snapshots} when map_size(Snapshots) > 0 ->
+                        ZS = maps:map(fun(_, #{zone_state := V}) -> V end, Snapshots),
+                        Ents = maps:map(fun(_, #{entities := V}) -> V end, Snapshots),
+                        SS = maps:map(fun(_, #{spawner_state := V}) -> V end, Snapshots),
+                        GS2 =
+                            case erlang:function_exported(GameMod, on_world_recovered, 2) of
+                                true ->
+                                    {ok, GS3} = GameMod:on_world_recovered(Snapshots, GS),
+                                    GS3;
+                                false ->
+                                    GS
+                            end,
+                        {ZS, Ents, SS, GS2};
+                    _ ->
+                        {generate_zone_states(GameMod, Config), #{}, #{}, GS}
+                end;
+            false ->
+                {generate_zone_states(GameMod, Config), #{}, #{}, GS}
+        end,
     ZonePids = lists:foldl(
         fun(Coords, Acc) ->
             ZoneState = maps:get(Coords, ZoneStates, #{}),
-            ZoneConfig = #{
+            RecoveredEnts = maps:get(Coords, Entities, #{}),
+            SpawnerS = maps:get(Coords, SpawnerStates, undefined),
+            ZoneConfig0 = #{
                 world_id => WorldId,
                 coords => Coords,
                 ticker_pid => TickerPid,
                 game_module => GameMod,
-                zone_state => ZoneState
+                zone_state => ZoneState,
+                spawn_templates => Templates,
+                persistence => Persistence,
+                snapshot_interval => maps:get(snapshot_interval, Config, 600)
             },
+            ZoneConfig =
+                case SpawnerS of
+                    undefined -> ZoneConfig0;
+                    _ -> ZoneConfig0#{spawner_state => SpawnerS}
+                end,
             {ok, Pid} = asobi_zone_sup:start_zone(ZoneSupPid, ZoneConfig),
+            %% Add recovered entities to zone
+            maps:foreach(
+                fun(EId, EState) -> asobi_zone:add_entity(Pid, EId, EState) end,
+                RecoveredEnts
+            ),
             Acc#{Coords => Pid}
         end,
         #{},
         AllCoords
     ),
-    State#{zone_pids => ZonePids}.
+    State#{zone_pids => ZonePids, game_state => GS1}.
 
-generate_zone_states(GameMod, Seed, Config, _GridSize) ->
+generate_zone_states(GameMod, Config) ->
+    Seed = maps:get(seed, Config, erlang:system_time(millisecond)),
     case erlang:function_exported(GameMod, generate_world, 2) of
         true ->
             {ok, ZoneStates} = GameMod:generate_world(Seed, Config),
             ZoneStates;
         false ->
             #{}
+    end.
+
+get_spawn_templates(GameMod, Config) ->
+    case erlang:function_exported(GameMod, spawn_templates, 1) of
+        true -> GameMod:spawn_templates(Config);
+        false -> maps:get(spawn_templates, Config, #{})
     end.
 
 %% --- Internal: Player Management ---

--- a/src/world/asobi_world_sup.erl
+++ b/src/world/asobi_world_sup.erl
@@ -32,6 +32,10 @@ init([]) ->
     },
     Children = [
         #{
+            id => asobi_zone_snapshotter,
+            start => {asobi_zone_snapshotter, start_link, []}
+        },
+        #{
             id => asobi_world_registry,
             start => {asobi_world_registry, start_link, []}
         },

--- a/src/world/asobi_zone.erl
+++ b/src/world/asobi_zone.erl
@@ -3,6 +3,7 @@
 
 -export([start_link/1]).
 -export([tick/2, player_input/3, add_entity/3, remove_entity/2]).
+-export([spawn_entity/3, spawn_entity/4, spawn_entities/2, despawn_entity/2]).
 -export([subscribe/2, unsubscribe/2]).
 -export([get_entities/1, get_subscriber_count/1]).
 -export([start_entity_timer/2, cancel_entity_timer/3]).
@@ -56,6 +57,22 @@ start_entity_timer(Pid, Config) ->
 cancel_entity_timer(Pid, EntityId, TimerId) ->
     gen_server:cast(Pid, {cancel_entity_timer, EntityId, TimerId}).
 
+-spec spawn_entity(pid(), binary(), {number(), number()}) -> ok.
+spawn_entity(Pid, TemplateId, Pos) ->
+    spawn_entity(Pid, TemplateId, Pos, #{}).
+
+-spec spawn_entity(pid(), binary(), {number(), number()}, map()) -> ok.
+spawn_entity(Pid, TemplateId, Pos, Overrides) ->
+    gen_server:cast(Pid, {spawn_entity, TemplateId, Pos, Overrides}).
+
+-spec spawn_entities(pid(), [{binary(), {number(), number()}, map()}]) -> ok.
+spawn_entities(Pid, Spawns) ->
+    gen_server:cast(Pid, {spawn_entities, Spawns}).
+
+-spec despawn_entity(pid(), binary()) -> ok.
+despawn_entity(Pid, EntityId) ->
+    gen_server:cast(Pid, {despawn_entity, EntityId}).
+
 %% --- gen_server callbacks ---
 
 -spec init(map()) -> {ok, map()}.
@@ -68,6 +85,19 @@ init(Config) ->
     pg:join(?PG_SCOPE, {asobi_zone, WorldId, Coords}, self()),
     %% Recover entity state from ETS backup if available (zone crash recovery)
     RecoveredEntities = recover_zone_state(WorldId, Coords),
+    Templates = maps:get(spawn_templates, Config, #{}),
+    SpawnerInit = maps:get(spawner_state, Config, undefined),
+    Spawner =
+        case SpawnerInit of
+            undefined ->
+                asobi_zone_spawner:new(Templates);
+            S when is_map(S) ->
+                asobi_zone_spawner:set_templates(
+                    Templates, asobi_zone_spawner:deserialise(S)
+                )
+        end,
+    Persistence = maps:get(persistence, Config, false),
+    SnapshotInterval = maps:get(snapshot_interval, Config, 600),
     {ok, #{
         world_id => WorldId,
         coords => Coords,
@@ -81,6 +111,9 @@ init(Config) ->
         zone_state => ZoneState,
         input_queue => [],
         entity_timers => asobi_entity_timer:new(),
+        spawner => Spawner,
+        persistence => Persistence,
+        snapshot_interval => SnapshotInterval,
         tick => 0
     }}.
 
@@ -127,6 +160,33 @@ handle_cast({start_entity_timer, Config}, #{entity_timers := ET} = State) ->
     {noreply, State#{entity_timers => asobi_entity_timer:start_timer(Config, ET)}};
 handle_cast({cancel_entity_timer, EntityId, TimerId}, #{entity_timers := ET} = State) ->
     {noreply, State#{entity_timers => asobi_entity_timer:cancel_timer(EntityId, TimerId, ET)}};
+handle_cast(
+    {spawn_entity, TemplateId, Pos, Overrides}, #{entities := Entities, spawner := Spawner} = State
+) ->
+    case asobi_zone_spawner:spawn_entity(TemplateId, Pos, Overrides, Spawner) of
+        {ok, {EntityId, Entity}, Spawner1} ->
+            {noreply, State#{entities => Entities#{EntityId => Entity}, spawner => Spawner1}};
+        {error, _} ->
+            {noreply, State}
+    end;
+handle_cast({spawn_entities, Spawns}, State) ->
+    State1 = lists:foldl(
+        fun({TemplateId, Pos, Overrides}, #{entities := Ents, spawner := Sp} = S) ->
+            case asobi_zone_spawner:spawn_entity(TemplateId, Pos, Overrides, Sp) of
+                {ok, {EntityId, Entity}, Sp1} ->
+                    S#{entities => Ents#{EntityId => Entity}, spawner => Sp1};
+                {error, _} ->
+                    S
+            end
+        end,
+        State,
+        Spawns
+    ),
+    {noreply, State1};
+handle_cast({despawn_entity, EntityId}, #{entities := Entities, spawner := Spawner} = State) ->
+    Now = erlang:system_time(millisecond),
+    Spawner1 = asobi_zone_spawner:entity_removed(EntityId, Now, Spawner),
+    {noreply, State#{entities => maps:remove(EntityId, Entities), spawner => Spawner1}};
 handle_cast(_Msg, State) ->
     {noreply, State}.
 
@@ -141,16 +201,19 @@ handle_info(_Info, State) ->
     {noreply, State}.
 
 -spec terminate(term(), map()) -> ok.
-terminate(normal, #{world_id := WorldId, coords := Coords}) ->
+terminate(normal, #{world_id := WorldId, coords := Coords} = State) ->
+    maybe_final_snapshot(State),
     clear_zone_backup(WorldId, Coords),
     pg:leave(?PG_SCOPE, {asobi_zone, WorldId, Coords}, self()),
     ok;
-terminate({shutdown, _}, #{world_id := WorldId, coords := Coords}) ->
+terminate({shutdown, _}, #{world_id := WorldId, coords := Coords} = State) ->
+    maybe_final_snapshot(State),
     clear_zone_backup(WorldId, Coords),
     pg:leave(?PG_SCOPE, {asobi_zone, WorldId, Coords}, self()),
     ok;
-terminate(_Reason, #{world_id := WorldId, coords := Coords, entities := Entities}) ->
+terminate(_Reason, #{world_id := WorldId, coords := Coords, entities := Entities} = State) ->
     %% Abnormal termination — save state for recovery
+    maybe_final_snapshot(State),
     backup_zone_state(WorldId, Coords, Entities),
     pg:leave(?PG_SCOPE, {asobi_zone, WorldId, Coords}, self()),
     ok.
@@ -180,28 +243,56 @@ do_tick(
     Now = erlang:system_time(millisecond),
     {TimerEvents, ET1} = asobi_entity_timer:tick(Now, ET),
     Entities3 = apply_timer_events(TimerEvents, Entities2),
+    %% Tick spawner — process respawn queue
+    Spawner = maps:get(spawner, State),
+    {Respawns, Spawner1} = asobi_zone_spawner:tick(Now, Spawner),
+    Entities4 = lists:foldl(
+        fun({EntityId, EntityState, _Pos}, Acc) ->
+            Acc#{EntityId => EntityState}
+        end,
+        Entities3,
+        Respawns
+    ),
     %% Only broadcast every Nth tick to reduce network traffic
     State1 =
         case TickN rem BroadcastInterval of
             0 ->
-                Deltas = compute_deltas(BroadcastEntities, Entities3),
+                Deltas = compute_deltas(BroadcastEntities, Entities4),
                 broadcast_deltas(TickN, Deltas, Subs),
-                State#{broadcast_entities => Entities3};
+                State#{broadcast_entities => Entities4};
             _ ->
                 State
         end,
     asobi_world_ticker:tick_done(TickerPid, self(), TickN),
     %% Periodic backup for crash recovery (every 20 ticks ≈ 1 second)
     case TickN rem 20 of
-        0 -> backup_zone_state(WorldId, Coords, Entities3);
+        0 -> backup_zone_state(WorldId, Coords, Entities4);
         _ -> ok
     end,
+    %% Periodic DB snapshot for persistence
+    SnapshotInterval = maps:get(snapshot_interval, State1),
+    Persistence = maps:get(persistence, State1),
+    case Persistence andalso SnapshotInterval > 0 andalso TickN rem SnapshotInterval =:= 0 of
+        true ->
+            asobi_zone_snapshotter:snapshot(#{
+                world_id => WorldId,
+                coords => Coords,
+                entities => snapshot_entities(Entities4),
+                zone_state => ZoneState1,
+                entity_timers => asobi_entity_timer:info(ET1),
+                spawner_state => asobi_zone_spawner:serialise(Spawner1),
+                tick => TickN
+            });
+        false ->
+            ok
+    end,
     State1#{
-        entities => Entities3,
-        prev_entities => Entities3,
+        entities => Entities4,
+        prev_entities => Entities4,
         zone_state => ZoneState1,
         input_queue => [],
         entity_timers => ET1,
+        spawner => Spawner1,
         tick => TickN
     }.
 
@@ -325,6 +416,43 @@ transfer_out_of_bounds_npcs(
     State#{entities => Entities1};
 transfer_out_of_bounds_npcs(State) ->
     State.
+
+%% --- Snapshot Helpers ---
+
+snapshot_entities(Entities) ->
+    maps:filter(
+        fun(_Id, E) ->
+            maps:get(type, E, ~"unknown") =/= ~"player" andalso
+                maps:get(persistent, E, true)
+        end,
+        Entities
+    ).
+
+maybe_final_snapshot(#{persistence := true} = State) ->
+    #{
+        world_id := WorldId,
+        coords := Coords,
+        entities := Entities,
+        zone_state := ZoneState,
+        entity_timers := ET,
+        spawner := Spawner,
+        tick := Tick
+    } = State,
+    try
+        asobi_zone_snapshotter:snapshot_sync(#{
+            world_id => WorldId,
+            coords => Coords,
+            entities => snapshot_entities(Entities),
+            zone_state => ZoneState,
+            entity_timers => asobi_entity_timer:info(ET),
+            spawner_state => asobi_zone_spawner:serialise(Spawner),
+            tick => Tick
+        })
+    catch
+        _:_ -> ok
+    end;
+maybe_final_snapshot(_) ->
+    ok.
 
 %% --- Zone State Backup/Recovery ---
 

--- a/src/world/asobi_zone_snapshot.erl
+++ b/src/world/asobi_zone_snapshot.erl
@@ -1,0 +1,36 @@
+-module(asobi_zone_snapshot).
+-behaviour(kura_schema).
+
+-include_lib("kura/include/kura.hrl").
+
+-export([table/0, fields/0, associations/0, indexes/0, generate_id/0]).
+
+-spec table() -> binary().
+table() -> ~"zone_snapshots".
+
+-spec fields() -> [#kura_field{}].
+fields() ->
+    [
+        #kura_field{name = id, type = uuid, primary_key = true, nullable = false},
+        #kura_field{name = world_id, type = uuid, nullable = false},
+        #kura_field{name = zone_x, type = integer, nullable = false},
+        #kura_field{name = zone_y, type = integer, nullable = false},
+        #kura_field{name = entities, type = jsonb, nullable = false, default = #{}},
+        #kura_field{name = zone_state, type = jsonb, default = #{}},
+        #kura_field{name = entity_timers, type = jsonb, default = #{}},
+        #kura_field{name = spawner_state, type = jsonb, default = #{}},
+        #kura_field{name = tick, type = bigint, nullable = false, default = 0},
+        #kura_field{name = snapshot_at, type = utc_datetime, nullable = false}
+    ].
+
+-spec generate_id() -> binary().
+generate_id() -> asobi_id:generate().
+
+-spec associations() -> [#kura_assoc{}].
+associations() -> [].
+
+-spec indexes() -> [{[atom()], map()}].
+indexes() ->
+    [
+        {[world_id, zone_x, zone_y], #{unique => true}}
+    ].

--- a/src/world/asobi_zone_snapshotter.erl
+++ b/src/world/asobi_zone_snapshotter.erl
@@ -1,0 +1,136 @@
+-module(asobi_zone_snapshotter).
+-behaviour(gen_server).
+
+%% Batched async DB writer for zone entity snapshots.
+%% Deduplicates per zone key, flushes every 1s.
+
+-export([start_link/0]).
+-export([snapshot/1, snapshot_sync/1, delete_world/1]).
+-export([load_snapshots/1]).
+-export([init/1, handle_call/3, handle_cast/2, handle_info/2]).
+
+-define(FLUSH_INTERVAL, 1000).
+
+%% --- Public API ---
+
+-spec start_link() -> gen_server:start_ret().
+start_link() ->
+    gen_server:start_link({local, ?MODULE}, ?MODULE, [], []).
+
+-spec snapshot(map()) -> ok.
+snapshot(Data) ->
+    gen_server:cast(?MODULE, {snapshot, Data}).
+
+-spec snapshot_sync(map()) -> ok.
+snapshot_sync(Data) ->
+    ok = gen_server:call(?MODULE, {snapshot_sync, Data}, 10000).
+
+-spec delete_world(binary()) -> ok.
+delete_world(WorldId) ->
+    gen_server:cast(?MODULE, {delete_world, WorldId}).
+
+-spec load_snapshots(binary()) -> {ok, map()} | {error, term()}.
+load_snapshots(WorldId) ->
+    Q = kura_query:where(kura_query:from(asobi_zone_snapshot), {world_id, WorldId}),
+    case asobi_repo:all(Q) of
+        {ok, Rows} ->
+            {ok, rows_to_map(Rows, #{})};
+        {error, _} = Err ->
+            Err
+    end.
+
+-spec rows_to_map([map()], map()) -> map().
+rows_to_map([], Acc) ->
+    Acc;
+rows_to_map([#{zone_x := ZX, zone_y := ZY} = Row | Rest], Acc) ->
+    rows_to_map(Rest, Acc#{{ZX, ZY} => Row}).
+
+%% --- gen_server callbacks ---
+
+-spec init([]) -> {ok, map()}.
+init([]) ->
+    erlang:send_after(?FLUSH_INTERVAL, self(), flush),
+    {ok, #{pending => #{}}}.
+
+-spec handle_call(term(), gen_server:from(), map()) -> {reply, term(), map()}.
+handle_call({snapshot_sync, Data}, _From, State) ->
+    write_snapshot(Data),
+    {reply, ok, State};
+handle_call(_Request, _From, State) ->
+    {reply, {error, unknown_request}, State}.
+
+-spec handle_cast(term(), map()) -> {noreply, map()}.
+handle_cast({snapshot, Data}, #{pending := Pending} = State) ->
+    Key = {maps:get(world_id, Data), maps:get(coords, Data)},
+    {noreply, State#{pending => Pending#{Key => Data}}};
+handle_cast({delete_world, WorldId}, State) ->
+    do_delete_world(WorldId),
+    {noreply, State};
+handle_cast(_Msg, State) ->
+    {noreply, State}.
+
+-spec handle_info(term(), map()) -> {noreply, map()}.
+handle_info(flush, #{pending := Pending} = State) ->
+    maps:foreach(fun(_Key, Data) -> write_snapshot(Data) end, Pending),
+    erlang:send_after(?FLUSH_INTERVAL, self(), flush),
+    {noreply, State#{pending => #{}}};
+handle_info(_Info, State) ->
+    {noreply, State}.
+
+%% --- Internal ---
+
+write_snapshot(#{world_id := WorldId, coords := {ZX, ZY}} = Data) ->
+    Entities = maps:get(entities, Data, #{}),
+    ZoneState = maps:get(zone_state, Data, #{}),
+    EntityTimers = maps:get(entity_timers, Data, #{}),
+    SpawnerState = maps:get(spawner_state, Data, #{}),
+    Tick = maps:get(tick, Data, 0),
+    Now = erlang:system_time(millisecond),
+    Fields = #{
+        id => asobi_id:generate(),
+        world_id => WorldId,
+        zone_x => ZX,
+        zone_y => ZY,
+        entities => Entities,
+        zone_state => ZoneState,
+        entity_timers => EntityTimers,
+        spawner_state => SpawnerState,
+        tick => Tick,
+        snapshot_at => Now
+    },
+    AllFields = [
+        id,
+        world_id,
+        zone_x,
+        zone_y,
+        entities,
+        zone_state,
+        entity_timers,
+        spawner_state,
+        tick,
+        snapshot_at
+    ],
+    CS = kura_changeset:cast(asobi_zone_snapshot, #{}, Fields, AllFields),
+    ConflictFields = [entities, zone_state, entity_timers, spawner_state, tick, snapshot_at],
+    Opts = #{
+        on_conflict => {
+            {constraint, ~"zone_snapshots_world_id_zone_x_zone_y_index"}, {replace, ConflictFields}
+        }
+    },
+    case asobi_repo:insert(CS, Opts) of
+        {ok, _} ->
+            ok;
+        {error, Reason} ->
+            logger:warning(#{msg => ~"zone snapshot write failed", reason => Reason}),
+            ok
+    end.
+
+do_delete_world(WorldId) ->
+    Q = kura_query:where(kura_query:from(asobi_zone_snapshot), {world_id, WorldId}),
+    case asobi_repo:delete_all(Q) of
+        {ok, _} ->
+            ok;
+        {error, Reason} ->
+            logger:warning(#{msg => ~"zone snapshot cleanup failed", reason => Reason}),
+            ok
+    end.

--- a/src/world/asobi_zone_spawner.erl
+++ b/src/world/asobi_zone_spawner.erl
@@ -1,0 +1,275 @@
+-module(asobi_zone_spawner).
+
+%% Pure functional spawn template registry with respawn queue.
+%% Stored in zone state, ticked each zone tick.
+
+-export([new/1, new/0]).
+-export([spawn_entity/3, spawn_entity/4, spawn_entity/5]).
+-export([entity_removed/3, tick/2]).
+-export([get_templates/1, get_spawn_count/2, info/1]).
+-export([set_templates/2]).
+-export([serialise/1, deserialise/1]).
+
+-export_type([state/0, spawn_template/0, respawn_rule/0]).
+
+-type spawn_template() :: #{
+    template_id := binary(),
+    type := binary(),
+    base_state := map(),
+    persistent => boolean(),
+    respawn => respawn_rule() | undefined
+}.
+
+-type respawn_rule() :: #{
+    strategy := timer,
+    delay := non_neg_integer(),
+    max_respawns => non_neg_integer() | infinity,
+    jitter => non_neg_integer()
+}.
+
+-type spawn_request() :: #{
+    template_id := binary(),
+    entity_id := binary(),
+    position := {number(), number()},
+    overrides := map(),
+    respawn_at := pos_integer()
+}.
+
+-opaque state() :: #{
+    templates := #{binary() => spawn_template()},
+    respawn_queue := [spawn_request()],
+    spawn_counts := #{binary() => non_neg_integer()},
+    entity_templates := #{binary() => binary()},
+    entity_positions := #{binary() => {number(), number()}}
+}.
+
+%% -------------------------------------------------------------------
+%% Constructor
+%% -------------------------------------------------------------------
+
+-spec new() -> state().
+new() ->
+    new(#{}).
+
+-spec new(#{binary() => spawn_template()}) -> state().
+new(Templates) ->
+    #{
+        templates => Templates,
+        respawn_queue => [],
+        spawn_counts => #{},
+        entity_templates => #{},
+        entity_positions => #{}
+    }.
+
+%% -------------------------------------------------------------------
+%% Spawn an entity from a template
+%% -------------------------------------------------------------------
+
+-spec spawn_entity(binary(), {number(), number()}, state()) ->
+    {ok, {binary(), map()}, state()} | {error, unknown_template}.
+spawn_entity(TemplateId, Pos, State) ->
+    spawn_entity(TemplateId, Pos, #{}, State).
+
+-spec spawn_entity(binary(), {number(), number()}, map(), state()) ->
+    {ok, {binary(), map()}, state()} | {error, unknown_template}.
+spawn_entity(TemplateId, Pos, Overrides, State) ->
+    EntityId = asobi_id:generate(),
+    spawn_entity(TemplateId, EntityId, Pos, Overrides, State).
+
+-spec spawn_entity(binary(), binary(), {number(), number()}, map(), state()) ->
+    {ok, {binary(), map()}, state()} | {error, unknown_template}.
+spawn_entity(TemplateId, EntityId, {X, Y} = Pos, Overrides, #{templates := Templates} = State) ->
+    case maps:find(TemplateId, Templates) of
+        {ok, #{type := Type, base_state := Base}} ->
+            Entity = maps:merge(Base, Overrides),
+            Entity1 = Entity#{x => X, y => Y, type => Type},
+            #{
+                spawn_counts := Counts,
+                entity_templates := ET,
+                entity_positions := EP
+            } = State,
+            Count = maps:get(TemplateId, Counts, 0),
+            State1 = State#{
+                spawn_counts => Counts#{TemplateId => Count + 1},
+                entity_templates => ET#{EntityId => TemplateId},
+                entity_positions => EP#{EntityId => Pos}
+            },
+            {ok, {EntityId, Entity1}, State1};
+        error ->
+            {error, unknown_template}
+    end.
+
+%% -------------------------------------------------------------------
+%% Notify entity removed — schedules respawn if applicable
+%% -------------------------------------------------------------------
+
+-spec entity_removed(binary(), pos_integer(), state()) -> state().
+entity_removed(EntityId, Now, #{entity_templates := ET} = State) ->
+    case maps:find(EntityId, ET) of
+        {ok, TemplateId} ->
+            schedule_respawn(EntityId, TemplateId, Now, State);
+        error ->
+            State
+    end.
+
+schedule_respawn(EntityId, TemplateId, Now, #{templates := Templates} = State) ->
+    case maps:find(TemplateId, Templates) of
+        {ok, #{respawn := #{strategy := timer, delay := Delay} = Rule}} ->
+            MaxRespawns = maps:get(max_respawns, Rule, infinity),
+            #{spawn_counts := Counts} = State,
+            Count = maps:get(TemplateId, Counts, 0),
+            case MaxRespawns =:= infinity orelse Count < MaxRespawns of
+                true ->
+                    Jitter = maps:get(jitter, Rule, 0),
+                    JitterMs =
+                        case Jitter of
+                            0 -> 0;
+                            J -> rand:uniform(J)
+                        end,
+                    #{respawn_queue := Queue, entity_positions := EP} = State,
+                    Pos = maps:get(EntityId, EP, {0.0, 0.0}),
+                    Request = #{
+                        template_id => TemplateId,
+                        entity_id => EntityId,
+                        position => Pos,
+                        overrides => #{},
+                        respawn_at => Now + Delay + JitterMs
+                    },
+                    State#{respawn_queue => [Request | Queue]};
+                false ->
+                    cleanup_entity(EntityId, State)
+            end;
+        _ ->
+            cleanup_entity(EntityId, State)
+    end.
+
+%% -------------------------------------------------------------------
+%% Tick — returns entities ready to respawn
+%% -------------------------------------------------------------------
+
+-spec tick(pos_integer(), state()) ->
+    {[{binary(), map(), {number(), number()}}], state()}.
+tick(Now, #{respawn_queue := Queue} = State) ->
+    {Ready, Remaining} = lists:partition(
+        fun(#{respawn_at := At}) -> Now >= At end,
+        Queue
+    ),
+    process_respawns(Ready, [], State#{respawn_queue => Remaining}).
+
+-spec process_respawns(
+    [spawn_request()],
+    [{binary(), map(), {number(), number()}}],
+    state()
+) ->
+    {[{binary(), map(), {number(), number()}}], state()}.
+process_respawns([], Acc, State) ->
+    {Acc, State};
+process_respawns(
+    [#{template_id := TId, entity_id := EId, position := Pos, overrides := Ov} | Rest], Acc, State
+) ->
+    case spawn_entity(TId, EId, Pos, Ov, State) of
+        {ok, {EId2, Entity}, State1} ->
+            {X, Y} = Pos,
+            process_respawns(Rest, [{EId2, Entity#{x => X, y => Y}, Pos} | Acc], State1);
+        {error, _} ->
+            process_respawns(Rest, Acc, State)
+    end.
+
+%% -------------------------------------------------------------------
+%% Queries
+%% -------------------------------------------------------------------
+
+-spec get_templates(state()) -> #{binary() => spawn_template()}.
+get_templates(#{templates := T}) -> T.
+
+-spec set_templates(#{binary() => spawn_template()}, state()) -> state().
+set_templates(Templates, State) ->
+    State#{templates => Templates}.
+
+-spec get_spawn_count(binary(), state()) -> non_neg_integer().
+get_spawn_count(TemplateId, #{spawn_counts := C}) ->
+    maps:get(TemplateId, C, 0).
+
+-spec info(state()) -> map().
+info(#{respawn_queue := Q, spawn_counts := C, entity_templates := ET}) ->
+    #{
+        pending_respawns => length(Q),
+        total_spawned => maps:fold(fun(_, V, Acc) -> Acc + V end, 0, C),
+        tracked_entities => map_size(ET)
+    }.
+
+%% -------------------------------------------------------------------
+%% Serialisation (for zone snapshots)
+%% -------------------------------------------------------------------
+
+-spec serialise(state()) -> map().
+serialise(#{
+    respawn_queue := Queue,
+    spawn_counts := Counts,
+    entity_templates := ET,
+    entity_positions := EP
+}) ->
+    #{
+        ~"respawn_queue" => [serialise_request(R) || R <- Queue],
+        ~"spawn_counts" => Counts,
+        ~"entity_templates" => ET,
+        ~"entity_positions" => maps:fold(
+            fun(K, {X, Y}, Acc) -> Acc#{K => #{~"x" => X, ~"y" => Y}} end,
+            #{},
+            EP
+        )
+    }.
+
+-spec deserialise(map()) -> state().
+deserialise(Data) ->
+    #{
+        templates => #{},
+        respawn_queue => [deserialise_request(R) || R <- maps:get(~"respawn_queue", Data, [])],
+        spawn_counts => maps:get(~"spawn_counts", Data, #{}),
+        entity_templates => maps:get(~"entity_templates", Data, #{}),
+        entity_positions => maps:fold(
+            fun(K, #{~"x" := X, ~"y" := Y}, Acc) -> Acc#{K => {X, Y}} end,
+            #{},
+            maps:get(~"entity_positions", Data, #{})
+        )
+    }.
+
+%% -------------------------------------------------------------------
+%% Internal
+%% -------------------------------------------------------------------
+
+cleanup_entity(EntityId, #{entity_templates := ET, entity_positions := EP} = State) ->
+    State#{
+        entity_templates => maps:remove(EntityId, ET),
+        entity_positions => maps:remove(EntityId, EP)
+    }.
+
+serialise_request(#{
+    template_id := TId,
+    entity_id := EId,
+    position := {X, Y},
+    overrides := Ov,
+    respawn_at := At
+}) ->
+    #{
+        ~"template_id" => TId,
+        ~"entity_id" => EId,
+        ~"position" => #{~"x" => X, ~"y" => Y},
+        ~"overrides" => Ov,
+        ~"respawn_at" => At
+    }.
+
+deserialise_request(#{
+    ~"template_id" := TId,
+    ~"entity_id" := EId,
+    ~"position" := #{~"x" := X, ~"y" := Y},
+    ~"overrides" := Ov,
+    ~"respawn_at" := At
+}) ->
+    #{
+        template_id => TId,
+        entity_id => EId,
+        position => {X, Y},
+        overrides => Ov,
+        respawn_at => At
+    }.

--- a/test/asobi_spatial_SUITE.erl
+++ b/test/asobi_spatial_SUITE.erl
@@ -1,0 +1,197 @@
+-module(asobi_spatial_SUITE).
+
+-include_lib("stdlib/include/assert.hrl").
+
+-export([all/0]).
+-export([
+    query_radius_basic/1,
+    query_radius_with_type_filter/1,
+    query_radius_with_exclude/1,
+    query_radius_with_custom_filter/1,
+    query_radius_sorted/1,
+    query_radius_max_results/1,
+    query_radius_empty/1,
+    query_rect_basic/1,
+    query_rect_with_opts/1,
+    nearest_basic/1,
+    nearest_with_type/1,
+    nearest_fewer_than_n/1,
+    in_range_true/1,
+    in_range_false/1,
+    distance_entities/1,
+    distance_pos/1,
+    entities_without_coords_skipped/1
+]).
+
+all() ->
+    [
+        query_radius_basic,
+        query_radius_with_type_filter,
+        query_radius_with_exclude,
+        query_radius_with_custom_filter,
+        query_radius_sorted,
+        query_radius_max_results,
+        query_radius_empty,
+        query_rect_basic,
+        query_rect_with_opts,
+        nearest_basic,
+        nearest_with_type,
+        nearest_fewer_than_n,
+        in_range_true,
+        in_range_false,
+        distance_entities,
+        distance_pos,
+        entities_without_coords_skipped
+    ].
+
+%% --- Test data ---
+
+entities() ->
+    #{
+        ~"a" => #{x => 0.0, y => 0.0, type => ~"npc", health => 100},
+        ~"b" => #{x => 3.0, y => 4.0, type => ~"npc", health => 50},
+        ~"c" => #{x => 10.0, y => 0.0, type => ~"player", health => 100},
+        ~"d" => #{x => 1.0, y => 1.0, type => ~"resource", health => 0},
+        ~"e" => #{x => 100.0, y => 100.0, type => ~"npc", health => 200},
+        ~"f" => #{name => ~"no_coords"}
+    }.
+
+%% --- Radius tests ---
+
+query_radius_basic(_Config) ->
+    E = entities(),
+    Results = asobi_spatial:query_radius(E, {0.0, 0.0}, 6.0),
+    Ids = [Id || {Id, _, _} <- Results],
+    ?assert(lists:member(~"a", Ids)),
+    ?assert(lists:member(~"b", Ids)),
+    ?assert(lists:member(~"d", Ids)),
+    ?assertNot(lists:member(~"c", Ids)),
+    ?assertNot(lists:member(~"e", Ids)),
+    ?assertNot(lists:member(~"f", Ids)),
+    %% Check distance for "b" (3-4-5 triangle)
+    {~"b", _, Dist} = lists:keyfind(~"b", 1, Results),
+    ?assert(abs(Dist - 5.0) < 0.001),
+    ok.
+
+query_radius_with_type_filter(_Config) ->
+    E = entities(),
+    Results = asobi_spatial:query_radius(E, {0.0, 0.0}, 6.0, #{type => ~"npc"}),
+    Ids = [Id || {Id, _, _} <- Results],
+    ?assert(lists:member(~"a", Ids)),
+    ?assert(lists:member(~"b", Ids)),
+    ?assertNot(lists:member(~"d", Ids)),
+    ok.
+
+query_radius_with_exclude(_Config) ->
+    E = entities(),
+    Results = asobi_spatial:query_radius(E, {0.0, 0.0}, 6.0, #{exclude => ~"a"}),
+    Ids = [Id || {Id, _, _} <- Results],
+    ?assertNot(lists:member(~"a", Ids)),
+    ?assert(lists:member(~"b", Ids)),
+    ok.
+
+query_radius_with_custom_filter(_Config) ->
+    E = entities(),
+    Results = asobi_spatial:query_radius(E, {0.0, 0.0}, 6.0, #{
+        filter => fun
+            (_Id, #{health := H}) -> H > 0;
+            (_, _) -> false
+        end
+    }),
+    Ids = [Id || {Id, _, _} <- Results],
+    ?assert(lists:member(~"a", Ids)),
+    ?assert(lists:member(~"b", Ids)),
+    ?assertNot(lists:member(~"d", Ids)),
+    ok.
+
+query_radius_sorted(_Config) ->
+    E = entities(),
+    Results = asobi_spatial:query_radius(E, {0.0, 0.0}, 6.0, #{sort => nearest}),
+    Distances = [D || {_, _, D} <- Results],
+    ?assertEqual(Distances, lists:sort(Distances)),
+    ok.
+
+query_radius_max_results(_Config) ->
+    E = entities(),
+    Results = asobi_spatial:query_radius(E, {0.0, 0.0}, 200.0, #{
+        max_results => 2, sort => nearest
+    }),
+    ?assertEqual(2, length(Results)),
+    ok.
+
+query_radius_empty(_Config) ->
+    Results = asobi_spatial:query_radius(#{}, {0.0, 0.0}, 10.0),
+    ?assertEqual([], Results),
+    ok.
+
+%% --- Rect tests ---
+
+query_rect_basic(_Config) ->
+    E = entities(),
+    Results = asobi_spatial:query_rect(E, {-1.0, -1.0}, {5.0, 5.0}),
+    Ids = [Id || {Id, _} <- Results],
+    ?assert(lists:member(~"a", Ids)),
+    ?assert(lists:member(~"b", Ids)),
+    ?assert(lists:member(~"d", Ids)),
+    ?assertNot(lists:member(~"c", Ids)),
+    ?assertNot(lists:member(~"e", Ids)),
+    ok.
+
+query_rect_with_opts(_Config) ->
+    E = entities(),
+    Results = asobi_spatial:query_rect(E, {-1.0, -1.0}, {5.0, 5.0}, #{
+        type => ~"npc", max_results => 1
+    }),
+    ?assertEqual(1, length(Results)),
+    ok.
+
+%% --- Nearest tests ---
+
+nearest_basic(_Config) ->
+    E = entities(),
+    [{Id, _, _}] = asobi_spatial:nearest(E, {0.0, 0.0}, 1),
+    ?assertEqual(~"a", Id),
+    ok.
+
+nearest_with_type(_Config) ->
+    E = entities(),
+    [{Id, _, _}] = asobi_spatial:nearest(E, {0.0, 0.0}, 1, #{type => ~"resource"}),
+    ?assertEqual(~"d", Id),
+    ok.
+
+nearest_fewer_than_n(_Config) ->
+    E = entities(),
+    Results = asobi_spatial:nearest(E, {0.0, 0.0}, 100, #{type => ~"resource"}),
+    ?assertEqual(1, length(Results)),
+    ok.
+
+%% --- Point utilities ---
+
+in_range_true(_Config) ->
+    A = #{x => 0.0, y => 0.0},
+    B = #{x => 3.0, y => 4.0},
+    ?assert(asobi_spatial:in_range(A, B, 5.0)),
+    ?assert(asobi_spatial:in_range(A, B, 6.0)),
+    ok.
+
+in_range_false(_Config) ->
+    A = #{x => 0.0, y => 0.0},
+    B = #{x => 3.0, y => 4.0},
+    ?assertNot(asobi_spatial:in_range(A, B, 4.9)),
+    ok.
+
+distance_entities(_Config) ->
+    A = #{x => 0.0, y => 0.0},
+    B = #{x => 3.0, y => 4.0},
+    ?assert(abs(asobi_spatial:distance(A, B) - 5.0) < 0.001),
+    ok.
+
+distance_pos(_Config) ->
+    ?assert(abs(asobi_spatial:distance_pos({0.0, 0.0}, {3.0, 4.0}) - 5.0) < 0.001),
+    ok.
+
+entities_without_coords_skipped(_Config) ->
+    E = #{~"no_pos" => #{name => ~"test"}, ~"with_pos" => #{x => 1.0, y => 1.0, type => ~"npc"}},
+    Results = asobi_spatial:query_radius(E, {0.0, 0.0}, 10.0),
+    ?assertEqual(1, length(Results)),
+    ok.

--- a/test/asobi_zone_spawner_SUITE.erl
+++ b/test/asobi_zone_spawner_SUITE.erl
@@ -1,0 +1,163 @@
+-module(asobi_zone_spawner_SUITE).
+
+-include_lib("stdlib/include/assert.hrl").
+
+-export([all/0, init_per_suite/1, end_per_suite/1]).
+-export([
+    spawn_from_template/1,
+    spawn_unknown_template/1,
+    spawn_with_overrides/1,
+    spawn_with_explicit_id/1,
+    entity_removed_schedules_respawn/1,
+    tick_respawns_entities/1,
+    respawn_max_limit/1,
+    no_respawn_when_undefined/1,
+    serialise_deserialise/1,
+    info_reports_state/1
+]).
+
+all() ->
+    [
+        spawn_from_template,
+        spawn_unknown_template,
+        spawn_with_overrides,
+        spawn_with_explicit_id,
+        entity_removed_schedules_respawn,
+        tick_respawns_entities,
+        respawn_max_limit,
+        no_respawn_when_undefined,
+        serialise_deserialise,
+        info_reports_state
+    ].
+
+init_per_suite(Config) ->
+    {ok, _} = application:ensure_all_started(asobi),
+    Config.
+
+end_per_suite(Config) ->
+    Config.
+
+templates() ->
+    #{
+        ~"goblin" => #{
+            template_id => ~"goblin",
+            type => ~"npc",
+            base_state => #{health => 100, ai => ~"patrol"},
+            respawn => #{strategy => timer, delay => 1000, max_respawns => infinity, jitter => 0}
+        },
+        ~"ore" => #{
+            template_id => ~"ore",
+            type => ~"resource",
+            base_state => #{quantity => 5},
+            respawn => #{strategy => timer, delay => 500, max_respawns => 2, jitter => 0}
+        },
+        ~"chest" => #{
+            template_id => ~"chest",
+            type => ~"object",
+            base_state => #{loot => ~"common"},
+            respawn => undefined
+        }
+    }.
+
+%% --- Tests ---
+
+spawn_from_template(_Config) ->
+    S0 = asobi_zone_spawner:new(templates()),
+    {ok, {Id, Entity}, S1} = asobi_zone_spawner:spawn_entity(~"goblin", {10.0, 20.0}, S0),
+    ?assert(is_binary(Id)),
+    ?assertMatch(#{type := ~"npc", health := 100, x := 10.0, y := 20.0}, Entity),
+    ?assertEqual(1, asobi_zone_spawner:get_spawn_count(~"goblin", S1)),
+    ok.
+
+spawn_unknown_template(_Config) ->
+    S0 = asobi_zone_spawner:new(templates()),
+    ?assertEqual(
+        {error, unknown_template}, asobi_zone_spawner:spawn_entity(~"dragon", {0.0, 0.0}, S0)
+    ),
+    ok.
+
+spawn_with_overrides(_Config) ->
+    S0 = asobi_zone_spawner:new(templates()),
+    {ok, {_, Entity}, _S1} = asobi_zone_spawner:spawn_entity(
+        ~"goblin", {5.0, 5.0}, #{health => 200}, S0
+    ),
+    ?assertMatch(#{health := 200, ai := ~"patrol"}, Entity),
+    ok.
+
+spawn_with_explicit_id(_Config) ->
+    S0 = asobi_zone_spawner:new(templates()),
+    {ok, {~"my-goblin", Entity}, _S1} = asobi_zone_spawner:spawn_entity(
+        ~"goblin", ~"my-goblin", {1.0, 2.0}, #{}, S0
+    ),
+    ?assertMatch(#{type := ~"npc", x := 1.0, y := 2.0}, Entity),
+    ok.
+
+entity_removed_schedules_respawn(_Config) ->
+    S0 = asobi_zone_spawner:new(templates()),
+    {ok, {Id, _}, S1} = asobi_zone_spawner:spawn_entity(~"goblin", {10.0, 20.0}, S0),
+    Now = erlang:system_time(millisecond),
+    S2 = asobi_zone_spawner:entity_removed(Id, Now, S1),
+    Info = asobi_zone_spawner:info(S2),
+    ?assertEqual(1, maps:get(pending_respawns, Info)),
+    ok.
+
+tick_respawns_entities(_Config) ->
+    S0 = asobi_zone_spawner:new(templates()),
+    {ok, {Id, _}, S1} = asobi_zone_spawner:spawn_entity(~"goblin", {10.0, 20.0}, S0),
+    Now = erlang:system_time(millisecond),
+    S2 = asobi_zone_spawner:entity_removed(Id, Now, S1),
+    %% Not ready yet
+    {[], S3} = asobi_zone_spawner:tick(Now + 500, S2),
+    %% Ready after delay
+    {Spawned, S4} = asobi_zone_spawner:tick(Now + 1001, S3),
+    ?assertEqual(1, length(Spawned)),
+    [{_, Entity, {10.0, 20.0}}] = Spawned,
+    ?assertMatch(#{type := ~"npc", health := 100}, Entity),
+    ?assertEqual(0, maps:get(pending_respawns, asobi_zone_spawner:info(S4))),
+    ok.
+
+respawn_max_limit(_Config) ->
+    S0 = asobi_zone_spawner:new(templates()),
+    %% Ore has max_respawns => 2, so after 2 spawns no more respawns
+    {ok, {Id, _}, S1} = asobi_zone_spawner:spawn_entity(~"ore", ~"ore1", {5.0, 5.0}, #{}, S0),
+    Now = erlang:system_time(millisecond),
+    %% First removal: count=1, should schedule respawn (1 < 2)
+    S2 = asobi_zone_spawner:entity_removed(Id, Now, S1),
+    {Spawned1, S3} = asobi_zone_spawner:tick(Now + 501, S2),
+    ?assertEqual(1, length(Spawned1)),
+    %% Second removal: count=2, should NOT schedule respawn (2 >= 2)
+    S4 = asobi_zone_spawner:entity_removed(Id, Now + 600, S3),
+    ?assertEqual(0, maps:get(pending_respawns, asobi_zone_spawner:info(S4))),
+    ok.
+
+no_respawn_when_undefined(_Config) ->
+    S0 = asobi_zone_spawner:new(templates()),
+    {ok, {Id, _}, S1} = asobi_zone_spawner:spawn_entity(~"chest", {1.0, 1.0}, S0),
+    Now = erlang:system_time(millisecond),
+    S2 = asobi_zone_spawner:entity_removed(Id, Now, S1),
+    ?assertEqual(0, maps:get(pending_respawns, asobi_zone_spawner:info(S2))),
+    ok.
+
+serialise_deserialise(_Config) ->
+    S0 = asobi_zone_spawner:new(templates()),
+    {ok, {Id, _}, S1} = asobi_zone_spawner:spawn_entity(~"goblin", ~"g1", {10.0, 20.0}, #{}, S0),
+    Now = erlang:system_time(millisecond),
+    S2 = asobi_zone_spawner:entity_removed(Id, Now, S1),
+    Serialised = asobi_zone_spawner:serialise(S2),
+    %% Should be JSON-safe maps
+    ?assert(is_map(Serialised)),
+    S3 = asobi_zone_spawner:deserialise(Serialised),
+    ?assertEqual(1, maps:get(pending_respawns, asobi_zone_spawner:info(S3))),
+    ok.
+
+info_reports_state(_Config) ->
+    S0 = asobi_zone_spawner:new(templates()),
+    Info0 = asobi_zone_spawner:info(S0),
+    ?assertEqual(0, maps:get(pending_respawns, Info0)),
+    ?assertEqual(0, maps:get(total_spawned, Info0)),
+    ?assertEqual(0, maps:get(tracked_entities, Info0)),
+    {ok, {_, _}, S1} = asobi_zone_spawner:spawn_entity(~"goblin", {0.0, 0.0}, S0),
+    Info1 = asobi_zone_spawner:info(S1),
+    ?assertEqual(1, maps:get(total_spawned, Info1)),
+    ?assertEqual(1, maps:get(tracked_entities, Info1)),
+    ok.


### PR DESCRIPTION
## Summary

- **Zone entity persistence** — new `asobi_zone_snapshotter` gen_server batches zone state to PostgreSQL via `zone_snapshots` table. Configurable interval, dedup per zone, upsert on conflict. On world startup, snapshots are loaded and entities/spawner state restored. Sync snapshot on graceful shutdown.
- **Dynamic entity spawn/despawn** — new `asobi_zone_spawner` pure functional module with template registry, respawn queue (timer-based with jitter and max limits), and serialisation for snapshot persistence. New zone API: `spawn_entity/3,4`, `spawn_entities/2`, `despawn_entity/2`. World-level `spawn_at/3,4` resolves zone from coordinates.
- **Spatial queries** — new `asobi_spatial` pure functional module with `query_radius/3,4`, `query_rect/3,4`, `nearest/3,4`, `in_range/3`, `distance/2`. Filter by type, exclude IDs, custom predicates, sort, limit. Squared-distance comparison avoids sqrt overhead.

### New modules
| Module | Type | Lines |
|--------|------|-------|
| `asobi_spatial` | Pure functional | 190 |
| `asobi_zone_spawner` | Pure functional | 230 |
| `asobi_zone_snapshot` | Kura schema | 35 |
| `asobi_zone_snapshotter` | gen_server | 140 |

### Modified modules
- `asobi_zone` — spawner + snapshotter integration in tick loop
- `asobi_world_server` — snapshot recovery, `spawn_at` API, template distribution
- `asobi_world` — new optional callbacks: `on_world_recovered/2`, `spawn_templates/1`
- `asobi_world_sup` — snapshotter in supervision tree

### New optional callbacks
- `spawn_templates(Config)` — return template registry for zones
- `on_world_recovered(Snapshots, GameState)` — called when world restarts from DB snapshots

## Test plan
- [x] 17 spatial query tests (radius, rect, nearest, distance, filters, edge cases)
- [x] 10 spawner tests (template spawn, respawn scheduling, max limits, serialisation)
- [x] Existing match tests pass (no regressions)
- [x] rebar3 compile, xref, dialyzer, fmt --check all clean
- [ ] Integration test with DB (snapshot write/read cycle)
- [ ] World restart recovery with populated zones