### PR TITLE
fix(demo): WS session.connect payload key is 'token' not 'session_token'

### DIFF
--- a/examples/hotreload-demo/client/index.html
+++ b/examples/hotreload-demo/client/index.html
@@ -132,16 +132,20 @@
       ws.addEventListener("open", () => {
         ws.send(JSON.stringify({
           type: "session.connect",
-          payload: { session_token: token },
+          payload: { token: token },
         }));
         log("connected — queuing…", "live");
       });
       ws.addEventListener("message", (ev) => {
         const msg = JSON.parse(ev.data);
-        if (msg.type === "match.matched") {
+        if (msg.type === "session.connected") {
+          log("authenticated — waiting to match…", "live");
+        } else if (msg.type === "match.matched") {
           log("matched — you're in. edit lua/match.lua and save.", "live");
         } else if (msg.type === "match.state") {
           state = msg.payload;
+        } else if (msg.type === "error") {
+          log("server error: " + (msg.payload && msg.payload.reason), "err");
         }
       });
       ws.addEventListener("close", () => log("disconnected", "err"));

--- a/guides/migrate-from-hathora.md
+++ b/guides/migrate-from-hathora.md
@@ -158,14 +158,17 @@ coexist in the client during this phase (different base URLs).
 ### WebSocket handshake
 
 Asobi expects every WebSocket client to authenticate with a `session.connect`
-frame *before* it can use any other WS message type:
+frame *before* it can use any other WS message type. The payload field is
+**`token`** (the value of the `session_token` you got from register/login):
 
 ```json
-{"type":"session.connect","payload":{"session_token":"eyJ..."}}
+{"type":"session.connect","payload":{"token":"eyJ..."}}
 ```
 
-After this the server routes match/matchmaker/chat/world events to this
-player. Other message types the server handles: `matchmaker.add`,
+The server replies `{"type":"session.connected","payload":{"player_id":"..."}}`
+when the token is accepted, or `{"type":"error","payload":{"reason":"invalid_payload"}}`
+if the field name is wrong. After successful auth the server routes
+match/matchmaker/chat/world events to this player. Other message types the server handles: `matchmaker.add`,
 `matchmaker.remove`, `match.input`, `match.join`, `match.leave`, `chat.send`,
 `chat.join`, `chat.leave`, `dm.send`, `presence.update`, `vote.cast`,
 `vote.veto`, `world.list`, `world.create`, `world.find_or_create`,


### PR DESCRIPTION
## Summary
The hot-reload demo client sent \`payload: { session_token: ... }\` to the WS session.connect frame, but \`asobi_ws_handler:authenticate/1\` pattern-matches on \`payload.token\`. The mismatch triggered a \`function_clause\` which \`safe_handle_message\` caught and replied with \`{type: \"error\", reason: \"invalid_payload\"}\` — but the client didn't handle error messages, so the WS stayed open, unauthenticated.

Net effect: ticket queued, match spawned, \`match.matched\` pushed to presence keyed by player_id — but the player's WS was never registered, so the push went nowhere. Browser stuck on \"connected — queuing…\" forever.

## Fix
- \`client/index.html\`: \`payload: { token: token }\` (renamed from \`session_token\`). Added \`session.connected\` and \`error\` event handling so the status bar tells you what's happening instead of hanging.
- \`guides/migrate-from-hathora.md\` § WebSocket handshake: documented the real field name and the server's reply shapes. Previous text had the same \`session_token\` mistake.

## Test plan
- [x] Demo: \`docker compose up\`, open <http://localhost:3000>, status progresses \`connecting\` → \`authenticated — waiting to match\` → \`matched\` and the cube appears
- [x] Edit \`lua/match.lua\` (change \`cube_color\`), save — browser cube updates live