### PR TITLE
feat: MMO-scale world server with lazy zones, terrain, perf optimisations

### DIFF
--- a/guides/large-worlds.md
+++ b/guides/large-worlds.md
@@ -1,0 +1,150 @@
+# Large Worlds
+
+Scale the world server to handle massive tile-based maps with lazy zone
+loading, terrain data serving, and configurable zone lifecycle management.
+
+## Lazy Zone Loading
+
+By default, all zones in a world are spawned at startup. For large worlds
+(thousands of zones), enable lazy loading so zones are created on demand
+when a player enters.
+
+```erlang
+Config = #{
+    game_module => my_world,
+    grid_size => 2000,          %% 2000x2000 zone grid
+    zone_size => 64,            %% 64 tiles per zone
+    lazy_zones => true,         %% auto-true when grid_size > 100
+    zone_idle_timeout => 30000, %% reap idle zones after 30s
+    max_active_zones => 10000   %% cap concurrent zone processes
+}.
+```
+
+With `lazy_zones => true`:
+
+- Zones are created when a player joins or moves into them
+- Interest zones (adjacent to the player) only subscribe if already loaded
+- Idle zones are snapshotted to the database and terminated after `zone_idle_timeout`
+- The `max_active_zones` cap prevents runaway memory usage
+
+For small worlds (`grid_size =< 100`), all zones are pre-warmed at startup
+regardless of the `lazy_zones` setting.
+
+## Zone Lifecycle
+
+Each zone follows this lifecycle:
+
+```
+[not loaded] --ensure_zone--> [active] --no subscribers--> [idle]
+     ^                                                        |
+     |                    idle_timeout expires                 |
+     +---<---snapshot + terminate---<---reap---<--------------+
+```
+
+Active zones call `touch_zone` each tick when they have subscribers,
+resetting the idle timer. When subscribers drop to zero and the zone has
+no tickable entities, it enters Erlang hibernation to reduce memory.
+
+## Terrain Data
+
+Terrain is separate from entities. Tile chunks are served as compressed
+binary blobs when a player subscribes to a zone -- not through the
+tick/delta loop.
+
+### Terrain Provider Behaviour
+
+Implement `asobi_terrain_provider` to supply terrain data:
+
+```erlang
+-module(my_terrain).
+-behaviour(asobi_terrain_provider).
+-export([init/1, load_chunk/2, generate_chunk/3]).
+
+init(Config) ->
+    {ok, Config}.
+
+load_chunk({X, Y}, State) ->
+    %% Load from file, database, etc.
+    {error, not_found}.  %% Falls back to generate_chunk/3
+
+generate_chunk({X, Y}, Seed, State) ->
+    %% Procedural generation
+    Tiles = generate_tiles(X, Y, Seed),
+    Bin = asobi_terrain:compress_chunk(
+        asobi_terrain:encode_chunk(Tiles)
+    ),
+    {ok, Bin, State}.
+```
+
+### Connecting to the World
+
+Add `terrain_provider/1` to your world game module:
+
+```erlang
+-module(my_world).
+-behaviour(asobi_world).
+
+terrain_provider(Config) ->
+    {my_terrain, #{seed => maps:get(seed, Config, 42)}}.
+```
+
+When a player subscribes to a zone, they receive a `world.terrain` message
+with the compressed chunk data (base64-encoded in JSON).
+
+### Terrain Encoding
+
+`asobi_terrain` encodes tiles as compact binaries:
+
+- Default format: 4 bytes per tile (2B tile_id, 1B flags, 1B elevation)
+- 64x64 chunk = 16KB raw, typically 2-4KB compressed
+- Custom formats via the `format` parameter
+
+```erlang
+Tiles = [{0, 0, 1, 0, 10}, {3, 5, 200, 15, 255}],
+Bin = asobi_terrain:encode_chunk(Tiles),
+Compressed = asobi_terrain:compress_chunk(Bin),
+%% Compressed is typically 75-85% smaller
+```
+
+### Terrain Store
+
+The terrain store is an ETS-backed cache that lazy-loads chunks from the
+provider. It is started automatically when the game module returns a
+terrain provider. Chunks are cached after first load.
+
+## Configuration Reference
+
+| Key | Default | Description |
+|-----|---------|-------------|
+| `lazy_zones` | `grid_size > 100` | Enable on-demand zone loading |
+| `zone_idle_timeout` | `30000` | Milliseconds before idle zones are reaped |
+| `max_active_zones` | `10000` | Maximum concurrent zone processes |
+| `grid_size` | `10` | Zones per dimension |
+| `zone_size` | `200` | World units per zone |
+
+## New Behaviour Callbacks
+
+These optional callbacks are available on `asobi_world`:
+
+```erlang
+-callback terrain_provider(Config :: map()) ->
+    {Module :: module(), ProviderArgs :: map()} | none.
+
+-callback on_zone_loaded(Coords :: {integer(), integer()}, GameState :: term()) ->
+    {ok, ZoneState :: map(), GameState1 :: term()}.
+
+-callback on_zone_unloaded(Coords :: {integer(), integer()}, GameState :: term()) ->
+    {ok, GameState1 :: term()}.
+```
+
+## Scaling Guidelines
+
+| Map Size | Zones | Recommended Config |
+|----------|-------|--------------------|
+| Small (1K x 1K) | 100 | Default (eager loading) |
+| Medium (10K x 10K) | 10,000 | `lazy_zones => true` |
+| Large (128K x 128K) | 4,000,000 | Lazy + terrain provider + tuned idle timeout |
+
+For large worlds, expect 200-500 concurrent zone processes per node with
+typical player clustering. The BEAM handles this efficiently -- the
+bottleneck is serialisation and network I/O, not process count.

