### PR TITLE
fix(world): lobby lifecycle bugs + empty_grace_ms feature

### DIFF
--- a/src/world/asobi_world_lobby.erl
+++ b/src/world/asobi_world_lobby.erl
@@ -113,7 +113,12 @@ matches_filters(Info, Filters) ->
             false ->
                 true
         end,
-    StatusOk = maps:get(status, Info, undefined) =:= running,
+    %% Include `loading` worlds: a freshly-created world is briefly in this state,
+    %% and joins arriving during loading are postponed by the world_server until
+    %% running. Excluding loading worlds caused races where two clients each
+    %% spawned their own world because neither saw the in-flight one.
+    Status = maps:get(status, Info, undefined),
+    StatusOk = Status =:= running orelse Status =:= loading,
     ModeOk andalso CapOk andalso StatusOk.
 
 -spec take_first([pid()]) -> [pid()].

--- a/src/world/asobi_world_server.erl
+++ b/src/world/asobi_world_server.erl
@@ -107,12 +107,15 @@ init(Config) ->
     VetoTokensPerPlayer = maps:get(veto_tokens_per_player, Config, 0),
     FrustrationBonus = maps:get(frustration_bonus, Config, 0.5),
     Persistent = maps:get(persistent, Config, false),
+    EmptyGraceMs = maps:get(empty_grace_ms, Config, 0),
     InstanceSup = maps:get(instance_sup, Config, undefined),
     PhaseState =
         case erlang:function_exported(GameMod, phases, 1) of
             true ->
-                Phases = GameMod:phases(GameConfig),
-                asobi_phase:init(Phases);
+                case GameMod:phases(GameConfig) of
+                    [] -> undefined;
+                    Phases -> asobi_phase:init(Phases)
+                end;
             false ->
                 undefined
         end,
@@ -144,6 +147,7 @@ init(Config) ->
         frustration_bonus => FrustrationBonus,
         active_votes => #{},
         persistent => Persistent,
+        empty_grace_ms => EmptyGraceMs,
         reconnect_state => init_reconnect(Config),
         chat_state => ChatState,
         phase_state => PhaseState
@@ -153,7 +157,7 @@ init(Config) ->
 %% --- loading state ---
 
 -spec loading(gen_statem:event_type() | enter, term(), map()) ->
-    gen_statem:state_enter_result(atom()).
+    gen_statem:state_enter_result(atom()) | gen_statem:event_handler_result(atom()).
 loading(enter, _OldState, _State) ->
     %% Defer zone spawning — supervisor:which_children deadlocks if called during init
     erlang:send(self(), resolve_and_spawn),
