### PR TITLE
chore(eqwalize): clean all 210 eqwalizer errors

### DIFF
--- a/src/asobi_telemetry.erl
+++ b/src/asobi_telemetry.erl
@@ -218,7 +218,12 @@ vote_resolved(VoteId, DurationMs, Result) ->
 
 %% --- Internal ---
 
--spec handle_event([atom()], map(), map(), map()) -> ok.
+-spec handle_event(
+    telemetry:event_name(),
+    telemetry:event_measurements(),
+    telemetry:event_metadata(),
+    telemetry:handler_config()
+) -> ok.
 handle_event(EventName, Measurements, Metadata, _Config) ->
     logger:debug(#{
         msg => ~"telemetry_event",

--- a/src/controllers/asobi_dm_controller.erl
+++ b/src/controllers/asobi_dm_controller.erl
@@ -6,7 +6,7 @@
 send(#{
     json := #{~"recipient_id" := RecipientId, ~"content" := Content},
     auth_data := #{player_id := PlayerId}
-}) ->
+}) when is_binary(RecipientId), is_binary(Content), is_binary(PlayerId) ->
     case asobi_dm:send(PlayerId, RecipientId, Content) of
         ok ->
             {json, 200, #{}, #{
@@ -21,7 +21,7 @@ history(#{
     bindings := #{~"player_id" := OtherPlayerId},
     qs := Qs,
     auth_data := #{player_id := PlayerId}
-}) ->
+}) when is_binary(OtherPlayerId), is_binary(PlayerId) ->
     Params = cow_qs:parse_qs(Qs),
     Limit =
         case proplists:get_value(~"limit", Params) of

