### PR TITLE
fix(world): handle WS disconnect with player_ttl_ms

### DIFF
--- a/src/asobi_game_modes.erl
+++ b/src/asobi_game_modes.erl
@@ -30,7 +30,7 @@ world_config(Mode) ->
     ModeConfig = mode_config(Mode),
     case resolve_game_module(Mode) of
         {ok, GameMod, ExtraConfig} ->
-            {ok, #{
+            Base = #{
                 mode => Mode,
                 game_module => GameMod,
                 game_config => ExtraConfig,
@@ -40,9 +40,19 @@ world_config(Mode) ->
                 tick_rate => maps:get(tick_rate, ModeConfig, 50),
                 view_radius => maps:get(view_radius, ModeConfig, 1),
                 persistent => maps:get(persistent, ModeConfig, false)
-            }};
+            },
+            {ok, forward_optional(ModeConfig, [empty_grace_ms, player_ttl_ms], Base)};
         {error, _} = Err ->
             Err
+    end.
+
+-spec forward_optional(map(), [atom()], map()) -> map().
+forward_optional(_Src, [], Acc) ->
+    Acc;
+forward_optional(Src, [Key | Rest], Acc) ->
+    case Src of
+        #{Key := Val} -> forward_optional(Src, Rest, Acc#{Key => Val});
+        _ -> forward_optional(Src, Rest, Acc)
     end.
 
 -spec ensure_map(term()) -> #{term() => term()}.

--- a/src/world/asobi_world_server.erl
+++ b/src/world/asobi_world_server.erl
@@ -148,6 +148,7 @@ init(Config) ->
         active_votes => #{},
         persistent => Persistent,
         empty_grace_ms => EmptyGraceMs,
+        player_ttl_ms => maps:get(player_ttl_ms, Config, 0),
         reconnect_state => init_reconnect(Config),
         chat_state => ChatState,
         phase_state => PhaseState
@@ -283,10 +284,21 @@ running(info, {asobi_message, _}, _State) ->
 running(
     info, {'DOWN', _MonRef, process, DownPid, _Reason}, #{reconnect_state := undefined} = State
 ) ->
-    %% No reconnect policy — no action (entity stays, player can rejoin)
+    %% No reconnect policy active. Behavior depends on player_ttl_ms:
+    %%   0  (default): immediate cleanup — remove entity, broadcast op="r"
+    %%   -1: keep entity forever (opt-in for persistent worlds where the
+    %%       game module manages reconnection state itself)
+    %% A positive player_ttl_ms is upgraded to a reconnect_state at world
+    %% init, so that path is handled by the {reconnect_state := RS} clause
+    %% below — never reaches here.
     case find_player_by_pid(DownPid, State) of
-        {ok, _PlayerId} -> keep_state_and_data;
-        none -> keep_state_and_data
+        {ok, PlayerId} ->
+            case maps:get(player_ttl_ms, State, 0) of
+                -1 -> keep_state_and_data;
+                _ -> handle_leave(PlayerId, State)
+            end;
+        none ->
+            keep_state_and_data
     end;
 running(info, {'DOWN', _MonRef, process, DownPid, _Reason}, #{reconnect_state := RS} = State) ->
     case find_player_by_pid(DownPid, State) of
@@ -991,10 +1003,30 @@ world_info(Status, #{world_id := WorldId, players := Players} = State) ->
 
 %% --- Internal: Reconnection ---
 
+%% Resolution order:
+%%   1. Explicit `reconnect` policy in Config (expert mode — full asobi_reconnect
+%%      policy with during_grace, on_reconnect, on_expire, etc.).
+%%   2. `player_ttl_ms` > 0 — synthesize a simple grace-then-remove policy.
+%%   3. Otherwise undefined — DOWN handler decides based on player_ttl_ms
+%%      (0 = immediate cleanup, -1 = keep forever).
 init_reconnect(Config) ->
     case maps:get(reconnect, Config, undefined) of
-        undefined -> undefined;
-        Policy when is_map(Policy) -> asobi_reconnect:new(Policy)
+        Policy when is_map(Policy) ->
+            asobi_reconnect:new(Policy);
+        undefined ->
+            case maps:get(player_ttl_ms, Config, 0) of
+                Ms when is_integer(Ms), Ms > 0 ->
+                    asobi_reconnect:new(#{
+                        grace_period => Ms,
+                        during_grace => removed,
+                        on_reconnect => respawn,
+                        on_expire => remove,
+                        pause_match => false,
+                        max_offline_total => infinity
+                    });
+                _ ->
+                    undefined
+            end
     end.
 
 tick_reconnect(#{reconnect_state := undefined} = State) ->

--- a/test/asobi_world_lobby_ws_SUITE.erl
+++ b/test/asobi_world_lobby_ws_SUITE.erl
@@ -44,7 +44,10 @@ init_per_suite(Config) ->
             max_players => 4,
             grid_size => 1,
             zone_size => 100,
-            tick_rate => 50
+            tick_rate => 50,
+            %% Hub-style modes need a grace window so the world survives across
+            %% brief disconnects (sequential clients reusing the lobby).
+            empty_grace_ms => 5000
         },
         ?MODE_ARENA => #{
             type => world,
@@ -52,7 +55,8 @@ init_per_suite(Config) ->
             max_players => 4,
             grid_size => 1,
             zone_size => 100,
-            tick_rate => 50
+            tick_rate => 50,
+            empty_grace_ms => 5000
         },
         ?MODE_SOLO => #{
             type => world,

