### PR TITLE
docs: fix quickstart (sys.config + rebar3 new app)

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,7 +156,7 @@ For Erlang/OTP developers who want full control, add asobi as a dependency:
 
 ```erlang
 {deps, [
-    {asobi, "~> 0.1"}
+    {asobi, "~> 0.25"}
 ]}.
 ```
 
@@ -204,7 +204,7 @@ Register it in `sys.config` and start with `rebar3 shell`. See the [Getting Star
 
 ## Status
 
-Asobi is in **public preview (v0.1)** — fully open-source, API stabilising.
+Asobi is in **public preview** — fully open-source, API stabilising.
 Early-adopter friendly; expect to read code occasionally.
 
 | Area                         | Status     |

--- a/guides/getting-started.md
+++ b/guides/getting-started.md
@@ -139,7 +139,7 @@ For Erlang developers who want full control.
 ### 1. Create a New Project
 
 ```bash
-rebar3 new nova my_game
+rebar3 new app my_game
 cd my_game
 ```
 
@@ -147,8 +147,14 @@ Add asobi to your dependencies in `rebar.config`:
 
 ```erlang
 {deps, [
-    {asobi, {git, "https://github.com/widgrensit/asobi.git", {branch, "main"}}}
+    {asobi, "~> 0.25"}
 ]}.
+```
+
+Point rebar3 at a `sys.config` for the shell (added below):
+
+```erlang
+{shell, [{config, "./config/sys.config"}]}.
 ```
 
 ### 2. Configure the Database
@@ -159,21 +165,19 @@ Create a PostgreSQL database:
 createdb my_game_dev
 ```
 
-Add configuration to your `sys.config`:
+Create `config/sys.config`. Asobi is hosted by Nova, so Nova needs to be
+told to bootstrap the `asobi` application, which plugins to run, and
+which `pg` scopes to register. `shigoto` (background jobs) needs to know
+which DB pool to use, and `kura` needs the connection details:
 
 ```erlang
 [
-    {kura, [
-        {repo, asobi_repo},
-        {host, "localhost"},
-        {database, "my_game_dev"},
-        {user, "postgres"},
-        {password, "postgres"}
-    ]},
-    {shigoto, [
-        {pool, asobi_repo}
-    ]},
-    {asobi, [
+    {nova, [
+        {environment, dev},
+        {dev_mode, true},
+        {bootstrap_application, asobi},
+        {json_lib, json},
+        {cowboy_configuration, #{port => 8080}},
         {plugins, [
             {pre_request, nova_request_plugin, #{
                 decode_json_body => true,
@@ -181,7 +185,23 @@ Add configuration to your `sys.config`:
             }},
             {pre_request, nova_cors_plugin, #{allow_origins => <<"*">>}},
             {pre_request, nova_correlation_plugin, #{}}
-        ]},
+        ]}
+    ]},
+    {kura, [
+        {repo, asobi_repo},
+        {host, "localhost"},
+        {port, 5432},
+        {database, "my_game_dev"},
+        {user, "postgres"},
+        {password, "postgres"},
+        {pool_size, 10}
+    ]},
+    {shigoto, [
+        {pool, asobi_repo},
+        {poll_interval, 200},
+        {queues, [{~"default", 10}]}
+    ]},
+    {asobi, [
         {game_modes, #{
             ~"my_mode" => my_game
         }},
@@ -193,9 +213,15 @@ Add configuration to your `sys.config`:
             token_ttl => 900,
             refresh_ttl => 2592000
         }}
-    ]}
+    ]},
+    {pg, [{scope, [nova_scope, asobi_presence, asobi_chat]}]}
 ].
 ```
+
+> **Why `{bootstrap_application, asobi}`?** Nova is a web framework that
+> hosts one or more applications. Without this key Nova doesn't know
+> which app owns its router, and the release dies at boot with
+> `{error, no_nova_app_defined}`.
 
 ### 3. Start the Server
 


### PR DESCRIPTION
## Summary
Companion to widgrensit/asobi_lua#7. Both together close blockers #1–#3 from the first-user onboarding audit.

- **guides/getting-started.md** said \`rebar3 new nova my_game\` which silently requires a user-installed template — readers without it hit \`Unknown template: nova\` in the first 30 seconds. Switched to \`rebar3 new app my_game\` so vanilla rebar3 works.
- **sys.config example was broken**: missing \`{bootstrap_application, asobi}\` (Nova dies with \`no_nova_app_defined\` without it), \`dev_mode\`, \`json_lib\`, \`cowboy_configuration\`, a proper \`shigoto\` pool + queues config, and the \`pg\` scope list. Plugins were nested under \`{asobi, ...}\` when they belong under \`{nova, ...}\`. Added a one-line note explaining \`bootstrap_application\` so readers don't learn it the hard way.
- **README pin** \`{asobi, "~> 0.1"}\` → \`{asobi, "~> 0.25"}\` (Hex is on 0.25.0). \`"public preview (v0.1)"\` → \`"public preview"\`.

## What we left alone
- \`matchmaking.\` vs \`matchmaker.\` WS topic names — the agent's report flagged a possible inconsistency but on inspection the code, \`websocket-protocol.md\` and all \`guides/*.md\` already use \`matchmaker.\*\` correctly.

## Test plan
- [x] Erlang quickstart config reviewed against the working asobi_lua sys.config
- [ ] Run-through on a clean machine once \`{asobi, "~> 0.25"}\` resolves from Hex and asobi_lua#7 is merged