### PR TITLE
docs: pre-launch audit cleanup — drop fictional APIs, fix REST routes

### DIFF
--- a/guides/authentication.md
+++ b/guides/authentication.md
@@ -10,7 +10,7 @@ Players can link multiple providers to a single account.
 The simplest method. Register and login to receive a session token:
 
 ```bash
-curl -X POST http://localhost:8082/api/v1/auth/register \
+curl -X POST http://localhost:8080/api/v1/auth/register \
   -H 'Content-Type: application/json' \
   -d '{"username": "player1", "password": "secret123"}'
 ```
@@ -47,7 +47,7 @@ POST /api/v1/auth/oauth
 ### Example
 
 ```bash
-curl -X POST http://localhost:8082/api/v1/auth/oauth \
+curl -X POST http://localhost:8080/api/v1/auth/oauth \
   -H 'Content-Type: application/json' \
   -d '{"provider": "google", "token": "eyJhbGciOiJSUzI1NiIs..."}'
 ```
@@ -117,7 +117,7 @@ Steam uses session tickets instead of OIDC. The game client obtains a ticket
 via `ISteamUser::GetAuthSessionTicket` and sends the hex-encoded ticket.
 
 ```bash
-curl -X POST http://localhost:8082/api/v1/auth/oauth \
+curl -X POST http://localhost:8080/api/v1/auth/oauth \
   -H 'Content-Type: application/json' \
   -d '{"provider": "steam", "token": "14000000..."}'
 ```
@@ -147,7 +147,7 @@ the same player).
 Requires an authenticated session.
 
 ```bash
-curl -X POST http://localhost:8082/api/v1/auth/link \
+curl -X POST http://localhost:8080/api/v1/auth/link \
   -H 'Authorization: Bearer <session_token>' \
   -H 'Content-Type: application/json' \
   -d '{"provider": "discord", "token": "eyJhbGciOi..."}'
@@ -162,7 +162,7 @@ curl -X POST http://localhost:8082/api/v1/auth/link \
 Asobi prevents unlinking the last auth method to avoid locking the player out.
 
 ```bash
-curl -X DELETE http://localhost:8082/api/v1/auth/unlink \
+curl -X DELETE http://localhost:8080/api/v1/auth/unlink \
   -H 'Authorization: Bearer <session_token>' \
   -H 'Content-Type: application/json' \
   -d '{"provider": "discord"}'

--- a/guides/configuration.md
+++ b/guides/configuration.md
@@ -115,12 +115,8 @@ Shorthand (Erlang module only):
 
 ## Sessions
 
-```erlang
-{session, #{
-    token_ttl => 900,          %% access token lifetime in seconds (default 15 min)
-    refresh_ttl => 2592000     %% refresh token lifetime in seconds (default 30 days)
-}}
-```
+Session token lifetime is handled by Nova's `nova_auth_session` — configure
+there (not under `asobi`). See the Nova docs for token/refresh TTL settings.
 
 ## Rate Limiting
 
@@ -139,11 +135,16 @@ Default: 300 requests per second for all groups.
 
 ## CORS
 
-```erlang
-{cors_allow_origins, ~"https://mygame.com"}
-```
+CORS is handled by `nova_cors_plugin` in the Nova plugin chain — configure
+it under `{nova, [{plugins, [...]}]}`:
 
-Default: `"*"` (allow all origins). Set to your domain in production.
+```erlang
+{nova, [
+    {plugins, [
+        {pre_request, nova_cors_plugin, #{allow_origins => ~"https://mygame.com"}}
+    ]}
+]}
+```
 
 ## Clustering
 