--- a/test/asobi_world_server_tests.erl
+++ b/test/asobi_world_server_tests.erl
@@ -68,7 +68,16 @@ world_server_test_() ->
         {timeout, 15, {"empty grace keeps world alive briefly", fun empty_grace_keeps_alive/0}},
         {timeout, 15, {"empty grace lapses when no one rejoins", fun empty_grace_lapses/0}},
         {timeout, 15,
-            {"empty phases() list does not auto-finish", fun empty_phases_does_not_finish/0}}
+            {"empty phases() list does not auto-finish", fun empty_phases_does_not_finish/0}},
+        {timeout, 15,
+            {"player_ttl_ms=0 (default): DOWN immediately removes player",
+                fun player_ttl_zero_removes_on_down/0}},
+        {timeout, 15,
+            {"player_ttl_ms=-1: DOWN keeps player (persistent world opt-in)",
+                fun player_ttl_minus_one_keeps_on_down/0}},
+        {timeout, 15,
+            {"player_ttl_ms>0: DOWN starts grace, fires reconnect events",
+                fun player_ttl_grace_starts_grace/0}}
     ]}.
 
 starts_running() ->
@@ -210,3 +219,59 @@ empty_phases_does_not_finish() ->
     after
         meck:unload(asobi_test_world_game)
     end.
+
+%% --- player_ttl_ms ---
+
+%% Spawn a fake player session and register it in the pg group the world
+%% server monitors via find_player_pid/1. Killing this pid triggers the
+%% world_server's 'DOWN' handler.
+fake_session(PlayerId) ->
+    Pid = spawn(fun Loop() ->
+        receive
+            stop -> ok;
+            _ -> Loop()
+        end
+    end),
+    ok = pg:join(nova_scope, {player, PlayerId}, Pid),
+    Pid.
+
+player_ttl_zero_removes_on_down() ->
+    %% Default behavior: WS drop with no reconnect policy should fully clean
+    %% up the player. Without this, the zone accumulates zombie entities.
+    Ctx = #{world_pid := Pid} = start_world(),
+    PlayerId = <<"ttl0">>,
+    SessionPid = fake_session(PlayerId),
+    asobi_world_server:join(Pid, PlayerId),
+    ?assertEqual(1, maps:get(player_count, asobi_world_server:get_info(Pid))),
+    exit(SessionPid, kill),
+    timer:sleep(50),
+    ?assertEqual(0, maps:get(player_count, asobi_world_server:get_info(Pid))),
+    stop_world(Ctx).
+
+player_ttl_minus_one_keeps_on_down() ->
+    %% Persistent-world opt-in: -1 means never auto-remove on disconnect.
+    %% The game module manages reconnection state itself.
+    Ctx = #{world_pid := Pid} = start_world(#{player_ttl_ms => -1}),
+    PlayerId = <<"ttlneg">>,
+    SessionPid = fake_session(PlayerId),
+    asobi_world_server:join(Pid, PlayerId),
+    ?assertEqual(1, maps:get(player_count, asobi_world_server:get_info(Pid))),
+    exit(SessionPid, kill),
+    timer:sleep(50),
+    ?assertEqual(1, maps:get(player_count, asobi_world_server:get_info(Pid))),
+    stop_world(Ctx).
+
+player_ttl_grace_starts_grace() ->
+    %% Positive ttl synthesizes a reconnect_state. DOWN must trigger the
+    %% grace flow; player count stays at 1 during the grace window.
+    Ctx = #{world_pid := Pid} = start_world(#{player_ttl_ms => 5_000}),
+    PlayerId = <<"ttlgrace">>,
+    SessionPid = fake_session(PlayerId),
+    asobi_world_server:join(Pid, PlayerId),
+    ?assertEqual(1, maps:get(player_count, asobi_world_server:get_info(Pid))),
+    exit(SessionPid, kill),
+    timer:sleep(100),
+    %% Player remains in the world during grace (entity may be hidden by
+    %% during_grace=removed but the player record is preserved for reconnect).
+    ?assertEqual(1, maps:get(player_count, asobi_world_server:get_info(Pid))),
+    stop_world(Ctx).

