### PR TITLE
fix(world): close triple race between world.join and immediate world.input

### DIFF
--- a/src/players/asobi_player_session.erl
+++ b/src/players/asobi_player_session.erl
@@ -2,7 +2,7 @@
 -behaviour(gen_server).
 
 -export([start_link/2, stop/1]).
--export([get_state/1, update_presence/2]).
+-export([get_state/1, update_presence/2, set_zone/3]).
 -export([init/1, handle_call/3, handle_cast/2, handle_info/2, terminate/2]).
 
 -spec start_link(binary(), pid()) -> gen_server:start_ret().
@@ -24,6 +24,14 @@ get_state(Pid) ->
 update_presence(Pid, Status) ->
     gen_server:cast(Pid, {update_presence, Status}).
 
+%% Synchronously bind world_pid + zone_pid into the session before the WS handler
+%% replies world.joined, so an immediately-following world.input is routed to the
+%% right zone instead of being silently dropped while the async {world_joined,...}
+%% message is still in flight.
+-spec set_zone(pid(), pid(), pid() | undefined) -> ok.
+set_zone(Pid, WorldPid, ZonePid) ->
+    ok = gen_server:call(Pid, {set_zone, WorldPid, ZonePid}).
+
 -spec init(map()) -> {ok, map()}.
 init(#{player_id := PlayerId, ws_pid := WsPid}) ->
     process_flag(trap_exit, true),
@@ -41,6 +49,8 @@ init(#{player_id := PlayerId, ws_pid := WsPid}) ->
 -spec handle_call(term(), gen_server:from(), map()) -> {reply, term(), map()}.
 handle_call(get_state, _From, State) ->
     {reply, State, State};
+handle_call({set_zone, WorldPid, ZonePid}, _From, State) ->
+    {reply, ok, State#{world_pid => WorldPid, zone_pid => ZonePid}};
 handle_call(_Request, _From, State) ->
     {reply, {error, unknown_request}, State}.
 

--- a/src/world/asobi_world_server.erl
+++ b/src/world/asobi_world_server.erl
@@ -1,7 +1,7 @@
 -module(asobi_world_server).
 -behaviour(gen_statem).
 
--export([start_link/1, join/2, leave/2, move_player/3, post_tick/2, get_info/1, cancel/1]).
+-export([start_link/1, join/2, join/3, leave/2, move_player/3, post_tick/2, get_info/1, cancel/1]).
 -export([spawn_at/3, spawn_at/4]).
 -export([reconnect/2]).
 -export([start_vote/2, cast_vote/4, use_veto/3]).
@@ -24,7 +24,24 @@ start_link(Config) ->
 
 -spec join(pid(), binary()) -> ok | {error, term()}.
 join(Pid, PlayerId) ->
-    narrow_ok_or_error(gen_statem:call(Pid, {join, PlayerId})).
+    case gen_statem:call(Pid, {join, PlayerId}) of
+        {ok, _ZonePid} -> ok;
+        {error, _} = Err -> Err
+    end.
+
+%% Variant of join/2 that also synchronously binds zone_pid into the caller's
+%% asobi_player_session via SessionPid before returning. Use this from the WS
+%% handler so an immediately-following world.input isn't dropped while the async
+%% {world_joined,...} notification is still in flight.
+-spec join(pid(), binary(), pid()) -> ok | {error, term()}.
+join(Pid, PlayerId, SessionPid) when is_pid(SessionPid) ->
+    case gen_statem:call(Pid, {join, PlayerId}) of
+        {ok, ZonePid} when is_pid(ZonePid) ->
+            ok = asobi_player_session:set_zone(SessionPid, Pid, ZonePid),
+            ok;
+        {error, _} = Err ->
+            Err
+    end.
 
 -spec leave(pid(), binary()) -> ok.
 leave(Pid, PlayerId) ->
@@ -531,7 +548,7 @@ handle_join(
                 {ok, GS1} ->
                     {ok, SpawnPos} = Mod:spawn_position(PlayerId, GS1),
                     State1 = State#{game_state => GS1},
-                    State2 = place_player(PlayerId, SpawnPos, State1),
+                    {State2, ZonePid} = place_player(PlayerId, SpawnPos, State1),
                     %% Monitor player session for reconnection handling
                     PlayerPid = find_player_pid(PlayerId),
                     MonRef = erlang:monitor(process, PlayerPid),
@@ -560,7 +577,7 @@ handle_join(
                     %% Cancel any pending empty_grace timer — this player rescued the world
                     %% from the grace window. The cancel is a no-op if no timer is pending.
                     {keep_state, State4, [
-                        {reply, From, ok},
+                        {reply, From, {ok, ZonePid}},
                         {{timeout, empty_grace}, infinity, undefined}
                     ]};
                 {error, Reason} ->
@@ -619,10 +636,19 @@ place_player(
     asobi_presence:send(PlayerId, {world_joined, self(), ZonePid}),
     InterestZones = interest_zones(ZoneCoords, ViewRadius, GridSize),
     subscribe_interest_zones(InterestZones, ZMPid, PlayerId, PlayerPid),
+    %% Drain the casts above (add_entity + subscribe) by issuing a sync call to
+    %% the zone. Without this, a world.input cast from the WS handler can race
+    %% past the add_entity cast (different sender = no FIFO) and the zone's
+    %% next tick runs apply_inputs against an entities map missing the player —
+    %% the Lua handle_input's "if not e then return entities end" guard then
+    %% silently drops the input. The sync call forces the zone to process its
+    %% mailbox up to here before we reply {ok, ZonePid} to the WS handler.
+    _ = asobi_zone:get_subscriber_count(ZonePid),
     PlayerZones = maps:get(player_zones, State),
-    State#{
+    State1 = State#{
         player_zones => PlayerZones#{PlayerId => #{zone => ZoneCoords, interest => InterestZones}}
-    }.
+    },
+    {State1, ZonePid}.
 
 remove_player_from_zones(
     PlayerId,
@@ -681,7 +707,7 @@ handle_move(
                     {keep_state, State#{players => Players1}};
                 false ->
                     State1 = remove_player_from_zones(PlayerId, State),
-                    State2 = place_player(PlayerId, NewPos, State1),
+                    {State2, _NewZonePid} = place_player(PlayerId, NewPos, State1),
                     asobi_world_chat:player_zone_changed(
                         PlayerId, OldZoneCoords, NewZoneCoords, GridSize, ChatState
                     ),

--- a/src/world/asobi_zone.erl
+++ b/src/world/asobi_zone.erl
@@ -338,9 +338,17 @@ do_tick(
         entity_timers := ET
     } = State
 ) ->
-    Entities1 = apply_inputs(GameMod, Queue, Entities),
+    %% Run zone_tick BEFORE apply_inputs so bridges that stash per-zone state
+    %% in the proc dict (e.g., asobi_lua_world) have a chance to populate it
+    %% before handle_input/3 reads it. Without this swap, the very first tick
+    %% on a freshly-spawned zone runs apply_inputs against an empty proc dict
+    %% and the bridge silently drops every queued input. The semantic effect
+    %% is that an input arrives one zone-tick later than it would have under
+    %% the previous order; broadcasts still reflect this tick's input because
+    %% the broadcast step runs after both.
     ZoneStateWithTick = ZoneState#{tick => TickN},
-    {Entities2, ZoneState1} = GameMod:zone_tick(Entities1, ZoneStateWithTick),
+    {Entities0, ZoneState1} = GameMod:zone_tick(Entities, ZoneStateWithTick),
+    Entities2 = apply_inputs(GameMod, Queue, Entities0),
     Now = erlang:system_time(millisecond),
     {TimerEvents, ET1} = asobi_entity_timer:tick(Now, ET),
     Entities3 = apply_timer_events(TimerEvents, Entities2),

--- a/src/ws/asobi_ws_handler.erl
+++ b/src/ws/asobi_ws_handler.erl
@@ -448,7 +448,9 @@ reply_error(Msg, Reason, State) ->
     Reply = encode_reply(Cid, ~"error", #{reason => Reason}),
     {reply, {text, Reply}, State}.
 
-join_and_reply(Cid, WorldPid, PlayerId, State) ->
+join_and_reply(Cid, WorldPid, PlayerId, #{session := SessionPid} = State) when
+    SessionPid =/= undefined
+->
     case current_player_world(PlayerId) of
         {ok, ExistingPid} when ExistingPid =/= WorldPid ->
             %% Player is already in a different (live) world. Force them to
@@ -456,7 +458,10 @@ join_and_reply(Cid, WorldPid, PlayerId, State) ->
             Reply = encode_reply(Cid, ~"error", #{reason => ~"already_in_world"}),
             {reply, {text, Reply}, State};
         _ ->
-            case asobi_world_server:join(WorldPid, PlayerId) of
+            %% join/3 (vs join/2) sets zone_pid synchronously in the player_session
+            %% before returning, so a world.input arriving right after world.joined
+            %% lands on the right zone instead of being silently dropped.
+            case asobi_world_server:join(WorldPid, PlayerId, SessionPid) of
                 ok ->
                     Info = asobi_world_server:get_info(WorldPid),
                     Reply = encode_reply(Cid, ~"world.joined", Info),

--- a/test/asobi_world_server_tests.erl
+++ b/test/asobi_world_server_tests.erl
@@ -29,6 +29,9 @@ setup() ->
     meck:expect(asobi_repo, insert, fun(_CS, _Opts) -> {ok, #{}} end),
     meck:new(asobi_presence, [non_strict, no_link]),
     meck:expect(asobi_presence, send, fun(_PlayerId, _Msg) -> ok end),
+    meck:expect(asobi_presence, track, fun(_PlayerId, _Pid) -> ok end),
+    meck:expect(asobi_presence, untrack, fun(_PlayerId) -> ok end),
+    meck:expect(asobi_presence, update, fun(_PlayerId, _Status) -> ok end),
     ok.
 
 cleanup(_) ->
@@ -77,7 +80,8 @@ world_server_test_() ->
                 fun player_ttl_minus_one_keeps_on_down/0}},
         {timeout, 15,
             {"player_ttl_ms>0: DOWN starts grace, fires reconnect events",
-                fun player_ttl_grace_starts_grace/0}}
+                fun player_ttl_grace_starts_grace/0}},
+        {"join/3 sets zone_pid in player_session synchronously", fun join_three_sets_zone_pid/0}
     ]}.
 
 starts_running() ->
@@ -274,4 +278,25 @@ player_ttl_grace_starts_grace() ->
     %% Player remains in the world during grace (entity may be hidden by
     %% during_grace=removed but the player record is preserved for reconnect).
     ?assertEqual(1, maps:get(player_count, asobi_world_server:get_info(Pid))),
+    stop_world(Ctx).
+
+join_three_sets_zone_pid() ->
+    %% Regression: world.input sent immediately after world.joined was silently
+    %% dropped because asobi_player_session.zone_pid was set via an async
+    %% {world_joined,...} message that hadn't been processed yet. join/3 sets
+    %% zone_pid synchronously in the player_session before returning.
+    Ctx = #{world_pid := Pid} = start_world(),
+    PlayerId = <<"sync_zone_pid">>,
+    {ok, SessionPid} = asobi_player_session:start_link(PlayerId, self()),
+    unlink(SessionPid),
+    ok = pg:join(nova_scope, {player, PlayerId}, SessionPid),
+    %% Pre-condition: zone_pid is undefined before join.
+    State0 = asobi_player_session:get_state(SessionPid),
+    ?assertEqual(undefined, maps:get(zone_pid, State0, undefined)),
+    %% join/3 must bind zone_pid + world_pid into the session synchronously.
+    ?assertEqual(ok, asobi_world_server:join(Pid, PlayerId, SessionPid)),
+    State1 = asobi_player_session:get_state(SessionPid),
+    ?assert(is_pid(maps:get(zone_pid, State1))),
+    ?assertEqual(Pid, maps:get(world_pid, State1)),
+    asobi_player_session:stop(SessionPid),
     stop_world(Ctx).


### PR DESCRIPTION
## Summary

Three independent races could cause a `world.input` sent immediately after a `world.joined` reply to be silently dropped:

1. **Async zone_pid binding** — `zone_pid` was set into `asobi_player_session` via an async `{world_joined,...}` notification; a `world.input` arriving before that message landed had no zone to route to. Fixed by `asobi_world_server:join/3` + new `asobi_player_session:set_zone/3` so the WS handler binds the zone synchronously before replying `world.joined`.

2. **Cross-sender cast race** — `add_entity` and `subscribe` casts to the zone race against the `player_input` cast across senders (Erlang only guarantees FIFO between the same pair). Fixed by a sync drain (`asobi_zone:get_subscriber_count/1`) at the end of `place_player`, so the zone has processed both casts before `world_server` returns `{ok, ZonePid}`.

3. **`do_tick` ordering vs proc-dict bridges** — `asobi_zone:do_tick` ran `apply_inputs` before `zone_tick`. Bridges that stash per-zone state in the process dictionary (e.g. `asobi_lua_world`) populate it inside `zone_tick`, so the first tick on a freshly-spawned zone read an empty PD and silently dropped every queued input. Fixed by swapping the order.

Surfaced by a new PropEr-driven CT suite in [`asobi-test-harness/multiplayer_ct`](https://github.com/widgrensit/asobi-test-harness/tree/test/multiplayer-coverage) that runs N=2..10 concurrent WS clients through host-create / guests-join / each-sends-input and asserts every client sees every other client's state within the fanout budget.

## Test plan

- [x] `rebar3 eunit` — 240/240 pass, including new `join_three_sets_zone_pid` regression test
- [x] `rebar3 xref` — clean
- [x] `rebar3 dialyzer` — clean
- [x] `rebar3 fmt --check` — clean
- [x] `~/bin/elp eqwalize-all` — NO ERRORS
- [x] `~/bin/elp lint` — only pre-existing warnings, no new ones
- [x] `multiplayer_ct` PropEr suite — 9/9 iterations pass with N=2..10 random concurrent clients, zero sleeps
- [ ] CI green