### PR TITLE
fix(world): wire generate_world zone states into zone init

### DIFF
--- a/src/world/asobi_world_server.erl
+++ b/src/world/asobi_world_server.erl
@@ -427,7 +427,7 @@ spawn_zones(
 ) ->
     Persistence = maps:get(persistence, Config, false),
     AllCoords = [{X, Y} || X <- lists:seq(0, GridSize - 1), Y <- lists:seq(0, GridSize - 1)],
-    {_ZoneStates, Entities, _SpawnerStates, GS1} =
+    {ZoneStates, Entities, _SpawnerStates, GS1} =
         case Persistence of
             true ->
                 case asobi_zone_snapshotter:load_snapshots(WorldId) of
@@ -450,6 +450,11 @@ spawn_zones(
             false ->
                 {generate_zone_states(GameMod, Config), #{}, #{}, GS}
         end,
+    %% Thread per-zone state from generate_world/2 (or recovered snapshots) into
+    %% the zone_manager so each zone's init sees its own zone_state. Without
+    %% this, callbacks like asobi_lua_world:handle_input/3 silently no-op
+    %% because the lua_state they need is buried in the discarded ZoneStates.
+    ok = asobi_zone_manager:set_initial_zone_states(ZoneManagerPid, ZoneStates),
     %% Pre-warm all zones via zone_manager (uses base config with terrain_store_pid etc.)
     ok = asobi_zone_manager:pre_warm(ZoneManagerPid),
     %% Add recovered entities to zones

--- a/src/world/asobi_zone_manager.erl
+++ b/src/world/asobi_zone_manager.erl
@@ -15,7 +15,7 @@ Hot-path lookups go through ETS directly, bypassing the gen_server.
 -export([start_link/1]).
 -export([ensure_zone/2, get_zone/2, touch_zone/2, release_zone/2]).
 -export([get_active_zones/1, zone_terminated/2, pre_warm/1]).
--export([register_zone/3, set_zone_config/2]).
+-export([register_zone/3, set_zone_config/2, set_initial_zone_states/2]).
 -export([init/1, handle_call/3, handle_cast/2, handle_info/2, terminate/2]).
 
 -define(REAP_INTERVAL, 10_000).
@@ -88,6 +88,17 @@ register_zone(Ref, Coords, ZonePid) ->
 set_zone_config(Ref, Config) ->
     ok = gen_server:call(Ref, {set_zone_config, Config}).
 
+-doc """
+Provide per-coord initial zone_state. Used to thread per-zone state from
+`GameMod:generate_world/2` (e.g. lua_state for the asobi_lua_world bridge,
+or station/planet seeds for sc_game) through to each zone's init. Without
+this, zones would all start with empty zone_state and any callback that
+needs per-zone setup would silently no-op.
+""".
+-spec set_initial_zone_states(pid() | atom(), map()) -> ok.
+set_initial_zone_states(Ref, ZoneStates) when is_map(ZoneStates) ->
+    ok = gen_server:call(Ref, {set_initial_zone_states, ZoneStates}).
+
 %% --- gen_server callbacks ---
 
 -spec init(map()) -> {ok, map()}.
@@ -123,6 +134,7 @@ init(Opts) ->
         grid_size => maps:get(grid_size, Opts),
         zone_size => maps:get(zone_size, Opts),
         zone_config => maps:get(zone_config, Opts, #{}),
+        initial_zone_states => maps:get(initial_zone_states, Opts, #{}),
         reap_ref => ReapRef
     }}.
 
@@ -162,6 +174,8 @@ handle_call(
     {reply, ok, State1};
 handle_call({set_zone_config, Config}, _From, State) ->
     {reply, ok, State#{zone_config => Config}};
+handle_call({set_initial_zone_states, ZoneStates}, _From, State) ->
+    {reply, ok, State#{initial_zone_states => ZoneStates}};
 handle_call({lookup_zone, Coords}, _From, #{ets_tab := Tab} = State) ->
     Result =
         case ets:lookup(Tab, Coords) of
@@ -220,14 +234,21 @@ start_zone(
         zone_last_active := Active,
         zone_monitors := Monitors,
         max_active_zones := MaxActive,
-        zone_config := BaseConfig
+        zone_config := BaseConfig,
+        initial_zone_states := InitialStates
     } = State
 ) ->
     case ets:info(Tab, size) >= MaxActive of
         true ->
             {error, max_zones_reached};
         false ->
-            Config = BaseConfig#{coords => Coords},
+            Config0 = BaseConfig#{coords => Coords},
+            Config =
+                case maps:get(Coords, InitialStates, undefined) of
+                    undefined -> Config0;
+                    ZS when is_map(ZS) -> Config0#{zone_state => ZS};
+                    _ -> Config0
+                end,
             case asobi_zone_sup:start_zone(ZoneSup, Config) of
                 {ok, Pid} ->
                     ets:insert(Tab, {Coords, Pid}),

--- a/test/asobi_zone_manager_tests.erl
+++ b/test/asobi_zone_manager_tests.erl
@@ -52,7 +52,9 @@ zone_manager_test_() ->
         {"max_active_zones enforced", fun max_zones_enforced/0},
         {"pre_warm spawns all zones", fun pre_warm_all/0},
         {"touch_zone resets timer", fun touch_zone_resets/0},
-        {"release_zone marks stale", fun release_zone_marks_stale/0}
+        {"release_zone marks stale", fun release_zone_marks_stale/0},
+        {"per-coord initial zone_state reaches zone init", fun initial_zone_states_threaded/0},
+        {"missing per-coord state leaves zone_state default", fun initial_zone_states_default/0}
     ]}.
 
 starts_ok() ->
@@ -147,4 +149,34 @@ release_zone_marks_stale() ->
     ok = asobi_zone_manager:release_zone(Mgr, {0, 0}),
     timer:sleep(10),
     ?assertMatch({ok, _}, asobi_zone_manager:get_zone(Mgr, {0, 0})),
+    stop_manager(Ctx).
+
+%% Regression: per-coord state from generate_world/2 must reach the zone's
+%% init. Before this fix, the world server discarded ZoneStates entirely so
+%% callbacks like asobi_lua_world:handle_input/3 (which need lua_state in
+%% zone_state) silently no-opped, breaking any Lua game's input handling.
+initial_zone_states_threaded() ->
+    Ctx = #{mgr := Mgr} = start_manager(),
+    States = #{
+        {0, 0} => #{marker => zero_zero, lua_state => fake_lua_zero},
+        {1, 1} => #{marker => one_one, lua_state => fake_lua_one}
+    },
+    ok = asobi_zone_manager:set_initial_zone_states(Mgr, States),
+    {ok, P00} = asobi_zone_manager:ensure_zone(Mgr, {0, 0}),
+    {ok, P11} = asobi_zone_manager:ensure_zone(Mgr, {1, 1}),
+    #{zone_state := ZS00} = sys:get_state(P00),
+    #{zone_state := ZS11} = sys:get_state(P11),
+    ?assertEqual(zero_zero, maps:get(marker, ZS00)),
+    ?assertEqual(fake_lua_zero, maps:get(lua_state, ZS00)),
+    ?assertEqual(one_one, maps:get(marker, ZS11)),
+    ?assertEqual(fake_lua_one, maps:get(lua_state, ZS11)),
+    stop_manager(Ctx).
+
+initial_zone_states_default() ->
+    Ctx = #{mgr := Mgr} = start_manager(),
+    %% No set_initial_zone_states call — zone should still start with the
+    %% default empty zone_state, not crash.
+    {ok, P} = asobi_zone_manager:ensure_zone(Mgr, {0, 0}),
+    #{zone_state := ZS} = sys:get_state(P),
+    ?assertEqual(#{}, ZS),
     stop_manager(Ctx).


### PR DESCRIPTION
## Summary
`asobi_world_server:spawn_zones` calls `GameMod:generate_world/2` to produce a coords→zone_state map, then discards it (`_ZoneStates`). `asobi_zone_manager` pre-warms every zone with the same `BaseConfig` and empty `zone_state`. Any callback expecting per-zone state silently no-ops on tick 0.

## User-visible symptom
**Barrow** (Lua game via asobi_lua_world): two players in the same hub world see each other's spawn entity but never each other's *movement*. The Lua bridge's `handle_input/3` needs `lua_state` stashed in `zone_state` via `zone_tick/2` — but with empty `zone_state`, `zone_tick` returns entities unchanged without invoking Lua, so the proc-dict stash never gets populated and `handle_input` falls through to its no-op clause. Move inputs are silently dropped at the bridge boundary.

**Space Corsairs** (Erlang game): `sc_game:generate_world/2` returns per-zone station/planet seeds, but `maybe_spawn_station` only fires when `ZoneState` has a `station` key. Same bug — stations never spawn. Movement still works because `sc_game:handle_input/3` is pure Erlang and operates on `Entities` directly.

## Fix
- **`asobi_zone_manager`**: new `set_initial_zone_states/2` stores a coords→state map. `start_zone` consults it and merges the per-coord state into the zone's `Config` under `zone_state`.
- **`asobi_world_server:spawn_zones`**: stop discarding `ZoneStates`; push them into the zone_manager before `pre_warm` so each zone's `init` sees its own state.

## Test plan
- [x] `rebar3 fmt --check` clean
- [x] `rebar3 xref` clean
- [x] `rebar3 dialyzer` clean
- [x] `rebar3 eunit` 236 tests, 0 failures (incl. 2 new regression tests)
- [x] `rebar3 ct` 210 tests, 0 failures
- [ ] After bumping asobi_lua + barrow image: probe two clients in same world, A moves → B receives `world.tick` updates with A's new position