### PR TITLE
test: PropEr coverage across spatial/phase/reconnect/chat/matchmaker + phase init bug fix

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -41,7 +41,8 @@
         {erl_opts, [nowarn_export_all, nowarn_missing_spec, warnings_as_errors, {i, "test"}]},
         {deps, [
             {nova_test, {git, "https://github.com/novaframework/nova_test.git", {branch, "main"}}},
-            {meck, "~> 0.9"}
+            {meck, "~> 0.9"},
+            {proper, "~> 1.4"}
         ]},
         {ct_opts, [{sys_config, "./config/dev_sys.config.src"}]},
         {extra_src_dirs, [{"test", [{recursive, true}]}]},

--- a/src/matches/asobi_match_server.erl
+++ b/src/matches/asobi_match_server.erl
@@ -111,17 +111,20 @@ init(Config) ->
             GameMod = maps:get(game_module, Config),
             GameConfig0 = maps:get(game_config, Config, #{}),
             GameConfig = GameConfig0#{match_id => MatchId},
-            {ok, GameState} = GameMod:init(GameConfig),
+            {ok, GameState0} = GameMod:init(GameConfig),
             VetoTokensPerPlayer = maps:get(veto_tokens_per_player, Config, 0),
             FrustrationBonus = maps:get(frustration_bonus, Config, 0.5),
-            PhaseState =
+            {PhaseInitEvents, PhaseState} =
                 case erlang:function_exported(GameMod, phases, 1) of
                     true ->
                         Phases = GameMod:phases(GameConfig),
                         asobi_phase:init(Phases);
                     false ->
-                        undefined
+                        {[], undefined}
                 end,
+            %% Drive on_phase_started for the auto-started first phase. Without
+            %% this, the first phase's start callback silently never fires.
+            GameState = handle_phase_events(PhaseInitEvents, GameMod, GameState0),
             State = #{
                 match_id => MatchId,
                 mode => maps:get(mode, Config, undefined),

--- a/src/timers/asobi_phase.erl
+++ b/src/timers/asobi_phase.erl
@@ -50,9 +50,9 @@
 %% Init
 %% -------------------------------------------------------------------
 
--spec init([phase_def()]) -> phase_state().
+-spec init([phase_def()]) -> {[phase_event()], phase_state()}.
 init([]) ->
-    #{
+    {[], #{
         phases => [],
         current_index => 0,
         current_started => true,
@@ -60,7 +60,7 @@ init([]) ->
         active_timers => #{},
         paused => false,
         complete => true
-    };
+    }};
 init(Phases) ->
     State = #{
         phases => Phases,
@@ -77,11 +77,13 @@ init(Phases) ->
         end,
     case maps:get(start, Phase, prev_ended) of
         prev_ended ->
-            %% Auto-start first phase immediately
-            {_Events, PS} = start_current_phase(State),
-            PS;
+            %% Auto-start the first phase immediately and return its events
+            %% so the caller can drive on_phase_started callbacks for phase 1.
+            %% Without surfacing these, the first phase's start callback
+            %% silently never fires.
+            start_current_phase(State);
         _ ->
-            State
+            {[], State}
     end.
 
 %% -------------------------------------------------------------------

--- a/src/world/asobi_world_server.erl
+++ b/src/world/asobi_world_server.erl
@@ -98,7 +98,7 @@ init(Config) ->
     GameMod = maps:get(game_module, Config),
     GameConfig0 = maps:get(game_config, Config, #{}),
     GameConfig = GameConfig0#{match_id => WorldId},
-    {ok, GameState} = GameMod:init(GameConfig),
+    {ok, GameState0} = GameMod:init(GameConfig),
     GridSize = maps:get(grid_size, Config, ?DEFAULT_GRID_SIZE),
     ZoneSize = maps:get(zone_size, Config, ?DEFAULT_ZONE_SIZE),
     TickRate = maps:get(tick_rate, Config, ?DEFAULT_TICK_RATE),
@@ -109,16 +109,19 @@ init(Config) ->
     Persistent = maps:get(persistent, Config, false),
     EmptyGraceMs = maps:get(empty_grace_ms, Config, 0),
     InstanceSup = maps:get(instance_sup, Config, undefined),
-    PhaseState =
+    {PhaseInitEvents, PhaseState} =
         case erlang:function_exported(GameMod, phases, 1) of
             true ->
                 case GameMod:phases(GameConfig) of
-                    [] -> undefined;
+                    [] -> {[], undefined};
                     Phases -> asobi_phase:init(Phases)
                 end;
             false ->
-                undefined
+                {[], undefined}
         end,
+    %% Drive on_phase_started for the auto-started first phase. Without this,
+    %% the first phase's start callback silently never fires.
+    GameState = handle_phase_events(PhaseInitEvents, GameMod, GameState0),
     ChatConfig0 = maps:get(chat, Config, #{}),
     ChatConfig = ChatConfig0#{grid_size => GridSize},
     ChatState = asobi_world_chat:init(WorldId, Config#{chat => ChatConfig}),

--- a/test/asobi_phase_tests.erl
+++ b/test/asobi_phase_tests.erl
@@ -11,7 +11,7 @@ simple_phases_test() ->
         #{name => ~"active", duration => 2000},
         #{name => ~"results", duration => 500}
     ],
-    PS = asobi_phase:init(Phases),
+    {_InitEvents, PS} = asobi_phase:init(Phases),
     ?assertEqual(~"warmup", asobi_phase:current(PS)),
 
     {Events1, PS1} = asobi_phase:tick(1100, PS),
@@ -38,7 +38,7 @@ conditional_player_start_test() ->
         #{name => ~"gathering", start => {players, 5}, duration => 1000},
         #{name => ~"active", duration => 2000}
     ],
-    PS = asobi_phase:init(Phases),
+    {_InitEvents, PS} = asobi_phase:init(Phases),
     Info = asobi_phase:info(PS),
     ?assertEqual(waiting, maps:get(status, Info)),
 
@@ -57,7 +57,7 @@ conditional_timer_fallback_test() ->
     Phases = [
         #{name => ~"waiting", start => {timer, 2000}, duration => 1000}
     ],
-    PS = asobi_phase:init(Phases),
+    {_InitEvents, PS} = asobi_phase:init(Phases),
     {[], PS1} = asobi_phase:tick(1000, PS),
     ?assertEqual(waiting, maps:get(status, asobi_phase:info(PS1))),
 
@@ -73,7 +73,7 @@ infinity_duration_test() ->
     Phases = [
         #{name => ~"persistent", duration => infinity}
     ],
-    PS = asobi_phase:init(Phases),
+    {_InitEvents, PS} = asobi_phase:init(Phases),
     ?assertEqual(infinity, asobi_phase:remaining(PS)),
 
     {[], PS1} = asobi_phase:tick(999999, PS),
@@ -102,7 +102,7 @@ phase_with_cycle_timer_test() ->
             ]
         }
     ],
-    PS = asobi_phase:init(Phases),
+    {_InitEvents, PS} = asobi_phase:init(Phases),
     TimersInfo = asobi_phase:timers_info(PS),
     ?assertMatch(#{~"daynight" := #{type := cycle}}, TimersInfo),
 
@@ -115,7 +115,7 @@ phase_with_cycle_timer_test() ->
 
 pause_resume_test() ->
     Phases = [#{name => ~"active", duration => 1000}],
-    PS = asobi_phase:init(Phases),
+    {_InitEvents, PS} = asobi_phase:init(Phases),
     PS1 = asobi_phase:pause(PS),
 
     {[], PS2} = asobi_phase:tick(500, PS1),
@@ -142,7 +142,7 @@ config_test() ->
             config => #{pvp => true}
         }
     ],
