### PR TITLE
docs: hathora-week polish — exit guide, PlayFab/Nakama migrations, demo, fixes

### DIFF
--- a/examples/hotreload-demo/README.md
+++ b/examples/hotreload-demo/README.md
@@ -1,0 +1,82 @@
+# Hot-reload demo
+
+A 60-second demo that shows asobi's killer feature: **edit Lua → live match updates**.
+No restart. No reconnect. No kicked players.
+
+Used to produce the landing-page video.
+
+## Run it
+
+```bash
+docker compose up -d
+```
+
+Open `client/index.html` in a browser (any modern one — drag the file in,
+or run `python3 -m http.server 3000 --directory client` and open
+`http://localhost:3000`).
+
+You'll see a cube you can drive with `W A S D`. The status line reads
+`matched — you're in. edit lua/match.lua and save.` once the match
+starts.
+
+## Edit while connected
+
+Open `lua/match.lua` in your editor. The top of the file is a config block:
+
+```lua
+cube_color = "#ff4757"     -- try "#4facfe" or "#2ed573"
+cube_size  = 60            -- try 20, 100, 140
+move_speed = 4             -- try 1, 8, 16
+bg_color   = "#1e272e"     -- try "#ffeaa7" or "#6c5ce7"
+message    = "Hello from Lua!"   -- change this text
+```
+
+Change any value. Save. **The browser cube updates on the next tick** —
+no reconnect, no reload, no message loss. Try:
+
+1. Change `cube_color` from `"#ff4757"` to `"#4facfe"` — cube goes from red to blue.
+2. Change `cube_size` from `60` to `140` — cube triples in size.
+3. Change `bg_color` — the backdrop shifts.
+4. Change `message` — the banner text updates.
+5. Change `move_speed` — your next `W A S D` input moves faster.
+
+## How it works
+
+asobi_lua runs your `match.lua` inside [Luerl](https://github.com/rvirding/luerl)
+— a pure-Erlang Lua 5.3 interpreter. When the mounted `.lua` file changes,
+the Luerl VM re-loads the module. In-flight match state is kept in the
+BEAM process heap, so reloading the script doesn't reset the game.
+
+`get_state/2` in this demo references the Lua globals directly, so every
+tick picks up the current value:
+
+```lua
+function get_state(_player_id, state)
+    return {
+        players    = state.players,
+        cube_color = cube_color,   -- reads the current global
+        ...
+    }
+end
+```
+
+If you instead bake the globals into `state` inside `init/1`, the
+globals become snapshot-on-match-start — hot-reload still works for
+*new* matches but not for the live one. That's sometimes what you want
+(e.g. balance changes that shouldn't alter a match mid-play). Up to you.
+
+## Record the video
+
+`RECORDING.md` has the shot list for the landing-page 15-second video.
+
+## Troubleshooting
+
+- **`matchmaker add failed: 429`** — you're rate-limited. Wait a minute
+  and retry.
+- **`socket error`** — check `docker compose logs asobi` for Lua
+  syntax errors; a bad `.lua` file breaks match start.
+- **The cube doesn't move** — make sure the browser window has focus
+  (keyboard events only fire on the focused window).
+- **Nothing happens on save** — confirm the file was mounted read-only
+  into the container with `docker compose exec asobi ls /app/game`. You
+  should see `match.lua`.

--- a/examples/hotreload-demo/RECORDING.md
+++ b/examples/hotreload-demo/RECORDING.md
@@ -1,0 +1,67 @@
+# Recording the hot-reload video
+
+Target: **15-second MP4** for the `asobi` and `asobi_lua` READMEs + the
+landing page.
+
+## Setup
+
+1. `docker compose up -d`
+2. Serve the client: `python3 -m http.server 3000 --directory client`
+3. Open `http://localhost:3000` in a browser, sized to a clean 16:9
+   (1280×720 is a good target — set the browser window to that size
+   before recording).
+4. Open `lua/match.lua` in your editor. Arrange the editor and browser
+   side-by-side so both are visible in the recording frame.
+
+## Shot list (15 seconds)
+
+| t    | Frame                                                   |
+| ---- | ------------------------------------------------------- |
+| 0.0s | Browser only, red cube on dark background, `message: "Hello from Lua!"` visible |
+| 2.0s | Cut to split-screen — editor on the left, browser on the right |
+| 3.0s | Cursor moves to `cube_color = "#ff4757"` line           |
+| 4.0s | Edit to `cube_color = "#4facfe"` — save (Ctrl-S)        |
+| 4.5s | Browser: cube flashes blue. No reload icon, no disconnect |
+| 6.0s | Cursor moves to `message` line                           |
+| 7.0s | Edit to `message = "edit · save · ship"` — save          |
+| 8.0s | Browser: banner text changes                             |
+| 10s  | Cursor moves to `cube_size`, edit to `140` — save        |
+| 11s  | Browser: cube triples in size                            |
+| 13s  | Overlay text (in post): **"No restart. No reconnect. No kicked players."** |
+| 15s  | End card: `asobi.dev` / GitHub URL                       |
+
+## Capture tool
+
+- macOS: QuickTime screen recording (Cmd-Shift-5, select the region)
+- Linux: OBS Studio or `wf-recorder -g "…"` for a region
+- Windows: OBS Studio
+
+Record at **60fps** so the cube-change frame is crisp. Crop to the exact
+editor+browser region before exporting.
+
+## Post
+
+- Export as **MP4 (H.264)**, target <5 MB (GitHub embeds MP4 up to 10 MB)
+- Also export a **GIF** fallback for non-video contexts (≤5 MB, ~800px wide)
+- Overlay captions in post — don't rely on the browser to show them
+
+## Where it goes
+
+- `asobi/README.md` and `asobi_lua/README.md` hero section — drag the MP4
+  into any GitHub issue comment, copy the `user-attachments/…` URL,
+  paste as `<video src="…" controls></video>` (or `<img>` for the GIF
+  fallback).
+- `asobi.dev` landing page — upload to the site's CDN / `priv/static/`
+- Twitter, Mastodon, Bluesky on launch day — MP4 is widely supported.
+- LinkedIn if you're that sort of person.
+
+## Script (if we want a 60-second cut)
+
+Extend the 15-second version:
+
+- 0-5s: same
+- 5-15s: show the cube editing (colour, size, bg)
+- 15-25s: zoom to the status line "matched — you're in" and call out "no disconnect"
+- 25-40s: show `docker compose logs asobi` side panel — point out the "reloading match.lua" log line and that the match PID doesn't change
+- 40-55s: quick intercut of the feature bullets from the README ("100K CCU/node", "Apache-2", "self-host")
+- 55-60s: end card + URL

--- a/examples/hotreload-demo/client/index.html
+++ b/examples/hotreload-demo/client/index.html
@@ -1,0 +1,209 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>asobi hot-reload demo</title>
+  <style>
+    * { box-sizing: border-box; margin: 0; padding: 0; }
+    body {
+      background: #0b0d11;
+      color: #e5e7eb;
+      font-family: ui-sans-serif, system-ui, -apple-system, sans-serif;
+      min-height: 100vh;
+      display: grid;
+      place-items: center;
+      padding: 2rem;
+    }
+    .wrap { max-width: 880px; width: 100%; }
+    h1 {
+      font-weight: 700;
+      font-size: 1.4rem;
+      margin-bottom: .5rem;
+    }
+    .sub {
+      color: #9ca3af;
+      margin-bottom: 1rem;
+      font-size: .95rem;
+    }
+    canvas {
+      display: block;
+      border-radius: 12px;
+      box-shadow: 0 10px 40px rgba(0,0,0,.5);
+    }
+    .status {
+      margin-top: .75rem;
+      font-family: ui-monospace, SFMono-Regular, monospace;
+      font-size: .85rem;
+      color: #6b7280;
+    }
+    .status.live { color: #10b981; }
+    .status.err  { color: #ef4444; }
+    .kbd {
+      display: inline-block;
+      padding: 2px 6px;
+      border: 1px solid #374151;
+      border-radius: 4px;
+      background: #111827;
+      font-family: ui-monospace, monospace;
+      font-size: .8rem;
+    }
+  </style>
+</head>
+<body>
+  <div class="wrap">
+    <h1>asobi hot-reload demo</h1>
+    <p class="sub">
+      Move with <span class="kbd">W</span>
+      <span class="kbd">A</span>
+      <span class="kbd">S</span>
+      <span class="kbd">D</span>.
+      Edit <code>lua/match.lua</code> &mdash; colour, size, and message update live.
+    </p>
+    <canvas id="canvas" width="800" height="600"></canvas>
+    <p class="status" id="status">connecting…</p>
+  </div>
+
+  <script>
+    const API = "http://localhost:8080";
+    const WS  = "ws://localhost:8080/ws";
+
+    const canvas = document.getElementById("canvas");
+    const ctx = canvas.getContext("2d");
+    const statusEl = document.getElementById("status");
+
+    let state = { players: {}, cube_color: "#888", cube_size: 60, bg_color: "#1e272e", message: "" };
+    let myPlayerId = null;
+    let ws = null;
+    const keys = {};
+
+    function log(msg, cls = "") {
+      statusEl.className = "status " + cls;
+      statusEl.textContent = msg;
+    }
+
+    // --- Auth: register or login with a locally persisted credential
+    async function auth() {
+      let creds = JSON.parse(localStorage.getItem("asobi_demo_creds") || "null");
+      if (!creds) {
+        creds = {
+          username: "demo-" + Math.random().toString(36).slice(2, 10),
+          password: Math.random().toString(36).slice(2)
+        };
+        localStorage.setItem("asobi_demo_creds", JSON.stringify(creds));
+        const r = await fetch(API + "/api/v1/auth/register", {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify(creds),
+        });
+        if (!r.ok) throw new Error("register failed: " + r.status);
+        return r.json();
+      } else {
+        const r = await fetch(API + "/api/v1/auth/login", {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify(creds),
+        });
+        if (r.ok) return r.json();
+        // Creds stale? re-register fresh.
+        localStorage.removeItem("asobi_demo_creds");
+        return auth();
+      }
+    }
+
+    // --- Queue for a match (size=1 + fill strategy = auto-start)
+    async function queue(token) {
+      const r = await fetch(API + "/api/v1/matchmaker", {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          "authorization": "Bearer " + token,
+        },
+        body: JSON.stringify({ mode: "default" }),
+      });
+      if (!r.ok) throw new Error("matchmaker add failed: " + r.status);
+      return r.json();
+    }
+
+    // --- WebSocket: session.connect, then match input
+    function openSocket(token) {
+      ws = new WebSocket(WS);
+      ws.addEventListener("open", () => {
+        ws.send(JSON.stringify({
+          type: "session.connect",
+          payload: { session_token: token },
+        }));
+        log("connected — queuing…", "live");
+      });
+      ws.addEventListener("message", (ev) => {
+        const msg = JSON.parse(ev.data);
+        if (msg.type === "match.matched") {
+          log("matched — you're in. edit lua/match.lua and save.", "live");
+        } else if (msg.type === "match.state") {
+          state = msg.payload;
+        }
+      });
+      ws.addEventListener("close", () => log("disconnected", "err"));
+      ws.addEventListener("error", () => log("socket error", "err"));
+    }
+
+    // --- Input
+    addEventListener("keydown", (e) => { keys[e.key.toLowerCase()] = true;  });
+    addEventListener("keyup",   (e) => { keys[e.key.toLowerCase()] = false; });
+
+    function sendInput() {
+      if (!ws || ws.readyState !== 1) return;
+      ws.send(JSON.stringify({
+        type: "match.input",
+        payload: {
+          left:  !!keys["a"],
+          right: !!keys["d"],
+          up:    !!keys["w"],
+          down:  !!keys["s"],
+        },
+      }));
+    }
+
+    // --- Render
+    function draw() {
+      ctx.fillStyle = state.bg_color || "#1e272e";
+      ctx.fillRect(0, 0, canvas.width, canvas.height);
+
+      const size  = state.cube_size  || 60;
+      const color = state.cube_color || "#ff4757";
+      ctx.fillStyle = color;
+      for (const id in state.players) {
+        const p = state.players[id];
+        ctx.fillRect(p.x - size / 2, p.y - size / 2, size, size);
+      }
+
+      if (state.message) {
+        ctx.fillStyle = "#ffffff";
+        ctx.font = "20px ui-sans-serif, system-ui, sans-serif";
+        ctx.textAlign = "center";
+        ctx.fillText(state.message, canvas.width / 2, 40);
+      }
+    }
+
+    // --- Main loop
+    function loop() {
+      sendInput();
+      draw();
+      requestAnimationFrame(loop);
+    }
+
+    (async () => {
+      try {
+        log("authenticating…");
+        const { session_token, player_id } = await auth();
+        myPlayerId = player_id;
+        openSocket(session_token);
+        await queue(session_token);
+        loop();
+      } catch (e) {
+        log("error: " + e.message, "err");
+        console.error(e);
+      }
+    })();
+  </script>
+</body>
+</html>

--- a/examples/hotreload-demo/docker-compose.yml
+++ b/examples/hotreload-demo/docker-compose.yml
@@ -1,0 +1,25 @@
+services:
+  postgres:
+    image: postgres:17
+    environment:
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: postgres
+      POSTGRES_DB: hotreload_demo
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U postgres"]
+      interval: 5s
+      timeout: 5s
+      retries: 5
+
+  asobi:
+    image: ghcr.io/widgrensit/asobi_lua:latest
+    depends_on:
+      postgres: { condition: service_healthy }
+    ports:
+      - "8080:8080"
+    volumes:
+      - ./lua:/app/game:ro
+    environment:
+      ASOBI_DB_HOST: postgres
+      ASOBI_DB_NAME: hotreload_demo
+      ASOBI_CORS_ORIGINS: "*"

--- a/examples/hotreload-demo/lua/match.lua
+++ b/examples/hotreload-demo/lua/match.lua
@@ -1,0 +1,76 @@
+-- examples/hotreload-demo/lua/match.lua
+--
+-- The demo. Edit the values below and save — the running game updates
+-- live. No restart, no reconnect.
+
+-- ==========================================================================
+-- EDIT ME: change the colour, save, watch the cube in your browser change.
+-- ==========================================================================
+cube_color = "#ff4757"     -- try "#4facfe" or "#2ed573"
+cube_size  = 60            -- try 20, 100, 140
+move_speed = 4             -- try 1, 8, 16
+bg_color   = "#1e272e"     -- try "#ffeaa7" or "#6c5ce7"
+message    = "Hello from Lua!"   -- change this text
+
+-- ==========================================================================
+-- Match config. You shouldn't need to touch these.
+-- ==========================================================================
+match_size  = 1
+max_players = 8
+strategy    = "fill"
+
+-- ==========================================================================
+-- Game logic.
+-- ==========================================================================
+
+function init(_config)
+    return {
+        players = {},
+        arena_w = 800,
+        arena_h = 600
+    }
+end
+
+function join(player_id, state)
+    state.players[player_id] = {
+        x = math.random(100, 700),
+        y = math.random(100, 500)
+    }
+    return state
+end
+
+function leave(player_id, state)
+    state.players[player_id] = nil
+    return state
+end
+
+function handle_input(player_id, input, state)
+    local p = state.players[player_id]
+    if not p then return state end
+
+    -- move_speed is a global — re-read every input so hot-reload applies.
+    if input.right then p.x = math.min(state.arena_w, p.x + move_speed) end
+    if input.left  then p.x = math.max(0,             p.x - move_speed) end
+    if input.down  then p.y = math.min(state.arena_h, p.y + move_speed) end
+    if input.up    then p.y = math.max(0,             p.y - move_speed) end
+
+    return state
+end
+
+function tick(state)
+    -- nothing to simulate — this demo is input-driven only.
+    return state
+end
+
+function get_state(_player_id, state)
+    -- Re-read the globals every tick so edits to match.lua take effect live.
+    return {
+        players    = state.players,
+        cube_color = cube_color,
+        cube_size  = cube_size,
+        bg_color   = bg_color,
+        message    = message,
+        arena_w    = state.arena_w,
+        arena_h    = state.arena_h
+    }
+end

--- a/guides/comparison.md
+++ b/guides/comparison.md
@@ -41,14 +41,37 @@ How Asobi compares to other open-source game backend platforms.
 
 - You want a **single deployable** with auth, matchmaking, economy, social, and real-time multiplayer
 - You need **fault-tolerant game sessions** that survive crashes without losing state
+- You want **hot-reloadable Lua** so bug-fixes ship without kicking players
 - You want **zero-downtime deploys** for game logic updates
 - You're building for **high concurrency** (many simultaneous matches/rooms)
-- You prefer **self-hosted** over managed cloud services
+- You prefer **self-hosted Apache-2** over closed managed clouds, with a real exit guarantee (see [exit.md](exit.md))
 - You want a **PostgreSQL-backed** system with a proper ORM
+
+## Don't know Erlang?
+
+You don't need to. Use [**asobi_lua**](https://github.com/widgrensit/asobi_lua) — the
+same engine packaged as a Docker image with Lua scripting. Write your match
+logic in a `.lua` file, `docker compose up`, you're running. The Erlang is
+underneath but you never touch it.
+
+The Erlang-library path (depending on `asobi` directly via rebar.config) is
+for teams that already write OTP and want to compose asobi with the rest of
+their release.
 
 ## When to Choose Something Else
 
-- You need a **managed cloud service** with no infrastructure to maintain (PlayFab, GameSparks)
-- Your team has **no Erlang/OTP experience** and prefers Go or JavaScript
-- You need **Unity/Unreal SDK** out of the box (Nakama has official SDKs)
-- You're building a **single-player** game that only needs analytics and IAP
+- You need **sub-3ms UDP latency** for a twitch FPS / fighting game / racer. Pair asobi with a UDP relay, or use Photon Fusion / Quantum for the physics.
+- You need **deep LiveOps tooling** (A/B testing, segmentation, push campaigns) today. PlayFab still leads here, though it's an operational/trust trade-off post-v2 migration.
+- You need a **fully managed cloud** and are willing to pay cloud-scale prices. Our managed tier opens later in 2026; until then, self-host.
+- You're building a **single-player** game that only needs analytics and IAP. Firebase Analytics + a simple store validator is cheaper than any backend here.
+
+## Client SDKs
+
+First-class SDKs for **Godot, Defold, Unity, Unreal, JavaScript/TypeScript, Dart/Flutter, Flame**
+— see the [asobi_lua README](https://github.com/widgrensit/asobi_lua#client-sdks) for the table.
+
+## Migrating from another backend?
+
+- [**from Hathora**](migrate-from-hathora.md) — shutdown 2026-05-05
+- [**from PlayFab**](migrate-from-playfab.md)
+- [**from Nakama self-host**](migrate-from-nakama.md)

--- a/guides/configuration.md
+++ b/guides/configuration.md
@@ -298,7 +298,7 @@ Database configuration is under the `kura` application key:
 # docker-compose.yml
 services:
   postgres:
-    image: postgres:16
+    image: postgres:17
     environment:
       POSTGRES_USER: postgres
       POSTGRES_PASSWORD: postgres

--- a/guides/exit.md
+++ b/guides/exit.md
@@ -1,0 +1,131 @@
+# If asobi disappears tomorrow
+
+This is a one-page runbook for keeping your game alive if Widgrensit AB
+(the company behind asobi) vanishes, pivots to AI, gets acquired, or
+otherwise ceases to exist. **We wrote it because you shouldn't have to
+trust us.**
+
+## What we commit to
+
+1. **Apache-2.0 forever.** The [asobi library](https://github.com/widgrensit/asobi)
+   and [asobi_lua runtime](https://github.com/widgrensit/asobi_lua) are
+   published under Apache-2.0. **We will never relicense** — no BSL, no
+   SSPL, no Business Source dual-track. If we need to change the licence
+   we'll fork our own project under a new name rather than take Apache-2
+   away from you.
+2. **No closed-core.** Every feature in the public repos is the feature you
+   run. Our commercial cloud runs the same binary you can pull from
+   `ghcr.io/widgrensit/asobi_lua:latest`.
+3. **Public Docker images mirrored.** Published to GitHub Container Registry
+   under `ghcr.io/widgrensit/*`. GHCR is free to pull without auth; you can
+   also mirror to your own registry.
+4. **No mandatory phone-home, no licence check-in.** The runtime works
+   indefinitely without talking to us.
+5. **Git history is the source of truth.** No force-pushes to release tags.
+   No rewritten history on `main`.
+
+## If we disappear, here's what to do
+
+### 1. Pin a known-good version
+
+As soon as you see us go quiet (no commits / no Discord / no blog posts for
+30+ days), pin your deployment to a specific Docker image digest:
+
+```yaml
+# docker-compose.yml
+services:
+  asobi:
+    # Before: ghcr.io/widgrensit/asobi_lua:latest
+    # After: pinned by digest
+    image: ghcr.io/widgrensit/asobi_lua@sha256:<digest-of-your-last-known-good>
+```
+
+Grab the digest from `docker pull` output or the
+[GHCR package page](https://github.com/widgrensit/asobi_lua/pkgs/container/asobi_lua).
+
+### 2. Mirror the image to your own registry
+
+```bash
+docker pull ghcr.io/widgrensit/asobi_lua:latest
+docker tag ghcr.io/widgrensit/asobi_lua:latest \
+           your-registry.example.com/asobi_lua:v-$(date +%Y-%m-%d)
+docker push your-registry.example.com/asobi_lua:v-$(date +%Y-%m-%d)
+```
+
+Point your `docker-compose.yml` / k8s manifest at `your-registry.example.com`.
+You now own the runtime.
+
+### 3. Fork the source
+
+```bash
+git clone https://github.com/widgrensit/asobi.git
+git clone https://github.com/widgrensit/asobi_lua.git
+# Push both to your own remote.
+```
+
+Both repos include the full history. You can build the Docker image yourself:
+
+```bash
+cd asobi_lua
+docker build -t myorg/asobi_lua:from-fork .
+```
+
+### 4. Export your data
+
+Every piece of state in asobi lives in PostgreSQL (the one you host). There
+is **no state outside your database**. To produce a cold-storage backup:
+
+```bash
+# Full logical backup
+docker compose exec postgres pg_dump -U postgres my_game > backup-$(date +%Y-%m-%d).sql
+
+# Binary backup (faster to restore)
+docker compose exec postgres pg_basebackup -U postgres -D /backup -Fp
+```
+
+Restoring onto any stock PostgreSQL server (any version within pgo's
+supported range) gets you back a functional asobi tenant.
+
+### 5. Update OTP / Postgres yourself
+
+asobi depends on standard, long-lived open-source infrastructure:
+
+- **Erlang/OTP** ≥ 28. Upgrade path: drop in a newer OTP version, run
+  `rebar3 compile`. asobi spec-is-clean and tested against recent OTP;
+  upstream OTP is Ericsson's responsibility and they don't disappear.
+- **PostgreSQL** ≥ 15. Standard `pg_upgrade` works.
+- **Lua** 5.3 via [Luerl](https://github.com/rvirding/luerl). Rob Virding
+  (the V in BEAM) maintains Luerl in Apache-2 as well.
+
+None of these depend on us being alive.
+
+### 6. Join the community fork
+
+If we go dark, it's likely someone in the Discord — or the closest thing
+the Discord becomes — will pick up maintenance. Keep an eye on:
+
+- GitHub forks of `widgrensit/asobi` and `widgrensit/asobi_lua`
+- The `#operations` channel on the [Asobi Discord](https://discord.gg/vYSfYYyXpu)
+- The Erlang Forum (`erlangforums.com`) and the #gamedev tag
+
+## What isn't here
+
+This guide covers the open-source library + runtime only. The commercial
+`asobi.dev` cloud (opens later in 2026) is a separate layer: if we shut down
+the managed service, we'll give you:
+
+- 60 days' notice minimum, in writing, before shutdown
+- A one-click **"export everything to a Docker bundle"** button that
+  produces a runnable self-host package with your data, your scripts, and
+  your PostgreSQL dump
+- Best-effort migration help through the shutdown date
+
+The open-source side stays open-source regardless.
+
+## Questions?
+
+Open an issue, post in the Discord `#operations` channel, or email
+`hello@asobi.dev`. If none of those still exist — fork the code, export
+your Postgres, and you're the custodian now.
+
+We'd rather earn your trust by making leaving easy.

--- a/guides/getting-started.md
+++ b/guides/getting-started.md
@@ -84,7 +84,7 @@ end
 ```yaml
 services:
   postgres:
-    image: postgres:16
+    image: postgres:17
     environment:
       POSTGRES_USER: postgres
       POSTGRES_PASSWORD: postgres
@@ -117,11 +117,41 @@ docker compose up -d
 Your game backend is running. Asobi reads your Lua scripts, sets up the
 database, and starts listening for WebSocket connections on port 8080.
 
-Edit your Lua files and restart to pick up changes:
+### 6. Verify it works
+
+Register a player:
 
 ```bash
-docker compose restart asobi
+curl -s localhost:8080/api/v1/auth/register \
+  -H 'content-type: application/json' \
+  -d '{"username":"alice","password":"hunter2"}' | jq
 ```
+
+Expected response:
+
+```json
+{
+  "player_id": "01HX...",
+  "session_token": "eyJ...",
+  "username": "alice"
+}
+```
+
+If you see that, everything is wired up — auth, database, REST, and the
+Lua runtime are all live. Save the `session_token` for the WebSocket
+handshake (see [WebSocket Protocol](websocket-protocol.md)).
+
+Common error responses:
+
+- `{"error": "missing_required_fields"}` — check your JSON shape.
+- Connection refused — the server hasn't finished booting; give it 10s
+  and retry, or check `docker compose logs asobi` for migration errors.
+
+### Hot-reloading Lua
+
+Edit any `.lua` file under `./lua/` and save. Asobi picks up the change
+**live** — in-flight matches keep running on the old code until they
+finish, new matches bind the new code. No restart, no reconnect.
 
 See the [Lua Scripting](lua-scripting.md) guide for the full callback
 reference and advanced patterns.

--- a/guides/migrate-from-nakama.md
+++ b/guides/migrate-from-nakama.md
@@ -1,0 +1,265 @@
+# Migrating from Nakama self-host to asobi
+
+You're running Nakama self-hosted on your own infra. It works. But maybe:
+
+- You're tired of Nakama requiring **CockroachDB** (vs plain PostgreSQL
+  everywhere else in your stack)
+- You want **hot-reload of Lua** that doesn't drop sessions on deploy
+  (Nakama issue [#192](https://github.com/heroiclabs/nakama/issues/192) has
+  been open since 2018)
+- You're bumping into **spatial / MMO** use cases Nakama wasn't designed
+  for
+- You prefer **BEAM's fault-tolerance** over Go's recovery-from-panic
+  model for a stateful realtime server
+- You want **Apache-2** without the BSL-adjacent ambiguity in some
+  Heroic Cloud components
+
+This guide walks you from a working Nakama deployment to an equivalent
+asobi deployment. It's the most straightforward of the three migration
+guides — Nakama and asobi are structurally the closest cousins in the
+OSS backend space.
+
+> **Draft notice.** This guide is a starting point, not a playbook —
+> nobody has yet migrated a shipped Nakama title to asobi. The asobi-side
+> endpoints and events below are verified against the current code.
+> Nakama-side method names come from Nakama's public docs. **Pair with us
+> in the [Discord](https://discord.gg/vYSfYYyXpu) `#migrations` channel
+> if you hit an API gap.**
+
+## Why migrate at all
+
+Nakama is a fine product. We respect Heroic Labs. You should only migrate
+if one of these reasons applies to you:
+
+- **You need hot-reload.** Editing a Lua runtime module in Nakama requires
+  a full server restart, which drops connections. asobi does it live via
+  Luerl module swap.
+- **Your infra is Postgres-only.** Moving CockroachDB off your ops plate
+  is worth real money.
+- **You're building an MMO / large-world game.** asobi has spatial zones,
+  lazy-zone loading, terrain chunks, and adaptive tick rates as first-class
+  primitives. Nakama's match handler is room-centric.
+- **You want truly-free OSS.** Nakama is Apache-2 at the core but Heroic
+  Cloud has commercial-only components (Satori, Hiro) that ease adoption.
+  If you're committed to OSS-only, asobi is structurally simpler.
+
+If none of those apply, stay on Nakama. Honestly.
+
+## Concept map
+
+Nakama and asobi agree on most of the vocabulary:
+
+| Nakama | asobi | Notes |
+|---|---|---|
+| **Match** (authoritative) | Match | Same: a BEAM/goroutine process owning state. |
+| **Match handler** (Lua / TS / Go) | `asobi_match` behaviour / `match.lua` | Callbacks: init, join, leave, handle_input, tick, get_state. |
+| **Match Handler's LoopTick** | `tick(state)` | Same cadence (configurable). |
+| **Parties** | Matchmaker tickets with `party` field | Send a list of player_ids in the ticket body. |
+| **MatchmakerAdd** | `POST /api/v1/matchmaker` | Body: `{mode, properties, party}`. |
+| **Storage Engine** | `/api/v1/storage/:collection/:key` | Collection+key+owner model is the same. Public/Owner/None permissions. |
+| **Leaderboards** | Leaderboards (`/api/v1/leaderboards/:id`) | Submit/top/around queries. |
+| **Tournaments** | Tournaments (`/api/v1/tournaments`) | Scheduled, entry fees, rewards. |
+| **Friends** | Friends (`/api/v1/friends`) | Request/approve/block. |
+| **Groups** | Groups (`/api/v1/groups`) | Roles, join/leave/kick. |
+| **Chat channels** | Chat channels + WS `chat.send` / `chat.join` | Per-channel history. |
+| **Notifications** | Notifications (`/api/v1/notifications`) | Plus WS push. |
+| **Wallets** | Economy wallets (`/api/v1/wallets`) | Multi-currency ledgers. |
+| **Purchases** | Economy store (`/api/v1/store/purchase`) | Integrates with IAP verification. |
+| **Authentication (Custom / Device / Email)** | `/api/v1/auth/register` + `/login` | Username + password (you generate creds client-side for "custom" flows). |
+| **Authentication (Google / Apple / Steam / ...)** | `/api/v1/auth/oauth` | OAuth/OIDC. |
+| **RPC endpoints** | Nova controllers (Erlang) or Lua callbacks | For per-match logic, use Lua in `match.lua`. For cross-match workflows, write a Nova controller. |
+| **Hooks (`before_authenticate`, `after_friendAdd`)** | Nova plugins + match lifecycle callbacks | Pre- and post-request middleware in Nova. |
+| **Runtime Lua / TS / Go** | Luerl Lua (for match logic), Erlang/OTP (for the engine) | One scripting language (Lua); the engine is all OTP. |
+| **Nakama Console** | [asobi_admin](https://github.com/widgrensit/asobi_admin) | Pre-1.0 admin surface. |
+| **`sessiontoken`** | `session_token` | Same concept, returned from `/register` or `/login`. |
+| **WebSocket** | `/ws` with `session.connect` first frame | See the Hathora guide's [WebSocket handshake](migrate-from-hathora.md#websocket-handshake) section for the protocol. |
+
+## Migration path
+
+### Phase 1 — stand up asobi alongside Nakama (0.5 days)
+
+```yaml
+# docker-compose.yml
+services:
+  postgres:
+    image: postgres:17
+    environment:
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: postgres
+      POSTGRES_DB: my_game
+
+  asobi:
+    image: ghcr.io/widgrensit/asobi_lua:latest
+    depends_on: [postgres]
+    ports: ["8080:8080"]
+    volumes: ["./lua:/app/game:ro"]
+    environment:
+      ASOBI_DB_HOST: postgres
+      ASOBI_DB_NAME: my_game
+```
+
+Note: plain PostgreSQL, no CockroachDB. If you currently run Nakama
+against Postgres-compatible Cockroach, you already have a backup strategy
+that works here.
+
+### Phase 2 — port the Lua runtime (1-3 days)
+
+Nakama's Lua API:
+
+```lua
+local nk = require("nakama")
+local function foo(context, payload)
+  nk.logger_info("hello")
+  local users = nk.storage_read({...})
+  return nk.json_encode({ok = true})
+end
+nk.register_rpc(foo, "my_rpc")
+```
+
+asobi's Lua API differs in key ways — the match is the first-class unit,
+not an RPC:
+
+```lua
+-- match.lua
+match_size = 2
+
+function init(_config)
+  return { players = {} }
+end
+
+function join(player_id, state)
+  state.players[player_id] = { score = 0 }
+  return state
+end
+
+function handle_input(player_id, input, state)
+  if input.type == "score" then
+    local p = state.players[player_id]
+    p.score = p.score + 1
+    game.broadcast("score", { player = player_id, score = p.score })
+  end
+  return state
+end
+```
+
+For cross-match logic (leaderboards, global state, scheduled jobs):
+
+- `game.leaderboard.submit("global", player_id, score)` in Lua
+- Shigoto background jobs in Erlang for scheduled cross-match workflows
+- Nova controllers in Erlang for custom REST endpoints (equivalent to
+  Nakama RPCs)
+
+If you have a lot of RPC-shaped logic (not per-match), budget Phase 2 for
+closer to a week.
+
+### Phase 3 — migrate the storage schema (1-2 days)
+
+```bash
+# Export from Nakama's Postgres (or CockroachDB):
+pg_dump -U nakama -t storage -d nakama > storage-export.sql
+
+# Transform storage rows to asobi's asobi_storage schema
+psql -U postgres -d my_game -c "
+  INSERT INTO asobi_storage (player_id, collection, key, value, permissions)
+  SELECT user_id::uuid, collection, key, value::jsonb, 'owner'
+  FROM old_nakama_storage;
+"
+```
+
+The same pattern applies to leaderboards, friends, groups, and wallets.
+Column names differ slightly (see the [Kura schemas](https://hexdocs.pm/asobi)
+for the target shape) but the data is 1:1 translatable.
+
+### Phase 4 — port the client (2-5 days)
+
+Nakama client SDKs and asobi client SDKs map cleanly:
+
+| Nakama SDK | asobi SDK |
+|---|---|
+| `nakama-unity` | [asobi-unity](https://github.com/widgrensit/asobi-unity) |
+| `nakama-godot` | [asobi-godot](https://github.com/widgrensit/asobi-godot) |
+| `nakama-defold` | [asobi-defold](https://github.com/widgrensit/asobi-defold) |
+| `nakama-unreal` | [asobi-unreal](https://github.com/widgrensit/asobi-unreal) |
+| `nakama-js` | [asobi-js](https://github.com/widgrensit/asobi-js) |
+
+The Unity example:
+
+```csharp
+// Before (Nakama)
+var client = new Client("defaultkey", "127.0.0.1", 7350, false);
+var session = await client.AuthenticateCustomAsync(deviceId);
+var socket = client.NewSocket();
+await socket.ConnectAsync(session);
+
+// After (asobi)
+var client = new AsobiClient("https://api.my-game.com");
+await client.Auth.RegisterAsync(deviceId, localPassword);   // or LoginAsync
+await client.WebSocket.ConnectAsync();
+client.WebSocket.SendSessionConnect(client.Session.Token);
+```
+
+### Phase 5 — cut over (1 day)
+
+Flip the client's base URL via a feature flag. Monitor for 24h. Shut
+down the Nakama server.
+
+## Things Nakama has that asobi doesn't (yet)
+
+- **Satori** (LiveOps platform). asobi's LiveOps story is rougher.
+- **Hiro** (progression system). asobi has tournaments, seasons, and
+  phases but nothing as opinionated as Hiro.
+- **Go and TypeScript runtimes** as alternatives to Lua. asobi is Lua or
+  Erlang — no JS/TS runtime.
+- **Nakama Console** is further along than asobi_admin today.
+- **Published case studies from AAA studios.** asobi is newer.
+
+If you're deeply reliant on Satori, you'll need to build the equivalent
+in asobi or accept the feature loss.
+
+## Things asobi has that Nakama doesn't
+
+- **Hot-reload Lua** — the [Nakama issue #192](https://github.com/heroiclabs/nakama/issues/192)
+  that's been open since 2018
+- **Plain PostgreSQL** — no CockroachDB requirement
+- **Spatial zones / terrain** — purpose-built for large-world games
+- **Built-in voting** (plurality / ranked / approval / weighted)
+- **Phases and seasons** as first-class primitives
+- **Per-match process isolation** via OTP supervision — crashes never
+  leak between matches, no shared GC pauses
+
+## Cost comparison
+
+Self-hosted Nakama and self-hosted asobi have similar infrastructure
+costs at the low end. The main operational difference:
+
+| | Nakama self-host | asobi self-host |
+|---|---|---|
+| Database | CockroachDB (3-node recommended) | PostgreSQL (1 node is fine) |
+| Hot ops | Restart on deploy | Live module swap |
+| Clustering | Nakama's cluster mode + Consul | OTP `pg` / distributed Erlang |
+| Typical idle cost | €30-60/mo (Cockroach is memory-hungry) | €5-15/mo |
+
+If you're already running Postgres for other services, consolidating onto
+one DB flavour is a meaningful win.
+
+## Do this today
+
+- [ ] `git clone` [asobi_lua](https://github.com/widgrensit/asobi_lua),
+  `docker compose up`, register a test player.
+- [ ] Port one Nakama RPC or match handler to `match.lua`. Compare the
+  feel.
+- [ ] Join the [Discord](https://discord.gg/vYSfYYyXpu) `#migrations`
+  channel — tell us what your Lua runtime does and we'll sketch the port.
+
+## Getting help
+
+- **Discord**: [#migrations](https://discord.gg/vYSfYYyXpu) channel
+- **Email**: hello@asobi.dev
+- **GitHub Discussions**: [widgrensit/asobi_lua/discussions](https://github.com/widgrensit/asobi_lua/discussions)
+
+## See also
+
+- [Migrating from Hathora](migrate-from-hathora.md)
+- [Migrating from PlayFab](migrate-from-playfab.md)
+- [Exit guarantee](exit.md)
+- [Comparison vs Nakama, Colyseus, SpacetimeDB](comparison.md)

--- a/guides/migrate-from-playfab.md
+++ b/guides/migrate-from-playfab.md
@@ -1,0 +1,236 @@
+# Migrating from PlayFab to asobi
+
+If you're reading this, you've probably been through the PlayFab v2
+migration, watched features quietly get removed, or watched your Azure
+bill climb while the product got thinner. You're not alone — the
+[Imperium42 write-up](https://medium.com/@imperium42/the-silent-death-of-playfab-29614f5b9f15)
+catalogues the situation far better than we can.
+
+This guide walks you from "my PlayFab stack is working but brittle" to
+"I run my game on a Docker container I own."
+
+> **Draft notice.** This guide is a starting point, not a playbook — nobody
+> has yet migrated a shipped PlayFab title to asobi end-to-end. The
+> asobi-side endpoints and events below are verified against the current
+> code. PlayFab-side SDK names come from the public PlayFab documentation
+> and may have drifted. **The fastest path is pairing with us in the
+> [Discord](https://discord.gg/vYSfYYyXpu) `#migrations` channel.**
+
+## TL;DR
+
+1. Your Unity/Unreal/JS game keeps shipping. You don't touch the client.
+2. Stand up asobi in parallel on Hetzner / Fly / your laptop.
+3. Port one PlayFab API domain at a time — usually **Auth → Player
+   Inventory → Virtual Currency → Leaderboards → Matchmaking**, in that
+   order.
+4. When all domains are ported, flip a feature flag to point at asobi and
+   retire the PlayFab Title.
+
+## Why asobi specifically
+
+- **Apache-2.0, open-source, self-hostable.** Not a Microsoft product, not
+  a SaaS. The repos are [widgrensit/asobi](https://github.com/widgrensit/asobi)
+  and [widgrensit/asobi_lua](https://github.com/widgrensit/asobi_lua). See
+  the [exit guide](exit.md) if you want to know what happens if *we*
+  disappear.
+- **Flat infra cost.** PlayFab Essentials starts free but scales steeply
+  through compute-based tiers, Data Explorer add-ons, and dedicated
+  multiplayer server VMs. asobi is a single container whose cost you
+  control — a small Hetzner box (€5-15/mo) comfortably holds thousands of
+  players.
+- **Linux dedicated servers work.** Unlike PlayFab's Unreal OSS SDK which
+  historically forced Windows hosts (and their licensing costs), asobi
+  just runs in any Linux container.
+- **Hot-reload Lua.** Ship a fix at 11pm. Connected players stay connected.
+- **One matchmaking service.** Not three (Client::Matchmaker, Multiplayer
+  Matchmaking 2.0, OSS SDK) with no canonical guidance — just
+  `asobi_matchmaker` with pluggable strategies.
+- **Friends work.** Request, approve, block — all in the library.
+- **Lobbies hold state.** Our matchmaker tickets + match "waiting" phase
+  replace the v1 Lobby. Not the stateless read-only v2 Lobby that broke
+  half the games on PlayFab.
+
+## Concept map
+
+| PlayFab | asobi | Notes |
+|---|---|---|
+| **Title** | Tenant / deployment | One Docker container per environment (dev/live). |
+| **TitleId** + SDK config | Base URL of your asobi deployment | No opaque ID — you point the SDK at a URL. |
+| **Entity (`master_player_account`)** | Player | Same concept: durable ID + profile. |
+| **Virtual Currency** | Economy | `game.economy.grant`, `debit`, `balance`, `purchase`. Multiple named currencies; per-player ledgers. |
+| **Catalog** | Store + inventory | `asobi_store_listing` + `asobi_item_def` tables; `/api/v1/store`. |
+| **Inventory** | Inventory | `game.player_items` in Lua / `/api/v1/inventory` REST. |
+| **CloudScript (JS functions)** | Lua in `match.lua` + REST controllers | Your server logic runs as part of the match process — no separate Functions runtime, no cold starts. |
+| **Matchmaking (Queue)** | `asobi_matchmaker` | Strategies: `fill`, `skill_based`, or bring your own via `asobi_matchmaker_strategy`. |
+| **Multiplayer Server (Build)** | Match process | No container-per-match. One Docker container hosts thousands of matches as BEAM processes. Simpler ops, cheaper. |
+| **Data → Player → KeyValue** | `/api/v1/storage/:collection/:key` | Per-player and shared collections with public/owner/none permissions. |
+| **Data → Title Data** | `/api/v1/storage/global/:key` | Use a well-known collection. |
+| **Data → Title Internal Data** | Erlang `sys.config` or Kura schema | Sensitive config stays out of the API. |
+| **Leaderboards + Statistics** | Leaderboards (`/api/v1/leaderboards/:id`) | ETS for microsecond reads, Postgres for persistence. |
+| **Friends list** | Friends (`/api/v1/friends`) | Request / approve / block / update status all work. |
+| **Player Groups** | Groups (`/api/v1/groups`) | Roles, member management, chat channel per group. |
+| **Push Notifications** | Notifications table + WS push | `match.notification` event or polled via `/api/v1/notifications`. |
+| **PlayFab Party (voice/chat)** | Chat channels + DM | Text only. For voice, pair asobi with Vivox / Dissonance / a WebRTC service. |
+| **Receipt validation (IAP)** | `/api/v1/iap/apple`, `/api/v1/iap/google` | Verifies Apple App Store and Google Play receipts. |
+| **Automation rules / webhooks** | Shigoto jobs | Write the rule as an Erlang callback or Lua handler. |
+| **Insights / Analytics** | `asobi_telemetry` + your pipeline | We emit telemetry; pipe to Prometheus / Grafana / ClickHouse. No hosted analytics yet. |
+| **Game Manager (web console)** | [asobi_admin](https://github.com/widgrensit/asobi_admin) | Players, leaderboards, economy, chat. Pre-1.0. |
+
+## Migration path
+
+### Phase 1 — stand up asobi alongside PlayFab (1 day)
+
+Bring up asobi on a spare machine:
+
+```yaml
+# docker-compose.yml
+services:
+  postgres:
+    image: postgres:17
+    environment:
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: postgres
+      POSTGRES_DB: my_game
+
+  asobi:
+    image: ghcr.io/widgrensit/asobi_lua:latest
+    depends_on: [postgres]
+    ports: ["8080:8080"]
+    volumes: ["./lua:/app/game:ro"]
+    environment:
+      ASOBI_DB_HOST: postgres
+      ASOBI_DB_NAME: my_game
+```
+
+```bash
+docker compose up -d
+curl localhost:8080/api/v1/auth/register \
+  -H 'content-type: application/json' \
+  -d '{"username":"alice","password":"hunter2"}'
+# → { "player_id": "...", "session_token": "...", "username": "alice" }
+```
+
+### Phase 2 — port Auth (2-5 days)
+
+PlayFab auth paths map 1:1:
+
+```csharp
+// Before (PlayFab)
+PlayFabClientAPI.LoginWithCustomID(new LoginWithCustomIDRequest {
+  CustomId = deviceId, CreateAccount = true
+}, OnSuccess, OnError);
+
+// After (asobi) — generate creds once, persist locally, then login
+var client = new AsobiClient("https://api.my-game.com");
+if (!PlayerPrefs.HasKey("asobi_pw")) {
+  PlayerPrefs.SetString("asobi_pw", Guid.NewGuid().ToString("N"));
+  await client.Auth.RegisterAsync(deviceId, PlayerPrefs.GetString("asobi_pw"));
+} else {
+  await client.Auth.LoginAsync(deviceId, PlayerPrefs.GetString("asobi_pw"));
+}
+```
+
+OAuth providers (Google, Apple, Steam) go through
+`POST /api/v1/auth/oauth` — same as PlayFab's `LoginWithGoogleAccount` etc.
+
+### Phase 3 — port the data domains one at a time (1-2 weeks)
+
+Run PlayFab and asobi in parallel. For each domain:
+
+- Migrate the PlayFab data snapshot to asobi's Postgres schema (one-off
+  script per domain)
+- Dual-write: the client hits PlayFab AND asobi for the same action
+- Read from asobi; diff vs PlayFab for a day
+- Switch reads to asobi; keep PlayFab dual-write for rollback
+- After a week of clean asobi reads, stop writing to PlayFab
+
+Order: **Leaderboards → Inventory → Virtual Currency → Storage → Friends →
+Groups → Matchmaking**. Leave matchmaking last because it's the most
+stateful handoff.
+
+### Phase 4 — port CloudScript (2 days – 2 weeks)
+
+Rewrite each CloudScript function either as:
+
+- A **Lua callback** in `match.lua` (for per-match logic — e.g.
+  `handle_input`, `tick`)
+- An **asobi REST controller** in Erlang (for domain logic — economy
+  rules, tournament brackets, daily quest resets)
+
+If your PlayFab workload is CloudScript-heavy, budget more time for this
+phase. The upside: hot-reload replaces the CloudScript deploy loop.
+
+### Phase 5 — cut over (1 day)
+
+Flip the SDK base URL from PlayFab to your asobi endpoint via a feature
+flag. Monitor for 24h. Retire the PlayFab Title.
+
+## Deploy story
+
+| Host | Fit | Rough cost |
+|---|---|---|
+| **Hetzner Cloud** (CX22–CX42) | Best price/perf. EU-only. | €4–15 / month |
+| **Scaleway Serverless** | Auto-scale for dev / low traffic | Free tier → pay per req |
+| **Fly.io** | Multi-region one-liner | $5+/month/region |
+| **Clever Cloud** | git-push deploy, EU | €10+/month |
+| **On-prem (your datacentre)** | Regulated / sovereign workloads | Your hardware cost |
+
+A studio running PlayFab Multiplayer Servers at, say, $300/month in VM
+credits typically fits on a €15/month Hetzner CX32 box with asobi.
+
+## Things asobi does NOT do (compared to PlayFab)
+
+- **No hosted analytics dashboard.** We emit telemetry; you pipe it
+  somewhere. PlayFab Insights is the biggest DX gap.
+- **No built-in A/B testing / segmentation framework.** Coming in 2026. For
+  now, roll it in your match logic.
+- **No push notification service.** Use OneSignal, Firebase Cloud
+  Messaging, or APNs directly.
+- **No hosted voice.** Pair with Vivox / Dissonance / Agora.
+- **No Title-as-a-product support tools** (refunds portal, player support
+  console). On the admin dashboard roadmap.
+- **No mandated Entity model.** asobi is pragmatic: player_id is the
+  primary key; you don't have to model everything as Entity-With-Objects.
+
+## Things asobi does that PlayFab doesn't
+
+- Hot-reload game logic without dropping players
+- Open-source — read the code, fork it, own it
+- Linux servers are first-class
+- One unified matchmaker, not three competing services
+- Friends / groups / chat / votes / tournaments / seasons / phases as
+  first-class primitives, not bolt-ons
+- Built-in voting system (plurality, ranked, approval, weighted)
+- Godot and Defold SDKs at engine-parity with Unity
+
+## Cost comparison
+
+| | PlayFab Essentials | PlayFab paid | asobi self-host | asobi managed (soon) |
+|---|---|---|---|---|
+| Base | Free tier | $99+/mo | €5–20/mo infra | ~€9–29/mo |
+| Multiplayer servers | N/A | VM-minute billing | Same container | Included |
+| Analytics add-ons | Limited | Data Explorer metered | Bring your own stack | Bring your own |
+| Egress | N/A | Azure rates | Your host's rates | Flat |
+| Vendor lock-in | High (Azure) | High | None (Apache-2) | Exit runbook |
+
+## Do this today
+
+- [ ] `git clone` [asobi_lua](https://github.com/widgrensit/asobi_lua) and
+  `docker compose up`. Register a player. Confirm it works.
+- [ ] Pick the smallest PlayFab API your game calls (often leaderboards
+  or a single CloudScript function). Port it to asobi in a feature flag.
+- [ ] Join the [Discord](https://discord.gg/vYSfYYyXpu) `#migrations`
+  channel. We'll sanity-check your staging order.
+
+## Getting help
+
+- **Discord**: [#migrations](https://discord.gg/vYSfYYyXpu) channel
+- **Email**: hello@asobi.dev
+- **GitHub Discussions**: [widgrensit/asobi_lua/discussions](https://github.com/widgrensit/asobi_lua/discussions)
+
+## See also
+
+- [Migrating from Hathora](migrate-from-hathora.md)
+- [Migrating from Nakama self-host](migrate-from-nakama.md)
+- [Exit guarantee](exit.md)
+- [Comparison vs Nakama, Colyseus, SpacetimeDB](comparison.md)


### PR DESCRIPTION
## Summary
Closes out the remaining P0 (this-week) items from the roadmap ahead of the 2026-05-05 Hathora cutoff.

- **`guides/exit.md`** — runbook for keeping your game alive if Widgrensit AB disappears. Apache-2 "never relicense" pledge, image mirroring, Postgres export, fork-and-build instructions. Post-Hathora trust anchor.
- **`guides/migrate-from-playfab.md`** — concept map (Title/Entity/CloudScript/Virtual Currency) + phased migration path. Targets the post-v2 silent-sunset audience.
- **`guides/migrate-from-nakama.md`** — structurally close migration (Postgres instead of CockroachDB, hot-reload Lua, spatial zones as wedges). Honest about Satori/Hiro gaps.
- **`guides/comparison.md`** — replaces the "no Erlang experience = don't use asobi" dismissal with a proper `asobi_lua` pointer; fixes the outdated "Nakama has official SDKs" line; adds migration links + hot-reload wedge.
- **`guides/getting-started.md`** — adds step 6 validation curl (`/api/v1/auth/register` → expected JSON); replaces the "restart to reload" line with the hot-reload workflow (the whole point of the product); standardises all docker-compose snippets on `postgres:17`.
- **`examples/hotreload-demo/`** — self-contained clone/run/edit demo. `docker compose up`, open `client/index.html`, edit `lua/match.lua`, watch the browser update live. `RECORDING.md` has the shot list for the 15-second landing-page video.

## Test plan
- [x] `rebar3 fmt --check` clean
- [x] `rebar3 xref` clean
- [x] No Erlang source touched — eqwalize/dialyzer/lint baseline unchanged
- [x] Markdown links cross-reference correctly (exit.md ↔ comparison.md ↔ migrate-from-* ↔ getting-started.md)
- [ ] Manual: bring up `examples/hotreload-demo` and confirm the visible-colour-change round-trip works (pending local verify before video recording)