### PR TITLE
fix(security): close all 4 Critical audit findings

### DIFF
--- a/src/auth/asobi_iap.erl
+++ b/src/auth/asobi_iap.erl
@@ -1,18 +1,34 @@
 -module(asobi_iap).
 
+-include_lib("public_key/include/public_key.hrl").
+
 -export([verify_apple/1, verify_google/1]).
 
+%% StoreKit 2 always signs JWS with ES256 (ECDSA over P-256, SHA-256).
+%% We refuse any other algorithm — `none`/HS256/RS256 etc. are out.
+-define(APPLE_REQUIRED_ALG, ~"ES256").
+
 %% Apple App Store Server API v2
-%% Validates a signed transaction (JWS) from StoreKit 2.
-%% The client sends the JWS transaction string obtained from StoreKit.
+%% Validates a signed transaction (JWS) from StoreKit 2: verifies the JWS
+%% signature against the leaf certificate from the `x5c` header, validates
+%% the certificate chain against the configured Apple root, then checks
+%% the bundle id and expiry. Refuses to run when not configured —
+%% callers see `{error, apple_iap_not_configured | apple_root_cert_*}`.
 -spec verify_apple(binary()) -> {ok, map()} | {error, binary()}.
-verify_apple(SignedTransaction) ->
+verify_apple(SignedTransaction) when is_binary(SignedTransaction) ->
     case apple_bundle_id() of
         undefined ->
             {error, ~"apple_iap_not_configured"};
         BundleId ->
-            do_verify_apple(SignedTransaction, BundleId)
-    end.
+            case apple_root_certs() of
+                {ok, RootCerts} ->
+                    do_verify_apple(SignedTransaction, BundleId, RootCerts);
+                {error, _} = Err ->
+                    Err
+            end
+    end;
+verify_apple(_) ->
+    {error, ~"invalid_jws"}.
 
 %% Google Play Developer API
 %% Validates a purchase using the purchase token from Google Play Billing.
@@ -30,51 +46,204 @@ verify_google(_) ->
 
 %% --- Apple Internal ---
 
--spec do_verify_apple(binary(), binary()) -> {ok, map()} | {error, binary()}.
-do_verify_apple(SignedTransaction, ExpectedBundleId) ->
-    case decode_jws_payload(SignedTransaction) of
+-spec do_verify_apple(binary(), binary(), [dynamic()]) -> {ok, map()} | {error, binary()}.
+do_verify_apple(JWS, ExpectedBundleId, RootCerts) ->
+    case parse_and_verify_jws(JWS, RootCerts) of
         {ok, Payload} ->
-            BundleId = maps:get(~"bundleId", Payload, undefined),
-            ExpiresMs = maps:get(~"expiresDate", Payload, undefined),
-            case BundleId of
-                ExpectedBundleId ->
-                    Result = #{
-                        product_id => maps:get(~"productId", Payload),
-                        transaction_id => maps:get(~"transactionId", Payload),
-                        original_transaction_id =>
-                            maps:get(~"originalTransactionId", Payload, undefined),
-                        purchase_date => maps:get(~"purchaseDate", Payload, undefined),
-                        expires_date => ExpiresMs,
-                        quantity => maps:get(~"quantity", Payload, 1),
-                        type => maps:get(~"type", Payload, ~"unknown"),
-                        valid => not is_expired(ExpiresMs)
-                    },
-                    {ok, Result};
-                _ ->
-                    {error, ~"bundle_id_mismatch"}
-            end;
-        {error, Reason} ->
-            {error, Reason}
+            check_apple_payload(Payload, ExpectedBundleId);
+        {error, _} = Err ->
+            Err
     end.
 
-%% Decode the payload section of a JWS (base64url-encoded JSON).
-%% Full signature verification against Apple's root CA should be added
-%% for production — this extracts the payload for validation.
--spec decode_jws_payload(binary()) -> {ok, map()} | {error, binary()}.
-decode_jws_payload(JWS) ->
+-spec check_apple_payload(map(), binary()) -> {ok, map()} | {error, binary()}.
+check_apple_payload(Payload, ExpectedBundleId) ->
+    BundleId = maps:get(~"bundleId", Payload, undefined),
+    ExpiresMs = maps:get(~"expiresDate", Payload, undefined),
+    case BundleId of
+        ExpectedBundleId ->
+            Result = #{
+                product_id => maps:get(~"productId", Payload, undefined),
+                transaction_id => maps:get(~"transactionId", Payload, undefined),
+                original_transaction_id =>
+                    maps:get(~"originalTransactionId", Payload, undefined),
+                purchase_date => maps:get(~"purchaseDate", Payload, undefined),
+                expires_date => ExpiresMs,
+                quantity => maps:get(~"quantity", Payload, 1),
+                type => maps:get(~"type", Payload, ~"unknown"),
+                valid => not is_expired(ExpiresMs)
+            },
+            {ok, Result};
+        _ ->
+            {error, ~"bundle_id_mismatch"}
+    end.
+
+%% Parse + verify the JWS in one shot; never returns the payload until
+%% header alg, certificate chain, and signature have all been validated.
+-spec parse_and_verify_jws(binary(), [dynamic()]) -> {ok, map()} | {error, binary()}.
+parse_and_verify_jws(JWS, RootCerts) ->
     case binary:split(JWS, ~".", [global]) of
-        [_, PayloadB64, _] ->
+        [HeaderB64, PayloadB64, SigB64] ->
             try