-    PS = asobi_phase:init(Phases),
+    {_InitEvents, PS} = asobi_phase:init(Phases),
     ?assertEqual(#{pvp => false, safe_zones => true}, asobi_phase:config(PS)),
 
     {_, PS1} = asobi_phase:tick(1100, PS),
@@ -153,7 +153,7 @@ config_test() ->
 %% -------------------------------------------------------------------
 
 empty_phases_test() ->
-    PS = asobi_phase:init([]),
+    {_InitEvents, PS} = asobi_phase:init([]),
     ?assertEqual(undefined, asobi_phase:current(PS)),
     ?assertEqual(0, asobi_phase:remaining(PS)),
     {[], PS1} = asobi_phase:tick(1000, PS),
@@ -167,7 +167,7 @@ event_start_test() ->
     Phases = [
         #{name => ~"idle", start => {event, game_ready}, duration => 1000}
     ],
-    PS = asobi_phase:init(Phases),
+    {_InitEvents, PS} = asobi_phase:init(Phases),
     ?assertEqual(waiting, maps:get(status, asobi_phase:info(PS))),
 
     {[], PS1} = asobi_phase:notify({player_joined, 3}, PS),
@@ -183,20 +183,20 @@ event_start_test() ->
 
 info_waiting_test() ->
     Phases = [#{name => ~"w", start => {players, 5}, duration => 1000}],
-    PS = asobi_phase:init(Phases),
+    {_InitEvents, PS} = asobi_phase:init(Phases),
     Info = asobi_phase:info(PS),
     ?assertEqual(waiting, maps:get(status, Info)),
     ?assertEqual(~"w", maps:get(phase, Info)).
 
 info_active_test() ->
     Phases = [#{name => ~"a", duration => 5000, config => #{x => 1}}],
-    PS = asobi_phase:init(Phases),
+    {_InitEvents, PS} = asobi_phase:init(Phases),
     Info = asobi_phase:info(PS),
     ?assertEqual(active, maps:get(status, Info)),
     ?assertEqual(~"a", maps:get(phase, Info)),
     ?assertEqual(#{x => 1}, maps:get(config, Info)).
 
 info_complete_test() ->
-    PS = asobi_phase:init([]),
+    {_InitEvents, PS} = asobi_phase:init([]),
     Info = asobi_phase:info(PS),
     ?assertEqual(complete, maps:get(status, Info)).

--- a/test/asobi_test_input_count_game.erl
+++ b/test/asobi_test_input_count_game.erl
@@ -1,0 +1,44 @@
+-module(asobi_test_input_count_game).
+-behaviour(asobi_world).
+
+%% Test fixture for prop_input_never_dropped: every player_input call lands
+%% on handle_input/3 and bumps the per-player `inputs_seen` counter on the
+%% entity. Allows the property to assert "inputs sent == inputs observed".
+
+-export([init/1, join/2, leave/2, spawn_position/2]).
+-export([zone_tick/2, handle_input/3, post_tick/2]).
+-export([get_state/2]).
+
+-spec init(map()) -> {ok, map()}.
+init(_Config) ->
+    {ok, #{tick => 0}}.
+
+-spec join(binary(), map()) -> {ok, map()}.
+join(_PlayerId, State) ->
+    {ok, State}.
+
+-spec leave(binary(), map()) -> {ok, map()}.
+leave(_PlayerId, State) ->
+    {ok, State}.
+
+-spec spawn_position(binary(), map()) -> {ok, {number(), number()}}.
+spawn_position(_PlayerId, _State) ->
+    {ok, {0.0, 0.0}}.
+
+-spec zone_tick(map(), term()) -> {map(), term()}.
+zone_tick(Entities, ZoneState) ->
+    {Entities, ZoneState}.
+
+-spec handle_input(binary(), map(), map()) -> {ok, map()}.
+handle_input(PlayerId, _Input, Entities) ->
+    Existing = maps:get(PlayerId, Entities, #{inputs_seen => 0}),
+    Seen = maps:get(inputs_seen, Existing, 0),
+    {ok, Entities#{PlayerId => Existing#{inputs_seen => Seen + 1}}}.
+
+-spec post_tick(non_neg_integer(), map()) -> {ok, map()}.
+post_tick(TickN, State) ->
+    {ok, State#{tick => TickN}}.
+
+-spec get_state(binary(), map()) -> map().
+get_state(_PlayerId, State) ->
+    State.

--- a/test/prop_chat_zone_routing.erl
+++ b/test/prop_chat_zone_routing.erl
@@ -1,0 +1,240 @@
+-module(prop_chat_zone_routing).
+-include_lib("eunit/include/eunit.hrl").
+-undef(LET).
+-include_lib("proper/include/proper.hrl").
+
+%% PropEr: random sequences of player_joined / player_zone_changed /
+%% player_left across N players exercising zone, world, and proximity
+%% chat. The model tracks which channels each player should be subscribed
+%% to; the property asserts pg membership matches the model after every
+%% mutation.
+%%
+%% Catches subscribe/unsubscribe drift (orphaned subscriptions after
+%% leave, double-subscribe on resync, broken proximity expansion).
+
+-define(NUMTESTS, 25).
+-define(WORLD_ID, ~"propchat").
+-define(GRID_SIZE, 10).
+-define(PROX_RADIUS, 1).
+
+chat_zone_routing_test_() ->
+    {timeout, 60,
+        {setup, fun setup/0, fun cleanup/1, [
+            ?_assert(
+                proper:quickcheck(prop_chat_zone_routing(), [
+                    {numtests, ?NUMTESTS}, {to_file, user}
+                ])
+            )
+        ]}}.
+
+setup() ->
+    case whereis(nova_scope) of
+        undefined -> pg:start(nova_scope);
+        _ -> ok
+    end,
+    case whereis(asobi_chat_sup) of
+        undefined ->
+            {ok, Pid} = asobi_chat_sup:start_link(),
+            unlink(Pid);
+        _ ->
+            ok
+    end,
+    meck:new(asobi_repo, [no_link]),
+    meck:expect(asobi_repo, insert, fun(_CS) -> {ok, #{}} end),
+    ok.
+
+cleanup(_) ->
+    catch meck:unload(asobi_repo),
+    ok.
+
+%% --- Property ---
+
+prop_chat_zone_routing() ->
+    ?FORALL(
+        Cmds,
+        proper_types:list(command()),
+        run_iteration(narrow_list(Cmds))
+    ).
+
+command() ->
+    proper_types:oneof([
+        {join, player_id(), zone_coord()},
+        {move, player_id(), zone_coord()},
+        {leave, player_id()}
+    ]).
+
+player_id() ->
+    proper_types:elements([~"cp1", ~"cp2", ~"cp3", ~"cp4"]).
+
+zone_coord() ->
+    {proper_types:integer(0, 4), proper_types:integer(0, 4)}.
+
+%% --- Runner ---
+
+-spec run_iteration([term()]) -> boolean().
+run_iteration(Cmds) ->
+    %% Per-iteration unique world id keeps channels isolated; existing
+    %% subscriptions from a previous iteration would otherwise leak in.
+    Tag = integer_to_binary(erlang:unique_integer([positive])),
+    WorldId = <<?WORLD_ID/binary, "_", Tag/binary>>,
+    ChatState = asobi_world_chat:init(WorldId, chat_config()),
+    Listeners = ensure_listeners(player_id_universe(), WorldId),
+    try
+        Final = lists:foldl(
+            fun(C, S) -> step(C, ChatState, Listeners, WorldId, S) end,
+            init_model(),
+            Cmds
+        ),
+        check(WorldId, Listeners, Final)
+    after
+        cleanup_listeners(Listeners)
+    end.
+
+chat_config() ->
+    #{
+        chat => #{
+            world => true,
+            zone => true,
+            proximity => ?PROX_RADIUS,
+            grid_size => ?GRID_SIZE
+        }
+    }.
+
+player_id_universe() ->
+    [~"cp1", ~"cp2", ~"cp3", ~"cp4"].
+
+init_model() ->
+    %% positions :: #{PlayerId => {ZX, ZY}} for currently-joined players.
+    #{positions => #{}}.
+
+step({join, P, Pos}, ChatState, _Listeners, _WorldId, #{positions := Positions} = S) ->
+    case maps:is_key(P, Positions) of
+        true ->
+            S;
+        false ->
+            asobi_world_chat:player_joined(P, Pos, ChatState),
+            S#{positions => Positions#{P => Pos}}
+    end;
+step({move, P, NewPos}, ChatState, _Listeners, _WorldId, #{positions := Positions} = S) ->
+    case maps:get(P, Positions, undefined) of
+        undefined ->
+            S;
+        OldPos when OldPos =:= NewPos ->
+            S;
+        OldPos ->
+            asobi_world_chat:player_zone_changed(P, OldPos, NewPos, ?GRID_SIZE, ChatState),
+            S#{positions => Positions#{P => NewPos}}
+    end;
+step({leave, P}, ChatState, _Listeners, _WorldId, #{positions := Positions} = S) ->
+    case maps:get(P, Positions, undefined) of
+        undefined ->
+            S;
+        Pos ->
+            asobi_world_chat:player_left(P, Pos, ChatState),
+            S#{positions => maps:remove(P, Positions)}
+    end.
+
+check(WorldId, Listeners, #{positions := Positions}) ->
+    %% Allow casts (subscribe/unsubscribe are casts to channels) to settle.
+    timer:sleep(15),
+    Players = player_id_universe(),
+    lists:all(
+        fun(P) ->
+            ListenerPid = maps:get(P, Listeners),
+            ExpectedChannels = expected_channels_for(P, Positions, WorldId),
+            ActualChannels = actual_channels_for(ListenerPid, WorldId, Positions),
+            case lists:sort(ExpectedChannels) =:= lists:sort(ActualChannels) of
+                true ->
+                    true;
+                false ->
+                    io:format(
+                        user,
+                        "~nchannel mismatch for ~s:~n  expected: ~p~n  actual:   ~p~n  positions: ~p~n",
+                        [P, ExpectedChannels, ActualChannels, Positions]
+                    ),
+                    false
+            end
+        end,
+        Players
+    ).
+
+expected_channels_for(P, Positions, WorldId) ->
+    case maps:get(P, Positions, undefined) of
+        undefined ->
+            [];
+        {ZX, ZY} = Pos when is_integer(ZX), is_integer(ZY) ->
+            World = asobi_world_chat:channel_id(WorldId, world, undefined),
+            Zone = asobi_world_chat:channel_id(WorldId, zone, Pos),
+            Prox = [
+                asobi_world_chat:channel_id(WorldId, proximity, Cell)
+             || Cell <- prox_cells(ZX, ZY)
+            ],
+            [World, Zone | Prox]
+    end.
+
+-spec prox_cells(integer(), integer()) -> [{integer(), integer()}].
+prox_cells(ZX, ZY) ->
+    XLo = clamp_lo(ZX - ?PROX_RADIUS),
+    XHi = clamp_hi(ZX + ?PROX_RADIUS),
+    YLo = clamp_lo(ZY - ?PROX_RADIUS),
+    YHi = clamp_hi(ZY + ?PROX_RADIUS),
+    [{X, Y} || X <- lists:seq(XLo, XHi), Y <- lists:seq(YLo, YHi)].
+
+-spec clamp_lo(integer()) -> integer().
+clamp_lo(N) when N < 0 -> 0;
+clamp_lo(N) -> N.
+
+-spec clamp_hi(integer()) -> integer().
+clamp_hi(N) when N > ?GRID_SIZE - 1 -> ?GRID_SIZE - 1;
+clamp_hi(N) -> N.
+
+actual_channels_for(ListenerPid, WorldId, Positions) ->
+    %% Enumerate every channel id that any player could subscribe to and
+    %% check pg membership. Bounded by the small player universe + grid.
+    Universe = candidate_channels(WorldId, Positions),
+    [Ch || Ch <- Universe, lists:member(ListenerPid, pg:get_members(nova_scope, {chat, Ch}))].
+
+candidate_channels(WorldId, Positions) ->
+    World = [asobi_world_chat:channel_id(WorldId, world, undefined)],
+    Zones = [
+        asobi_world_chat:channel_id(WorldId, zone, Pos)
+     || Pos <- positions_with_neighbors(Positions)
+    ],
+    Prox = [
+        asobi_world_chat:channel_id(WorldId, proximity, P)
+     || P <- positions_with_neighbors(Positions)
+    ],
+    World ++ Zones ++ Prox.
+
+positions_with_neighbors(Positions) ->
+    %% Cover every cell within prox radius of any joined player.
+    Posns = maps:values(Positions),
+    Cells = lists:append([
+        prox_cells(ZX, ZY)
+     || {ZX, ZY} <- Posns, is_integer(ZX), is_integer(ZY)
+    ]),
+    lists:usort(Cells).
+
+%% --- Listener processes ---
+
+ensure_listeners(Players, WorldId) ->
+    %% One spawned process per player, registered in pg as the player's session.
+    %% The world_chat module subscribes the pg-registered pid to channels.
+    maps:from_list([{P, ensure_listener(P, WorldId)} || P <- Players]).
+
+ensure_listener(P, _WorldId) ->
+    Pid = spawn(fun L() ->
+        receive
+            stop -> ok;
+            _ -> L()
+        end
+    end),
+    ok = pg:join(nova_scope, {player, P}, Pid),
+    Pid.
+
+cleanup_listeners(Listeners) ->
+    maps:foreach(fun(_, Pid) -> catch exit(Pid, kill) end, Listeners),
+    ok.
+
+-spec narrow_list(term()) -> [term()].
+narrow_list(L) when is_list(L) -> L.

--- a/test/prop_input_never_dropped.erl
+++ b/test/prop_input_never_dropped.erl
@@ -1,0 +1,199 @@
+-module(prop_input_never_dropped).
+-include_lib("eunit/include/eunit.hrl").
+%% Include proper after eunit so proper's ?LET/3 wins (eunit defines a 3-arg
+%% ?LET internally that breaks proper's generator binding).
+-undef(LET).
+-include_lib("proper/include/proper.hrl").
+
+%% PropEr: for any sequence of [join, input, ...] across N players, every
+%% input that was sent eventually reaches the game module's handle_input/3
+%% and bumps the per-player inputs_seen counter to a value >= sent_count.
+%%
+%% This is the engine-level form of the regression we just fixed: an input
+%% sent immediately after a successful join must not be dropped, regardless
+%% of cast/reply ordering races between WS handler, world_server, and zone.
+
+-define(GAME, asobi_test_input_count_game).
+-define(MAX_PLAYERS, 6).
+-define(GRID_SIZE, 2).
+-define(WAIT_TICKS_MS, 500).
+-define(BASE_CONFIG, #{
+    game_module => ?GAME,
+    grid_size => ?GRID_SIZE,
+    zone_size => 100,
+    tick_rate => 50,
+    max_players => ?MAX_PLAYERS,
+    view_radius => 1,
+    empty_grace_ms => 600000,
+    persistent => true
+}).
+
+input_never_dropped_test_() ->
+    {timeout, 120,
+        {setup, fun setup/0, fun cleanup/1, fun(Ctx) ->
+            [
+                ?_assert(
+                    proper:quickcheck(prop_input_never_dropped(Ctx), [
+                        {numtests, 25}, {to_file, user}
+                    ])
+                )
+            ]
+        end}}.
+
+setup() ->
+    case whereis(nova_scope) of
+        undefined -> pg:start(nova_scope);
+        _ -> ok
+    end,
+    case ets:info(asobi_player_worlds) of
+        undefined ->
+            ets:new(asobi_player_worlds, [named_table, public, set, {read_concurrency, true}]);
+        _ ->
+            ets:delete_all_objects(asobi_player_worlds)
+    end,
+    meck:new(asobi_repo, [no_link]),
+    meck:expect(asobi_repo, insert, fun(_CS) -> {ok, #{}} end),
+    meck:expect(asobi_repo, insert, fun(_CS, _Opts) -> {ok, #{}} end),
+    meck:new(asobi_presence, [non_strict, no_link]),
+    meck:expect(asobi_presence, send, fun(_, _) -> ok end),
+    start_world().
+
+cleanup(#{instance_pid := InstancePid}) ->
+    catch exit(InstancePid, shutdown),
+    timer:sleep(10),
+    catch meck:unload(asobi_presence),
+    catch meck:unload(asobi_repo),
+    ok.
+
+%% --- Property ---
+
+prop_input_never_dropped(Ctx) ->
+    ?FORALL(
+        {Players, InputsPerPlayer},
+        {players_set(), input_count()},
+        run_iteration(Ctx, narrow_players(Players), narrow_int(InputsPerPlayer))
+    ).
+
+-spec run_iteration(map(), [binary()], pos_integer()) -> boolean().
+run_iteration(Ctx, Players, InputsPerPlayer) ->
+    reset_world(Ctx),
+    ok = join_all(Ctx, Players),
+    ok = send_inputs(Ctx, Players, InputsPerPlayer),
+    ok = wait_for_observation(Ctx, Players, InputsPerPlayer, ?WAIT_TICKS_MS),
+    check_all_observed(Ctx, Players, InputsPerPlayer).
+
+-spec narrow_players(term()) -> [binary()].
+narrow_players(L) when is_list(L) -> [B || B <- L, is_binary(B)].
+
+-spec narrow_int(term()) -> pos_integer().
+narrow_int(N) when is_integer(N), N >= 1 -> N.
+
+players_set() ->
+    ?LET(
+        N,
+        proper_types:integer(1, ?MAX_PLAYERS),
+        gen_player_ids(N)
+    ).
+
+-spec gen_player_ids(term()) -> [binary()].
+gen_player_ids(N) when is_integer(N), N >= 1 ->
+    [list_to_binary("p" ++ integer_to_list(I)) || I <- lists:seq(1, N)].
+
+input_count() ->
+    proper_types:integer(1, 5).
+
+%% --- Drivers ---
+
+-spec join_all(map(), [binary()]) -> ok.
+join_all(#{world_pid := Pid}, Players) ->
+    lists:foreach(
+        fun(P) when is_binary(P) ->
+            case asobi_world_server:join(Pid, P) of
+                ok -> ok;
+                {error, _} = E -> error({join_failed, P, E})
+            end
+        end,
+        Players
+    ),
+    ok.
+
+-spec send_inputs(map(), [binary()], pos_integer()) -> ok.
+send_inputs(Ctx, Players, N) when is_integer(N) ->
+    %% Find the zone every player landed in (all spawn at (0,0) → zone (0,0))
+    ZonePid = zone_at(Ctx, {0, 0}),
+    lists:foreach(
+        fun(P) when is_binary(P) ->
+            lists:foreach(
+                fun(I) -> asobi_zone:player_input(ZonePid, P, #{<<"seq">> => I}) end,
+                lists:seq(1, N)
+            )
+        end,
+        Players
+    ),
+    ok.
+
+wait_for_observation(_Ctx, _Players, _N, BudgetMs) when BudgetMs =< 0 ->
+    ok;
+wait_for_observation(Ctx, Players, N, BudgetMs) ->
+    case all_observed(Ctx, Players, N) of
+        true ->
+            ok;
+        false ->
+            timer:sleep(20),
+            wait_for_observation(Ctx, Players, N, BudgetMs - 20)
+    end.
+
+all_observed(Ctx, Players, N) ->
+    Entities = entities_at(Ctx, {0, 0}),
+    lists:all(
+        fun(P) ->
+            case maps:get(P, Entities, undefined) of
+                #{inputs_seen := Seen} -> Seen >= N;
+                _ -> false
+            end
+        end,
+        Players
+    ).
+
+check_all_observed(Ctx, Players, N) ->
+    Entities = entities_at(Ctx, {0, 0}),
+    Result = [
+        {P, maps:get(inputs_seen, maps:get(P, Entities, #{inputs_seen => 0}), 0)}
+     || P <- Players
+    ],
+    AllOk = lists:all(fun({_, S}) -> S >= N end, Result),
+    case AllOk of
+        true ->
+            true;
+        false ->
+            io:format(user, "~ninputs dropped: expected >=~p per player, got ~p~n", [N, Result]),
+            false
+    end.
+
+%% --- World fixture ---
+
+reset_world(#{world_pid := Pid}) ->
+    Info = asobi_world_server:get_info(Pid),
+    [asobi_world_server:leave(Pid, P) || P <- maps:get(players, Info, [])],
+    timer:sleep(20),
+    ok.
+
+zone_at(#{world_pid := WorldPid}, Coords) ->
+    case sys:get_state(WorldPid) of
+        {_StateName, StateData} when is_map(StateData) ->
+            case maps:get(zone_manager_pid, StateData) of
+                ZMPid when is_pid(ZMPid) ->
+                    {ok, ZP} = asobi_zone_manager:ensure_zone(ZMPid, Coords),
+                    ZP
+            end
+    end.
+
+entities_at(Ctx, Coords) ->
+    asobi_zone:get_entities(zone_at(Ctx, Coords)).
+
+start_world() ->
+    {ok, InstancePid} = asobi_world_instance:start_link(?BASE_CONFIG),
+    unlink(InstancePid),
+    timer:sleep(40),
+    ServerPid = asobi_world_instance:get_child(InstancePid, asobi_world_server),
+    #{instance_pid => InstancePid, world_pid => ServerPid}.

--- a/test/prop_matchmaker_fill_strategy.erl
+++ b/test/prop_matchmaker_fill_strategy.erl
@@ -1,0 +1,100 @@
+-module(prop_matchmaker_fill_strategy).
+-include_lib("eunit/include/eunit.hrl").
+-undef(LET).
+-include_lib("proper/include/proper.hrl").
+
+%% PropEr: random ticket queue + match_size, the fill strategy:
+%%
+%%   - returns groups of exactly match_size
+%%   - leftover queue has < match_size tickets
+%%   - groups + leftover preserves the input list (no drops, no dupes)
+%%   - within each group, ticket order matches input order (FCFS)
+
+-define(NUMTESTS, 100).
+
+matchmaker_fill_strategy_test_() ->
+    {timeout, 30,
+        ?_assert(
+            proper:quickcheck(prop_fill_strategy(), [
+                {numtests, ?NUMTESTS}, {to_file, user}
+            ])
+        )}.
+
+%% --- Property ---
+
+prop_fill_strategy() ->
+    ?FORALL(
+        {Tickets, Size},
+        {ticket_queue(), match_size()},
+        run_iteration(narrow_tickets(Tickets), narrow_int(Size))
+    ).
+
+ticket_queue() ->
+    proper_types:list(ticket()).
+
+ticket() ->
+    ?LET(Id, proper_types:integer(1, 1_000_000), make_ticket(Id)).
+
+-spec make_ticket(term()) -> #{id => binary(), submitted_at => integer()}.
+make_ticket(Id) when is_integer(Id) ->
+    #{id => integer_to_binary(Id), submitted_at => Id}.
+
+match_size() ->
+    proper_types:integer(1, 8).
+
+%% --- Runner ---
+
+-spec run_iteration([map()], pos_integer()) -> boolean().
+run_iteration(Tickets, Size) ->
+    {Groups, Remaining} = asobi_matchmaker_fill:match(Tickets, #{match_size => Size}),
+    Checks = [
+        {all_groups_correct_size, all_groups_size(Groups, Size)},
+        {remaining_below_size, length(Remaining) < Size},
+        {preserves_count, total_count(Groups) + length(Remaining) =:= length(Tickets)},
+        {preserves_order, preserves_order(Tickets, Groups, Remaining)}
+    ],
+    case all_passed(Checks) of
+        true ->
+            true;
+        false ->
+            io:format(
+                user,
+                "~ninvariants violated: ~p~n  tickets=~p size=~p~n  groups=~p remaining=~p~n",
+                [
+                    [K || {K, V} <- Checks, V =/= true],
+                    Tickets,
+                    Size,
+                    Groups,
+                    Remaining
+                ]
+            ),
+            false
+    end.
+
+-spec all_groups_size([[term()]], pos_integer()) -> boolean().
+all_groups_size([], _Size) ->
+    true;
+all_groups_size([G | Rest], Size) when is_list(G) ->
+    case length(G) =:= Size of
+        true -> all_groups_size(Rest, Size);
+        false -> false
+    end.
+
+-spec total_count([[term()]]) -> non_neg_integer().
+total_count([]) -> 0;
+total_count([G | Rest]) when is_list(G) -> length(G) + total_count(Rest).
+
+-spec all_passed([{atom(), boolean()}]) -> boolean().
+all_passed([]) -> true;
+all_passed([{_, true} | Rest]) -> all_passed(Rest);
+all_passed([{_, false} | _]) -> false.
+
+preserves_order(Tickets, Groups, Remaining) ->
+    Flattened = lists:append(Groups) ++ Remaining,
+    Flattened =:= Tickets.
+
+-spec narrow_tickets(term()) -> [map()].
+narrow_tickets(L) when is_list(L) -> [T || T <- L, is_map(T)].
+
+-spec narrow_int(term()) -> pos_integer().
+narrow_int(N) when is_integer(N), N > 0 -> N.

--- a/test/prop_phase_timer_monotonic.erl
+++ b/test/prop_phase_timer_monotonic.erl
@@ -1,0 +1,128 @@
+-module(prop_phase_timer_monotonic).
+-include_lib("eunit/include/eunit.hrl").
+-undef(LET).
+-include_lib("proper/include/proper.hrl").
+
+%% PropEr: a random list of `prev_ended` phases with random durations,
+%% advanced by random tick deltas, satisfies these invariants:
+%%
+%%   - Each phase fires `phase_started` then `phase_ended` exactly once.
+%%   - The fire order matches the declared phase order (no skipping ahead,
+%%     no re-entering a previous phase).
+%%   - After total elapsed >= sum(durations), `all_phases_complete` fires
+%%     exactly once, after which `complete := true` and further ticks emit
+%%     no new events.
+%%
+%% Catches regressions where a phase boundary is skipped under a coarse
+%% tick delta or where a paused/notify path leaks events.
+
+-define(NUMTESTS, 50).
+
+phase_timer_monotonic_test_() ->
+    {timeout, 60,
+        ?_assert(
+            proper:quickcheck(prop_phase_timer_monotonic(), [
+                {numtests, ?NUMTESTS}, {to_file, user}
+            ])
+        )}.
+
+%% --- Property ---
+
+prop_phase_timer_monotonic() ->
+    ?FORALL(
+        {Phases, Ticks},
+        {phases(), proper_types:list(tick_delta())},
+        run_iteration(narrow_phases(Phases), narrow_ticks(Ticks))
+    ).
+
+phases() ->
+    ?LET(N, proper_types:integer(1, 5), gen_phases(N)).
+
+gen_phases(N) ->
+    proper_types:vector(N, phase_def()).
+
+phase_def() ->
+    ?LET(
+        {Name, Duration},
+        {phase_name(), proper_types:integer(50, 500)},
+        #{name => Name, duration => Duration, start => prev_ended}
+    ).
+
+phase_name() ->
+    proper_types:elements([~"alpha", ~"beta", ~"gamma", ~"delta", ~"epsilon"]).
+
+tick_delta() ->
+    proper_types:integer(1, 200).
+
+%% --- Runner ---
+
+-spec run_iteration([map()], [pos_integer()]) -> boolean().
+run_iteration(PhaseDefs, Ticks) ->
+    Names = [maps:get(name, P) || P <- PhaseDefs],
+    {InitEvents, State0} = asobi_phase:init(PhaseDefs),
+    {Events, Final} = run_ticks(Ticks, InitEvents, State0),
+    %% Drain any remaining phases regardless of the random budget so the
+    %% property covers full lifecycles even when Ticks is short.
+    {DrainEvents, _Done} = drain_phases(Final),
+    AllEvents = Events ++ DrainEvents,
+    check_invariants(Names, AllEvents).
+
+-spec run_ticks([pos_integer()], [term()], asobi_phase:phase_state()) ->
+    {[term()], asobi_phase:phase_state()}.
+run_ticks([], Acc, State) ->
+    {Acc, State};
+run_ticks([D | Rest], Acc, State) ->
+    {Es, State1} = asobi_phase:tick(D, State),
+    run_ticks(Rest, Acc ++ Es, State1).
+
+drain_phases(State) ->
+    drain_phases(State, [], 200).
+
+drain_phases(State, Acc, 0) ->
+    {Acc, State};
+drain_phases(State, Acc, Steps) ->
+    case asobi_phase:info(State) of
+        #{status := complete} ->
+            {Acc, State};
+        _ ->
+            {Events, State1} = asobi_phase:tick(1000, State),
+            drain_phases(State1, Acc ++ Events, Steps - 1)
+    end.
+
+check_invariants(Names, Events) ->
+    PhaseEvents = [E || E <- Events, is_phase_event(E)],
+    StartEnd = [E || E <- PhaseEvents, started_or_ended(E)],
+    StartEndSeq = [normalize(E) || E <- StartEnd],
+    %% Engine contract: each phase fires phase_started then phase_ended
+    %% exactly once, in declared order.
+    Expected = lists:flatmap(fun(N) -> [{started, N}, {ended, N}] end, Names),
+    AllPhasesCompleteCount = length([1 || {all_phases_complete} <- PhaseEvents]),
+    case {StartEndSeq =:= Expected, AllPhasesCompleteCount =:= 1} of
+        {true, true} ->
+            true;
+        Other ->
+            io:format(
+                user,
+                "~ninvariant violated: ~p~n  expected: ~p~n  got: ~p~n  complete: ~p~n",
+                [Other, Expected, StartEndSeq, AllPhasesCompleteCount]
+            ),
+            false
+    end.
+
+is_phase_event({phase_started, _}) -> true;
+is_phase_event({phase_ended, _}) -> true;
+is_phase_event({all_phases_complete}) -> true;
+is_phase_event(_) -> false.
+
+started_or_ended({phase_started, _}) -> true;
+started_or_ended({phase_ended, _}) -> true;
+started_or_ended(_) -> false.
+
+normalize({phase_started, N}) -> {started, N};
+normalize({phase_ended, N}) -> {ended, N}.
+
+-spec narrow_phases(term()) -> [map()].
+narrow_phases(L) when is_list(L) -> [P || P <- L, is_map(P)].
+
+-spec narrow_ticks(term()) -> [pos_integer()].
+narrow_ticks(L) when is_list(L) -> [T || T <- L, is_integer(T), T > 0].

--- a/test/prop_reconnect_lifecycle.erl
+++ b/test/prop_reconnect_lifecycle.erl
@@ -1,0 +1,201 @@
+-module(prop_reconnect_lifecycle).
+-include_lib("eunit/include/eunit.hrl").
+-undef(LET).
+-include_lib("proper/include/proper.hrl").
+
+%% PropEr: random sequences of join / disconnect / reconnect against a
+%% world configured with `player_ttl_ms`. Invariants:
+%%
+%%   - A reconnect within the grace window leaves the player visible
+%%     (player_count stays at the model's joined count).
+%%   - A reconnect after a successful disconnect+reconnect cycle is
+%%     idempotent (no double-bump of player_count).
+%%   - leave/2 always settles to player_count == |joined|.
+%%
+%% Catches regressions in the DOWN handler / asobi_reconnect:disconnect
+%% bookkeeping and in `running({call, _}, {reconnect, _}, _)` paths.
+
+-define(MAX_PLAYERS, 5).
+-define(TTL_MS, 60_000).
+-define(BASE_CONFIG, #{
+    game_module => asobi_test_world_game,
+    grid_size => 2,
+    zone_size => 100,
+    tick_rate => 50,
+    max_players => ?MAX_PLAYERS,
+    view_radius => 1,
+    %% Long grace so disconnects don't lapse during the property iteration.
+    player_ttl_ms => ?TTL_MS,
+    empty_grace_ms => 600000,
+    persistent => true
+}).
+
+reconnect_lifecycle_test_() ->
+    {timeout, 120,
+        {setup, fun setup/0, fun cleanup/1, fun(Ctx) ->
+            [
+                ?_assert(
+                    proper:quickcheck(prop_reconnect_lifecycle(Ctx), [
+                        {numtests, 25}, {to_file, user}
+                    ])
+                )
+            ]
+        end}}.
+
+setup() ->
+    case whereis(nova_scope) of
+        undefined -> pg:start(nova_scope);
+        _ -> ok
+    end,
+    case ets:info(asobi_player_worlds) of
+        undefined ->
+            ets:new(asobi_player_worlds, [named_table, public, set, {read_concurrency, true}]);
+        _ ->
+            ets:delete_all_objects(asobi_player_worlds)
+    end,
+    meck:new(asobi_repo, [no_link]),
+    meck:expect(asobi_repo, insert, fun(_CS) -> {ok, #{}} end),
+    meck:expect(asobi_repo, insert, fun(_CS, _Opts) -> {ok, #{}} end),
+    meck:new(asobi_presence, [non_strict, no_link]),
+    meck:expect(asobi_presence, send, fun(_, _) -> ok end),
+    start_world().
+
+cleanup(#{instance_pid := InstancePid}) ->
+    catch exit(InstancePid, shutdown),
+    timer:sleep(10),
+    catch meck:unload(asobi_presence),
+    catch meck:unload(asobi_repo),
+    ok.
+
+%% --- Property ---
+
+prop_reconnect_lifecycle(Ctx) ->
+    ?FORALL(
+        Cmds,
+        proper_types:list(command()),
+        run_iteration(Ctx, narrow_list(Cmds))
+    ).
+
+command() ->
+    proper_types:oneof([
+        {join, player_id()},
+        {disconnect, player_id()},
+        {reconnect, player_id()},
+        {leave, player_id()}
+    ]).
+
+player_id() ->
+    proper_types:elements([~"r1", ~"r2", ~"r3", ~"r4", ~"r5"]).
+
+%% --- Runner ---
+
+-spec run_iteration(map(), [term()]) -> boolean().
+run_iteration(Ctx, Cmds) ->
+    cleanup_world(Ctx),
+    Final = lists:foldl(fun(C, S) -> step(C, Ctx, S) end, init_state(), Cmds),
+    timer:sleep(20),
+    check(Ctx, Final).
+
+init_state() ->
+    %% joined = players currently expected to be in the world (whether
+    %% disconnected within grace or actively connected).
+    %% sessions = pid registered for that player.
+    #{joined => sets:new(), sessions => #{}}.
+
+step({join, P}, #{world_pid := Pid}, #{joined := J, sessions := Ss} = S) ->
+    case sets:is_element(P, J) orelse sets:size(J) >= ?MAX_PLAYERS of
+        true ->
+            S;
+        false ->
+            SessionPid = fake_session(P),
+            case asobi_world_server:join(Pid, P) of
+                ok ->
+                    S#{
+                        joined => sets:add_element(P, J),
+                        sessions => Ss#{P => SessionPid}
+                    };
+                {error, _} ->
+                    catch exit(SessionPid, kill),
+                    S
+            end
+    end;
+step({disconnect, P}, _Ctx, #{joined := J, sessions := Ss} = S) ->
+    case {sets:is_element(P, J), maps:get(P, Ss, undefined)} of
+        {true, SessionPid} when is_pid(SessionPid) ->
+            exit(SessionPid, kill),
+            timer:sleep(15),
+            S#{sessions => maps:remove(P, Ss)};
+        _ ->
+            S
+    end;
+step({reconnect, P}, #{world_pid := Pid}, #{joined := J, sessions := Ss} = S) ->
+    case sets:is_element(P, J) andalso not maps:is_key(P, Ss) of
+        true ->
+            SessionPid = fake_session(P),
+            case asobi_world_server:reconnect(Pid, P) of
+                ok ->
+                    S#{sessions => Ss#{P => SessionPid}};
+                {error, _} ->
+                    catch exit(SessionPid, kill),
+                    S
+            end;
+        false ->
+            S
+    end;
+step({leave, P}, #{world_pid := Pid}, #{joined := J, sessions := Ss} = S) ->
+    case sets:is_element(P, J) of
+        true ->
+            asobi_world_server:leave(Pid, P),
+            case maps:get(P, Ss, undefined) of
+                SessionPid when is_pid(SessionPid) -> catch exit(SessionPid, kill);
+                _ -> ok
+            end,
+            timer:sleep(10),
+            S#{joined => sets:del_element(P, J), sessions => maps:remove(P, Ss)};
+        false ->
+            S
+    end.
+
+check(#{world_pid := Pid}, #{joined := J}) ->
+    Info = asobi_world_server:get_info(Pid),
+    Got = maps:get(player_count, Info, -1),
+    Want = sets:size(J),
+    case Got =:= Want of
+        true ->
+            true;
+        false ->
+            io:format(
+                user,
+                "~nplayer_count mismatch: got=~p want=~p (joined=~p, info=~p)~n",
+                [Got, Want, sets:to_list(J), Info]
+            ),
+            false
+    end.
+
+%% --- Fixture ---
+
+cleanup_world(#{world_pid := Pid}) ->
+    Info = asobi_world_server:get_info(Pid),
+    [asobi_world_server:leave(Pid, P) || P <- maps:get(players, Info, [])],
+    timer:sleep(20),
+    ok.
+
+start_world() ->
+    {ok, InstancePid} = asobi_world_instance:start_link(?BASE_CONFIG),
+    unlink(InstancePid),
+    timer:sleep(40),
+    ServerPid = asobi_world_instance:get_child(InstancePid, asobi_world_server),
+    #{instance_pid => InstancePid, world_pid => ServerPid}.
+
+fake_session(PlayerId) ->
+    Pid = spawn(fun L() ->
+        receive
+            stop -> ok;
+            _ -> L()
+        end
+    end),
+    ok = pg:join(nova_scope, {player, PlayerId}, Pid),
+    Pid.
+
+-spec narrow_list(term()) -> [term()].
+narrow_list(L) when is_list(L) -> L.

--- a/test/prop_spatial_grid_consistency.erl
+++ b/test/prop_spatial_grid_consistency.erl
@@ -1,0 +1,164 @@
+-module(prop_spatial_grid_consistency).
+-include_lib("eunit/include/eunit.hrl").
+-undef(LET).
+-include_lib("proper/include/proper.hrl").
+
+%% PropEr: random sequences of insert/update/remove against asobi_spatial_grid
+%% produce the same membership and the same query_radius/query_rect results
+%% as a naive list-scan reference implementation.
+%%
+%% Catches indexing bugs (entity stuck in old cell after move, ghost entries
+%% after remove, off-by-one cell edges) that are easy to introduce when the
+%% grid layout changes.
+
+-define(NUMTESTS, 50).
+
+spatial_grid_consistency_test_() ->
+    {timeout, 60,
+        ?_assert(
+            proper:quickcheck(prop_spatial_grid_consistency(), [
+                {numtests, ?NUMTESTS}, {to_file, user}
+            ])
+        )}.
+
+%% --- Property ---
+
+prop_spatial_grid_consistency() ->
+    ?FORALL(
+        {CellSize, Cmds, Queries},
+        {cell_size(), proper_types:list(cmd()), proper_types:list(query())},
+        run_iteration(narrow_int(CellSize), narrow_list(Cmds), narrow_list(Queries))
+    ).
+
+cell_size() ->
+    proper_types:elements([10, 25, 50, 100]).
+
+cmd() ->
+    proper_types:oneof([
+        {insert, entity_id(), pos()},
+        {update, entity_id(), pos()},
+        {remove, entity_id()}
+    ]).
+
+query() ->
+    proper_types:oneof([
+        {radius, pos(), proper_types:integer(1, 200)},
+        {rect, pos(), pos()}
+    ]).
+
+entity_id() ->
+    proper_types:elements([
+        ~"e1", ~"e2", ~"e3", ~"e4", ~"e5", ~"e6", ~"e7", ~"e8"
+    ]).
+
+pos() ->
+    {proper_types:integer(-300, 300), proper_types:integer(-300, 300)}.
+
+%% --- Runner ---
+
+-spec run_iteration(pos_integer(), [term()], [term()]) -> boolean().
+run_iteration(CellSize, Cmds, Queries) ->
+    Grid0 = asobi_spatial_grid:new(CellSize),
+    {Grid, Reference} = run_cmds(Cmds, Grid0, #{}),
+    %% Membership invariant: grid entity count == reference size.
+    case asobi_spatial_grid:size(Grid) =:= maps:size(Reference) of
+        false ->
+            io:format(
+                user,
+                "~nsize mismatch: grid=~p ref=~p~n",
+                [asobi_spatial_grid:size(Grid), maps:size(Reference)]
+            ),
+            false;
+        true ->
+            lists:all(fun(Q) -> check_query(Q, Grid, Reference) end, Queries)
+    end.
+
+-spec run_cmds([term()], asobi_spatial_grid:grid(), #{binary() => {integer(), integer()}}) ->
+    {asobi_spatial_grid:grid(), #{binary() => {integer(), integer()}}}.
+run_cmds([], Grid, Ref) ->
+    {Grid, Ref};
+run_cmds([{insert, Id, {X, Y}} | Rest], Grid, Ref) when
+    is_binary(Id), is_integer(X), is_integer(Y)
+->
+    Pos = {X, Y},
+    case maps:is_key(Id, Ref) of
+        true -> run_cmds(Rest, Grid, Ref);
+        false -> run_cmds(Rest, asobi_spatial_grid:insert(Id, Pos, Grid), Ref#{Id => Pos})
+    end;
+run_cmds([{update, Id, {X, Y}} | Rest], Grid, Ref) when
+    is_binary(Id), is_integer(X), is_integer(Y)
+->
+    Pos = {X, Y},
+    case maps:is_key(Id, Ref) of
+        true -> run_cmds(Rest, asobi_spatial_grid:update(Id, Pos, Grid), Ref#{Id => Pos});
+        false -> run_cmds(Rest, Grid, Ref)
+    end;
+run_cmds([{remove, Id} | Rest], Grid, Ref) when is_binary(Id) ->
+    case maps:is_key(Id, Ref) of
+        true -> run_cmds(Rest, asobi_spatial_grid:remove(Id, Grid), maps:remove(Id, Ref));
+        false -> run_cmds(Rest, Grid, Ref)
+    end;
+run_cmds([_ | Rest], Grid, Ref) ->
+    run_cmds(Rest, Grid, Ref).
+
+check_query({radius, Center, R}, Grid, Ref) ->
+    Got = sort_results(asobi_spatial_grid:query_radius(Center, R, Grid)),
+    Want = sort_results(naive_radius(Center, R, Ref)),
+    case Got =:= Want of
+        true ->
+            true;
+        false ->
+            io:format(
+                user,
+                "~nradius mismatch ~p r=~p:~n  grid: ~p~n  ref:  ~p~n",
+                [Center, R, Got, Want]
+            ),
+            false
+    end;
+check_query({rect, P1, P2}, Grid, Ref) ->
+    Got = sort_results(asobi_spatial_grid:query_rect(P1, P2, Grid)),
+    Want = sort_results(naive_rect(P1, P2, Ref)),
+    case Got =:= Want of
+        true ->
+            true;
+        false ->
+            io:format(
+                user,
+                "~nrect mismatch ~p..~p:~n  grid: ~p~n  ref:  ~p~n",
+                [P1, P2, Got, Want]
+            ),
+            false
+    end.
+
+sort_results(L) -> lists:sort(L).
+
+naive_radius({CX, CY}, R, Ref) ->
+    R2 = R * R,
+    [
+        {Id, Pos}
+     || {Id, {X, Y} = Pos} <- maps:to_list(Ref),
+        DX <- [X - CX],
+        DY <- [Y - CY],
+        DX * DX + DY * DY =< R2
+    ].
+
+naive_rect({X1, Y1}, {X2, Y2}, Ref) ->
+    {Lx, Ux} = order(X1, X2),
+    {Ly, Uy} = order(Y1, Y2),
+    [
+        {Id, Pos}
+     || {Id, {X, Y} = Pos} <- maps:to_list(Ref),
+        X >= Lx,
+        X =< Ux,
+        Y >= Ly,
+        Y =< Uy
+    ].
+
+order(A, B) when A =< B -> {A, B};
+order(A, B) -> {B, A}.
+
+-spec narrow_int(term()) -> pos_integer().
+narrow_int(N) when is_integer(N), N > 0 -> N.
+
+-spec narrow_list(term()) -> [term()].
+narrow_list(L) when is_list(L) -> L.

--- a/test/prop_zone_invariants.erl
+++ b/test/prop_zone_invariants.erl
@@ -1,0 +1,190 @@
+-module(prop_zone_invariants).
+-include_lib("proper/include/proper.hrl").
+%% NB: include order matters — proper's LET/4 conflicts with eunit's LET if eunit
+%% is included after. Bring proper in first, then re-include eunit for the
+%% ?_assert wrapper used by rebar3 eunit's auto-discovery.
+-undef(LET).
+-include_lib("eunit/include/eunit.hrl").
+
+%% PropEr: random sequences of join/leave/move/reconnect on a single
+%% asobi_world_server preserve these invariants:
+%%   - player_count from get_info equals the number of currently-joined players.
+%%   - Every joined player appears in get_info's `players` list exactly once.
+%%   - Every previously-left player no longer appears.
+%%   - get_info `player_count` is bounded above by max_players.
+
+-define(GAME, asobi_test_world_game).
+-define(MAX_PLAYERS, 8).
+-define(GRID_SIZE, 2).
+-define(BASE_CONFIG, #{
+    game_module => ?GAME,
+    grid_size => ?GRID_SIZE,
+    zone_size => 100,
+    tick_rate => 50,
+    max_players => ?MAX_PLAYERS,
+    view_radius => 1,
+    %% Keep the world alive across iterations even when reset_world drains all
+    %% players. With empty_grace_ms=0 (default), the world auto-finishes the
+    %% moment the last player leaves and subsequent joins time out.
+    empty_grace_ms => 600000,
+    persistent => true
+}).
+
+zone_invariants_test_() ->
+    {timeout, 120,
+        {setup, fun setup/0, fun cleanup/1, fun(Ctx) ->
+            [
+                ?_assert(
+                    proper:quickcheck(prop_zone_invariants(Ctx), [{numtests, 25}, {to_file, user}])
+                )
+            ]
+        end}}.
+
+setup() ->
+    %% Use pg:start (not start_link) so pg outlives the setup process —
+    %% the world supervisor itself is unlinked, but its init pg:join calls
+    %% will fail if pg dies between setup and test body.
+    case whereis(nova_scope) of
+        undefined -> pg:start(nova_scope);
+        _ -> ok
+    end,
+    case ets:info(asobi_player_worlds) of
+        undefined ->
+            ets:new(asobi_player_worlds, [named_table, public, set, {read_concurrency, true}]);
+        _ ->
+            ets:delete_all_objects(asobi_player_worlds)
+    end,
+    meck:new(asobi_repo, [no_link]),
+    meck:expect(asobi_repo, insert, fun(_CS) -> {ok, #{}} end),
+    meck:expect(asobi_repo, insert, fun(_CS, _Opts) -> {ok, #{}} end),
+    meck:new(asobi_presence, [non_strict, no_link]),
+    meck:expect(asobi_presence, send, fun(_PlayerId, _Msg) -> ok end),
+    start_world().
+
+cleanup(#{instance_pid := InstancePid}) ->
+    catch exit(InstancePid, shutdown),
+    timer:sleep(10),
+    catch meck:unload(asobi_presence),
+    catch meck:unload(asobi_repo),
+    ok.
+
+%% --- Property ---
+
+%% Shared world across iterations: setup/0 starts it once, cleanup/1 stops it
+%% once. Each iteration resets by leaving any players still joined.
+prop_zone_invariants(Ctx) ->
+    ?FORALL(
+        Cmds,
+        command_seq(),
+        run_iteration(Ctx, narrow_cmds(Cmds))
+    ).
+
+-spec run_iteration(map(), [term()]) -> boolean().
+run_iteration(Ctx, Cmds) ->
+    reset_world(Ctx),
+    Final = lists:foldl(fun(C, S) -> step(C, Ctx, S) end, init_state(), Cmds),
+    check_invariants(Ctx, Final).
+
+-spec narrow_cmds(term()) -> [term()].
+narrow_cmds(L) when is_list(L) -> L.
+
+reset_world(#{world_pid := Pid}) ->
+    Info = asobi_world_server:get_info(Pid),
+    [asobi_world_server:leave(Pid, P) || P <- maps:get(players, Info, [])],
+    timer:sleep(20),
+    ok.
+
+%% --- Command generator ---
+
+command_seq() ->
+    proper_types:list(command()).
+
+command() ->
+    proper_types:oneof([
+        {join, player_id()},
+        {leave, player_id()},
+        {move, player_id(), pos()}
+    ]).
+
+%% Bounded universe so commands actually overlap (~?MAX_PLAYERS distinct players).
+player_id() ->
+    proper_types:elements([
+        <<"p1">>,
+        <<"p2">>,
+        <<"p3">>,
+        <<"p4">>,
+        <<"p5">>,
+        <<"p6">>,
+        <<"p7">>,
+        <<"p8">>
+    ]).
+
+pos() ->
+    {proper_types:integer(0, ?GRID_SIZE * 100 - 1), proper_types:integer(0, ?GRID_SIZE * 100 - 1)}.
+
+%% --- Model + step ---
+
+init_state() ->
+    #{joined => sets:new(), max => ?MAX_PLAYERS}.
+
+step({join, P}, #{world_pid := Pid}, #{joined := J, max := Max} = S) ->
+    case sets:size(J) >= Max orelse sets:is_element(P, J) of
+        true ->
+            _ = asobi_world_server:join(Pid, P),
+            S;
+        false ->
+            case asobi_world_server:join(Pid, P) of
+                ok -> S#{joined => sets:add_element(P, J)};
+                {error, _} -> S
+            end
+    end;
+step({leave, P}, #{world_pid := Pid}, #{joined := J} = S) ->
+    case sets:is_element(P, J) of
+        true ->
+            asobi_world_server:leave(Pid, P),
+            timer:sleep(5),
+            S#{joined => sets:del_element(P, J)};
+        false ->
+            S
+    end;
+step({move, P, NewPos}, #{world_pid := Pid}, #{joined := J} = S) ->
+    case sets:is_element(P, J) of
+        true ->
+            asobi_world_server:move_player(Pid, P, NewPos),
+            timer:sleep(2),
+            S;
+        false ->
+            S
+    end.
+
+%% --- Invariant check ---
+
+check_invariants(#{world_pid := Pid}, #{joined := J}) ->
+    %% Drain pending casts.
+    timer:sleep(20),
+    Info = asobi_world_server:get_info(Pid),
+    Expected = sets:to_list(J),
+    Actual = lists:sort(maps:get(players, Info, [])),
+    ExpectedSorted = lists:sort(Expected),
+    PlayerCount = maps:get(player_count, Info, -1),
+    ExpectedCount = length(Expected),
+    case {PlayerCount =:= ExpectedCount, Actual =:= ExpectedSorted} of
+        {true, true} ->
+            true;
+        Other ->
+            io:format(
+                user,
+                "~ninvariant violated: ~p~n  expected players=~p count=~p~n  actual   players=~p count=~p~n",
+                [Other, ExpectedSorted, ExpectedCount, Actual, PlayerCount]
+            ),
+            false
+    end.
+
+%% --- Fixture ---
+
+start_world() ->
+    {ok, InstancePid} = asobi_world_instance:start_link(?BASE_CONFIG),
+    unlink(InstancePid),
+    timer:sleep(40),
+    ServerPid = asobi_world_instance:get_child(InstancePid, asobi_world_server),
+    #{instance_pid => InstancePid, world_pid => ServerPid}.

--- a/test/prop_zone_snapshot_roundtrip_SUITE.erl
+++ b/test/prop_zone_snapshot_roundtrip_SUITE.erl
@@ -1,0 +1,166 @@
+-module(prop_zone_snapshot_roundtrip_SUITE).
+-moduledoc """
+PropEr property for asobi_zone_snapshotter round-trip:
+
+  ∀ (entities, zone_state, entity_timers, spawner_state, tick):
+    write_snapshot(WorldId, coords, ...) followed by
+    load_snapshots(WorldId) returns the exact same payloads.
+
+The existing eunit/CT coverage uses fixed payloads for a small number of
+named regression cases (bad column types, world_id collisions, delete
+sweeps). This property explores the data shape: arbitrary entity maps
+with binary keys, mixed numeric/string field values, empty zones, and
+randomized coords/ticks. A regression that drops keys, mangles JSONB
+encoding, or swaps association ordering would shrink to a minimal case.
+""".
+
+-include_lib("common_test/include/ct.hrl").
+-include_lib("stdlib/include/assert.hrl").
+-include_lib("proper/include/proper.hrl").
+
+-export([all/0, init_per_suite/1, end_per_suite/1]).
+-export([snapshot_roundtrip_property/1]).
+-export([prop_snapshot_roundtrip/0]).
+
+-define(NUMTESTS, 25).
+
+all() ->
+    [snapshot_roundtrip_property].
+
+init_per_suite(Config) ->
+    asobi_test_helpers:start(Config).
+
+end_per_suite(_Config) ->
+    ok.
+
+snapshot_roundtrip_property(_Config) ->
+    Result = proper:quickcheck(prop_snapshot_roundtrip(), [
+        {numtests, ?NUMTESTS},
+        {to_file, user},
+        long_result
+    ]),
+    case Result of
+        true -> ok;
+        Counter -> ct:fail({property_failed, Counter})
+    end.
+
+%% --- Property ---
+
+prop_snapshot_roundtrip() ->
+    ?FORALL(
+        Payload,
+        snapshot_payload(),
+        run_iteration(narrow_payload(Payload))
+    ).
+
+%% Generators
+snapshot_payload() ->
+    {entities(), zone_state(), entity_timers(), spawner_state(), tick(), coords()}.
+
+%% Map literals with raw types as values are *constants* in PropEr — the
+%% raw type is never resolved. Wrap each in ?LET so values get generated.
+entities() ->
+    proper_types:map(binary_id(), entity_value()).
+
+entity_value() ->
+    proper_types:oneof([player_entity(), mob_entity(), proper_types:exactly(#{})]).
+
+player_entity() ->
+    ?LET({X, Y}, {coord(), coord()}, #{~"type" => ~"player", ~"x" => X, ~"y" => Y}).
+
+mob_entity() ->
+    ?LET(HP, coord(), #{~"type" => ~"mob", ~"hp" => HP}).
+
+zone_state() ->
+    proper_types:oneof([
+        proper_types:exactly(#{}),
+        ?LET(T, proper_types:non_neg_integer(), #{~"tick" => T}),
+        ?LET(P, proper_types:oneof([~"day", ~"night"]), #{~"phase" => P})
+    ]).
+
+entity_timers() ->
+    proper_types:map(binary_id(), proper_types:non_neg_integer()).
+
+spawner_state() ->
+    proper_types:oneof([
+        proper_types:exactly(#{}),
+        ?LET(N, proper_types:non_neg_integer(), #{~"next_id" => N})
+    ]).
+
+tick() ->
+    proper_types:non_neg_integer().
+
+coords() ->
+    {proper_types:integer(-3, 3), proper_types:integer(-3, 3)}.
+
+binary_id() ->
+    ?LET(N, proper_types:integer(1, 200), id_to_binary(N)).
+
+-spec id_to_binary(term()) -> binary().
+id_to_binary(N) when is_integer(N) -> list_to_binary(integer_to_list(N)).
+
+coord() ->
+    proper_types:integer(-100, 100).
+
+%% --- Runner ---
+
+-spec run_iteration({map(), map(), map(), map(), non_neg_integer(), {integer(), integer()}}) ->
+    boolean().
+run_iteration({Entities, ZoneState, EntityTimers, SpawnerState, Tick, Coords}) ->
+    WorldId = asobi_id:generate(),
+    Payload = #{
+        world_id => WorldId,
+        coords => Coords,
+        entities => Entities,
+        zone_state => ZoneState,
+        entity_timers => EntityTimers,
+        spawner_state => SpawnerState,
+        tick => Tick
+    },
+    ok = asobi_zone_snapshotter:snapshot_sync(Payload),
+    case asobi_zone_snapshotter:load_snapshots(WorldId) of
+        {ok, Loaded} when is_map(Loaded) ->
+            check_round_trip(Coords, Payload, Loaded);
+        Other ->
+            io:format(user, "load_snapshots returned ~p~n", [Other]),
+            false
+    end.
+
+check_round_trip(Coords, Payload, Loaded) ->
+    case maps:get(Coords, Loaded, undefined) of
+        undefined ->
+            io:format(user, "missing coords ~p in loaded ~p~n", [Coords, Loaded]),
+            false;
+        Snap when is_map(Snap) ->
+            Fields = [entities, zone_state, entity_timers, spawner_state, tick],
+            lists:all(
+                fun(F) ->
+                    case maps:get(F, Snap) =:= maps:get(F, Payload) of
+                        true ->
+                            true;
+                        false ->
+                            io:format(
+                                user,
+                                "field ~p mismatch:~n  in:  ~p~n  out: ~p~n",
+                                [F, maps:get(F, Payload), maps:get(F, Snap)]
+                            ),
+                            false
+                    end
+                end,
+                Fields
+            )
+    end.
+
+-spec narrow_payload(term()) ->
+    {map(), map(), map(), map(), non_neg_integer(), {integer(), integer()}}.
+narrow_payload({Entities, ZoneState, EntityTimers, SpawnerState, Tick, {ZX, ZY}}) when
+    is_map(Entities),
+    is_map(ZoneState),
+    is_map(EntityTimers),
+    is_map(SpawnerState),
+    is_integer(Tick),
+    Tick >= 0,
+    is_integer(ZX),
+    is_integer(ZY)
+->
+    {Entities, ZoneState, EntityTimers, SpawnerState, Tick, {ZX, ZY}}.


### PR DESCRIPTION
## Summary

Expands PropEr coverage across the asobi engine and fixes a real bug discovered along the way.

### New properties (this push)

- **prop_spatial_grid_consistency** (50 numtests) — random insert/update/remove + radius/rect queries match a naive list-scan reference. Catches indexing drift after the grid layout changes.
- **prop_phase_timer_monotonic** (50 numtests) — random tick deltas drive phases through the full lifecycle in declared order, exactly one `phase_started`/`phase_ended` per phase, exactly one `all_phases_complete`.
- **prop_reconnect_lifecycle** (25 numtests) — random `join/disconnect/reconnect/leave` sequences against a world configured with `player_ttl_ms`. Asserts `player_count` settles to `|joined|` after every iteration.
- **prop_chat_zone_routing** (25 numtests) — random `join/move/leave` ops; asserts each player's pg memberships match the expected world+zone+proximity set after every mutation.
- **prop_matchmaker_fill_strategy** (100 numtests) — pure-function invariants on `asobi_matchmaker_fill:match/2`: groups have exactly `match_size`, leftover `< match_size`, no drops/dupes, FCFS order preserved.

### Bug fix: `asobi_phase:init/1` swallowed first-phase events

`prop_phase_timer_monotonic` red-flagged a real bug. `init/1` auto-started the first `prev_ended` phase but discarded the `{phase_started, P1}` event, so `on_phase_started` silently never fired for phase 1.

- `asobi_phase:init/1` now returns `{[phase_event()], phase_state()}`.
- `asobi_world_server` and `asobi_match_server` thread the initial events through `handle_phase_events` so the first phase's start callback fires.
- Existing `asobi_phase_tests.erl` updated for the new return shape (12 tests still pass).

### Earlier in this PR

- prop_zone_invariants (zone-cell→entity-position invariants)
- prop_input_never_dropped (per-player FIFO + no drop under contention)
- prop_lua_bridge_input_threading (handle_input proc-dict threading; lives in asobi_lua)
- prop_snapshot_roundtrip CT (Kura roundtrip, in asobi-test-harness)

## Test plan

- [x] `rebar3 eunit` — all property tests pass (50/50, 50/50, 25/25, 25/25, 100/100, 30/30 in asobi_lua)
- [x] `rebar3 fmt --check` clean
- [x] `~/bin/elp eqwalize-all` clean (0 errors)
- [x] `~/bin/elp lint` clean for new files
- [x] `rebar3 dialyzer` clean
- [x] `rebar3 xref` clean