### PR TITLE
docs: rewrite README + add Hathora migration guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,247 +1,117 @@
 <p align="center">
-  <img src="docs/logo.png" alt="Asobi" width="420">
+  <img src="docs/logo.png" alt="asobi" height="96">
+</p>
+
+<h1 align="center">asobi</h1>
+
+<p align="center">
+  <b>Multiplayer game backend on Erlang/OTP. Hot-reloadable, Apache-2.</b>
 </p>
 
 <p align="center">
   <a href="https://hex.pm/packages/asobi"><img alt="Hex.pm" src="https://img.shields.io/hexpm/v/asobi.svg"></a>
+  <a href="https://hexdocs.pm/asobi"><img alt="Hexdocs" src="https://img.shields.io/badge/hex-docs-green"></a>
   <a href="https://github.com/widgrensit/asobi/actions/workflows/ci.yml"><img alt="CI" src="https://github.com/widgrensit/asobi/actions/workflows/ci.yml/badge.svg"></a>
   <a href="LICENSE"><img alt="License" src="https://img.shields.io/badge/license-Apache--2.0-blue.svg"></a>
 </p>
 
 <p align="center">
-  <strong>Multiplayer game backend on Erlang/OTP.</strong><br>
-  Per-match supervision. Hot-reloadable Lua. Zero-downtime deploys. 100K+ connections per node.
+  <a href="https://asobi.dev/docs">Docs</a> •
+  <a href="https://asobi.dev/demo">Live demo</a> •
+  <a href="https://discord.gg/vYSfYYyXpu">Discord</a> •
+  <a href="https://github.com/widgrensit/asobi/issues">Issues</a>
 </p>
 
-<p align="center">
-  <a href="https://play.asobi.dev">
-    <img src="docs/arena-demo.gif" alt="Asobi Arena Demo" width="640">
-  </a>
-  <br>
-  <em><a href="https://play.asobi.dev">Try the live demo</a> · <a href="https://asobi.dev">asobi.dev</a></em>
-</p>
+---
 
-## Why Asobi
+## Two ways to use asobi
 