--- a/src/controllers/asobi_social_controller.erl
+++ b/src/controllers/asobi_social_controller.erl
@@ -175,7 +175,7 @@ update_member_role(#{
     bindings := #{~"id" := GroupId, ~"player_id" := TargetPlayerId},
     json := #{~"role" := NewRole},
     auth_data := #{player_id := ActorId}
-}) ->
+}) when is_binary(NewRole) ->
     case asobi_group_roles:valid_role(NewRole) of
         false ->
             {json, 400, #{}, #{error => ~"invalid_role"}};
@@ -230,11 +230,7 @@ update_group(#{
                             Updates = maps:with(
                                 [~"name", ~"description", ~"max_members", ~"open"], Params
                             ),
-                            Atomized = maps:fold(
-                                fun(K, V, Acc) -> Acc#{binary_to_existing_atom(K) => V} end,
-                                #{},
-                                Updates
-                            ),
+                            Atomized = atomize_keys(maps:to_list(Updates)),
                             CS = asobi_group:changeset(Group, Atomized),
                             {ok, Updated} = asobi_repo:update(CS),
                             {json, 200, #{}, Updated};
@@ -265,3 +261,12 @@ qs_integer(Key, Params, Default) ->
         V when is_binary(V) -> binary_to_integer(V);
         _ -> Default
     end.
+
+-spec atomize_keys([{term(), term()}]) -> #{atom() => term()}.
+atomize_keys([]) ->
+    #{};
+atomize_keys([{K, V} | Rest]) when is_binary(K) ->
+    Acc = atomize_keys(Rest),
+    Acc#{binary_to_existing_atom(K) => V};
+atomize_keys([_ | Rest]) ->
+    atomize_keys(Rest).

--- a/src/matches/asobi_match_server.erl
+++ b/src/matches/asobi_match_server.erl
@@ -576,24 +576,25 @@ build_vote_config(VoteConfig, MatchId, Players, State) ->
 merge_vote_weights(VoteConfig, PlayerIds, State) ->
     Frustration = maps:get(vote_frustration, State, #{}),
     FBonus = maps:get(frustration_bonus, State, 0),
-    FWeights = lists:foldl(
-        fun(PId, Acc) ->
-            FVal =
-                case maps:get(PId, Frustration, 0) of
-                    N when is_number(N) -> N;
-                    _ -> 0
-                end,
-            Acc#{PId => 1 + FVal * FBonus}
-        end,
-        #{},
-        PlayerIds
-    ),
+    FWeights = build_frustration_weights(PlayerIds, Frustration, FBonus),
     BaseWeights =
         case maps:get(weights, VoteConfig, #{}) of
             BW when is_map(BW) -> BW;
             _ -> #{}
         end,
     maps:merge(FWeights, BaseWeights).
+
+-spec build_frustration_weights([binary()], map(), number()) -> #{binary() => number()}.
+build_frustration_weights([], _Frustration, _FBonus) ->
+    #{};
+build_frustration_weights([PId | Rest], Frustration, FBonus) ->
+    FVal =
+        case maps:get(PId, Frustration, 0) of
+            N when is_number(N) -> N;
+            _ -> 0
+        end,
+    Acc = build_frustration_weights(Rest, Frustration, FBonus),
+    Acc#{PId => 1 + FVal * FBonus}.
 
 notify_vote_started(Mod, GS, State) ->
     case erlang:function_exported(Mod, vote_started, 1) of

--- a/src/matches/asobi_matchmaker.erl
+++ b/src/matches/asobi_matchmaker.erl
@@ -415,6 +415,5 @@ generate_id() ->
 ensure_map(M) when is_map(M) -> M;
 ensure_map(_) -> #{}.
 
--spec pos_len([term()]) -> pos_integer().
-pos_len([]) -> 1;
-pos_len(L) -> length(L).
+-spec pos_len([term(), ...]) -> pos_integer().
+pos_len([_ | _] = L) -> length(L).

--- a/src/matches/asobi_matchmaker.erl
+++ b/src/matches/asobi_matchmaker.erl
@@ -54,18 +54,25 @@ init([]) ->
     }}.
 
 -spec handle_call(term(), gen_server:from(), map()) -> {reply, term(), map()}.
-handle_call({add, PlayerId, Params}, _From, #{tickets := Tickets} = State) when is_map(Params) ->
+handle_call({add, PlayerId, Params}, _From, #{tickets := Tickets} = State) when
+    is_binary(PlayerId), is_map(Params)
+->
     TicketId = generate_id(),
+    Mode =
+        case maps:get(mode, Params, ~"default") of
+            M when is_binary(M) -> M;
+            _ -> ~"default"
+        end,
     Ticket = #{
         id => TicketId,
         player_id => PlayerId,
-        mode => maps:get(mode, Params, ~"default"),
+        mode => Mode,
         properties => maps:get(properties, Params, #{}),
         party => maps:get(party, Params, [PlayerId]),
         submitted_at => erlang:system_time(millisecond),
         status => pending
     },
-    asobi_telemetry:matchmaker_queued(PlayerId, maps:get(mode, Ticket)),
+    asobi_telemetry:matchmaker_queued(PlayerId, Mode),
     {reply, {ok, TicketId}, State#{tickets => Tickets#{TicketId => Ticket}}};
 handle_call({get_ticket, TicketId}, _From, #{tickets := Tickets} = State) ->
     case Tickets of
@@ -102,7 +109,9 @@ handle_call(_Request, _From, State) ->
     {reply, {error, unknown_request}, State}.
 
 -spec handle_cast(term(), map()) -> {noreply, map()}.
-handle_cast({remove, PlayerId, TicketId}, #{tickets := Tickets} = State) ->
+handle_cast({remove, PlayerId, TicketId}, #{tickets := Tickets} = State) when
+    is_binary(PlayerId)
+->
     asobi_telemetry:matchmaker_removed(PlayerId, cancelled),
     {noreply, State#{tickets => maps:remove(TicketId, Tickets)}};
 handle_cast(_Msg, State) ->
@@ -259,7 +268,7 @@ spawn_match(Mode, ModeConfig, PlayerIds, Group, Rest, Failed) ->
                     Now = erlang:system_time(millisecond),
                     AvgWait =
                         lists:sum([Now - maps:get(submitted_at, T) || T <- Group]) div
-                            max(1, length(Group)),
+                            pos_len(Group),
                     asobi_telemetry:matchmaker_formed(Mode, length(PlayerIds), AvgWait),
                     MatchInfo = asobi_match_server:get_info(MatchPid),
                     lists:foreach(
@@ -315,13 +324,18 @@ spawn_world(Mode, ModeConfig, PlayerIds, Group, Rest, Failed) ->
                             Now = erlang:system_time(millisecond),
                             AvgWait =
                                 lists:sum([Now - maps:get(submitted_at, T) || T <- SpawnGroup]) div
-                                    max(1, length(SpawnGroup)),
+                                    pos_len(SpawnGroup),
                             asobi_telemetry:matchmaker_formed(
                                 Mode, length(SpawnPlayerIds), AvgWait
                             ),
-                            WorldPid = asobi_world_instance:get_child(
-                                InstancePid, asobi_world_server
-                            ),
+                            WorldPid =
+                                case
+                                    asobi_world_instance:get_child(
+                                        InstancePid, asobi_world_server
+                                    )
+                                of
+                                    WP when is_pid(WP) -> WP
+                                end,
                             logger:notice(#{
                                 msg => ~"world spawn complete",
                                 world_pid => WorldPid,
@@ -400,3 +414,7 @@ generate_id() ->
 -spec ensure_map(term()) -> #{term() => term()}.
 ensure_map(M) when is_map(M) -> M;
 ensure_map(_) -> #{}.
+
+-spec pos_len([term()]) -> pos_integer().
+pos_len([]) -> 1;
+pos_len(L) -> length(L).

--- a/src/matches/asobi_matchmaker_fill.erl
+++ b/src/matches/asobi_matchmaker_fill.erl
@@ -15,7 +15,20 @@ match(Tickets, Config) ->
 
 -spec group([map()], pos_integer(), [[map()]]) -> {[[map()]], [map()]}.
 group(Remaining, Size, Matched) when length(Remaining) < Size ->
-    {lists:reverse(Matched), Remaining};
+    {rev(Matched, []), Remaining};
 group(Tickets, Size, Matched) ->
-    {Group, Rest} = lists:split(Size, Tickets),
+    {Group, Rest} = split_at(Size, Tickets),
     group(Rest, Size, [Group | Matched]).
+
+-spec split_at(non_neg_integer(), [T]) -> {[T], [T]}.
+split_at(0, Rest) ->
+    {[], Rest};
+split_at(_, []) ->
+    {[], []};
+split_at(N, [H | T]) ->
+    {Taken, Rest} = split_at(N - 1, T),
+    {[H | Taken], Rest}.
+
+-spec rev([T], [T]) -> [T].
+rev([], Acc) -> Acc;
+rev([H | T], Acc) -> rev(T, [H | Acc]).

--- a/src/matches/asobi_matchmaker_skill.erl
+++ b/src/matches/asobi_matchmaker_skill.erl
@@ -18,36 +18,65 @@ match(Tickets, Config) ->
     Size = maps:get(match_size, Config, 2),
     Window = maps:get(skill_window, Config, 200),
     ExpandRate = maps:get(skill_expand_rate, Config, 50),
-    Sorted = lists:sort(fun(A, B) -> skill(A) =< skill(B) end, Tickets),
+    Sorted = sort_by_skill(Tickets),
     match_groups(Sorted, Size, Window, ExpandRate, [], []).
+
+-spec sort_by_skill([map()]) -> [map()].
+sort_by_skill(Tickets) ->
+    Tagged = tag_skill(Tickets),
+    Sorted = lists:keysort(1, Tagged),
+    untag_skill(Sorted).
+
+-spec tag_skill([map()]) -> [{integer(), map()}].
+tag_skill([]) -> [];
+tag_skill([T | Rest]) -> [{skill(T), T} | tag_skill(Rest)].
+
+-spec untag_skill([{integer(), map()}]) -> [map()].
+untag_skill([]) -> [];
+untag_skill([{_, T} | Rest]) -> [T | untag_skill(Rest)].
 
 -spec match_groups([map()], pos_integer(), integer(), integer(), [[map()]], [map()]) ->
     {[[map()]], [map()]}.
 match_groups([], _Size, _Window, _Rate, Matched, Unmatched) ->
-    {lists:reverse(Matched), Unmatched};
+    {rev(Matched, []), Unmatched};
 match_groups(Tickets, Size, _Window, _Rate, Matched, Unmatched) when length(Tickets) < Size ->
-    {lists:reverse(Matched), Tickets ++ Unmatched};
-match_groups(Tickets, Size, Window, Rate, Matched, Unmatched) ->
-    {Candidate, Rest} = lists:split(Size, Tickets),
+    {rev(Matched, []), Tickets ++ Unmatched};
+match_groups([First | _] = Tickets, Size, Window, Rate, Matched, Unmatched) ->
+    {Candidate, Rest} = split_at(Size, Tickets, []),
     case group_within_window(Candidate, Window, Rate) of
         true ->
             match_groups(Rest, Size, Window, Rate, [Candidate | Matched], Unmatched);
         false ->
-            [First | Remaining] = Tickets,
+            [_ | Remaining] = Tickets,
             match_groups(Remaining, Size, Window, Rate, Matched, [First | Unmatched])
     end.
+
+-spec split_at(non_neg_integer(), [T], [T]) -> {[T], [T]}.
+split_at(0, Rest, Acc) ->
+    {rev(Acc, []), Rest};
+split_at(_, [], Acc) ->
+    {rev(Acc, []), []};
+split_at(N, [H | T], Acc) ->
+    split_at(N - 1, T, [H | Acc]).
+
+-spec rev([T], [T]) -> [T].
+rev([], Acc) -> Acc;
+rev([H | T], Acc) -> rev(T, [H | Acc]).
 
 -spec group_within_window([map()], integer(), integer()) -> boolean().
 group_within_window([], _Window, _Rate) ->
     true;
 group_within_window([_], _Window, _Rate) ->
     true;
-group_within_window(Group, BaseWindow, Rate) ->
-    First = hd(Group),
-    Last = lists:last(Group),
+group_within_window([First | _] = Group, BaseWindow, Rate) ->
+    Last = last_elem(Group),
     Diff = abs(skill(First) - skill(Last)),
     EffectiveWindow = effective_window(First, BaseWindow, Rate),
     Diff =< EffectiveWindow.
+
+-spec last_elem([T, ...]) -> T.
+last_elem([X]) -> X;
+last_elem([_ | Rest]) -> last_elem(Rest).
 
 -spec effective_window(map(), integer(), integer()) -> integer().
 effective_window(#{submitted_at := Sub}, BaseWindow, Rate) ->

--- a/src/timers/asobi_phase.erl
+++ b/src/timers/asobi_phase.erl
@@ -71,7 +71,10 @@ init(Phases) ->
         paused => false,
         complete => false
     },
-    Phase = lists:nth(1, Phases),
+    Phase =
+        case lists:nth(1, Phases) of
+            P when is_map(P) -> P
+        end,
     case maps:get(start, Phase, prev_ended) of
         prev_ended ->
             %% Auto-start first phase immediately
@@ -124,7 +127,7 @@ notify({event, Name}, #{current_started := false} = PS) ->
         {event, Name} -> start_current_phase(PS);
         _ -> {[], PS}
     end;
-notify(Event, #{active_timers := Timers} = PS) ->
+notify(Event, #{active_timers := Timers} = PS) when is_atom(Event) ->
     {AllEvents, Timers1} = maps:fold(
         fun(TId, T, {Evts, Acc}) ->
             {TEvts, T1} = asobi_timer:notify(Event, undefined, T),
@@ -133,7 +136,9 @@ notify(Event, #{active_timers := Timers} = PS) ->
         {[], #{}},
         Timers
     ),
-    {AllEvents, PS#{active_timers => Timers1}}.
+    {AllEvents, PS#{active_timers => Timers1}};
+notify(_Event, PS) ->
+    {[], PS}.
 
 %% -------------------------------------------------------------------
 %% Pause / Resume
@@ -288,7 +293,10 @@ advance_phase(PS) ->
         true ->
             {EndEvents ++ [{all_phases_complete}], PS#{complete => true, active_timers => #{}}};
         false ->
-            NextPhase = lists:nth(NextIdx + 1, Phases),
+            NextPhase =
+                case lists:nth(NextIdx + 1, Phases) of
+                    P when is_map(P) -> P
+                end,
             PS1 = PS#{
                 current_index => NextIdx,
                 current_started => false,
@@ -311,20 +319,22 @@ advance_phase(PS) ->
 current_phase_def(#{phases := Phases, current_index := Idx}) ->
     lists:nth(Idx + 1, Phases).
 
-build_timers(TimerConfigs) ->
-    lists:foldl(
-        fun(Config, Acc) ->
-            Type = maps:get(type, Config),
-            Id = maps:get(id, Config),
-            Timer =
-                case Type of
-                    countdown -> asobi_timer:countdown(Config);
-                    conditional -> asobi_timer:conditional(Config);
-                    cycle -> asobi_timer:cycle(Config);
-                    scheduled -> asobi_timer:scheduled(Config)
-                end,
-            Acc#{Id => Timer}
+-spec build_timers([term()]) -> #{binary() => asobi_timer:timer()}.
+build_timers([]) ->
+    #{};
+build_timers([Config | Rest]) when is_map(Config) ->
+    Type = maps:get(type, Config),
+    Id = maps:get(id, Config),
+    Timer =
+        case Type of
+            countdown -> asobi_timer:countdown(Config);
+            conditional -> asobi_timer:conditional(Config);
+            cycle -> asobi_timer:cycle(Config);
+            scheduled -> asobi_timer:scheduled(Config)
         end,
-        #{},
-        TimerConfigs
-    ).
+    Acc = build_timers(Rest),
+    case Id of
+        IdBin when is_binary(IdBin) -> Acc#{IdBin => Timer}
+    end;
+build_timers([_ | Rest]) ->
+    build_timers(Rest).

--- a/src/timers/asobi_season.erl
+++ b/src/timers/asobi_season.erl
@@ -79,12 +79,16 @@ history() ->
         _ -> []
     end.
 
--spec time_remaining() -> pos_integer() | infinity.
+-spec time_remaining() -> non_neg_integer() | infinity.
 time_remaining() ->
     case current() of
-        {ok, #{ends_at := EndsAt}} ->
+        {ok, #{ends_at := EndsAt}} when is_integer(EndsAt) ->
             Now = erlang:system_time(millisecond),
-            max(0, EndsAt - Now);
+            Remaining = EndsAt - Now,
+            if
+                Remaining > 0 -> Remaining;
+                true -> 0
+            end;
         _ ->
             infinity
     end.

--- a/src/timers/asobi_timer.erl
+++ b/src/timers/asobi_timer.erl
@@ -80,10 +80,19 @@ conditional(Config) ->
 -spec cycle(map()) -> timer().
 cycle(Config) ->
     Id = maps:get(id, Config),
-    Phases = maps:get(phases, Config),
+    Phases =
+        case maps:get(phases, Config) of
+            Ps when is_list(Ps) -> Ps
+        end,
     Repeat = maps:get(repeat, Config, true),
-    StartIndex = maps:get(start_index, Config, 0),
-    Phase = lists:nth(StartIndex + 1, Phases),
+    StartIndex =
+        case maps:get(start_index, Config, 0) of
+            N when is_integer(N), N >= 0 -> N
+        end,
+    Phase =
+        case lists:nth(StartIndex + 1, Phases) of
+            P when is_map(P) -> P
+        end,
     PhaseDuration = maps:get(duration, Phase),
     #{
         type => cycle,
@@ -124,7 +133,7 @@ tick(_DeltaMs, #{paused := true} = Timer) ->
 tick(_DeltaMs, #{expired := true} = Timer) ->
     {[], Timer};
 %% Countdown
-tick(DeltaMs, #{type := countdown, id := Id, remaining := Rem} = Timer) ->
+tick(DeltaMs, #{type := countdown, id := Id, remaining := Rem} = Timer) when is_number(Rem) ->
     Rem1 = Rem - DeltaMs,
     {WarningEvents, Timer1} = check_warnings(Id, Rem1, Timer),
     case Rem1 =< 0 of
@@ -137,7 +146,10 @@ tick(DeltaMs, #{type := countdown, id := Id, remaining := Rem} = Timer) ->
 %% Conditional — not yet started, waiting for condition or fallback
 tick(DeltaMs, #{type := conditional, started := false} = Timer) ->
     #{id := Id, fallback_timeout := Fallback, fallback_elapsed := Elapsed} = Timer,
-    Elapsed1 = Elapsed + DeltaMs,
+    Elapsed1 =
+        case Elapsed of
+            E when is_number(E) -> E + DeltaMs
+        end,
     case Fallback =/= infinity andalso Elapsed1 >= Fallback of
         true ->
             Timer1 = Timer#{
@@ -150,7 +162,9 @@ tick(DeltaMs, #{type := conditional, started := false} = Timer) ->
             {[], Timer#{fallback_elapsed => Elapsed1}}
     end;
 %% Conditional — started, counting down
-tick(DeltaMs, #{type := conditional, started := true, id := Id, remaining := Rem} = Timer) ->
+tick(DeltaMs, #{type := conditional, started := true, id := Id, remaining := Rem} = Timer) when
+    is_number(Rem)
+->
     Rem1 = Rem - DeltaMs,
     {WarningEvents, Timer1} = check_warnings(Id, Rem1, Timer),
     case Rem1 =< 0 of
@@ -218,25 +232,38 @@ resume(Timer) ->
 %% -------------------------------------------------------------------
 
 -spec is_expired(timer()) -> boolean().
-is_expired(#{expired := Expired}) -> Expired.
+is_expired(#{expired := Expired}) when is_boolean(Expired) -> Expired.
 
 -spec is_started(timer()) -> boolean().
-is_started(#{type := conditional, started := Started}) -> Started;
+is_started(#{type := conditional, started := Started}) when is_boolean(Started) -> Started;
 is_started(_Timer) -> true.
 
 -spec is_paused(timer()) -> boolean().
-is_paused(#{paused := Paused}) -> Paused.
+is_paused(#{paused := Paused}) when is_boolean(Paused) -> Paused.
 
--spec remaining(timer()) -> pos_integer() | infinity.
-remaining(#{type := conditional, started := false}) -> infinity;
-remaining(#{type := scheduled}) -> infinity;
-remaining(#{type := cycle, phase_remaining := Rem}) -> Rem;
-remaining(#{remaining := Rem}) -> max(0, Rem).
+-spec remaining(timer()) -> number() | infinity.
+remaining(#{type := conditional, started := false}) ->
+    infinity;
+remaining(#{type := scheduled}) ->
+    infinity;
+remaining(#{type := cycle, phase_remaining := Rem}) when is_number(Rem); Rem =:= infinity ->
+    Rem;
+remaining(#{remaining := Rem}) when is_number(Rem), Rem > 0 ->
+    Rem;
+remaining(#{remaining := Rem}) when is_number(Rem) ->
+    0.
 
 -spec current_phase(timer()) -> binary() | undefined.
-current_phase(#{type := cycle, phases := Phases, phase_index := Idx}) ->
-    Phase = lists:nth(Idx + 1, Phases),
-    maps:get(name, Phase);
+current_phase(#{type := cycle, phases := Phases, phase_index := Idx}) when
+    is_list(Phases), is_integer(Idx)
+->
+    case lists:nth(Idx + 1, Phases) of
+        P when is_map(P) ->
+            case maps:get(name, P) of
+                Name when is_binary(Name) -> Name;
+                _ -> undefined
+            end
+    end;
 current_phase(_) ->
     undefined.
 
@@ -256,7 +283,7 @@ info(#{
     remaining := Rem,
     paused := Paused,
     expired := Expired
-}) ->
+}) when is_number(Rem) ->
     #{
         type => conditional,
         id => Id,
@@ -291,8 +318,11 @@ info(#{
     phase_remaining := Rem,
     paused := Paused,
     expired := Expired
-}) ->
-    Phase = lists:nth(Idx + 1, Phases),
+}) when is_list(Phases), is_integer(Idx), is_number(Rem) ->
+    Phase =
+        case lists:nth(Idx + 1, Phases) of
+            P when is_map(P) -> P
+        end,
     #{
         type => cycle,
         id => Id,
@@ -319,7 +349,7 @@ tick_cycle(
         id := Id
     } = Timer,
     Events
-) ->
+) when is_list(Phases), is_integer(Idx), is_number(Rem) ->
     Rem1 = Rem - DeltaMs,
     case Rem1 =< 0 of
         false ->
@@ -329,7 +359,10 @@ tick_cycle(
             NextIdx = Idx + 1,
             case NextIdx >= length(Phases) of
                 true when Repeat ->
-                    NewPhase = lists:nth(1, Phases),
+                    NewPhase =
+                        case lists:nth(1, Phases) of
+                            P when is_map(P) -> P
+                        end,
                     NewDuration = maps:get(duration, NewPhase),
                     PhaseName = maps:get(name, NewPhase),
                     Events1 = [{phase_changed, Id, PhaseName} | Events],
@@ -342,7 +375,10 @@ tick_cycle(
                     Events1 = [{timer_expired, Id} | Events],
                     {lists:reverse(Events1), Timer#{expired => true, phase_remaining => 0}};
                 false ->
-                    NewPhase = lists:nth(NextIdx + 1, Phases),
+                    NewPhase =
+                        case lists:nth(NextIdx + 1, Phases) of
+                            P when is_map(P) -> P
+                        end,
                     NewDuration = maps:get(duration, NewPhase),
                     PhaseName = maps:get(name, NewPhase),
                     Events1 = [{phase_changed, Id, PhaseName} | Events],
@@ -358,20 +394,39 @@ tick_cycle(
 %% Internal — warning checks
 %% -------------------------------------------------------------------
 
-check_warnings(Id, Remaining, #{warnings := Warnings, warnings_fired := Fired} = Timer) ->
-    {NewEvents, NewFired} = lists:foldl(
-        fun(Threshold, {Evts, F}) ->
-            case Remaining =< Threshold andalso not lists:member(Threshold, F) of
-                true ->
-                    {[{timer_warning, Id, Threshold} | Evts], [Threshold | F]};
-                false ->
-                    {Evts, F}
-            end
-        end,
-        {[], Fired},
-        Warnings
-    ),
-    {lists:reverse(NewEvents), Timer#{warnings_fired => NewFired}}.
+-spec check_warnings(binary(), number(), timer()) -> {[timer_event()], timer()}.
+check_warnings(Id, Remaining, #{warnings := Warnings, warnings_fired := Fired} = Timer) when
+    is_list(Warnings), is_list(Fired)
+->
+    NewEvents = collect_warning_events(Warnings, Id, Remaining, Fired),
+    NewFired = collect_warning_fired(Warnings, Remaining, Fired),
+    {NewEvents, Timer#{warnings_fired => NewFired}}.
+
+-spec collect_warning_events([term()], binary(), number(), [term()]) -> [timer_event()].
+collect_warning_events([], _Id, _Remaining, _Fired) ->
+    [];
+collect_warning_events([Threshold | Rest], Id, Remaining, Fired) when
+    is_integer(Threshold), Threshold > 0
+->
+    case Remaining =< Threshold andalso not lists:member(Threshold, Fired) of
+        true ->
+            [{timer_warning, Id, Threshold} | collect_warning_events(Rest, Id, Remaining, Fired)];
+        false ->
+            collect_warning_events(Rest, Id, Remaining, Fired)
+    end;
+collect_warning_events([_ | Rest], Id, Remaining, Fired) ->
+    collect_warning_events(Rest, Id, Remaining, Fired).
+
+-spec collect_warning_fired([term()], number(), [term()]) -> [term()].
+collect_warning_fired([], _Remaining, Fired) ->
+    Fired;
+collect_warning_fired([Threshold | Rest], Remaining, Fired) when is_number(Threshold) ->
+    case Remaining =< Threshold andalso not lists:member(Threshold, Fired) of
+        true -> collect_warning_fired(Rest, Remaining, [Threshold | Fired]);
+        false -> collect_warning_fired(Rest, Remaining, Fired)
+    end;
+collect_warning_fired([_ | Rest], Remaining, Fired) ->
+    collect_warning_fired(Rest, Remaining, Fired).
 
 %% -------------------------------------------------------------------
 %% Internal — condition checking
@@ -395,7 +450,7 @@ check_condition(_Event, _Data, _Condition) ->
 %% -------------------------------------------------------------------
 
 -spec check_schedule(term(), integer()) -> boolean().
-check_schedule({window, WindowConfig}, NowSec) ->
+check_schedule({window, WindowConfig}, NowSec) when is_map(WindowConfig) ->
     {{_Y, _M, _D} = Date, {H, Mi, _S}} = calendar:system_time_to_universal_time(NowSec, second),
     DayOfWeek = calendar:day_of_the_week(Date),
     Key =
@@ -406,15 +461,26 @@ check_schedule({window, WindowConfig}, NowSec) ->
     case maps:get(Key, WindowConfig, undefined) of
         undefined ->
             false;
-        {StartH, StartM, EndH, EndM} ->
+        {StartH, StartM, EndH, EndM} when
+            is_integer(StartH), is_integer(StartM), is_integer(EndH), is_integer(EndM)
+        ->
             NowMins = H * 60 + Mi,
             StartMins = StartH * 60 + StartM,
             EndMins = EndH * 60 + EndM,
-            NowMins >= StartMins andalso NowMins < EndMins
+            NowMins >= StartMins andalso NowMins < EndMins;
+        _ ->
+            false
     end;
-check_schedule({once, TargetDatetime}, NowSec) ->
+check_schedule({once, {{Y, Mo, D}, {H, Mi, S}}}, NowSec) when
+    is_integer(Y),
+    is_integer(Mo),
+    is_integer(D),
+    is_integer(H),
+    is_integer(Mi),
+    is_integer(S)
+->
     TargetSec =
-        calendar:datetime_to_gregorian_seconds(TargetDatetime) -
+        calendar:datetime_to_gregorian_seconds({{Y, Mo, D}, {H, Mi, S}}) -
             calendar:datetime_to_gregorian_seconds({{1970, 1, 1}, {0, 0, 0}}),
     NowSec >= TargetSec;
 check_schedule(_Schedule, _NowSec) ->

--- a/src/world/asobi_spatial.erl
+++ b/src/world/asobi_spatial.erl
@@ -109,8 +109,16 @@ nearest(Entities, {CX, CY}, N, Opts) ->
     All = collect_with_distance(
         maps:to_list(Entities), CX, CY, TypeFilter, Exclude, CustomFilter, []
     ),
-    Sorted = lists:sort(fun({D1, _, _}, {D2, _, _}) -> D1 =< D2 end, All),
-    format_nearest(lists:sublist(Sorted, N), []).
+    Sorted = keysort_by_distance(All),
+    format_nearest(take(Sorted, N)).
+
+-spec keysort_by_distance([T]) -> [T] when T :: {float(), binary(), map()}.
+keysort_by_distance(L) -> lists:keysort(1, L).
+
+-spec take([T], non_neg_integer()) -> [T].
+take(_, 0) -> [];
+take([], _) -> [];
+take([H | T], N) -> [H | take(T, N - 1)].
 
 -spec collect_with_distance(
     [{binary(), map()}],
@@ -134,12 +142,11 @@ collect_with_distance([{Id, #{x := X, y := Y} = Entity} | Rest], CX, CY, TF, Exc
 collect_with_distance([_ | Rest], CX, CY, TF, Excl, CF, Acc) ->
     collect_with_distance(Rest, CX, CY, TF, Excl, CF, Acc).
 
--spec format_nearest([{float(), binary(), map()}], [{binary(), map(), float()}]) ->
-    [{binary(), map(), float()}].
-format_nearest([], Acc) ->
-    lists:reverse(Acc);
-format_nearest([{D2, Id, E} | Rest], Acc) ->
-    format_nearest(Rest, [{Id, E, math:sqrt(D2)} | Acc]).
+-spec format_nearest([{float(), binary(), map()}]) -> [{binary(), map(), float()}].
+format_nearest([]) ->
+    [];
+format_nearest([{D2, Id, E} | Rest]) ->
+    [{Id, E, math:sqrt(D2)} | format_nearest(Rest)].
 
 %% -------------------------------------------------------------------
 %% Point utilities

--- a/src/world/asobi_spatial_grid.erl
+++ b/src/world/asobi_spatial_grid.erl
@@ -108,10 +108,8 @@ query_radius({CX, CY}, Radius, #{cell_size := CS, cells := Cells}) ->
 
 -spec query_rect(pos(), pos(), grid()) -> [{binary(), pos()}].
 query_rect({X1, Y1}, {X2, Y2}, #{cell_size := CS, cells := Cells}) ->
-    MinX = min(X1, X2),
-    MinY = min(Y1, Y2),
-    MaxX = max(X1, X2),
-    MaxY = max(Y1, Y2),
+    {MinX, MaxX} = order_pair(X1, X2),
+    {MinY, MaxY} = order_pair(Y1, Y2),
     {MinCellX, MinCellY} = pos_to_cell(MinX, MinY, CS),
     {MaxCellX, MaxCellY} = pos_to_cell(MaxX, MaxY, CS),
     scan_cells(
@@ -124,6 +122,10 @@ query_rect({X1, Y1}, {X2, Y2}, #{cell_size := CS, cells := Cells}) ->
             X >= MinX andalso X =< MaxX andalso Y >= MinY andalso Y =< MaxY
         end
     ).
+
+-spec order_pair(number(), number()) -> {number(), number()}.
+order_pair(A, B) when A =< B -> {A, B};
+order_pair(A, B) -> {B, A}.
 
 -spec entities_in_cell(cell_coords(), grid()) -> [{binary(), pos()}].
 entities_in_cell(Cell, #{cells := Cells}) ->
@@ -150,30 +152,46 @@ pos_to_cell(X, Y, CS) ->
     fun((binary(), pos()) -> boolean())
 ) -> [{binary(), pos()}].
 scan_cells(MinCX, MinCY, MaxCX, MaxCY, Cells, Filter) ->
-    lists:foldl(
-        fun(CellX, Acc1) ->
-            lists:foldl(
-                fun(CellY, Acc2) ->
-                    case maps:find({CellX, CellY}, Cells) of
-                        {ok, CellEntities} ->
-                            maps:fold(
-                                fun(Id, Pos, Acc3) ->
-                                    case Filter(Id, Pos) of
-                                        true -> [{Id, Pos} | Acc3];
-                                        false -> Acc3
-                                    end
-                                end,
-                                Acc2,
-                                CellEntities
-                            );
-                        error ->
-                            Acc2
-                    end
-                end,
-                Acc1,
-                lists:seq(MinCY, MaxCY)
-            )
+    scan_cells_x(lists:seq(MinCX, MaxCX), MinCY, MaxCY, Cells, Filter, []).
+
+-spec scan_cells_x(
+    [integer()],
+    integer(),
+    integer(),
+    #{cell_coords() => #{binary() => pos()}},
+    fun((binary(), pos()) -> boolean()),
+    [{binary(), pos()}]
+) -> [{binary(), pos()}].
+scan_cells_x([], _MinCY, _MaxCY, _Cells, _Filter, Acc) ->
+    Acc;
+scan_cells_x([CellX | Rest], MinCY, MaxCY, Cells, Filter, Acc) ->
+    Acc1 = scan_cells_y(lists:seq(MinCY, MaxCY), CellX, Cells, Filter, Acc),
+    scan_cells_x(Rest, MinCY, MaxCY, Cells, Filter, Acc1).
+
+-spec scan_cells_y(
+    [integer()],
+    integer(),
+    #{cell_coords() => #{binary() => pos()}},
+    fun((binary(), pos()) -> boolean()),
+    [{binary(), pos()}]
+) -> [{binary(), pos()}].
+scan_cells_y([], _CellX, _Cells, _Filter, Acc) ->
+    Acc;
+scan_cells_y([CellY | Rest], CellX, Cells, Filter, Acc) ->
+    Acc1 =
+        case maps:find({CellX, CellY}, Cells) of
+            {ok, CellEntities} ->
+                maps:fold(
+                    fun(Id, Pos, A) ->
+                        case Filter(Id, Pos) of
+                            true -> [{Id, Pos} | A];
+                            false -> A
+                        end
+                    end,
+                    Acc,
+                    CellEntities
+                );
+            error ->
+                Acc
         end,
-        [],
-        lists:seq(MinCX, MaxCX)
-    ).
+    scan_cells_y(Rest, CellX, Cells, Filter, Acc1).

--- a/src/world/asobi_spatial_grid.erl
+++ b/src/world/asobi_spatial_grid.erl
@@ -8,7 +8,7 @@
 -export([query_radius/3, query_rect/3]).
 -export([entities_in_cell/2, size/1]).
 
--export_type([grid/0, cell_coords/0]).
+-export_type([grid/0, cell_coords/0, pos/0]).
 
 -type cell_coords() :: {integer(), integer()}.
 -type pos() :: {number(), number()}.

--- a/src/world/asobi_terrain.erl
+++ b/src/world/asobi_terrain.erl
@@ -10,7 +10,7 @@
 -export([compress_chunk/1, decompress_chunk/1]).
 -export([default_format/0, chunk_byte_size/1]).
 
--export_type([tile/0, format/0]).
+-export_type([tile/0, tile_map/0, format/0]).
 
 -type tile() :: {
     X :: non_neg_integer(),
@@ -18,6 +18,10 @@
     TileId :: non_neg_integer(),
     Flags :: non_neg_integer(),
     Elevation :: non_neg_integer()
+}.
+-type tile_map() :: #{
+    {non_neg_integer(), non_neg_integer()} =>
+        {non_neg_integer(), non_neg_integer(), non_neg_integer()}
 }.
 -type format() :: #{
     tile_size := pos_integer(),
@@ -39,21 +43,19 @@ chunk_byte_size(#{tile_size := TS, chunk_width := W, chunk_height := H}) ->
 encode_chunk(Tiles) ->
     encode_chunk(Tiles, default_format()).
 
--spec encode_chunk([tile()] | #{}, format()) -> binary().
+-spec encode_chunk([tile()] | tile_map(), format()) -> binary().
 encode_chunk(Tiles, Fmt) when is_list(Tiles) ->
-    Map = lists:foldl(
-        fun({X, Y, TileId, Flags, Elev}, Acc) ->
-            Acc#{{X, Y} => {TileId, Flags, Elev}}
-        end,
-        #{},
-        Tiles
-    ),
+    Map = tiles_to_map(Tiles),
     encode_chunk(Map, Fmt);
 encode_chunk(TileMap, #{chunk_width := W, chunk_height := H} = _Fmt) when is_map(TileMap) ->
     iolist_to_binary([
         encode_tile(maps:get({X, Y}, TileMap, {0, 0, 0}))
      || Y <- lists:seq(0, H - 1), X <- lists:seq(0, W - 1)
     ]).
+
+-spec tiles_to_map([tile()]) -> tile_map().
+tiles_to_map(Tiles) ->
+    maps:from_list([{{X, Y}, {TileId, Flags, Elev}} || {X, Y, TileId, Flags, Elev} <- Tiles]).
 
 -spec decode_chunk(binary()) -> [tile()].
 decode_chunk(Bin) ->

--- a/src/world/asobi_terrain_store.erl
+++ b/src/world/asobi_terrain_store.erl
@@ -16,13 +16,21 @@ start_link(Opts) ->
 -spec get_chunk(pid(), {integer(), integer()}) ->
     {ok, binary()} | {error, term()}.
 get_chunk(Pid, Coords) ->
-    Tab = gen_server:call(Pid, get_ets_tab),
+    Tab = narrow_tid(gen_server:call(Pid, get_ets_tab)),
     case ets:lookup(Tab, Coords) of
-        [{Coords, Data}] ->
+        [{Coords, Data}] when is_binary(Data) ->
             {ok, Data};
+        [{Coords, _}] ->
+            {error, invalid_cache_entry};
         [] ->
-            gen_server:call(Pid, {load_chunk, Coords})
+            case gen_server:call(Pid, {load_chunk, Coords}) of
+                {ok, D} when is_binary(D) -> {ok, D};
+                {error, _} = Err -> Err
+            end
     end.
+
+-spec narrow_tid(term()) -> ets:tid().
+narrow_tid(T) when is_reference(T) -> T.
 
 -spec preload_chunks(pid(), [{integer(), integer()}]) -> ok.
 preload_chunks(Pid, CoordsList) ->
@@ -34,7 +42,9 @@ evict_chunk(Pid, Coords) ->
 
 -spec stats(pid()) -> map().
 stats(Pid) ->
-    gen_server:call(Pid, stats).
+    case gen_server:call(Pid, stats) of
+        M when is_map(M) -> M
+    end.
 
 %% --- gen_server callbacks ---
 
@@ -69,10 +79,15 @@ handle_call({load_chunk, Coords}, _From, #{ets_tab := Tab} = State) ->
             end
     end;
 handle_call(stats, _From, #{ets_tab := Tab, hits := H, misses := M} = State) ->
+    MemWords =
+        case ets:info(Tab, memory) of
+            N when is_integer(N) -> N;
+            _ -> 0
+        end,
     {reply,
         #{
             cached_chunks => ets:info(Tab, size),
-            memory_bytes => ets:info(Tab, memory) * erlang:system_info(wordsize),
+            memory_bytes => MemWords * erlang:system_info(wordsize),
             hits => H,
             misses => M
         },
@@ -81,25 +96,8 @@ handle_call(_Request, _From, State) ->
     {reply, {error, unknown_request}, State}.
 
 -spec handle_cast(term(), map()) -> {noreply, map()}.
-handle_cast({preload, CoordsList}, #{ets_tab := Tab} = State) ->
-    State1 = lists:foldl(
-        fun(Coords, SAcc) ->
-            case ets:lookup(Tab, Coords) of
-                [{_, _}] ->
-                    SAcc;
-                [] ->
-                    case load_from_provider(Coords, SAcc) of
-                        {ok, Data, SAcc1} ->
-                            ets:insert(Tab, {Coords, Data}),
-                            SAcc1;
-                        {error, _, SAcc1} ->
-                            SAcc1
-                    end
-            end
-        end,
-        State,
-        CoordsList
-    ),
+handle_cast({preload, CoordsList}, #{ets_tab := Tab} = State) when is_list(CoordsList) ->
+    State1 = preload_chunks_do(CoordsList, Tab, State),
     {noreply, State1};
 handle_cast({evict, Coords}, #{ets_tab := Tab} = State) ->
     ets:delete(Tab, Coords),
@@ -147,3 +145,22 @@ generate_fallback(Coords, #{provider_mod := Mod, provider_state := PS, seed := S
 
 inc_hits(#{hits := H} = State) -> State#{hits => H + 1}.
 inc_misses(#{misses := M} = State) -> State#{misses => M + 1}.
+
+-spec preload_chunks_do([term()], ets:tid(), map()) -> map().
+preload_chunks_do([], _Tab, State) ->
+    State;
+preload_chunks_do([Coords | Rest], Tab, State) ->
+    State1 =
+        case ets:lookup(Tab, Coords) of
+            [{_, _}] ->
+                State;
+            [] ->
+                case load_from_provider(Coords, State) of
+                    {ok, Data, S1} ->
+                        ets:insert(Tab, {Coords, Data}),
+                        S1;
+                    {error, _, S1} ->
+                        S1
+                end
+        end,
+    preload_chunks_do(Rest, Tab, State1).

--- a/src/world/asobi_terrain_store.erl
+++ b/src/world/asobi_terrain_store.erl
@@ -16,21 +16,10 @@ start_link(Opts) ->
 -spec get_chunk(pid(), {integer(), integer()}) ->
     {ok, binary()} | {error, term()}.
 get_chunk(Pid, Coords) ->
-    Tab = narrow_tid(gen_server:call(Pid, get_ets_tab)),
-    case ets:lookup(Tab, Coords) of
-        [{Coords, Data}] when is_binary(Data) ->
-            {ok, Data};
-        [{Coords, _}] ->
-            {error, invalid_cache_entry};
-        [] ->
-            case gen_server:call(Pid, {load_chunk, Coords}) of
-                {ok, D} when is_binary(D) -> {ok, D};
-                {error, _} = Err -> Err
-            end
+    case gen_server:call(Pid, {get_chunk, Coords}) of
+        {ok, Data} when is_binary(Data) -> {ok, Data};
+        {error, _} = Err -> Err
     end.
-
--spec narrow_tid(term()) -> ets:tid().
-narrow_tid(T) when is_reference(T) -> T.
 
 -spec preload_chunks(pid(), [{integer(), integer()}]) -> ok.
 preload_chunks(Pid, CoordsList) ->
@@ -63,9 +52,7 @@ init(Opts) ->
     }}.
 
 -spec handle_call(term(), gen_server:from(), map()) -> {reply, term(), map()}.
-handle_call(get_ets_tab, _From, #{ets_tab := Tab} = State) ->
-    {reply, Tab, State};
-handle_call({load_chunk, Coords}, _From, #{ets_tab := Tab} = State) ->
+handle_call({get_chunk, Coords}, _From, #{ets_tab := Tab} = State) ->
     case ets:lookup(Tab, Coords) of
         [{Coords, Data}] ->
             {reply, {ok, Data}, inc_hits(State)};

--- a/src/world/asobi_world_chat.erl
+++ b/src/world/asobi_world_chat.erl
@@ -103,9 +103,9 @@ player_zone_changed(
 -spec channel_id(binary(), atom(), term()) -> binary().
 channel_id(WorldId, world, _) ->
     iolist_to_binary([~"world:", WorldId]);
-channel_id(WorldId, zone, {X, Y}) ->
+channel_id(WorldId, zone, {X, Y}) when is_integer(X), is_integer(Y) ->
     iolist_to_binary([~"zone:", WorldId, ~":", integer_to_binary(X), ~",", integer_to_binary(Y)]);
-channel_id(WorldId, proximity, {X, Y}) ->
+channel_id(WorldId, proximity, {X, Y}) when is_integer(X), is_integer(Y) ->
     iolist_to_binary([~"prox:", WorldId, ~":", integer_to_binary(X), ~",", integer_to_binary(Y)]).
 
 %% --- Internal ---
@@ -154,12 +154,16 @@ leave_zone_chats(PlayerId, PlayerPid, WorldId, ZoneCoords, ChatConfig) ->
     end,
     ignore_result(PlayerId).
 
-proximity_zones({ZX, ZY}, Radius, GridSize) ->
+proximity_zones({ZX, ZY}, Radius, GridSize) when is_integer(ZX), is_integer(ZY) ->
     [
         {X, Y}
-     || X <- lists:seq(max(0, ZX - Radius), min(GridSize - 1, ZX + Radius)),
-        Y <- lists:seq(max(0, ZY - Radius), min(GridSize - 1, ZY + Radius))
+     || X <- lists:seq(clamp_lo(ZX - Radius), min(GridSize - 1, ZX + Radius)),
+        Y <- lists:seq(clamp_lo(ZY - Radius), min(GridSize - 1, ZY + Radius))
     ].
+
+-spec clamp_lo(integer()) -> non_neg_integer().
+clamp_lo(N) when N < 0 -> 0;
+clamp_lo(N) -> N.
 
 find_player_pid(PlayerId) ->
     case pg:get_members(nova_scope, {player, PlayerId}) of

--- a/src/world/asobi_world_lobby.erl
+++ b/src/world/asobi_world_lobby.erl
@@ -39,9 +39,9 @@ list_worlds(Filters) ->
 find_or_create(Mode) ->
     Worlds = list_worlds(#{mode => Mode, has_capacity => true}),
     case Worlds of
-        [#{world_id := WorldId} | _] ->
+        [#{world_id := WorldId} = First | _] ->
             case asobi_world_server:whereis(WorldId) of
-                {ok, Pid} -> {ok, Pid, hd(Worlds)};
+                {ok, Pid} -> {ok, Pid, First};
                 error -> create_world(Mode)
             end;
         [] ->
@@ -54,7 +54,7 @@ create_world(Mode) ->
     case asobi_game_modes:world_config(Mode) of
         {ok, Config} ->
             case asobi_world_instance_sup:start_world(Config) of
-                {ok, InstancePid} ->
+                {ok, InstancePid} when is_pid(InstancePid) ->
                     WorldPid = wait_for_world_server(InstancePid, 10),
                     case WorldPid of
                         undefined ->

--- a/src/world/asobi_world_registry.erl
+++ b/src/world/asobi_world_registry.erl
@@ -23,11 +23,18 @@ unregister_world(WorldId) ->
 
 -spec get_world(binary()) -> {ok, map()} | error.
 get_world(WorldId) ->
-    gen_server:call(?MODULE, {get, WorldId}).
+    case gen_server:call(?MODULE, {get, WorldId}) of
+        {ok, M} when is_map(M) -> {ok, M};
+        error -> error
+    end.
 
 -spec list_worlds() -> [map()].
 list_worlds() ->
-    gen_server:call(?MODULE, list).
+    narrow_map_list(gen_server:call(?MODULE, list)).
+
+-spec narrow_map_list(term()) -> [map()].
+narrow_map_list([]) -> [];
+narrow_map_list([M | Rest]) when is_map(M) -> [M | narrow_map_list(Rest)].
 
 -spec init([]) -> {ok, map()}.
 init([]) ->

--- a/src/world/asobi_world_server.erl
+++ b/src/world/asobi_world_server.erl
@@ -24,7 +24,7 @@ start_link(Config) ->
 
 -spec join(pid(), binary()) -> ok | {error, term()}.
 join(Pid, PlayerId) ->
-    gen_statem:call(Pid, {join, PlayerId}).
+    narrow_ok_or_error(gen_statem:call(Pid, {join, PlayerId})).
 
 -spec leave(pid(), binary()) -> ok.
 leave(Pid, PlayerId) ->
@@ -40,11 +40,13 @@ post_tick(Pid, TickN) ->
 
 -spec get_info(pid()) -> map().
 get_info(Pid) ->
-    gen_statem:call(Pid, get_info).
+    case gen_statem:call(Pid, get_info) of
+        M when is_map(M) -> M
+    end.
 
 -spec reconnect(pid(), binary()) -> ok | {error, term()}.
 reconnect(Pid, PlayerId) ->
-    gen_statem:call(Pid, {reconnect, PlayerId}).
+    narrow_ok_or_error(gen_statem:call(Pid, {reconnect, PlayerId})).
 
 -spec cancel(pid()) -> ok.
 cancel(Pid) ->
@@ -60,15 +62,22 @@ spawn_at(Pid, TemplateId, Pos, Overrides) ->
 
 -spec start_vote(pid(), map()) -> {ok, pid()} | {error, term()}.
 start_vote(Pid, VoteConfig) ->
-    gen_statem:call(Pid, {start_vote, VoteConfig}).
+    case gen_statem:call(Pid, {start_vote, VoteConfig}) of
+        {ok, P} when is_pid(P) -> {ok, P};
+        {error, _} = Err -> Err
+    end.
 
 -spec cast_vote(pid(), binary(), binary(), binary()) -> ok | {error, term()}.
 cast_vote(Pid, PlayerId, VoteId, OptionId) ->
-    gen_statem:call(Pid, {cast_vote, PlayerId, VoteId, OptionId}).
+    narrow_ok_or_error(gen_statem:call(Pid, {cast_vote, PlayerId, VoteId, OptionId})).
 
 -spec use_veto(pid(), binary(), binary()) -> ok | {error, term()}.
 use_veto(Pid, PlayerId, VoteId) ->
-    gen_statem:call(Pid, {use_veto, PlayerId, VoteId}).
+    narrow_ok_or_error(gen_statem:call(Pid, {use_veto, PlayerId, VoteId})).
+
+-spec narrow_ok_or_error(term()) -> ok | {error, term()}.
+narrow_ok_or_error(ok) -> ok;
+narrow_ok_or_error({error, _} = Err) -> Err.
 
 -spec whereis(binary()) -> {ok, pid()} | error.
 whereis(WorldId) ->
@@ -235,9 +244,9 @@ running({call, From}, {use_veto, PlayerId, VoteId}, State) ->
     handle_use_veto(From, PlayerId, VoteId, State);
 running(
     cast,
-    {spawn_at, TemplateId, {_X, _Y} = Pos, Overrides},
+    {spawn_at, TemplateId, {X, Y} = Pos, Overrides},
     #{zone_manager_pid := ZMPid, zone_size := ZS} = _State
-) ->
+) when is_binary(TemplateId), is_number(X), is_number(Y), is_map(Overrides) ->
     Coords = pos_to_zone(Pos, ZS),
     case asobi_zone_manager:ensure_zone(ZMPid, Coords) of
         {ok, ZonePid} ->
@@ -274,7 +283,7 @@ running(info, {'DOWN', _MonRef, process, DownPid, _Reason}, #{reconnect_state :=
         none ->
             keep_state_and_data
     end;
-running({call, From}, {reconnect, PlayerId}, State) ->
+running({call, From}, {reconnect, PlayerId}, State) when is_binary(PlayerId) ->
     #{
         reconnect_state := RS,
         player_zones := PZ,
@@ -285,20 +294,15 @@ running({call, From}, {reconnect, PlayerId}, State) ->
             {keep_state_and_data, [{reply, From, {error, no_reconnect_policy}}]};
         {_, undefined} ->
             {keep_state_and_data, [{reply, From, {error, not_in_world}}]};
-        {_, #{zone := ZoneCoords, interest := InterestZones}} ->
+        {_, #{zone := {ZX, ZY}, interest := InterestZones}} when
+            is_integer(ZX), is_integer(ZY), is_list(InterestZones)
+        ->
+            ZoneCoords = {ZX, ZY},
             {_Events, RS1} = asobi_reconnect:reconnect(PlayerId, RS),
             PlayerPid = find_player_pid(PlayerId),
             MonRef = erlang:monitor(process, PlayerPid),
             %% Re-subscribe to all interest zones
-            lists:foreach(
-                fun(Coords) ->
-                    case asobi_zone_manager:get_zone(ZMPid, Coords) of
-                        {ok, ZPid} -> asobi_zone:subscribe(ZPid, {PlayerId, PlayerPid});
-                        not_loaded -> ok
-                    end
-                end,
-                InterestZones
-            ),
+            subscribe_interest_zones(InterestZones, ZMPid, PlayerId, PlayerPid),
             %% Notify session of world/zone
             ZonePid =
                 case asobi_zone_manager:get_zone(ZMPid, ZoneCoords) of
@@ -430,23 +434,29 @@ spawn_zones(
     %% Pre-warm all zones via zone_manager (uses base config with terrain_store_pid etc.)
     ok = asobi_zone_manager:pre_warm(ZoneManagerPid),
     %% Add recovered entities to zones
-    lists:foreach(
-        fun(Coords) ->
-            RecoveredEnts = maps:get(Coords, Entities, #{}),
-            case map_size(RecoveredEnts) of
-                0 ->
-                    ok;
-                _ ->
-                    {ok, ZonePid} = asobi_zone_manager:ensure_zone(ZoneManagerPid, Coords),
-                    maps:foreach(
-                        fun(EId, EState) -> asobi_zone:add_entity(ZonePid, EId, EState) end,
-                        RecoveredEnts
-                    )
-            end
-        end,
-        AllCoords
-    ),
+    restore_entities(AllCoords, Entities, ZoneManagerPid),
     State#{game_state => GS1}.
+
+-spec restore_entities([term()], map(), pid() | atom()) -> ok.
+restore_entities([], _Entities, _ZoneManagerPid) ->
+    ok;
+restore_entities([{CX, CY} = Coords | Rest], Entities, ZoneManagerPid) when
+    is_integer(CX), is_integer(CY)
+->
+    RecoveredEnts = maps:get(Coords, Entities, #{}),
+    case map_size(RecoveredEnts) of
+        0 ->
+            ok;
+        _ ->
+            {ok, ZonePid} = asobi_zone_manager:ensure_zone(ZoneManagerPid, Coords),
+            maps:foreach(
+                fun(EId, EState) -> asobi_zone:add_entity(ZonePid, EId, EState) end,
+                RecoveredEnts
+            )
+    end,
+    restore_entities(Rest, Entities, ZoneManagerPid);
+restore_entities([_ | Rest], Entities, ZoneManagerPid) ->
+    restore_entities(Rest, Entities, ZoneManagerPid).
 
 generate_zone_states(GameMod, Config) ->
     Seed = maps:get(seed, Config, erlang:system_time(millisecond)),
@@ -563,15 +573,7 @@ place_player(
     asobi_zone:add_entity(ZonePid, PlayerId, #{x => X, y => Y, type => ~"player"}),
     asobi_presence:send(PlayerId, {world_joined, self(), ZonePid}),
     InterestZones = interest_zones(ZoneCoords, ViewRadius, GridSize),
-    lists:foreach(
-        fun(Coords) ->
-            case asobi_zone_manager:get_zone(ZMPid, Coords) of
-                {ok, ZPid} -> asobi_zone:subscribe(ZPid, {PlayerId, PlayerPid});
-                not_loaded -> ok
-            end
-        end,
-        InterestZones
-    ),
+    subscribe_interest_zones(InterestZones, ZMPid, PlayerId, PlayerPid),
     PlayerZones = maps:get(player_zones, State),
     State#{
         player_zones => PlayerZones#{PlayerId => #{zone => ZoneCoords, interest => InterestZones}}
@@ -592,15 +594,7 @@ remove_player_from_zones(
                 {ok, ZonePid} -> asobi_zone:remove_entity(ZonePid, PlayerId);
                 not_loaded -> ok
             end,
-            lists:foreach(
-                fun(Coords) ->
-                    case asobi_zone_manager:get_zone(ZMPid, Coords) of
-                        {ok, ZPid} -> asobi_zone:unsubscribe(ZPid, PlayerId);
-                        not_loaded -> ok
-                    end
-                end,
-                InterestZones
-            ),
+            unsubscribe_interest_zones(InterestZones, ZMPid, PlayerId),
             %% Release primary zone if no other players need it
             asobi_zone_manager:release_zone(ZMPid, ZoneCoords),
             State#{player_zones => maps:remove(PlayerId, PlayerZones)}
@@ -677,23 +671,71 @@ leave_chat(PlayerId, #{player_zones := PlayerZones, chat_state := ChatState}) ->
 
 -spec pos_to_zone({number(), number()}, non_neg_integer()) ->
     {non_neg_integer(), non_neg_integer()}.
-pos_to_zone({X, Y}, ZoneSize) ->
-    {max(0, trunc(X) div ZoneSize), max(0, trunc(Y) div ZoneSize)}.
+pos_to_zone({X, Y}, ZoneSize) when is_number(X), is_number(Y), ZoneSize > 0 ->
+    TX = trunc(X) div ZoneSize,
+    TY = trunc(Y) div ZoneSize,
+    ZX =
+        if
+            TX < 0 -> 0;
+            true -> TX
+        end,
+    ZY =
+        if
+            TY < 0 -> 0;
+            true -> TY
+        end,
+    {ZX, ZY}.
 
 -spec interest_zones({integer(), integer()}, non_neg_integer(), non_neg_integer()) ->
     [{integer(), integer()}].
 interest_zones({ZX, ZY}, Radius, GridSize) ->
+    XLo = clamp_lo(ZX - Radius),
+    XHi = min(GridSize - 1, ZX + Radius),
+    YLo = clamp_lo(ZY - Radius),
+    YHi = min(GridSize - 1, ZY + Radius),
     [
         {X, Y}
-     || X <- lists:seq(max(0, ZX - Radius), min(GridSize - 1, ZX + Radius)),
-        Y <- lists:seq(max(0, ZY - Radius), min(GridSize - 1, ZY + Radius))
+     || X <- lists:seq(XLo, XHi),
+        Y <- lists:seq(YLo, YHi)
     ].
+
+-spec clamp_lo(integer()) -> non_neg_integer().
+clamp_lo(N) when N < 0 -> 0;
+clamp_lo(N) -> N.
 
 find_player_pid(PlayerId) ->
     case pg:get_members(?PG_SCOPE, {player, PlayerId}) of
         [Pid | _] -> Pid;
         [] -> self()
     end.
+
+-spec subscribe_interest_zones([term()], pid() | atom(), binary(), pid()) -> ok.
+subscribe_interest_zones([], _ZMPid, _PlayerId, _PlayerPid) ->
+    ok;
+subscribe_interest_zones([{CX, CY} | Rest], ZMPid, PlayerId, PlayerPid) when
+    is_integer(CX), is_integer(CY)
+->
+    case asobi_zone_manager:get_zone(ZMPid, {CX, CY}) of
+        {ok, ZPid} -> asobi_zone:subscribe(ZPid, {PlayerId, PlayerPid});
+        not_loaded -> ok
+    end,
+    subscribe_interest_zones(Rest, ZMPid, PlayerId, PlayerPid);
+subscribe_interest_zones([_ | Rest], ZMPid, PlayerId, PlayerPid) ->
+    subscribe_interest_zones(Rest, ZMPid, PlayerId, PlayerPid).
+
+-spec unsubscribe_interest_zones([term()], pid() | atom(), binary()) -> ok.
+unsubscribe_interest_zones([], _ZMPid, _PlayerId) ->
+    ok;
+unsubscribe_interest_zones([{CX, CY} | Rest], ZMPid, PlayerId) when
+    is_integer(CX), is_integer(CY)
+->
+    case asobi_zone_manager:get_zone(ZMPid, {CX, CY}) of
+        {ok, ZPid} -> asobi_zone:unsubscribe(ZPid, PlayerId);
+        not_loaded -> ok
+    end,
+    unsubscribe_interest_zones(Rest, ZMPid, PlayerId);
+unsubscribe_interest_zones([_ | Rest], ZMPid, PlayerId) ->
+    unsubscribe_interest_zones(Rest, ZMPid, PlayerId).
 
 %% --- Internal: Voting ---
 
@@ -804,24 +846,25 @@ handle_vote_resolved(
     end.
 
 merge_vote_weights(VoteConfig, PlayerIds, Frustration, FBonus) ->
-    FWeights = lists:foldl(
-        fun(PId, Acc) ->
-            FVal =
-                case maps:get(PId, Frustration, 0) of
-                    N when is_number(N) -> N;
-                    _ -> 0
-                end,
-            Acc#{PId => 1 + FVal * FBonus}
-        end,
-        #{},
-        PlayerIds
-    ),
+    FWeights = build_frustration_weights(PlayerIds, Frustration, FBonus),
     BaseWeights =
         case maps:get(weights, VoteConfig, #{}) of
             BW when is_map(BW) -> BW;
             _ -> #{}
         end,
     maps:merge(FWeights, BaseWeights).
+
+-spec build_frustration_weights([term()], map(), number()) -> #{term() => number()}.
+build_frustration_weights([], _Frustration, _FBonus) ->
+    #{};
+build_frustration_weights([PId | Rest], Frustration, FBonus) ->
+    FVal =
+        case maps:get(PId, Frustration, 0) of
+            N when is_number(N) -> N;
+            _ -> 0
+        end,
+    Acc = build_frustration_weights(Rest, Frustration, FBonus),
+    Acc#{PId => 1 + FVal * FBonus}.
 
 update_frustration(#{winner := undefined}, Frustration) ->
     Frustration;

--- a/src/world/asobi_world_ticker.erl
+++ b/src/world/asobi_world_ticker.erl
@@ -26,7 +26,9 @@ set_zone_manager(TickerPid, ZoneManagerPid, WorldPid) ->
 
 -spec get_tick(pid()) -> non_neg_integer().
 get_tick(TickerPid) ->
-    gen_server:call(TickerPid, get_tick).
+    case gen_server:call(TickerPid, get_tick) of
+        N when is_integer(N), N >= 0 -> N
+    end.
 
 -spec promote_zone(pid(), pid()) -> ok.
 promote_zone(TickerPid, ZonePid) ->
@@ -102,7 +104,7 @@ handle_cast(
         pending := Pending,
         world_pid := WorldPid
     } = State
-) ->
+) when is_integer(TickN) ->
     case TickN =:= CurrentTick of
         true ->
             Pending1 = maps:remove(ZonePid, Pending),
@@ -151,7 +153,7 @@ handle_info(
             false -> Hot
         end,
     Pending = maps:from_keys(ZonesToTick, true),
-    lists:foreach(fun(Z) -> asobi_zone:tick(Z, NextTick) end, ZonesToTick),
+    tick_zones(ZonesToTick, NextTick),
     erlang:send_after(TickRate, self(), tick),
     case map_size(Pending) of
         0 ->
@@ -162,3 +164,12 @@ handle_info(
     end;
 handle_info(_Info, State) ->
     {noreply, State}.
+
+-spec tick_zones([term()], non_neg_integer()) -> ok.
+tick_zones([], _NextTick) ->
+    ok;
+tick_zones([Z | Rest], NextTick) when is_pid(Z) ->
+    asobi_zone:tick(Z, NextTick),
+    tick_zones(Rest, NextTick);
+tick_zones([_ | Rest], NextTick) ->
+    tick_zones(Rest, NextTick).

--- a/src/world/asobi_zone.erl
+++ b/src/world/asobi_zone.erl
@@ -44,11 +44,15 @@ unsubscribe(Pid, PlayerId) ->
 
 -spec get_entities(pid()) -> map().
 get_entities(Pid) ->
-    gen_server:call(Pid, get_entities).
+    case gen_server:call(Pid, get_entities) of
+        M when is_map(M) -> M
+    end.
 
 -spec get_subscriber_count(pid()) -> non_neg_integer().
 get_subscriber_count(Pid) ->
-    gen_server:call(Pid, get_subscriber_count).
+    case gen_server:call(Pid, get_subscriber_count) of
+        N when is_integer(N), N >= 0 -> N
+    end.
 
 -spec start_entity_timer(pid(), map()) -> ok.
 start_entity_timer(Pid, Config) ->
@@ -76,12 +80,20 @@ despawn_entity(Pid, EntityId) ->
 
 -spec query_radius(pid(), {number(), number()}, number()) -> [{binary(), {number(), number()}}].
 query_radius(Pid, Center, Radius) ->
-    gen_server:call(Pid, {query_radius, Center, Radius}).
+    narrow_id_pos_list(gen_server:call(Pid, {query_radius, Center, Radius})).
 
 -spec query_rect(pid(), {number(), number()}, {number(), number()}) ->
     [{binary(), {number(), number()}}].
 query_rect(Pid, TopLeft, BottomRight) ->
-    gen_server:call(Pid, {query_rect, TopLeft, BottomRight}).
+    narrow_id_pos_list(gen_server:call(Pid, {query_rect, TopLeft, BottomRight})).
+
+-spec narrow_id_pos_list(term()) -> [{binary(), {number(), number()}}].
+narrow_id_pos_list([]) ->
+    [];
+narrow_id_pos_list([{Id, {X, Y}} | Rest]) when
+    is_binary(Id), is_number(X), is_number(Y)
+->
+    [{Id, {X, Y}} | narrow_id_pos_list(Rest)].
 
 %% --- gen_server callbacks ---
 
@@ -143,8 +155,10 @@ handle_call(get_entities, _From, #{entities := Entities} = State) ->
 handle_call(get_subscriber_count, _From, #{subscribers := Subs} = State) ->
     {reply, map_size(Subs), State};
 handle_call(
-    {query_radius, Center, Radius}, _From, #{spatial_grid := Grid, entities := Entities} = State
-) ->
+    {query_radius, {CX, CY} = Center, Radius},
+    _From,
+    #{spatial_grid := Grid, entities := Entities} = State
+) when is_number(CX), is_number(CY), is_number(Radius) ->
     Result =
         case Grid of
             undefined ->
@@ -157,8 +171,10 @@ handle_call(
         end,
     {reply, Result, State};
 handle_call(
-    {query_rect, TopLeft, BottomRight}, _From, #{spatial_grid := Grid, entities := Entities} = State
-) ->
+    {query_rect, {TLX, TLY} = TopLeft, {BRX, BRY} = BottomRight},
+    _From,
+    #{spatial_grid := Grid, entities := Entities} = State
+) when is_number(TLX), is_number(TLY), is_number(BRX), is_number(BRY) ->
     Result =
         case Grid of
             undefined ->
@@ -173,7 +189,7 @@ handle_call(
 handle_call(_Request, _From, State) ->
     {reply, {error, unknown_request}, State}.
 
--spec handle_cast(term(), map()) -> {noreply, map()}.
+-spec handle_cast(term(), map()) -> {noreply, map()} | {noreply, map(), hibernate}.
 handle_cast({tick, TickN}, State) ->
     State1 = do_tick(TickN, State),
     State2 = transfer_out_of_bounds_npcs(State1),
@@ -204,7 +220,7 @@ handle_cast({remove_entity, EntityId}, #{entities := Entities, spatial_grid := G
 handle_cast(
     {subscribe, PlayerId, PlayerPid},
     #{subscribers := Subs, entities := Entities, coords := Coords} = State
-) ->
+) when is_binary(PlayerId), is_pid(PlayerPid) ->
     MonRef = monitor(process, PlayerPid),
     %% Send immediate snapshot so new subscribers see all current entities
     _ =
@@ -236,14 +252,16 @@ handle_cast({unsubscribe, PlayerId}, #{subscribers := Subs} = State) ->
             demonitor(MonRef, [flush]),
             {noreply, State#{subscribers => maps:remove(PlayerId, Subs)}}
     end;
-handle_cast({start_entity_timer, Config}, #{entity_timers := ET} = State) ->
+handle_cast({start_entity_timer, Config}, #{entity_timers := ET} = State) when is_map(Config) ->
     {noreply, State#{entity_timers => asobi_entity_timer:start_timer(Config, ET)}};
-handle_cast({cancel_entity_timer, EntityId, TimerId}, #{entity_timers := ET} = State) ->
+handle_cast({cancel_entity_timer, EntityId, TimerId}, #{entity_timers := ET} = State) when
+    is_binary(EntityId), is_binary(TimerId)
+->
     {noreply, State#{entity_timers => asobi_entity_timer:cancel_timer(EntityId, TimerId, ET)}};
 handle_cast(
-    {spawn_entity, TemplateId, Pos, Overrides},
+    {spawn_entity, TemplateId, {PX, PY} = Pos, Overrides},
     #{entities := Entities, spawner := Spawner, spatial_grid := Grid} = State
-) ->
+) when is_binary(TemplateId), is_number(PX), is_number(PY), is_map(Overrides) ->
     case asobi_zone_spawner:spawn_entity(TemplateId, Pos, Overrides, Spawner) of
         {ok, {EntityId, Entity}, Spawner1} ->
             Grid1 = spatial_grid_insert(EntityId, Entity, Grid),
@@ -255,27 +273,12 @@ handle_cast(
         {error, _} ->
             {noreply, State}
     end;
-handle_cast({spawn_entities, Spawns}, State) ->
-    State1 = lists:foldl(
-        fun(
-            {TemplateId, Pos, Overrides}, #{entities := Ents, spawner := Sp, spatial_grid := Gr} = S
-        ) ->
-            case asobi_zone_spawner:spawn_entity(TemplateId, Pos, Overrides, Sp) of
-                {ok, {EntityId, Entity}, Sp1} ->
-                    Gr1 = spatial_grid_insert(EntityId, Entity, Gr),
-                    S#{entities => Ents#{EntityId => Entity}, spawner => Sp1, spatial_grid => Gr1};
-                {error, _} ->
-                    S
-            end
-        end,
-        State,
-        Spawns
-    ),
-    {noreply, State1};
+handle_cast({spawn_entities, Spawns}, State) when is_list(Spawns) ->
+    {noreply, apply_spawns(Spawns, State)};
 handle_cast(
     {despawn_entity, EntityId},
     #{entities := Entities, spawner := Spawner, spatial_grid := Grid} = State
-) ->
+) when is_binary(EntityId) ->
     Now = erlang:system_time(millisecond),
     Spawner1 = asobi_zone_spawner:entity_removed(EntityId, Now, Spawner),
     Grid1 = spatial_grid_remove(EntityId, Grid),
@@ -344,13 +347,7 @@ do_tick(
     %% Tick spawner — process respawn queue
     Spawner = maps:get(spawner, State),
     {Respawns, Spawner1} = asobi_zone_spawner:tick(Now, Spawner),
-    Entities4 = lists:foldl(
-        fun({EntityId, EntityState, _Pos}, Acc) ->
-            Acc#{EntityId => EntityState}
-        end,
-        Entities3,
-        Respawns
-    ),
+    Entities4 = apply_respawns(Respawns, Entities3),
     %% Only broadcast every Nth tick to reduce network traffic
     State1 =
         case TickN rem BroadcastInterval of
@@ -520,7 +517,7 @@ transfer_out_of_bounds_npcs(
     %% Remove transferred NPCs from this zone
     Entities1 = maps:without(ToRemove, Entities),
     Grid = maps:get(spatial_grid, State, undefined),
-    Grid1 = lists:foldl(fun(Id, G) -> spatial_grid_remove(Id, G) end, Grid, ToRemove),
+    Grid1 = remove_from_grid(ToRemove, Grid),
     State#{entities => Entities1, spatial_grid => Grid1};
 transfer_out_of_bounds_npcs(State) ->
     State.
@@ -619,12 +616,58 @@ spatial_grid_remove(_EntityId, undefined) ->
 spatial_grid_remove(EntityId, Grid) ->
     asobi_spatial_grid:remove(EntityId, Grid).
 
+-spec apply_spawns([term()], map()) -> map().
+apply_spawns([], State) ->
+    State;
+apply_spawns(
+    [{TemplateId, {PX, PY} = Pos, Overrides} | Rest],
+    #{entities := Ents, spawner := Sp, spatial_grid := Gr} = State
+) when is_binary(TemplateId), is_number(PX), is_number(PY), is_map(Overrides) ->
+    State1 =
+        case asobi_zone_spawner:spawn_entity(TemplateId, Pos, Overrides, Sp) of
+            {ok, {EntityId, Entity}, Sp1} ->
+                Gr1 = spatial_grid_insert(EntityId, Entity, Gr),
+                State#{
+                    entities => Ents#{EntityId => Entity},
+                    spawner => Sp1,
+                    spatial_grid => Gr1
+                };
+            {error, _} ->
+                State
+        end,
+    apply_spawns(Rest, State1);
+apply_spawns([_ | Rest], State) ->
+    apply_spawns(Rest, State).
+
+-spec apply_respawns([{binary(), map(), {number(), number()}}], map()) -> map().
+apply_respawns([], Entities) ->
+    Entities;
+apply_respawns([{EntityId, EntityState, _Pos} | Rest], Entities) when is_binary(EntityId) ->
+    apply_respawns(Rest, Entities#{EntityId => EntityState});
+apply_respawns([_ | Rest], Entities) ->
+    apply_respawns(Rest, Entities).
+
+-spec remove_from_grid([term()], asobi_spatial_grid:grid() | undefined) ->
+    asobi_spatial_grid:grid() | undefined.
+remove_from_grid(_Ids, undefined) ->
+    undefined;
+remove_from_grid(Ids, Grid) ->
+    remove_from_grid_do(Ids, Grid).
+
+-spec remove_from_grid_do([term()], asobi_spatial_grid:grid()) -> asobi_spatial_grid:grid().
+remove_from_grid_do([], Grid) ->
+    Grid;
+remove_from_grid_do([Id | Rest], Grid) when is_binary(Id) ->
+    remove_from_grid_do(Rest, asobi_spatial_grid:remove(Id, Grid));
+remove_from_grid_do([_ | Rest], Grid) ->
+    remove_from_grid_do(Rest, Grid).
+
 sync_spatial_grid(_OldEntities, _NewEntities, undefined) ->
     undefined;
-sync_spatial_grid(OldEntities, NewEntities, Grid) ->
+sync_spatial_grid(OldEntities, NewEntities, Grid) when is_map(Grid) ->
     %% Remove entities that no longer exist
     Removed = maps:keys(OldEntities) -- maps:keys(NewEntities),
-    Grid1 = lists:foldl(fun(Id, G) -> asobi_spatial_grid:remove(Id, G) end, Grid, Removed),
+    Grid1 = remove_from_grid_do(Removed, Grid),
     %% Update/insert entities with changed or new positions
     maps:fold(
         fun

--- a/src/world/asobi_zone.erl
+++ b/src/world/asobi_zone.erl
@@ -643,9 +643,7 @@ apply_spawns([_ | Rest], State) ->
 apply_respawns([], Entities) ->
     Entities;
 apply_respawns([{EntityId, EntityState, _Pos} | Rest], Entities) when is_binary(EntityId) ->
-    apply_respawns(Rest, Entities#{EntityId => EntityState});
-apply_respawns([_ | Rest], Entities) ->
-    apply_respawns(Rest, Entities).
+    apply_respawns(Rest, Entities#{EntityId => EntityState}).
 
 -spec remove_from_grid([term()], asobi_spatial_grid:grid() | undefined) ->
     asobi_spatial_grid:grid() | undefined.

--- a/src/world/asobi_zone_manager.erl
+++ b/src/world/asobi_zone_manager.erl
@@ -37,7 +37,10 @@ ensure_zone(Ref, Coords) ->
         {ok, Pid} ->
             {ok, Pid};
         not_loaded ->
-            gen_server:call(Ref, {ensure_zone, Coords})
+            case gen_server:call(Ref, {ensure_zone, Coords}) of
+                {ok, P} when is_pid(P) -> {ok, P};
+                {error, _} = Err -> Err
+            end
     end.
 
 -doc "Non-creating lookup. ETS only.".
@@ -69,26 +72,29 @@ zone_terminated(Ref, Coords) ->
 -doc "Spawn all zones in grid. Backward compat for small grids.".
 -spec pre_warm(pid() | atom()) -> ok.
 pre_warm(Ref) ->
-    gen_server:call(Ref, pre_warm, 60_000).
+    ok = gen_server:call(Ref, pre_warm, 60_000).
 
 -doc "Register an externally-spawned zone with the manager.".
 -spec register_zone(pid() | atom(), {integer(), integer()}, pid()) -> ok.
 register_zone(Ref, Coords, ZonePid) ->
-    gen_server:call(Ref, {register_zone, Coords, ZonePid}).
+    ok = gen_server:call(Ref, {register_zone, Coords, ZonePid}).
 
 -doc "Update the base zone config used when spawning new zones.".
 -spec set_zone_config(pid() | atom(), map()) -> ok.
 set_zone_config(Ref, Config) ->
-    gen_server:call(Ref, {set_zone_config, Config}).
+    ok = gen_server:call(Ref, {set_zone_config, Config}).
 
 %% --- gen_server callbacks ---
 
 -doc "Return the ETS table id. Useful for external fast-path reads.".
 -spec get_ets_tab(pid() | atom()) -> ets:tid().
 get_ets_tab(Ref) when is_atom(Ref) ->
-    persistent_term:get({?MODULE, Ref});
+    narrow_tid(persistent_term:get({?MODULE, Ref}));
 get_ets_tab(Ref) when is_pid(Ref) ->
-    gen_server:call(Ref, get_ets_tab).
+    narrow_tid(gen_server:call(Ref, get_ets_tab)).
+
+-spec narrow_tid(term()) -> ets:tid().
+narrow_tid(T) when is_reference(T) -> T.
 
 -spec init(map()) -> {ok, map()}.
 init(Opts) ->
@@ -139,21 +145,7 @@ handle_call({ensure_zone, Coords}, _From, #{ets_tab := Tab} = State) ->
     end;
 handle_call(pre_warm, _From, #{grid_size := GridSize} = State) ->
     AllCoords = [{X, Y} || X <- lists:seq(0, GridSize - 1), Y <- lists:seq(0, GridSize - 1)],
-    State1 = lists:foldl(
-        fun(Coords, SAcc) ->
-            case ets:lookup(maps:get(ets_tab, SAcc), Coords) of
-                [{_, _}] ->
-                    SAcc;
-                [] ->
-                    case start_zone(Coords, SAcc) of
-                        {ok, _Pid, SAcc1} -> SAcc1;
-                        {error, _} -> SAcc
-                    end
-            end
-        end,
-        State,
-        AllCoords
-    ),
+    State1 = prewarm_zones(AllCoords, State),
     {reply, ok, State1};
 handle_call(
     {register_zone, Coords, ZonePid},
@@ -163,7 +155,7 @@ handle_call(
         zone_last_active := Active,
         zone_monitors := Monitors
     } = State
-) ->
+) when is_pid(ZonePid) ->
     ets:insert(Tab, {Coords, ZonePid}),
     MonRef = monitor(process, ZonePid),
     Now = erlang:monotonic_time(millisecond),
@@ -348,14 +340,30 @@ schedule_reap() ->
     Ref.
 
 ets_lookup(Ref, Coords) when is_atom(Ref) ->
-    Tab = persistent_term:get({?MODULE, Ref}),
+    Tab = narrow_tid(persistent_term:get({?MODULE, Ref})),
     case ets:lookup(Tab, Coords) of
         [{Coords, Pid}] -> {ok, Pid};
         [] -> not_loaded
     end;
 ets_lookup(Ref, Coords) when is_pid(Ref) ->
-    Tab = gen_server:call(Ref, get_ets_tab),
+    Tab = narrow_tid(gen_server:call(Ref, get_ets_tab)),
     case ets:lookup(Tab, Coords) of
         [{Coords, Pid}] -> {ok, Pid};
         [] -> not_loaded
     end.
+
+-spec prewarm_zones([{integer(), integer()}], map()) -> map().
+prewarm_zones([], State) ->
+    State;
+prewarm_zones([Coords | Rest], #{ets_tab := Tab} = State) ->
+    State1 =
+        case ets:lookup(Tab, Coords) of
+            [{_, _}] ->
+                State;
+            [] ->
+                case start_zone(Coords, State) of
+                    {ok, _Pid, S1} -> S1;
+                    {error, _} -> State
+                end
+        end,
+    prewarm_zones(Rest, State1).

--- a/src/world/asobi_zone_manager.erl
+++ b/src/world/asobi_zone_manager.erl
@@ -16,7 +16,6 @@ Hot-path lookups go through ETS directly, bypassing the gen_server.
 -export([ensure_zone/2, get_zone/2, touch_zone/2, release_zone/2]).
 -export([get_active_zones/1, zone_terminated/2, pre_warm/1]).
 -export([register_zone/3, set_zone_config/2]).
--export([get_ets_tab/1]).
 -export([init/1, handle_call/3, handle_cast/2, handle_info/2, terminate/2]).
 
 -define(REAP_INTERVAL, 10_000).
@@ -60,9 +59,14 @@ release_zone(Ref, Coords) ->
 
 -doc "Return all active zone pids. For the ticker.".
 -spec get_active_zones(pid() | atom()) -> [pid()].
-get_active_zones(Ref) ->
-    Tab = get_ets_tab(Ref),
-    [Pid || {_Coords, Pid} <- ets:tab2list(Tab)].
+get_active_zones(Ref) when is_atom(Ref) ->
+    [Pid || {_Coords, Pid} <- ets:tab2list(Ref)];
+get_active_zones(Ref) when is_pid(Ref) ->
+    narrow_pid_list(gen_server:call(Ref, get_active_zones)).
+
+-spec narrow_pid_list(term()) -> [pid()].
+narrow_pid_list([]) -> [];
+narrow_pid_list([P | Rest]) when is_pid(P) -> [P | narrow_pid_list(Rest)].
 
 -doc "Called by zone on terminate. Cleans up ETS entry.".
 -spec zone_terminated(pid() | atom(), {integer(), integer()}) -> ok.
@@ -86,25 +90,17 @@ set_zone_config(Ref, Config) ->
 
 %% --- gen_server callbacks ---
 
--doc "Return the ETS table id. Useful for external fast-path reads.".
--spec get_ets_tab(pid() | atom()) -> ets:tid().
-get_ets_tab(Ref) when is_atom(Ref) ->
-    narrow_tid(persistent_term:get({?MODULE, Ref}));
-get_ets_tab(Ref) when is_pid(Ref) ->
-    narrow_tid(gen_server:call(Ref, get_ets_tab)).
-
--spec narrow_tid(term()) -> ets:tid().
-narrow_tid(T) when is_reference(T) -> T.
-
 -spec init(map()) -> {ok, map()}.
 init(Opts) ->
     WorldId = maps:get(world_id, Opts),
-    Tab = ets:new(asobi_zone_mgr, [set, public, {read_concurrency, true}]),
     Name = maps:get(name, Opts, undefined),
-    case Name of
-        undefined -> ok;
-        _ -> persistent_term:put({?MODULE, Name}, Tab)
-    end,
+    Tab =
+        case Name of
+            undefined ->
+                ets:new(asobi_zone_mgr, [set, public, {read_concurrency, true}]);
+            N when is_atom(N) ->
+                ets:new(N, [set, public, named_table, {read_concurrency, true}])
+        end,
     ZoneSup =
         case maps:get(zone_sup, Opts, undefined) of
             undefined ->
@@ -166,8 +162,15 @@ handle_call(
     {reply, ok, State1};
 handle_call({set_zone_config, Config}, _From, State) ->
     {reply, ok, State#{zone_config => Config}};
-handle_call(get_ets_tab, _From, #{ets_tab := Tab} = State) ->
-    {reply, Tab, State};
+handle_call({lookup_zone, Coords}, _From, #{ets_tab := Tab} = State) ->
+    Result =
+        case ets:lookup(Tab, Coords) of
+            [{Coords, Pid}] -> {ok, Pid};
+            [] -> not_loaded
+        end,
+    {reply, Result, State};
+handle_call(get_active_zones, _From, #{ets_tab := Tab} = State) ->
+    {reply, [Pid || {_Coords, Pid} <- ets:tab2list(Tab)], State};
 handle_call(_Request, _From, State) ->
     {reply, {error, unknown_request}, State}.
 
@@ -203,11 +206,7 @@ handle_info(_Info, State) ->
     {noreply, State}.
 
 -spec terminate(term(), map()) -> ok.
-terminate(_Reason, #{ets_tab := Tab, name := Name}) ->
-    case Name of
-        undefined -> ok;
-        _ -> persistent_term:erase({?MODULE, Name})
-    end,
+terminate(_Reason, #{ets_tab := Tab}) ->
     ets:delete(Tab),
     ok.
 
@@ -340,16 +339,14 @@ schedule_reap() ->
     Ref.
 
 ets_lookup(Ref, Coords) when is_atom(Ref) ->
-    Tab = narrow_tid(persistent_term:get({?MODULE, Ref})),
-    case ets:lookup(Tab, Coords) of
+    case ets:lookup(Ref, Coords) of
         [{Coords, Pid}] -> {ok, Pid};
         [] -> not_loaded
     end;
 ets_lookup(Ref, Coords) when is_pid(Ref) ->
-    Tab = narrow_tid(gen_server:call(Ref, get_ets_tab)),
-    case ets:lookup(Tab, Coords) of
-        [{Coords, Pid}] -> {ok, Pid};
-        [] -> not_loaded
+    case gen_server:call(Ref, {lookup_zone, Coords}) of
+        {ok, P} when is_pid(P) -> {ok, P};
+        not_loaded -> not_loaded
     end.
 
 -spec prewarm_zones([{integer(), integer()}], map()) -> map().

--- a/src/world/asobi_zone_snapshotter.erl
+++ b/src/world/asobi_zone_snapshotter.erl
@@ -60,7 +60,7 @@ handle_call(_Request, _From, State) ->
     {reply, {error, unknown_request}, State}.
 
 -spec handle_cast(term(), map()) -> {noreply, map()}.
-handle_cast({snapshot, Data}, #{pending := Pending} = State) ->
+handle_cast({snapshot, Data}, #{pending := Pending} = State) when is_map(Data) ->
     Key = {maps:get(world_id, Data), maps:get(coords, Data)},
     {noreply, State#{pending => Pending#{Key => Data}}};
 handle_cast({delete_world, WorldId}, State) ->

--- a/src/ws/asobi_ws_binary.erl
+++ b/src/ws/asobi_ws_binary.erl
@@ -50,16 +50,19 @@ is_binary_mode(State) when is_map(State) ->
 
 encode_delta(#{op := Op, entity_id := EntityId, fields := Fields}) ->
     OpByte = op_to_byte(Op),
-    IdBin = unicode:characters_to_binary(EntityId),
+    IdBin = to_binary(unicode:characters_to_binary(EntityId)),
     IdLen = byte_size(IdBin),
     FieldsBin = iolist_to_binary(json:encode(Fields)),
     FieldsLen = byte_size(FieldsBin),
     <<OpByte:8, IdLen:16/big, IdBin/binary, FieldsLen:32/big, FieldsBin/binary>>;
 encode_delta(#{op := Op, entity_id := EntityId}) ->
     OpByte = op_to_byte(Op),
-    IdBin = unicode:characters_to_binary(EntityId),
+    IdBin = to_binary(unicode:characters_to_binary(EntityId)),
     IdLen = byte_size(IdBin),
     <<OpByte:8, IdLen:16/big, IdBin/binary, 0:32/big>>.
+
+-spec to_binary(term()) -> binary().
+to_binary(B) when is_binary(B) -> B.
 
 decode_deltas(Rest, 0, Acc) ->
     {lists:reverse(Acc), Rest};

--- a/src/ws/asobi_ws_handler.erl
+++ b/src/ws/asobi_ws_handler.erl
@@ -61,12 +61,12 @@ websocket_info({asobi_message, {match_event, Event, Payload}}, State) when is_at
     Type = iolist_to_binary([~"match.", atom_to_binary(Event)]),
     Reply = encode_reply(undefined, Type, Payload),
     {reply, {text, Reply}, State};
-websocket_info({asobi_message, {zone_delta_raw, PreEncoded}}, State) ->
+websocket_info({asobi_message, {zone_delta_raw, PreEncoded}}, State) when is_binary(PreEncoded) ->
     {reply, {text, PreEncoded}, State};
 websocket_info({asobi_message, {zone_delta, TickN, Deltas}}, State) ->
     Reply = encode_reply(undefined, ~"world.tick", #{tick => TickN, updates => Deltas}),
     {reply, {text, Reply}, State};
-websocket_info({asobi_message, {terrain_chunk, {CX, CY}, Data}}, State) ->
+websocket_info({asobi_message, {terrain_chunk, {CX, CY}, Data}}, State) when is_binary(Data) ->
     Reply = encode_reply(undefined, ~"world.terrain", #{
         coords => [CX, CY],
         data => base64:encode(Data)

--- a/test/asobi_broadcast_batch_tests.erl
+++ b/test/asobi_broadcast_batch_tests.erl
@@ -11,13 +11,16 @@ pre_encoded_binary_is_valid_json_test() ->
     ?assert(is_binary(PreEncoded)),
     Decoded = json:decode(PreEncoded),
     ?assertMatch(#{~"type" := ~"world.tick", ~"payload" := _}, Decoded),
-    #{~"payload" := #{~"tick" := 1, ~"updates" := Updates}} = Decoded,
+    #{~"payload" := #{~"tick" := 1, ~"updates" := UpdatesRaw}} = Decoded,
+    Updates = as_list(UpdatesRaw),
     ?assertEqual(2, length(Updates)),
     [First, Second] = Updates,
-    ?assertEqual(~"a", maps:get(~"op", First)),
-    ?assertEqual(~"e1", maps:get(~"id", First)),
-    ?assertEqual(~"r", maps:get(~"op", Second)),
-    ?assertEqual(~"e2", maps:get(~"id", Second)).
+    FirstMap = as_map(First),
+    SecondMap = as_map(Second),
+    ?assertEqual(~"a", maps:get(~"op", FirstMap)),
+    ?assertEqual(~"e1", maps:get(~"id", FirstMap)),
+    ?assertEqual(~"r", maps:get(~"op", SecondMap)),
+    ?assertEqual(~"e2", maps:get(~"id", SecondMap)).
 
 pre_encoded_empty_deltas_test() ->
     Payload = #{~"type" => ~"world.tick", ~"payload" => #{~"tick" => 5, ~"updates" => []}},
@@ -33,7 +36,8 @@ pre_encoded_update_delta_test() ->
     },
     PreEncoded = iolist_to_binary(json:encode(Payload)),
     Decoded = json:decode(PreEncoded),
-    #{~"payload" := #{~"updates" := [Update]}} = Decoded,
+    #{~"payload" := #{~"updates" := [UpdateRaw]}} = Decoded,
+    Update = as_map(UpdateRaw),
     ?assertEqual(~"u", maps:get(~"op", Update)),
     ?assertEqual(~"e3", maps:get(~"id", Update)),
     ?assertEqual(50, maps:get(~"hp", Update)).
@@ -45,3 +49,9 @@ encode_delta({added, Id, FullState}) ->
     FullState#{~"op" => ~"a", ~"id" => Id};
 encode_delta({removed, Id}) ->
     #{~"op" => ~"r", ~"id" => Id}.
+
+-spec as_map(term()) -> map().
+as_map(M) when is_map(M) -> M.
+
+-spec as_list(term()) -> list().
+as_list(L) when is_list(L) -> L.

--- a/test/asobi_spatial_grid_tests.erl
+++ b/test/asobi_spatial_grid_tests.erl
@@ -117,11 +117,7 @@ query_radius_vs_brute_force_test() ->
         {list_to_binary(integer_to_list(I)), {float(I rem 64), float(I div 64)}}
      || I <- lists:seq(0, 255)
     ],
-    G = lists:foldl(
-        fun({Id, Pos}, Acc) -> asobi_spatial_grid:insert(Id, Pos, Acc) end,
-        G0,
-        AllEntities
-    ),
+    G = insert_all(AllEntities, G0),
     Center = {32.0, 2.0},
     Radius = 10.0,
     GridResults = lists:sort(asobi_spatial_grid:query_radius(Center, Radius, G)),
@@ -153,14 +149,17 @@ query_rect_vs_brute_force_test() ->
         {list_to_binary(integer_to_list(I)), {float(I rem 64), float(I div 64)}}
      || I <- lists:seq(0, 255)
     ],
-    G = lists:foldl(
-        fun({Id, Pos}, Acc) -> asobi_spatial_grid:insert(Id, Pos, Acc) end,
-        G0,
-        AllEntities
-    ),
+    G = insert_all(AllEntities, G0),
     GridResults = lists:sort(asobi_spatial_grid:query_rect({10.0, 1.0}, {40.0, 3.0}, G)),
     BruteResults = lists:sort(brute_force_rect(AllEntities, {10.0, 1.0}, {40.0, 3.0})),
     ?assertEqual(BruteResults, GridResults).
+
+-spec insert_all([{binary(), asobi_spatial_grid:pos()}], asobi_spatial_grid:grid()) ->
+    asobi_spatial_grid:grid().
+insert_all([], Grid) ->
+    Grid;
+insert_all([{Id, Pos} | Rest], Grid) ->
+    insert_all(Rest, asobi_spatial_grid:insert(Id, Pos, Grid)).
 
 %% -------------------------------------------------------------------
 %% entities_in_cell

--- a/test/asobi_terrain_integration_tests.erl
+++ b/test/asobi_terrain_integration_tests.erl
@@ -50,8 +50,10 @@ terrain_store_started() ->
     {ok, InstancePid} = asobi_world_instance:start_link(world_config()),
     unlink(InstancePid),
     timer:sleep(100),
-    WorldPid = asobi_world_instance:get_child(InstancePid, asobi_world_server),
-    ?assert(is_pid(WorldPid)),
+    WorldPid =
+        case asobi_world_instance:get_child(InstancePid, asobi_world_server) of
+            WP when is_pid(WP) -> WP
+        end,
     ?assertEqual(running, maps:get(status, asobi_world_server:get_info(WorldPid))),
     catch exit(InstancePid, shutdown),
     timer:sleep(50).

--- a/test/asobi_world_ticker_tests.erl
+++ b/test/asobi_world_ticker_tests.erl
@@ -9,6 +9,12 @@ start_ticker(Overrides) ->
     {ok, Pid} = asobi_world_ticker:start_link(Config),
     Pid.
 
+-spec get_state_map(pid()) -> map().
+get_state_map(Pid) ->
+    case sys:get_state(Pid) of
+        S when is_map(S) -> S
+    end.
+
 ticker_test_() ->
     {foreach, fun() -> ok end, fun(_) -> ok end, [
         {"get_tick starts at 0", fun get_tick_starts_at_zero/0},
@@ -40,7 +46,7 @@ set_zones_all_hot() ->
     end),
     asobi_world_ticker:set_zones(Pid, [Z1, Z2], self()),
     timer:sleep(10),
-    State = sys:get_state(Pid),
+    State = get_state_map(Pid),
     ?assertEqual([Z1, Z2], maps:get(hot_zones, State)),
     ?assertEqual([], maps:get(cold_zones, State)).
 
@@ -53,7 +59,7 @@ promote_zone_adds_to_hot() ->
     end),
     asobi_world_ticker:promote_zone(Pid, Z1),
     timer:sleep(10),
-    State = sys:get_state(Pid),
+    State = get_state_map(Pid),
     ?assert(lists:member(Z1, maps:get(hot_zones, State))),
     ?assertNot(lists:member(Z1, maps:get(cold_zones, State))).
 
@@ -68,7 +74,7 @@ demote_zone_moves_to_cold() ->
     timer:sleep(10),
     asobi_world_ticker:demote_zone(Pid, Z1),
     timer:sleep(10),
-    State = sys:get_state(Pid),
+    State = get_state_map(Pid),
     ?assertNot(lists:member(Z1, maps:get(hot_zones, State))),
     ?assert(lists:member(Z1, maps:get(cold_zones, State))).
 
@@ -83,7 +89,7 @@ remove_zone_removes() ->
     timer:sleep(10),
     asobi_world_ticker:remove_zone(Pid, Z1),
     timer:sleep(10),
-    State = sys:get_state(Pid),
+    State = get_state_map(Pid),
     ?assertNot(lists:member(Z1, maps:get(hot_zones, State))),
     ?assertNot(lists:member(Z1, maps:get(cold_zones, State))).
 
@@ -98,7 +104,7 @@ promote_idempotent() ->
     timer:sleep(10),
     asobi_world_ticker:promote_zone(Pid, Z1),
     timer:sleep(10),
-    State = sys:get_state(Pid),
+    State = get_state_map(Pid),
     Hot = maps:get(hot_zones, State),
     ?assertEqual(1, length([Z || Z <- Hot, Z =:= Z1])).
 
@@ -113,16 +119,16 @@ demote_idempotent() ->
     timer:sleep(10),
     asobi_world_ticker:demote_zone(Pid, Z1),
     timer:sleep(10),
-    State = sys:get_state(Pid),
+    State = get_state_map(Pid),
     Cold = maps:get(cold_zones, State),
     ?assertEqual(1, length([Z || Z <- Cold, Z =:= Z1])).
 
 cold_divisor_default() ->
     Pid = start_ticker(),
-    State = sys:get_state(Pid),
+    State = get_state_map(Pid),
     ?assertEqual(10, maps:get(cold_tick_divisor, State)).
 
 cold_divisor_configurable() ->
     Pid = start_ticker(#{cold_tick_divisor => 5}),
-    State = sys:get_state(Pid),
+    State = get_state_map(Pid),
     ?assertEqual(5, maps:get(cold_tick_divisor, State)).

--- a/test/asobi_world_zone_integration_tests.erl
+++ b/test/asobi_world_zone_integration_tests.erl
@@ -62,7 +62,7 @@ default_prespawns_all() ->
     Active = asobi_zone_manager:get_active_zones(Mgr),
     ?assertEqual(9, length(Active)),
     lists:foreach(
-        fun(Coords) ->
+        fun({CX, CY} = Coords) when is_integer(CX), is_integer(CY) ->
             ?assertMatch({ok, _}, asobi_zone_manager:get_zone(Mgr, Coords))
         end,
         [{X, Y} || X <- lists:seq(0, 2), Y <- lists:seq(0, 2)]

--- a/test/asobi_ws_bench.erl
+++ b/test/asobi_ws_bench.erl
@@ -97,7 +97,7 @@ ws_throughput(Config) ->
     ct:pal("  Blasting ~w msgs each...", [MsgsPerConn]),
     BlastRef = make_ref(),
     lists:foreach(
-        fun({ConnPid, StreamRef}) ->
+        fun({ConnPid, StreamRef}) when is_pid(ConnPid) ->
             spawn_link(fun() ->
                 T0B = erlang:monotonic_time(microsecond),
                 blast_messages(ConnPid, StreamRef, MsgsPerConn),
@@ -162,7 +162,7 @@ ws_throughput(Config) ->
 
     %% Per-worker RTT (total elapsed / msgs)
     WorkerRtts = [
-        E div max(1, S)
+        E div safe_pos(S)
      || {ok, #{elapsed_us := E, sent := S}} <- Successes, is_integer(E), is_integer(S)
     ],
     print_latency_report(WorkerRtts),
@@ -338,3 +338,7 @@ nth_pct(Sorted, Len, P) ->
 
 env_int(Name, Default) ->
     list_to_integer(os:getenv(Name, integer_to_list(Default))).
+
+-spec safe_pos(integer()) -> pos_integer().
+safe_pos(N) when N < 1 -> 1;
+safe_pos(N) -> N.


### PR DESCRIPTION
## Summary

- **210 eqwalize errors → 0** across 20 modules (src + test).
- Dialyzer, xref, fmt, and all 230 eunit tests stay green.
- No `-dialyzer` or `eqwalizer:fixme` suppressions — errors solved at the root.

## Approach

Applied consistent patterns across modules, documented in `feedback_no_foldl`:

- **Narrow wrappers** on `gen_server:call` / `gen_statem:call` returns that specs typed narrowly (e.g. `ok | {error, _}`, `ets:tid()`, `map()`).
- **Guards on tuple-destructured message args** to narrow `term()` components in `handle_call` / `handle_cast` clauses.
- **Named recursive functions** replacing `lists:foldl` (and a handful of `lists:sort`, `lists:split`, `lists:last`, `lists:reverse` calls that lose parametric types under eqwalizer).
- **Tagged-sort** pattern (`tag_skill/1` + `lists:keysort/2` + `untag_skill/1`) instead of `lists:sort/2` with a lambda.
- **Explicit case-narrows** for `erlang:max/2` results that eqwalizer types as `term()`.

## Notable refactor: ETS ownership

The tid-leak through `persistent_term:get/1` + `gen_server:call(_, get_ets_tab)` couldn't be narrowed without violating `ets:tid()`'s opacity or suppressing dialyzer. Restructured instead:

- `asobi_zone_manager` uses `named_table` when `name` opt is provided — the atom *is* the `ets:table()`, no tid leak. Pid-based access now routes through `{lookup_zone, Coords}` / `get_active_zones` gen_server calls.
- `asobi_terrain_store`: dropped `get_ets_tab` handler; consolidated `{get_chunk, Coords}` handle_call to do lookup-or-load internally.

Minor perf trade-off on the pid-based fast-path in exchange for a clean type story.

## Commits

| Commit | Scope | Errors cleared |
|---|---|---|
| `ee89abd` | telemetry, season, spatial, terrain | 3 |
| `3ebacba` | ws_handler, zone_snapshotter, world_registry, world_lobby, match_server, world_ticker, matchmaker_fill, social_controller | 23 |
| `14da574` | asobi_zone, asobi_timer, asobi_world_server | 84 |
| `4a84b68` | zone_manager, matchmaker_skill, phase, dm_controller, matchmaker, world_chat, terrain_store, ws_binary, spatial_grid | 68 |
| `783b362` | test modules + ETS ownership refactor | 32 |

## Test plan

- [x] `rebar3 fmt --check` clean
- [x] `rebar3 xref` clean
- [x] `rebar3 dialyzer` clean (no new warnings vs `main`)
- [x] `~/bin/elp eqwalize-all` → **0 errors**
- [x] `rebar3 eunit` → 230 tests, 0 failures