@@ -265,11 +266,6 @@ Database configuration is under the `kura` application key:
         {pool, asobi_repo}
     ]},
     {asobi, [
-        {cors_allow_origins, ~"*"},
-        {session, #{
-            token_ttl => 900,
-            refresh_ttl => 2592000
-        }},
         {rate_limits, #{
             auth => #{limit => 10, window => 60000},
             api => #{limit => 300, window => 1000}

--- a/guides/economy.md
+++ b/guides/economy.md
@@ -103,13 +103,16 @@ programmatically:
 
 ```erlang
 %% Grant currency
-asobi_economy:credit(PlayerId, ~"gold", 100, #{reason => match_reward}).
+asobi_economy:grant(PlayerId, ~"gold", 100, #{reason => ~"match_reward"}).
 
 %% Debit currency
-asobi_economy:debit(PlayerId, ~"gold", 50, #{reason => store_purchase}).
+asobi_economy:debit(PlayerId, ~"gold", 50, #{reason => ~"store_purchase"}).
 
-%% Grant item
-asobi_economy:grant_item(PlayerId, ~"sword_of_fire", 1).
+%% Read a wallet (creates one with balance 0 if missing)
+{ok, #{balance := Bal}} = asobi_economy:get_or_create_wallet(PlayerId, ~"gold").
+
+%% Purchase a store listing (atomically debits wallet and grants item)
+{ok, _} = asobi_economy:purchase(PlayerId, ListingId).
 ```
 
 All economy operations use ACID transactions to prevent double-spending

--- a/guides/iap.md
+++ b/guides/iap.md
@@ -20,7 +20,7 @@ POST /api/v1/iap/apple
 ### Example
 
 ```bash
-curl -X POST http://localhost:8082/api/v1/iap/apple \
+curl -X POST http://localhost:8080/api/v1/iap/apple \
   -H 'Authorization: Bearer <session_token>' \
   -H 'Content-Type: application/json' \
   -d '{"signed_transaction": "eyJhbGciOi..."}'
@@ -82,7 +82,7 @@ POST /api/v1/iap/google
 ### Example
 
 ```bash
-curl -X POST http://localhost:8082/api/v1/iap/google \
+curl -X POST http://localhost:8080/api/v1/iap/google \
   -H 'Authorization: Bearer <session_token>' \
   -H 'Content-Type: application/json' \
   -d '{

--- a/guides/lua-bots.md
+++ b/guides/lua-bots.md
@@ -31,39 +31,40 @@ Enable bots in your game mode configuration:
 
 ## Lua Bot Scripts
 
-Bot scripts implement a `bot_tick` callback that runs each tick:
+Bot scripts implement a top-level `think` callback that runs each bot tick.
+It receives the bot's own ID and the latest match state for that bot and
+returns an input table (or an empty table to skip the tick):
 
 ```lua
-function bot_tick(bot_id, state, entities)
-    -- Find nearest player
+function think(bot_id, state)
+    local players = state.players or {}
+    local me = players[bot_id]
+    if not me then return {} end
+
+    -- Find nearest other player
     local target = nil
     local min_dist = math.huge
-
-    for id, entity in pairs(entities) do
-        if entity.type == "player" and id ~= bot_id then
-            local dx = entity.x - state.x
-            local dy = entity.y - state.y
+    for id, p in pairs(players) do
+        if id ~= bot_id then
+            local dx = p.x - me.x
+            local dy = p.y - me.y
             local dist = math.sqrt(dx * dx + dy * dy)
             if dist < min_dist then
                 min_dist = dist
-                target = entity
+                target = p
             end
         end
     end
 
-    -- Move towards target
     if target then
-        local dx = target.x - state.x
-        local dy = target.y - state.y
-        local len = math.sqrt(dx * dx + dy * dy)
         return {
-            action = "move",
-            x = state.x + (dx / len) * 2.0,
-            y = state.y + (dy / len) * 2.0
+            right = target.x > me.x,
+            left  = target.x < me.x,
+            up    = target.y < me.y,
+            down  = target.y > me.y,
         }
     end
-
-    return nil
+    return {}
 end
 ```
 

--- a/guides/lua-scripting.md
+++ b/guides/lua-scripting.md
@@ -30,7 +30,10 @@ function join(player_id, state)
     return state
 end
 
-function tick(tick_n, state, players)
+function tick(state)
+    -- To finish the match, set reserved keys on the state and return it:
+    --   state._finished = true
+    --   state._result   = { winner = "..." }
     return state
 end
 
@@ -74,11 +77,11 @@ The `game.*` namespace provides access to engine features from Lua:
 | Function | Description |
 |----------|-------------|
 | `game.id()` | Generate a unique ID |
-| `game.broadcast(event, data)` | Broadcast to all players |
-| `game.send(player_id, event, data)` | Send to a specific player |
+| `game.broadcast(event, payload)` | Broadcast to all players |
+| `game.send(player_id, message)` | Send to a specific player |
 | `game.economy.grant(player, currency, amount, reason)` | Grant currency |
 | `game.economy.debit(player, currency, amount, reason)` | Debit currency |
-| `game.economy.balance(player, currency)` | Check balance |
+| `game.economy.balance(player_id)` | Return the player's full wallet list |
 | `game.economy.purchase(player, listing_id)` | Purchase store item |
 | `game.leaderboard.submit(board, player, score)` | Submit score |
 | `game.leaderboard.top(board, limit)` | Get top scores |

--- a/guides/matchmaking.md
+++ b/guides/matchmaking.md
@@ -1,15 +1,15 @@
 # Matchmaking
 
-Asobi includes a query-based matchmaker that runs as a periodic tick via
-the `asobi_matchmaker` gen_server.
+Asobi ships a periodic-tick matchmaker (`asobi_matchmaker` gen_server) that
+groups tickets into matches using a per-mode strategy module.
 
 ## How It Works
 
-1. Player submits a matchmaking ticket with properties and a query
-2. Matchmaker ticks periodically (default every 1 second)
-3. Each tick groups tickets by mode/region, finds mutually compatible pairs
-4. When enough compatible players are found, a match is spawned
-5. Players are notified via WebSocket (`matchmaker.matched`)
+1. Player submits a matchmaking ticket with a mode, optional properties, and an optional party.
+2. Matchmaker ticks periodically (default every 1 second).
+3. Each tick groups tickets by mode, and the mode's strategy module decides which tickets form a match.
+4. When a group is formed, a match is spawned.
+5. Players are notified via WebSocket (`matchmaker.matched`).
 
 ## Submitting a Ticket
 
@@ -21,8 +21,7 @@ curl -X POST http://localhost:8080/api/v1/matchmaker \
   -H 'Content-Type: application/json' \
   -d '{
     "mode": "arena",
-    "properties": {"skill": 1200, "region": "eu-west"},
-    "query": "+region:eu-west skill:>=1000 skill:<=1400"
+    "properties": {"skill": 1200, "region": "eu-west"}
   }'
 ```
 
@@ -33,31 +32,58 @@ curl -X POST http://localhost:8080/api/v1/matchmaker \
   "type": "matchmaker.add",
   "payload": {
     "mode": "arena",
-    "properties": {"skill": 1200, "region": "eu-west"},
-    "query": "+region:eu-west skill:>=1000 skill:<=1400"
+    "properties": {"skill": 1200, "region": "eu-west"}
   }
 }
 ```
 
-## Query Language
+A ticket currently supports `mode`, `properties`, and `party`. A
+query-language extension (numeric ranges, required keys, automatic skill
+window expansion) is on the roadmap but not shipped — do that filtering
+inside your strategy module instead.
 
-Tickets include a query that specifies what opponents the player will accept.
-Both players must match each other's query for a pairing to form.
+## Strategies
 
+Strategy is selected per mode via the `strategy` key in `game_modes`. Two
+are built in:
+
+- `fill` (default) — first-come-first-matched, groups players in submission
+  order until `match_size` is reached.
+- `skill_based` — sorts tickets by `properties.skill` and pairs within an
+  expanding window (configurable via `skill_window` and
+  `skill_expand_rate`).
+
+## Custom Strategies
+
+Implement `asobi_matchmaker_strategy` (a single `match/2` callback):
+
+```erlang
+-module(my_matchmaker).
+-behaviour(asobi_matchmaker_strategy).
+
+-export([match/2]).
+
+-spec match([map()], map()) -> {[[map()]], [map()]}.
+match(Tickets, Config) ->
+    Size = maps:get(match_size, Config, 4),
+    %% Return {Matched, Unmatched}, where Matched is a list of
+    %% groups (each group a list of tickets that form a match).
+    group_by_size(Tickets, Size).
 ```
-+region:eu-west mode:ranked skill:>=800 skill:<=1200
+
+Wire it up per mode:
+
+```erlang
+{asobi, [
+    {game_modes, #{
+        ~"ranked" => #{
+            module     => my_arena,
+            match_size => 4,
+            strategy   => my_matchmaker
+        }
+    }}
+]}
 ```
-
-- `key:value` -- exact match
-- `+key:value` -- required (must match)
-- `key:>=N` / `key:<=N` -- numeric range
-- Multiple conditions are AND-ed
-
-## Skill Window Expansion
-
-When a player waits too long, the matchmaker automatically widens the skill
-window. Each tick increments the `expansion_level` for unfilled tickets,
-relaxing numeric range constraints.
 
 ## Configuration
 
@@ -80,8 +106,7 @@ Players can queue as a party. All party members are placed in the same match:
   "payload": {
     "mode": "arena",
     "party": ["player_id_2", "player_id_3"],
-    "properties": {"skill": 1200},
-    "query": "skill:>=1000 skill:<=1400"
+    "properties": {"skill": 1200}
   }
 }
 ```

--- a/guides/rest-api.md
+++ b/guides/rest-api.md
@@ -7,9 +7,12 @@ Authenticated endpoints require the `Authorization: Bearer <session_token>` head
 ## Auth
 
 ```