-The BEAM VM was built for telecoms switches handling millions of concurrent
-connections with soft real-time guarantees. That turns out to be the exact
-shape of a multiplayer game backend.
+**Write your game in Lua** — use the [**asobi_lua**](https://github.com/widgrensit/asobi_lua)
+Docker runtime. One container, hot-reloadable Lua match scripts, batteries
+included. No Erlang required. **This is what most people want.**
 
-- **Each match is an OTP process** — crashes restart in milliseconds without
-  touching the neighbours. No stop-the-world GC pauses affecting other players.
-- **Lua scripting with hot reload** — edit your match module, save, watch the
-  server pick it up live. No container rebuilds, no reconnects.
-- **Zero-downtime deploys** — rolling releases via standard OTP release
-  handling. Players keep playing through the upgrade.
-- **Single-node capacity** — one machine comfortably holds 100K+ WebSocket
-  connections, so "scale" usually means "shard by game", not "rebuild for
-  Kubernetes".
-- **No external state stores** — ETS replaces Redis for hot state; OTP `pg`
-  replaces Redis pub/sub. One release, one PostgreSQL, done.
-
-## How Asobi compares
-
-|                      | **Asobi**                  | Nakama            | Colyseus        | SpacetimeDB      |
-| -------------------- | -------------------------- | ----------------- | --------------- | ---------------- |
-| Runtime              | BEAM (Erlang/OTP)          | Go                | Node.js         | Rust + WASM      |
-| GC model             | Per-process, isolated      | Stop-the-world    | Stop-the-world  | Custom           |
-| Fault tolerance      | OTP supervision trees      | Manual recovery   | Manual recovery | Transactional    |
-| Pub/Sub              | Built-in (`pg`)            | Requires Redis    | Built-in        | Built-in         |
-| Connections / node   | 100K+                      | ~50K              | ~10K            | ~10K             |
-| Hot reload           | Yes (Lua + Erlang modules) | Lua/TypeScript    | TypeScript      | No               |
-| Scripting            | Lua (Luerl, in-VM)         | Lua / JS / Go     | JS / TS         | Rust / C#        |
-| License              | Apache-2.0                 | Apache-2.0 / BSL  | MIT             | BSL              |
-
-## Features
-
-- **Authentication** — register, login, session tokens via [nova_auth](https://github.com/novaframework/nova_auth)
-- **Player management** — profiles, stats, metadata
-- **Real-time multiplayer** — WebSocket transport, server-authoritative game loop with configurable tick rate
-- **Matchmaking** — pluggable strategies (fill, skill-based) with query windows and party support
-- **Leaderboards** — ETS for microsecond reads, PostgreSQL for persistence
-- **Virtual economy** — wallets, transactions, item definitions, store, inventory
-- **Social** — friends, groups/guilds, chat channels, presence, notifications
-- **Tournaments** — scheduled competitions with entry fees and rewards
-- **Cloud saves** — per-slot save data with optimistic concurrency
-- **Generic storage** — key-value storage with permissions (public/owner/none)
-- **Background jobs** — powered by [Shigoto](https://github.com/Taure/shigoto)
-- **Admin dashboard** — real-time console via [Arizona](https://github.com/novaframework/arizona_core)
-
-## Quick start with Lua (Docker)
-
-No Erlang needed. Just Lua scripts and Docker.
-
-```bash
-mkdir my_game && cd my_game
-mkdir -p lua/bots
-```
-
-Write your game logic in Lua:
-
-```lua
--- lua/match.lua
-match_size = 2
-max_players = 4
-strategy = "fill"
-
-function init(config)
-    return { players = {} }
-end
-
-function join(player_id, state)
-    state.players[player_id] = { x = 400, y = 300, hp = 100 }
-    return state
-end
-
-function leave(player_id, state)
-    state.players[player_id] = nil
-    return state
-end
-
-function handle_input(player_id, input, state)
-    local p = state.players[player_id]
-    if not p then return state end
-    if input.right then p.x = p.x + 5 end
-    if input.left  then p.x = p.x - 5 end
-    return state
-end
-
-function tick(state)
-    return state
-end
-
-function get_state(player_id, state)
-    return { players = state.players }
-end
-```
-
-Add a `docker-compose.yml`:
-
-```yaml
-services:
-  postgres:
-    image: postgres:16
-    environment:
-      POSTGRES_USER: postgres
-      POSTGRES_PASSWORD: postgres
-      POSTGRES_DB: my_game_dev
-    healthcheck:
-      test: ["CMD-SHELL", "pg_isready -U postgres"]
-      interval: 5s
-      timeout: 5s
-      retries: 5
-
-  asobi:
-    image: ghcr.io/widgrensit/asobi_lua:latest
-    depends_on:
-      postgres: { condition: service_healthy }
-    ports:
-      - "8080:8080"
-    volumes:
-      - ./lua:/app/game:ro
-    environment:
-      ASOBI_DB_HOST: postgres
-      ASOBI_DB_NAME: my_game_dev
-```
-
-```bash
-docker compose up -d
-```
-
-Your game backend is running — authentication, matchmaking, WebSocket transport, and everything else handled by Asobi.
-
-## Quick start with Erlang
-
-For Erlang/OTP developers who want full control, add asobi as a dependency:
+**Write your game in Erlang** — depend on this library directly. You get the
+same match supervisor, matchmaker, leaderboards, economy, world server, and
+voting primitives, implemented as OTP behaviours you compose with the rest of
+your release.
 
 ```erlang
+%% rebar.config
 {deps, [
-    {asobi, "~> 0.25"}
+    {asobi, "~> 0.1"}
 ]}.
 ```
 
-Implement the `asobi_match` behaviour:
+## Features
 
-```erlang
--module(my_arena_game).
--behaviour(asobi_match).
+- **`asobi_match`** — behaviour for per-match logic, backed by a supervised `gen_server` with ETS state backup on crash.
+- **`asobi_matchmaker`** — pluggable strategies (`fill`, `skill_based`); your own via the `asobi_matchmaker_strategy` behaviour.
+- **`asobi_world_server`** — persistent worlds with lazy zones, spatial grid indexing, terrain chunk serving, adaptive tick rates.
+- **`asobi_vote_server`** — plurality, ranked choice, approval, weighted. Fixed / ready-up / hybrid / adaptive windows. Spectator voting, veto tokens, majority-tyranny mitigations.
+- **`asobi_phase`, `asobi_season_manager`, `asobi_timer`** — phase engine, season lifecycles, five timer primitives.
+- **Rate limiting** via `seki` (sliding window, per route group), **sessions** cached in ETS, **presence** via `pg`, **chat / social / economy / inventory / storage / tournaments / notifications** as Nova controllers.
+- **Client SDKs** for Godot, Defold, Unity, Unreal, JS/TS, Dart, Flame — [see below](#client-sdks).
 
--export([init/1, join/2, leave/2, handle_input/3, tick/1, get_state/2]).
+## Benchmarks
 
-init(_Config) ->
-    {ok, #{players => #{}}}.
+Single node, 8 cores, same-machine client. See [guides/benchmarks.md](guides/benchmarks.md) for full numbers.
 
-join(PlayerId, #{players := Players} = State) ->
-    {ok, State#{players => Players#{PlayerId => #{x => 0, y => 0}}}}.
+| | Peak |
+|---|---|
+| WebSocket throughput | **83,000 msg/sec** @ 3,500 concurrent connections |
+| RTT p50 / p99 | 4.4 ms / 6.5 ms |
+| REST reads (matches / friends / wallets) | 7–14 ms p50 |
+| Memory per connection | ~15 KB |
 
-leave(PlayerId, #{players := Players} = State) ->
-    {ok, State#{players => maps:remove(PlayerId, Players)}}.
+Not a twitch-FPS backend — WebSocket/TCP has a latency floor. Excellent for
+turn-based, casual, MMO zone, roguelike, co-op, and party games. Pair with a
+UDP relay if you need sub-3ms physics.
 
-handle_input(_PlayerId, _Input, State) ->
-    {ok, State}.
+## Client SDKs
 
-tick(State) ->
-    {ok, State}.
-
-get_state(_PlayerId, #{players := Players}) ->
-    Players.
-```
-
-Register it in `sys.config` and start with `rebar3 shell`. See the [Getting Started](guides/getting-started.md) guide for the full walkthrough.
-
-## Stack
-
-| Layer             | Technology                                                          |
-| ----------------- | ------------------------------------------------------------------- |
-| HTTP / REST       | [Nova](https://github.com/novaframework/nova) (Cowboy)              |
-| WebSocket         | Nova WebSocket (Cowboy)                                             |
-| Database / ORM    | [Kura](https://github.com/Taure/kura) (PostgreSQL via pgo)          |
-| Real-time UI      | [Arizona](https://github.com/novaframework/arizona_core)            |
-| Authentication    | [nova_auth](https://github.com/novaframework/nova_auth)             |
-| Background jobs   | [Shigoto](https://github.com/Taure/shigoto)                         |
-| Pub/Sub           | OTP `pg` module                                                     |
-| Lua runtime       | [Luerl](https://github.com/rvirding/luerl) (Lua-on-BEAM)            |
-
-## Status
-
-Asobi is in **public preview** — fully open-source, API stabilising.
-Early-adopter friendly; expect to read code occasionally.
-
-| Area                         | Status     |
-| ---------------------------- | ---------- |
-| Authentication               | Stable     |
-| Matchmaking                  | Stable     |
-| Real-time WebSocket transport| Stable     |
-| Leaderboards                 | Stable     |
-| Virtual economy              | Stable     |
-| Social (friends / chat)      | Stable     |
-| Lua scripting + hot reload   | Stable     |
-| Admin dashboard (Arizona)    | Beta       |
-| Cloud saves                  | Beta       |
-| Tournaments                  | Beta       |
-| Client SDKs (Unity/Godot/Defold/Dart) | Alpha |
-| Managed cloud offering       | [Coming soon](https://asobi.dev/cloud) |
+Godot, Defold, Unity, Unreal, JS/TS, Dart/Flutter, Flame — all under the
+[widgrensit](https://github.com/widgrensit?tab=repositories&q=asobi-&type=public)
+org, each with install instructions and a sample game. The
+[asobi_lua README](https://github.com/widgrensit/asobi_lua#client-sdks) has
+the table.
 
 ## Documentation
 
-- [Getting started](guides/getting-started.md) — Lua (Docker) or Erlang setup
-- [Lua scripting](guides/lua-scripting.md) — write game logic in Lua
-- [Bots](guides/lua-bots.md) — add AI-controlled players
-- [Configuration](guides/configuration.md) — all configuration options
-- [REST API](guides/rest-api.md) — full API reference
-- [WebSocket protocol](guides/websocket-protocol.md) — real-time message types
-- [Matchmaking](guides/matchmaking.md) — query-based player matching
-- [Economy](guides/economy.md) — wallets, items, and store
-- [Architecture](docs/ARCHITECTURE.md) — system design
+- [**Getting started**](guides/getting-started.md) — stand up a local asobi node from Erlang
+- [**Architecture**](guides/architecture.md) — supervision tree, modules, design
+- [**REST API**](guides/rest-api.md) · [**WebSocket protocol**](guides/websocket-protocol.md)
+- [**Matchmaking**](guides/matchmaking.md) · [**Voting**](guides/voting.md) · [**World server**](guides/world-server.md) · [**Large worlds**](guides/large-worlds.md)
+- [**Economy**](guides/economy.md) · [**Authentication**](guides/authentication.md) · [**IAP**](guides/iap.md)
+- [**Lua scripting**](guides/lua-scripting.md) · [**Lua bots**](guides/lua-bots.md)
+- [**Configuration**](guides/configuration.md) · [**Clustering**](guides/clustering.md) · [**Performance tuning**](guides/performance-tuning.md)
+- [**Benchmarks**](guides/benchmarks.md) · [**Comparison vs Nakama / Colyseus / SpacetimeDB**](guides/comparison.md)
+- [**HexDocs**](https://hexdocs.pm/asobi) — full API reference
 
-Full API docs on [HexDocs](https://hexdocs.pm/asobi).
+## Migrating?
 
-## Community
+- [**from Hathora**](guides/migrate-from-hathora.md) — Hathora shuts down 2026-05-05.
+- [**from PlayFab**](guides/migrate-from-playfab.md)
+- [**from Nakama self-host**](guides/migrate-from-nakama.md)
 
-- [Discord](https://discord.gg/vYSfYYyXpu) — ask questions, share what you're building
-- [Issues](https://github.com/widgrensit/asobi/issues) — bug reports and feature requests
-- [asobi.dev/blog](https://asobi.dev/blog) — design notes and release updates
+## Related projects
+
+- [**asobi_lua**](https://github.com/widgrensit/asobi_lua) — Lua scripting runtime + Docker image (`ghcr.io/widgrensit/asobi_lua`)
+- [**asobi-cli**](https://github.com/widgrensit/asobi-cli) — deploy, manage, and scaffold games
+- [**asobi_admin**](https://github.com/widgrensit/asobi_admin) — admin dashboard
+- Client SDKs: [asobi-godot](https://github.com/widgrensit/asobi-godot) · [asobi-defold](https://github.com/widgrensit/asobi-defold) · [asobi-unity](https://github.com/widgrensit/asobi-unity) · [asobi-unreal](https://github.com/widgrensit/asobi-unreal) · [asobi-js](https://github.com/widgrensit/asobi-js) · [asobi-dart](https://github.com/widgrensit/asobi-dart) · [flame_asobi](https://github.com/widgrensit/flame_asobi)
+
+## Stability
+
+> [!NOTE]
+> asobi is pre-1.0. The API is stabilising; expect minor breaking changes
+> until 1.0. We will never relicense — see [guides/exit.md](guides/exit.md)
+> for the "if asobi disappears tomorrow" runbook.
+
+## Contributing
+
+See [CONTRIBUTING.md](CONTRIBUTING.md) for the build setup, pre-push
+checklist, and test matrix. Security issues: see [SECURITY.md](SECURITY.md).
 
 ## License
 
-Apache-2.0
+Apache-2.0. See [LICENSE](LICENSE).

--- a/guides/migrate-from-hathora.md
+++ b/guides/migrate-from-hathora.md
@@ -1,0 +1,298 @@
+# Migrating from Hathora to asobi
+
+**Hathora's game-hosting service shuts down on 2026-05-05.** If you're reading
+this with a running game on `hathora.dev` or `hathora.cloud`, this guide walks
+you from "we need a new backend by May" to "we're running on asobi and we
+never have to do this again."
+
+> **Draft notice.** This guide is a starting point, not a battle-tested
+> playbook — nobody has yet migrated a Hathora game to asobi end-to-end.
+> The asobi-side endpoint and event names below are **verified against the
+> current code**. The Hathora-side method names come from our memory of the
+> pre-shutdown SDK and may have drifted. **The fastest path to a working
+> migration is pairing with us in the
+> [Discord](https://discord.gg/vYSfYYyXpu) `#migrations` channel** — we'll
+> walk through your specific setup rather than you fighting this doc in the
+> dark.
+
+> This guide targets studios on Hathora's *managed* service. If you're a
+> self-hosted `hathora-core` user your situation is different — skip to
+> [§ Self-hosted Hathora users](#self-hosted-hathora-users).
+
+## TL;DR
+
+1. Your game-server logic (C#, Go, Node, whatever it is today) **keeps
+   running in its own process** while you migrate.
+2. You bring up an asobi_lua container. Your game-server talks to it over
+   WebSocket like it would any other auth/matchmaker/leaderboard service.
+3. You port the Hathora-specific calls — `createLobby`, `getRoomInfo`,
+   `listActivePublicLobbies`, `HathoraClient.loginAnonymous`, etc. — to the
+   asobi equivalents in the table below.
+4. Once asobi is doing auth/matchmaking/lobbies, you drop Hathora entirely
+   and either (a) keep running your existing server code in a plain
+   container on Hetzner / Fly / Scaleway or (b) fold your game logic into an
+   asobi Lua script and let asobi host that too.
+
+Option (b) is more work up front, but it means no game-server container at
+all. For most Hathora games the game-server is a few hundred lines of
+state-mutation code — well within the scope of a `match.lua` file.
+
+## Why asobi specifically
+
+The reason you're reading this is that Hathora pivoted to AI. We don't want
+that to be you again.
+
+- **Apache-2.0, open-source, self-hostable.** The engine is at
+  [github.com/widgrensit/asobi](https://github.com/widgrensit/asobi) and the
+  Docker runtime is at
+  [github.com/widgrensit/asobi_lua](https://github.com/widgrensit/asobi_lua).
+  Fork it. Mirror it. Run it on your own hardware. Our [exit
+  guide](exit.md) is a 1-page runbook for keeping your game alive if we
+  vanish tomorrow.
+- **No CCU billing.** Managed asobi cloud (opening later in 2026) is flat
+  per-container. Self-host is free.
+- **Hot-reload Lua.** Edit your match logic, save, connected matches pick it
+  up — no rebuild, no redeploy, no kicked players.
+- **One container, one Postgres.** No CockroachDB. No Redis. No Kubernetes.
+- **Matchmaking, lobbies, rooms, leaderboards, economy, chat, friends,
+  tournaments, voting, phases, seasons, reconnection** are all already there
+  — see the [feature list](../README.md#features).
+- **Godot and Defold SDKs are first-class**, alongside Unity/Unreal/JS/Flutter.
+- **EU-hosted, GDPR-ready, NIS2-aware** if that matters to you.
+
+## Concept map
+
+| Hathora | asobi | Notes |
+|---|---|---|
+| Application | asobi deployment | One container per environment (dev/live). |
+| Room | Match | An OTP process per match, state kept in the process heap with ETS backup. |
+| Process | *(no equivalent)* | asobi doesn't spin a container per match. One container hosts thousands of matches as BEAM processes. Simpler ops. |
+| Lobby | Matchmaker ticket + Match in "waiting" phase | Players hit `/matchmaker/tickets`; when `match_size` is reached the match transitions to "running". |
+| Region | Deployment location | Deploy one container per region. No region abstraction baked in — you pick where to run the container. |
+| Matchmaker (2.0) | `asobi_matchmaker` | Pluggable strategies (`fill`, `skill_based`); custom via `asobi_matchmaker_strategy` behaviour. |
+| `HathoraClient.loginAnonymous` | `POST /api/v1/auth/register` with `username` + `password` | **No anonymous flag today.** You generate a random username/password in the client and persist it locally (or use OAuth). Response fields: `player_id`, `session_token`, `username`. |
+| `HathoraClient.loginGoogle` | `POST /api/v1/auth/oauth` | OAuth/OIDC flow. |
+| `createLobby` / `createRoom` / queue | `POST /api/v1/matchmaker` body `{"mode":"default","properties":{},"party":[playerId]}` | Response: `{"ticket_id":"...","status":"pending"}`. |
+| Ticket poll | `GET /api/v1/matchmaker/:ticket_id` | |
+| Cancel | `DELETE /api/v1/matchmaker/:ticket_id` | |
+| `listActivePublicLobbies` | `GET /api/v1/matches` | Query params filter results. |
+| `getConnectionInfo(roomId)` | WebSocket upgrade on `GET /ws` | See [§ WebSocket handshake](#websocket-handshake) — first frame must authenticate. |
+| `ping` region API | *(none)* | If you need client-side region selection, probe each deployment endpoint yourself. |
+| Hathora SDK | asobi SDKs | [asobi-unity](https://github.com/widgrensit/asobi-unity), [asobi-unreal](https://github.com/widgrensit/asobi-unreal), [asobi-js](https://github.com/widgrensit/asobi-js), [asobi-godot](https://github.com/widgrensit/asobi-godot), [asobi-defold](https://github.com/widgrensit/asobi-defold), [asobi-dart](https://github.com/widgrensit/asobi-dart), [flame_asobi](https://github.com/widgrensit/flame_asobi). |
+| Hathora Console | [asobi-admin](https://github.com/widgrensit/asobi_admin) | Tenants, games, API keys, match inspection. Pre-1.0. |
+| `hathora.yml` | `docker-compose.yml` | Plain Compose, no proprietary spec. |
+| Process-hour billing | Flat per-container | No surprise invoices. |
+
+## Migration path
+
+### Phase 1 — stand up asobi alongside Hathora (1 day)
+
+Run asobi on the same cloud (or locally) without touching the Hathora
+deployment. Goal: verify auth, a lobby, and a match work end-to-end from
+your client.
+
+```yaml
+# docker-compose.yml
+services:
+  postgres:
+    image: postgres:17
+    environment:
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: postgres
+      POSTGRES_DB: my_game
+
+  asobi:
+    image: ghcr.io/widgrensit/asobi_lua:latest
+    depends_on: [postgres]
+    ports: ["8080:8080"]
+    volumes: ["./lua:/app/game:ro"]
+    environment:
+      ASOBI_DB_HOST: postgres
+      ASOBI_DB_NAME: my_game
+```
+
+Put a minimal `lua/match.lua` in place (see the [asobi_lua
+README](https://github.com/widgrensit/asobi_lua#quick-start)) and bring it
+up:
+
+```bash
+docker compose up -d
+curl localhost:8080/api/v1/auth/register \
+  -H 'content-type: application/json' \
+  -d '{"username":"test","password":"test1234"}'
+# → { "player_id": "01HX...", "session_token": "...", "username": "test" }
+```
+
+### Phase 2 — port the client SDK calls (2–5 days)
+
+In your Unity / Unreal / JS / Godot client, replace the Hathora SDK with the
+asobi one for the same engine. The call shape is close but not identical:
+
+**Unity — before (Hathora):**
+```csharp
+var client = new HathoraClient("my-app-id");
+await client.LoginAnonymousAsync();
+var lobby = await client.CreateLobbyAsync(Visibility.Public, …);
+var info = await client.GetConnectionInfoAsync(lobby.RoomId);
+// then open a websocket to info.ExposedPort.Host:Port
+```
+
+**Unity — after (asobi):**
+```csharp
+var client = new AsobiClient("https://api.my-game.com");
+await client.Auth.RegisterAsync("alice", "hunter2");     // or LoginAsync
+await client.WebSocket.ConnectAsync();                    // /ws
+client.WebSocket.SendSessionConnect(sessionToken);        // first frame
+client.WebSocket.On("match.matched", OnMatched);          // payload: { match_id, players }
+await client.Matchmaker.QueueAsync(mode: "default");      // POST /api/v1/matchmaker
+```
+
+Matchmaker tickets resolve asynchronously over the WebSocket via the
+`match.matched` event (payload `{match_id, players}`). You can poll
+`GET /api/v1/matchmaker/:ticket_id` if you prefer.
+
+Do this one feature at a time: **auth first, then WebSocket handshake, then
+matchmaking, then the game-session messages**. Hathora and asobi can
+coexist in the client during this phase (different base URLs).
+
+### WebSocket handshake
+
+Asobi expects every WebSocket client to authenticate with a `session.connect`
+frame *before* it can use any other WS message type:
+
+```json
+{"type":"session.connect","payload":{"session_token":"eyJ..."}}
+```
+
+After this the server routes match/matchmaker/chat/world events to this
+player. Other message types the server handles: `matchmaker.add`,
+`matchmaker.remove`, `match.input`, `match.join`, `match.leave`, `chat.send`,
+`chat.join`, `chat.leave`, `dm.send`, `presence.update`, `vote.cast`,
+`vote.veto`, `world.list`, `world.create`, `world.find_or_create`,
+`world.join`, `world.leave`, `session.heartbeat`.
+
+Server-pushed event types follow the pattern `{domain}.{event}` — notably:
+`match.matched` (matched into a game), `match.state` (full state push),
+`match.finished`, `world.tick`, `world.terrain`, `chat.message`,
+`dm.message`, `error`.
+
+### Phase 3 — port the game logic (2 days – 2 weeks)
+
+You have two choices here.
+
+**Option A — keep your existing game server.** If you've got a lot of C#/Go
+server code you'd rather not rewrite, keep running it in its own container
+on Hetzner / Fly / Scaleway. Use asobi for auth, matchmaking, lobbies,
+leaderboards, and persistence. When the matchmaker fires `match.matched`,
+the client has a `session_token` from asobi — pass it (plus `player_id` and
+`match_id`) to your game server over your own connection, and have your
+game server validate the token with asobi before accepting input.
+
+> **Reality check:** the public asobi library does not ship a built-in
+> "server-to-server token validation" endpoint today — token verification
+> on your own server means calling `POST /api/v1/auth/refresh` with the
+> token, or adding a small validation route yourself. If this is a blocker
+> for you, ping us in Discord — it's a natural library addition and we'll
+> prioritise it.
+
+**Option B — fold the game logic into Lua.** Rewrite your tick / input /
+state logic as a `match.lua` file. The callbacks are:
+
+```lua
+function init(config)         -- once per match
+function join(player_id, state)
+function leave(player_id, state)
+function handle_input(player_id, input, state)
+function tick(state)           -- default 10Hz, configurable
+function get_state(player_id, state)   -- per-player view
+```
+
+For most Hathora games this is a few hundred lines of Lua. You get hot
+reload for free (edit + save + live matches update) and you delete a
+container.
+
+### Phase 4 — cut over (1 day)
+
+Flip a feature flag in the client to point at the asobi endpoint. Monitor
+for 24h. Shut Hathora down.
+
+## Deploy story
+
+You can run asobi anywhere Docker runs. Common choices:
+
+| Host | Fit | Rough cost |
+|---|---|---|
+| **Hetzner Cloud** (CX22–CX42) | Best price/perf. EU-only if that matters. | €4–15 / month |
+| **Scaleway Serverless** | Auto-scale for dev / low traffic | Free tier → pay per req |
+| **Fly.io** | Multi-region one-liner | $5+/month/region |
+| **Clever Cloud** | git-push deploy, EU | €10+/month |
+| **Your laptop** | Development / LAN party | — |
+
+Typical Hathora cost for a small-indie game was **$200–800 / month** on
+process-hours. The same game on asobi at Hetzner is **€5–20 / month**,
+often 10–40× cheaper.
+
+## Pricing comparison
+
+| | Hathora (pre-shutdown) | asobi self-host | asobi managed (soon) |
+|---|---|---|---|
+| Pricing model | Process-hours ($0.03–0.15/hr) + bandwidth | Flat infra cost you choose | Flat per-container |
+| Free tier | Small credit | Unlimited | TBD |
+| 100 CCU | ~$50–150/mo | €5–15/mo infra | ~€9/mo |
+| 1,000 CCU | ~$300–800/mo | €15–50/mo infra | ~€29/mo |
+| Bandwidth surcharges | Yes | No (infra cost) | No |
+| Multi-region | First-class, auto | DIY (one container per region) | Per-region tier |
+
+## Self-hosted Hathora users
+
+If you run `hathora-core` on your own infra, your situation is better: you
+still own the stack. You can keep running it as long as it works. But the
+same migration strategy applies when you decide to move — asobi's single
+container + Postgres is operationally simpler than Hathora's Go monolith +
+Redis + Cockroach.
+
+## Things asobi does NOT do (yet)
+
+Be honest with yourself before committing:
+
+- **No UDP transport.** WebSocket/TCP only. If you're a twitch FPS /
+  fighting game / racing game that needs sub-3ms physics, pair asobi with a
+  UDP relay (Photon, ENet server, custom). Use asobi for auth / matchmaker
+  / economy / leaderboard / social.
+- **No anonymous-login shortcut.** Auth is `username+password` or OAuth.
+  If your Hathora game used `loginAnonymous`, you'll generate a random
+  username/password in the client and persist it locally, or wire OAuth.
+- **No server-to-server token validation endpoint** in the public library
+  (see Option A note above).
+- **No auto multi-region.** Deploy one container per region yourself.
+- **No client-side prediction / rollback netcode primitives.** On the
+  roadmap.
+- **Pre-1.0 API.** Minor breaking changes possible until 1.0.
+- **Managed cloud opens later in 2026** — today, self-host.
+
+## Do this today
+
+- [ ] `git clone` [asobi_lua](https://github.com/widgrensit/asobi_lua) and
+  bring up `docker compose up` locally. Register a player. Confirm it works.
+- [ ] Pick a single SDK call in your client to port first (usually
+  `loginAnonymous`). Get it compiling against asobi.
+- [ ] Join the [Discord](https://discord.gg/vYSfYYyXpu). We'll help you debug.
+- [ ] Decide Option A (keep game server) vs Option B (Lua rewrite). Open
+  a thread in [Discussions](https://github.com/widgrensit/asobi_lua/discussions)
+  and we'll sanity-check.
+- [ ] Set a cutover date before 2026-05-05.
+
+## Getting help
+
+- **Discord**: [#migrations](https://discord.gg/vYSfYYyXpu) channel
+- **Email**: hello@asobi.dev
+- **GitHub Discussions**: [widgrensit/asobi_lua/discussions](https://github.com/widgrensit/asobi_lua/discussions)
+
+We'll prioritise Hathora-migration support through May 2026.
+
+## See also
+
+- [Migrating from PlayFab](migrate-from-playfab.md)
+- [Migrating from Nakama self-host](migrate-from-nakama.md)
+- [Exit guarantee](exit.md) — if asobi disappears tomorrow
+- [Comparison vs Nakama, Colyseus, SpacetimeDB](comparison.md)


### PR DESCRIPTION
## Summary
- Rewrites `README.md` to the research-backed Phoenix-style OSS README pattern — ~100 lines, ≤4 badges, nav bar, tagline, Erlang-install snippet, SDK + migration links, pre-1.0 / exit-guaranteed note. Points non-Erlang readers at `asobi_lua`.
- Adds `guides/migrate-from-hathora.md` — concept map + phased migration path for studios stranded by the 2026-05-05 Hathora shutdown. Endpoint/event shapes verified against `asobi_router` and `asobi_ws_handler`. Draft notice at top directs readers to Discord `#migrations`.

Companion PR: [asobi_site#34](https://github.com/widgrensit/asobi_site/pull/34) — the blog post that points here.

## Test plan
- [x] `rebar3 fmt --check` clean
- [x] `rebar3 xref` clean
- [x] `rebar3 dialyzer` clean
- [x] No new eqwalize/lint errors (210-error eqwalize baseline pre-existed — out of scope for a docs-only PR)
- [x] CT/EUnit skipped (docs-only change, cannot break)
- [x] All internal links resolve (SDK repos + guide pages)