-                Decoded = base64:decode(PayloadB64, #{mode => urlsafe, padding => false}),
-                case json:decode(Decoded) of
-                    M when is_map(M) -> {ok, M};
-                    _ -> {error, ~"invalid_jws_payload"}
-                end
+                Header = decode_b64_json(HeaderB64),
+                ok = require_alg(Header),
+                {LeafCert, ValidationChain} = require_x5c(Header),
+                ok = verify_chain(ValidationChain, RootCerts),
+                ok = verify_signature(HeaderB64, PayloadB64, SigB64, LeafCert),
+                Payload = decode_b64_json(PayloadB64),
+                {ok, Payload}
             catch
-                _:_ -> {error, ~"invalid_jws"}
+                throw:Reason when is_binary(Reason) ->
+                    {error, Reason};
+                _:_ ->
+                    {error, ~"invalid_jws"}
             end;
         _ ->
             {error, ~"invalid_jws_format"}
+    end.
+
+-spec decode_b64_json(binary()) -> map().
+decode_b64_json(B64) ->
+    Decoded = base64:decode(B64, #{mode => urlsafe, padding => false}),
+    case json:decode(Decoded) of
+        M when is_map(M) -> M;
+        _ -> throw(~"invalid_jws")
+    end.
+
+-spec require_alg(map()) -> ok.
+require_alg(#{~"alg" := ?APPLE_REQUIRED_ALG}) -> ok;
+require_alg(_) -> throw(~"unsupported_alg").
+
+%% Apple JWS x5c is always [leaf, intermediate, root] in DER-base64. We
+%% decode the leaf and intermediate, drop the embedded root (we trust our
+%% own configured root), and return the leaf + the validation-order chain
+%% (`[Intermediate, Leaf]`).
+-spec require_x5c(map()) -> {dynamic(), [dynamic()]}.
+require_x5c(#{~"x5c" := [LeafB64, IntB64, RootB64]}) when
+    is_binary(LeafB64), is_binary(IntB64), is_binary(RootB64)
+->
+    Leaf = decode_x5c_cert(LeafB64),
+    Intermediate = decode_x5c_cert(IntB64),
+    %% RootB64 is intentionally not used: we never trust the chain's
+    %% own embedded root, only the operator-configured one.
+    _ = decode_x5c_cert(RootB64),
+    {Leaf, [Intermediate, Leaf]};
+require_x5c(_) ->
+    throw(~"invalid_x5c").
+
+-spec decode_x5c_cert(binary()) -> dynamic().
+decode_x5c_cert(B64) ->
+    Der = base64:decode(B64, #{mode => standard, padding => true}),
+    public_key:pkix_decode_cert(Der, otp).
+
+-spec verify_chain([dynamic()], [dynamic()]) -> ok.
+verify_chain(Chain, RootCerts) ->
+    case try_roots(RootCerts, Chain) of
+        ok -> ok;
+        error -> throw(~"chain_validation_failed")
+    end.
+
+-spec try_roots([dynamic()], [dynamic()]) -> ok | error.
+try_roots([], _Chain) ->
+    error;
+try_roots([Root | Rest], Chain) ->
+    case public_key:pkix_path_validation(Root, Chain, []) of
+        {ok, _} -> ok;
+        {error, _} -> try_roots(Rest, Chain)
+    end.
+
+-spec verify_signature(binary(), binary(), binary(), dynamic()) -> ok.
+verify_signature(HeaderB64, PayloadB64, SigB64, LeafCert) ->
+    SignInput = <<HeaderB64/binary, ".", PayloadB64/binary>>,
+    RawSig = base64:decode(SigB64, #{mode => urlsafe, padding => false}),
+    DerSig = ecdsa_raw_to_der(RawSig),
+    PubKeyInfo = pubkey_from_cert(LeafCert),
+    case public_key:verify(SignInput, sha256, DerSig, PubKeyInfo) of
+        true -> ok;
+        false -> throw(~"signature_invalid")
+    end.
+
+%% JWS ES256 signatures are 64-byte raw `r || s`. `public_key:verify/4`
+%% wants DER-encoded `Ecdsa-Sig-Value SEQUENCE { r INTEGER, s INTEGER }`.
+-spec ecdsa_raw_to_der(binary()) -> binary().
+ecdsa_raw_to_der(<<R:32/binary, S:32/binary>>) ->
+    Rint = binary:decode_unsigned(R),
+    Sint = binary:decode_unsigned(S),
+    public_key:der_encode('ECDSA-Sig-Value', {'ECDSA-Sig-Value', Rint, Sint});
+ecdsa_raw_to_der(_) ->
+    throw(~"signature_invalid").
+
+-spec pubkey_from_cert(dynamic()) -> dynamic().
+pubkey_from_cert(#'OTPCertificate'{tbsCertificate = TBS}) ->
+    SPKI = TBS#'OTPTBSCertificate'.subjectPublicKeyInfo,
+    Algorithm = SPKI#'OTPSubjectPublicKeyInfo'.algorithm,
+    PubKey = SPKI#'OTPSubjectPublicKeyInfo'.subjectPublicKey,
+    Params = Algorithm#'PublicKeyAlgorithm'.parameters,
+    {PubKey, Params}.
+
+-spec apple_root_certs() -> {ok, [dynamic()]} | {error, binary()}.
+apple_root_certs() ->
+    case application:get_env(asobi, apple_root_certs) of
+        {ok, Certs} when is_list(Certs), Certs =/= [] ->
+            normalise_root_certs(Certs);
+        _ ->
+            case application:get_env(asobi, apple_root_cert_path) of
+                {ok, Path} when is_binary(Path) ->
+                    load_root_cert_file(Path);
+                {ok, Path} when is_list(Path) ->
+                    load_root_cert_file(coerce_path(Path));
+                _ ->
+                    {error, ~"apple_root_cert_not_configured"}
+            end
+    end.
+
+-spec normalise_root_certs([term()]) -> {ok, [dynamic()]} | {error, binary()}.
+normalise_root_certs(Certs) ->
+    try
+        {ok, [normalise_root_cert(C) || C <- Certs]}
+    catch
+        _:_ -> {error, ~"apple_root_cert_invalid"}
+    end.
+
+-spec normalise_root_cert(term()) -> dynamic().
+normalise_root_cert(#'OTPCertificate'{} = C) ->
+    C;
+normalise_root_cert(Bin) when is_binary(Bin) ->
+    case decode_root_pem_or_der(Bin) of
+        {ok, Cert} -> Cert;
+        error -> erlang:error(apple_root_cert_invalid)
+    end.
+
+-spec coerce_path(dynamic()) -> binary().
+coerce_path(L) ->
+    iolist_to_binary(L).
+
+-spec load_root_cert_file(binary()) -> {ok, [dynamic()]} | {error, binary()}.
+load_root_cert_file(Path) ->
+    case file:read_file(Path) of
+        {ok, Bin} ->
+            case decode_root_pem_or_der(Bin) of
+                {ok, Cert} -> {ok, [Cert]};
+                error -> {error, ~"apple_root_cert_invalid"}
+            end;
+        {error, _} ->
+            {error, ~"apple_root_cert_not_found"}
+    end.
+
+-spec decode_root_pem_or_der(binary()) -> {ok, dynamic()} | error.
+decode_root_pem_or_der(Bin) ->
+    case public_key:pem_decode(Bin) of
+        [{'Certificate', Der, _} | _] ->
+            try
+                {ok, public_key:pkix_decode_cert(Der, otp)}
+            catch
+                _:_ -> error
+            end;
+        _ ->
+            try
+                {ok, public_key:pkix_decode_cert(Bin, otp)}
+            catch
+                _:_ -> error
+            end
     end.
 
 %% --- Google Internal ---

--- a/src/controllers/asobi_leaderboard_controller.erl
+++ b/src/controllers/asobi_leaderboard_controller.erl
@@ -22,26 +22,48 @@ around(#{bindings := #{~"id" := BoardId, ~"player_id" := PlayerId}, qs := Qs} = 
 submit(
     #{bindings := #{~"id" := BoardId}, json := Params, auth_data := #{player_id := PlayerId}} = _Req
 ) when is_binary(BoardId), is_binary(PlayerId), is_map(Params) ->
-    Score =
-        case maps:get(~"score", Params) of
-            S when is_number(S) -> S;
-            _ -> 0
-        end,
-    SubScore = maps:get(~"sub_score", Params, 0),
-    asobi_leaderboard_server:submit(BoardId, PlayerId, Score),
-    Rank =
-        case asobi_leaderboard_server:rank(BoardId, PlayerId) of
-            {ok, R} -> R;
-            {error, not_found} -> null
-        end,
-    {json, 200, #{}, #{
-        leaderboard_id => BoardId,
-        player_id => PlayerId,
-        score => Score,
-        sub_score => SubScore,
-        rank => Rank,
-        updated_at => format_timestamp(erlang:system_time(millisecond))
-    }}.
+    case client_submit_allowed(BoardId) of
+        false ->
+            {json, 403, #{}, #{error => ~"client_submit_disabled"}};
+        true ->
+            Score =
+                case maps:get(~"score", Params) of
+                    S when is_number(S) -> S;
+                    _ -> 0
+                end,
+            SubScore = maps:get(~"sub_score", Params, 0),
+            case asobi_leaderboard_server:submit(BoardId, PlayerId, Score) of
+                {error, capacity_reached} ->
+                    {json, 503, #{}, #{error => ~"leaderboard_capacity_reached"}};
+                _ ->
+                    Rank =
+                        case asobi_leaderboard_server:rank(BoardId, PlayerId) of
+                            {ok, R} -> R;
+                            {error, not_found} -> null
+                        end,
+                    {json, 200, #{}, #{
+                        leaderboard_id => BoardId,
+                        player_id => PlayerId,
+                        score => Score,
+                        sub_score => SubScore,
+                        rank => Rank,
+                        updated_at => format_timestamp(erlang:system_time(millisecond))
+                    }}
+            end
+    end.
+
+%% Client score submissions are off by default — server-side game logic
+%% should call asobi_leaderboard_server:submit/3 directly. To opt a board
+%% in for client writes (typical for casual scoreboards where cheating
+%% is acceptable), set `leaderboard_client_submit` to a list of allowed
+%% board ids or to `all`.
+-spec client_submit_allowed(binary()) -> boolean().
+client_submit_allowed(BoardId) ->
+    case application:get_env(asobi, leaderboard_client_submit, []) of
+        all -> true;
+        L when is_list(L) -> lists:member(BoardId, L);
+        _ -> false
+    end.
 
 %% --- Internal ---
 

--- a/src/controllers/asobi_storage_controller.erl
+++ b/src/controllers/asobi_storage_controller.erl
@@ -152,11 +152,21 @@ delete_storage(
     end.
 
 -spec list_storage(cowboy_req:req()) -> {json, map()}.
-list_storage(#{bindings := #{~"collection" := Col}, qs := Qs} = _Req) when is_binary(Qs) ->
+list_storage(
+    #{bindings := #{~"collection" := Col}, qs := Qs, auth_data := #{player_id := PlayerId}} = _Req
+) when is_binary(Qs), is_binary(PlayerId) ->
     Params = cow_qs:parse_qs(Qs),
     Limit = qs_integer(~"limit", Params, 50),
+    %% Mirror get_storage's ACL: only return rows the caller is allowed
+    %% to read (public objects, or owner-restricted objects they own).
     Q = kura_query:limit(
-        kura_query:where(kura_query:from(asobi_storage), {collection, Col}),
+        kura_query:where(
+            kura_query:where(kura_query:from(asobi_storage), {collection, Col}),
+            {'or', [
+                {read_perm, ~"public"},
+                {'and', [{read_perm, ~"owner"}, {player_id, PlayerId}]}
+            ]}
+        ),
         Limit
     ),
     {ok, Objects} = asobi_repo:all(Q),

--- a/src/leaderboards/asobi_leaderboard_server.erl
+++ b/src/leaderboards/asobi_leaderboard_server.erl
@@ -5,59 +5,95 @@
 -export([init/1, handle_call/3, handle_cast/2, handle_info/2, terminate/2]).
 
 -define(PG_SCOPE, nova_scope).
+-define(DEFAULT_MAX_BOARDS, 1000).
 
 -spec start_link(binary()) -> gen_server:start_ret().
 start_link(BoardId) ->
     gen_server:start_link(?MODULE, BoardId, []).
 
--spec submit(binary(), binary(), integer()) -> ok.
+%% Submit is the only path that spawns a leaderboard process. Reads
+%% return empty results when the board doesn't exist yet — that prevents
+%% an attacker from filling the supervisor with thousands of boards just
+%% by reading random ids.
+-spec submit(binary(), binary(), integer()) -> ok | {error, capacity_reached}.
 submit(BoardId, PlayerId, Score) ->
-    ensure_started(BoardId),
-    gen_server:cast(whereis_board(BoardId), {submit, PlayerId, Score}).
+    case ensure_started(BoardId) of
+        ok ->
+            case whereis_board_optional(BoardId) of
+                {ok, Pid} -> gen_server:cast(Pid, {submit, PlayerId, Score});
+                not_found -> ok
+            end;
+        {error, _} = Err ->
+            Err
+    end.
 
 -spec top(binary(), pos_integer()) -> [{binary(), number(), pos_integer()}].
 top(BoardId, N) ->
-    ensure_started(BoardId),
-    case gen_server:call(whereis_board(BoardId), {top, N}) of
-        Entries when is_list(Entries) -> validate_entries(Entries);
-        _ -> []
+    case whereis_board_optional(BoardId) of
+        {ok, Pid} ->
+            case gen_server:call(Pid, {top, N}) of
+                Entries when is_list(Entries) -> validate_entries(Entries);
+                _ -> []
+            end;
+        not_found ->
+            []
     end.
 
 -spec rank(binary(), binary()) -> {ok, pos_integer()} | {error, not_found}.
 rank(BoardId, PlayerId) ->
-    ensure_started(BoardId),
-    case gen_server:call(whereis_board(BoardId), {rank, PlayerId}) of
-        {ok, Pos} when is_integer(Pos) -> {ok, Pos};
-        {error, not_found} -> {error, not_found}
+    case whereis_board_optional(BoardId) of
+        {ok, Pid} ->
+            case gen_server:call(Pid, {rank, PlayerId}) of
+                {ok, Pos} when is_integer(Pos) -> {ok, Pos};
+                {error, not_found} -> {error, not_found}
+            end;
+        not_found ->
+            {error, not_found}
     end.
 
 -spec around(binary(), binary(), pos_integer()) -> [{binary(), number(), pos_integer()}].
 around(BoardId, PlayerId, N) ->
-    ensure_started(BoardId),
-    case gen_server:call(whereis_board(BoardId), {around, PlayerId, N}) of
-        Entries when is_list(Entries) -> validate_entries(Entries);
-        _ -> []
+    case whereis_board_optional(BoardId) of
+        {ok, Pid} ->
+            case gen_server:call(Pid, {around, PlayerId, N}) of
+                Entries when is_list(Entries) -> validate_entries(Entries);
+                _ -> []
+            end;
+        not_found ->
+            []
     end.
 
 -spec validate_entries([term()]) -> [{binary(), number(), pos_integer()}].
 validate_entries(Entries) ->
     [{P, S, R} || {P, S, R} <- Entries, is_binary(P), is_number(S), is_integer(R)].
 
--spec ensure_started(binary()) -> ok.
+-spec ensure_started(binary()) -> ok | {error, capacity_reached}.
 ensure_started(BoardId) ->
     case pg:get_members(?PG_SCOPE, {?MODULE, BoardId}) of
         [] ->
-            _ = asobi_leaderboard_sup:start_board(BoardId),
-            ok;
+            case at_capacity() of
+                true ->
+                    {error, capacity_reached};
+                false ->
+                    _ = asobi_leaderboard_sup:start_board(BoardId),
+                    ok
+            end;
         [_ | _] ->
             ok
     end.
 
--spec whereis_board(binary()) -> pid().
-whereis_board(BoardId) ->
+-spec at_capacity() -> boolean().
+at_capacity() ->
+    Max = application:get_env(asobi, leaderboard_max_boards, ?DEFAULT_MAX_BOARDS),
+    Counts = supervisor:count_children(asobi_leaderboard_sup),
+    Active = proplists:get_value(active, Counts, 0),
+    Active >= Max.
+
+-spec whereis_board_optional(binary()) -> {ok, pid()} | not_found.
+whereis_board_optional(BoardId) ->
     case pg:get_members(?PG_SCOPE, {?MODULE, BoardId}) of
-        [Pid | _] -> Pid;
-        [] -> error({leaderboard_not_found, BoardId})
+        [Pid | _] -> {ok, Pid};
+        [] -> not_found
     end.
 
 -spec init(binary()) -> {ok, map()}.

--- a/src/players/asobi_player_controller.erl
+++ b/src/players/asobi_player_controller.erl
@@ -34,8 +34,13 @@ update(
             end
     end.
 
+%% Positive whitelist: only fields safe for any authenticated viewer.
+%% Never expose `hashed_password` (or any future credential fields).
 sanitize(Player) ->
-    maps:without([banned_at], Player).
+    maps:with(
+        [id, username, display_name, avatar_url, metadata, inserted_at, updated_at],
+        Player
+    ).
 
 format_errors(CS) ->
     kura_changeset:traverse_errors(CS, fun(_Field, Msg) -> Msg end).

--- a/test/asobi_api_SUITE.erl
+++ b/test/asobi_api_SUITE.erl
@@ -216,6 +216,9 @@ get_player(Config) ->
     ?assertStatus(200, Resp),
     Body = nova_test:json(Resp),
     ?assertMatch(#{~"username" := _}, Body),
+    %% Regression: hashed_password and password must never leak.
+    ?assertEqual(error, maps:find(~"hashed_password", Body)),
+    ?assertEqual(error, maps:find(~"password", Body)),
     Config.
 
 update_player(Config) ->
@@ -234,6 +237,7 @@ update_player(Config) ->
     ?assertStatus(200, Resp),
     Body = nova_test:json(Resp),
     ?assertMatch(#{~"display_name" := ~"Updated Name"}, Body),
+    ?assertEqual(error, maps:find(~"hashed_password", Body)),
     Config.
 
 update_player_unauthorized(Config) ->

--- a/test/asobi_iap_SUITE.erl
+++ b/test/asobi_iap_SUITE.erl
@@ -1,13 +1,21 @@
 -module(asobi_iap_SUITE).
 
 -include_lib("nova_test/include/nova_test.hrl").
+-include_lib("public_key/include/public_key.hrl").
+-include_lib("common_test/include/ct.hrl").
 
 -export([all/0, groups/0, init_per_suite/1, end_per_suite/1]).
 -export([
     apple_missing_fields/1,
     apple_not_configured/1,
+    apple_root_not_configured/1,
     apple_invalid_jws/1,
+    apple_unsupported_alg/1,
+    apple_missing_x5c/1,
+    apple_signature_invalid/1,
+    apple_chain_validation_failed/1,
     apple_valid_jws_wrong_bundle/1,
+    apple_valid_jws_correct_bundle/1,
     google_missing_fields/1,
     google_not_configured/1
 ]).
@@ -19,8 +27,14 @@ groups() ->
         {apple_iap, [], [
             apple_missing_fields,
             apple_not_configured,
+            apple_root_not_configured,
             apple_invalid_jws,
-            apple_valid_jws_wrong_bundle
+            apple_unsupported_alg,
+            apple_missing_x5c,
+            apple_signature_invalid,
+            apple_chain_validation_failed,
+            apple_valid_jws_wrong_bundle,
+            apple_valid_jws_correct_bundle
         ]},
         {google_iap, [], [
             google_missing_fields, google_not_configured
@@ -36,18 +50,15 @@ init_per_suite(Config) ->
         Config0
     ),
     #{~"session_token" := P1Token} = nova_test:json(R1),
+    Chain = build_test_chain(),
     [
-        {player1_token, P1Token}
+        {player1_token, P1Token},
+        {test_chain, Chain}
         | Config0
     ].
 
 end_per_suite(Config) ->
     Config.
-
-auth(Config) ->
-    {player1_token, Token} = lists:keyfind(player1_token, 1, Config),
-    true = is_binary(Token),
-    [{~"authorization", <<"Bearer ", Token/binary>>}].
 
 %% --- Apple IAP ---
 
@@ -71,11 +82,27 @@ apple_not_configured(Config) ->
         Config
     ),
     ?assertStatus(422, Resp),
-    #{~"error" := ~"apple_iap_not_configured"} = nova_test:json(Resp),
+    Config.
+
+apple_root_not_configured(Config) ->
+    application:set_env(asobi, apple_bundle_id, ~"com.test.app"),
+    application:unset_env(asobi, apple_root_certs),
+    application:unset_env(asobi, apple_root_cert_path),
+    {ok, Resp} = nova_test:post(
+        "/api/v1/iap/apple",
+        #{
+            headers => auth(Config),
+            json => #{~"signed_transaction" => ~"fake.fake.fake"}
+        },
+        Config
+    ),
+    ?assertStatus(422, Resp),
+    #{~"error" := ~"apple_root_cert_not_configured"} = nova_test:json(Resp),
+    cleanup_apple_env(),
     Config.
 
 apple_invalid_jws(Config) ->
-    application:set_env(asobi, apple_bundle_id, ~"com.test.app"),
+    configure_apple(Config, ~"com.test.app"),
     {ok, Resp} = nova_test:post(
         "/api/v1/iap/apple",
         #{
@@ -85,31 +112,129 @@ apple_invalid_jws(Config) ->
         Config
     ),
     ?assertStatus(422, Resp),
-    application:unset_env(asobi, apple_bundle_id),
+    cleanup_apple_env(),
     Config.
 
-apple_valid_jws_wrong_bundle(Config) ->
-    application:set_env(asobi, apple_bundle_id, ~"com.expected.app"),
-    Payload = iolist_to_binary(
-        json:encode(#{
-            ~"bundleId" => ~"com.wrong.app",
-            ~"productId" => ~"test_product",
-            ~"transactionId" => ~"12345"
-        })
-    ),
-    PayloadB64 = base64:encode(Payload, #{mode => urlsafe, padding => false}),
-    FakeJws = iolist_to_binary([~"eyJhbGciOiJSUzI1NiJ9.", PayloadB64, ~".fakesig"]),
+apple_unsupported_alg(Config) ->
+    configure_apple(Config, ~"com.test.app"),
+    Chain = ?config(test_chain, Config),
+    %% Build a JWS with alg=HS256 — must be rejected even if everything
+    %% else looks plausible.
+    Jws = build_jws(Chain, #{~"alg" => ~"HS256"}, #{~"bundleId" => ~"com.test.app"}),
     {ok, Resp} = nova_test:post(
         "/api/v1/iap/apple",
         #{
             headers => auth(Config),
-            json => #{~"signed_transaction" => FakeJws}
+            json => #{~"signed_transaction" => Jws}
+        },
+        Config
+    ),
+    ?assertStatus(422, Resp),
+    #{~"error" := ~"unsupported_alg"} = nova_test:json(Resp),
+    cleanup_apple_env(),
+    Config.
+
+apple_missing_x5c(Config) ->
+    configure_apple(Config, ~"com.test.app"),
+    Chain = ?config(test_chain, Config),
+    %% alg=ES256 but no x5c header.
+    Jws = build_jws(Chain, #{~"alg" => ~"ES256"}, #{~"bundleId" => ~"com.test.app"}),
+    {ok, Resp} = nova_test:post(
+        "/api/v1/iap/apple",
+        #{
+            headers => auth(Config),
+            json => #{~"signed_transaction" => Jws}
+        },
+        Config
+    ),
+    ?assertStatus(422, Resp),
+    #{~"error" := ~"invalid_x5c"} = nova_test:json(Resp),
+    cleanup_apple_env(),
+    Config.
+
+apple_signature_invalid(Config) ->
+    configure_apple(Config, ~"com.test.app"),
+    Chain = ?config(test_chain, Config),
+    %% Build the payload and sign it, then swap the signature for one
+    %% over a *different* payload — verification should fail because the
+    %% signature no longer matches header.payload.
+    Good = build_signed_jws(Chain, #{~"bundleId" => ~"com.test.app"}),
+    Other = build_signed_jws(Chain, #{~"bundleId" => ~"com.test.app", ~"nonce" => ~"x"}),
+    Bad = swap_signature(Good, Other),
+    {ok, Resp} = nova_test:post(
+        "/api/v1/iap/apple",
+        #{
+            headers => auth(Config),
+            json => #{~"signed_transaction" => Bad}
+        },
+        Config
+    ),
+    ?assertStatus(422, Resp),
+    #{~"error" := ~"signature_invalid"} = nova_test:json(Resp),
+    cleanup_apple_env(),
+    Config.
+
+apple_chain_validation_failed(Config) ->
+    application:set_env(asobi, apple_bundle_id, ~"com.test.app"),
+    %% Configure a *different* root cert as the trust anchor — chain
+    %% should fail to validate even though the JWS is internally consistent.
+    Other = build_test_chain(),
+    application:set_env(asobi, apple_root_certs, [maps:get(root_der, Other)]),
+    Chain = ?config(test_chain, Config),
+    Jws = build_signed_jws(Chain, #{~"bundleId" => ~"com.test.app"}),
+    {ok, Resp} = nova_test:post(
+        "/api/v1/iap/apple",
+        #{
+            headers => auth(Config),
+            json => #{~"signed_transaction" => Jws}
+        },
+        Config
+    ),
+    ?assertStatus(422, Resp),
+    #{~"error" := ~"chain_validation_failed"} = nova_test:json(Resp),
+    cleanup_apple_env(),
+    Config.
+
+apple_valid_jws_wrong_bundle(Config) ->
+    configure_apple(Config, ~"com.expected.app"),
+    Chain = ?config(test_chain, Config),
+    %% Signs successfully but bundleId mismatches the configured one.
+    Jws = build_signed_jws(Chain, #{~"bundleId" => ~"com.wrong.app"}),
+    {ok, Resp} = nova_test:post(
+        "/api/v1/iap/apple",
+        #{
+            headers => auth(Config),
+            json => #{~"signed_transaction" => Jws}
         },
         Config
     ),
     ?assertStatus(422, Resp),
     #{~"error" := ~"bundle_id_mismatch"} = nova_test:json(Resp),
-    application:unset_env(asobi, apple_bundle_id),
+    cleanup_apple_env(),
+    Config.
+
+apple_valid_jws_correct_bundle(Config) ->
+    configure_apple(Config, ~"com.test.app"),
+    Chain = ?config(test_chain, Config),
+    Jws = build_signed_jws(Chain, #{
+        ~"bundleId" => ~"com.test.app",
+        ~"productId" => ~"premium_pack",
+        ~"transactionId" => ~"txn-1",
+        ~"quantity" => 1,
+        ~"type" => ~"Consumable"
+    }),
+    {ok, Resp} = nova_test:post(
+        "/api/v1/iap/apple",
+        #{
+            headers => auth(Config),
+            json => #{~"signed_transaction" => Jws}
+        },
+        Config
+    ),
+    ?assertStatus(200, Resp),
+    Body = nova_test:json(Resp),
+    ?assertMatch(#{~"product_id" := ~"premium_pack", ~"valid" := true}, Body),
+    cleanup_apple_env(),
     Config.
 
 %% --- Google IAP ---
@@ -136,3 +261,111 @@ google_not_configured(Config) ->
     ?assertStatus(422, Resp),
     #{~"error" := ~"google_iap_not_configured"} = nova_test:json(Resp),
     Config.
+
+%% --- Helpers ---
+
+auth(Config) ->
+    {player1_token, Token} = lists:keyfind(player1_token, 1, Config),
+    true = is_binary(Token),
+    [{~"authorization", <<"Bearer ", Token/binary>>}].
+
+configure_apple(Config, Bundle) ->
+    application:set_env(asobi, apple_bundle_id, Bundle),
+    Chain = ?config(test_chain, Config),
+    application:set_env(asobi, apple_root_certs, [maps:get(root_der, Chain)]).
+
+cleanup_apple_env() ->
+    application:unset_env(asobi, apple_bundle_id),
+    application:unset_env(asobi, apple_root_certs),
+    application:unset_env(asobi, apple_root_cert_path).
+
+-spec build_test_chain() -> map().
+build_test_chain() ->
+    Opts = #{
+        root => [{key, {namedCurve, secp256r1}}],
+        intermediates => [[{key, {namedCurve, secp256r1}}]],
+        peer => [{key, {namedCurve, secp256r1}}]
+    },
+    TD = pkix_test_data(Opts),
+    KeyDer = key_der(proplists:get_value(key, TD)),
+    LeafKey = public_key:der_decode('ECPrivateKey', KeyDer),
+    LeafDer = as_binary(proplists:get_value(cert, TD)),
+    [RootDer, IntermediateDer | _] = as_list(proplists:get_value(cacerts, TD)),
+    #{
+        leaf_der => LeafDer,
+        leaf_key => LeafKey,
+        intermediate_der => IntermediateDer,
+        root_der => RootDer
+    }.
+
+%% pkix_test_data's spec is too narrow for our (valid) input; cast through
+%% dynamic() so eqwalizer accepts the runtime-correct proplist shape.
+-spec pkix_test_data(dynamic()) -> dynamic().
+pkix_test_data(Opts) ->
+    public_key:pkix_test_data(Opts).
+
+-spec key_der(dynamic()) -> binary().
+key_der({'ECPrivateKey', Der}) when is_binary(Der) -> Der.
+
+-spec as_binary(dynamic()) -> binary().
+as_binary(B) when is_binary(B) -> B.
+
+-spec as_list(dynamic()) -> [binary()].
+as_list(L) when is_list(L) -> L.
+
+%% Build a JWS with explicit header (e.g. wrong alg / no x5c) and
+%% signed payload. Signature is computed over header.payload using the
+%% test chain's leaf private key — so the JWS is byte-perfect except
+%% for whatever header field the caller wants to break.
+build_jws(Chain, Header, Payload) ->
+    HeaderB64 = b64url(json:encode(Header)),
+    PayloadB64 = b64url(json:encode(Payload)),
+    SignInput = <<HeaderB64/binary, ".", PayloadB64/binary>>,
+    LeafKey = maps:get(leaf_key, Chain),
+    DerSig = public_key:sign(SignInput, sha256, LeafKey),
+    RawSig = der_to_raw_ecdsa(DerSig),
+    SigB64 = b64url(RawSig),
+    <<HeaderB64/binary, ".", PayloadB64/binary, ".", SigB64/binary>>.
+
+%% Standard happy-path JWS (alg=ES256, x5c=[leaf, int, root]).
+build_signed_jws(Chain, Payload) ->
+    LeafB64 = base64:encode(maps:get(leaf_der, Chain), #{padding => true}),
+    IntB64 = base64:encode(maps:get(intermediate_der, Chain), #{padding => true}),
+    RootB64 = base64:encode(maps:get(root_der, Chain), #{padding => true}),
+    Header = #{
+        ~"alg" => ~"ES256",
+        ~"x5c" => [LeafB64, IntB64, RootB64]
+    },
+    build_jws(Chain, Header, Payload).
+
+%% Replace a JWS's signature with one signed over a *different*
+%% header.payload. Both inputs were produced by `build_signed_jws/2`,
+%% so the result is well-formed but its signature won't verify against
+%% the new payload.
+swap_signature(Target, Donor) ->
+    [TargetHeader, TargetPayload, _TargetSig] = binary:split(Target, ~".", [global]),
+    [_DonorHeader, _DonorPayload, DonorSig] = binary:split(Donor, ~".", [global]),
+    <<TargetHeader/binary, ".", TargetPayload/binary, ".", DonorSig/binary>>.
+
+b64url(IoData) when is_list(IoData); is_binary(IoData) ->
+    base64:encode(iolist_to_binary(IoData), #{mode => urlsafe, padding => false}).
+
+-spec der_to_raw_ecdsa(binary()) -> binary().
+der_to_raw_ecdsa(Der) ->
+    {'ECDSA-Sig-Value', R, S} = public_key:der_decode('ECDSA-Sig-Value', Der),
+    Rb = pad_left(binary:encode_unsigned(as_int(R)), 32),
+    Sb = pad_left(binary:encode_unsigned(as_int(S)), 32),
+    <<Rb/binary, Sb/binary>>.
+
+-spec as_int(dynamic()) -> non_neg_integer().
+as_int(I) when is_integer(I), I >= 0 -> I.
+
+pad_left(Bin, Size) when byte_size(Bin) =:= Size -> Bin;
+pad_left(Bin, Size) when byte_size(Bin) < Size ->
+    Pad = binary:copy(<<0>>, Size - byte_size(Bin)),
+    <<Pad/binary, Bin/binary>>;
+pad_left(Bin, Size) when byte_size(Bin) > Size ->
+    %% Trim leading zeros (decode_unsigned strips them, encode_unsigned
+    %% can sometimes produce one extra byte for top-bit-set values).
+    Excess = byte_size(Bin) - Size,
+    binary:part(Bin, Excess, Size).

--- a/test/asobi_leaderboard_api_SUITE.erl
+++ b/test/asobi_leaderboard_api_SUITE.erl
@@ -5,6 +5,7 @@
 -export([all/0, groups/0, init_per_suite/1, end_per_suite/1]).
 -export([
     submit_score/1,
+    submit_score_disabled/1,
     get_top/1,
     get_top_with_limit/1,
     get_around/1,
@@ -16,7 +17,12 @@ all() -> [{group, leaderboard_api}].
 groups() ->
     [
         {leaderboard_api, [sequence], [
-            get_top_empty, submit_score, get_top, get_top_with_limit, get_around
+            get_top_empty,
+            submit_score_disabled,
+            submit_score,
+            get_top,
+            get_top_with_limit,
+            get_around
         ]}
     ].
 
@@ -41,9 +47,16 @@ init_per_suite(Config) ->
     BoardId = iolist_to_binary([
         ~"test_board_", integer_to_binary(erlang:unique_integer([positive]))
     ]),
+    DisabledBoardId = iolist_to_binary([
+        ~"test_board_disabled_", integer_to_binary(erlang:unique_integer([positive]))
+    ]),
     {ok, _} = asobi_leaderboard_sup:start_board(BoardId),
+    %% Whitelist this board for client submits — submit_score_disabled
+    %% deliberately uses an un-whitelisted board to confirm the gate.
+    application:set_env(asobi, leaderboard_client_submit, [BoardId]),
     [
         {board_id, BoardId},
+        {disabled_board_id, DisabledBoardId},
         {player1_id, P1Id},
         {player1_token, P1Token},
         {players, Players}
@@ -51,6 +64,7 @@ init_per_suite(Config) ->
     ].
 
 end_per_suite(Config) ->
+    application:unset_env(asobi, leaderboard_client_submit),
     Config.
 
 auth(Token) when is_binary(Token) ->
@@ -68,6 +82,22 @@ get_top_empty(Config) ->
     ),
     ?assertStatus(200, Resp),
     ?assertJson(#{~"entries" := []}, Resp),
+    Config.
+
+submit_score_disabled(Config) ->
+    %% A board not on the whitelist must reject client submits with 403,
+    %% even from an authenticated player.
+    {disabled_board_id, BoardId} = lists:keyfind(disabled_board_id, 1, Config),
+    {player1_token, Token} = lists:keyfind(player1_token, 1, Config),
+    true = is_binary(BoardId),
+    true = is_binary(Token),
+    {ok, Resp} = nova_test:post(
+        "/api/v1/leaderboards/" ++ binary_to_list(BoardId),
+        #{headers => auth(Token), json => #{~"score" => 9001}},
+        Config
+    ),
+    ?assertStatus(403, Resp),
+    ?assertJson(#{~"error" := ~"client_submit_disabled"}, Resp),
     Config.
 
 submit_score(Config) ->

--- a/test/asobi_storage_SUITE.erl
+++ b/test/asobi_storage_SUITE.erl
@@ -14,6 +14,7 @@
     put_storage/1,
     get_storage/1,
     list_storage/1,
+    list_storage_filters_owner_perm/1,
     delete_storage/1,
     storage_owner_permission/1
 ]).
@@ -26,7 +27,12 @@ groups() ->
             list_saves_empty, create_save, get_save, update_save, save_version_conflict
         ]},
         {generic_storage, [sequence], [
-            put_storage, get_storage, list_storage, delete_storage, storage_owner_permission
+            put_storage,
+            get_storage,
+            list_storage,
+            list_storage_filters_owner_perm,
+            delete_storage,
+            storage_owner_permission
         ]}
     ].
 
@@ -165,6 +171,54 @@ list_storage(Config) ->
     true = is_list(Objects),
     ?assert(length(Objects) >= 1),
     Config.
+
+%% Regression for F-4: list_storage must filter by read_perm. Player1's
+%% owner-restricted object must be invisible to player2 even when listing
+%% the same collection.
+list_storage_filters_owner_perm(Config) ->
+    %% Unique collection/key per run so the asserts aren't polluted by
+    %% leftover rows from previous test runs (the storage table persists
+    %% across runs).
+    Suffix = integer_to_binary(erlang:unique_integer([positive])),
+    Col = <<"private_listing_", Suffix/binary>>,
+    Key = <<"p1_secret_", Suffix/binary>>,
+    {ok, PutResp} = nova_test:put(
+        binary_to_list(<<"/api/v1/storage/", Col/binary, "/", Key/binary>>),
+        #{
+            headers => auth(Config, player1),
+            json => #{~"value" => #{~"data" => ~"player1_only"}}
+        },
+        Config
+    ),
+    ?assertStatus(200, PutResp),
+    {ok, P1Resp} = nova_test:get(
+        binary_to_list(<<"/api/v1/storage/", Col/binary>>),
+        #{headers => auth(Config, player1)},
+        Config
+    ),
+    ?assertStatus(200, P1Resp),
+    #{~"objects" := P1ObjectsRaw} = nova_test:json(P1Resp),
+    P1Objects = ensure_list(P1ObjectsRaw),
+    ?assert(lists:any(fun(O) -> object_has_key(O, Key) end, P1Objects)),
+    {ok, P2Resp} = nova_test:get(
+        binary_to_list(<<"/api/v1/storage/", Col/binary>>),
+        #{headers => auth(Config, player2)},
+        Config
+    ),
+    ?assertStatus(200, P2Resp),
+    #{~"objects" := P2ObjectsRaw} = nova_test:json(P2Resp),
+    P2Objects = ensure_list(P2ObjectsRaw),
+    %% Either empty list or no objects bearing the key — but never the
+    %% private one.
+    ?assertNot(lists:any(fun(O) -> object_has_key(O, Key) end, P2Objects)),
+    Config.
+
+-spec ensure_list(dynamic()) -> [dynamic()].
+ensure_list(L) when is_list(L) -> L.
+
+-spec object_has_key(dynamic(), binary()) -> boolean().
+object_has_key(#{~"key" := K}, K) -> true;
+object_has_key(_, _) -> false.
 
 delete_storage(Config) ->
     {ok, Resp} = nova_test:delete(


### PR DESCRIPTION
## Summary
Closes the four Critical findings from the 2026-04-30 audit (`/tmp/asobi_security_audit_2026-04-30.md`):

- **F-1** `asobi_iap` — Apple StoreKit JWS signatures are now actually verified. Fail-closed when `apple_root_certs` / `apple_root_cert_path` is unconfigured. Reject anything but ES256, decode `x5c`, validate the leaf+intermediate chain against the configured Apple root via `public_key:pkix_path_validation/3`, then verify the signature with `public_key:verify/4`. Bundle id is only checked once the JWS is authenticated.
- **F-2** `asobi_player_controller` — Replace deny-list `sanitize/1` with a positive whitelist; `hashed_password` can no longer reach a client response.
- **F-3** `asobi_leaderboard` — Client `POST /leaderboards/:id` returns 403 unless the board is whitelisted via `leaderboard_client_submit` (`all` or list of board ids). Read paths no longer spawn a board on demand, and `submit/3` enforces a configurable `leaderboard_max_boards` cap (default 1000).
- **F-4** `asobi_storage` — `GET /storage/:collection` now filters by `read_perm = 'public' OR (read_perm = 'owner' AND player_id = self)`.

## Test plan
- [x] `rebar3 fmt --check` clean
- [x] `rebar3 xref` clean
- [x] `rebar3 dialyzer` clean
- [x] `~/bin/elp eqwalize-all` — NO ERRORS
- [x] `~/bin/elp lint` — at parity with main
- [x] `rebar3 eunit` — 247/247 pass
- [x] `rebar3 ct` — 219/219 pass (12 new IAP cases including positive ES256 path via `public_key:pkix_test_data/1`)

## Operator notes
- IAP integrators must now configure `apple_root_certs` (list of DER/PEM binaries) **or** `apple_root_cert_path` (filesystem path to Apple Root CA G3) before `/api/v1/iap/apple` will accept any JWS — previously this endpoint silently returned `valid: true` for any forged receipt.
- Games that relied on `POST /api/v1/leaderboards/:id` from the client must now opt the board id into `leaderboard_client_submit` (or set the env to `all`); server-side game logic should call `asobi_leaderboard_server:submit/3` directly.

Follow-ups (separate PRs): 9 Highs, 11 Mediums, 6 Lows, 4 Info from the same audit.