### PR TITLE
fix(ci): wipe stale project test artifacts before tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,4 +19,10 @@ jobs:
       extra-services-compose: 'docker-compose.yml'
       enable-dependency-submission: true
       enable-summary: true
+      # erlang-ci restores _build from cache keyed on rebar.lock, then runs
+      # `rebar3 clean` which only wipes ebin. Stale test artifacts copied in
+      # by previous runs survive and get executed by rebar3 eunit/ct. That's
+      # how asobi_lua_SUITE.beam (removed in #59) keeps reappearing in CT
+      # and crashing on `luerl:init/0` undef. Force-fresh project test tree.
+      pre-test-command: 'rm -rf _build/default/lib/asobi/test _build/test/lib/asobi/test'
     secrets: inherit


### PR DESCRIPTION
## Summary
asobi's CI has a cache-dependent flake — `asobi_lua_SUITE` (deleted in #59 when Lua moved to its own repo) keeps reappearing and crashing on `luerl:init/0` undef. Hit #85's post-merge run, my #86's pre-merge run, and will keep biting any PR with the same `rebar.lock` hash.

## Root cause
`Taure/erlang-ci` restores `_build` from a cache keyed on `rebar.lock`, then runs `rebar3 clean` — which only wipes the project's own `ebin`. Stale test artifacts copied into `_build/{default,test}/lib/asobi/test/` by a prior run survive the restore. `rebar3 eunit/ct` then loads and runs them.

Locally this never reproduces because there's no cache restore — `_build` reflects current source.

## Fix
Use the existing `pre-test-command` input to force a fresh project test tree before each test job:

```yaml
pre-test-command: 'rm -rf _build/default/lib/asobi/test _build/test/lib/asobi/test'
```

Surgical — only wipes the project's own test/ output. Deps cache is untouched, so build remains fast.

## Test plan
- [x] Confirmed root cause: stale `asobi_lua_SUITE.beam` from before #59 surviving cache restore
- [ ] CI on this PR — both EUnit and CT should pass without `luerl,init` undef
- [ ] Once merged, push to main re-runs CI on the merge commit and should also be green

## Future
The shared `Taure/erlang-ci` action could do this generically (wipe `_build/{default,test}/lib/<project_app>/`) so consumers don't have to. Out of scope here.