--- a/test/asobi_zone_manager_tests.erl
+++ b/test/asobi_zone_manager_tests.erl
@@ -166,10 +166,8 @@ initial_zone_states_threaded() ->
     {ok, P11} = asobi_zone_manager:ensure_zone(Mgr, {1, 1}),
     #{zone_state := ZS00} = sys:get_state(P00),
     #{zone_state := ZS11} = sys:get_state(P11),
-    ?assertEqual(zero_zero, maps:get(marker, ZS00)),
-    ?assertEqual(fake_lua_zero, maps:get(lua_state, ZS00)),
-    ?assertEqual(one_one, maps:get(marker, ZS11)),
-    ?assertEqual(fake_lua_one, maps:get(lua_state, ZS11)),
+    ?assertMatch(#{marker := zero_zero, lua_state := fake_lua_zero}, ZS00),
+    ?assertMatch(#{marker := one_one, lua_state := fake_lua_one}, ZS11),
     stop_manager(Ctx).
 
 initial_zone_states_default() ->


### PR DESCRIPTION
## Summary

- Add `player_ttl_ms` config knob (Photon-style: `0`=remove on DOWN default, `-1`=keep forever, `N`>0=grace window). Previously, when a player's session pid went DOWN with no reconnect policy active, the world server kept the phantom player record forever — every WS drop leaked an entity.
- Forward `empty_grace_ms` and `player_ttl_ms` through `asobi_game_modes:world_config/1`. The curated allowlist had been silently dropping these keys, so config declared in mode definitions never reached the world server. (This is the underlying reason barrow's `empty_grace_ms = 900000` in `world.lua` had no observable effect.)
- Hub-style test modes (`test_ws_hub`, `test_ws_arena`) now declare `empty_grace_ms`, the realistic config for lobby/hub worlds where an empty world should survive sequential reconnects.
- Drive-by: tighten `asobi_zone_manager_tests` to use `?assertMatch` on map patterns, fixing 4 pre-existing eqwalizer `incompatible_types` errors that landed with #88.

## Why

Was tracking down "why do two Defold clients see ghost players standing around" in barrow. Root cause: every Build & Run cycle disconnected the previous WS without cleaning up the player record, so the zone accumulated zombies. The fix needs to be at the asobi layer because asobi serves many game types — hub/lobby worlds, competitive matches, MMO-scale worlds, async/AFK co-op — and each wants a different disconnect behavior. `player_ttl_ms` is the standard "reconnect grace" knob from major game backends (Photon, Colyseus). Default `0` cleans up immediately (the safe default for matches); set `-1` for persistent worlds; set `N`>0 for grace.

## Test plan

- [x] `rebar3 eunit` (239 tests, 0 failures) — covers 3 new `player_ttl_ms` branches
- [x] `rebar3 ct` (210 tests, 0 failures)
- [x] `rebar3 fmt --check`
- [x] `rebar3 xref`, `rebar3 dialyzer`
- [x] `~/bin/elp eqwalize-all` (NO ERRORS — fixes 4 pre-existing)
- [x] `~/bin/elp lint` (clean for changed files)