--- a/guides/lua-bots.md
+++ b/guides/lua-bots.md
@@ -1,0 +1,73 @@
+# Bots
+
+Asobi supports AI-controlled bot players that participate in matches and worlds
+alongside real players. Bots are configured per game mode and scripted in Lua
+via the [`asobi_lua`](https://hexdocs.pm/asobi_lua) package.
+
+## Configuration
+
+Enable bots in your game mode configuration:
+
+```erlang
+{game_modes, #{
+    ~"deathmatch" => #{
+        game_module => my_game,
+        bots => #{
+            enabled => true,
+            count => 4,
+            script => ~"bots/patrol.lua",
+            fill => true
+        }
+    }
+}}
+```
+
+| Option | Default | Description |
+|--------|---------|-------------|
+| `enabled` | `false` | Enable bot spawning |
+| `count` | `0` | Number of bots to spawn |
+| `script` | `undefined` | Path to bot Lua script |
+| `fill` | `false` | Auto-fill empty slots with bots |
+
+## Lua Bot Scripts
+
+Bot scripts implement a `bot_tick` callback that runs each tick:
+
+```lua
+function bot_tick(bot_id, state, entities)
+    -- Find nearest player
+    local target = nil
+    local min_dist = math.huge
+
+    for id, entity in pairs(entities) do
+        if entity.type == "player" and id ~= bot_id then
+            local dx = entity.x - state.x
+            local dy = entity.y - state.y
+            local dist = math.sqrt(dx * dx + dy * dy)
+            if dist < min_dist then
+                min_dist = dist
+                target = entity
+            end
+        end
+    end
+
+    -- Move towards target
+    if target then
+        local dx = target.x - state.x
+        local dy = target.y - state.y
+        local len = math.sqrt(dx * dx + dy * dy)
+        return {
+            action = "move",
+            x = state.x + (dx / len) * 2.0,
+            y = state.y + (dy / len) * 2.0
+        }
+    end
+
+    return nil
+end
+```
+
+## Further Reading
+
+See the full [`asobi_lua` documentation](https://hexdocs.pm/asobi_lua) for advanced
+bot patterns including state machines, group coordination, and difficulty scaling.

--- a/guides/lua-scripting.md
+++ b/guides/lua-scripting.md
@@ -1,0 +1,96 @@
+# Lua Scripting
+
+Lua scripting support is provided by the [`asobi_lua`](https://hexdocs.pm/asobi_lua) package,
+a standalone runtime that wraps the asobi library with [Luerl](https://github.com/rvirding/luerl)
+for writing game logic in Lua.
+
+## Quick Start
+
+The fastest way to get started is with the Docker image:
+
+```bash
+docker run -v ./game:/game -p 8080:8080 ghcr.io/widgrensit/asobi_lua
+```
+
+Place your Lua scripts in the `game/` directory and the runtime picks them up automatically.
+
+## Game Callbacks
+
+Your Lua scripts implement callbacks that asobi invokes at the right time:
+
+### Match Mode
+
+```lua
+function init(config)
+    return { score = {} }
+end
+
+function join(player_id, state)
+    state.score[player_id] = 0
+    return state
+end
+
+function tick(tick_n, state, players)
+    return state
+end
+
+function handle_input(player_id, input, state)
+    return state
+end
+```
+
+### World Mode
+
+```lua
+function init(config)
+    return {}
+end
+
+function join(player_id, state)
+    return state
+end
+
+function spawn_position(player_id, state)
+    return { x = 100.0, y = 100.0 }
+end
+
+function zone_tick(entities, zone_state)
+    return entities, zone_state
+end
+
+function handle_input(player_id, input, entities)
+    return entities
+end
+
+function post_tick(tick, state)
+    return state
+end
+```
+
+## Lua API
+
+The `game.*` namespace provides access to engine features from Lua:
+
+| Function | Description |
+|----------|-------------|
+| `game.id()` | Generate a unique ID |
+| `game.broadcast(event, data)` | Broadcast to all players |
+| `game.send(player_id, event, data)` | Send to a specific player |
+| `game.economy.grant(player, currency, amount, reason)` | Grant currency |
+| `game.economy.debit(player, currency, amount, reason)` | Debit currency |
+| `game.economy.balance(player, currency)` | Check balance |
+| `game.economy.purchase(player, listing_id)` | Purchase store item |
+| `game.leaderboard.submit(board, player, score)` | Submit score |
+| `game.leaderboard.top(board, limit)` | Get top scores |
+| `game.storage.get(collection, key)` | Read storage value |
+| `game.storage.set(collection, key, value)` | Write storage value |
+| `game.chat.send(channel, player, content)` | Send chat message |
+
+## Further Reading
+
+See the full [`asobi_lua` documentation](https://hexdocs.pm/asobi_lua) for:
+
+- Configuration options
+- Bot scripting
+- Advanced patterns
+- Docker deployment

--- a/guides/performance-tuning.md
+++ b/guides/performance-tuning.md
@@ -1,0 +1,106 @@
+# Performance Tuning
+
+Optimisation features for high-throughput world servers. These are all
+opt-in and backward compatible -- existing configurations work unchanged.
+
+## Spatial Grid Index
+
+By default, spatial queries (`query_radius`, `query_rect`) scan all
+entities in a zone via `maps:fold` -- O(n). For zones with many entities,
+enable the cell-based spatial grid for O(1) cell lookup + local scan.
+
+```erlang
+Config = #{
+    game_module => my_world,
+    spatial_grid_cell_size => 16  %% units per cell
+}.
+```
+
+The grid is maintained automatically as entities are added, removed, or
+moved during ticks. Query through the zone API:
+
+```erlang
+Results = asobi_zone:query_radius(ZonePid, {100.0, 200.0}, 50.0).
+%% Returns [{EntityId, {X, Y}}, ...]
+```
+
+When no `spatial_grid_cell_size` is configured, the zone falls back to
+the brute-force scan (existing behaviour).
+
+### Cell Size Guidelines
+
+| Entity Density | Recommended Cell Size |
+|---------------|----------------------|
+| Sparse (< 50/zone) | Don't enable (overhead not worth it) |
+| Medium (50-200/zone) | 32-64 units |
+| Dense (200+/zone) | 8-16 units |
+
+## Broadcast Batching
+
+Zone deltas are JSON-encoded once and the pre-encoded binary is sent to
+all subscribers. This replaces N `json:encode` calls with exactly 1.
+
+This is automatic -- no configuration needed. Subscribers receive
+`zone_delta_raw` messages containing pre-encoded JSON, which the
+WebSocket handler forwards directly without re-encoding.
+
+## Adaptive Tick Rates
+
+Zones with no subscribers tick at a reduced rate to save CPU:
+
+```erlang
+Config = #{
+    cold_tick_divisor => 10  %% cold zones tick 10x less often (default)
+}.
+```
+
+| Zone State | Tick Rate | When |
+|-----------|-----------|------|
+| Hot | Full (every tick) | Has subscribers |
+| Cold | 1/N (every Nth tick) | Entities but no subscribers |
+| Empty | Not ticked | No entities, no subscribers |
+
+The ticker provides manual controls:
+
+```erlang
+asobi_world_ticker:promote_zone(TickerPid, ZonePid).  %% → hot
+asobi_world_ticker:demote_zone(TickerPid, ZonePid).   %% → cold
+asobi_world_ticker:remove_zone(TickerPid, ZonePid).   %% → stop ticking
+```
+
+Zone promotion/demotion is typically handled automatically by the zone
+manager based on subscriber presence.
+
+## Binary Protocol
+
+For maximum throughput, clients can negotiate binary WebSocket frames
+instead of JSON. Set `binary_protocol: true` in the `session.connect`
+payload.
+
+Binary frames use a Tag-Length-Value format:
+
+```
+[type:u8][length:u32be][payload:bytes]
+```
+
+### Message Types
+
+| Tag | Type | Payload |
+|-----|------|---------|
+| 0x01 | Terrain chunk | coords (2x i32) + compressed data |
+| 0x02 | Entity deltas | tick (u64) + counted delta list |
+| 0x03 | Match state | Reserved |
+
+### Size Savings
+
+Terrain chunks save ~25% vs JSON+base64 encoding. Entity deltas save
+varies based on field count but typically 15-30%.
+
+Use `asobi_ws_binary` for encoding/decoding:
+
+```erlang
+Bin = asobi_ws_binary:encode_terrain_chunk({5, 10}, CompressedData).
+{{5, 10}, Data} = asobi_ws_binary:decode_terrain_chunk(Bin).
+```
+
+JSON remains the default protocol. Binary is opt-in per connection.

--- a/guides/world-server.md
+++ b/guides/world-server.md
@@ -9,6 +9,9 @@ Use the world server when your game has players moving through a shared
 space (co-op dungeons, open worlds, large-scale survival). For arena-style
 games with smaller player counts, use the standard [match server](matchmaking.md).
 
+For massive tile-based worlds (10K+ zones), see [Large Worlds](large-worlds.md)
+for lazy zone loading, terrain data, and scaling configuration.
+
 ## How It Works
 
 A world is divided into a grid of **zones** -- each zone is a separate

--- a/rebar.config
+++ b/rebar.config
@@ -84,6 +84,8 @@
     {extras, [
         <<"README.md">>,
         <<"guides/getting-started.md">>,
+        <<"guides/lua-scripting.md">>,
+        <<"guides/lua-bots.md">>,
         <<"guides/configuration.md">>,
         <<"guides/rest-api.md">>,
         <<"guides/websocket-protocol.md">>,
@@ -100,6 +102,8 @@
     {groups_for_extras, [
         {<<"Getting Started">>, [
             <<"guides/getting-started.md">>,
+            <<"guides/lua-scripting.md">>,
+            <<"guides/lua-bots.md">>,
             <<"guides/comparison.md">>
         ]},
         {<<"Guides">>, [

--- a/rebar.config
+++ b/rebar.config
@@ -97,7 +97,9 @@
         <<"guides/authentication.md">>,
         <<"guides/iap.md">>,
         <<"guides/voting.md">>,
-        <<"guides/world-server.md">>
+        <<"guides/world-server.md">>,
+        <<"guides/large-worlds.md">>,
+        <<"guides/performance-tuning.md">>
     ]},
     {groups_for_extras, [
         {<<"Getting Started">>, [
@@ -116,7 +118,9 @@
             <<"guides/authentication.md">>,
             <<"guides/iap.md">>,
             <<"guides/voting.md">>,
-            <<"guides/world-server.md">>
+            <<"guides/world-server.md">>,
+            <<"guides/large-worlds.md">>,
+            <<"guides/performance-tuning.md">>
         ]},
         {<<"Reference">>, [
             <<"docs/ARCHITECTURE.md">>

--- a/src/world/asobi_spatial_grid.erl
+++ b/src/world/asobi_spatial_grid.erl
@@ -1,0 +1,179 @@
+-module(asobi_spatial_grid).
+
+%% Cell-based spatial index for fast entity queries within zones.
+%% Pure functional — no process, no state.
+
+-export([new/1]).
+-export([insert/3, update/3, remove/2]).
+-export([query_radius/3, query_rect/3]).
+-export([entities_in_cell/2, size/1]).
+
+-export_type([grid/0, cell_coords/0]).
+
+-type cell_coords() :: {integer(), integer()}.
+-type pos() :: {number(), number()}.
+-type grid() :: #{
+    cell_size := number(),
+    cells := #{cell_coords() => #{binary() => pos()}},
+    entity_cells := #{binary() => cell_coords()}
+}.
+
+%% -------------------------------------------------------------------
+%% Construction
+%% -------------------------------------------------------------------
+
+-spec new(number()) -> grid().
+new(CellSize) when CellSize > 0 ->
+    #{
+        cell_size => CellSize,
+        cells => #{},
+        entity_cells => #{}
+    }.
+
+%% -------------------------------------------------------------------
+%% Mutations
+%% -------------------------------------------------------------------
+
+-spec insert(binary(), pos(), grid()) -> grid().
+insert(EntityId, {X, Y} = Pos, #{cell_size := CS, cells := Cells, entity_cells := EC} = Grid) ->
+    Cell = pos_to_cell(X, Y, CS),
+    CellEntities = maps:get(Cell, Cells, #{}),
+    Grid#{
+        cells := Cells#{Cell => CellEntities#{EntityId => Pos}},
+        entity_cells := EC#{EntityId => Cell}
+    }.
+
+-spec update(binary(), pos(), grid()) -> grid().
+update(EntityId, {X, Y} = Pos, #{cell_size := CS, cells := Cells, entity_cells := EC} = Grid) ->
+    NewCell = pos_to_cell(X, Y, CS),
+    case maps:find(EntityId, EC) of
+        {ok, NewCell} ->
+            CellEntities = maps:get(NewCell, Cells, #{}),
+            Grid#{cells := Cells#{NewCell => CellEntities#{EntityId => Pos}}};
+        {ok, OldCell} ->
+            OldCellEntities = maps:remove(EntityId, maps:get(OldCell, Cells, #{})),
+            Cells1 =
+                case map_size(OldCellEntities) of
+                    0 -> maps:remove(OldCell, Cells);
+                    _ -> Cells#{OldCell => OldCellEntities}
+                end,
+            NewCellEntities = maps:get(NewCell, Cells1, #{}),
+            Grid#{
+                cells := Cells1#{NewCell => NewCellEntities#{EntityId => Pos}},
+                entity_cells := EC#{EntityId => NewCell}
+            };
+        error ->
+            insert(EntityId, Pos, Grid)
+    end.
+
+-spec remove(binary(), grid()) -> grid().
+remove(EntityId, #{cells := Cells, entity_cells := EC} = Grid) ->
+    case maps:find(EntityId, EC) of
+        {ok, Cell} ->
+            CellEntities = maps:remove(EntityId, maps:get(Cell, Cells, #{})),
+            Cells1 =
+                case map_size(CellEntities) of
+                    0 -> maps:remove(Cell, Cells);
+                    _ -> Cells#{Cell => CellEntities}
+                end,
+            Grid#{
+                cells := Cells1,
+                entity_cells := maps:remove(EntityId, EC)
+            };
+        error ->
+            Grid
+    end.
+
+%% -------------------------------------------------------------------
+%% Queries
+%% -------------------------------------------------------------------
+
+-spec query_radius(pos(), number(), grid()) -> [{binary(), pos()}].
+query_radius({CX, CY}, Radius, #{cell_size := CS, cells := Cells}) ->
+    R2 = Radius * Radius,
+    {MinCellX, MinCellY} = pos_to_cell(CX - Radius, CY - Radius, CS),
+    {MaxCellX, MaxCellY} = pos_to_cell(CX + Radius, CY + Radius, CS),
+    scan_cells(
+        MinCellX,
+        MinCellY,
+        MaxCellX,
+        MaxCellY,
+        Cells,
+        fun(_, {X, Y}) ->
+            DX = X - CX,
+            DY = Y - CY,
+            DX * DX + DY * DY =< R2
+        end
+    ).
+
+-spec query_rect(pos(), pos(), grid()) -> [{binary(), pos()}].
+query_rect({X1, Y1}, {X2, Y2}, #{cell_size := CS, cells := Cells}) ->
+    MinX = min(X1, X2),
+    MinY = min(Y1, Y2),
+    MaxX = max(X1, X2),
+    MaxY = max(Y1, Y2),
+    {MinCellX, MinCellY} = pos_to_cell(MinX, MinY, CS),
+    {MaxCellX, MaxCellY} = pos_to_cell(MaxX, MaxY, CS),
+    scan_cells(
+        MinCellX,
+        MinCellY,
+        MaxCellX,
+        MaxCellY,
+        Cells,
+        fun(_, {X, Y}) ->
+            X >= MinX andalso X =< MaxX andalso Y >= MinY andalso Y =< MaxY
+        end
+    ).
+
+-spec entities_in_cell(cell_coords(), grid()) -> [{binary(), pos()}].
+entities_in_cell(Cell, #{cells := Cells}) ->
+    maps:to_list(maps:get(Cell, Cells, #{})).
+
+-spec size(grid()) -> non_neg_integer().
+size(#{entity_cells := EC}) ->
+    map_size(EC).
+
+%% -------------------------------------------------------------------
+%% Internal
+%% -------------------------------------------------------------------
+
+-spec pos_to_cell(number(), number(), number()) -> cell_coords().
+pos_to_cell(X, Y, CS) ->
+    {floor(X / CS), floor(Y / CS)}.
+
+-spec scan_cells(
+    integer(),
+    integer(),
+    integer(),
+    integer(),
+    #{cell_coords() => #{binary() => pos()}},
+    fun((binary(), pos()) -> boolean())
+) -> [{binary(), pos()}].
+scan_cells(MinCX, MinCY, MaxCX, MaxCY, Cells, Filter) ->
+    lists:foldl(
+        fun(CellX, Acc1) ->
+            lists:foldl(
+                fun(CellY, Acc2) ->
+                    case maps:find({CellX, CellY}, Cells) of
+                        {ok, CellEntities} ->
+                            maps:fold(
+                                fun(Id, Pos, Acc3) ->
+                                    case Filter(Id, Pos) of
+                                        true -> [{Id, Pos} | Acc3];
+                                        false -> Acc3
+                                    end
+                                end,
+                                Acc2,
+                                CellEntities
+                            );
+                        error ->
+                            Acc2
+                    end
+                end,
+                Acc1,
+                lists:seq(MinCY, MaxCY)
+            )
+        end,
+        [],
+        lists:seq(MinCX, MaxCX)
+    ).

--- a/src/world/asobi_terrain.erl
+++ b/src/world/asobi_terrain.erl
@@ -1,0 +1,88 @@
+-module(asobi_terrain).
+
+%% Pure functional terrain chunk encoding/decoding.
+%%
+%% Encodes tile grids as compact binaries. Default format: 4 bytes per tile
+%% (2B tile_id, 1B flags, 1B elevation). A 64x64 chunk = 16KB raw.
+
+-export([encode_chunk/1, encode_chunk/2]).
+-export([decode_chunk/1, decode_chunk/2]).
+-export([compress_chunk/1, decompress_chunk/1]).
+-export([default_format/0, chunk_byte_size/1]).
+
+-export_type([tile/0, format/0]).
+
+-type tile() :: {
+    X :: non_neg_integer(),
+    Y :: non_neg_integer(),
+    TileId :: non_neg_integer(),
+    Flags :: non_neg_integer(),
+    Elevation :: non_neg_integer()
+}.
+-type format() :: #{
+    tile_size := pos_integer(),
+    chunk_width := pos_integer(),
+    chunk_height := pos_integer()
+}.
+
+%% --- Public API ---
+
+-spec default_format() -> format().
+default_format() ->
+    #{tile_size => 4, chunk_width => 64, chunk_height => 64}.
+
+-spec chunk_byte_size(format()) -> pos_integer().
+chunk_byte_size(#{tile_size := TS, chunk_width := W, chunk_height := H}) ->
+    W * H * TS.
+
+-spec encode_chunk([tile()]) -> binary().
+encode_chunk(Tiles) ->
+    encode_chunk(Tiles, default_format()).
+
+-spec encode_chunk([tile()] | #{}, format()) -> binary().
+encode_chunk(Tiles, Fmt) when is_list(Tiles) ->
+    Map = lists:foldl(
+        fun({X, Y, TileId, Flags, Elev}, Acc) ->
+            Acc#{{X, Y} => {TileId, Flags, Elev}}
+        end,
+        #{},
+        Tiles
+    ),
+    encode_chunk(Map, Fmt);
+encode_chunk(TileMap, #{chunk_width := W, chunk_height := H} = _Fmt) when is_map(TileMap) ->
+    iolist_to_binary([
+        encode_tile(maps:get({X, Y}, TileMap, {0, 0, 0}))
+     || Y <- lists:seq(0, H - 1), X <- lists:seq(0, W - 1)
+    ]).
+
+-spec decode_chunk(binary()) -> [tile()].
+decode_chunk(Bin) ->
+    decode_chunk(Bin, default_format()).
+
+-spec decode_chunk(binary(), format()) -> [tile()].
+decode_chunk(Bin, #{chunk_width := W} = _Fmt) ->
+    decode_tiles(Bin, 0, W, []).
+
+-spec compress_chunk(binary()) -> binary().
+compress_chunk(Bin) ->
+    zlib:compress(Bin).
+
+-spec decompress_chunk(binary()) -> binary().
+decompress_chunk(Bin) ->
+    zlib:uncompress(Bin).
+
+%% --- Internal ---
+
+encode_tile({TileId, Flags, Elev}) ->
+    <<TileId:16/big-unsigned, Flags:8/unsigned, Elev:8/unsigned>>.
+
+decode_tiles(<<>>, _Idx, _W, Acc) ->
+    lists:reverse(Acc);
+decode_tiles(<<0:16, _Flags:8, _Elev:8, Rest/binary>>, Idx, W, Acc) ->
+    decode_tiles(Rest, Idx + 1, W, Acc);
+decode_tiles(
+    <<TileId:16/big-unsigned, Flags:8/unsigned, Elev:8/unsigned, Rest/binary>>, Idx, W, Acc
+) ->
+    X = Idx rem W,
+    Y = Idx div W,
+    decode_tiles(Rest, Idx + 1, W, [{X, Y, TileId, Flags, Elev} | Acc]).

--- a/src/world/asobi_terrain_provider.erl
+++ b/src/world/asobi_terrain_provider.erl
@@ -1,0 +1,16 @@
+-module(asobi_terrain_provider).
+
+%% Behaviour for terrain data providers.
+%%
+%% Game developers implement this to supply terrain chunk data from
+%% files, databases, or procedural generation.
+
+-callback init(Config :: map()) -> {ok, State :: term()}.
+
+-callback load_chunk(Coords :: {integer(), integer()}, State :: term()) ->
+    {ok, CompressedBinary :: binary(), NewState :: term()} | {error, term()}.
+
+-callback generate_chunk(Coords :: {integer(), integer()}, Seed :: integer(), State :: term()) ->
+    {ok, CompressedBinary :: binary(), NewState :: term()}.
+
+-optional_callbacks([generate_chunk/3]).

--- a/src/world/asobi_terrain_store.erl
+++ b/src/world/asobi_terrain_store.erl
@@ -1,0 +1,149 @@
+-module(asobi_terrain_store).
+-behaviour(gen_server).
+
+%% ETS-backed terrain chunk cache with lazy loading from a provider.
+
+-export([start_link/1]).
+-export([get_chunk/2, preload_chunks/2, evict_chunk/2, stats/1]).
+-export([init/1, handle_call/3, handle_cast/2, handle_info/2, terminate/2]).
+
+%% --- Public API ---
+
+-spec start_link(map()) -> gen_server:start_ret().
+start_link(Opts) ->
+    gen_server:start_link(?MODULE, Opts, []).
+
+-spec get_chunk(pid(), {integer(), integer()}) ->
+    {ok, binary()} | {error, term()}.
+get_chunk(Pid, Coords) ->
+    Tab = gen_server:call(Pid, get_ets_tab),
+    case ets:lookup(Tab, Coords) of
+        [{Coords, Data}] ->
+            {ok, Data};
+        [] ->
+            gen_server:call(Pid, {load_chunk, Coords})
+    end.
+
+-spec preload_chunks(pid(), [{integer(), integer()}]) -> ok.
+preload_chunks(Pid, CoordsList) ->
+    gen_server:cast(Pid, {preload, CoordsList}).
+
+-spec evict_chunk(pid(), {integer(), integer()}) -> ok.
+evict_chunk(Pid, Coords) ->
+    gen_server:cast(Pid, {evict, Coords}).
+
+-spec stats(pid()) -> map().
+stats(Pid) ->
+    gen_server:call(Pid, stats).
+
+%% --- gen_server callbacks ---
+
+-spec init(map()) -> {ok, map()}.
+init(Opts) ->
+    {ProvMod, ProvArgs} = maps:get(provider, Opts),
+    {ok, ProvState} = ProvMod:init(ProvArgs),
+    Tab = ets:new(asobi_terrain_cache, [set, public, {read_concurrency, true}]),
+    {ok, #{
+        ets_tab => Tab,
+        provider_mod => ProvMod,
+        provider_state => ProvState,
+        seed => maps:get(seed, Opts, 0),
+        hits => 0,
+        misses => 0
+    }}.
+
+-spec handle_call(term(), gen_server:from(), map()) -> {reply, term(), map()}.
+handle_call(get_ets_tab, _From, #{ets_tab := Tab} = State) ->
+    {reply, Tab, State};
+handle_call({load_chunk, Coords}, _From, #{ets_tab := Tab} = State) ->
+    case ets:lookup(Tab, Coords) of
+        [{Coords, Data}] ->
+            {reply, {ok, Data}, inc_hits(State)};
+        [] ->
+            case load_from_provider(Coords, State) of
+                {ok, Data, State1} ->
+                    ets:insert(Tab, {Coords, Data}),
+                    {reply, {ok, Data}, inc_misses(State1)};
+                {error, Reason, State1} ->
+                    {reply, {error, Reason}, State1}
+            end
+    end;
+handle_call(stats, _From, #{ets_tab := Tab, hits := H, misses := M} = State) ->
+    {reply,
+        #{
+            cached_chunks => ets:info(Tab, size),
+            memory_bytes => ets:info(Tab, memory) * erlang:system_info(wordsize),
+            hits => H,
+            misses => M
+        },
+        State};
+handle_call(_Request, _From, State) ->
+    {reply, {error, unknown_request}, State}.
+
+-spec handle_cast(term(), map()) -> {noreply, map()}.
+handle_cast({preload, CoordsList}, #{ets_tab := Tab} = State) ->
+    State1 = lists:foldl(
+        fun(Coords, SAcc) ->
+            case ets:lookup(Tab, Coords) of
+                [{_, _}] ->
+                    SAcc;
+                [] ->
+                    case load_from_provider(Coords, SAcc) of
+                        {ok, Data, SAcc1} ->
+                            ets:insert(Tab, {Coords, Data}),
+                            SAcc1;
+                        {error, _, SAcc1} ->
+                            SAcc1
+                    end
+            end
+        end,
+        State,
+        CoordsList
+    ),
+    {noreply, State1};
+handle_cast({evict, Coords}, #{ets_tab := Tab} = State) ->
+    ets:delete(Tab, Coords),
+    {noreply, State};
+handle_cast(_Msg, State) ->
+    {noreply, State}.
+
+-spec handle_info(term(), map()) -> {noreply, map()}.
+handle_info(_Info, State) ->
+    {noreply, State}.
+
+-spec terminate(term(), map()) -> ok.
+terminate(_Reason, #{ets_tab := Tab}) ->
+    ets:delete(Tab),
+    ok.
+
+%% --- Internal ---
+
+load_from_provider(Coords, #{provider_mod := Mod, provider_state := PS} = State) ->
+    case Mod:load_chunk(Coords, PS) of
+        {ok, Data, PS1} ->
+            {ok, Data, State#{provider_state => PS1}};
+        {error, not_found, PS1} ->
+            generate_fallback(Coords, State#{provider_state => PS1});
+        {error, not_found} ->
+            generate_fallback(Coords, State);
+        {error, Reason, PS1} ->
+            {error, Reason, State#{provider_state => PS1}};
+        {error, Reason} ->
+            {error, Reason, State}
+    end.
+
+generate_fallback(Coords, #{provider_mod := Mod, provider_state := PS, seed := Seed} = State) ->
+    case erlang:function_exported(Mod, generate_chunk, 3) of
+        true ->
+            case Mod:generate_chunk(Coords, Seed, PS) of
+                {ok, Data, PS1} ->
+                    {ok, Data, State#{provider_state => PS1}};
+                {error, Reason} ->
+                    {error, Reason, State}
+            end;
+        false ->
+            {error, not_found, State}
+    end.
+
+inc_hits(#{hits := H} = State) -> State#{hits => H + 1}.
+inc_misses(#{misses := M} = State) -> State#{misses => M + 1}.

--- a/src/world/asobi_world.erl
+++ b/src/world/asobi_world.erl
@@ -48,6 +48,15 @@
 -callback spawn_templates(Config :: map()) ->
     #{binary() => asobi_zone_spawner:spawn_template()}.
 
+-callback terrain_provider(Config :: map()) ->
+    {Module :: module(), ProviderArgs :: map()} | none.
+
+-callback on_zone_loaded(Coords :: {integer(), integer()}, GameState :: term()) ->
+    {ok, ZoneState :: map(), GameState1 :: term()}.
+
+-callback on_zone_unloaded(Coords :: {integer(), integer()}, GameState :: term()) ->
+    {ok, GameState1 :: term()}.
+
 -optional_callbacks([
     generate_world/2,
     get_state/2,
@@ -55,5 +64,8 @@
     on_phase_started/2,
     on_phase_ended/2,
     on_world_recovered/2,
-    spawn_templates/1
+    spawn_templates/1,
+    terrain_provider/1,
+    on_zone_loaded/2,
+    on_zone_unloaded/2
 ]).

--- a/src/world/asobi_world_instance.erl
+++ b/src/world/asobi_world_instance.erl
@@ -34,6 +34,17 @@ init(Config) ->
         intensity => 5,
         period => 60
     },
+    GridSize = maps:get(grid_size, Config, 10),
+    ZoneSize = maps:get(zone_size, Config, 200),
+    ZoneManagerConfig = #{
+        world_id => maps:get(world_id, Config, undefined),
+        instance_sup => self(),
+        grid_size => GridSize,
+        zone_size => ZoneSize,
+        zone_config => maps:get(zone_manager_config, Config, #{}),
+        idle_timeout => maps:get(zone_idle_timeout, Config, 30_000),
+        max_active_zones => maps:get(max_active_zones, Config, 10_000)
+    },
     TickerConfig = #{
         tick_rate => maps:get(tick_rate, Config, 50),
         world_pid => self()
@@ -46,6 +57,11 @@ init(Config) ->
             id => asobi_zone_sup,
             start => {asobi_zone_sup, start_link, []},
             type => supervisor
+        },
+        #{
+            id => asobi_zone_manager,
+            start => {asobi_zone_manager, start_link, [ZoneManagerConfig]},
+            restart => transient
         },
         #{
             id => asobi_world_ticker,

--- a/src/world/asobi_world_server.erl
+++ b/src/world/asobi_world_server.erl
@@ -123,9 +123,10 @@ init(Config) ->
         view_radius => ViewRadius,
         players => #{},
         player_zones => #{},
-        zone_pids => #{},
         instance_sup => InstanceSup,
         zone_sup_pid => undefined,
+        zone_manager_pid => undefined,
+        terrain_store_pid => undefined,
         ticker_pid => undefined,
         started_at => undefined,
         vote_frustration => #{},
@@ -148,10 +149,20 @@ loading(enter, _OldState, _State) ->
     %% Defer zone spawning — supervisor:which_children deadlocks if called during init
     erlang:send(self(), resolve_and_spawn),
     keep_state_and_data;
-loading(info, resolve_and_spawn, #{instance_sup := InstanceSup} = State) ->
-    {ZoneSupPid, TickerPid} = resolve_siblings(#{instance_sup => InstanceSup}),
-    State1 = State#{zone_sup_pid => ZoneSupPid, ticker_pid => TickerPid},
-    State2 = spawn_zones(State1),
+loading(info, resolve_and_spawn, #{instance_sup := InstanceSup, grid_size := GridSize} = State) ->
+    {ZoneSupPid, TickerPid, ZoneManagerPid} = resolve_siblings(#{instance_sup => InstanceSup}),
+    LazyZones = maps:get(lazy_zones, maps:get(config, State, #{}), GridSize > 100),
+    State1 = State#{
+        zone_sup_pid => ZoneSupPid,
+        ticker_pid => TickerPid,
+        zone_manager_pid => ZoneManagerPid
+    },
+    State1a = configure_zone_manager(State1),
+    State2 =
+        case LazyZones of
+            false -> spawn_zones(State1a);
+            true -> State1a
+        end,
     {keep_state, State2, [{state_timeout, 0, zones_ready}]};
 loading(state_timeout, zones_ready, State) ->
     {next_state, running, State#{started_at => erlang:system_time(millisecond)}};
@@ -169,12 +180,11 @@ running(
     _OldState,
     #{
         ticker_pid := TickerPid,
-        zone_pids := ZonePids,
+        zone_manager_pid := ZoneManagerPid,
         world_id := WorldId
     } = State
 ) ->
-    Zones = maps:values(ZonePids),
-    asobi_world_ticker:set_zones(TickerPid, Zones, self()),
+    asobi_world_ticker:set_zone_manager(TickerPid, ZoneManagerPid, self()),
     asobi_telemetry:world_started(WorldId, maps:get(mode, State, undefined)),
     keep_state_and_data;
 running({call, From}, {join, PlayerId}, State) ->
@@ -226,14 +236,14 @@ running({call, From}, {use_veto, PlayerId, VoteId}, State) ->
 running(
     cast,
     {spawn_at, TemplateId, {_X, _Y} = Pos, Overrides},
-    #{zone_pids := ZP, zone_size := ZS} = _State
+    #{zone_manager_pid := ZMPid, zone_size := ZS} = _State
 ) ->
     Coords = pos_to_zone(Pos, ZS),
-    case maps:get(Coords, ZP, undefined) of
-        undefined ->
-            keep_state_and_data;
-        ZonePid ->
+    case asobi_zone_manager:ensure_zone(ZMPid, Coords) of
+        {ok, ZonePid} ->
             asobi_zone:spawn_entity(ZonePid, TemplateId, Pos, Overrides),
+            keep_state_and_data;
+        {error, _} ->
             keep_state_and_data
     end;
 running(cast, cancel, State) ->
@@ -268,9 +278,7 @@ running({call, From}, {reconnect, PlayerId}, State) ->
     #{
         reconnect_state := RS,
         player_zones := PZ,
-        zone_pids := ZP,
-        view_radius := _ViewRadius,
-        grid_size := _GridSize
+        zone_manager_pid := ZMPid
     } = State,
     case {RS, maps:get(PlayerId, PZ, undefined)} of
         {undefined, _} ->
@@ -284,15 +292,19 @@ running({call, From}, {reconnect, PlayerId}, State) ->
             %% Re-subscribe to all interest zones
             lists:foreach(
                 fun(Coords) ->
-                    case maps:get(Coords, ZP, undefined) of
-                        undefined -> ok;
-                        ZPid -> asobi_zone:subscribe(ZPid, {PlayerId, PlayerPid})
+                    case asobi_zone_manager:get_zone(ZMPid, Coords) of
+                        {ok, ZPid} -> asobi_zone:subscribe(ZPid, {PlayerId, PlayerPid});
+                        not_loaded -> ok
                     end
                 end,
                 InterestZones
             ),
             %% Notify session of world/zone
-            ZonePid = maps:get(ZoneCoords, ZP, undefined),
+            ZonePid =
+                case asobi_zone_manager:get_zone(ZMPid, ZoneCoords) of
+                    {ok, ZP} -> ZP;
+                    not_loaded -> undefined
+                end,
             asobi_presence:send(PlayerId, {world_joined, self(), ZonePid}),
             %% Update player entry with new session
             Players = maps:get(players, State),
@@ -338,22 +350,61 @@ terminate(_Reason, _StateName, #{world_id := WorldId}) ->
 
 %% --- Internal: Zone Management ---
 
+configure_zone_manager(
+    #{
+        zone_manager_pid := ZoneManagerPid,
+        ticker_pid := TickerPid,
+        world_id := WorldId,
+        game_module := GameMod,
+        config := Config
+    } = State
+) ->
+    Templates = get_spawn_templates(GameMod, Config),
+    Persistence = maps:get(persistence, Config, false),
+    TerrainStorePid = start_terrain_store(GameMod, Config),
+    BaseZoneConfig = #{
+        world_id => WorldId,
+        ticker_pid => TickerPid,
+        game_module => GameMod,
+        spawn_templates => Templates,
+        persistence => Persistence,
+        snapshot_interval => maps:get(snapshot_interval, Config, 600),
+        zone_manager_pid => ZoneManagerPid,
+        terrain_store_pid => TerrainStorePid
+    },
+    asobi_zone_manager:set_zone_config(ZoneManagerPid, BaseZoneConfig),
+    State#{terrain_store_pid => TerrainStorePid}.
+
+start_terrain_store(GameMod, Config) ->
+    case erlang:function_exported(GameMod, terrain_provider, 1) of
+        true ->
+            case GameMod:terrain_provider(Config) of
+                none ->
+                    undefined;
+                {ProvMod, ProvArgs} ->
+                    {ok, Pid} = asobi_terrain_store:start_link(#{
+                        provider => {ProvMod, ProvArgs},
+                        seed => maps:get(seed, Config, 0)
+                    }),
+                    Pid
+            end;
+        false ->
+            undefined
+    end.
+
 spawn_zones(
     #{
         grid_size := GridSize,
         game_module := GameMod,
         config := Config,
-        zone_sup_pid := ZoneSupPid,
-        ticker_pid := TickerPid,
+        zone_manager_pid := ZoneManagerPid,
         world_id := WorldId,
         game_state := GS
     } = State
 ) ->
     Persistence = maps:get(persistence, Config, false),
-    Templates = get_spawn_templates(GameMod, Config),
     AllCoords = [{X, Y} || X <- lists:seq(0, GridSize - 1), Y <- lists:seq(0, GridSize - 1)],
-    %% Check for existing snapshots when persistence is enabled
-    {ZoneStates, Entities, SpawnerStates, GS1} =
+    {_ZoneStates, Entities, _SpawnerStates, GS1} =
         case Persistence of
             true ->
                 case asobi_zone_snapshotter:load_snapshots(WorldId) of
@@ -376,38 +427,26 @@ spawn_zones(
             false ->
                 {generate_zone_states(GameMod, Config), #{}, #{}, GS}
         end,
-    ZonePids = lists:foldl(
-        fun(Coords, Acc) ->
-            ZoneState = maps:get(Coords, ZoneStates, #{}),
+    %% Pre-warm all zones via zone_manager (uses base config with terrain_store_pid etc.)
+    ok = asobi_zone_manager:pre_warm(ZoneManagerPid),
+    %% Add recovered entities to zones
+    lists:foreach(
+        fun(Coords) ->
             RecoveredEnts = maps:get(Coords, Entities, #{}),
-            SpawnerS = maps:get(Coords, SpawnerStates, undefined),
-            ZoneConfig0 = #{
-                world_id => WorldId,
-                coords => Coords,
-                ticker_pid => TickerPid,
-                game_module => GameMod,
-                zone_state => ZoneState,
-                spawn_templates => Templates,
-                persistence => Persistence,
-                snapshot_interval => maps:get(snapshot_interval, Config, 600)
-            },
-            ZoneConfig =
-                case SpawnerS of
-                    undefined -> ZoneConfig0;
-                    _ -> ZoneConfig0#{spawner_state => SpawnerS}
-                end,
-            {ok, Pid} = asobi_zone_sup:start_zone(ZoneSupPid, ZoneConfig),
-            %% Add recovered entities to zone
-            maps:foreach(
-                fun(EId, EState) -> asobi_zone:add_entity(Pid, EId, EState) end,
-                RecoveredEnts
-            ),
-            Acc#{Coords => Pid}
+            case map_size(RecoveredEnts) of
+                0 ->
+                    ok;
+                _ ->
+                    {ok, ZonePid} = asobi_zone_manager:ensure_zone(ZoneManagerPid, Coords),
+                    maps:foreach(
+                        fun(EId, EState) -> asobi_zone:add_entity(ZonePid, EId, EState) end,
+                        RecoveredEnts
+                    )
+            end
         end,
-        #{},
         AllCoords
     ),
-    State#{zone_pids => ZonePids, game_state => GS1}.
+    State#{game_state => GS1}.
 
 generate_zone_states(GameMod, Config) ->
     Seed = maps:get(seed, Config, erlang:system_time(millisecond)),
@@ -512,23 +551,23 @@ place_player(
     PlayerId,
     {X, Y} = _Pos,
     #{
-        zone_pids := ZonePids,
+        zone_manager_pid := ZMPid,
         view_radius := ViewRadius,
         zone_size := ZoneSize,
         grid_size := GridSize
     } = State
 ) ->
     ZoneCoords = pos_to_zone({X, Y}, ZoneSize),
-    ZonePid = maps:get(ZoneCoords, ZonePids),
+    {ok, ZonePid} = asobi_zone_manager:ensure_zone(ZMPid, ZoneCoords),
     PlayerPid = find_player_pid(PlayerId),
     asobi_zone:add_entity(ZonePid, PlayerId, #{x => X, y => Y, type => ~"player"}),
     asobi_presence:send(PlayerId, {world_joined, self(), ZonePid}),
     InterestZones = interest_zones(ZoneCoords, ViewRadius, GridSize),
     lists:foreach(
         fun(Coords) ->
-            case maps:get(Coords, ZonePids, undefined) of
-                undefined -> ok;
-                ZPid -> asobi_zone:subscribe(ZPid, {PlayerId, PlayerPid})
+            case asobi_zone_manager:get_zone(ZMPid, Coords) of
+                {ok, ZPid} -> asobi_zone:subscribe(ZPid, {PlayerId, PlayerPid});
+                not_loaded -> ok
             end
         end,
         InterestZones
@@ -542,24 +581,28 @@ remove_player_from_zones(
     PlayerId,
     #{
         player_zones := PlayerZones,
-        zone_pids := ZonePids
+        zone_manager_pid := ZMPid
     } = State
 ) ->
     case maps:get(PlayerId, PlayerZones, undefined) of
         undefined ->
             State;
         #{zone := ZoneCoords, interest := InterestZones} ->
-            ZonePid = maps:get(ZoneCoords, ZonePids),
-            asobi_zone:remove_entity(ZonePid, PlayerId),
+            case asobi_zone_manager:get_zone(ZMPid, ZoneCoords) of
+                {ok, ZonePid} -> asobi_zone:remove_entity(ZonePid, PlayerId);
+                not_loaded -> ok
+            end,
             lists:foreach(
                 fun(Coords) ->
-                    case maps:get(Coords, ZonePids, undefined) of
-                        undefined -> ok;
-                        ZPid -> asobi_zone:unsubscribe(ZPid, PlayerId)
+                    case asobi_zone_manager:get_zone(ZMPid, Coords) of
+                        {ok, ZPid} -> asobi_zone:unsubscribe(ZPid, PlayerId);
+                        not_loaded -> ok
                     end
                 end,
                 InterestZones
             ),
+            %% Release primary zone if no other players need it
+            asobi_zone_manager:release_zone(ZMPid, ZoneCoords),
             State#{player_zones => maps:remove(PlayerId, PlayerZones)}
     end.
 
@@ -569,7 +612,7 @@ handle_move(
     #{
         players := Players,
         player_zones := PlayerZones,
-        zone_pids := ZonePids,
+        zone_manager_pid := ZMPid,
         zone_size := ZoneSize,
         view_radius := ViewRadius,
         grid_size := GridSize,
@@ -583,9 +626,14 @@ handle_move(
             NewZoneCoords = pos_to_zone(NewPos, ZoneSize),
             case OldZoneCoords =:= NewZoneCoords of
                 true ->
-                    %% Same zone — just update entity position
-                    ZonePid = maps:get(OldZoneCoords, ZonePids),
-                    asobi_zone:add_entity(ZonePid, PlayerId, #{x => X, y => Y, type => ~"player"}),
+                    case asobi_zone_manager:get_zone(ZMPid, OldZoneCoords) of
+                        {ok, ZonePid} ->
+                            asobi_zone:add_entity(ZonePid, PlayerId, #{
+                                x => X, y => Y, type => ~"player"
+                            });
+                        not_loaded ->
+                            ok
+                    end,
                     Players1 = maps:update_with(
                         PlayerId,
                         fun(Meta) -> Meta#{position => NewPos} end,
@@ -593,7 +641,6 @@ handle_move(
                     ),
                     {keep_state, State#{players => Players1}};
                 false ->
-                    %% Zone crossing — full handoff
                     State1 = remove_player_from_zones(PlayerId, State),
                     State2 = place_player(PlayerId, NewPos, State1),
                     asobi_world_chat:player_zone_changed(
@@ -605,7 +652,7 @@ handle_move(
                         maps:get(players, State2)
                     ),
                     PlayerPid = find_player_pid(PlayerId),
-                    ZonePid = maps:get(NewZoneCoords, ZonePids),
+                    {ok, ZonePid} = asobi_zone_manager:ensure_zone(ZMPid, NewZoneCoords),
                     PlayerPid ! {asobi_message, {world_zone_changed, ZonePid}},
                     NewInterest = interest_zones(NewZoneCoords, ViewRadius, GridSize),
                     PZ = maps:get(player_zones, State2),
@@ -898,7 +945,8 @@ find_player_by_pid(Pid, #{players := Players}) ->
 resolve_siblings(#{instance_sup := InstanceSup}) ->
     ZoneSupPid = asobi_world_instance:get_child(InstanceSup, asobi_zone_sup),
     TickerPid = asobi_world_instance:get_child(InstanceSup, asobi_world_ticker),
-    {ZoneSupPid, TickerPid}.
+    ZoneManagerPid = asobi_world_instance:get_child(InstanceSup, asobi_zone_manager),
+    {ZoneSupPid, TickerPid, ZoneManagerPid}.
 
 %% --- Internal: Phases ---
 

--- a/src/world/asobi_world_ticker.erl
+++ b/src/world/asobi_world_ticker.erl
@@ -2,7 +2,8 @@
 -behaviour(gen_server).
 
 -export([start_link/1]).
--export([tick_done/3, set_zones/3, get_tick/1]).
+-export([tick_done/3, set_zones/3, set_zone_manager/3, get_tick/1]).
+-export([promote_zone/2, demote_zone/2, remove_zone/2]).
 -export([init/1, handle_call/3, handle_cast/2, handle_info/2]).
 
 %% --- Public API ---
@@ -19,9 +20,25 @@ tick_done(TickerPid, ZonePid, TickN) ->
 set_zones(TickerPid, Zones, WorldPid) ->
     gen_server:cast(TickerPid, {set_zones, Zones, WorldPid}).
 
+-spec set_zone_manager(pid(), pid(), pid()) -> ok.
+set_zone_manager(TickerPid, ZoneManagerPid, WorldPid) ->
+    gen_server:cast(TickerPid, {set_zone_manager, ZoneManagerPid, WorldPid}).
+
 -spec get_tick(pid()) -> non_neg_integer().
 get_tick(TickerPid) ->
     gen_server:call(TickerPid, get_tick).
+
+-spec promote_zone(pid(), pid()) -> ok.
+promote_zone(TickerPid, ZonePid) ->
+    gen_server:cast(TickerPid, {promote_zone, ZonePid}).
+
+-spec demote_zone(pid(), pid()) -> ok.
+demote_zone(TickerPid, ZonePid) ->
+    gen_server:cast(TickerPid, {demote_zone, ZonePid}).
+
+-spec remove_zone(pid(), pid()) -> ok.
+remove_zone(TickerPid, ZonePid) ->
+    gen_server:cast(TickerPid, {remove_zone, ZonePid}).
 
 %% --- gen_server callbacks ---
 
@@ -29,11 +46,17 @@ get_tick(TickerPid) ->
 init(Config) ->
     TickRate = maps:get(tick_rate, Config, 50),
     WorldPid = maps:get(world_pid, Config, undefined),
+    ZoneManager = maps:get(zone_manager, Config, undefined),
+    ColdTickDivisor = maps:get(cold_tick_divisor, Config, 10),
     {ok, #{
         tick => 0,
         tick_rate => TickRate,
         world_pid => WorldPid,
-        zones => [],
+        zone_manager => ZoneManager,
+        hot_zones => [],
+        cold_zones => [],
+        cold_tick_divisor => ColdTickDivisor,
+        tick_count => 0,
         pending => #{},
         running => false
     }}.
@@ -47,7 +70,31 @@ handle_call(_Request, _From, State) ->
 -spec handle_cast(term(), map()) -> {noreply, map()}.
 handle_cast({set_zones, Zones, WorldPid}, #{tick_rate := TickRate} = State) ->
     erlang:send_after(TickRate, self(), tick),
-    {noreply, State#{zones => Zones, world_pid => WorldPid, running => true}};
+    {noreply, State#{hot_zones => Zones, world_pid => WorldPid, running => true}};
+handle_cast({set_zone_manager, ZoneManagerPid, WorldPid}, #{tick_rate := TickRate} = State) ->
+    erlang:send_after(TickRate, self(), tick),
+    {noreply, State#{zone_manager => ZoneManagerPid, world_pid => WorldPid, running => true}};
+handle_cast({promote_zone, ZonePid}, #{hot_zones := Hot, cold_zones := Cold} = State) ->
+    Cold1 = lists:delete(ZonePid, Cold),
+    Hot1 =
+        case lists:member(ZonePid, Hot) of
+            true -> Hot;
+            false -> [ZonePid | Hot]
+        end,
+    {noreply, State#{hot_zones => Hot1, cold_zones => Cold1}};
+handle_cast({demote_zone, ZonePid}, #{hot_zones := Hot, cold_zones := Cold} = State) ->
+    Hot1 = lists:delete(ZonePid, Hot),
+    Cold1 =
+        case lists:member(ZonePid, Cold) of
+            true -> Cold;
+            false -> [ZonePid | Cold]
+        end,
+    {noreply, State#{hot_zones => Hot1, cold_zones => Cold1}};
+handle_cast({remove_zone, ZonePid}, #{hot_zones := Hot, cold_zones := Cold} = State) ->
+    {noreply, State#{
+        hot_zones => lists:delete(ZonePid, Hot),
+        cold_zones => lists:delete(ZonePid, Cold)
+    }};
 handle_cast(
     {tick_done, ZonePid, TickN},
     #{
@@ -80,13 +127,38 @@ handle_info(
     #{
         tick := Tick,
         tick_rate := TickRate,
-        zones := Zones
+        tick_count := TickCount,
+        cold_tick_divisor := ColdTickDivisor,
+        hot_zones := StaticHot,
+        cold_zones := StaticCold,
+        zone_manager := ZoneManager
     } = State
 ) ->
     NextTick = Tick + 1,
-    Pending = maps:from_keys(Zones, true),
-    lists:foreach(fun(Z) -> asobi_zone:tick(Z, NextTick) end, Zones),
+    NextTickCount = TickCount + 1,
+    {Hot, Cold} =
+        case ZoneManager of
+            undefined ->
+                {StaticHot, StaticCold};
+            ZMPid ->
+                AllZones = asobi_zone_manager:get_active_zones(ZMPid),
+                {AllZones, []}
+        end,
+    TickCold = (NextTickCount rem ColdTickDivisor) =:= 0,
+    ZonesToTick =
+        case TickCold of
+            true -> Hot ++ Cold;
+            false -> Hot
+        end,
+    Pending = maps:from_keys(ZonesToTick, true),
+    lists:foreach(fun(Z) -> asobi_zone:tick(Z, NextTick) end, ZonesToTick),
     erlang:send_after(TickRate, self(), tick),
-    {noreply, State#{tick => NextTick, pending => Pending}};
+    case map_size(Pending) of
+        0 ->
+            asobi_world_server:post_tick(maps:get(world_pid, State), NextTick),
+            {noreply, State#{tick => NextTick, tick_count => NextTickCount, pending => #{}}};
+        _ ->
+            {noreply, State#{tick => NextTick, tick_count => NextTickCount, pending => Pending}}
+    end;
 handle_info(_Info, State) ->
     {noreply, State}.

--- a/src/world/asobi_zone.erl
+++ b/src/world/asobi_zone.erl
@@ -7,6 +7,7 @@
 -export([subscribe/2, unsubscribe/2]).
 -export([get_entities/1, get_subscriber_count/1]).
 -export([start_entity_timer/2, cancel_entity_timer/3]).
+-export([query_radius/3, query_rect/3]).
 -export([init/1, handle_call/3, handle_cast/2, handle_info/2, terminate/2]).
 
 -define(PG_SCOPE, nova_scope).
@@ -73,6 +74,15 @@ spawn_entities(Pid, Spawns) ->
 despawn_entity(Pid, EntityId) ->
     gen_server:cast(Pid, {despawn_entity, EntityId}).
 
+-spec query_radius(pid(), {number(), number()}, number()) -> [{binary(), {number(), number()}}].
+query_radius(Pid, Center, Radius) ->
+    gen_server:call(Pid, {query_radius, Center, Radius}).
+
+-spec query_rect(pid(), {number(), number()}, {number(), number()}) ->
+    [{binary(), {number(), number()}}].
+query_rect(Pid, TopLeft, BottomRight) ->
+    gen_server:call(Pid, {query_rect, TopLeft, BottomRight}).
+
 %% --- gen_server callbacks ---
 
 -spec init(map()) -> {ok, map()}.
@@ -82,6 +92,8 @@ init(Config) ->
     TickerPid = maps:get(ticker_pid, Config),
     GameModule = maps:get(game_module, Config),
     ZoneState = maps:get(zone_state, Config, #{}),
+    ZoneManagerPid = maps:get(zone_manager_pid, Config, undefined),
+    TerrainStorePid = maps:get(terrain_store_pid, Config, undefined),
     pg:join(?PG_SCOPE, {asobi_zone, WorldId, Coords}, self()),
     %% Recover entity state from ETS backup if available (zone crash recovery)
     RecoveredEntities = recover_zone_state(WorldId, Coords),
@@ -98,11 +110,18 @@ init(Config) ->
         end,
     Persistence = maps:get(persistence, Config, false),
     SnapshotInterval = maps:get(snapshot_interval, Config, 600),
+    SpatialGrid =
+        case maps:get(spatial_grid_cell_size, Config, undefined) of
+            undefined -> undefined;
+            CellSize -> asobi_spatial_grid:new(CellSize)
+        end,
     {ok, #{
         world_id => WorldId,
         coords => Coords,
         ticker_pid => TickerPid,
         game_module => GameModule,
+        zone_manager_pid => ZoneManagerPid,
+        terrain_store_pid => TerrainStorePid,
         entities => RecoveredEntities,
         prev_entities => #{},
         broadcast_entities => #{},
@@ -114,6 +133,7 @@ init(Config) ->
         spawner => Spawner,
         persistence => Persistence,
         snapshot_interval => SnapshotInterval,
+        spatial_grid => SpatialGrid,
         tick => 0
     }}.
 
@@ -122,6 +142,34 @@ handle_call(get_entities, _From, #{entities := Entities} = State) ->
     {reply, Entities, State};
 handle_call(get_subscriber_count, _From, #{subscribers := Subs} = State) ->
     {reply, map_size(Subs), State};
+handle_call(
+    {query_radius, Center, Radius}, _From, #{spatial_grid := Grid, entities := Entities} = State
+) ->
+    Result =
+        case Grid of
+            undefined ->
+                [
+                    {Id, {maps:get(x, E), maps:get(y, E)}}
+                 || {Id, E, _Dist} <- asobi_spatial:query_radius(Entities, Center, Radius)
+                ];
+            _ ->
+                asobi_spatial_grid:query_radius(Center, Radius, Grid)
+        end,
+    {reply, Result, State};
+handle_call(
+    {query_rect, TopLeft, BottomRight}, _From, #{spatial_grid := Grid, entities := Entities} = State
+) ->
+    Result =
+        case Grid of
+            undefined ->
+                [
+                    {Id, {maps:get(x, E), maps:get(y, E)}}
+                 || {Id, E, _Dist} <- asobi_spatial:query_rect(Entities, TopLeft, BottomRight)
+                ];
+            _ ->
+                asobi_spatial_grid:query_rect(TopLeft, BottomRight, Grid)
+        end,
+    {reply, Result, State};
 handle_call(_Request, _From, State) ->
     {reply, {error, unknown_request}, State}.
 
@@ -129,14 +177,34 @@ handle_call(_Request, _From, State) ->
 handle_cast({tick, TickN}, State) ->
     State1 = do_tick(TickN, State),
     State2 = transfer_out_of_bounds_npcs(State1),
-    {noreply, State2};
+    #{subscribers := Subs, entities := Ents, zone_manager_pid := ZMPid, coords := Coords} = State2,
+    case map_size(Subs) of
+        0 ->
+            case has_tickable_entities(Ents) of
+                false -> {noreply, State2, hibernate};
+                true -> {noreply, State2}
+            end;
+        _ ->
+            case ZMPid of
+                undefined -> ok;
+                _ -> asobi_zone_manager:touch_zone(ZMPid, Coords)
+            end,
+            {noreply, State2}
+    end;
 handle_cast({input, PlayerId, Input}, #{input_queue := Queue} = State) ->
     {noreply, State#{input_queue => [{PlayerId, Input} | Queue]}};
-handle_cast({add_entity, EntityId, EntityState}, #{entities := Entities} = State) ->
-    {noreply, State#{entities => Entities#{EntityId => EntityState}}};
-handle_cast({remove_entity, EntityId}, #{entities := Entities} = State) ->
-    {noreply, State#{entities => maps:remove(EntityId, Entities)}};
-handle_cast({subscribe, PlayerId, PlayerPid}, #{subscribers := Subs, entities := Entities} = State) ->
+handle_cast(
+    {add_entity, EntityId, EntityState}, #{entities := Entities, spatial_grid := Grid} = State
+) ->
+    Grid1 = spatial_grid_insert(EntityId, EntityState, Grid),
+    {noreply, State#{entities => Entities#{EntityId => EntityState}, spatial_grid => Grid1}};
+handle_cast({remove_entity, EntityId}, #{entities := Entities, spatial_grid := Grid} = State) ->
+    Grid1 = spatial_grid_remove(EntityId, Grid),
+    {noreply, State#{entities => maps:remove(EntityId, Entities), spatial_grid => Grid1}};
+handle_cast(
+    {subscribe, PlayerId, PlayerPid},
+    #{subscribers := Subs, entities := Entities, coords := Coords} = State
+) ->
     MonRef = monitor(process, PlayerPid),
     %% Send immediate snapshot so new subscribers see all current entities
     _ =
@@ -147,6 +215,15 @@ handle_cast({subscribe, PlayerId, PlayerPid}, #{subscribers := Subs, entities :=
                 Snapshot = [E#{~"op" => ~"a", ~"id" => Id} || {Id, E} <- maps:to_list(Entities)],
                 PlayerPid ! {asobi_message, {zone_delta, 0, Snapshot}}
         end,
+    case maps:get(terrain_store_pid, State, undefined) of
+        undefined ->
+            ok;
+        StorePid ->
+            case asobi_terrain_store:get_chunk(StorePid, Coords) of
+                {ok, Data} -> PlayerPid ! {asobi_message, {terrain_chunk, Coords, Data}};
+                _ -> ok
+            end
+    end,
     {noreply, State#{subscribers => Subs#{PlayerId => {PlayerPid, MonRef}}}};
 handle_cast({unsubscribe, PlayerId}, #{subscribers := Subs} = State) ->
     case maps:get(PlayerId, Subs, undefined) of
@@ -161,20 +238,29 @@ handle_cast({start_entity_timer, Config}, #{entity_timers := ET} = State) ->
 handle_cast({cancel_entity_timer, EntityId, TimerId}, #{entity_timers := ET} = State) ->
     {noreply, State#{entity_timers => asobi_entity_timer:cancel_timer(EntityId, TimerId, ET)}};
 handle_cast(
-    {spawn_entity, TemplateId, Pos, Overrides}, #{entities := Entities, spawner := Spawner} = State
+    {spawn_entity, TemplateId, Pos, Overrides},
+    #{entities := Entities, spawner := Spawner, spatial_grid := Grid} = State
 ) ->
     case asobi_zone_spawner:spawn_entity(TemplateId, Pos, Overrides, Spawner) of
         {ok, {EntityId, Entity}, Spawner1} ->
-            {noreply, State#{entities => Entities#{EntityId => Entity}, spawner => Spawner1}};
+            Grid1 = spatial_grid_insert(EntityId, Entity, Grid),
+            {noreply, State#{
+                entities => Entities#{EntityId => Entity},
+                spawner => Spawner1,
+                spatial_grid => Grid1
+            }};
         {error, _} ->
             {noreply, State}
     end;
 handle_cast({spawn_entities, Spawns}, State) ->
     State1 = lists:foldl(
-        fun({TemplateId, Pos, Overrides}, #{entities := Ents, spawner := Sp} = S) ->
+        fun(
+            {TemplateId, Pos, Overrides}, #{entities := Ents, spawner := Sp, spatial_grid := Gr} = S
+        ) ->
             case asobi_zone_spawner:spawn_entity(TemplateId, Pos, Overrides, Sp) of
                 {ok, {EntityId, Entity}, Sp1} ->
-                    S#{entities => Ents#{EntityId => Entity}, spawner => Sp1};
+                    Gr1 = spatial_grid_insert(EntityId, Entity, Gr),
+                    S#{entities => Ents#{EntityId => Entity}, spawner => Sp1, spatial_grid => Gr1};
                 {error, _} ->
                     S
             end
@@ -183,10 +269,16 @@ handle_cast({spawn_entities, Spawns}, State) ->
         Spawns
     ),
     {noreply, State1};
-handle_cast({despawn_entity, EntityId}, #{entities := Entities, spawner := Spawner} = State) ->
+handle_cast(
+    {despawn_entity, EntityId},
+    #{entities := Entities, spawner := Spawner, spatial_grid := Grid} = State
+) ->
     Now = erlang:system_time(millisecond),
     Spawner1 = asobi_zone_spawner:entity_removed(EntityId, Now, Spawner),
-    {noreply, State#{entities => maps:remove(EntityId, Entities), spawner => Spawner1}};
+    Grid1 = spatial_grid_remove(EntityId, Grid),
+    {noreply, State#{
+        entities => maps:remove(EntityId, Entities), spawner => Spawner1, spatial_grid => Grid1
+    }};
 handle_cast(_Msg, State) ->
     {noreply, State}.
 
@@ -204,17 +296,20 @@ handle_info(_Info, State) ->
 terminate(normal, #{world_id := WorldId, coords := Coords} = State) ->
     maybe_final_snapshot(State),
     clear_zone_backup(WorldId, Coords),
+    notify_zone_manager_terminated(State),
     pg:leave(?PG_SCOPE, {asobi_zone, WorldId, Coords}, self()),
     ok;
 terminate({shutdown, _}, #{world_id := WorldId, coords := Coords} = State) ->
     maybe_final_snapshot(State),
     clear_zone_backup(WorldId, Coords),
+    notify_zone_manager_terminated(State),
     pg:leave(?PG_SCOPE, {asobi_zone, WorldId, Coords}, self()),
     ok;
 terminate(_Reason, #{world_id := WorldId, coords := Coords, entities := Entities} = State) ->
     %% Abnormal termination — save state for recovery
     maybe_final_snapshot(State),
     backup_zone_state(WorldId, Coords, Entities),
+    notify_zone_manager_terminated(State),
     pg:leave(?PG_SCOPE, {asobi_zone, WorldId, Coords}, self()),
     ok.
 
@@ -286,6 +381,8 @@ do_tick(
         false ->
             ok
     end,
+    Grid = maps:get(spatial_grid, State1),
+    Grid1 = sync_spatial_grid(Entities, Entities4, Grid),
     State1#{
         entities => Entities4,
         prev_entities => Entities4,
@@ -293,6 +390,7 @@ do_tick(
         input_queue => [],
         entity_timers => ET1,
         spawner => Spawner1,
+        spatial_grid => Grid1,
         tick => TickN
     }.
 
@@ -356,9 +454,14 @@ compute_deltas(OldEntities, NewEntities) ->
 broadcast_deltas(_TickN, [], _Subs) ->
     ok;
 broadcast_deltas(TickN, Deltas, Subs) ->
-    Msg = {asobi_message, {zone_delta, TickN, encode_deltas(Deltas)}},
+    EncodedDeltas = encode_deltas(Deltas),
+    Payload = #{
+        ~"type" => ~"world.tick", ~"payload" => #{~"tick" => TickN, ~"updates" => EncodedDeltas}
+    },
+    PreEncoded = iolist_to_binary(json:encode(Payload)),
+    RawMsg = {asobi_message, {zone_delta_raw, PreEncoded}},
     maps:foreach(
-        fun(_PlayerId, {Pid, _MonRef}) -> Pid ! Msg end,
+        fun(_PlayerId, {Pid, _MonRef}) -> Pid ! RawMsg end,
         Subs
     ).
 
@@ -413,7 +516,9 @@ transfer_out_of_bounds_npcs(
     ),
     %% Remove transferred NPCs from this zone
     Entities1 = maps:without(ToRemove, Entities),
-    State#{entities => Entities1};
+    Grid = maps:get(spatial_grid, State, undefined),
+    Grid1 = lists:foldl(fun(Id, G) -> spatial_grid_remove(Id, G) end, Grid, ToRemove),
+    State#{entities => Entities1, spatial_grid => Grid1};
 transfer_out_of_bounds_npcs(State) ->
     State.
 
@@ -481,3 +586,53 @@ clear_zone_backup(WorldId, Coords) ->
         undefined -> ok;
         _ -> ets:delete(asobi_world_state, {WorldId, Coords})
     end.
+
+notify_zone_manager_terminated(#{zone_manager_pid := ZMPid, coords := Coords}) when is_pid(ZMPid) ->
+    asobi_zone_manager:zone_terminated(ZMPid, Coords);
+notify_zone_manager_terminated(_) ->
+    ok.
+
+has_tickable_entities(Entities) ->
+    maps:fold(
+        fun
+            (_, #{type := ~"npc"}, _) -> true;
+            (_, _, Acc) -> Acc
+        end,
+        false,
+        Entities
+    ).
+
+%% --- Spatial Grid Helpers ---
+
+spatial_grid_insert(_EntityId, _EntityState, undefined) ->
+    undefined;
+spatial_grid_insert(EntityId, #{x := X, y := Y}, Grid) ->
+    asobi_spatial_grid:insert(EntityId, {X, Y}, Grid);
+spatial_grid_insert(_EntityId, _EntityState, Grid) ->
+    Grid.
+
+spatial_grid_remove(_EntityId, undefined) ->
+    undefined;
+spatial_grid_remove(EntityId, Grid) ->
+    asobi_spatial_grid:remove(EntityId, Grid).
+
+sync_spatial_grid(_OldEntities, _NewEntities, undefined) ->
+    undefined;
+sync_spatial_grid(OldEntities, NewEntities, Grid) ->
+    %% Remove entities that no longer exist
+    Removed = maps:keys(OldEntities) -- maps:keys(NewEntities),
+    Grid1 = lists:foldl(fun(Id, G) -> asobi_spatial_grid:remove(Id, G) end, Grid, Removed),
+    %% Update/insert entities with changed or new positions
+    maps:fold(
+        fun
+            (Id, #{x := X, y := Y}, G) ->
+                case maps:find(Id, OldEntities) of
+                    {ok, #{x := X, y := Y}} -> G;
+                    _ -> asobi_spatial_grid:update(Id, {X, Y}, G)
+                end;
+            (_Id, _Entity, G) ->
+                G
+        end,
+        Grid1,
+        NewEntities
+    ).

--- a/src/world/asobi_zone.erl
+++ b/src/world/asobi_zone.erl
@@ -164,7 +164,7 @@ handle_call(
             undefined ->
                 [
                     {Id, {maps:get(x, E), maps:get(y, E)}}
-                 || {Id, E, _Dist} <- asobi_spatial:query_rect(Entities, TopLeft, BottomRight)
+                 || {Id, E} <- asobi_spatial:query_rect(Entities, TopLeft, BottomRight)
                 ];
             _ ->
                 asobi_spatial_grid:query_rect(TopLeft, BottomRight, Grid)
@@ -215,15 +215,18 @@ handle_cast(
                 Snapshot = [E#{~"op" => ~"a", ~"id" => Id} || {Id, E} <- maps:to_list(Entities)],
                 PlayerPid ! {asobi_message, {zone_delta, 0, Snapshot}}
         end,
-    case maps:get(terrain_store_pid, State, undefined) of
-        undefined ->
-            ok;
-        StorePid ->
-            case asobi_terrain_store:get_chunk(StorePid, Coords) of
-                {ok, Data} -> PlayerPid ! {asobi_message, {terrain_chunk, Coords, Data}};
-                _ -> ok
-            end
-    end,
+    _ =
+        case maps:get(terrain_store_pid, State, undefined) of
+            undefined ->
+                ok;
+            StorePid ->
+                case asobi_terrain_store:get_chunk(StorePid, Coords) of
+                    {ok, Data} ->
+                        PlayerPid ! {asobi_message, {terrain_chunk, Coords, Data}};
+                    _ ->
+                        ok
+                end
+        end,
     {noreply, State#{subscribers => Subs#{PlayerId => {PlayerPid, MonRef}}}};
 handle_cast({unsubscribe, PlayerId}, #{subscribers := Subs} = State) ->
     case maps:get(PlayerId, Subs, undefined) of

--- a/src/world/asobi_zone_manager.erl
+++ b/src/world/asobi_zone_manager.erl
@@ -300,7 +300,7 @@ reap_idle_zones(
                 [{Coords, Pid}] ->
                     snapshot_before_reap(WorldId, Coords, Pid),
                     SAcc1 = cleanup_zone(Coords, SAcc),
-                    terminate_zone(ZoneSup, Pid),
+                    _ = terminate_zone(ZoneSup, Pid),
                     SAcc1;
                 [] ->
                     cleanup_zone(Coords, SAcc)

--- a/src/world/asobi_zone_manager.erl
+++ b/src/world/asobi_zone_manager.erl
@@ -1,0 +1,361 @@
+-module(asobi_zone_manager).
+-behaviour(gen_server).
+
+-moduledoc """
+Lazy zone lifecycle manager for the world server.
+
+Replaces the static zone_pids map with on-demand zone creation and idle
+reaping. For large worlds (2000x2000 grids), spawning all zones at startup
+is untenable — this module creates zones on first access and reaps them
+after an idle timeout.
+
+Hot-path lookups go through ETS directly, bypassing the gen_server.
+""".
+
+-export([start_link/1]).
+-export([ensure_zone/2, get_zone/2, touch_zone/2, release_zone/2]).
+-export([get_active_zones/1, zone_terminated/2, pre_warm/1]).
+-export([register_zone/3, set_zone_config/2]).
+-export([get_ets_tab/1]).
+-export([init/1, handle_call/3, handle_cast/2, handle_info/2, terminate/2]).
+
+-define(REAP_INTERVAL, 10_000).
+-define(DEFAULT_IDLE_TIMEOUT, 30_000).
+-define(DEFAULT_MAX_ACTIVE, 10_000).
+
+%% --- Public API ---
+
+-doc "Start the zone manager.".
+-spec start_link(map()) -> gen_server:start_ret().
+start_link(Opts) ->
+    gen_server:start_link(?MODULE, Opts, []).
+
+-doc "Return existing zone or start a new one. ETS fast path first.".
+-spec ensure_zone(pid() | atom(), {integer(), integer()}) -> {ok, pid()} | {error, term()}.
+ensure_zone(Ref, Coords) ->
+    case ets_lookup(Ref, Coords) of
+        {ok, Pid} ->
+            {ok, Pid};
+        not_loaded ->
+            gen_server:call(Ref, {ensure_zone, Coords})
+    end.
+
+-doc "Non-creating lookup. ETS only.".
+-spec get_zone(pid() | atom(), {integer(), integer()}) -> {ok, pid()} | not_loaded.
+get_zone(Ref, Coords) ->
+    ets_lookup(Ref, Coords).
+
+-doc "Reset idle timer for a zone. Fire-and-forget.".
+-spec touch_zone(pid() | atom(), {integer(), integer()}) -> ok.
+touch_zone(Ref, Coords) ->
+    gen_server:cast(Ref, {touch_zone, Coords}).
+
+-doc "Hint that zone can be unloaded.".
+-spec release_zone(pid() | atom(), {integer(), integer()}) -> ok.
+release_zone(Ref, Coords) ->
+    gen_server:cast(Ref, {release_zone, Coords}).
+
+-doc "Return all active zone pids. For the ticker.".
+-spec get_active_zones(pid() | atom()) -> [pid()].
+get_active_zones(Ref) ->
+    Tab = get_ets_tab(Ref),
+    [Pid || {_Coords, Pid} <- ets:tab2list(Tab)].
+
+-doc "Called by zone on terminate. Cleans up ETS entry.".
+-spec zone_terminated(pid() | atom(), {integer(), integer()}) -> ok.
+zone_terminated(Ref, Coords) ->
+    gen_server:cast(Ref, {zone_terminated, Coords}).
+
+-doc "Spawn all zones in grid. Backward compat for small grids.".
+-spec pre_warm(pid() | atom()) -> ok.
+pre_warm(Ref) ->
+    gen_server:call(Ref, pre_warm, 60_000).
+
+-doc "Register an externally-spawned zone with the manager.".
+-spec register_zone(pid() | atom(), {integer(), integer()}, pid()) -> ok.
+register_zone(Ref, Coords, ZonePid) ->
+    gen_server:call(Ref, {register_zone, Coords, ZonePid}).
+
+-doc "Update the base zone config used when spawning new zones.".
+-spec set_zone_config(pid() | atom(), map()) -> ok.
+set_zone_config(Ref, Config) ->
+    gen_server:call(Ref, {set_zone_config, Config}).
+
+%% --- gen_server callbacks ---
+
+-doc "Return the ETS table id. Useful for external fast-path reads.".
+-spec get_ets_tab(pid() | atom()) -> ets:tid().
+get_ets_tab(Ref) when is_atom(Ref) ->
+    persistent_term:get({?MODULE, Ref});
+get_ets_tab(Ref) when is_pid(Ref) ->
+    gen_server:call(Ref, get_ets_tab).
+
+-spec init(map()) -> {ok, map()}.
+init(Opts) ->
+    WorldId = maps:get(world_id, Opts),
+    Tab = ets:new(asobi_zone_mgr, [set, public, {read_concurrency, true}]),
+    Name = maps:get(name, Opts, undefined),
+    case Name of
+        undefined -> ok;
+        _ -> persistent_term:put({?MODULE, Name}, Tab)
+    end,
+    ZoneSup =
+        case maps:get(zone_sup, Opts, undefined) of
+            undefined ->
+                erlang:send(self(), resolve_zone_sup),
+                undefined;
+            Pid ->
+                Pid
+        end,
+    ReapRef = schedule_reap(),
+    {ok, #{
+        world_id => WorldId,
+        name => Name,
+        instance_sup => maps:get(instance_sup, Opts, undefined),
+        zone_sup => ZoneSup,
+        ets_tab => Tab,
+        zone_last_active => #{},
+        zone_monitors => #{},
+        idle_timeout => maps:get(idle_timeout, Opts, ?DEFAULT_IDLE_TIMEOUT),
+        max_active_zones => maps:get(max_active_zones, Opts, ?DEFAULT_MAX_ACTIVE),
+        grid_size => maps:get(grid_size, Opts),
+        zone_size => maps:get(zone_size, Opts),
+        zone_config => maps:get(zone_config, Opts, #{}),
+        reap_ref => ReapRef
+    }}.
+
+-spec handle_call(term(), gen_server:from(), map()) -> {reply, term(), map()}.
+handle_call({ensure_zone, Coords}, _From, #{ets_tab := Tab} = State) ->
+    case ets:lookup(Tab, Coords) of
+        [{Coords, Pid}] ->
+            {reply, {ok, Pid}, touch(Coords, State)};
+        [] ->
+            case start_zone(Coords, State) of
+                {ok, Pid, State1} ->
+                    {reply, {ok, Pid}, State1};
+                {error, Reason} ->
+                    {reply, {error, Reason}, State}
+            end
+    end;
+handle_call(pre_warm, _From, #{grid_size := GridSize} = State) ->
+    AllCoords = [{X, Y} || X <- lists:seq(0, GridSize - 1), Y <- lists:seq(0, GridSize - 1)],
+    State1 = lists:foldl(
+        fun(Coords, SAcc) ->
+            case ets:lookup(maps:get(ets_tab, SAcc), Coords) of
+                [{_, _}] ->
+                    SAcc;
+                [] ->
+                    case start_zone(Coords, SAcc) of
+                        {ok, _Pid, SAcc1} -> SAcc1;
+                        {error, _} -> SAcc
+                    end
+            end
+        end,
+        State,
+        AllCoords
+    ),
+    {reply, ok, State1};
+handle_call(
+    {register_zone, Coords, ZonePid},
+    _From,
+    #{
+        ets_tab := Tab,
+        zone_last_active := Active,
+        zone_monitors := Monitors
+    } = State
+) ->
+    ets:insert(Tab, {Coords, ZonePid}),
+    MonRef = monitor(process, ZonePid),
+    Now = erlang:monotonic_time(millisecond),
+    State1 = State#{
+        zone_last_active => Active#{Coords => Now},
+        zone_monitors => Monitors#{MonRef => Coords, Coords => MonRef}
+    },
+    {reply, ok, State1};
+handle_call({set_zone_config, Config}, _From, State) ->
+    {reply, ok, State#{zone_config => Config}};
+handle_call(get_ets_tab, _From, #{ets_tab := Tab} = State) ->
+    {reply, Tab, State};
+handle_call(_Request, _From, State) ->
+    {reply, {error, unknown_request}, State}.
+
+-spec handle_cast(term(), map()) -> {noreply, map()}.
+handle_cast({touch_zone, Coords}, State) ->
+    {noreply, touch(Coords, State)};
+handle_cast({release_zone, Coords}, #{zone_last_active := Active, idle_timeout := Timeout} = State) ->
+    Stale = erlang:monotonic_time(millisecond) - Timeout - 1,
+    {noreply, State#{zone_last_active => Active#{Coords => Stale}}};
+handle_cast({zone_terminated, Coords}, State) ->
+    {noreply, cleanup_zone(Coords, State)};
+handle_cast(_Msg, State) ->
+    {noreply, State}.
+
+-spec handle_info(term(), map()) -> {noreply, map()}.
+handle_info({reap_idle, Ref}, #{reap_ref := Ref} = State) ->
+    State1 = reap_idle_zones(State),
+    State2 = State1#{reap_ref => schedule_reap()},
+    {noreply, State2};
+handle_info({reap_idle, _OldRef}, State) ->
+    {noreply, State};
+handle_info(resolve_zone_sup, #{instance_sup := InstanceSup} = State) ->
+    ZoneSup = asobi_world_instance:get_child(InstanceSup, asobi_zone_sup),
+    {noreply, State#{zone_sup => ZoneSup}};
+handle_info({'DOWN', MonRef, process, _Pid, _Reason}, #{zone_monitors := Monitors} = State) ->
+    case maps:get(MonRef, Monitors, undefined) of
+        undefined ->
+            {noreply, State};
+        Coords ->
+            {noreply, cleanup_zone(Coords, State)}
+    end;
+handle_info(_Info, State) ->
+    {noreply, State}.
+
+-spec terminate(term(), map()) -> ok.
+terminate(_Reason, #{ets_tab := Tab, name := Name}) ->
+    case Name of
+        undefined -> ok;
+        _ -> persistent_term:erase({?MODULE, Name})
+    end,
+    ets:delete(Tab),
+    ok.
+
+%% --- Internal ---
+
+start_zone(
+    Coords,
+    #{
+        ets_tab := Tab,
+        zone_sup := ZoneSup,
+        zone_last_active := Active,
+        zone_monitors := Monitors,
+        max_active_zones := MaxActive,
+        zone_config := BaseConfig
+    } = State
+) ->
+    case ets:info(Tab, size) >= MaxActive of
+        true ->
+            {error, max_zones_reached};
+        false ->
+            Config = BaseConfig#{coords => Coords},
+            case asobi_zone_sup:start_zone(ZoneSup, Config) of
+                {ok, Pid} ->
+                    ets:insert(Tab, {Coords, Pid}),
+                    MonRef = monitor(process, Pid),
+                    Now = erlang:monotonic_time(millisecond),
+                    State1 = State#{
+                        zone_last_active => Active#{Coords => Now},
+                        zone_monitors => Monitors#{MonRef => Coords, Coords => MonRef}
+                    },
+                    {ok, Pid, State1};
+                {error, _} = Err ->
+                    Err
+            end
+    end.
+
+cleanup_zone(
+    Coords,
+    #{
+        ets_tab := Tab,
+        zone_last_active := Active,
+        zone_monitors := Monitors
+    } = State
+) ->
+    ets:delete(Tab, Coords),
+    Monitors1 =
+        case maps:get(Coords, Monitors, undefined) of
+            undefined ->
+                Monitors;
+            MonRef ->
+                demonitor(MonRef, [flush]),
+                maps:without([Coords, MonRef], Monitors)
+        end,
+    State#{
+        zone_last_active => maps:remove(Coords, Active),
+        zone_monitors => Monitors1
+    }.
+
+reap_idle_zones(
+    #{
+        world_id := WorldId,
+        zone_last_active := Active,
+        idle_timeout := Timeout,
+        ets_tab := Tab,
+        zone_sup := ZoneSup
+    } = State
+) ->
+    Now = erlang:monotonic_time(millisecond),
+    Expired = maps:fold(
+        fun(Coords, LastActive, Acc) ->
+            case Now - LastActive > Timeout of
+                true -> [Coords | Acc];
+                false -> Acc
+            end
+        end,
+        [],
+        Active
+    ),
+    lists:foldl(
+        fun(Coords, SAcc) ->
+            case ets:lookup(Tab, Coords) of
+                [{Coords, Pid}] ->
+                    snapshot_before_reap(WorldId, Coords, Pid),
+                    SAcc1 = cleanup_zone(Coords, SAcc),
+                    terminate_zone(ZoneSup, Pid),
+                    SAcc1;
+                [] ->
+                    cleanup_zone(Coords, SAcc)
+            end
+        end,
+        State,
+        Expired
+    ).
+
+snapshot_before_reap(WorldId, Coords, Pid) ->
+    try
+        Entities = asobi_zone:get_entities(Pid),
+        case map_size(Entities) of
+            0 ->
+                ok;
+            _ ->
+                asobi_zone_snapshotter:snapshot_sync(#{
+                    world_id => WorldId,
+                    coords => Coords,
+                    entities => Entities,
+                    zone_state => #{},
+                    entity_timers => #{},
+                    spawner_state => #{},
+                    tick => 0
+                })
+        end
+    catch
+        _:_ -> ok
+    end.
+
+terminate_zone(ZoneSup, Pid) ->
+    try
+        supervisor:terminate_child(ZoneSup, Pid)
+    catch
+        _:_ -> ok
+    end.
+
+touch(Coords, #{zone_last_active := Active} = State) ->
+    Now = erlang:monotonic_time(millisecond),
+    State#{zone_last_active => Active#{Coords => Now}}.
+
+schedule_reap() ->
+    Ref = make_ref(),
+    erlang:send_after(?REAP_INTERVAL, self(), {reap_idle, Ref}),
+    Ref.
+
+ets_lookup(Ref, Coords) when is_atom(Ref) ->
+    Tab = persistent_term:get({?MODULE, Ref}),
+    case ets:lookup(Tab, Coords) of
+        [{Coords, Pid}] -> {ok, Pid};
+        [] -> not_loaded
+    end;
+ets_lookup(Ref, Coords) when is_pid(Ref) ->
+    Tab = gen_server:call(Ref, get_ets_tab),
+    case ets:lookup(Tab, Coords) of
+        [{Coords, Pid}] -> {ok, Pid};
+        [] -> not_loaded
+    end.

--- a/src/ws/asobi_ws_binary.erl
+++ b/src/ws/asobi_ws_binary.erl
@@ -1,0 +1,87 @@
+-module(asobi_ws_binary).
+
+-export([
+    encode_terrain_chunk/2,
+    decode_terrain_chunk/1,
+    encode_entity_deltas/2,
+    decode_entity_deltas/1,
+    is_binary_mode/1
+]).
+
+-define(TYPE_TERRAIN_CHUNK, 16#01).
+-define(TYPE_ENTITY_DELTA, 16#02).
+-define(TYPE_MATCH_STATE, 16#03).
+
+-define(OP_ADD, 0).
+-define(OP_UPDATE, 1).
+-define(OP_REMOVE, 2).
+
+-spec encode_terrain_chunk({integer(), integer()}, binary()) -> binary().
+encode_terrain_chunk({CX, CY}, CompressedData) ->
+    Payload = <<CX:32/signed-big, CY:32/signed-big, CompressedData/binary>>,
+    Len = byte_size(Payload),
+    <<?TYPE_TERRAIN_CHUNK:8, Len:32/big, Payload/binary>>.
+
+-spec decode_terrain_chunk(binary()) -> {{integer(), integer()}, binary()}.
+decode_terrain_chunk(<<?TYPE_TERRAIN_CHUNK:8, Len:32/big, Payload:Len/binary>>) ->
+    <<CX:32/signed-big, CY:32/signed-big, CompressedData/binary>> = Payload,
+    {{CX, CY}, CompressedData}.
+
+-spec encode_entity_deltas(non_neg_integer(), [map()]) -> binary().
+encode_entity_deltas(TickN, Deltas) ->
+    EncodedDeltas = [encode_delta(D) || D <- Deltas],
+    Count = length(Deltas),
+    DeltaBin = iolist_to_binary(EncodedDeltas),
+    Payload = <<TickN:64/big, Count:32/big, DeltaBin/binary>>,
+    Len = byte_size(Payload),
+    <<?TYPE_ENTITY_DELTA:8, Len:32/big, Payload/binary>>.
+
+-spec decode_entity_deltas(binary()) -> {non_neg_integer(), [map()]}.
+decode_entity_deltas(<<?TYPE_ENTITY_DELTA:8, Len:32/big, Payload:Len/binary>>) ->
+    <<TickN:64/big, Count:32/big, Rest/binary>> = Payload,
+    {Deltas, <<>>} = decode_deltas(Rest, Count, []),
+    {TickN, Deltas}.
+
+-spec is_binary_mode(map()) -> boolean().
+is_binary_mode(State) when is_map(State) ->
+    maps:get(binary_protocol, State, false) =:= true.
+
+%% --- Internal ---
+
+encode_delta(#{op := Op, entity_id := EntityId, fields := Fields}) ->
+    OpByte = op_to_byte(Op),
+    IdBin = unicode:characters_to_binary(EntityId),
+    IdLen = byte_size(IdBin),
+    FieldsBin = iolist_to_binary(json:encode(Fields)),
+    FieldsLen = byte_size(FieldsBin),
+    <<OpByte:8, IdLen:16/big, IdBin/binary, FieldsLen:32/big, FieldsBin/binary>>;
+encode_delta(#{op := Op, entity_id := EntityId}) ->
+    OpByte = op_to_byte(Op),
+    IdBin = unicode:characters_to_binary(EntityId),
+    IdLen = byte_size(IdBin),
+    <<OpByte:8, IdLen:16/big, IdBin/binary, 0:32/big>>.
+
+decode_deltas(Rest, 0, Acc) ->
+    {lists:reverse(Acc), Rest};
+decode_deltas(
+    <<OpByte:8, IdLen:16/big, IdBin:IdLen/binary, FieldsLen:32/big, FieldsBin:FieldsLen/binary,
+        Rest/binary>>,
+    Count,
+    Acc
+) ->
+    Op = byte_to_op(OpByte),
+    Delta0 = #{op => Op, entity_id => IdBin},
+    Delta =
+        case FieldsLen of
+            0 -> Delta0;
+            _ -> Delta0#{fields => json:decode(FieldsBin)}
+        end,
+    decode_deltas(Rest, Count - 1, [Delta | Acc]).
+
+op_to_byte(add) -> ?OP_ADD;
+op_to_byte(update) -> ?OP_UPDATE;
+op_to_byte(remove) -> ?OP_REMOVE.
+
+byte_to_op(?OP_ADD) -> add;
+byte_to_op(?OP_UPDATE) -> update;
+byte_to_op(?OP_REMOVE) -> remove.

--- a/src/ws/asobi_ws_handler.erl
+++ b/src/ws/asobi_ws_handler.erl
@@ -61,8 +61,16 @@ websocket_info({asobi_message, {match_event, Event, Payload}}, State) when is_at
     Type = iolist_to_binary([~"match.", atom_to_binary(Event)]),
     Reply = encode_reply(undefined, Type, Payload),
     {reply, {text, Reply}, State};
+websocket_info({asobi_message, {zone_delta_raw, PreEncoded}}, State) ->
+    {reply, {text, PreEncoded}, State};
 websocket_info({asobi_message, {zone_delta, TickN, Deltas}}, State) ->
     Reply = encode_reply(undefined, ~"world.tick", #{tick => TickN, updates => Deltas}),
+    {reply, {text, Reply}, State};
+websocket_info({asobi_message, {terrain_chunk, {CX, CY}, Data}}, State) ->
+    Reply = encode_reply(undefined, ~"world.terrain", #{
+        coords => [CX, CY],
+        data => base64:encode(Data)
+    }),
     {reply, {text, Reply}, State};
 websocket_info({asobi_message, {world_event, Event, Payload}}, State) when is_atom(Event) ->
     Type = iolist_to_binary([~"world.", atom_to_binary(Event)]),

--- a/test/asobi_broadcast_batch_tests.erl
+++ b/test/asobi_broadcast_batch_tests.erl
@@ -1,0 +1,47 @@
+-module(asobi_broadcast_batch_tests).
+-include_lib("eunit/include/eunit.hrl").
+
+pre_encoded_binary_is_valid_json_test() ->
+    Deltas = [{added, ~"e1", #{~"x" => 10, ~"y" => 20}}, {removed, ~"e2"}],
+    EncodedDeltas = [encode_delta(D) || D <- Deltas],
+    Payload = #{
+        ~"type" => ~"world.tick", ~"payload" => #{~"tick" => 1, ~"updates" => EncodedDeltas}
+    },
+    PreEncoded = iolist_to_binary(json:encode(Payload)),
+    ?assert(is_binary(PreEncoded)),
+    Decoded = json:decode(PreEncoded),
+    ?assertMatch(#{~"type" := ~"world.tick", ~"payload" := _}, Decoded),
+    #{~"payload" := #{~"tick" := 1, ~"updates" := Updates}} = Decoded,
+    ?assertEqual(2, length(Updates)),
+    [First, Second] = Updates,
+    ?assertEqual(~"a", maps:get(~"op", First)),
+    ?assertEqual(~"e1", maps:get(~"id", First)),
+    ?assertEqual(~"r", maps:get(~"op", Second)),
+    ?assertEqual(~"e2", maps:get(~"id", Second)).
+
+pre_encoded_empty_deltas_test() ->
+    Payload = #{~"type" => ~"world.tick", ~"payload" => #{~"tick" => 5, ~"updates" => []}},
+    PreEncoded = iolist_to_binary(json:encode(Payload)),
+    Decoded = json:decode(PreEncoded),
+    #{~"payload" := #{~"updates" := []}} = Decoded.
+
+pre_encoded_update_delta_test() ->
+    Deltas = [{updated, ~"e3", #{~"hp" => 50}}],
+    EncodedDeltas = [encode_delta(D) || D <- Deltas],
+    Payload = #{
+        ~"type" => ~"world.tick", ~"payload" => #{~"tick" => 7, ~"updates" => EncodedDeltas}
+    },
+    PreEncoded = iolist_to_binary(json:encode(Payload)),
+    Decoded = json:decode(PreEncoded),
+    #{~"payload" := #{~"updates" := [Update]}} = Decoded,
+    ?assertEqual(~"u", maps:get(~"op", Update)),
+    ?assertEqual(~"e3", maps:get(~"id", Update)),
+    ?assertEqual(50, maps:get(~"hp", Update)).
+
+%% Mirror of asobi_zone:encode_delta/1
+encode_delta({updated, Id, Diff}) ->
+    Diff#{~"op" => ~"u", ~"id" => Id};
+encode_delta({added, Id, FullState}) ->
+    FullState#{~"op" => ~"a", ~"id" => Id};
+encode_delta({removed, Id}) ->
+    #{~"op" => ~"r", ~"id" => Id}.

--- a/test/asobi_spatial_grid_tests.erl
+++ b/test/asobi_spatial_grid_tests.erl
@@ -1,0 +1,209 @@
+-module(asobi_spatial_grid_tests).
+
+-include_lib("eunit/include/eunit.hrl").
+
+%% -------------------------------------------------------------------
+%% Helpers
+%% -------------------------------------------------------------------
+
+empty_grid() ->
+    asobi_spatial_grid:new(16).
+
+populated_grid() ->
+    G0 = asobi_spatial_grid:new(16),
+    G1 = asobi_spatial_grid:insert(~"a", {5.0, 5.0}, G0),
+    G2 = asobi_spatial_grid:insert(~"b", {20.0, 20.0}, G1),
+    G3 = asobi_spatial_grid:insert(~"c", {50.0, 50.0}, G2),
+    asobi_spatial_grid:insert(~"d", {5.0, 20.0}, G3).
+
+brute_force_radius(Entities, {CX, CY}, Radius) ->
+    R2 = Radius * Radius,
+    [
+        {Id, Pos}
+     || {Id, Pos = {X, Y}} <- Entities,
+        (X - CX) * (X - CX) + (Y - CY) * (Y - CY) =< R2
+    ].
+
+brute_force_rect(Entities, {X1, Y1}, {X2, Y2}) ->
+    MinX = min(X1, X2),
+    MinY = min(Y1, Y2),
+    MaxX = max(X1, X2),
+    MaxY = max(Y1, Y2),
+    [
+        {Id, Pos}
+     || {Id, Pos = {X, Y}} <- Entities,
+        X >= MinX,
+        X =< MaxX,
+        Y >= MinY,
+        Y =< MaxY
+    ].
+
+%% -------------------------------------------------------------------
+%% Construction
+%% -------------------------------------------------------------------
+
+new_test() ->
+    G = empty_grid(),
+    ?assertEqual(0, asobi_spatial_grid:size(G)).
+
+%% -------------------------------------------------------------------
+%% Insert / Remove / Size
+%% -------------------------------------------------------------------
+
+insert_test() ->
+    G0 = empty_grid(),
+    G1 = asobi_spatial_grid:insert(~"e1", {10.0, 10.0}, G0),
+    ?assertEqual(1, asobi_spatial_grid:size(G1)),
+    G2 = asobi_spatial_grid:insert(~"e2", {30.0, 30.0}, G1),
+    ?assertEqual(2, asobi_spatial_grid:size(G2)).
+
+remove_test() ->
+    G0 = asobi_spatial_grid:insert(~"e1", {10.0, 10.0}, empty_grid()),
+    G1 = asobi_spatial_grid:remove(~"e1", G0),
+    ?assertEqual(0, asobi_spatial_grid:size(G1)).
+
+remove_nonexistent_test() ->
+    G = empty_grid(),
+    ?assertEqual(0, asobi_spatial_grid:size(asobi_spatial_grid:remove(~"nope", G))).
+
+%% -------------------------------------------------------------------
+%% Update
+%% -------------------------------------------------------------------
+
+update_same_cell_test() ->
+    G0 = asobi_spatial_grid:insert(~"e1", {1.0, 1.0}, empty_grid()),
+    G1 = asobi_spatial_grid:update(~"e1", {2.0, 2.0}, G0),
+    ?assertEqual(1, asobi_spatial_grid:size(G1)),
+    Results = asobi_spatial_grid:query_radius({2.0, 2.0}, 0.1, G1),
+    ?assertEqual([{~"e1", {2.0, 2.0}}], Results).
+
+update_cross_cell_test() ->
+    G0 = asobi_spatial_grid:insert(~"e1", {1.0, 1.0}, empty_grid()),
+    G1 = asobi_spatial_grid:update(~"e1", {20.0, 20.0}, G0),
+    ?assertEqual(1, asobi_spatial_grid:size(G1)),
+    NearOld = asobi_spatial_grid:query_radius({1.0, 1.0}, 1.0, G1),
+    ?assertEqual([], NearOld),
+    NearNew = asobi_spatial_grid:query_radius({20.0, 20.0}, 1.0, G1),
+    ?assertEqual([{~"e1", {20.0, 20.0}}], NearNew).
+
+update_nonexistent_inserts_test() ->
+    G = asobi_spatial_grid:update(~"e1", {5.0, 5.0}, empty_grid()),
+    ?assertEqual(1, asobi_spatial_grid:size(G)).
+
+%% -------------------------------------------------------------------
+%% query_radius
+%% -------------------------------------------------------------------
+
+query_radius_empty_test() ->
+    ?assertEqual([], asobi_spatial_grid:query_radius({0.0, 0.0}, 100.0, empty_grid())).
+
+query_radius_basic_test() ->
+    G = populated_grid(),
+    Results = asobi_spatial_grid:query_radius({5.0, 5.0}, 1.0, G),
+    Ids = [Id || {Id, _} <- Results],
+    ?assertEqual([~"a"], lists:sort(Ids)).
+
+query_radius_multiple_test() ->
+    G = populated_grid(),
+    Results = asobi_spatial_grid:query_radius({10.0, 10.0}, 20.0, G),
+    Ids = lists:sort([Id || {Id, _} <- Results]),
+    ?assert(lists:member(~"a", Ids)),
+    ?assert(lists:member(~"b", Ids)),
+    ?assert(lists:member(~"d", Ids)).
+
+query_radius_vs_brute_force_test() ->
+    G0 = asobi_spatial_grid:new(8),
+    AllEntities = [
+        {list_to_binary(integer_to_list(I)), {float(I rem 64), float(I div 64)}}
+     || I <- lists:seq(0, 255)
+    ],
+    G = lists:foldl(
+        fun({Id, Pos}, Acc) -> asobi_spatial_grid:insert(Id, Pos, Acc) end,
+        G0,
+        AllEntities
+    ),
+    Center = {32.0, 2.0},
+    Radius = 10.0,
+    GridResults = lists:sort(asobi_spatial_grid:query_radius(Center, Radius, G)),
+    BruteResults = lists:sort(brute_force_radius(AllEntities, Center, Radius)),
+    ?assertEqual(BruteResults, GridResults).
+
+%% -------------------------------------------------------------------
+%% query_rect
+%% -------------------------------------------------------------------
+
+query_rect_empty_test() ->
+    ?assertEqual([], asobi_spatial_grid:query_rect({0.0, 0.0}, {100.0, 100.0}, empty_grid())).
+
+query_rect_basic_test() ->
+    G = populated_grid(),
+    Results = asobi_spatial_grid:query_rect({0.0, 0.0}, {10.0, 10.0}, G),
+    Ids = lists:sort([Id || {Id, _} <- Results]),
+    ?assertEqual([~"a"], Ids).
+
+query_rect_multiple_test() ->
+    G = populated_grid(),
+    Results = asobi_spatial_grid:query_rect({0.0, 0.0}, {25.0, 25.0}, G),
+    Ids = lists:sort([Id || {Id, _} <- Results]),
+    ?assertEqual([~"a", ~"b", ~"d"], Ids).
+
+query_rect_vs_brute_force_test() ->
+    G0 = asobi_spatial_grid:new(8),
+    AllEntities = [
+        {list_to_binary(integer_to_list(I)), {float(I rem 64), float(I div 64)}}
+     || I <- lists:seq(0, 255)
+    ],
+    G = lists:foldl(
+        fun({Id, Pos}, Acc) -> asobi_spatial_grid:insert(Id, Pos, Acc) end,
+        G0,
+        AllEntities
+    ),
+    GridResults = lists:sort(asobi_spatial_grid:query_rect({10.0, 1.0}, {40.0, 3.0}, G)),
+    BruteResults = lists:sort(brute_force_rect(AllEntities, {10.0, 1.0}, {40.0, 3.0})),
+    ?assertEqual(BruteResults, GridResults).
+
+%% -------------------------------------------------------------------
+%% entities_in_cell
+%% -------------------------------------------------------------------
+
+entities_in_cell_test() ->
+    G = asobi_spatial_grid:insert(
+        ~"e1",
+        {1.0, 1.0},
+        asobi_spatial_grid:insert(~"e2", {2.0, 3.0}, empty_grid())
+    ),
+    Results = asobi_spatial_grid:entities_in_cell({0, 0}, G),
+    Ids = lists:sort([Id || {Id, _} <- Results]),
+    ?assertEqual([~"e1", ~"e2"], Ids).
+
+entities_in_empty_cell_test() ->
+    ?assertEqual([], asobi_spatial_grid:entities_in_cell({99, 99}, empty_grid())).
+
+%% -------------------------------------------------------------------
+%% Edge cases
+%% -------------------------------------------------------------------
+
+entity_on_cell_boundary_test() ->
+    G0 = asobi_spatial_grid:new(16),
+    G1 = asobi_spatial_grid:insert(~"edge", {16.0, 16.0}, G0),
+    ?assertEqual(1, asobi_spatial_grid:size(G1)),
+    Results = asobi_spatial_grid:query_radius({16.0, 16.0}, 0.1, G1),
+    ?assertEqual([{~"edge", {16.0, 16.0}}], Results).
+
+single_entity_test() ->
+    G = asobi_spatial_grid:insert(~"solo", {32.0, 32.0}, empty_grid()),
+    ?assertEqual(1, asobi_spatial_grid:size(G)),
+    ?assertEqual(
+        [{~"solo", {32.0, 32.0}}],
+        asobi_spatial_grid:query_radius({32.0, 32.0}, 1.0, G)
+    ),
+    ?assertEqual(
+        [],
+        asobi_spatial_grid:query_radius({0.0, 0.0}, 1.0, G)
+    ).
+
+negative_coords_test() ->
+    G0 = asobi_spatial_grid:new(16),
+    G1 = asobi_spatial_grid:insert(~"neg", {-5.0, -5.0}, G0),
+    Results = asobi_spatial_grid:query_radius({-5.0, -5.0}, 1.0, G1),
+    ?assertEqual([{~"neg", {-5.0, -5.0}}], Results).

--- a/test/asobi_terrain_integration_tests.erl
+++ b/test/asobi_terrain_integration_tests.erl
@@ -1,0 +1,103 @@
+-module(asobi_terrain_integration_tests).
+-include_lib("eunit/include/eunit.hrl").
+
+%% End-to-end: terrain provider → store → zone subscribe → player receives chunk
+
+-define(GAME, asobi_terrain_test_game).
+
+setup() ->
+    case whereis(nova_scope) of
+        undefined -> pg:start_link(nova_scope);
+        _ -> ok
+    end,
+    meck:new(asobi_repo, [no_link, non_strict]),
+    meck:expect(asobi_repo, insert, fun(_) -> {ok, #{}} end),
+    meck:expect(asobi_repo, insert, fun(_, _) -> {ok, #{}} end),
+    meck:new(asobi_presence, [no_link, non_strict]),
+    meck:expect(asobi_presence, send, fun(_, _) -> ok end),
+    meck:new(asobi_zone_snapshotter, [no_link, non_strict]),
+    meck:expect(asobi_zone_snapshotter, load_snapshots, fun(_) -> {ok, #{}} end),
+    meck:expect(asobi_zone_snapshotter, delete_world, fun(_) -> ok end),
+    meck:expect(asobi_zone_snapshotter, snapshot_sync, fun(_) -> ok end),
+    meck:expect(asobi_zone_snapshotter, snapshot, fun(_) -> ok end),
+    ok.
+
+cleanup(_) ->
+    meck:unload(asobi_zone_snapshotter),
+    meck:unload(asobi_presence),
+    meck:unload(asobi_repo),
+    ok.
+
+world_config() ->
+    #{
+        game_module => ?GAME,
+        grid_size => 3,
+        zone_size => 100,
+        tick_rate => 50,
+        max_players => 10,
+        view_radius => 1,
+        lazy_zones => false
+    }.
+
+terrain_integration_test_() ->
+    {setup, fun setup/0, fun cleanup/1, [
+        {"world starts with terrain store", fun terrain_store_started/0},
+        {"zone subscribe sends terrain chunk", fun terrain_chunk_on_subscribe/0},
+        {"terrain chunk has correct data", fun terrain_data_correct/0}
+    ]}.
+
+terrain_store_started() ->
+    {ok, InstancePid} = asobi_world_instance:start_link(world_config()),
+    unlink(InstancePid),
+    timer:sleep(100),
+    WorldPid = asobi_world_instance:get_child(InstancePid, asobi_world_server),
+    ?assert(is_pid(WorldPid)),
+    ?assertEqual(running, maps:get(status, asobi_world_server:get_info(WorldPid))),
+    catch exit(InstancePid, shutdown),
+    timer:sleep(50).
+
+terrain_chunk_on_subscribe() ->
+    {ok, InstancePid} = asobi_world_instance:start_link(world_config()),
+    unlink(InstancePid),
+    timer:sleep(100),
+    ZMPid = asobi_world_instance:get_child(InstancePid, asobi_zone_manager),
+    {ok, ZonePid} = asobi_zone_manager:ensure_zone(ZMPid, {0, 0}),
+    asobi_zone:subscribe(ZonePid, {~"test_player", self()}),
+    Received = collect_messages(500),
+    HasTerrain = lists:any(
+        fun
+            ({asobi_message, {terrain_chunk, {0, 0}, _}}) -> true;
+            (_) -> false
+        end,
+        Received
+    ),
+    ?assert(HasTerrain),
+    catch exit(InstancePid, shutdown),
+    timer:sleep(50).
+
+terrain_data_correct() ->
+    {ok, InstancePid} = asobi_world_instance:start_link(world_config()),
+    unlink(InstancePid),
+    timer:sleep(100),
+    ZMPid = asobi_world_instance:get_child(InstancePid, asobi_zone_manager),
+    {ok, ZonePid} = asobi_zone_manager:ensure_zone(ZMPid, {1, 2}),
+    asobi_zone:subscribe(ZonePid, {~"test_player2", self()}),
+    Received = collect_messages(500),
+    [{asobi_message, {terrain_chunk, {1, 2}, ChunkData}}] =
+        [M || {asobi_message, {terrain_chunk, _, _}} = M <- Received],
+    Tiles = asobi_terrain:decode_chunk(asobi_terrain:decompress_chunk(ChunkData)),
+    %% Provider: tile_id = X + Y + Seed + 1, Seed from store config (default 0)
+    %% So tile_id = 1 + 2 + 0 + 1 = 4
+    ?assert(lists:member({0, 0, 4, 0, 0}, Tiles)),
+    catch exit(InstancePid, shutdown),
+    timer:sleep(50).
+
+collect_messages(Timeout) ->
+    collect_messages(Timeout, []).
+
+collect_messages(Timeout, Acc) ->
+    receive
+        Msg -> collect_messages(Timeout, [Msg | Acc])
+    after Timeout ->
+        lists:reverse(Acc)
+    end.

--- a/test/asobi_terrain_store_tests.erl
+++ b/test/asobi_terrain_store_tests.erl
@@ -1,0 +1,88 @@
+-module(asobi_terrain_store_tests).
+-include_lib("eunit/include/eunit.hrl").
+
+%% --- Mock terrain provider ---
+
+-behaviour(asobi_terrain_provider).
+-export([init/1, load_chunk/2, generate_chunk/3]).
+
+init(Config) ->
+    {ok, Config}.
+
+load_chunk(Coords, #{chunks := Chunks} = State) ->
+    case maps:get(Coords, Chunks, undefined) of
+        undefined -> {error, not_found};
+        Data -> {ok, Data, State}
+    end;
+load_chunk(_Coords, State) ->
+    {error, not_found, State}.
+
+generate_chunk({X, Y}, Seed, State) ->
+    Bin = asobi_terrain:compress_chunk(
+        asobi_terrain:encode_chunk([{0, 0, X + Y + Seed, 0, 0}])
+    ),
+    {ok, Bin, State}.
+
+%% --- Helpers ---
+
+start_store(ProviderArgs) ->
+    {ok, Pid} = asobi_terrain_store:start_link(#{
+        provider => {?MODULE, ProviderArgs},
+        seed => 42
+    }),
+    unlink(Pid),
+    Pid.
+
+stop_store(Pid) ->
+    catch exit(Pid, shutdown),
+    timer:sleep(10).
+
+%% --- Tests ---
+
+cache_miss_loads_from_provider_test() ->
+    Chunk = asobi_terrain:compress_chunk(asobi_terrain:encode_chunk([{0, 0, 1, 0, 0}])),
+    Pid = start_store(#{chunks => #{{5, 5} => Chunk}}),
+    ?assertEqual({ok, Chunk}, asobi_terrain_store:get_chunk(Pid, {5, 5})),
+    stop_store(Pid).
+
+cache_hit_returns_same_data_test() ->
+    Chunk = asobi_terrain:compress_chunk(asobi_terrain:encode_chunk([{0, 0, 1, 0, 0}])),
+    Pid = start_store(#{chunks => #{{0, 0} => Chunk}}),
+    {ok, D1} = asobi_terrain_store:get_chunk(Pid, {0, 0}),
+    {ok, D2} = asobi_terrain_store:get_chunk(Pid, {0, 0}),
+    ?assertEqual(D1, D2),
+    #{misses := 1} = asobi_terrain_store:stats(Pid),
+    stop_store(Pid).
+
+generate_fallback_test() ->
+    Pid = start_store(#{chunks => #{}}),
+    {ok, Data} = asobi_terrain_store:get_chunk(Pid, {3, 4}),
+    ?assert(is_binary(Data)),
+    Decoded = asobi_terrain:decode_chunk(asobi_terrain:decompress_chunk(Data)),
+    ?assert(lists:member({0, 0, 3 + 4 + 42, 0, 0}, Decoded)),
+    stop_store(Pid).
+
+evict_test() ->
+    Chunk = asobi_terrain:compress_chunk(asobi_terrain:encode_chunk([{0, 0, 1, 0, 0}])),
+    Pid = start_store(#{chunks => #{{0, 0} => Chunk}}),
+    {ok, _} = asobi_terrain_store:get_chunk(Pid, {0, 0}),
+    #{cached_chunks := 1} = asobi_terrain_store:stats(Pid),
+    ok = asobi_terrain_store:evict_chunk(Pid, {0, 0}),
+    timer:sleep(10),
+    #{cached_chunks := 0} = asobi_terrain_store:stats(Pid),
+    stop_store(Pid).
+
+preload_test() ->
+    C1 = asobi_terrain:compress_chunk(asobi_terrain:encode_chunk([{0, 0, 1, 0, 0}])),
+    C2 = asobi_terrain:compress_chunk(asobi_terrain:encode_chunk([{0, 0, 2, 0, 0}])),
+    Pid = start_store(#{chunks => #{{0, 0} => C1, {1, 0} => C2}}),
+    ok = asobi_terrain_store:preload_chunks(Pid, [{0, 0}, {1, 0}]),
+    timer:sleep(50),
+    #{cached_chunks := 2} = asobi_terrain_store:stats(Pid),
+    stop_store(Pid).
+
+stats_memory_test() ->
+    Pid = start_store(#{chunks => #{}}),
+    #{memory_bytes := Mem} = asobi_terrain_store:stats(Pid),
+    ?assert(Mem > 0),
+    stop_store(Pid).

--- a/test/asobi_terrain_test_game.erl
+++ b/test/asobi_terrain_test_game.erl
@@ -1,0 +1,14 @@
+-module(asobi_terrain_test_game).
+-behaviour(asobi_world).
+
+-export([init/1, join/2, leave/2, spawn_position/2]).
+-export([zone_tick/2, handle_input/3, post_tick/2, terrain_provider/1]).
+
+init(_Config) -> {ok, #{players => #{}, tick_count => 0}}.
+join(PlayerId, #{players := P} = S) -> {ok, S#{players => P#{PlayerId => #{}}}}.
+leave(PlayerId, #{players := P} = S) -> {ok, S#{players => maps:remove(PlayerId, P)}}.
+spawn_position(_PlayerId, _State) -> {ok, {50.0, 50.0}}.
+zone_tick(E, Z) -> {E, Z}.
+handle_input(_P, _I, E) -> {ok, E}.
+post_tick(T, S) -> {ok, S#{tick_count => T}}.
+terrain_provider(_Config) -> {asobi_terrain_test_provider, #{seed => 99}}.

--- a/test/asobi_terrain_test_provider.erl
+++ b/test/asobi_terrain_test_provider.erl
@@ -1,0 +1,13 @@
+-module(asobi_terrain_test_provider).
+-behaviour(asobi_terrain_provider).
+
+-export([init/1, load_chunk/2, generate_chunk/3]).
+
+init(Config) -> {ok, Config}.
+
+load_chunk(_Coords, State) -> {error, not_found, State}.
+
+generate_chunk({X, Y}, Seed, State) ->
+    Tiles = [{0, 0, X + Y + Seed + 1, 0, 0}],
+    Bin = asobi_terrain:compress_chunk(asobi_terrain:encode_chunk(Tiles)),
+    {ok, Bin, State}.

--- a/test/asobi_terrain_tests.erl
+++ b/test/asobi_terrain_tests.erl
@@ -1,0 +1,67 @@
+-module(asobi_terrain_tests).
+-include_lib("eunit/include/eunit.hrl").
+
+default_format_test() ->
+    Fmt = asobi_terrain:default_format(),
+    ?assertEqual(64, maps:get(chunk_width, Fmt)),
+    ?assertEqual(64, maps:get(chunk_height, Fmt)),
+    ?assertEqual(4, maps:get(tile_size, Fmt)).
+
+chunk_byte_size_test() ->
+    ?assertEqual(16384, asobi_terrain:chunk_byte_size(asobi_terrain:default_format())).
+
+encode_decode_roundtrip_test() ->
+    Tiles = [{0, 0, 1, 0, 10}, {3, 5, 200, 15, 255}, {63, 63, 65535, 255, 128}],
+    Bin = asobi_terrain:encode_chunk(Tiles),
+    Decoded = asobi_terrain:decode_chunk(Bin),
+    lists:foreach(
+        fun(Tile) ->
+            ?assert(lists:member(Tile, Decoded))
+        end,
+        Tiles
+    ).
+
+encode_size_test() ->
+    Bin = asobi_terrain:encode_chunk([]),
+    ?assertEqual(16384, byte_size(Bin)).
+
+encode_map_input_test() ->
+    TileMap = #{{0, 0} => {1, 0, 10}, {1, 0} => {2, 3, 50}},
+    Bin = asobi_terrain:encode_chunk(TileMap, asobi_terrain:default_format()),
+    ?assertEqual(16384, byte_size(Bin)),
+    Decoded = asobi_terrain:decode_chunk(Bin),
+    ?assert(lists:member({0, 0, 1, 0, 10}, Decoded)),
+    ?assert(lists:member({1, 0, 2, 3, 50}, Decoded)).
+
+decode_skips_zero_tiles_test() ->
+    Decoded = asobi_terrain:decode_chunk(asobi_terrain:encode_chunk([])),
+    ?assertEqual([], Decoded).
+
+compress_decompress_roundtrip_test() ->
+    Tiles = [{X, Y, X + Y + 1, 0, 0} || X <- lists:seq(0, 63), Y <- lists:seq(0, 63)],
+    Bin = asobi_terrain:encode_chunk(Tiles),
+    Compressed = asobi_terrain:compress_chunk(Bin),
+    ?assert(byte_size(Compressed) < byte_size(Bin)),
+    Decompressed = asobi_terrain:decompress_chunk(Compressed),
+    ?assertEqual(Bin, Decompressed).
+
+compression_ratio_test() ->
+    Bin = asobi_terrain:encode_chunk([{0, 0, 1, 0, 0}]),
+    Compressed = asobi_terrain:compress_chunk(Bin),
+    ?assert(byte_size(Compressed) < byte_size(Bin) div 2).
+
+custom_format_test() ->
+    Fmt = #{tile_size => 4, chunk_width => 4, chunk_height => 4},
+    ?assertEqual(64, asobi_terrain:chunk_byte_size(Fmt)),
+    Tiles = [{0, 0, 1, 0, 0}, {3, 3, 2, 0, 0}],
+    Bin = asobi_terrain:encode_chunk(Tiles, Fmt),
+    ?assertEqual(64, byte_size(Bin)),
+    Decoded = asobi_terrain:decode_chunk(Bin, Fmt),
+    ?assert(lists:member({0, 0, 1, 0, 0}, Decoded)),
+    ?assert(lists:member({3, 3, 2, 0, 0}, Decoded)).
+
+max_tile_values_test() ->
+    Tiles = [{0, 0, 65535, 255, 255}],
+    Bin = asobi_terrain:encode_chunk(Tiles),
+    Decoded = asobi_terrain:decode_chunk(Bin),
+    ?assert(lists:member({0, 0, 65535, 255, 255}, Decoded)).

--- a/test/asobi_world_callbacks_tests.erl
+++ b/test/asobi_world_callbacks_tests.erl
@@ -1,0 +1,28 @@
+-module(asobi_world_callbacks_tests).
+-include_lib("eunit/include/eunit.hrl").
+
+%% Verify the new optional callbacks are defined in the behaviour
+
+terrain_provider_callback_defined_test() ->
+    Callbacks = asobi_world:behaviour_info(callbacks),
+    ?assert(lists:member({terrain_provider, 1}, Callbacks)).
+
+on_zone_loaded_callback_defined_test() ->
+    Callbacks = asobi_world:behaviour_info(callbacks),
+    ?assert(lists:member({on_zone_loaded, 2}, Callbacks)).
+
+on_zone_unloaded_callback_defined_test() ->
+    Callbacks = asobi_world:behaviour_info(callbacks),
+    ?assert(lists:member({on_zone_unloaded, 2}, Callbacks)).
+
+optional_callbacks_test() ->
+    Opts = asobi_world:behaviour_info(optional_callbacks),
+    ?assert(lists:member({terrain_provider, 1}, Opts)),
+    ?assert(lists:member({on_zone_loaded, 2}, Opts)),
+    ?assert(lists:member({on_zone_unloaded, 2}, Opts)).
+
+ws_handler_terrain_message_test() ->
+    %% Verify the ws handler can encode a terrain chunk message
+    %% by checking the module exports websocket_info/2
+    Exports = asobi_ws_handler:module_info(exports),
+    ?assert(lists:member({websocket_info, 2}, Exports)).

--- a/test/asobi_world_ticker_tests.erl
+++ b/test/asobi_world_ticker_tests.erl
@@ -1,0 +1,128 @@
+-module(asobi_world_ticker_tests).
+-include_lib("eunit/include/eunit.hrl").
+
+start_ticker() ->
+    start_ticker(#{}).
+
+start_ticker(Overrides) ->
+    Config = maps:merge(#{tick_rate => 100}, Overrides),
+    {ok, Pid} = asobi_world_ticker:start_link(Config),
+    Pid.
+
+ticker_test_() ->
+    {foreach, fun() -> ok end, fun(_) -> ok end, [
+        {"get_tick starts at 0", fun get_tick_starts_at_zero/0},
+        {"set_zones puts all zones in hot", fun set_zones_all_hot/0},
+        {"promote_zone adds to hot", fun promote_zone_adds_to_hot/0},
+        {"demote_zone moves to cold", fun demote_zone_moves_to_cold/0},
+        {"remove_zone removes from both", fun remove_zone_removes/0},
+        {"promote is idempotent", fun promote_idempotent/0},
+        {"demote is idempotent", fun demote_idempotent/0},
+        {"cold_tick_divisor defaults to 10", fun cold_divisor_default/0},
+        {"cold_tick_divisor is configurable", fun cold_divisor_configurable/0}
+    ]}.
+
+get_tick_starts_at_zero() ->
+    Pid = start_ticker(),
+    ?assertEqual(0, asobi_world_ticker:get_tick(Pid)).
+
+set_zones_all_hot() ->
+    Pid = start_ticker(),
+    Z1 = spawn(fun() ->
+        receive
+            stop -> ok
+        end
+    end),
+    Z2 = spawn(fun() ->
+        receive
+            stop -> ok
+        end
+    end),
+    asobi_world_ticker:set_zones(Pid, [Z1, Z2], self()),
+    timer:sleep(10),
+    State = sys:get_state(Pid),
+    ?assertEqual([Z1, Z2], maps:get(hot_zones, State)),
+    ?assertEqual([], maps:get(cold_zones, State)).
+
+promote_zone_adds_to_hot() ->
+    Pid = start_ticker(),
+    Z1 = spawn(fun() ->
+        receive
+            stop -> ok
+        end
+    end),
+    asobi_world_ticker:promote_zone(Pid, Z1),
+    timer:sleep(10),
+    State = sys:get_state(Pid),
+    ?assert(lists:member(Z1, maps:get(hot_zones, State))),
+    ?assertNot(lists:member(Z1, maps:get(cold_zones, State))).
+
+demote_zone_moves_to_cold() ->
+    Pid = start_ticker(),
+    Z1 = spawn(fun() ->
+        receive
+            stop -> ok
+        end
+    end),
+    asobi_world_ticker:promote_zone(Pid, Z1),
+    timer:sleep(10),
+    asobi_world_ticker:demote_zone(Pid, Z1),
+    timer:sleep(10),
+    State = sys:get_state(Pid),
+    ?assertNot(lists:member(Z1, maps:get(hot_zones, State))),
+    ?assert(lists:member(Z1, maps:get(cold_zones, State))).
+
+remove_zone_removes() ->
+    Pid = start_ticker(),
+    Z1 = spawn(fun() ->
+        receive
+            stop -> ok
+        end
+    end),
+    asobi_world_ticker:promote_zone(Pid, Z1),
+    timer:sleep(10),
+    asobi_world_ticker:remove_zone(Pid, Z1),
+    timer:sleep(10),
+    State = sys:get_state(Pid),
+    ?assertNot(lists:member(Z1, maps:get(hot_zones, State))),
+    ?assertNot(lists:member(Z1, maps:get(cold_zones, State))).
+
+promote_idempotent() ->
+    Pid = start_ticker(),
+    Z1 = spawn(fun() ->
+        receive
+            stop -> ok
+        end
+    end),
+    asobi_world_ticker:promote_zone(Pid, Z1),
+    timer:sleep(10),
+    asobi_world_ticker:promote_zone(Pid, Z1),
+    timer:sleep(10),
+    State = sys:get_state(Pid),
+    Hot = maps:get(hot_zones, State),
+    ?assertEqual(1, length([Z || Z <- Hot, Z =:= Z1])).
+
+demote_idempotent() ->
+    Pid = start_ticker(),
+    Z1 = spawn(fun() ->
+        receive
+            stop -> ok
+        end
+    end),
+    asobi_world_ticker:demote_zone(Pid, Z1),
+    timer:sleep(10),
+    asobi_world_ticker:demote_zone(Pid, Z1),
+    timer:sleep(10),
+    State = sys:get_state(Pid),
+    Cold = maps:get(cold_zones, State),
+    ?assertEqual(1, length([Z || Z <- Cold, Z =:= Z1])).
+
+cold_divisor_default() ->
+    Pid = start_ticker(),
+    State = sys:get_state(Pid),
+    ?assertEqual(10, maps:get(cold_tick_divisor, State)).
+
+cold_divisor_configurable() ->
+    Pid = start_ticker(#{cold_tick_divisor => 5}),
+    State = sys:get_state(Pid),
+    ?assertEqual(5, maps:get(cold_tick_divisor, State)).

--- a/test/asobi_world_zone_integration_tests.erl
+++ b/test/asobi_world_zone_integration_tests.erl
@@ -1,0 +1,140 @@
+-module(asobi_world_zone_integration_tests).
+-include_lib("eunit/include/eunit.hrl").
+
+-define(GAME, asobi_test_world_game).
+-define(BASE_CONFIG, #{
+    game_module => ?GAME,
+    grid_size => 3,
+    zone_size => 100,
+    tick_rate => 50,
+    max_players => 10,
+    view_radius => 1
+}).
+
+setup() ->
+    case whereis(nova_scope) of
+        undefined -> pg:start_link(nova_scope);
+        _ -> ok
+    end,
+    meck:new(asobi_repo, [no_link]),
+    meck:expect(asobi_repo, insert, fun(_CS) -> {ok, #{}} end),
+    meck:expect(asobi_repo, insert, fun(_CS, _Opts) -> {ok, #{}} end),
+    meck:new(asobi_presence, [non_strict, no_link]),
+    meck:expect(asobi_presence, send, fun(_PlayerId, _Msg) -> ok end),
+    ok.
+
+cleanup(_) ->
+    meck:unload(asobi_presence),
+    meck:unload(asobi_repo),
+    ok.
+
+start_world() ->
+    start_world(#{}).
+
+start_world(Overrides) ->
+    Config = maps:merge(?BASE_CONFIG, Overrides),
+    {ok, InstancePid} = asobi_world_instance:start_link(Config),
+    unlink(InstancePid),
+    timer:sleep(50),
+    ServerPid = asobi_world_instance:get_child(InstancePid, asobi_world_server),
+    ZoneManagerPid = asobi_world_instance:get_child(InstancePid, asobi_zone_manager),
+    #{instance_pid => InstancePid, world_pid => ServerPid, zone_mgr => ZoneManagerPid}.
+
+stop_world(#{instance_pid := InstancePid}) ->
+    catch exit(InstancePid, shutdown),
+    timer:sleep(10),
+    ok.
+
+world_zone_integration_test_() ->
+    {setup, fun setup/0, fun cleanup/1, [
+        {"default config pre-spawns all zones", fun default_prespawns_all/0},
+        {"lazy_zones=true starts with no zones", fun lazy_starts_empty/0},
+        {"player join on lazy world creates zone", fun lazy_join_creates_zone/0},
+        {"player move across boundary creates new zone", fun lazy_move_creates_zone/0},
+        {"multiple players share same zone process", fun shared_zone_process/0},
+        {"get_active_zones correct after lazy joins", fun active_zones_after_joins/0},
+        {"small grid backward compat", fun small_grid_backward_compat/0}
+    ]}.
+
+%% Default (lazy_zones=false, grid_size=3) pre-spawns all 9 zones
+default_prespawns_all() ->
+    Ctx = #{zone_mgr := Mgr} = start_world(),
+    Active = asobi_zone_manager:get_active_zones(Mgr),
+    ?assertEqual(9, length(Active)),
+    lists:foreach(
+        fun(Coords) ->
+            ?assertMatch({ok, _}, asobi_zone_manager:get_zone(Mgr, Coords))
+        end,
+        [{X, Y} || X <- lists:seq(0, 2), Y <- lists:seq(0, 2)]
+    ),
+    stop_world(Ctx).
+
+%% lazy_zones=true means no zones spawned at startup
+lazy_starts_empty() ->
+    Ctx = #{zone_mgr := Mgr} = start_world(#{lazy_zones => true}),
+    Active = asobi_zone_manager:get_active_zones(Mgr),
+    ?assertEqual(0, length(Active)),
+    stop_world(Ctx).
+
+%% Joining a lazy world triggers zone creation via ensure_zone
+lazy_join_creates_zone() ->
+    Ctx = #{world_pid := Pid, zone_mgr := Mgr} = start_world(#{lazy_zones => true}),
+    ?assertEqual(ok, asobi_world_server:join(Pid, ~"p1")),
+    timer:sleep(20),
+    Active = asobi_zone_manager:get_active_zones(Mgr),
+    ?assert(length(Active) > 0),
+    %% spawn_position returns {100.0, 100.0}, zone_size=100 => zone {1,1}
+    ?assertMatch({ok, _}, asobi_zone_manager:get_zone(Mgr, {1, 1})),
+    stop_world(Ctx).
+
+%% Moving to a different zone on a lazy world creates the new zone
+lazy_move_creates_zone() ->
+    Ctx = #{world_pid := Pid, zone_mgr := Mgr} = start_world(#{lazy_zones => true}),
+    ?assertEqual(ok, asobi_world_server:join(Pid, ~"p1")),
+    timer:sleep(20),
+    %% Player starts at {100.0, 100.0} => zone {1,1}
+    %% Move to {250.0, 250.0} => zone {2,2}
+    asobi_world_server:move_player(Pid, ~"p1", {250.0, 250.0}),
+    timer:sleep(20),
+    ?assertMatch({ok, _}, asobi_zone_manager:get_zone(Mgr, {2, 2})),
+    stop_world(Ctx).
+
+%% Two players in same zone get the same zone pid
+shared_zone_process() ->
+    Ctx = #{world_pid := Pid, zone_mgr := Mgr} = start_world(#{lazy_zones => true}),
+    ?assertEqual(ok, asobi_world_server:join(Pid, ~"p1")),
+    ?assertEqual(ok, asobi_world_server:join(Pid, ~"p2")),
+    timer:sleep(20),
+    %% Both spawn at {100.0, 100.0} => zone {1,1}
+    {ok, ZonePid1} = asobi_zone_manager:get_zone(Mgr, {1, 1}),
+    {ok, ZonePid2} = asobi_zone_manager:ensure_zone(Mgr, {1, 1}),
+    ?assertEqual(ZonePid1, ZonePid2),
+    ?assert(is_process_alive(ZonePid1)),
+    stop_world(Ctx).
+
+%% Active zone count reflects zones created by player joins
+active_zones_after_joins() ->
+    Ctx = #{world_pid := Pid, zone_mgr := Mgr} = start_world(#{lazy_zones => true}),
+    ?assertEqual(0, length(asobi_zone_manager:get_active_zones(Mgr))),
+    ?assertEqual(ok, asobi_world_server:join(Pid, ~"p1")),
+    timer:sleep(20),
+    Count1 = length(asobi_zone_manager:get_active_zones(Mgr)),
+    ?assert(Count1 > 0),
+    %% Move to a new zone to bump the count
+    asobi_world_server:move_player(Pid, ~"p1", {250.0, 250.0}),
+    timer:sleep(20),
+    Count2 = length(asobi_zone_manager:get_active_zones(Mgr)),
+    ?assert(Count2 > Count1),
+    stop_world(Ctx).
+
+%% Small grid (grid_size=3) without explicit lazy_zones works like before
+small_grid_backward_compat() ->
+    Ctx = #{world_pid := Pid, zone_mgr := Mgr} = start_world(#{grid_size => 3}),
+    %% All 9 zones pre-spawned
+    ?assertEqual(9, length(asobi_zone_manager:get_active_zones(Mgr))),
+    %% Join still works
+    ?assertEqual(ok, asobi_world_server:join(Pid, ~"p1")),
+    Info = asobi_world_server:get_info(Pid),
+    ?assertEqual(1, maps:get(player_count, Info)),
+    ?assertEqual(running, maps:get(status, Info)),
+    stop_world(Ctx).

--- a/test/asobi_ws_binary_tests.erl
+++ b/test/asobi_ws_binary_tests.erl
@@ -1,0 +1,103 @@
+-module(asobi_ws_binary_tests).
+
+-include_lib("eunit/include/eunit.hrl").
+
+%% --- Terrain Chunk ---
+
+terrain_chunk_roundtrip_test() ->
+    Coords = {10, -5},
+    Data = crypto:strong_rand_bytes(256),
+    Encoded = asobi_ws_binary:encode_terrain_chunk(Coords, Data),
+    ?assertEqual({Coords, Data}, asobi_ws_binary:decode_terrain_chunk(Encoded)).
+
+terrain_chunk_negative_coords_test() ->
+    Coords = {-100, -200},
+    Data = ~"terrain_data",
+    Encoded = asobi_ws_binary:encode_terrain_chunk(Coords, Data),
+    ?assertEqual({Coords, Data}, asobi_ws_binary:decode_terrain_chunk(Encoded)).
+
+terrain_chunk_empty_data_test() ->
+    Coords = {0, 0},
+    Encoded = asobi_ws_binary:encode_terrain_chunk(Coords, <<>>),
+    ?assertEqual({Coords, <<>>}, asobi_ws_binary:decode_terrain_chunk(Encoded)).
+
+terrain_chunk_tlv_structure_test() ->
+    Data = ~"abc",
+    Encoded = asobi_ws_binary:encode_terrain_chunk({1, 2}, Data),
+    <<Type:8, Len:32/big, _Payload:Len/binary>> = Encoded,
+    ?assertEqual(16#01, Type),
+    ?assertEqual(4 + 4 + 3, Len).
+
+terrain_chunk_size_vs_json_test() ->
+    ChunkData = crypto:strong_rand_bytes(1024),
+    BinaryEncoded = asobi_ws_binary:encode_terrain_chunk({5, 10}, ChunkData),
+    JsonPayload = json:encode(#{
+        coords => [5, 10],
+        data => base64:encode(ChunkData)
+    }),
+    BinarySize = byte_size(BinaryEncoded),
+    JsonSize = byte_size(iolist_to_binary(JsonPayload)),
+    ?assert(BinarySize < JsonSize),
+    Savings = (1 - BinarySize / JsonSize) * 100,
+    ct:pal(
+        "Binary: ~B bytes, JSON+base64: ~B bytes, savings: ~.1f%",
+        [BinarySize, JsonSize, Savings]
+    ).
+
+%% --- Entity Deltas ---
+
+entity_deltas_roundtrip_test() ->
+    Deltas = [
+        #{op => add, entity_id => ~"player-1", fields => #{~"x" => 10, ~"y" => 20}},
+        #{op => update, entity_id => ~"player-2", fields => #{~"hp" => 50}},
+        #{op => remove, entity_id => ~"mob-99"}
+    ],
+    Encoded = asobi_ws_binary:encode_entity_deltas(42, Deltas),
+    {TickN, Decoded} = asobi_ws_binary:decode_entity_deltas(Encoded),
+    ?assertEqual(42, TickN),
+    ?assertEqual(3, length(Decoded)),
+    [D1, D2, D3] = Decoded,
+    ?assertEqual(add, maps:get(op, D1)),
+    ?assertEqual(~"player-1", maps:get(entity_id, D1)),
+    ?assertEqual(10, maps:get(~"x", maps:get(fields, D1))),
+    ?assertEqual(update, maps:get(op, D2)),
+    ?assertEqual(remove, maps:get(op, D3)),
+    ?assertEqual(false, maps:is_key(fields, D3)).
+
+entity_deltas_empty_test() ->
+    Encoded = asobi_ws_binary:encode_entity_deltas(0, []),
+    ?assertEqual({0, []}, asobi_ws_binary:decode_entity_deltas(Encoded)).
+
+entity_deltas_tlv_structure_test() ->
+    Deltas = [#{op => add, entity_id => ~"e1", fields => #{~"a" => 1}}],
+    Encoded = asobi_ws_binary:encode_entity_deltas(1, Deltas),
+    <<Type:8, _Len:32/big, _/binary>> = Encoded,
+    ?assertEqual(16#02, Type).
+
+entity_deltas_large_tick_test() ->
+    TickN = 1 bsl 48,
+    Deltas = [#{op => update, entity_id => ~"e1", fields => #{~"v" => true}}],
+    Encoded = asobi_ws_binary:encode_entity_deltas(TickN, Deltas),
+    {DecodedTick, _} = asobi_ws_binary:decode_entity_deltas(Encoded),
+    ?assertEqual(TickN, DecodedTick).
+
+entity_deltas_unicode_id_test() ->
+    Id = unicode:characters_to_binary([16#1F680, $-, $a]),
+    Deltas = [#{op => add, entity_id => Id, fields => #{}}],
+    Encoded = asobi_ws_binary:encode_entity_deltas(1, Deltas),
+    {_, [D]} = asobi_ws_binary:decode_entity_deltas(Encoded),
+    ?assertEqual(Id, maps:get(entity_id, D)).
+
+%% --- is_binary_mode ---
+
+is_binary_mode_true_test() ->
+    ?assertEqual(true, asobi_ws_binary:is_binary_mode(#{binary_protocol => true})).
+
+is_binary_mode_false_test() ->
+    ?assertEqual(false, asobi_ws_binary:is_binary_mode(#{binary_protocol => false})).
+
+is_binary_mode_missing_test() ->
+    ?assertEqual(false, asobi_ws_binary:is_binary_mode(#{})).
+
+is_binary_mode_non_boolean_test() ->
+    ?assertEqual(false, asobi_ws_binary:is_binary_mode(#{binary_protocol => ~"yes"})).

--- a/test/asobi_zone_manager_tests.erl
+++ b/test/asobi_zone_manager_tests.erl
@@ -1,0 +1,150 @@
+-module(asobi_zone_manager_tests).
+-include_lib("eunit/include/eunit.hrl").
+
+-define(BASE_OPTS, #{
+    world_id => ~"test-world",
+    grid_size => 3,
+    zone_size => 100,
+    zone_config => #{
+        world_id => ~"test-world",
+        ticker_pid => self(),
+        game_module => asobi_test_world_game
+    }
+}).
+
+setup() ->
+    case whereis(nova_scope) of
+        undefined -> pg:start_link(nova_scope);
+        _ -> ok
+    end,
+    ok.
+
+cleanup(_) ->
+    ok.
+
+start_manager() ->
+    start_manager(#{}).
+
+start_manager(Overrides) ->
+    {ok, ZoneSup} = asobi_zone_sup:start_link(),
+    unlink(ZoneSup),
+    Opts = maps:merge(?BASE_OPTS, Overrides#{zone_sup => ZoneSup}),
+    {ok, Pid} = asobi_zone_manager:start_link(Opts),
+    unlink(Pid),
+    #{mgr => Pid, zone_sup => ZoneSup}.
+
+stop_manager(#{mgr := Pid, zone_sup := ZoneSup}) ->
+    catch exit(Pid, shutdown),
+    catch exit(ZoneSup, shutdown),
+    timer:sleep(10),
+    ok.
+
+zone_manager_test_() ->
+    {setup, fun setup/0, fun cleanup/1, [
+        {"starts successfully", fun starts_ok/0},
+        {"ensure_zone creates zone on demand", fun ensure_zone_creates/0},
+        {"ensure_zone returns existing zone", fun ensure_zone_existing/0},
+        {"get_zone returns not_loaded for missing", fun get_zone_not_loaded/0},
+        {"get_zone returns pid for loaded", fun get_zone_loaded/0},
+        {"get_active_zones returns all pids", fun get_active_zones/0},
+        {"zone_terminated cleans up", fun zone_terminated_cleanup/0},
+        {"DOWN monitor cleans up", fun down_monitor_cleanup/0},
+        {"max_active_zones enforced", fun max_zones_enforced/0},
+        {"pre_warm spawns all zones", fun pre_warm_all/0},
+        {"touch_zone resets timer", fun touch_zone_resets/0},
+        {"release_zone marks stale", fun release_zone_marks_stale/0}
+    ]}.
+
+starts_ok() ->
+    Ctx = start_manager(),
+    ?assertMatch(#{mgr := Pid} when is_pid(Pid), Ctx),
+    stop_manager(Ctx).
+
+ensure_zone_creates() ->
+    Ctx = #{mgr := Mgr} = start_manager(),
+    {ok, ZonePid} = asobi_zone_manager:ensure_zone(Mgr, {0, 0}),
+    ?assert(is_pid(ZonePid)),
+    ?assert(is_process_alive(ZonePid)),
+    stop_manager(Ctx).
+
+ensure_zone_existing() ->
+    Ctx = #{mgr := Mgr} = start_manager(),
+    {ok, Pid1} = asobi_zone_manager:ensure_zone(Mgr, {1, 1}),
+    {ok, Pid2} = asobi_zone_manager:ensure_zone(Mgr, {1, 1}),
+    ?assertEqual(Pid1, Pid2),
+    stop_manager(Ctx).
+
+get_zone_not_loaded() ->
+    Ctx = #{mgr := Mgr} = start_manager(),
+    ?assertEqual(not_loaded, asobi_zone_manager:get_zone(Mgr, {2, 2})),
+    stop_manager(Ctx).
+
+get_zone_loaded() ->
+    Ctx = #{mgr := Mgr} = start_manager(),
+    {ok, ZonePid} = asobi_zone_manager:ensure_zone(Mgr, {0, 1}),
+    ?assertEqual({ok, ZonePid}, asobi_zone_manager:get_zone(Mgr, {0, 1})),
+    stop_manager(Ctx).
+
+get_active_zones() ->
+    Ctx = #{mgr := Mgr} = start_manager(),
+    {ok, P1} = asobi_zone_manager:ensure_zone(Mgr, {0, 0}),
+    {ok, P2} = asobi_zone_manager:ensure_zone(Mgr, {1, 0}),
+    Active = asobi_zone_manager:get_active_zones(Mgr),
+    ?assertEqual(2, length(Active)),
+    ?assert(lists:member(P1, Active)),
+    ?assert(lists:member(P2, Active)),
+    stop_manager(Ctx).
+
+zone_terminated_cleanup() ->
+    Ctx = #{mgr := Mgr} = start_manager(),
+    {ok, ZonePid} = asobi_zone_manager:ensure_zone(Mgr, {0, 0}),
+    exit(ZonePid, kill),
+    timer:sleep(50),
+    ?assertEqual(not_loaded, asobi_zone_manager:get_zone(Mgr, {0, 0})),
+    stop_manager(Ctx).
+
+down_monitor_cleanup() ->
+    Ctx = #{mgr := Mgr} = start_manager(),
+    {ok, ZonePid} = asobi_zone_manager:ensure_zone(Mgr, {2, 1}),
+    exit(ZonePid, kill),
+    timer:sleep(50),
+    ?assertEqual(not_loaded, asobi_zone_manager:get_zone(Mgr, {2, 1})),
+    %% Can recreate after cleanup
+    {ok, NewPid} = asobi_zone_manager:ensure_zone(Mgr, {2, 1}),
+    ?assert(is_pid(NewPid)),
+    ?assertNotEqual(ZonePid, NewPid),
+    stop_manager(Ctx).
+
+max_zones_enforced() ->
+    Ctx = #{mgr := Mgr} = start_manager(#{max_active_zones => 2}),
+    {ok, _} = asobi_zone_manager:ensure_zone(Mgr, {0, 0}),
+    {ok, _} = asobi_zone_manager:ensure_zone(Mgr, {1, 0}),
+    ?assertEqual({error, max_zones_reached}, asobi_zone_manager:ensure_zone(Mgr, {2, 0})),
+    stop_manager(Ctx).
+
+pre_warm_all() ->
+    Ctx = #{mgr := Mgr} = start_manager(#{grid_size => 2}),
+    ok = asobi_zone_manager:pre_warm(Mgr),
+    Active = asobi_zone_manager:get_active_zones(Mgr),
+    ?assertEqual(4, length(Active)),
+    ?assertMatch({ok, _}, asobi_zone_manager:get_zone(Mgr, {0, 0})),
+    ?assertMatch({ok, _}, asobi_zone_manager:get_zone(Mgr, {0, 1})),
+    ?assertMatch({ok, _}, asobi_zone_manager:get_zone(Mgr, {1, 0})),
+    ?assertMatch({ok, _}, asobi_zone_manager:get_zone(Mgr, {1, 1})),
+    stop_manager(Ctx).
+
+touch_zone_resets() ->
+    Ctx = #{mgr := Mgr} = start_manager(),
+    {ok, _} = asobi_zone_manager:ensure_zone(Mgr, {0, 0}),
+    ok = asobi_zone_manager:touch_zone(Mgr, {0, 0}),
+    timer:sleep(10),
+    ?assertMatch({ok, _}, asobi_zone_manager:get_zone(Mgr, {0, 0})),
+    stop_manager(Ctx).
+
+release_zone_marks_stale() ->
+    Ctx = #{mgr := Mgr} = start_manager(),
+    {ok, _} = asobi_zone_manager:ensure_zone(Mgr, {0, 0}),
+    ok = asobi_zone_manager:release_zone(Mgr, {0, 0}),
+    timer:sleep(10),
+    ?assertMatch({ok, _}, asobi_zone_manager:get_zone(Mgr, {0, 0})),
+    stop_manager(Ctx).

--- a/test/asobi_zone_spatial_test_game.erl
+++ b/test/asobi_zone_spatial_test_game.erl
@@ -1,0 +1,9 @@
+-module(asobi_zone_spatial_test_game).
+
+-export([zone_tick/2, handle_input/3]).
+
+zone_tick(Entities, ZoneState) ->
+    {Entities, ZoneState}.
+
+handle_input(_PlayerId, _Input, Entities) ->
+    {ok, Entities}.

--- a/test/asobi_zone_spatial_tests.erl
+++ b/test/asobi_zone_spatial_tests.erl
@@ -1,0 +1,106 @@
+-module(asobi_zone_spatial_tests).
+
+-include_lib("eunit/include/eunit.hrl").
+
+%% -------------------------------------------------------------------
+%% Helpers
+%% -------------------------------------------------------------------
+
+base_config() ->
+    %% Ensure ETS table and pg scope exist
+    ensure_ets(),
+    ensure_pg(),
+    #{
+        world_id => ~"test-world",
+        coords => {0, 0},
+        ticker_pid => self(),
+        game_module => asobi_zone_spatial_test_game
+    }.
+
+config_with_grid() ->
+    (base_config())#{spatial_grid_cell_size => 16}.
+
+ensure_ets() ->
+    case ets:info(asobi_world_state) of
+        undefined -> ets:new(asobi_world_state, [named_table, public, set]);
+        _ -> ok
+    end.
+
+ensure_pg() ->
+    case pg:start(nova_scope) of
+        {ok, _} -> ok;
+        {error, {already_started, _}} -> ok
+    end.
+
+start_zone(Config) ->
+    {ok, Pid} = asobi_zone:start_link(Config),
+    Pid.
+
+stop_zone(Pid) ->
+    gen_server:stop(Pid).
+
+%% -------------------------------------------------------------------
+%% Test game module (minimal mock)
+%% -------------------------------------------------------------------
+
+%% -------------------------------------------------------------------
+%% Tests
+%% -------------------------------------------------------------------
+
+grid_created_when_configured_test() ->
+    Pid = start_zone(config_with_grid()),
+    %% The zone should start without error; query_radius should work
+    Result = asobi_zone:query_radius(Pid, {0.0, 0.0}, 100.0),
+    ?assertEqual([], Result),
+    stop_zone(Pid).
+
+no_grid_without_config_test() ->
+    Pid = start_zone(base_config()),
+    %% query_radius should still work via fallback
+    Result = asobi_zone:query_radius(Pid, {0.0, 0.0}, 100.0),
+    ?assertEqual([], Result),
+    stop_zone(Pid).
+
+add_entity_reflected_in_grid_test() ->
+    Pid = start_zone(config_with_grid()),
+    asobi_zone:add_entity(Pid, ~"e1", #{x => 10.0, y => 10.0}),
+    timer:sleep(50),
+    Result = asobi_zone:query_radius(Pid, {10.0, 10.0}, 5.0),
+    ?assertEqual([{~"e1", {10.0, 10.0}}], Result),
+    stop_zone(Pid).
+
+remove_entity_reflected_in_grid_test() ->
+    Pid = start_zone(config_with_grid()),
+    asobi_zone:add_entity(Pid, ~"e1", #{x => 10.0, y => 10.0}),
+    timer:sleep(50),
+    asobi_zone:remove_entity(Pid, ~"e1"),
+    timer:sleep(50),
+    Result = asobi_zone:query_radius(Pid, {10.0, 10.0}, 5.0),
+    ?assertEqual([], Result),
+    stop_zone(Pid).
+
+query_radius_returns_nearby_only_test() ->
+    Pid = start_zone(config_with_grid()),
+    asobi_zone:add_entity(Pid, ~"near", #{x => 5.0, y => 5.0}),
+    asobi_zone:add_entity(Pid, ~"far", #{x => 500.0, y => 500.0}),
+    timer:sleep(50),
+    Result = asobi_zone:query_radius(Pid, {5.0, 5.0}, 10.0),
+    Ids = [Id || {Id, _} <- Result],
+    ?assertEqual([~"near"], Ids),
+    stop_zone(Pid).
+
+fallback_without_grid_test() ->
+    Pid = start_zone(base_config()),
+    asobi_zone:add_entity(Pid, ~"e1", #{x => 10.0, y => 10.0}),
+    timer:sleep(50),
+    Result = asobi_zone:query_radius(Pid, {10.0, 10.0}, 5.0),
+    ?assertEqual([{~"e1", {10.0, 10.0}}], Result),
+    stop_zone(Pid).
+
+entity_without_position_ignored_by_grid_test() ->
+    Pid = start_zone(config_with_grid()),
+    asobi_zone:add_entity(Pid, ~"nopos", #{type => ~"marker"}),
+    timer:sleep(50),
+    Result = asobi_zone:query_radius(Pid, {0.0, 0.0}, 1000.0),
+    ?assertEqual([], Result),
+    stop_zone(Pid).

--- a/test/asobi_zone_tests.erl
+++ b/test/asobi_zone_tests.erl
@@ -38,7 +38,10 @@ zone_test_() ->
         {"tick processes inputs and broadcasts deltas", fun tick_broadcasts/0},
         {"tick with no changes sends no deltas", fun tick_no_changes/0},
         {"tick acks to ticker", fun tick_acks/0},
-        {"subscriber DOWN cleans up", fun subscriber_down_cleanup/0}
+        {"subscriber DOWN cleans up", fun subscriber_down_cleanup/0},
+        {"tick touches zone_manager when subscribers present", fun tick_touches_zone_manager/0},
+        {"tick hibernates when empty", fun tick_hibernates_when_empty/0},
+        {"tick does not hibernate with NPC entities", fun tick_no_hibernate_with_npcs/0}
     ]}.
 
 starts_empty() ->
@@ -88,14 +91,16 @@ tick_broadcasts() ->
     asobi_zone:tick(Pid, 2),
     asobi_zone:tick(Pid, 3),
     receive
-        {asobi_message, {zone_delta, 3, _Deltas}} -> ok
+        {asobi_message, {zone_delta_raw, Bin}} when is_binary(Bin) ->
+            #{~"type" := ~"world.tick", ~"payload" := #{~"tick" := 3}} = json:decode(Bin),
+            ok
     after 1000 ->
         ?assert(false)
     end,
     %% Tick 4 does not broadcast (4 rem 3 = 1)
     asobi_zone:tick(Pid, 4),
     receive
-        {asobi_message, {zone_delta, 4, _}} ->
+        {asobi_message, {zone_delta_raw, _}} ->
             ?assert(false)
     after 100 ->
         ok
@@ -109,6 +114,8 @@ tick_no_changes() ->
     asobi_zone:tick(Pid, 1),
     receive
         {asobi_message, {zone_delta, 1, _}} ->
+            ?assert(false);
+        {asobi_message, {zone_delta_raw, _}} ->
             ?assert(false)
     after 100 ->
         ok
@@ -141,3 +148,64 @@ subscriber_down_cleanup() ->
     timer:sleep(50),
     ?assertEqual(0, asobi_zone:get_subscriber_count(Pid)),
     gen_server:stop(Pid).
+
+tick_touches_zone_manager() ->
+    ZMPid = start_mock_zone_manager(),
+    Pid = start_zone(#{zone_manager_pid => ZMPid}),
+    asobi_zone:subscribe(Pid, {<<"p1">>, self()}),
+    flush_messages(),
+    timer:sleep(10),
+    asobi_zone:tick(Pid, 1),
+    timer:sleep(50),
+    ZMPid ! {get_touches, self()},
+    receive
+        {touches, Touches} ->
+            ?assert(length(Touches) > 0),
+            ?assertEqual({0, 0}, hd(Touches))
+    after 1000 ->
+        ?assert(false)
+    end,
+    gen_server:stop(Pid),
+    ZMPid ! stop.
+
+tick_hibernates_when_empty() ->
+    Pid = start_zone(),
+    asobi_zone:tick(Pid, 1),
+    timer:sleep(50),
+    {current_function, {Mod, Fun, _}} = erlang:process_info(Pid, current_function),
+    HibernateStr = atom_to_list(Fun),
+    ?assert(
+        string:find(HibernateStr, "hibernate") =/= nomatch,
+        lists:flatten(io_lib:format("expected hibernate, got ~p:~p", [Mod, Fun]))
+    ),
+    gen_server:stop(Pid).
+
+tick_no_hibernate_with_npcs() ->
+    Pid = start_zone(),
+    asobi_zone:add_entity(Pid, <<"npc1">>, #{type => ~"npc", x => 0, y => 0}),
+    timer:sleep(10),
+    asobi_zone:tick(Pid, 1),
+    timer:sleep(50),
+    {current_function, CF} = erlang:process_info(Pid, current_function),
+    ?assertNotEqual({erlang, hibernate, 3}, CF),
+    gen_server:stop(Pid).
+
+start_mock_zone_manager() ->
+    spawn(fun() -> mock_zm_loop([]) end).
+
+mock_zm_loop(Touches) ->
+    receive
+        {'$gen_cast', {touch_zone, Coords}} ->
+            mock_zm_loop([Coords | Touches]);
+        {get_touches, From} ->
+            From ! {touches, Touches},
+            mock_zm_loop(Touches);
+        stop ->
+            ok
+    end.
+
+flush_messages() ->
+    receive
+        _ -> flush_messages()
+    after 0 -> ok
+    end.


### PR DESCRIPTION
## Summary

Scales the world server to handle large tile-based MMOs (128K x 128K+ tiles, 500+ players per shard). Validated with a 5-minute benchmark of 500 real WebSocket players on a 2000x2000 zone grid: 6.4M messages, 9.88 GB of delta updates, zero failures.

## Key additions

- **Lazy zone loading** — on-demand zone spawn, idle reaping. 4M potential zones → only ~1000 alive at peak.
- **Terrain system** — `asobi_terrain` encoding, `asobi_terrain_provider` behaviour, `asobi_terrain_store` cache. Serves 2-4KB compressed chunks on zone subscribe.
- **Spatial grid index** — O(1) cell lookup for entity queries in dense zones.
- **Performance optimisations** — broadcast batching (encode once, send to N), adaptive tick rates (hot/cold/empty), opt-in binary protocol (~25% bandwidth savings).
- **New callbacks** — `terrain_provider/1`, `on_zone_loaded/2`, `on_zone_unloaded/2`.

## Benchmark results (500 players, 2000x2000 grid, 5 min)

- 500/500 players connected with zero join errors
- 17,850 msg/sec avg, 22,722 peak
- 9.88 GB of real WebSocket traffic
- Peak memory: 208 MB (single node)
- Peak processes: 1,073 (out of 4M possible zones)
- Connection time p99: 57ms under full load

## Test plan

- [ ] All 230 existing tests pass
- [ ] 65+ new tests covering terrain, zone manager, spatial grid, broadcast batching, adaptive ticks, binary protocol
- [ ] End-to-end integration test verifies terrain serving chain
- [ ] Benchmark project at widgrensit/asobi_bench validates real WebSocket performance

## Related

- widgrensit/asobi_lua#4 — Lua API for the new features
- widgrensit/asobi_bench — standalone load benchmark (private)