### PR TITLE
ci: nightly property soak workflow + PROPER_NUMTESTS env hook

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1,0 +1,111 @@
+name: Nightly
+
+on:
+  schedule:
+    - cron: '0 3 * * *'  # 03:00 UTC daily
+  workflow_dispatch:     # manual trigger from Actions UI
+
+concurrency:
+  group: nightly-${{ github.workflow }}
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  property-soak:
+    name: Property Tests (high numtests)
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    services:
+      postgres:
+        image: postgres:16
+        env:
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: postgres
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U postgres"
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 10
+    env:
+      # Property modules read this with a per-file default fallback.
+      # Pure props handle 5000 in seconds; fixture-heavy props (world
+      # startup per iteration) cap at ~1000 to stay under ~3 min.
+      PROPER_NUMTESTS: '1000'
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: erlef/setup-beam@v1
+        with:
+          version-file: '.tool-versions'
+          version-type: strict
+
+      - name: Cache _build
+        uses: actions/cache@v4
+        with:
+          path: _build
+          key: nightly-prop-${{ hashFiles('rebar.lock') }}
+          restore-keys: |
+            nightly-prop-
+
+      - name: Run property tests at high numtests
+        run: |
+          rebar3 eunit --module=\
+          prop_zone_invariants,\
+          prop_input_never_dropped,\
+          prop_spatial_grid_consistency,\
+          prop_phase_timer_monotonic,\
+          prop_reconnect_lifecycle,\
+          prop_chat_zone_routing,\
+          prop_matchmaker_fill_strategy
+
+      - name: Run snapshot round-trip CT
+        run: rebar3 ct --suite=test/prop_zone_snapshot_roundtrip_SUITE
+
+  soak:
+    name: Multiplayer Soak (placeholder)
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: erlef/setup-beam@v1
+        with:
+          version-file: '.tool-versions'
+          version-type: strict
+
+      - name: Run soak suite if present
+        # Requires test/soak_SUITE.erl driving N players for ~10 min and
+        # asserting no leaks (process count stable, ETS sizes stable, no
+        # DOWN cascades). Skip the job until the suite exists.
+        run: |
+          if [ -f test/soak_SUITE.erl ]; then
+            rebar3 ct --suite=test/soak_SUITE
+          else
+            echo "soak_SUITE not yet present — skipping"
+          fi
+
+  notify-failure:
+    name: Open regression issue
+    needs: [property-soak, soak]
+    if: failure() && github.event_name == 'schedule'
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+    steps:
+      - uses: actions/github-script@v7
+        with:
+          script: |
+            const title = `Nightly failure: ${new Date().toISOString().slice(0,10)}`;
+            const url = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+            await github.rest.issues.create({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              title,
+              body: `Nightly workflow failed.\n\nRun: ${url}\n\nThis issue is auto-opened by \`.github/workflows/nightly.yml\`.`,
+              labels: ['nightly-regression']
+            });

--- a/test/prop_chat_zone_routing.erl
+++ b/test/prop_chat_zone_routing.erl
@@ -12,7 +12,7 @@
 %% Catches subscribe/unsubscribe drift (orphaned subscriptions after
 %% leave, double-subscribe on resync, broken proximity expansion).
 
--define(NUMTESTS, 25).
+-define(NUMTESTS, list_to_integer(os:getenv("PROPER_NUMTESTS", "25"))).
 -define(WORLD_ID, ~"propchat").
 -define(GRID_SIZE, 10).
 -define(PROX_RADIUS, 1).

--- a/test/prop_input_never_dropped.erl
+++ b/test/prop_input_never_dropped.erl
@@ -17,6 +17,7 @@
 -define(MAX_PLAYERS, 6).
 -define(GRID_SIZE, 2).
 -define(WAIT_TICKS_MS, 500).