@@ -177,6 +181,10 @@ loading(state_timeout, zones_ready, State) ->
     {next_state, running, State#{started_at => erlang:system_time(millisecond)}};
 loading({call, From}, get_info, State) ->
     {keep_state_and_data, [{reply, From, world_info(loading, State)}]};
+loading({call, _From}, {join, _PlayerId}, _State) ->
+    %% Postpone join until we transition to running. Otherwise the call
+    %% would crash with function_clause and the caller would time out.
+    {keep_state_and_data, [postpone]};
 loading(cast, cancel, State) ->
     {stop, {shutdown, cancelled}, State}.
 
@@ -233,6 +241,13 @@ running(
             do_start_vote(VoteConfig, State1);
         {finished, Result, GS1} ->
             {next_state, finished, State#{game_state => GS1, result => Result}}
+    end;
+running({timeout, empty_grace}, _Content, #{players := Players} = State) ->
+    case map_size(Players) of
+        0 ->
+            {next_state, finished, State#{result => #{status => ~"empty_grace_expired"}}};
+        _ ->
+            keep_state_and_data
     end;
 running({call, From}, get_info, State) ->
     {keep_state_and_data, [{reply, From, world_info(running, State)}]};
@@ -348,8 +363,12 @@ finished(_EventType, _Event, _State) ->
     keep_state_and_data.
 
 -spec terminate(term(), atom(), map()) -> ok.
-terminate(_Reason, _StateName, #{world_id := WorldId}) ->
+terminate(_Reason, _StateName, #{world_id := WorldId} = State) ->
     pg:leave(?PG_SCOPE, {asobi_world_server, WorldId}, self()),
+    %% Clean up player→world ETS entries for any players still in the map.
+    %% Normal handle_leave removes them per-player; this catches abrupt shutdowns.
+    Players = maps:get(players, State, #{}),
+    maps:foreach(fun(PlayerId, _) -> forget_player_world(PlayerId) end, Players),
     ok.
 
 %% --- Internal: Zone Management ---
@@ -508,10 +527,7 @@ handle_join(
                         }
                     },
                     %% Track player→world for reconnection lookup
-                    case ets:info(asobi_player_worlds) of
-                        undefined -> ok;
-                        _ -> ets:insert(asobi_player_worlds, {PlayerId, self()})
-                    end,
+                    remember_player_world(PlayerId, self()),
                     VetoTokens = maps:get(veto_tokens, State2),
                     VetoCount = maps:get(veto_tokens_per_player, State2),
                     State3 = State2#{
@@ -524,7 +540,12 @@ handle_join(
                         PlayerId, ZoneCoords, maps:get(chat_state, State3)
                     ),
                     State4 = notify_phase_player_joined(State3),
-                    {keep_state, State4, [{reply, From, ok}]};
+                    %% Cancel any pending empty_grace timer — this player rescued the world
+                    %% from the grace window. The cancel is a no-op if no timer is pending.
+                    {keep_state, State4, [
+                        {reply, From, ok},
+                        {{timeout, empty_grace}, infinity, undefined}
+                    ]};
                 {error, Reason} ->
                     {keep_state_and_data, [{reply, From, {error, Reason}}]}
             end
@@ -547,13 +568,20 @@ handle_leave(
             leave_chat(PlayerId, State),
             State1 = remove_player_from_zones(PlayerId, State),
             Players1 = maps:remove(PlayerId, Players),
-            case {map_size(Players1), maps:get(persistent, State, false)} of
-                {0, false} ->
-                    {next_state, finished, State1#{
-                        players => Players1, game_state => GS1, result => #{status => ~"empty"}
-                    }};
+            forget_player_world(PlayerId),
+            State2 = State1#{players => Players1, game_state => GS1},
+            Persistent = maps:get(persistent, State2, false),
+            GraceMs = maps:get(empty_grace_ms, State2, 0),
+            case {map_size(Players1), Persistent, GraceMs} of
+                {0, false, 0} ->
+                    {next_state, finished, State2#{result => #{status => ~"empty"}}};
+                {0, false, _} ->
+                    %% Schedule a generic timeout; if a player rejoins before it fires,
+                    %% handle_join cancels it. Generic timeouts persist across events
+                    %% in the same state (unlike state_timeout, which resets).
+                    {keep_state, State2, [{{timeout, empty_grace}, GraceMs, fire}]};
                 _ ->
-                    {keep_state, State1#{players => Players1, game_state => GS1}}
+                    {keep_state, State2}
             end
     end.
 
@@ -707,6 +735,26 @@ find_player_pid(PlayerId) ->
     case pg:get_members(?PG_SCOPE, {player, PlayerId}) of
         [Pid | _] -> Pid;
         [] -> self()
+    end.
+
+-spec remember_player_world(binary(), pid()) -> ok.
+remember_player_world(PlayerId, WorldPid) ->
+    case ets:info(asobi_player_worlds) of
+        undefined ->
+            ok;
+        _ ->
+            ets:insert(asobi_player_worlds, {PlayerId, WorldPid}),
+            ok
+    end.
+
+-spec forget_player_world(binary()) -> ok.
+forget_player_world(PlayerId) ->
+    case ets:info(asobi_player_worlds) of
+        undefined ->
+            ok;
+        _ ->
+            ets:delete(asobi_player_worlds, PlayerId),
+            ok
     end.
 
 -spec subscribe_interest_zones([term()], pid() | atom(), binary(), pid()) -> ok.
@@ -958,10 +1006,7 @@ handle_reconnect_events([{grace_expired, PlayerId, Action} | Rest], State) ->
         case Action of
             remove ->
                 #{world_id := WorldId} = State,
-                case ets:info(asobi_player_worlds) of
-                    undefined -> ok;
-                    _ -> ets:delete(asobi_player_worlds, PlayerId)
-                end,
+                forget_player_world(PlayerId),
                 asobi_telemetry:world_player_left(WorldId, PlayerId),
                 State2 = remove_player_from_zones(PlayerId, State),
                 Players = maps:remove(PlayerId, maps:get(players, State2)),

--- a/src/ws/asobi_ws_handler.erl
+++ b/src/ws/asobi_ws_handler.erl
@@ -345,10 +345,8 @@ handle_message(
 ) ->
     Cid = maps:get(~"cid", Msg, undefined),
     case asobi_world_lobby:create_world(Mode) of
-        {ok, WorldPid, Info} ->
-            _ = asobi_world_server:join(WorldPid, PlayerId),
-            Reply = encode_reply(Cid, ~"world.joined", Info),
-            {reply, {text, Reply}, State};
+        {ok, WorldPid, _Info} ->
+            join_and_reply(Cid, WorldPid, PlayerId, State);
         {error, Reason} ->
             Reply = encode_reply(Cid, ~"error", #{reason => Reason}),
             {reply, {text, Reply}, State}
@@ -359,10 +357,8 @@ handle_message(
 ) ->
     Cid = maps:get(~"cid", Msg, undefined),
     case asobi_world_lobby:find_or_create(Mode) of
-        {ok, WorldPid, Info} ->
-            _ = asobi_world_server:join(WorldPid, PlayerId),
-            Reply = encode_reply(Cid, ~"world.joined", Info),
-            {reply, {text, Reply}, State};
+        {ok, WorldPid, _Info} ->
+            join_and_reply(Cid, WorldPid, PlayerId, State);
         {error, Reason} ->
             Reply = encode_reply(Cid, ~"error", #{reason => Reason}),
             {reply, {text, Reply}, State}
@@ -377,15 +373,7 @@ handle_message(
             Reply = encode_reply(Cid, ~"error", #{reason => ~"world_not_found"}),
             {reply, {text, Reply}, State};
         {ok, WorldPid} ->
-            case asobi_world_server:join(WorldPid, PlayerId) of
-                ok ->
-                    Info = asobi_world_server:get_info(WorldPid),
-                    Reply = encode_reply(Cid, ~"world.joined", Info),
-                    {reply, {text, Reply}, State};
-                {error, Reason} ->
-                    Reply = encode_reply(Cid, ~"error", #{reason => Reason}),
-                    {reply, {text, Reply}, State}
-            end
+            join_and_reply(Cid, WorldPid, PlayerId, State)
     end;
 handle_message(
     #{~"type" := ~"world.leave"} = Msg,
@@ -459,6 +447,41 @@ reply_error(Msg, Reason, State) ->
     Cid = maps:get(~"cid", Msg, undefined),
     Reply = encode_reply(Cid, ~"error", #{reason => Reason}),
     {reply, {text, Reply}, State}.
+
+join_and_reply(Cid, WorldPid, PlayerId, State) ->
+    case current_player_world(PlayerId) of
+        {ok, ExistingPid} when ExistingPid =/= WorldPid ->
+            %% Player is already in a different (live) world. Force them to
+            %% world.leave first; otherwise they'd appear in two worlds at once.
+            Reply = encode_reply(Cid, ~"error", #{reason => ~"already_in_world"}),
+            {reply, {text, Reply}, State};
+        _ ->
+            case asobi_world_server:join(WorldPid, PlayerId) of
+                ok ->
+                    Info = asobi_world_server:get_info(WorldPid),
+                    Reply = encode_reply(Cid, ~"world.joined", Info),
+                    {reply, {text, Reply}, State};
+                {error, Reason} ->
+                    Reply = encode_reply(Cid, ~"error", #{reason => Reason}),
+                    {reply, {text, Reply}, State}
+            end
+    end.
+
+current_player_world(PlayerId) ->
+    case ets:info(asobi_player_worlds) of
+        undefined ->
+            none;
+        _ ->
+            case ets:lookup(asobi_player_worlds, PlayerId) of
+                [{PlayerId, Pid}] when is_pid(Pid) ->
+                    case is_process_alive(Pid) of
+                        true -> {ok, Pid};
+                        false -> none
+                    end;
+                _ ->
+                    none
+            end
+    end.
 
 %% --- Internal ---
 

--- a/test/asobi_world_lobby_ws_SUITE.erl
+++ b/test/asobi_world_lobby_ws_SUITE.erl
@@ -114,11 +114,16 @@ sequential_clients_reuse_existing_world(Config) ->
     Config.
 
 different_modes_get_different_worlds(Config) ->
-    {_P, Tok} = register_player(~"d", Config),
-    Conn = ws_connect_authed(Tok, Config),
-    Hub = ws_find_or_create(?MODE_HUB, ~"d1", Conn),
-    Arena = ws_find_or_create(?MODE_ARENA, ~"d2", Conn),
-    nova_test_ws:close(Conn),
+    %% Two clients — a single connected player can no longer be in two
+    %% worlds at once (see join_rejects_when_player_already_in_other_world).
+    {_P1, Tok1} = register_player(~"dh", Config),
+    {_P2, Tok2} = register_player(~"da", Config),
+    Conn1 = ws_connect_authed(Tok1, Config),
+    Conn2 = ws_connect_authed(Tok2, Config),
+    Hub = ws_find_or_create(?MODE_HUB, ~"d1", Conn1),
+    Arena = ws_find_or_create(?MODE_ARENA, ~"d2", Conn2),
+    nova_test_ws:close(Conn1),
+    nova_test_ws:close(Conn2),
     ?assertNotEqual(Hub, Arena),
     Config.
 
@@ -158,21 +163,23 @@ create_reply_reflects_creator_in_player_count(Config) ->
 
 join_rejects_when_player_already_in_other_world(Config) ->
     %% A single player connected via WS must not be able to be in two worlds
-    %% at once. world.join into a different world while still in another must
-    %% reply with `error` and reason=already_in_world.
-    {_P, Tok} = register_player(~"al", Config),
-    Conn = ws_connect_authed(Tok, Config),
-    %% Create world A.
-    {WorldA, _} = ws_create(?MODE_HUB, ~"al1", Conn),
-    %% Create world B (forces a new world by going through full mode capacity).
-    %% Easier path: spawn a second hub world by filling the first... but max=4.
-    %% Instead, use ARENA mode for B so we deterministically get a different world.
-    {WorldB, _} = ws_create(?MODE_ARENA, ~"al2", Conn),
-    %% At this point, player is implicitly in WorldB (the most recent join).
-    %% Now try to world.join WorldA — should be rejected.
-    Result = ws_join(WorldA, ~"al3", Conn),
-    nova_test_ws:close(Conn),
-    ?assertNotEqual(WorldA, WorldB),
+    %% at once. world.join into a different world while already in another
+    %% must reply with `error` and reason=already_in_world.
+    %%
+    %% Setup: client A creates HUB, client B creates ARENA. Client A then
+    %% tries to join ARENA (already-in-world should reject).
+    {_P1, Tok1} = register_player(~"al", Config),
+    {_P2, Tok2} = register_player(~"bl", Config),
+    Conn1 = ws_connect_authed(Tok1, Config),
+    Conn2 = ws_connect_authed(Tok2, Config),
+    {WorldHub, _} = ws_create(?MODE_HUB, ~"al1", Conn1),
+    {WorldArena, _} = ws_create(?MODE_ARENA, ~"bl1", Conn2),
+    %% Sanity: distinct worlds.
+    ?assertNotEqual(WorldHub, WorldArena),
+    %% Client A (in HUB) attempts to join the arena world.
+    Result = ws_join(WorldArena, ~"al2", Conn1),
+    nova_test_ws:close(Conn1),
+    nova_test_ws:close(Conn2),
     case Result of
         {error, Reason} ->
             ?assertEqual(~"already_in_world", Reason);

--- a/test/asobi_world_lobby_ws_SUITE.erl
+++ b/test/asobi_world_lobby_ws_SUITE.erl
@@ -16,7 +16,9 @@ identity returned to the client.
     two_clients_share_hub_world/1,
     sequential_clients_reuse_existing_world/1,
     different_modes_get_different_worlds/1,
-    full_world_spawns_a_new_one/1
+    full_world_spawns_a_new_one/1,
+    create_reply_reflects_creator_in_player_count/1,
+    join_rejects_when_player_already_in_other_world/1
 ]).
 
 -define(MODE_HUB, ~"test_ws_hub").
@@ -28,7 +30,9 @@ all() ->
         two_clients_share_hub_world,
         sequential_clients_reuse_existing_world,
         different_modes_get_different_worlds,
-        full_world_spawns_a_new_one
+        full_world_spawns_a_new_one,
+        create_reply_reflects_creator_in_player_count,
+        join_rejects_when_player_already_in_other_world
     ].
 
 init_per_suite(Config) ->
@@ -135,6 +139,48 @@ full_world_spawns_a_new_one(Config) ->
     ),
     Config.
 
+create_reply_reflects_creator_in_player_count(Config) ->
+    %% Pre-fix, world.create replied with Info captured BEFORE the implicit
+    %% join, so player_count was always 0 even though the creator was about
+    %% to be in the world. Lobby UIs rendering "0/N" on freshly-created
+    %% worlds is the user-visible symptom.
+    {_P, Tok} = register_player(~"crc", Config),
+    Conn = ws_connect_authed(Tok, Config),
+    {WorldId, PlayerCount} = ws_create(?MODE_HUB, ~"crc1", Conn),
+    nova_test_ws:close(Conn),
+    ?assert(is_binary(WorldId)),
+    ?assertEqual(
+        1,
+        PlayerCount,
+        "world.create reply must report player_count=1 because the creator was joined"
+    ),
+    Config.
+
+join_rejects_when_player_already_in_other_world(Config) ->
+    %% A single player connected via WS must not be able to be in two worlds
+    %% at once. world.join into a different world while still in another must
+    %% reply with `error` and reason=already_in_world.
+    {_P, Tok} = register_player(~"al", Config),
+    Conn = ws_connect_authed(Tok, Config),
+    %% Create world A.
+    {WorldA, _} = ws_create(?MODE_HUB, ~"al1", Conn),
+    %% Create world B (forces a new world by going through full mode capacity).
+    %% Easier path: spawn a second hub world by filling the first... but max=4.
+    %% Instead, use ARENA mode for B so we deterministically get a different world.
+    {WorldB, _} = ws_create(?MODE_ARENA, ~"al2", Conn),
+    %% At this point, player is implicitly in WorldB (the most recent join).
+    %% Now try to world.join WorldA — should be rejected.
+    Result = ws_join(WorldA, ~"al3", Conn),
+    nova_test_ws:close(Conn),
+    ?assertNotEqual(WorldA, WorldB),
+    case Result of
+        {error, Reason} ->
+            ?assertEqual(~"already_in_world", Reason);
+        {ok, _} ->
+            ct:fail("world.join must reject when player is already in another world")
+    end,
+    Config.
+
 %% --- helpers ---
 
 register_player(Suffix, Config) ->
@@ -185,6 +231,45 @@ ws_find_or_create(Mode, Cid, Conn) ->
     ),
     Payload = maps:get(~"payload", Joined),
     maps:get(~"world_id", Payload).
+
+ws_create(Mode, Cid, Conn) ->
+    ok = nova_test_ws:send_json(
+        #{
+            ~"type" => ~"world.create",
+            ~"cid" => Cid,
+            ~"payload" => #{~"mode" => Mode}
+        },
+        Conn
+    ),
+    {ok, Joined} = recv_until(
+        fun(M) ->
+            maps:get(~"type", M, undefined) =:= ~"world.joined" andalso
+                maps:get(~"cid", M, undefined) =:= Cid
+        end,
+        Conn
+    ),
+    Payload = maps:get(~"payload", Joined),
+    {maps:get(~"world_id", Payload), maps:get(~"player_count", Payload, undefined)}.
+
+ws_join(WorldId, Cid, Conn) ->
+    ok = nova_test_ws:send_json(
+        #{
+            ~"type" => ~"world.join",
+            ~"cid" => Cid,
+            ~"payload" => #{~"world_id" => WorldId}
+        },
+        Conn
+    ),
+    {ok, Reply} = recv_until(
+        fun(M) ->
+            maps:get(~"cid", M, undefined) =:= Cid
+        end,
+        Conn
+    ),
+    case maps:get(~"type", Reply) of
+        ~"world.joined" -> {ok, maps:get(~"payload", Reply)};
+        ~"error" -> {error, maps:get(~"reason", maps:get(~"payload", Reply))}
+    end.
 
 recv_until(Pred, Conn) ->
     recv_until(Pred, Conn, 50).

--- a/test/asobi_world_server_tests.erl
+++ b/test/asobi_world_server_tests.erl
@@ -16,6 +16,14 @@ setup() ->
         undefined -> pg:start_link(nova_scope);
         _ -> ok
     end,
+    case ets:info(asobi_player_worlds) of
+        undefined ->
+            ets:new(asobi_player_worlds, [
+                named_table, public, set, {read_concurrency, true}
+            ]);
+        _ ->
+            ets:delete_all_objects(asobi_player_worlds)
+    end,
     meck:new(asobi_repo, [no_link]),
     meck:expect(asobi_repo, insert, fun(_CS) -> {ok, #{}} end),
     meck:expect(asobi_repo, insert, fun(_CS, _Opts) -> {ok, #{}} end),
@@ -55,7 +63,12 @@ world_server_test_() ->
         {timeout, 15, {"leave last player finishes world", fun leave_last_finishes/0}},
         {"get_info returns world metadata", fun get_info/0},
         {timeout, 15, {"cancel finishes world", fun cancel_world/0}},
-        {"whereis finds world by id", fun whereis_world/0}
+        {"whereis finds world by id", fun whereis_world/0},
+        {"join records player in ETS, leave clears it", fun ets_tracks_player_world/0},
+        {timeout, 15, {"empty grace keeps world alive briefly", fun empty_grace_keeps_alive/0}},
+        {timeout, 15, {"empty grace lapses when no one rejoins", fun empty_grace_lapses/0}},
+        {timeout, 15,
+            {"empty phases() list does not auto-finish", fun empty_phases_does_not_finish/0}}
     ]}.
 
 starts_running() ->
@@ -138,3 +151,62 @@ whereis_world() ->
     WorldId = maps:get(world_id, Info),
     ?assertEqual({ok, Pid}, asobi_world_server:whereis(WorldId)),
     stop_world(Ctx).
+
+ets_tracks_player_world() ->
+    Ctx = #{world_pid := Pid} = start_world(),
+    asobi_world_server:join(Pid, <<"p_ets">>),
+    ?assertEqual([{<<"p_ets">>, Pid}], ets:lookup(asobi_player_worlds, <<"p_ets">>)),
+    asobi_world_server:join(Pid, <<"p_ets2">>),
+    asobi_world_server:leave(Pid, <<"p_ets">>),
+    timer:sleep(20),
+    ?assertEqual([], ets:lookup(asobi_player_worlds, <<"p_ets">>)),
+    %% Force a graceful gen_statem stop so terminate runs and cleans up the
+    %% remaining player's ETS entry. (Supervisor-shutdown does NOT call terminate
+    %% on processes that don't trap_exit, so we use gen_statem:stop directly.)
+    ok = gen_statem:stop(Pid),
+    ?assertEqual([], ets:lookup(asobi_player_worlds, <<"p_ets2">>)),
+    stop_world(Ctx).
+
+empty_grace_keeps_alive() ->
+    Ctx = #{world_pid := Pid} = start_world(#{empty_grace_ms => 500}),
+    MonRef = monitor(process, Pid),
+    asobi_world_server:join(Pid, <<"g1">>),
+    asobi_world_server:leave(Pid, <<"g1">>),
+    %% Grace window is 500ms; rejoin within 200ms must keep world alive.
+    timer:sleep(200),
+    ?assertEqual(ok, asobi_world_server:join(Pid, <<"g2">>)),
+    %% Sleep past the original grace window — world must still be alive because grace was cancelled.
+    timer:sleep(500),
+    ?assertEqual(running, maps:get(status, asobi_world_server:get_info(Pid))),
+    demonitor(MonRef, [flush]),
+    stop_world(Ctx).
+
+empty_grace_lapses() ->
+    Ctx = #{world_pid := Pid} = start_world(#{empty_grace_ms => 200}),
+    MonRef = monitor(process, Pid),
+    asobi_world_server:join(Pid, <<"g3">>),
+    asobi_world_server:leave(Pid, <<"g3">>),
+    %% No rejoin: grace fires after 200ms and the world finishes.
+    receive
+        {'DOWN', MonRef, process, Pid, _} -> ok
+    after 10000 ->
+        stop_world(Ctx),
+        ?assert(false)
+    end.
+
+empty_phases_does_not_finish() ->
+    %% Inject phases/1 that returns []. Before the fix, the world would
+    %% transition to `finished` on the first post_tick because asobi_phase:init([])
+    %% returns a state with status=complete.
+    meck:new(asobi_test_world_game, [passthrough, non_strict]),
+    meck:expect(asobi_test_world_game, phases, fun(_GameConfig) -> [] end),
+    try
+        Ctx = #{world_pid := Pid} = start_world(),
+        asobi_world_server:join(Pid, <<"ph1">>),
+        %% Wait several ticks; if the bug is present, world transitions to finished.
+        timer:sleep(300),
+        ?assertEqual(running, maps:get(status, asobi_world_server:get_info(Pid))),
+        stop_world(Ctx)
+    after
+        meck:unload(asobi_test_world_game)
+    end.


### PR DESCRIPTION
## Summary

A focused series of related fixes to the world lifecycle, plus one small feature, all uncovered while building a world-list lobby for a downstream game (barrow).

### Fixes

- **`phases() = []` → world dies on first tick.** `asobi_phase:init([])` produces a phase_state with `complete=true`. Combined with the `function_exported(GameMod, phases, 1)` check, any game whose bridge exports `phases/1` but where the underlying script defines no phases died immediately. Affects every Lua world (asobi_lua_world always exports `phases/1`) without an explicit `phases()` list.
- **`world.create` / `world.find_or_create` reply with stale `Info`.** `Info` was captured *before* the implicit join, so `player_count` was always 0. Lobby UIs rendering "0/N" on freshly-created worlds was the user-visible symptom. Now captured after join.
- **`world.create` / `world.find_or_create` discarded join errors.** `_ = asobi_world_server:join(...)` swallowed errors; clients got `world.joined` even when the join failed. Errors now propagate as `error` replies.
- **`loading` state crashed on join calls.** `gen_statem` raised `function_clause` when a join arrived during the brief loading window — racing the ws_handler's create+join pattern. Joins are now postponed until `running` enters.
- **`world.list` hid loading worlds.** Filtering to `status=running` exposed two-client races where each spawned its own world (the first was still loading and invisible). Loading worlds are now included.
- **`world.join` allowed double-membership.** A connected player could be in two worlds at once. Now rejected with `already_in_world` if the player is in a different live world; stale ETS entries (dead pids) are treated as "not in a world".
- **`handle_leave` didn't clean up player→world ETS.** Only the reconnect-grace path was. Plus `terminate` now catches abrupt-shutdown cases for any remaining players.

### Feature

- **`empty_grace_ms` config option.** Default `0` keeps current instant-close behavior. When `>0`, last-leave schedules a generic timeout instead of finishing immediately; a player rejoining cancels it. Lets games survive brief disconnects without dying.

## Test plan

- [x] `rebar3 fmt --check` clean
- [x] `rebar3 xref` clean
- [x] `rebar3 dialyzer` clean
- [x] `~/bin/elp eqwalize-all` clean
- [x] `~/bin/elp lint` only pre-existing warnings
- [x] `rebar3 eunit` — 234 tests pass (adds 4 new world_server tests covering ETS cleanup, empty grace alive/lapse, empty `phases()` doesn't auto-finish)
- [x] `rebar3 ct --suite=asobi_world_lobby_SUITE` — 9 tests pass
- [x] `rebar3 ct --suite=asobi_world_lobby_ws_SUITE` — 6 tests pass (adds 2 new tests covering player_count in create reply + already_in_world rejection; updated 1 existing test to use two clients since single-client multi-world membership is now correctly rejected)