-POST /api/v1/auth/register     Register a new player
-POST /api/v1/auth/login        Login, returns session token
-POST /api/v1/auth/refresh      Refresh session token
+POST   /api/v1/auth/register     Register a new player
+POST   /api/v1/auth/login        Login, returns session token
+POST   /api/v1/auth/refresh      Refresh session token
+POST   /api/v1/auth/oauth        OAuth / Steam token validation
+POST   /api/v1/auth/link         Link a provider to the current account
+DELETE /api/v1/auth/unlink       Unlink a provider
 ```
 
 ### Register
@@ -46,15 +49,19 @@ PUT /api/v1/players/:id        Update own profile
 ## Social
 
 ```
-GET    /api/v1/friends                List friends
-POST   /api/v1/friends                Send friend request
-PUT    /api/v1/friends/:id            Accept/reject/block
-DELETE /api/v1/friends/:id            Remove friend
+GET    /api/v1/friends                               List friends
+POST   /api/v1/friends                               Send friend request
+PUT    /api/v1/friends/:friend_id                    Accept/reject/block
+DELETE /api/v1/friends/:friend_id                    Remove friend
 
-POST   /api/v1/groups                 Create group
-GET    /api/v1/groups/:id             Get group
-POST   /api/v1/groups/:id/join        Join group
-POST   /api/v1/groups/:id/leave       Leave group
+POST   /api/v1/groups                                Create group
+GET    /api/v1/groups/:id                            Get group
+PUT    /api/v1/groups/:id                            Update group
+POST   /api/v1/groups/:id/join                       Join group
+POST   /api/v1/groups/:id/leave                      Leave group
+GET    /api/v1/groups/:id/members                    List group members
+PUT    /api/v1/groups/:id/members/:player_id/role    Update member role
+DELETE /api/v1/groups/:id/members/:player_id         Kick member
 ```
 
 ## Economy
@@ -66,6 +73,9 @@ GET  /api/v1/store                     List store catalog
 POST /api/v1/store/purchase            Purchase item
 GET  /api/v1/inventory                 List player items
 POST /api/v1/inventory/consume         Consume item
+
+POST /api/v1/iap/apple                 Validate an Apple receipt
+POST /api/v1/iap/google                Validate a Google Play receipt
 ```
 
 ## Leaderboards