+-define(NUMTESTS, list_to_integer(os:getenv("PROPER_NUMTESTS", "25"))).
 -define(BASE_CONFIG, #{
     game_module => ?GAME,
     grid_size => ?GRID_SIZE,
@@ -34,7 +35,7 @@ input_never_dropped_test_() ->
             [
                 ?_assert(
                     proper:quickcheck(prop_input_never_dropped(Ctx), [
-                        {numtests, 25}, {to_file, user}
+                        {numtests, ?NUMTESTS}, {to_file, user}
                     ])
                 )
             ]

--- a/test/prop_matchmaker_fill_strategy.erl
+++ b/test/prop_matchmaker_fill_strategy.erl
@@ -10,7 +10,7 @@
 %%   - groups + leftover preserves the input list (no drops, no dupes)
 %%   - within each group, ticket order matches input order (FCFS)
 
--define(NUMTESTS, 100).
+-define(NUMTESTS, list_to_integer(os:getenv("PROPER_NUMTESTS", "100"))).
 
 matchmaker_fill_strategy_test_() ->
     {timeout, 30,

--- a/test/prop_phase_timer_monotonic.erl
+++ b/test/prop_phase_timer_monotonic.erl
@@ -16,7 +16,7 @@
 %% Catches regressions where a phase boundary is skipped under a coarse
 %% tick delta or where a paused/notify path leaks events.
 
--define(NUMTESTS, 50).
+-define(NUMTESTS, list_to_integer(os:getenv("PROPER_NUMTESTS", "50"))).
 
 phase_timer_monotonic_test_() ->
     {timeout, 60,

--- a/test/prop_reconnect_lifecycle.erl
+++ b/test/prop_reconnect_lifecycle.erl
@@ -17,6 +17,7 @@
 
 -define(MAX_PLAYERS, 5).
 -define(TTL_MS, 60_000).
+-define(NUMTESTS, list_to_integer(os:getenv("PROPER_NUMTESTS", "25"))).
 -define(BASE_CONFIG, #{
     game_module => asobi_test_world_game,
     grid_size => 2,
@@ -36,7 +37,7 @@ reconnect_lifecycle_test_() ->
             [
                 ?_assert(
                     proper:quickcheck(prop_reconnect_lifecycle(Ctx), [
-                        {numtests, 25}, {to_file, user}
+                        {numtests, ?NUMTESTS}, {to_file, user}
                     ])
                 )
             ]

--- a/test/prop_spatial_grid_consistency.erl
+++ b/test/prop_spatial_grid_consistency.erl
@@ -11,7 +11,7 @@
 %% after remove, off-by-one cell edges) that are easy to introduce when the
 %% grid layout changes.
 
--define(NUMTESTS, 50).
+-define(NUMTESTS, list_to_integer(os:getenv("PROPER_NUMTESTS", "50"))).
 
 spatial_grid_consistency_test_() ->
     {timeout, 60,

--- a/test/prop_zone_invariants.erl
+++ b/test/prop_zone_invariants.erl
@@ -16,6 +16,7 @@
 -define(GAME, asobi_test_world_game).
 -define(MAX_PLAYERS, 8).
 -define(GRID_SIZE, 2).
+-define(NUMTESTS, list_to_integer(os:getenv("PROPER_NUMTESTS", "25"))).
 -define(BASE_CONFIG, #{
     game_module => ?GAME,
     grid_size => ?GRID_SIZE,
@@ -35,7 +36,9 @@ zone_invariants_test_() ->
         {setup, fun setup/0, fun cleanup/1, fun(Ctx) ->
             [
                 ?_assert(
-                    proper:quickcheck(prop_zone_invariants(Ctx), [{numtests, 25}, {to_file, user}])
+                    proper:quickcheck(prop_zone_invariants(Ctx), [
+                        {numtests, ?NUMTESTS}, {to_file, user}
+                    ])
                 )
             ]
         end}}.

--- a/test/prop_zone_snapshot_roundtrip_SUITE.erl
+++ b/test/prop_zone_snapshot_roundtrip_SUITE.erl
@@ -22,7 +22,7 @@ encoding, or swaps association ordering would shrink to a minimal case.
 -export([snapshot_roundtrip_property/1]).
 -export([prop_snapshot_roundtrip/0]).
 
--define(NUMTESTS, 25).
+-define(NUMTESTS, list_to_integer(os:getenv("PROPER_NUMTESTS", "25"))).
 
 all() ->
     [snapshot_roundtrip_property].


### PR DESCRIPTION
## Summary

Adds a nightly workflow that runs the PropEr suite at high numtests on a 03:00 UTC schedule (with manual \`workflow_dispatch\` trigger). Wires \`PROPER_NUMTESTS\` env into all prop test files — defaults are unchanged so per-PR runs aren't affected.

### Per-PR vs nightly numtests

| Test | Per-PR (default) | Nightly (\`PROPER_NUMTESTS=1000\`) |
|---|---|---|
| prop_matchmaker_fill_strategy (pure) | 100 | 1000 |
| prop_phase_timer_monotonic (pure) | 50 | 1000 |
| prop_spatial_grid_consistency (pure) | 50 | 1000 |
| prop_zone_invariants (fixture-heavy) | 25 | 1000 |
| prop_input_never_dropped (fixture-heavy) | 25 | 1000 |
| prop_reconnect_lifecycle (fixture-heavy) | 25 | 1000 |
| prop_chat_zone_routing (fixture-heavy) | 25 | 1000 |
| prop_zone_snapshot_roundtrip_SUITE (CT) | 25 | 1000 |

### Workflow shape

- \`property-soak\` — runs all 7 prop tests + the snapshot CT, ~3 min
- \`soak\` — placeholder for \`test/soak_SUITE.erl\` (long-running multiplayer churn). Skips silently until the suite lands.
- \`notify-failure\` — opens a \`nightly-regression\` issue if the schedule run fails. Manual \`workflow_dispatch\` runs don't open issues.

### Why no mutation testing

Local dry-run with \`rebar3 mutate -m asobi_matchmaker_fill\` returned **0/501 mutants killed in 8s** — too fast to actually be running the property tests against mutants. The plugin loads but doesn't seem to discover/exercise the prop_*.erl test files. Needs upstream investigation in \`Taure/rebar3_mutate\` before earning a nightly slot.

## Test plan

- [x] \`rebar3 fmt --check\` clean
- [x] \`~/bin/elp eqwalize-all\` clean (0 errors)
- [x] \`~/bin/elp lint\` no warnings on changed files
- [x] Default behavior verified: \`rebar3 eunit\` runs at hardcoded numtests
- [x] Override verified: \`PROPER_NUMTESTS=500 rebar3 eunit\` runs at 500