@@ -115,6 +125,13 @@ Real-time chat messages are sent and received over WebSocket.
 GET    /api/v1/notifications           List notifications (paginated)
 PUT    /api/v1/notifications/:id/read  Mark as read
 DELETE /api/v1/notifications/:id       Delete notification
+```
+
+## Direct messages
+
+```
+POST /api/v1/dm                        Send a direct message
+GET  /api/v1/dm/:player_id/history     DM history with a player
 ```
 
 ## Storage

--- a/guides/voting.md
+++ b/guides/voting.md
@@ -386,7 +386,7 @@ A player has vetoed the vote (when `veto_enabled` is true).
 ### List votes for a match
 
 ```bash
-curl http://localhost:8082/api/v1/matches/<match_id>/votes \
+curl http://localhost:8080/api/v1/matches/<match_id>/votes \
   -H 'Authorization: Bearer <token>'
 ```
 
@@ -395,7 +395,7 @@ Returns the most recent 50 votes for the match, ordered by newest first.
 ### Get a single vote
 
 ```bash
-curl http://localhost:8082/api/v1/votes/<vote_id> \
+curl http://localhost:8080/api/v1/votes/<vote_id> \
   -H 'Authorization: Bearer <token>'
 ```
 


### PR DESCRIPTION
## Summary

Pre-launch docs audit found ~40 defects across the docs. This PR covers the library-guide side (asobi_site gets the same treatment in widgrensit/asobi_site#32).

## What changed
- Lua match `tick(state)` — fixed the guide that showed the wrong arity.
- Lua end-of-match idiom: `state._finished = true` + `state._result = R`, return state. Returning `{finished = true, ...}` silently did nothing.
- `game.send(player_id, message)` takes a single payload.
- `game.economy.balance(player_id)` returns the full wallet list (no (player, currency) form).
- Bots: the real callback is top-level `think(bot_id, state)`, not `bot_tick(bot_id, state, entities)`.
- Economy: dropped `asobi_economy:credit/4` and `asobi_economy:grant_item/3` (neither exists); pointed at `grant/4` / `get_or_create_wallet/2` / `purchase/2`.
- Matchmaking: removed the entire query-language section (+key:value / key:>=N / `query` field / `expansion_level`) — not implemented. Rewrote custom-strategy example against the real `asobi_matchmaker_strategy` behaviour (`match/2` callback). Strategy is per-mode via `game_modes`.
- Configuration: removed `{session, ...}` (not read; Nova handles it) and top-level `{cors_allow_origins, ...}` (CORS lives in the `nova_cors_plugin` entry under `{nova, [{plugins, ...}]}`).
- REST routes: IAP paths drop `/validate`, friends use `:friend_id`, added missing group routes (PUT, members list, member role, member kick), added DM section, added full auth route list.
- All curl examples use `localhost:8080` (not 8082).

Commits split by concern (Lua systemic, config/matchmaking rewrites, REST routes) so reviewers can cherry-pick.

## Test plan
- [ ] Render the guides (`rebar3 ex_doc` or equivalent) and spot-check the touched files render cleanly.