### PR TITLE
fix(security): address Highs/Mediums/Lows/Info audit findings (F-5..F-33)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,4 +7,5 @@ ebin/
 log/
 .rebar3/
 rebar3.crashdump
+erl_crash.dump
 doc/

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -43,3 +43,19 @@ Either of these channels work:
 
 We credit security researchers who report responsibly. Past advisories:
 [Security advisories](https://github.com/widgrensit/asobi/security/advisories).
+
+## Security architecture
+
+Engineering documentation about how the runtime defends itself, and what
+operators are responsible for, is published as part of the project
+guides:
+
+- [Threat model](guides/security-threat-model.md) — what asobi treats
+  as trusted vs. untrusted, the single-node design constraint, BEAM
+  distribution and public-ETS assumptions.
+- [Authentication & rate limiting](guides/security-auth.md) — Apple
+  StoreKit 2 JWS verification chain, per-route rate-limit groups, the
+  brute-force surface, and the integration test suite that pins it.
+- [Known limitations](guides/security-known-limitations.md) — the
+  resource-exhaustion gaps the runtime does **not** close (mostly
+  operator-facing), and the rationale for each.

--- a/config/dev_sys.config.src
+++ b/config/dev_sys.config.src
@@ -34,7 +34,9 @@
                 allow_origins => ~"*"
             }},
             {pre_request, nova_correlation_plugin, #{}},
-            {pre_request, asobi_rate_limit_plugin, #{limiter => asobi_api_limiter}},
+            %% F-19: leave limiter unset so the plugin selects per-path
+            %% (auth/iap/api). See asobi_rate_limit_plugin:select_limiter/1.
+            {pre_request, asobi_rate_limit_plugin, #{}},
             {post_request, asobi_security_headers_plugin, #{}}
         ]}
     ]},
@@ -61,9 +63,15 @@
         }},
         {rate_limits, #{
             %% Per-group rate limits: #{limit => requests, window => milliseconds}
-            %% auth => #{limit => 300, window => 1000},
-            %% iap => #{limit => 300, window => 1000},
-            %% api => #{limit => 300, window => 1000}
+            %%
+            %% In dev/test the per-IP brute-force pressure is absent and CT
+            %% fires a burst of register/login calls against 127.0.0.1. The
+            %% production-default `auth` cap of 5/sec will fail these
+            %% suites; loosen here. Production callers should override
+            %% these via OS env / prod sys config.
+            auth => #{limit => 1000, window => 1000},
+            iap => #{limit => 1000, window => 1000},
+            api => #{limit => 1000, window => 1000}
         }},
         {matchmaker, #{
             tick_interval => 1000,

--- a/config/prod_sys.config.src
+++ b/config/prod_sys.config.src
@@ -31,7 +31,9 @@
                 allow_origins => <<"${ASOBI_CORS_ORIGINS}">>
             }},
             {pre_request, nova_correlation_plugin, #{}},
-            {pre_request, asobi_rate_limit_plugin, #{limiter => asobi_api_limiter}},
+            %% F-19: leave limiter unset so the plugin selects per-path
+            %% (auth/iap/api). See asobi_rate_limit_plugin:select_limiter/1.
+            {pre_request, asobi_rate_limit_plugin, #{}},
             {post_request, asobi_security_headers_plugin, #{}}
         ]}
     ]},

--- a/config/vm.args.src
+++ b/config/vm.args.src
@@ -2,6 +2,23 @@
 
 -setcookie ${ERLANG_COOKIE}
 
+## F-30: tighten Erlang distribution exposure.
+##
+## asobi is single-node by design — one VM owns the world processes and
+## ETS tables. The distribution port is therefore unnecessary in
+## production and is a serious lateral-movement risk if the cookie
+## leaks. For single-node deployments uncomment the line below to bind
+## EPMD/dist to localhost only:
+##
+##     -kernel inet_dist_use_interface "{127,0,0,1}"
+##
+## For clustered deploys (`asobi_cluster.erl`) constrain the dist port
+## range and enable TLS for distribution:
+##
+##     -kernel inet_dist_listen_min 9100 inet_dist_listen_max 9105
+##     -proto_dist inet_tls
+##     -ssl_dist_optfile /etc/asobi/ssl_dist.config
+
 +K true
 +A30
 

--- a/guides/security-auth.md
+++ b/guides/security-auth.md
@@ -1,0 +1,126 @@
+# Authentication & rate limiting
+
+This guide documents how asobi authenticates clients, validates
+purchases, and bounds the brute-force surface. For the higher-level
+trust assumptions see [Threat model](security-threat-model.md).
+
+## Session bearer tokens
+
+Every authenticated route is gated by `asobi_auth_plugin:verify/1`,
+which expects an `Authorization: Bearer <token>` header. Tokens are
+issued by `nova_auth_session:generate_session_token/2` after a
+successful `register/1`, `login/1`, `refresh/1`, or OAuth flow. The
+plugin attaches `auth_data => #{player_id => Id, ...}` to the request
+map — controllers should pattern-match on that rather than parsing the
+header themselves.
+
+Tokens are stored in `asobi_player_token` and revocable via
+`nova_auth_session:delete_session_token/2`.
+
+## Apple StoreKit 2 JWS verification
+
+`asobi_iap:verify_apple/1` parses an Apple-signed JWS receipt and
+verifies it end-to-end:
+
+1. Header `alg` is required to be `ES256`. Other algorithms are
+   rejected.
+2. The `x5c` chain is decoded (DER-encoded certificates, base64'd in
+   JWS order: leaf → intermediate → root).
+3. The chain is validated against a configured Apple Root CA via
+   `public_key:pkix_path_validation/3`. Operators ship the root in
+   `priv/apple_root_ca.pem` (or override the path via
+   `application:get_env(asobi, apple_root_ca_path, ...)`).
+4. The signature on `<header>.<payload>` is verified with the leaf
+   cert's public key. A bit-flipped signature, swapped signature, or
+   any chain mismatch fails the verification.
+
+Failures return `{error, Reason}` with a sanitised reason atom. The
+controller (`asobi_iap_controller`) maps them to 400/401 responses
+without leaking JWS internals to the client.
+
+## Steam ticket validation
+
+`asobi_steam:validate_ticket/1` validates a hex-encoded Steam session
+ticket against the Steam Web API:
+
+1. The ticket character class is enforced (`[0-9a-fA-F]+`, max 4096
+   bytes). Anything else is rejected before any HTTP call.
+2. All dynamic URL components (key, app id, ticket, steam id) are
+   passed through `uri_string:quote/1` so an `&` or `=` in user input
+   cannot inject query parameters into the Steam call.
+
+The ticket validator is invoked from `asobi_oauth_controller` for
+`provider = "steam"` flows.
+
+## Per-route rate limits
+
+`asobi_rate_limit_plugin` is wired as a `pre_request` plugin in
+`config/{dev,prod}_sys.config.src`. It selects a Seki limiter group
+based on the request path:
+
+| Path prefix | Limiter | Default limit (req/sec/IP) |
+|-------------|---------|----------------------------|
+| `/api/v1/auth/*` | `asobi_auth_limiter` | 5 |
+| `/api/v1/iap/*` | `asobi_iap_limiter` | 10 |
+| everything else | `asobi_api_limiter` | 300 |
+
+The auth limiter is the brute-force gate: a 5/sec cap plus the bcrypt
+cost on `nova_auth_accounts:authenticate/3` makes online password
+guessing infeasible at internet scale. Operators can override the
+limits via the `asobi, rate_limits` env in their sys config:
+
+```erlang
+{rate_limits, #{
+    auth => #{limit => 10, window => 1000},
+    iap  => #{limit => 20, window => 1000},
+    api  => #{limit => 600, window => 1000}
+}}
+```
+
+The dev / test sys config bumps all three to 1000 because CT bursts
+register/login calls against `127.0.0.1` and the production-default
+auth cap would fail the suites.
+
+## DDoS / DoS surface notes
+
+These are the deliberate per-call upper bounds in the runtime that
+exist purely to bound the cost of a single hostile request:
+
+- **Cloud saves** (`/saves/:slot`) — body capped at 256 KB; per-player
+  slot count capped at 10.
+- **Storage** (`/storage/:collection/:key`) — `read_perm` /
+  `write_perm` whitelisted to `["public", "owner"]`; arbitrary strings
+  rejected with 400.
+- **Inventory consume** — quantity range `[1, 1_000_000]`.
+- **Leaderboard** `top` / `around` — `?limit` clamped to 100, `?range`
+  to 50 (mitigates an O(N) ETS scan attack).
+- **Chat history** — `?limit` clamped to `[1, 200]`; channel
+  membership is enforced (DM participants, world joiners, group
+  members).
+- **DM send** — content capped at 2000 bytes; non-binary or empty
+  content rejected.
+- **Group chat / WS `chat.join`** — channel id namespaced
+  (`dm:`, `world:`, `zone:`, `prox:`, `room:`); per-connection cap of
+  32 simultaneously joined channels; idle channels stop after 60s
+  with no live members.
+- **Per-player world creation** — capped via pg group; default 5
+  worlds per player, 1000 globally. Tunable via `world_max_per_player`
+  / `world_max` env.
+- **Matchmaker** — party entries that don't match the requester are
+  silently dropped; ticket reads / cancellations require ownership.
+
+## Test coverage
+
+Regressions for the items above live under `test/`:
+
+- `asobi_iap_SUITE.erl` — Apple JWS happy path + 14 negative cases
+  (bad alg, missing x5c, swapped signature, expired cert, untrusted
+  root, …).
+- `asobi_world_lobby_SUITE.erl` — F-9 per-player + global world caps.
+- `asobi_matchmaker_api_SUITE.erl` — F-7/F-8 party consent + ticket
+  ownership.
+- `asobi_social_api_SUITE.erl` — F-10 chat history membership (DM,
+  group, non-member denial).
+- `asobi_dm_tests.erl` — F-11 length cap, empty-content rejection.
+
+Run with `rebar3 ct,eunit`.

--- a/guides/security-known-limitations.md
+++ b/guides/security-known-limitations.md
@@ -1,0 +1,69 @@
+# Known limitations
+
+The asobi runtime closes a deliberate set of attack surfaces
+(documented in [Threat model](security-threat-model.md) and
+[Authentication & rate limiting](security-auth.md)). The list below
+is the complement: properties the runtime does **not** enforce, and
+where the responsibility lies.
+
+## Game module crashes can take the lobby down
+
+`asobi_match_server` calls game-module callbacks (`Mod:join/2`,
+`Mod:tick/1`, `Mod:handle_input/3`, phase / vote callbacks) inline and
+**without** wrapping them in `try/catch`. This is intentional:
+
+- asobi is single-tenant by design — one VM owns the world processes
+  and there is no other game module to fail over to.
+- A crash is treated as a **bug** worth surfacing (transient restart,
+  intensity 10 / period 60). After 10 crashes in 60s the entire
+  `asobi_match_sup` falls over, intentionally taking the lobby with it
+  so an obviously broken game cannot keep churning silently.
+- For multi-tenant or sandboxed scenarios, layer `asobi_lua` or your
+  own sandbox on top — that is the place to put callback hardening.
+
+If you need callback isolation in your custom game module, run the
+hot-path logic in a worker process so a crash is contained.
+
+## Erlang distribution is enabled by default
+
+`config/vm.args.src` sets `-name asobi@${ASOBI_NODE_HOST}` and
+`-setcookie ${ERLANG_COOKIE}`. EPMD binds to `0.0.0.0:4369` and dist
+ports are unbounded; the cookie is the only protection. If the cookie
+leaks (env var, container snapshot, k8s secret), anyone with network
+reach to the dist port has full code-execution.
+
+For single-node deploys, uncomment the localhost-bind line in
+`vm.args.src`. For clusters, configure `inet_dist_listen_min/max` and
+TLS for distribution. See [Threat model](security-threat-model.md).
+
+## Public ETS tables are reachable from any in-VM code
+
+`asobi_world_state`, `asobi_player_worlds`, `asobi_match_state`,
+`asobi_chat_registry`, `asobi_zone_mgr` are all `public` named ETS
+tables. Plugins, custom game modules, and NIFs in the same BEAM can
+read or mutate them. asobi treats this as acceptable because all in-VM
+code is trusted by design (see [Threat model](security-threat-model.md)).
+
+Any Lua sandbox layered on top (`asobi_lua`) MUST keep its sandbox out
+of these tables.
+
+## UUIDv7 ids leak creation timestamp
+
+`asobi_id:generate/0` produces UUIDv7. The high 48 bits are a
+millisecond timestamp. `player.id` lives forever and reveals account
+creation time when exposed. For unguessable, non-correlatable
+identifiers (auth tokens, invite codes, session secrets) use
+`crypto:strong_rand_bytes/1` — never `asobi_id:generate/0`.
+
+## Compute / memory bounds are best-effort
+
+The runtime caps individual *requests* (limits, body sizes, quantities;
+see [Authentication & rate limiting](security-auth.md)). It does **not**
+enforce a per-process reduction count, heap cap, or scheduler quota.
+Enforcement of those happens at the OS / container layer:
+
+- Production deployments should run with cgroup memory + CPU limits.
+- Set `+P` (process limit) and `+Q` (port limit) in `vm.args` to
+  bound BEAM-level resources.
+- A long-running plugin or game module that allocates without bound
+  will pressure the OS allocator before any in-VM mechanism notices.

--- a/guides/security-threat-model.md
+++ b/guides/security-threat-model.md
@@ -1,0 +1,79 @@
+# Threat model
+
+asobi is a **single-tenant, single-node** game backend library by
+design. The trust assumptions and architectural constraints below
+follow from that.
+
+## Trusted vs. untrusted code
+
+| Component | Status | Notes |
+|-----------|--------|-------|
+| asobi library code | trusted | this repo |
+| Loaded game module (`Mod:tick/1`, `Mod:join/2`, …) | **trusted** | callbacks run inline in the match gen_server. A crash in a callback restarts the match (transient + intensity 10) and can take the lobby down. |
+| Loaded NIFs | trusted | NIFs run in-VM; a misbehaving NIF crashes the BEAM. |
+| Loaded plugins | trusted | plugins observe / mutate every request and have full access to public ETS. |
+| Lua scripts (via `asobi_lua` runtime) | sandboxed | see `asobi_lua` SECURITY.md. The Lua sandbox sits *on top* of the asobi-side trust boundary; it is the place where untrusted-script hardening belongs. |
+| HTTP request bodies / WS payloads | untrusted | input validation lives in controllers / `asobi_ws_handler`. |
+| Bearer tokens, OAuth claims, IAP receipts | untrusted | verified via `asobi_auth_plugin`, `asobi_oauth_controller`, `asobi_iap`. |
+
+## Single-node BEAM distribution
+
+`config/vm.args.src` boots with `-name` and `-setcookie`. EPMD binds to
+`0.0.0.0:4369` and the dist port range is unbounded. The cookie is the
+only protection.
+
+For single-node deploys (the default), uncomment the localhost-bind
+line in `vm.args.src`:
+
+```
+-kernel inet_dist_use_interface "{127,0,0,1}"
+```
+
+For clustered deploys via `asobi_cluster.erl` (k8s DNS discovery),
+constrain the dist port range and enable TLS for distribution:
+
+```
+-kernel inet_dist_listen_min 9100 inet_dist_listen_max 9105
+-proto_dist inet_tls
+-ssl_dist_optfile /etc/asobi/ssl_dist.config
+```
+
+## Public ETS tables
+
+These named ETS tables are `public` and hold live game state:
+
+- `asobi_world_state` (`asobi_world_sup`)
+- `asobi_player_worlds` (`asobi_world_sup`)
+- `asobi_match_state` (`asobi_match_sup`)
+- `asobi_chat_registry` (`asobi_chat_channel`)
+- `asobi_zone_mgr` (`asobi_zone_manager`)
+
+Anything in the same BEAM (game callbacks, plugins) can read, mutate,
+or delete entries. asobi treats this as acceptable because all in-VM
+code is trusted (above). Any sandboxed runtime layered on top
+(`asobi_lua`) MUST keep its sandbox out of these tables — Luerl is
+not given access to ETS.
+
+## UUIDv7 and timestamp leakage
+
+`asobi_id:generate/0` produces UUIDv7 ids that embed a millisecond
+timestamp in the high 48 bits. Match ids, world ids, ticket ids, and
+`player.id` all use this generator. `player.id` is the long-lived
+case: the timestamp inside it reveals account-creation time, which is
+acceptable for a game backend but worth knowing if you build features
+on top.
+
+If you ever need an unguessable, non-correlatable id (auth tokens,
+invite codes, etc.) generate them via `crypto:strong_rand_bytes/1`
+rather than `asobi_id:generate/0`.
+
+## What the supervisor will tolerate
+
+`asobi_match_sup` runs each match gen_server with `transient` restart
+and `intensity 10 / period 60`. After 10 crashes in 60s the entire
+match supervisor falls over, intentionally taking the lobby with it so
+an obviously broken game module cannot keep churning silently.
+
+`asobi_world_lobby_server` serializes `find_or_create/1` to close a
+documented TOCTOU race (two concurrent `find_or_create` for the same
+mode no longer spawn duplicate worlds).

--- a/rebar.config
+++ b/rebar.config
@@ -100,7 +100,11 @@
         <<"guides/voting.md">>,
         <<"guides/world-server.md">>,
         <<"guides/large-worlds.md">>,
-        <<"guides/performance-tuning.md">>
+        <<"guides/performance-tuning.md">>,
+        <<"guides/security-threat-model.md">>,
+        <<"guides/security-auth.md">>,
+        <<"guides/security-known-limitations.md">>,
+        <<"SECURITY.md">>
     ]},
     {groups_for_extras, [
         {<<"Getting Started">>, [
@@ -122,6 +126,12 @@
             <<"guides/world-server.md">>,
             <<"guides/large-worlds.md">>,
             <<"guides/performance-tuning.md">>
+        ]},
+        {<<"Security">>, [
+            <<"guides/security-threat-model.md">>,
+            <<"guides/security-auth.md">>,
+            <<"guides/security-known-limitations.md">>,
+            <<"SECURITY.md">>
         ]},
         {<<"Reference">>, [
             <<"docs/ARCHITECTURE.md">>

--- a/src/asobi_id.erl
+++ b/src/asobi_id.erl
@@ -6,6 +6,15 @@ Generates UUIDv7 (RFC 9562) identifiers via `jhn_uuid`. UUIDv7 embeds a
 millisecond timestamp in the high 48 bits, giving time-ordered IDs that
 improve PostgreSQL B-tree index locality, reduce WAL writes, and enable
 native time-range queries on primary keys.
+
+**Privacy note (F-31)**: the embedded timestamp leaks the creation
+time of any id we expose. Match ids, world ids, ticket ids and similar
+ephemeral resources are an accepted trade-off, but `player.id` —
+which uses the same generator and persists for life — also reveals
+account-creation time. Treat the trade-off as acceptable for this
+codebase; if a future requirement needs unguessable, non-correlatable
+ids (e.g. for tokens, invite codes, etc.) generate them via
+`crypto:strong_rand_bytes/1` rather than this function.
 """.
 
 -export([generate/0]).

--- a/src/asobi_qs.erl
+++ b/src/asobi_qs.erl
@@ -1,0 +1,40 @@
+-module(asobi_qs).
+-moduledoc """
+Query-string parsing helpers shared across controllers.
+
+The previous per-controller `qs_integer/3` helpers called
+`binary_to_integer/1` directly; bad input (`?limit=abc`) raised `badarg`,
+Cowboy's default error handler returned 500, and an attacker could
+flood the error logs.
+
+`integer/3` returns the default on parse failure. `integer/5` additionally
+clamps to `[Min, Max]` so a malicious `?limit=10000000` cannot pull
+megabytes of rows. F-15 / F-21.
+""".
+
+-export([integer/3, integer/5]).
+
+-spec integer(binary(), proplists:proplist(), integer()) -> integer().
+integer(Key, Params, Default) when is_binary(Key), is_integer(Default) ->
+    case proplists:get_value(Key, Params) of
+        V when is_binary(V) ->
+            try binary_to_integer(V) of
+                N when is_integer(N) -> N
+            catch
+                _:_ -> Default
+            end;
+        _ ->
+            Default
+    end.
+
+-spec integer(binary(), proplists:proplist(), integer(), integer(), integer()) -> integer().
+integer(Key, Params, Default, Min, Max) when
+    is_integer(Default), is_integer(Min), is_integer(Max), Min =< Max
+->
+    N0 = integer(Key, Params, Default),
+    clamp(N0, Min, Max).
+
+-spec clamp(integer(), integer(), integer()) -> integer().
+clamp(N, Min, _Max) when N < Min -> Min;
+clamp(N, _Min, Max) when N > Max -> Max;
+clamp(N, _Min, _Max) -> N.

--- a/src/asobi_sup.erl
+++ b/src/asobi_sup.erl
@@ -107,9 +107,13 @@ rate_limit_spec() ->
     }.
 
 register_limiters() ->
+    %% F-19: auth and iap routes get tighter per-IP / per-token limits.
+    %% Brute-force resistance: 5 auth requests/sec was the historical
+    %% setting and is reasonable for honest UX; iap is per-purchase so
+    %% 10/sec is plenty. The general-purpose api limiter stays at 300.
     Defaults = #{
-        auth => #{algorithm => sliding_window, limit => 300, window => 1000},
-        iap => #{algorithm => sliding_window, limit => 300, window => 1000},
+        auth => #{algorithm => sliding_window, limit => 5, window => 1000},
+        iap => #{algorithm => sliding_window, limit => 10, window => 1000},
         api => #{algorithm => sliding_window, limit => 300, window => 1000}
     },
     Configured =

--- a/src/auth/asobi_steam.erl
+++ b/src/auth/asobi_steam.erl
@@ -9,27 +9,60 @@
 %% The game client obtains a ticket via ISteamUser::GetAuthSessionTicket
 %% and sends the hex-encoded ticket to this endpoint.
 -spec validate_ticket(binary()) -> {ok, map()} | {error, binary()}.
-validate_ticket(Ticket) ->
-    case steam_api_key() of
-        undefined ->
-            {error, ~"steam_not_configured"};
-        ApiKey ->
-            AppId = steam_app_id(),
-            do_validate_ticket(ApiKey, AppId, Ticket)
-    end.
+validate_ticket(Ticket) when is_binary(Ticket) ->
+    case is_hex_ticket(Ticket) of
+        false ->
+            {error, ~"invalid_ticket_format"};
+        true ->
+            case steam_api_key() of
+                undefined ->
+                    {error, ~"steam_not_configured"};
+                ApiKey ->
+                    AppId = steam_app_id(),
+                    do_validate_ticket(ApiKey, AppId, Ticket)
+            end
+    end;
+validate_ticket(_) ->
+    {error, ~"invalid_ticket_format"}.
 
 %% --- Internal ---
 
+%% F-18: tickets are documented as hex-encoded by Valve. Reject anything
+%% else early so the ticket cannot be used to inject query parameters
+%% even if downstream URL-encoding regresses.
+-spec is_hex_ticket(binary()) -> boolean().
+is_hex_ticket(<<>>) ->
+    false;
+is_hex_ticket(Bin) when byte_size(Bin) > 4096 ->
+    false;
+is_hex_ticket(Bin) ->
+    is_hex_chars(Bin).
+
+is_hex_chars(<<>>) ->
+    true;
+is_hex_chars(<<C, Rest/binary>>) when
+    (C >= $0 andalso C =< $9) orelse
+        (C >= $a andalso C =< $f) orelse
+        (C >= $A andalso C =< $F)
+->
+    is_hex_chars(Rest);
+is_hex_chars(_) ->
+    false.
+
 -spec do_validate_ticket(binary(), binary(), binary()) -> {ok, map()} | {error, binary()}.
 do_validate_ticket(ApiKey, AppId, Ticket) ->
+    %% F-18: defense in depth — even though we already validated the
+    %% ticket character class above, URL-encode every dynamic component
+    %% so an accidental rule loosening can't be exploited to inject
+    %% additional query parameters into the Steam request.
     Url = iolist_to_binary([
         ?STEAM_API_URL,
         ~"?key=",
-        ApiKey,
+        url_encode(ApiKey),
         ~"&appid=",
-        AppId,
+        url_encode(AppId),
         ~"&ticket=",
-        Ticket
+        url_encode(Ticket)
     ]),
     case
         httpc:request(get, {binary_to_list(Url), []}, [{timeout, 10000}], [{body_format, binary}])
@@ -82,9 +115,9 @@ fetch_player_summary(SteamId) ->
             Url = iolist_to_binary([
                 ?STEAM_PLAYER_URL,
                 ~"?key=",
-                ApiKey,
+                url_encode(ApiKey),
                 ~"&steamids=",
-                SteamId
+                url_encode(SteamId)
             ]),
             case
                 httpc:request(
@@ -116,3 +149,7 @@ steam_app_id() ->
         V when is_binary(V) -> V;
         _ -> ~"0"
     end.
+
+-spec url_encode(binary()) -> binary().
+url_encode(Bin) when is_binary(Bin) ->
+    iolist_to_binary(uri_string:quote(Bin)).

--- a/src/controllers/asobi_auth_controller.erl
+++ b/src/controllers/asobi_auth_controller.erl
@@ -3,7 +3,9 @@
 -export([register/1, login/1, refresh/1]).
 
 -spec register(cowboy_req:req()) -> {json, map()} | {json, integer(), map(), map()}.
-register(#{json := #{~"username" := Username, ~"password" := Password} = Params} = _Req) ->
+register(
+    #{json := #{~"username" := Username, ~"password" := Password} = Params} = _Req
+) when is_binary(Username), is_binary(Password) ->
     RegParams = #{
         username => Username,
         password => Password,
@@ -67,5 +69,17 @@ refresh(_Req) ->
 -spec init_player_stats(binary()) -> ok.
 init_player_stats(PlayerId) ->
     CS = kura_changeset:cast(asobi_player_stats, #{}, #{player_id => PlayerId}, [player_id]),
-    _ = asobi_repo:insert(CS),
-    ok.
+    %% F-25: previously errors were swallowed silently which left players
+    %% registered without a stats row. Log so we notice the regression
+    %% without blocking the registration flow.
+    case asobi_repo:insert(CS) of
+        {ok, _} ->
+            ok;
+        {error, Reason} ->
+            logger:warning(#{
+                msg => ~"player_stats_init_failed",
+                player_id => PlayerId,
+                reason => Reason
+            }),
+            ok
+    end.

--- a/src/controllers/asobi_chat_controller.erl
+++ b/src/controllers/asobi_chat_controller.erl
@@ -2,24 +2,105 @@
 
 -export([history/1]).
 
--spec history(cowboy_req:req()) -> {json, map()}.
-history(#{bindings := #{~"channel_id" := ChannelId}, qs := Qs} = _Req) when
-    is_binary(ChannelId), is_binary(Qs)
-->
-    Params = cow_qs:parse_qs(Qs),
-    Limit = qs_integer(~"limit", Params, 50),
-    Q = kura_query:limit(
-        kura_query:order_by(
-            kura_query:where(kura_query:from(asobi_chat_message), {channel_id, ChannelId}),
-            [{sent_at, desc}]
-        ),
-        Limit
-    ),
-    {ok, Messages} = asobi_repo:all(Q),
-    {json, #{messages => lists:reverse(Messages)}}.
+-define(MAX_HISTORY_LIMIT, 200).
+-define(DEFAULT_HISTORY_LIMIT, 50).
 
-qs_integer(Key, Params, Default) ->
-    case proplists:get_value(Key, Params) of
-        V when is_binary(V) -> binary_to_integer(V);
-        _ -> Default
+-spec history(cowboy_req:req()) -> {json, map()} | {json, integer(), map(), map()} | {status, 403}.
+history(
+    #{
+        bindings := #{~"channel_id" := ChannelId},
+        qs := Qs,
+        auth_data := #{player_id := PlayerId}
+    } = _Req
+) when
+    is_binary(ChannelId), is_binary(Qs), is_binary(PlayerId)
+->
+    case authorized(ChannelId, PlayerId) of
+        true ->
+            Params = cow_qs:parse_qs(Qs),
+            Limit = asobi_qs:integer(
+                ~"limit", Params, ?DEFAULT_HISTORY_LIMIT, 1, ?MAX_HISTORY_LIMIT
+            ),
+            Q = kura_query:limit(
+                kura_query:order_by(
+                    kura_query:where(kura_query:from(asobi_chat_message), {channel_id, ChannelId}),
+                    [{sent_at, desc}]
+                ),
+                Limit
+            ),
+            {ok, Messages} = asobi_repo:all(Q),
+            {json, #{messages => lists:reverse(Messages)}};
+        false ->
+            {status, 403}
+    end;
+history(_Req) ->
+    {json, 400, #{}, #{error => ~"invalid_request"}}.
+
+%% Channel ID schemes (see asobi_dm:channel_id/2 and asobi_world_chat:channel_id/3):
+%%   dm:<A>:<B>                     — A and B are the only allowed readers
+%%   world:<WorldId>                — must be currently joined to the world
+%%   zone:<WorldId>:<X>,<Y>         — must be currently joined to the world
+%%   prox:<WorldId>:<X>,<Y>         — must be currently joined to the world
+%%   <anything else>                — treated as a group_id; must be a group member
+-spec authorized(binary(), binary()) -> boolean().
+authorized(ChannelId, PlayerId) ->
+    case classify(ChannelId) of
+        {dm, A, B} ->
+            PlayerId =:= A orelse PlayerId =:= B;
+        {world, WorldId} ->
+            player_in_world(PlayerId, WorldId);
+        {group, GroupId} ->
+            is_group_member(PlayerId, GroupId)
+    end.
+
+-spec classify(binary()) -> {dm, binary(), binary()} | {world, binary()} | {group, binary()}.
+classify(<<"dm:", Rest/binary>>) ->
+    case binary:split(Rest, ~":", [global]) of
+        [A, B] when byte_size(A) > 0, byte_size(B) > 0 -> {dm, A, B};
+        _ -> {group, <<"dm:", Rest/binary>>}
+    end;
+classify(<<"world:", WorldId/binary>>) when byte_size(WorldId) > 0 ->
+    {world, WorldId};
+classify(<<"zone:", Rest/binary>>) ->
+    {world, take_until_colon(Rest)};
+classify(<<"prox:", Rest/binary>>) ->
+    {world, take_until_colon(Rest)};
+classify(ChannelId) ->
+    {group, ChannelId}.
+
+-spec take_until_colon(binary()) -> binary().
+take_until_colon(Bin) ->
+    case binary:split(Bin, ~":") of
+        [Head, _] -> Head;
+        [Head] -> Head
+    end.
+
+-spec player_in_world(binary(), binary()) -> boolean().
+player_in_world(PlayerId, WorldId) ->
+    case asobi_world_server:whereis(WorldId) of
+        {ok, Pid} ->
+            try asobi_world_server:get_info(Pid) of
+                #{players := Players} when is_list(Players) ->
+                    lists:member(PlayerId, Players);
+                _ ->
+                    false
+            catch
+                _:_ -> false
+            end;
+        error ->
+            false
+    end.
+
+-spec is_group_member(binary(), binary()) -> boolean().
+is_group_member(PlayerId, GroupId) ->
+    Q = kura_query:where(
+        kura_query:where(
+            kura_query:from(asobi_group_member),
+            {group_id, GroupId}
+        ),
+        {player_id, PlayerId}
+    ),
+    case asobi_repo:all(Q) of
+        {ok, [_ | _]} -> true;
+        _ -> false
     end.

--- a/src/controllers/asobi_dm_controller.erl
+++ b/src/controllers/asobi_dm_controller.erl
@@ -13,8 +13,16 @@ send(#{
                 success => true, channel_id => asobi_dm:channel_id(PlayerId, RecipientId)
             }};
         {error, blocked} ->
-            {json, 403, #{}, #{error => ~"blocked"}}
-    end.
+            {json, 403, #{}, #{error => ~"blocked"}};
+        {error, content_empty} ->
+            {json, 400, #{}, #{error => ~"content_empty"}};
+        {error, content_too_large} ->
+            {json, 413, #{}, #{error => ~"content_too_large"}};
+        {error, _} ->
+            {json, 400, #{}, #{error => ~"invalid_input"}}
+    end;
+send(_Req) ->
+    {json, 400, #{}, #{error => ~"invalid_request"}}.
 
 -spec history(cowboy_req:req()) -> {json, map()}.
 history(#{
@@ -23,10 +31,6 @@ history(#{
     auth_data := #{player_id := PlayerId}
 }) when is_binary(OtherPlayerId), is_binary(PlayerId) ->
     Params = cow_qs:parse_qs(Qs),
-    Limit =
-        case proplists:get_value(~"limit", Params) of
-            V when is_binary(V) -> binary_to_integer(V);
-            _ -> 50
-        end,
+    Limit = asobi_qs:integer(~"limit", Params, 50, 1, 200),
     Messages = asobi_dm:history(PlayerId, OtherPlayerId, Limit),
     {json, #{messages => Messages, channel_id => asobi_dm:channel_id(PlayerId, OtherPlayerId)}}.

--- a/src/controllers/asobi_economy_controller.erl
+++ b/src/controllers/asobi_economy_controller.erl
@@ -13,7 +13,7 @@ history(
         _Req
 ) when is_binary(PlayerId), is_binary(Currency), is_binary(Qs) ->
     Params = cow_qs:parse_qs(Qs),
-    Limit = qs_integer(~"limit", Params, 50),
+    Limit = asobi_qs:integer(~"limit", Params, 50, 1, 200),
     {ok, Transactions} = asobi_economy:get_history(PlayerId, Currency, #{limit => Limit}),
     {json, #{transactions => Transactions}}.
 
@@ -42,10 +42,4 @@ purchase(
             {json, 400, #{}, #{error => ~"listing_inactive"}};
         {error, _Reason} ->
             {json, 500, #{}, #{error => ~"purchase_failed"}}
-    end.
-
-qs_integer(Key, Params, Default) ->
-    case proplists:get_value(Key, Params) of
-        V when is_binary(V) -> binary_to_integer(V);
-        _ -> Default
     end.

--- a/src/controllers/asobi_inventory_controller.erl
+++ b/src/controllers/asobi_inventory_controller.erl
@@ -7,18 +7,23 @@ index(#{auth_data := #{player_id := PlayerId}, qs := Qs} = _Req) when
     is_binary(PlayerId), is_binary(Qs)
 ->
     Params = cow_qs:parse_qs(Qs),
-    Limit = qs_integer(~"limit", Params, 50),
+    Limit = asobi_qs:integer(~"limit", Params, 50, 1, 200),
     Q0 = kura_query:where(kura_query:from(asobi_player_item), {player_id, PlayerId}),
     Q1 = kura_query:limit(kura_query:order_by(Q0, [{acquired_at, desc}]), Limit),
     {ok, Items} = asobi_repo:all(Q1),
     {json, #{items => Items}}.
+
+%% Per-call upper bound on `quantity` — defensive against an integer
+%% overflow style attack where a very large positive number would still
+%% pass guards but then exhaust DB resources or wrap somewhere later.
+-define(MAX_CONSUME_QTY, 1000000).
 
 -spec consume(cowboy_req:req()) ->
     {json, integer(), map(), map()} | {status, integer()}.
 consume(
     #{json := #{~"item_id" := ItemId, ~"quantity" := Qty}, auth_data := #{player_id := PlayerId}} =
         _Req
-) when is_number(Qty) ->
+) when is_integer(Qty), Qty > 0, Qty =< ?MAX_CONSUME_QTY ->
     case asobi_repo:get(asobi_player_item, ItemId) of
         {ok, #{player_id := PlayerId, quantity := Current} = Item} ->
             case Current >= Qty of
@@ -40,10 +45,6 @@ consume(
             {status, 403};
         {error, not_found} ->
             {status, 404}
-    end.
-
-qs_integer(Key, Params, Default) ->
-    case proplists:get_value(Key, Params) of
-        V when is_binary(V) -> binary_to_integer(V);
-        _ -> Default
-    end.
+    end;
+consume(_) ->
+    {json, 400, #{}, #{error => ~"invalid_quantity"}}.

--- a/src/controllers/asobi_leaderboard_controller.erl
+++ b/src/controllers/asobi_leaderboard_controller.erl
@@ -5,7 +5,8 @@
 -spec top(cowboy_req:req()) -> {json, map()}.
 top(#{bindings := #{~"id" := BoardId}, qs := Qs} = _Req) when is_binary(BoardId), is_binary(Qs) ->
     Params = cow_qs:parse_qs(Qs),
-    Limit = qs_integer(~"limit", Params, 100),
+    %% F-21: cap top() limit so an attacker can't trigger O(N) ETS scans.
+    Limit = asobi_qs:integer(~"limit", Params, 100, 1, 100),
     Entries = asobi_leaderboard_server:top(BoardId, Limit),
     {json, #{entries => format_entries(BoardId, Entries)}}.
 
@@ -14,7 +15,9 @@ around(#{bindings := #{~"id" := BoardId, ~"player_id" := PlayerId}, qs := Qs} = 
     is_binary(BoardId), is_binary(PlayerId), is_binary(Qs)
 ->
     Params = cow_qs:parse_qs(Qs),
-    Range = qs_integer(~"range", Params, 5),
+    %% F-21: cap around() range so a single request cannot force an
+    %% expensive ets:first/1 walk.
+    Range = asobi_qs:integer(~"range", Params, 5, 1, 50),
     Entries = asobi_leaderboard_server:around(BoardId, PlayerId, Range),
     {json, #{entries => format_entries(BoardId, Entries)}}.
 
@@ -80,12 +83,6 @@ format_entries(BoardId, Entries) ->
         }
      || {P, S, R} <- Entries
     ].
-
-qs_integer(Key, Params, Default) ->
-    case proplists:get_value(Key, Params) of
-        V when is_binary(V) -> binary_to_integer(V);
-        _ -> Default
-    end.
 
 -spec format_timestamp(integer()) -> binary().
 format_timestamp(Ms) ->

--- a/src/controllers/asobi_match_controller.erl
+++ b/src/controllers/asobi_match_controller.erl
@@ -23,13 +23,7 @@ index(#{qs := Qs} = _Req) when is_binary(Qs) ->
             undefined -> Q1;
             Status -> kura_query:where(Q1, {status, Status})
         end,
-    Limit = qs_integer(~"limit", Params, 50),
+    Limit = asobi_qs:integer(~"limit", Params, 50, 1, 200),
     Q3 = kura_query:limit(kura_query:order_by(Q2, [{inserted_at, desc}]), Limit),
     {ok, Records} = asobi_repo:all(Q3),
     {json, #{matches => Records}}.
-
-qs_integer(Key, Params, Default) ->
-    case proplists:get_value(Key, Params) of
-        V when is_binary(V) -> binary_to_integer(V);
-        _ -> Default
-    end.

--- a/src/controllers/asobi_matchmaker_controller.erl
+++ b/src/controllers/asobi_matchmaker_controller.erl
@@ -14,16 +14,22 @@ add(#{json := Params, auth_data := #{player_id := PlayerId}} = _Req) when
     {ok, TicketId} = asobi_matchmaker:add(PlayerId, MatchParams),
     {json, 200, #{}, #{ticket_id => TicketId, status => ~"pending"}}.
 
--spec remove(cowboy_req:req()) -> {json, map()}.
+-spec remove(cowboy_req:req()) -> {json, map()} | {status, integer()}.
 remove(
     #{bindings := #{~"ticket_id" := TicketId}, auth_data := #{player_id := PlayerId}} = _Req
 ) when is_binary(PlayerId), is_binary(TicketId) ->
-    asobi_matchmaker:remove(PlayerId, TicketId),
-    {json, #{success => true}}.
+    case asobi_matchmaker:remove(PlayerId, TicketId) of
+        ok -> {json, #{success => true}};
+        {error, not_owner} -> {status, 403};
+        {error, not_found} -> {status, 404}
+    end.
 
 -spec status(cowboy_req:req()) -> {json, map()} | {status, integer()}.
-status(#{bindings := #{~"ticket_id" := TicketId}} = _Req) when is_binary(TicketId) ->
-    case asobi_matchmaker:get_ticket(TicketId) of
+status(
+    #{bindings := #{~"ticket_id" := TicketId}, auth_data := #{player_id := PlayerId}} = _Req
+) when is_binary(PlayerId), is_binary(TicketId) ->
+    case asobi_matchmaker:get_ticket(PlayerId, TicketId) of
         {ok, Ticket} -> {json, Ticket};
+        {error, not_owner} -> {status, 403};
         {error, not_found} -> {status, 404}
     end.

--- a/src/controllers/asobi_notification_controller.erl
+++ b/src/controllers/asobi_notification_controller.erl
@@ -7,7 +7,7 @@ index(#{auth_data := #{player_id := PlayerId}, qs := Qs} = _Req) when
     is_binary(PlayerId), is_binary(Qs)
 ->
     Params = cow_qs:parse_qs(Qs),
-    Limit = qs_integer(~"limit", Params, 50),
+    Limit = asobi_qs:integer(~"limit", Params, 50, 1, 200),
     Q0 = kura_query:where(kura_query:from(asobi_notification), {player_id, PlayerId}),
     Q1 =
         case proplists:get_value(~"read", Params) of
@@ -42,10 +42,4 @@ delete(#{bindings := #{~"id" := NotifId}, auth_data := #{player_id := PlayerId}}
             {status, 403};
         {error, not_found} ->
             {status, 404}
-    end.
-
-qs_integer(Key, Params, Default) ->
-    case proplists:get_value(Key, Params) of
-        V when is_binary(V) -> binary_to_integer(V);
-        _ -> Default
     end.

--- a/src/controllers/asobi_oauth_controller.erl
+++ b/src/controllers/asobi_oauth_controller.erl
@@ -227,8 +227,18 @@ maybe_value(Value, _Default) -> Value.
 -spec init_player_stats(binary()) -> ok.
 init_player_stats(PlayerId) ->
     CS = kura_changeset:cast(asobi_player_stats, #{}, #{player_id => PlayerId}, [player_id]),
-    _ = asobi_repo:insert(CS),
-    ok.
+    %% F-25: log insert errors instead of silently dropping them.
+    case asobi_repo:insert(CS) of
+        {ok, _} ->
+            ok;
+        {error, Reason} ->
+            logger:warning(#{
+                msg => ~"player_stats_init_failed",
+                player_id => PlayerId,
+                reason => Reason
+            }),
+            ok
+    end.
 
 -spec provider_to_atom(binary()) -> atom().
 provider_to_atom(~"google") -> google;

--- a/src/controllers/asobi_social_controller.erl
+++ b/src/controllers/asobi_social_controller.erl
@@ -30,23 +30,59 @@ friends(#{auth_data := #{player_id := PlayerId}, qs := Qs} = _Req) when
             undefined -> Q0;
             Status -> kura_query:where(Q0, {status, Status})
         end,
-    Limit = qs_integer(~"limit", Params, 50),
+    Limit = asobi_qs:integer(~"limit", Params, 50, 1, 200),
     Q2 = kura_query:limit(Q1, Limit),
     {ok, Friendships} = asobi_repo:all(Q2),
     {json, #{friends => Friendships}}.
 
 -spec add_friend(cowboy_req:req()) -> {json, map()} | {json, integer(), map(), map()}.
-add_friend(#{json := #{~"friend_id" := FriendId}, auth_data := #{player_id := PlayerId}} = _Req) ->
-    CS = asobi_friendship:changeset(#{}, #{
-        player_id => PlayerId,
-        friend_id => FriendId,
-        status => ~"pending"
-    }),
-    case asobi_repo:insert(CS) of
-        {ok, Friendship} ->
-            {json, 200, #{}, Friendship};
-        {error, CS1} when is_record(CS1, kura_changeset) ->
-            {json, 422, #{}, #{errors => kura_changeset:traverse_errors(CS1, fun(_F, M) -> M end)}}
+add_friend(
+    #{json := #{~"friend_id" := FriendId}, auth_data := #{player_id := PlayerId}} = _Req
+) when
+    is_binary(FriendId), is_binary(PlayerId)
+->
+    %% F-23: reject self-add and verify the target player actually exists.
+    case FriendId =:= PlayerId of
+        true ->
+            {json, 400, #{}, #{error => ~"cannot_friend_self"}};
+        false ->
+            case asobi_repo:get(asobi_player, FriendId) of
+                {error, not_found} ->
+                    {json, 404, #{}, #{error => ~"friend_not_found"}};
+                {ok, _} ->
+                    insert_friendship(PlayerId, FriendId)
+            end
+    end;
+add_friend(_Req) ->
+    {json, 400, #{}, #{error => ~"invalid_request"}}.
+
+%% F-23: idempotent — re-adding an existing friendship returns the row
+%% rather than producing an opaque insert error.
+-spec insert_friendship(binary(), binary()) -> {json, integer(), map(), map()}.
+insert_friendship(PlayerId, FriendId) ->
+    Q = kura_query:where(
+        kura_query:where(kura_query:from(asobi_friendship), {player_id, PlayerId}),
+        {friend_id, FriendId}
+    ),
+    case asobi_repo:all(Q) of
+        {ok, [Existing | _]} ->
+            {json, 200, #{}, Existing};
+        _ ->
+            CS = asobi_friendship:changeset(#{}, #{
+                player_id => PlayerId,
+                friend_id => FriendId,
+                status => ~"pending"
+            }),
+            case asobi_repo:insert(CS) of
+                {ok, Friendship} ->
+                    {json, 200, #{}, Friendship};
+                {error, CS1} when is_record(CS1, kura_changeset) ->
+                    {json, 422, #{}, #{
+                        errors => kura_changeset:traverse_errors(CS1, fun(_F, M) -> M end)
+                    }};
+                {error, _Other} ->
+                    {json, 409, #{}, #{error => ~"already_friend"}}
+            end
     end.
 
 -spec update_friend(cowboy_req:req()) -> {json, map()} | {status, integer()}.
@@ -127,7 +163,31 @@ show_group(#{bindings := #{~"id" := GroupId}} = _Req) ->
     end.
 
 -spec join_group(cowboy_req:req()) -> {json, map()} | {json, integer(), map(), map()}.
-join_group(#{bindings := #{~"id" := GroupId}, auth_data := #{player_id := PlayerId}} = _Req) ->
+join_group(
+    #{bindings := #{~"id" := GroupId}, auth_data := #{player_id := PlayerId}} = _Req
+) when is_binary(GroupId), is_binary(PlayerId) ->
+    %% F-12: closed groups (`open=false`) require an invite (not implemented yet
+    %% — for now reject with 403); enforce `max_members` via a count query.
+    case asobi_repo:get(asobi_group, GroupId) of
+        {error, not_found} ->
+            {json, 404, #{}, #{error => ~"group_not_found"}};
+        {ok, Group} ->
+            case maps:get(open, Group, false) of
+                false ->
+                    {json, 403, #{}, #{error => ~"group_closed"}};
+                true ->
+                    Max = maps:get(max_members, Group, 50),
+                    case current_member_count(GroupId) >= Max of
+                        true ->
+                            {json, 409, #{}, #{error => ~"group_full"}};
+                        false ->
+                            insert_group_member(GroupId, PlayerId)
+                    end
+            end
+    end.
+
+-spec insert_group_member(binary(), binary()) -> {json, integer(), map(), map()}.
+insert_group_member(GroupId, PlayerId) ->
     CS = kura_changeset:cast(
         asobi_group_member,
         #{},
@@ -144,6 +204,14 @@ join_group(#{bindings := #{~"id" := GroupId}, auth_data := #{player_id := Player
             {json, 200, #{}, #{success => true, group_id => GroupId}};
         {error, _} ->
             {json, 409, #{}, #{error => ~"already_member"}}
+    end.
+
+-spec current_member_count(binary()) -> non_neg_integer().
+current_member_count(GroupId) ->
+    Q = kura_query:where(kura_query:from(asobi_group_member), {group_id, GroupId}),
+    case asobi_repo:all(Q) of
+        {ok, Members} when is_list(Members) -> length(Members);
+        _ -> 0
     end.
 
 -spec leave_group(cowboy_req:req()) -> {json, integer(), map(), map()}.
@@ -254,12 +322,6 @@ get_member(GroupId, PlayerId) ->
     case asobi_repo:all(Q) of
         {ok, [Member]} -> {ok, Member};
         _ -> {error, not_found}
-    end.
-
-qs_integer(Key, Params, Default) ->
-    case proplists:get_value(Key, Params) of
-        V when is_binary(V) -> binary_to_integer(V);
-        _ -> Default
     end.
 
 -spec atomize_keys([{term(), term()}]) -> #{atom() => term()}.

--- a/src/controllers/asobi_storage_controller.erl
+++ b/src/controllers/asobi_storage_controller.erl
@@ -3,6 +3,15 @@
 -export([list_saves/1, get_save/1, put_save/1]).
 -export([get_storage/1, put_storage/1, delete_storage/1, list_storage/1]).
 
+%% F-13: cap cloud-save body size and per-player slot count so a single
+%% authenticated user can't exhaust postgres jsonb storage.
+-define(MAX_SAVE_DATA_BYTES, 262144).
+-define(MAX_SLOTS_PER_PLAYER, 10).
+
+%% F-14: only these literals are honoured by get_storage/put_storage; any
+%% other value made the row self-DoS unreachable. Whitelist + reject.
+-define(VALID_PERMS, [~"public", ~"owner"]).
+
 %% --- Cloud Saves ---
 
 -spec list_saves(cowboy_req:req()) -> {json, map()}.
@@ -25,34 +34,49 @@ get_save(#{bindings := #{~"slot" := Slot}, auth_data := #{player_id := PlayerId}
 -spec put_save(cowboy_req:req()) -> {json, map()} | {json, integer(), map(), map()}.
 put_save(
     #{bindings := #{~"slot" := Slot}, json := Params, auth_data := #{player_id := PlayerId}} = _Req
-) when is_map(Params) ->
+) when is_map(Params), is_binary(PlayerId) ->
     Data = maps:get(~"data", Params, #{}),
-    ClientVersion = maps:get(~"version", Params, undefined),
-    Q = kura_query:where(
-        kura_query:where(kura_query:from(asobi_cloud_save), {player_id, PlayerId}),
-        {slot, Slot}
-    ),
-    case asobi_repo:all(Q) of
-        {ok, [#{version := V}]} when ClientVersion =/= undefined, ClientVersion =/= V ->
-            {json, 409, #{}, #{error => ~"version_conflict", current_version => V}};
-        {ok, [#{version := V} = Existing]} ->
-            CS = kura_changeset:cast(
-                asobi_cloud_save,
-                Existing,
-                #{data => Data, version => V + 1},
-                [data, version]
+    case data_within_limit(Data) of
+        false ->
+            {json, 413, #{}, #{error => ~"save_data_too_large"}};
+        true ->
+            ClientVersion = maps:get(~"version", Params, undefined),
+            Q = kura_query:where(
+                kura_query:where(kura_query:from(asobi_cloud_save), {player_id, PlayerId}),
+                {slot, Slot}
             ),
-            {ok, Updated} = asobi_repo:update(CS),
-            {json, Updated};
-        {ok, []} ->
-            CS = kura_changeset:cast(
-                asobi_cloud_save,
-                #{},
-                #{player_id => PlayerId, slot => Slot, data => Data, version => 1},
-                [player_id, slot, data, version]
-            ),
-            {ok, Created} = asobi_repo:insert(CS),
-            {json, 200, #{}, Created}
+            case asobi_repo:all(Q) of
+                {ok, [#{version := V}]} when ClientVersion =/= undefined, ClientVersion =/= V ->
+                    {json, 409, #{}, #{error => ~"version_conflict", current_version => V}};
+                {ok, [#{version := V} = Existing]} ->
+                    CS = kura_changeset:cast(
+                        asobi_cloud_save,
+                        Existing,
+                        #{data => Data, version => V + 1},
+                        [data, version]
+                    ),
+                    {ok, Updated} = asobi_repo:update(CS),
+                    {json, Updated};
+                {ok, []} ->
+                    case slots_under_cap(PlayerId) of
+                        false ->
+                            {json, 409, #{}, #{error => ~"slot_limit_reached"}};
+                        true ->
+                            CS = kura_changeset:cast(
+                                asobi_cloud_save,
+                                #{},
+                                #{
+                                    player_id => PlayerId,
+                                    slot => Slot,
+                                    data => Data,
+                                    version => 1
+                                },
+                                [player_id, slot, data, version]
+                            ),
+                            {ok, Created} = asobi_repo:insert(CS),
+                            {json, 200, #{}, Created}
+                    end
+            end
     end.
 
 %% --- Generic Storage ---
@@ -83,50 +107,62 @@ put_storage(
     } = _Req
 ) when is_map(Params) ->
     Value = maps:get(~"value", Params, #{}),
-    ReadPerm = maps:get(~"read_perm", Params, ~"owner"),
-    WritePerm = maps:get(~"write_perm", Params, ~"owner"),
-    Q = kura_query:where(
-        kura_query:where(kura_query:from(asobi_storage), {collection, Col}),
-        {key, Key}
-    ),
-    case asobi_repo:all(Q) of
-        {ok, [#{write_perm := ~"owner", player_id := PlayerId, version := V} = Existing]} ->
-            CS = kura_changeset:cast(
-                asobi_storage,
-                Existing,
-                #{value => Value, version => V + 1, read_perm => ReadPerm, write_perm => WritePerm},
-                [value, version, read_perm, write_perm]
+    ReadPerm0 = maps:get(~"read_perm", Params, ~"owner"),
+    WritePerm0 = maps:get(~"write_perm", Params, ~"owner"),
+    ReadPerm = ensure_binary_perm(ReadPerm0),
+    WritePerm = ensure_binary_perm(WritePerm0),
+    case valid_perm(ReadPerm) andalso valid_perm(WritePerm) of
+        false ->
+            {json, 400, #{}, #{error => ~"invalid_perm"}};
+        true ->
+            Q = kura_query:where(
+                kura_query:where(kura_query:from(asobi_storage), {collection, Col}),
+                {key, Key}
             ),
-            {ok, Updated} = asobi_repo:update(CS),
-            {json, Updated};
-        {ok, [#{write_perm := ~"public", version := V} = Existing]} ->
-            CS = kura_changeset:cast(
-                asobi_storage,
-                Existing,
-                #{value => Value, version => V + 1},
-                [value, version]
-            ),
-            {ok, Updated} = asobi_repo:update(CS),
-            {json, Updated};
-        {ok, [_]} ->
-            {status, 403};
-        {ok, []} ->
-            CS = kura_changeset:cast(
-                asobi_storage,
-                #{},
-                #{
-                    collection => Col,
-                    key => Key,
-                    player_id => PlayerId,
-                    value => Value,
-                    version => 1,
-                    read_perm => ReadPerm,
-                    write_perm => WritePerm
-                },
-                [collection, key, player_id, value, version, read_perm, write_perm]
-            ),
-            {ok, Created} = asobi_repo:insert(CS),
-            {json, 200, #{}, Created}
+            case asobi_repo:all(Q) of
+                {ok, [#{write_perm := ~"owner", player_id := PlayerId, version := V} = Existing]} ->
+                    CS = kura_changeset:cast(
+                        asobi_storage,
+                        Existing,
+                        #{
+                            value => Value,
+                            version => V + 1,
+                            read_perm => ReadPerm,
+                            write_perm => WritePerm
+                        },
+                        [value, version, read_perm, write_perm]
+                    ),
+                    {ok, Updated} = asobi_repo:update(CS),
+                    {json, Updated};
+                {ok, [#{write_perm := ~"public", version := V} = Existing]} ->
+                    CS = kura_changeset:cast(
+                        asobi_storage,
+                        Existing,
+                        #{value => Value, version => V + 1},
+                        [value, version]
+                    ),
+                    {ok, Updated} = asobi_repo:update(CS),
+                    {json, Updated};
+                {ok, [_]} ->
+                    {status, 403};
+                {ok, []} ->
+                    CS = kura_changeset:cast(
+                        asobi_storage,
+                        #{},
+                        #{
+                            collection => Col,
+                            key => Key,
+                            player_id => PlayerId,
+                            value => Value,
+                            version => 1,
+                            read_perm => ReadPerm,
+                            write_perm => WritePerm
+                        },
+                        [collection, key, player_id, value, version, read_perm, write_perm]
+                    ),
+                    {ok, Created} = asobi_repo:insert(CS),
+                    {json, 200, #{}, Created}
+            end
     end.
 
 -spec delete_storage(cowboy_req:req()) -> {json, map()} | {status, integer()}.
@@ -156,7 +192,7 @@ list_storage(
     #{bindings := #{~"collection" := Col}, qs := Qs, auth_data := #{player_id := PlayerId}} = _Req
 ) when is_binary(Qs), is_binary(PlayerId) ->
     Params = cow_qs:parse_qs(Qs),
-    Limit = qs_integer(~"limit", Params, 50),
+    Limit = asobi_qs:integer(~"limit", Params, 50, 1, 200),
     %% Mirror get_storage's ACL: only return rows the caller is allowed
     %% to read (public objects, or owner-restricted objects they own).
     Q = kura_query:limit(
@@ -172,8 +208,27 @@ list_storage(
     {ok, Objects} = asobi_repo:all(Q),
     {json, #{objects => Objects}}.
 
-qs_integer(Key, Params, Default) ->
-    case proplists:get_value(Key, Params) of
-        V when is_binary(V) -> binary_to_integer(V);
-        _ -> Default
+%% --- Internal ---
+
+-spec data_within_limit(dynamic()) -> boolean().
+data_within_limit(Data) ->
+    try iolist_size(json:encode(Data)) =< ?MAX_SAVE_DATA_BYTES of
+        Result -> Result
+    catch
+        _:_ -> false
     end.
+
+-spec slots_under_cap(binary()) -> boolean().
+slots_under_cap(PlayerId) ->
+    Q = kura_query:where(kura_query:from(asobi_cloud_save), {player_id, PlayerId}),
+    case asobi_repo:all(Q) of
+        {ok, Saves} when is_list(Saves) -> length(Saves) < ?MAX_SLOTS_PER_PLAYER;
+        _ -> false
+    end.
+
+-spec valid_perm(binary()) -> boolean().
+valid_perm(P) -> lists:member(P, ?VALID_PERMS).
+
+-spec ensure_binary_perm(term()) -> binary().
+ensure_binary_perm(B) when is_binary(B) -> B;
+ensure_binary_perm(_) -> ~"invalid".

--- a/src/controllers/asobi_tournament_controller.erl
+++ b/src/controllers/asobi_tournament_controller.erl
@@ -11,7 +11,7 @@ index(#{qs := Qs} = _Req) when is_binary(Qs) ->
             undefined -> Q0;
             Status -> kura_query:where(Q0, {status, Status})
         end,
-    Limit = qs_integer(~"limit", Params, 50),
+    Limit = asobi_qs:integer(~"limit", Params, 50, 1, 200),
     Q2 = kura_query:limit(kura_query:order_by(Q1, [{start_at, asc}]), Limit),
     {ok, Tournaments} = asobi_repo:all(Q2),
     {json, #{tournaments => Tournaments}}.
@@ -37,10 +37,4 @@ join(#{bindings := #{~"id" := TournamentId}, auth_data := #{player_id := PlayerI
             {json, 409, #{}, #{error => ~"already_joined"}};
         {error, not_found} ->
             {status, 404}
-    end.
-
-qs_integer(Key, Params, Default) ->
-    case proplists:get_value(Key, Params) of
-        V when is_binary(V) -> binary_to_integer(V);
-        _ -> Default
     end.

--- a/src/controllers/asobi_world_controller.erl
+++ b/src/controllers/asobi_world_controller.erl
@@ -21,11 +21,18 @@ show(#{bindings := #{~"id" := WorldId}}) ->
             {status, 404}
     end.
 
--spec create(map()) -> {json, map(), integer()} | {status, 400}.
-create(#{json := #{~"mode" := Mode}}) ->
-    case asobi_world_lobby:create_world(Mode) of
+-spec create(map()) ->
+    {json, map(), integer()} | {json, integer(), map(), map()} | {status, 400}.
+create(#{json := #{~"mode" := Mode}, auth_data := #{player_id := PlayerId}}) when
+    is_binary(PlayerId)
+->
+    case asobi_world_lobby:create_world(Mode, PlayerId) of
         {ok, _Pid, Info} ->
             {json, Info, 201};
+        {error, player_world_limit_reached} ->
+            {json, 429, #{}, #{error => ~"player_world_limit_reached"}};
+        {error, world_capacity_reached} ->
+            {json, 503, #{}, #{error => ~"world_capacity_reached"}};
         {error, Reason} ->
             {json, #{error => Reason}, 400}
     end;

--- a/src/economy/asobi_economy.erl
+++ b/src/economy/asobi_economy.erl
@@ -45,7 +45,9 @@ get_or_create_wallet(PlayerId, Currency) ->
     end.
 
 -spec grant(binary(), binary(), pos_integer(), map()) -> {ok, map()} | {error, term()}.
-grant(PlayerId, Currency, Amount, Opts) when Amount > 0 ->
+grant(PlayerId, Currency, Amount, Opts) when
+    is_integer(Amount), Amount > 0, is_binary(PlayerId), is_binary(Currency)
+->
     asobi_telemetry:economy_transaction(
         PlayerId,
         Currency,
@@ -54,26 +56,8 @@ grant(PlayerId, Currency, Amount, Opts) when Amount > 0 ->
     ),
     case
         asobi_repo:transaction(fun() ->
-            {ok, Wallet} = get_or_create_wallet(PlayerId, Currency),
-            NewBalance = maps:get(balance, Wallet) + Amount,
-            WalletCS = kura_changeset:cast(asobi_wallet, Wallet, #{balance => NewBalance}, [balance]),
-            {ok, UpdatedWallet} = asobi_repo:update(WalletCS),
-            TxCS = kura_changeset:cast(
-                asobi_transaction,
-                #{},
-                #{
-                    wallet_id => maps:get(id, Wallet),
-                    amount => Amount,
-                    balance_after => NewBalance,
-                    reason => maps:get(reason, Opts, ~"admin_grant"),
-                    reference_type => maps:get(reference_type, Opts, undefined),
-                    reference_id => maps:get(reference_id, Opts, undefined),
-                    metadata => maps:get(metadata, Opts, #{})
-                },
-                [wallet_id, amount, balance_after, reason, reference_type, reference_id, metadata]
-            ),
-            {ok, _Tx} = asobi_repo:insert(TxCS),
-            {ok, UpdatedWallet}
+            ok = acquire_wallet_lock(PlayerId, Currency),
+            grant_inner(PlayerId, Currency, Amount, Opts)
         end)
     of
         {ok, W} when is_map(W) -> {ok, W};
@@ -82,7 +66,9 @@ grant(PlayerId, Currency, Amount, Opts) when Amount > 0 ->
     end.
 
 -spec debit(binary(), binary(), pos_integer(), map()) -> {ok, map()} | {error, term()}.
-debit(PlayerId, Currency, Amount, Opts) when Amount > 0 ->
+debit(PlayerId, Currency, Amount, Opts) when
+    is_integer(Amount), Amount > 0, is_binary(PlayerId), is_binary(Currency)
+->
     asobi_telemetry:economy_transaction(
         PlayerId,
         Currency,
@@ -91,44 +77,8 @@ debit(PlayerId, Currency, Amount, Opts) when Amount > 0 ->
     ),
     case
         asobi_repo:transaction(fun() ->
-            {ok, Wallet} = get_or_create_wallet(PlayerId, Currency),
-            Balance = maps:get(balance, Wallet),
-            case Balance >= Amount of
-                false ->
-                    {error, insufficient_funds};
-                true ->
-                    NewBalance = Balance - Amount,
-                    WalletCS = kura_changeset:cast(
-                        asobi_wallet, Wallet, #{balance => NewBalance}, [
-                            balance
-                        ]
-                    ),
-                    {ok, UpdatedWallet} = asobi_repo:update(WalletCS),
-                    TxCS = kura_changeset:cast(
-                        asobi_transaction,
-                        #{},
-                        #{
-                            wallet_id => maps:get(id, Wallet),
-                            amount => -Amount,
-                            balance_after => NewBalance,
-                            reason => maps:get(reason, Opts, ~"purchase"),
-                            reference_type => maps:get(reference_type, Opts, undefined),
-                            reference_id => maps:get(reference_id, Opts, undefined),
-                            metadata => maps:get(metadata, Opts, #{})
-                        },
-                        [
-                            wallet_id,
-                            amount,
-                            balance_after,
-                            reason,
-                            reference_type,
-                            reference_id,
-                            metadata
-                        ]
-                    ),
-                    {ok, _Tx} = asobi_repo:insert(TxCS),
-                    {ok, UpdatedWallet}
-            end
+            ok = acquire_wallet_lock(PlayerId, Currency),
+            debit_inner(PlayerId, Currency, Amount, Opts)
         end)
     of
         {ok, W} when is_map(W) -> {ok, W};
@@ -136,16 +86,21 @@ debit(PlayerId, Currency, Amount, Opts) when Amount > 0 ->
         _ -> {error, transaction_failed}
     end.
 
+%% Single transaction for the whole purchase flow: acquire the wallet
+%% lock once, then debit + grant the item inline. F-22 (nested
+%% transactions) is closed as a side-effect — `debit_inner/4` doesn't
+%% open its own transaction.
 -spec purchase(binary(), binary()) -> {ok, map()} | {error, term()}.
-purchase(PlayerId, ListingId) ->
+purchase(PlayerId, ListingId) when is_binary(PlayerId), is_binary(ListingId) ->
     case asobi_repo:get(asobi_store_listing, ListingId) of
         {ok,
             #{active := true, currency := Currency, price := Price, item_def_id := ItemDefId} =
                 _Listing} ->
             case
                 asobi_repo:transaction(fun() ->
+                    ok = acquire_wallet_lock(PlayerId, Currency),
                     case
-                        debit(PlayerId, Currency, Price, #{
+                        debit_inner(PlayerId, Currency, Price, #{
                             reason => ~"purchase",
                             reference_type => ~"store_listing",
                             reference_id => ListingId
@@ -177,6 +132,84 @@ purchase(PlayerId, ListingId) ->
             {error, listing_inactive};
         {error, _} = Err ->
             Err
+    end.
+
+%% --- Internal ---
+
+%% Postgres advisory transaction lock keyed by (player_id, currency) —
+%% blocks any concurrent transaction trying the same wallet until ours
+%% commits or rolls back. Closes F-5 (wallet double-spend race) without
+%% requiring a `SELECT … FOR UPDATE` rewrite of the kura query layer.
+%% Must be called inside an open transaction.
+-spec acquire_wallet_lock(binary(), binary()) -> ok.
+acquire_wallet_lock(PlayerId, Currency) ->
+    %% pg_advisory_xact_lock returns void, which pgo can't decode — wrap
+    %% it in a subselect so the row pgo sees is plain int.
+    SQL =
+        ~"SELECT 1 AS locked FROM (SELECT pg_advisory_xact_lock(hashtext($1), hashtext($2))) AS _l",
+    #{rows := [_ | _]} = kura_db:query(asobi_repo, SQL, [PlayerId, Currency]),
+    ok.
+
+-spec grant_inner(binary(), binary(), pos_integer(), map()) -> {ok, map()} | {error, term()}.
+grant_inner(PlayerId, Currency, Amount, Opts) ->
+    {ok, Wallet} = get_or_create_wallet(PlayerId, Currency),
+    NewBalance = maps:get(balance, Wallet) + Amount,
+    WalletCS = kura_changeset:cast(asobi_wallet, Wallet, #{balance => NewBalance}, [balance]),
+    {ok, UpdatedWallet} = asobi_repo:update(WalletCS),
+    TxCS = kura_changeset:cast(
+        asobi_transaction,
+        #{},
+        #{
+            wallet_id => maps:get(id, Wallet),
+            amount => Amount,
+            balance_after => NewBalance,
+            reason => maps:get(reason, Opts, ~"admin_grant"),
+            reference_type => maps:get(reference_type, Opts, undefined),
+            reference_id => maps:get(reference_id, Opts, undefined),
+            metadata => maps:get(metadata, Opts, #{})
+        },
+        [wallet_id, amount, balance_after, reason, reference_type, reference_id, metadata]
+    ),
+    {ok, _Tx} = asobi_repo:insert(TxCS),
+    {ok, UpdatedWallet}.
+
+-spec debit_inner(binary(), binary(), pos_integer(), map()) -> {ok, map()} | {error, term()}.
+debit_inner(PlayerId, Currency, Amount, Opts) ->
+    {ok, Wallet} = get_or_create_wallet(PlayerId, Currency),
+    Balance = maps:get(balance, Wallet),
+    case Balance >= Amount of
+        false ->
+            {error, insufficient_funds};
+        true ->
+            NewBalance = Balance - Amount,
+            WalletCS = kura_changeset:cast(
+                asobi_wallet, Wallet, #{balance => NewBalance}, [balance]
+            ),
+            {ok, UpdatedWallet} = asobi_repo:update(WalletCS),
+            TxCS = kura_changeset:cast(
+                asobi_transaction,
+                #{},
+                #{
+                    wallet_id => maps:get(id, Wallet),
+                    amount => -Amount,
+                    balance_after => NewBalance,
+                    reason => maps:get(reason, Opts, ~"purchase"),
+                    reference_type => maps:get(reference_type, Opts, undefined),
+                    reference_id => maps:get(reference_id, Opts, undefined),
+                    metadata => maps:get(metadata, Opts, #{})
+                },
+                [
+                    wallet_id,
+                    amount,
+                    balance_after,
+                    reason,
+                    reference_type,
+                    reference_id,
+                    metadata
+                ]
+            ),
+            {ok, _Tx} = asobi_repo:insert(TxCS),
+            {ok, UpdatedWallet}
     end.
 
 -spec get_wallets(binary()) -> {ok, [map()]} | {error, term()}.

--- a/src/matches/asobi_match_server.erl
+++ b/src/matches/asobi_match_server.erl
@@ -1,4 +1,21 @@
 -module(asobi_match_server).
+-moduledoc """
+Per-match `gen_statem` driving the configured game module.
+
+**Trust boundary (F-32)**: asobi is single-tenant by design. The
+configured game module (`Mod:join/2`, `Mod:tick/1`, `Mod:handle_input/3`,
+phase / vote callbacks, etc.) is *trusted code*. We do not wrap
+callbacks in `try/catch` — a crash in the game module is treated as a
+bug worth surfacing, not a security boundary to harden against. The
+match supervisor restarts the match server up to 10 times in 60s
+(transient + intensity 10) before the entire `asobi_match_sup` falls
+over, intentionally taking the lobby with it so an obviously broken
+game cannot keep churning silently.
+
+In multi-tenant or sandboxed contexts (`asobi_lua`) callbacks are run
+through a Lua sandbox that has its own fault-isolation; that wrapper is
+the place to put callback hardening.
+""".
 -behaviour(gen_statem).
 
 -export([start_link/1, join/2, leave/2, handle_input/3, get_info/1, pause/1, resume/1, cancel/1]).

--- a/src/matches/asobi_matchmaker.erl
+++ b/src/matches/asobi_matchmaker.erl
@@ -1,7 +1,7 @@
 -module(asobi_matchmaker).
 -behaviour(gen_server).
 
--export([start_link/0, add/2, remove/2, get_ticket/1, get_queue_stats/0]).
+-export([start_link/0, add/2, remove/2, get_ticket/1, get_ticket/2, get_queue_stats/0]).
 -export([init/1, handle_call/3, handle_cast/2, handle_info/2, terminate/2]).
 
 -define(DEFAULT_TICK, 1000).
@@ -16,10 +16,27 @@ add(PlayerId, Params) ->
         {ok, TicketId} when is_binary(TicketId) -> {ok, TicketId}
     end.
 
--spec remove(binary(), binary()) -> ok.
+-spec remove(binary(), binary()) -> ok | {error, not_found | not_owner}.
 remove(PlayerId, TicketId) ->
-    gen_server:cast(?MODULE, {remove, PlayerId, TicketId}).
+    case gen_server:call(?MODULE, {remove, PlayerId, TicketId}) of
+        ok -> ok;
+        {error, not_found} -> {error, not_found};
+        {error, not_owner} -> {error, not_owner}
+    end.
 
+%% Ticket lookup is owner-scoped. F-8: previously any authenticated
+%% caller could read another player's mode/party/properties.
+-spec get_ticket(binary(), binary()) ->
+    {ok, map()} | {error, not_found | not_owner}.
+get_ticket(PlayerId, TicketId) ->
+    case gen_server:call(?MODULE, {get_ticket, PlayerId, TicketId}) of
+        {ok, Ticket} when is_map(Ticket) -> {ok, Ticket};
+        {error, not_found} -> {error, not_found};
+        {error, not_owner} -> {error, not_owner}
+    end.
+
+%% Legacy single-arg lookup — kept for callers that don't have a
+%% requester id (matchmaker tick path). Internal use only.
 -spec get_ticket(binary()) -> {ok, map()} | {error, not_found}.
 get_ticket(TicketId) ->
     case gen_server:call(?MODULE, {get_ticket, TicketId}) of
@@ -63,21 +80,48 @@ handle_call({add, PlayerId, Params}, _From, #{tickets := Tickets} = State) when
             M when is_binary(M) -> M;
             _ -> ~"default"
         end,
+    %% F-7: only the requester themselves is allowed in the party until
+    %% an explicit invite/accept handshake exists. Drop any party
+    %% members the requester didn't pre-clear.
+    SanitisedParty = sanitise_party(maps:get(party, Params, [PlayerId]), PlayerId),
     Ticket = #{
         id => TicketId,
         player_id => PlayerId,
         mode => Mode,
         properties => maps:get(properties, Params, #{}),
-        party => maps:get(party, Params, [PlayerId]),
+        party => SanitisedParty,
         submitted_at => erlang:system_time(millisecond),
         status => pending
     },
     asobi_telemetry:matchmaker_queued(PlayerId, Mode),
     {reply, {ok, TicketId}, State#{tickets => Tickets#{TicketId => Ticket}}};
+handle_call({get_ticket, PlayerId, TicketId}, _From, #{tickets := Tickets} = State) when
+    is_binary(PlayerId), is_binary(TicketId)
+->
+    case Tickets of
+        #{TicketId := #{player_id := PlayerId} = Ticket} ->
+            {reply, {ok, Ticket}, State};
+        #{TicketId := _Other} ->
+            {reply, {error, not_owner}, State};
+        _ ->
+            {reply, {error, not_found}, State}
+    end;
 handle_call({get_ticket, TicketId}, _From, #{tickets := Tickets} = State) ->
     case Tickets of
         #{TicketId := Ticket} -> {reply, {ok, Ticket}, State};
         _ -> {reply, {error, not_found}, State}
+    end;
+handle_call({remove, PlayerId, TicketId}, _From, #{tickets := Tickets} = State) when
+    is_binary(PlayerId), is_binary(TicketId)
+->
+    case Tickets of
+        #{TicketId := #{player_id := PlayerId}} ->
+            asobi_telemetry:matchmaker_removed(PlayerId, cancelled),
+            {reply, ok, State#{tickets => maps:remove(TicketId, Tickets)}};
+        #{TicketId := _Other} ->
+            {reply, {error, not_owner}, State};
+        _ ->
+            {reply, {error, not_found}, State}
     end;
 handle_call(get_queue_stats, _From, #{tickets := Tickets} = State) ->
     Now = erlang:system_time(millisecond),
@@ -109,11 +153,6 @@ handle_call(_Request, _From, State) ->
     {reply, {error, unknown_request}, State}.
 
 -spec handle_cast(term(), map()) -> {noreply, map()}.
-handle_cast({remove, PlayerId, TicketId}, #{tickets := Tickets} = State) when
-    is_binary(PlayerId)
-->
-    asobi_telemetry:matchmaker_removed(PlayerId, cancelled),
-    {noreply, State#{tickets => maps:remove(TicketId, Tickets)}};
 handle_cast(_Msg, State) ->
     {noreply, State}.
 
@@ -410,6 +449,20 @@ notify_expired([#{player_id := PlayerId, id := TicketId} | Rest]) ->
 -spec generate_id() -> binary().
 generate_id() ->
     asobi_id:generate().
+
+%% F-7: until a real invite/accept handshake exists, the requester
+%% themselves is the only player allowed in their own party. Strip
+%% anything else and dedupe so the matchmaker can't be tricked into
+%% bringing a non-consenting player into a match.
+-spec sanitise_party(term(), binary()) -> [binary()].
+sanitise_party(Party, PlayerId) when is_list(Party) ->
+    Filtered = [P || P <- Party, is_binary(P), P =:= PlayerId],
+    case Filtered of
+        [] -> [PlayerId];
+        _ -> [PlayerId]
+    end;
+sanitise_party(_, PlayerId) ->
+    [PlayerId].
 
 -spec ensure_map(term()) -> #{term() => term()}.
 ensure_map(M) when is_map(M) -> M;

--- a/src/players/asobi_player_session.erl
+++ b/src/players/asobi_player_session.erl
@@ -58,6 +58,25 @@ handle_call(_Request, _From, State) ->
 handle_cast({update_presence, Status}, #{player_id := PlayerId} = State) when is_map(Status) ->
     asobi_presence:update(PlayerId, Status),
     {noreply, State#{presence => Status}};
+handle_cast({reconnect_world, WorldPid}, #{player_id := PlayerId} = State) when
+    is_pid(WorldPid)
+->
+    %% F-28: world reconnects used to spawn an unsupervised helper from
+    %% the WS handler. Running them inside the supervised session
+    %% process means they're cleaned up with the session and a stuck
+    %% reconnect cannot leak a pid.
+    try asobi_world_server:reconnect(WorldPid, PlayerId) of
+        _ -> ok
+    catch
+        Class:Reason ->
+            logger:debug(#{
+                msg => ~"world_reconnect_failed",
+                player_id => PlayerId,
+                class => Class,
+                reason => Reason
+            })
+    end,
+    {noreply, State};
 handle_cast(_Msg, State) ->
     {noreply, State}.
 

--- a/src/plugins/asobi_rate_limit_plugin.erl
+++ b/src/plugins/asobi_rate_limit_plugin.erl
@@ -6,7 +6,16 @@
 -spec pre_request(cowboy_req:req(), map(), map(), term()) ->
     {ok, cowboy_req:req(), term()} | {break, cowboy_req:req(), term()}.
 pre_request(Req, _Env, Options, State) ->
-    Limiter = maps:get(limiter, Options, asobi_api),
+    %% F-19: select a limiter based on the request path so
+    %% `/api/v1/auth/*` runs through `asobi_auth_limiter` (low limit)
+    %% and `/api/v1/iap/*` through `asobi_iap_limiter`. Everything else
+    %% falls back to `asobi_api_limiter`. Configured via Options first,
+    %% then path-derived, then default.
+    Limiter =
+        case maps:get(limiter, Options, undefined) of
+            undefined -> select_limiter(Req);
+            L -> L
+        end,
     Key = rate_limit_key(Req),
     case seki:check(Limiter, Key) of
         {allow, #{remaining := Remaining, reset := Reset}} ->
@@ -62,4 +71,13 @@ peer_ip(Req) ->
     case inet:ntoa(IP) of
         Addr when is_list(Addr) -> list_to_binary(Addr);
         _ -> ~"unknown"
+    end.
+
+-spec select_limiter(cowboy_req:req()) -> atom().
+select_limiter(Req) ->
+    Path = cowboy_req:path(Req),
+    case Path of
+        <<"/api/v1/auth/", _/binary>> -> asobi_auth_limiter;
+        <<"/api/v1/iap/", _/binary>> -> asobi_iap_limiter;
+        _ -> asobi_api_limiter
     end.

--- a/src/social/asobi_chat_channel.erl
+++ b/src/social/asobi_chat_channel.erl
@@ -7,6 +7,9 @@
 -define(MAX_BUFFER, 100).
 -define(REGISTRY, asobi_chat_registry).
 -define(PG_SCOPE, nova_scope).
+%% F-16: stop channels with no live members after this many ms so an
+%% attacker who joins-then-disconnects cannot leak channel processes.
+-define(IDLE_TIMEOUT_MS, 60000).
 
 -spec start_link(binary(), binary()) -> gen_server:start_ret().
 start_link(ChannelId, ChannelType) ->
@@ -47,26 +50,28 @@ get_history(ChannelId, Limit) when is_integer(Limit) ->
             []
     end.
 
--spec init({binary(), binary()}) -> {ok, map()}.
+-spec init({binary(), binary()}) -> {ok, map(), pos_integer()}.
 init({ChannelId, ChannelType}) ->
     ensure_registry(),
     ets:insert(?REGISTRY, {ChannelId, self()}),
     process_flag(trap_exit, true),
-    {ok, #{
-        channel_id => ChannelId,
-        channel_type => ChannelType,
-        buffer => [],
-        buffer_size => 0
-    }}.
+    {ok,
+        #{
+            channel_id => ChannelId,
+            channel_type => ChannelType,
+            buffer => [],
+            buffer_size => 0
+        },
+        ?IDLE_TIMEOUT_MS}.
 
--spec handle_call(term(), gen_server:from(), map()) -> {reply, term(), map()}.
+-spec handle_call(term(), gen_server:from(), map()) -> {reply, term(), map(), pos_integer()}.
 handle_call({history, Limit}, _From, #{buffer := Buffer} = State) when is_integer(Limit) ->
     History = lists:sublist(Buffer, Limit),
-    {reply, lists:reverse(History), State};
+    {reply, lists:reverse(History), State, ?IDLE_TIMEOUT_MS};
 handle_call(_Request, _From, State) ->
-    {reply, ok, State}.
+    {reply, ok, State, ?IDLE_TIMEOUT_MS}.
 
--spec handle_cast(term(), map()) -> {noreply, map()}.
+-spec handle_cast(term(), map()) -> {noreply, map(), pos_integer()}.
 handle_cast(
     {message, SenderId, Content},
     #{
@@ -92,13 +97,21 @@ handle_cast(
             true -> [Msg | lists:droplast(Buffer)];
             false -> [Msg | Buffer]
         end,
-    {noreply, State#{buffer => Buffer1, buffer_size => min(Size + 1, ?MAX_BUFFER)}};
+    {noreply, State#{buffer => Buffer1, buffer_size => min(Size + 1, ?MAX_BUFFER)},
+        ?IDLE_TIMEOUT_MS};
 handle_cast(_Msg, State) ->
-    {noreply, State}.
+    {noreply, State, ?IDLE_TIMEOUT_MS}.
 
--spec handle_info(term(), map()) -> {noreply, map()}.
+-spec handle_info(term(), map()) -> {noreply, map(), pos_integer()} | {stop, normal, map()}.
+handle_info(timeout, #{channel_id := ChannelId} = State) ->
+    %% F-16: stop only if there are zero live joiners; otherwise keep
+    %% running so persistent broadcasts (e.g. world chat) don't churn.
+    case pg:get_members(?PG_SCOPE, {chat, ChannelId}) of
+        [] -> {stop, normal, State};
+        _ -> {noreply, State, ?IDLE_TIMEOUT_MS}
+    end;
 handle_info(_Info, State) ->
-    {noreply, State}.
+    {noreply, State, ?IDLE_TIMEOUT_MS}.
 
 -spec terminate(term(), map()) -> ok.
 terminate(_Reason, #{channel_id := ChannelId}) ->

--- a/src/social/asobi_dm.erl
+++ b/src/social/asobi_dm.erl
@@ -8,25 +8,44 @@
 
 -export([send/3, history/3, channel_id/2]).
 
+-define(MAX_DM_CONTENT_BYTES, 2000).
+
 -spec send(binary(), binary(), binary()) -> ok | {error, term()}.
-send(SenderId, RecipientId, Content) ->
-    case is_blocked(SenderId, RecipientId) of
-        true ->
-            {error, blocked};
-        false ->
-            ChannelId = channel_id(SenderId, RecipientId),
-            asobi_chat_channel:send_message(ChannelId, SenderId, Content),
-            asobi_presence:send(
-                RecipientId,
-                {dm_message, #{
-                    sender_id => SenderId,
-                    content => Content,
-                    channel_id => ChannelId,
-                    sent_at => erlang:system_time(millisecond)
-                }}
-            ),
-            ok
-    end.
+send(SenderId, RecipientId, Content) when
+    is_binary(SenderId), is_binary(RecipientId), is_binary(Content)
+->
+    case validate_content(Content) of
+        ok ->
+            case is_blocked(SenderId, RecipientId) of
+                true ->
+                    {error, blocked};
+                false ->
+                    ChannelId = channel_id(SenderId, RecipientId),
+                    asobi_chat_channel:send_message(ChannelId, SenderId, Content),
+                    asobi_presence:send(
+                        RecipientId,
+                        {dm_message, #{
+                            sender_id => SenderId,
+                            content => Content,
+                            channel_id => ChannelId,
+                            sent_at => erlang:system_time(millisecond)
+                        }}
+                    ),
+                    ok
+            end;
+        {error, _} = Err ->
+            Err
+    end;
+send(_SenderId, _RecipientId, _Content) ->
+    {error, invalid_input}.
+
+-spec validate_content(binary()) -> ok | {error, content_empty | content_too_large}.
+validate_content(<<>>) ->
+    {error, content_empty};
+validate_content(Content) when byte_size(Content) > ?MAX_DM_CONTENT_BYTES ->
+    {error, content_too_large};
+validate_content(_) ->
+    ok.
 
 -spec history(binary(), binary(), pos_integer()) -> [map()].
 history(PlayerId, OtherPlayerId, Limit) ->

--- a/src/social/asobi_group.erl
+++ b/src/social/asobi_group.erl
@@ -43,4 +43,7 @@ changeset(Data, Params) ->
         name, description, max_members, open, creator_id, metadata
     ]),
     CS1 = kura_changeset:validate_required(CS, [name, creator_id]),
-    kura_changeset:validate_length(CS1, name, [{min, 2}, {max, 64}]).
+    CS2 = kura_changeset:validate_length(CS1, name, [{min, 2}, {max, 64}]),
+    %% F-17: cap description length so an attacker cannot store
+    %% megabytes of text in the groups table.
+    kura_changeset:validate_length(CS2, description, [{max, 1024}]).

--- a/src/votes/asobi_vote_controller.erl
+++ b/src/votes/asobi_vote_controller.erl
@@ -4,17 +4,57 @@
 -export([index/1, show/1]).
 
 -spec index(cowboy_req:req()) -> {json, map()} | {status, integer()}.
-index(#{bindings := #{~"id" := MatchId}, auth_data := #{player_id := _PlayerId}} = _Req) ->
-    Q0 = kura_query:from(asobi_vote),
-    Q1 = kura_query:where(Q0, {match_id, MatchId}),
-    Q2 = kura_query:order_by(Q1, [{inserted_at, desc}]),
-    Q3 = kura_query:limit(Q2, 50),
-    case asobi_repo:all(Q3) of
-        {ok, Votes} ->
-            {json, #{votes => Votes}};
-        {error, _} ->
-            {status, 500}
+index(#{bindings := #{~"id" := MatchId}, auth_data := #{player_id := PlayerId}} = _Req) when
+    is_binary(MatchId), is_binary(PlayerId)
+->
+    %% F-20: vote history is restricted to participants of the match. Look
+    %% up the match record (or live match server) and reject non-players.
+    case is_match_participant(MatchId, PlayerId) of
+        false ->
+            {status, 403};
+        true ->
+            Q0 = kura_query:from(asobi_vote),
+            Q1 = kura_query:where(Q0, {match_id, MatchId}),
+            Q2 = kura_query:order_by(Q1, [{inserted_at, desc}]),
+            Q3 = kura_query:limit(Q2, 50),
+            case asobi_repo:all(Q3) of
+                {ok, Votes} ->
+                    {json, #{votes => [strip_hidden(V) || V <- Votes]}};
+                {error, _} ->
+                    {status, 500}
+            end
     end.
+
+-spec is_match_participant(binary(), binary()) -> boolean().
+is_match_participant(MatchId, PlayerId) ->
+    case asobi_repo:get(asobi_match_record, MatchId) of
+        {ok, #{players := Players}} when is_list(Players) ->
+            lists:member(PlayerId, Players);
+        _ ->
+            %% Match still in flight; defer to the live server. The server
+            %% takes a pid, so resolve by id first.
+            case asobi_match_server:whereis(MatchId) of
+                {ok, Pid} when is_pid(Pid) ->
+                    try asobi_match_server:get_info(Pid) of
+                        #{players := Players} when is_list(Players) ->
+                            lists:member(PlayerId, Players);
+                        _ ->
+                            false
+                    catch
+                        _:_ -> false
+                    end;
+                _ ->
+                    false
+            end
+    end.
+
+%% F-20: hidden-visibility votes must not leak per-voter ballots even to
+%% participants until the vote has resolved.
+-spec strip_hidden(map()) -> map().
+strip_hidden(#{visibility := ~"hidden", status := S} = Vote) when S =/= ~"resolved" ->
+    maps:remove(votes_cast, Vote);
+strip_hidden(Vote) ->
+    Vote.
 
 -spec show(cowboy_req:req()) -> {json, map()} | {status, integer()}.
 show(#{bindings := #{~"id" := VoteId}, auth_data := #{player_id := _PlayerId}} = _Req) ->

--- a/src/world/asobi_world_lobby.erl
+++ b/src/world/asobi_world_lobby.erl
@@ -1,9 +1,14 @@
 -module(asobi_world_lobby).
 
--export([list_worlds/0, list_worlds/1, find_or_create/1, create_world/1]).
--export([find_or_create_unsafe/1]).
+-export([
+    list_worlds/0, list_worlds/1, find_or_create/1, find_or_create/2, create_world/1, create_world/2
+]).
+-export([find_or_create_unsafe/1, find_or_create_unsafe/2]).
+-export([player_owned_world_count/1, world_capacity_state/1]).
 
 -define(PG_SCOPE, nova_scope).
+-define(DEFAULT_MAX_WORLDS_PER_PLAYER, 5).
+-define(DEFAULT_MAX_WORLDS, 1000).
 
 -doc "List all running worlds.".
 -spec list_worlds() -> [map()].
@@ -46,7 +51,12 @@ same mode. Serializing closes the window.
 """.
 -spec find_or_create(binary()) -> {ok, pid(), map()} | {error, term()}.
 find_or_create(Mode) ->
-    asobi_world_lobby_server:find_or_create(Mode).
+    find_or_create(Mode, undefined).
+
+-spec find_or_create(binary(), binary() | undefined) ->
+    {ok, pid(), map()} | {error, term()}.
+find_or_create(Mode, PlayerId) ->
+    asobi_world_lobby_server:find_or_create(Mode, PlayerId).
 
 -doc """
 The non-serialized implementation. Only `asobi_world_lobby_server`
@@ -55,20 +65,49 @@ serializer holds no state and just delegates back here.
 """.
 -spec find_or_create_unsafe(binary()) -> {ok, pid(), map()} | {error, term()}.
 find_or_create_unsafe(Mode) ->
+    find_or_create_unsafe(Mode, undefined).
+
+-spec find_or_create_unsafe(binary(), binary() | undefined) ->
+    {ok, pid(), map()} | {error, term()}.
+find_or_create_unsafe(Mode, PlayerId) ->
     Worlds = list_worlds(#{mode => Mode, has_capacity => true}),
     case Worlds of
         [#{world_id := WorldId} = First | _] ->
             case asobi_world_server:whereis(WorldId) of
                 {ok, Pid} -> {ok, Pid, First};
-                error -> create_world(Mode)
+                error -> create_world(Mode, PlayerId)
             end;
         [] ->
-            create_world(Mode)
+            create_world(Mode, PlayerId)
     end.
 
--doc "Create a new world for the given mode.".
+-doc "Create a new world for the given mode (no owner — anonymous create).".
 -spec create_world(binary()) -> {ok, pid(), map()} | {error, term()}.
 create_world(Mode) ->
+    create_world(Mode, undefined).
+
+-doc """
+Create a new world for the given mode and tag the player as owner.
+
+Refuses with `{error, world_capacity_reached}` when the global cap
+(`asobi:world_max`, default 1000) is hit, and `{error, player_world_limit_reached}`
+when the player is already at the per-player cap (`asobi:world_max_per_player`,
+default 5). The cap is enforced via a pg group joined on creation so it
+naturally clears when the world process dies.
+""".
+-spec create_world(binary(), binary() | undefined) ->
+    {ok, pid(), map()} | {error, term()}.
+create_world(Mode, PlayerId) ->
+    case check_world_capacity(PlayerId) of
+        ok ->
+            do_create_world(Mode, PlayerId);
+        {error, _} = Err ->
+            Err
+    end.
+
+-spec do_create_world(binary(), binary() | undefined) ->
+    {ok, pid(), map()} | {error, term()}.
+do_create_world(Mode, PlayerId) ->
     case asobi_game_modes:world_config(Mode) of
         {ok, Config0} ->
             %% Pre-allocate the world_id so the zone_manager (started before
@@ -80,11 +119,11 @@ create_world(Mode) ->
             Config = Config0#{world_id => WorldId},
             case asobi_world_instance_sup:start_world(Config) of
                 {ok, InstancePid} when is_pid(InstancePid) ->
-                    WorldPid = wait_for_world_server(InstancePid, 10),
-                    case WorldPid of
+                    case wait_for_world_server(InstancePid, 10) of
                         undefined ->
                             {error, world_server_not_started};
-                        _ ->
+                        WorldPid ->
+                            register_world_owner(WorldPid, PlayerId),
                             Info = asobi_world_server:get_info(WorldPid),
                             {ok, WorldPid, Info}
                     end;
@@ -94,6 +133,68 @@ create_world(Mode) ->
         {error, _} = Err ->
             Err
     end.
+
+%% F-9: track per-player and global concurrent-world caps via pg.
+%% Joining the world pid into `{asobi_owned_worlds, PlayerId}` and
+%% `asobi_owned_worlds_global` ties the count to the world process
+%% lifetime — when the world dies the pg group entry vanishes
+%% automatically.
+-spec check_world_capacity(binary() | undefined) -> ok | {error, term()}.
+check_world_capacity(PlayerId) ->
+    GlobalCount = global_world_count(),
+    GlobalMax = application:get_env(asobi, world_max, ?DEFAULT_MAX_WORLDS),
+    case GlobalCount >= GlobalMax of
+        true ->
+            {error, world_capacity_reached};
+        false ->
+            check_per_player_cap(PlayerId)
+    end.
+
+-spec check_per_player_cap(binary() | undefined) -> ok | {error, term()}.
+check_per_player_cap(undefined) ->
+    %% Anonymous creates (internal callers, not request-driven) bypass
+    %% the per-player cap. The global cap above still applies.
+    ok;
+check_per_player_cap(PlayerId) when is_binary(PlayerId) ->
+    PlayerCount = player_owned_world_count(PlayerId),
+    PlayerMax =
+        application:get_env(asobi, world_max_per_player, ?DEFAULT_MAX_WORLDS_PER_PLAYER),
+    case PlayerCount >= PlayerMax of
+        true -> {error, player_world_limit_reached};
+        false -> ok
+    end.
+
+-spec register_world_owner(pid(), binary() | undefined) -> ok.
+register_world_owner(WorldPid, undefined) ->
+    pg:join(?PG_SCOPE, asobi_owned_worlds_global, WorldPid),
+    ok;
+register_world_owner(WorldPid, PlayerId) when is_binary(PlayerId) ->
+    pg:join(?PG_SCOPE, asobi_owned_worlds_global, WorldPid),
+    pg:join(?PG_SCOPE, {asobi_owned_worlds, PlayerId}, WorldPid),
+    ok.
+
+-spec player_owned_world_count(binary()) -> non_neg_integer().
+player_owned_world_count(PlayerId) when is_binary(PlayerId) ->
+    length(pg:get_members(?PG_SCOPE, {asobi_owned_worlds, PlayerId})).
+
+-spec global_world_count() -> non_neg_integer().
+global_world_count() ->
+    length(pg:get_members(?PG_SCOPE, asobi_owned_worlds_global)).
+
+-spec world_capacity_state(binary() | undefined) -> map().
+world_capacity_state(PlayerId) ->
+    Per =
+        case PlayerId of
+            undefined -> 0;
+            _ -> player_owned_world_count(PlayerId)
+        end,
+    #{
+        global => global_world_count(),
+        global_max => application:get_env(asobi, world_max, ?DEFAULT_MAX_WORLDS),
+        player => Per,
+        player_max =>
+            application:get_env(asobi, world_max_per_player, ?DEFAULT_MAX_WORLDS_PER_PLAYER)
+    }.
 
 %%--------------------------------------------------------------------
 %% Internal

--- a/src/world/asobi_world_lobby_server.erl
+++ b/src/world/asobi_world_lobby_server.erl
@@ -20,7 +20,7 @@ typical deployment supports, the queue stays empty.
 """.
 -behaviour(gen_server).
 
--export([start_link/0, find_or_create/1]).
+-export([start_link/0, find_or_create/1, find_or_create/2]).
 -export([init/1, handle_call/3, handle_cast/2]).
 
 -define(CALL_TIMEOUT, 30000).
@@ -36,7 +36,12 @@ directly is racy.
 """.
 -spec find_or_create(binary()) -> {ok, pid(), map()} | {error, term()}.
 find_or_create(Mode) ->
-    case gen_server:call(?MODULE, {find_or_create, Mode}, ?CALL_TIMEOUT) of
+    find_or_create(Mode, undefined).
+
+-spec find_or_create(binary(), binary() | undefined) ->
+    {ok, pid(), map()} | {error, term()}.
+find_or_create(Mode, PlayerId) ->
+    case gen_server:call(?MODULE, {find_or_create, Mode, PlayerId}, ?CALL_TIMEOUT) of
         {ok, Pid, Meta} when is_pid(Pid), is_map(Meta) -> {ok, Pid, Meta};
         {error, Reason} -> {error, Reason};
         Other -> {error, {unexpected_reply, Other}}
@@ -52,8 +57,10 @@ init([]) ->
 
 -spec handle_call(term(), gen_server:from(), map()) ->
     {reply, term(), map()}.
-handle_call({find_or_create, Mode}, _From, State) when is_binary(Mode) ->
-    Result = asobi_world_lobby:find_or_create_unsafe(Mode),
+handle_call({find_or_create, Mode, PlayerId}, _From, State) when
+    is_binary(Mode), (is_binary(PlayerId) orelse PlayerId =:= undefined)
+->
+    Result = asobi_world_lobby:find_or_create_unsafe(Mode, PlayerId),
     {reply, Result, State};
 handle_call(_Other, _From, State) ->
     {reply, {error, unknown_request}, State}.

--- a/src/world/asobi_world_sup.erl
+++ b/src/world/asobi_world_sup.erl
@@ -1,4 +1,15 @@
 -module(asobi_world_sup).
+-moduledoc """
+Top-level world supervisor.
+
+**Public ETS trust assumption (F-33)**: `asobi_world_state` and
+`asobi_player_worlds` are `public` named ETS tables. Anything running
+in the same BEAM (game callbacks, plugins, etc.) can read and mutate
+them. asobi is single-tenant and the loaded code is trusted, so this
+is acceptable — but it's an explicit trust boundary worth surfacing
+in the threat model. Any sandboxed runtime layered on top of asobi
+(e.g. `asobi_lua`) MUST keep its sandbox out of these tables.
+""".
 -behaviour(supervisor).
 
 -export([start_link/0]).

--- a/src/ws/asobi_ws_handler.erl
+++ b/src/ws/asobi_ws_handler.erl
@@ -6,6 +6,9 @@
 -define(WS_MSG_LIMIT, 60).
 -define(WS_MSG_WINDOW_MS, 1000).
 -define(WS_MAX_PAYLOAD_BYTES, 65536).
+%% F-16: per-connection cap on simultaneously joined chat channels.
+-define(MAX_JOINED_CHANNELS_PER_CONN, 32).
+-define(MAX_CHANNEL_ID_BYTES, 256).
 
 -spec init(map()) -> {ok, map()}.
 init(State) ->
@@ -108,16 +111,15 @@ handle_message(#{~"type" := ~"session.connect", ~"payload" := Payload} = Msg, St
         {ok, PlayerId} ->
             {ok, SessionPid} = asobi_player_session_sup:start_session(PlayerId, self()),
             asobi_telemetry:session_connected(PlayerId),
-            %% Check for pending world reconnection
-            _ =
-                case ets:lookup(asobi_player_worlds, PlayerId) of
-                    [{PlayerId, WorldPid}] ->
-                        _ = spawn(fun() ->
-                            catch asobi_world_server:reconnect(WorldPid, PlayerId)
-                        end);
-                    [] ->
-                        ok
-                end,
+            %% F-28: drive the world reconnect from the supervised player
+            %% session process rather than an unsupervised spawn — a slow
+            %% or crashing reconnect cannot leak processes anymore.
+            case ets:lookup(asobi_player_worlds, PlayerId) of
+                [{PlayerId, WorldPid}] when is_pid(WorldPid) ->
+                    gen_server:cast(SessionPid, {reconnect_world, WorldPid});
+                _ ->
+                    ok
+            end,
             Reply = encode_reply(Cid, ~"session.connected", #{player_id => PlayerId}),
             {reply, {text, Reply}, State#{session => SessionPid, player_id => PlayerId}};
         {error, Reason} ->
@@ -188,24 +190,41 @@ handle_message(
                 channel_id => asobi_dm:channel_id(PlayerId, RecipientId)
             }),
             {reply, {text, Reply}, State};
-        {error, blocked} ->
-            Reply = encode_reply(Cid, ~"error", #{reason => ~"blocked"}),
+        {error, Reason} ->
+            Reply = encode_reply(Cid, ~"error", #{reason => to_reason_binary(Reason)}),
             {reply, {text, Reply}, State}
     end;
 handle_message(
     #{~"type" := ~"chat.join", ~"payload" := #{~"channel_id" := ChannelId}} = Msg, State
-) ->
+) when is_binary(ChannelId) ->
     Cid = maps:get(~"cid", Msg, undefined),
-    asobi_chat_channel:join(ChannelId, self()),
-    Reply = encode_reply(Cid, ~"chat.joined", #{channel_id => ChannelId}),
-    {reply, {text, Reply}, State};
+    %% F-16: bound channel id length, namespace it, and cap how many channels
+    %% one connection may join. Prevents one socket from spawning unbounded
+    %% chat channel processes on the host.
+    case validate_channel_id(ChannelId) of
+        false ->
+            Reply = encode_reply(Cid, ~"error", #{reason => ~"invalid_channel_id"}),
+            {reply, {text, Reply}, State};
+        true ->
+            Joined = maps:get(joined_channels, State, #{}),
+            case map_size(Joined) >= ?MAX_JOINED_CHANNELS_PER_CONN of
+                true ->
+                    Reply = encode_reply(Cid, ~"error", #{reason => ~"too_many_channels"}),
+                    {reply, {text, Reply}, State};
+                false ->
+                    asobi_chat_channel:join(ChannelId, self()),
+                    Reply = encode_reply(Cid, ~"chat.joined", #{channel_id => ChannelId}),
+                    {reply, {text, Reply}, State#{joined_channels => Joined#{ChannelId => true}}}
+            end
+    end;
 handle_message(
     #{~"type" := ~"chat.leave", ~"payload" := #{~"channel_id" := ChannelId}} = Msg, State
-) ->
+) when is_binary(ChannelId) ->
     Cid = maps:get(~"cid", Msg, undefined),
     asobi_chat_channel:leave(ChannelId, self()),
+    Joined = maps:get(joined_channels, State, #{}),
     Reply = encode_reply(Cid, ~"chat.left", #{channel_id => ChannelId}),
-    {reply, {text, Reply}, State};
+    {reply, {text, Reply}, State#{joined_channels => maps:remove(ChannelId, Joined)}};
 handle_message(
     #{~"type" := ~"matchmaker.add", ~"payload" := Payload} = Msg,
     #{player_id := PlayerId} = State
@@ -223,8 +242,15 @@ handle_message(
     #{player_id := PlayerId} = State
 ) ->
     Cid = maps:get(~"cid", Msg, undefined),
-    asobi_matchmaker:remove(PlayerId, TicketId),
-    Reply = encode_reply(Cid, ~"matchmaker.removed", #{success => true}),
+    Reply =
+        case asobi_matchmaker:remove(PlayerId, TicketId) of
+            ok ->
+                encode_reply(Cid, ~"matchmaker.removed", #{success => true});
+            {error, Reason} ->
+                encode_reply(Cid, ~"error", #{
+                    type => ~"matchmaker.remove", reason => atom_to_binary(Reason, utf8)
+                })
+        end,
     {reply, {text, Reply}, State};
 handle_message(
     #{~"type" := ~"presence.update", ~"payload" := Payload} = Msg,
@@ -329,22 +355,25 @@ handle_message(
 handle_message(
     #{~"type" := ~"world.list", ~"payload" := Payload} = Msg,
     #{player_id := _PlayerId} = State
-) ->
+) when is_map(Payload) ->
     Cid = maps:get(~"cid", Msg, undefined),
-    Filters = #{
-        mode => maps:get(~"mode", Payload, undefined),
-        has_capacity => maps:get(~"has_capacity", Payload, false)
-    },
-    Filters1 = maps:filter(fun(_, V) -> V =/= undefined end, Filters),
-    Worlds = asobi_world_lobby:list_worlds(Filters1),
-    Reply = encode_reply(Cid, ~"world.list", #{worlds => Worlds}),
-    {reply, {text, Reply}, State};
+    %% F-29: validate filter values rather than silently degrading on
+    %% bad types.
+    case build_world_filters(Payload) of
+        {ok, Filters} ->
+            Worlds = asobi_world_lobby:list_worlds(Filters),
+            Reply = encode_reply(Cid, ~"world.list", #{worlds => Worlds}),
+            {reply, {text, Reply}, State};
+        {error, Reason} ->
+            Reply = encode_reply(Cid, ~"error", #{reason => Reason}),
+            {reply, {text, Reply}, State}
+    end;
 handle_message(
     #{~"type" := ~"world.create", ~"payload" := #{~"mode" := Mode}} = Msg,
     #{player_id := PlayerId} = State
 ) ->
     Cid = maps:get(~"cid", Msg, undefined),
-    case asobi_world_lobby:create_world(Mode) of
+    case asobi_world_lobby:create_world(Mode, PlayerId) of
         {ok, WorldPid, _Info} ->
             join_and_reply(Cid, WorldPid, PlayerId, State);
         {error, Reason} ->
@@ -356,7 +385,7 @@ handle_message(
     #{player_id := PlayerId} = State
 ) ->
     Cid = maps:get(~"cid", Msg, undefined),
-    case asobi_world_lobby:find_or_create(Mode) of
+    case asobi_world_lobby:find_or_create(Mode, PlayerId) of
         {ok, WorldPid, _Info} ->
             join_and_reply(Cid, WorldPid, PlayerId, State);
         {error, Reason} ->
@@ -412,9 +441,13 @@ handle_message(
         exit:{noproc, _} ->
             {ok, State#{session => undefined}}
     end;
-handle_message(#{~"type" := Type} = Msg, State) ->
+handle_message(#{~"type" := _Type} = Msg, State) ->
+    %% F-26: do NOT echo the client-supplied `type` back into the error
+    %% reply or logs — an attacker could craft strings that pollute the
+    %% structured-log pipeline. The client knows what it sent, so the
+    %% reason alone is enough.
     Cid = maps:get(~"cid", Msg, undefined),
-    Reply = encode_reply(Cid, ~"error", #{reason => ~"unknown_type", type => Type}),
+    Reply = encode_reply(Cid, ~"error", #{reason => ~"unknown_type"}),
     {reply, {text, Reply}, State};
 handle_message(_Msg, State) ->
     {ok, State}.
@@ -517,3 +550,48 @@ encode_reply(Cid, Type, Payload) ->
             _ -> Msg0#{~"cid" => Cid}
         end,
     json:encode(Msg).
+
+to_reason_binary(R) when is_atom(R) -> atom_to_binary(R, utf8).
+
+%% F-16: chat.join must require a small, namespaced channel id so an
+%% attacker can't spawn unbounded chat channel gen_servers via WS.
+%% Allowed prefixes mirror the channel id schemes documented in
+%% asobi_chat_controller's classify/1 (`dm:`, `world:`, `zone:`,
+%% `prox:`, plus a `room:` namespace for app-defined group chats).
+validate_channel_id(ChannelId) when is_binary(ChannelId) ->
+    byte_size(ChannelId) > 0 andalso
+        byte_size(ChannelId) =< ?MAX_CHANNEL_ID_BYTES andalso
+        valid_channel_prefix(ChannelId).
+
+valid_channel_prefix(<<"dm:", _/binary>>) -> true;
+valid_channel_prefix(<<"world:", _/binary>>) -> true;
+valid_channel_prefix(<<"zone:", _/binary>>) -> true;
+valid_channel_prefix(<<"prox:", _/binary>>) -> true;
+valid_channel_prefix(<<"room:", _/binary>>) -> true;
+valid_channel_prefix(_) -> false.
+
+%% F-29: world.list filter values must be the right type or we reject the
+%% request rather than silently returning unfiltered results.
+build_world_filters(Payload) ->
+    Acc1 =
+        case maps:find(~"mode", Payload) of
+            error ->
+                {ok, #{}};
+            {ok, undefined} ->
+                {ok, #{}};
+            {ok, Mode} when is_binary(Mode), byte_size(Mode) =< 64 ->
+                {ok, #{mode => Mode}};
+            _ ->
+                {error, ~"invalid_mode_filter"}
+        end,
+    case Acc1 of
+        {error, _} = E1 ->
+            E1;
+        {ok, A1} ->
+            case maps:find(~"has_capacity", Payload) of
+                error -> {ok, A1};
+                {ok, true} -> {ok, A1#{has_capacity => true}};
+                {ok, false} -> {ok, A1};
+                _ -> {error, ~"invalid_has_capacity_filter"}
+            end
+    end.

--- a/test/asobi_dm_tests.erl
+++ b/test/asobi_dm_tests.erl
@@ -17,3 +17,24 @@ channel_id_same_order_test() ->
 channel_id_prefix_test() ->
     Id = asobi_dm:channel_id(~"p1", ~"p2"),
     ?assertMatch(<<"dm:", _/binary>>, Id).
+
+%% F-11: DM content must be capped at 2000 bytes; oversized payloads must
+%% return {error, content_too_large} rather than being silently relayed.
+send_rejects_oversized_content_test() ->
+    Big = binary:copy(<<"x">>, 2001),
+    ?assertEqual(
+        {error, content_too_large},
+        asobi_dm:send(~"alice", ~"bob", Big)
+    ).
+
+send_rejects_empty_content_test() ->
+    ?assertEqual(
+        {error, content_empty},
+        asobi_dm:send(~"alice", ~"bob", <<>>)
+    ).
+
+%% Note: non-binary content is rejected by the eqWAlizer-checked
+%% function head; we don't dispatch through there in tests because
+%% eqWAlizer would refuse the bad call. The runtime guard remains as
+%% defense-in-depth and is exercised via the HTTP/WS layer where
+%% input types are dynamic.

--- a/test/asobi_economy_SUITE.erl
+++ b/test/asobi_economy_SUITE.erl
@@ -9,10 +9,18 @@
     debit_currency/1,
     debit_insufficient_funds/1,
     get_history/1,
-    concurrent_wallet_creation/1
+    concurrent_wallet_creation/1,
+    concurrent_debits_no_overspend/1,
+    debit_rejects_negative_amount/1
 ]).
 
-all() -> [{group, wallet}, concurrent_wallet_creation].
+all() ->
+    [
+        {group, wallet},
+        concurrent_wallet_creation,
+        concurrent_debits_no_overspend,
+        debit_rejects_negative_amount
+    ].
 
 groups() ->
     [
@@ -86,6 +94,52 @@ get_history(Config) ->
     #{~"transactions" := History} = nova_test:json(Resp),
     true = is_list(History),
     ?assert(length(History) >= 2),
+    Config.
+
+%% F-5 regression: N parallel debits of the same wallet must never let
+%% the balance go below zero (no double-spend). Without
+%% pg_advisory_xact_lock around the read-check-write window, two
+%% concurrent debits could both pass the `Balance >= Amount` guard.
+concurrent_debits_no_overspend(Config) ->
+    {player_id, PlayerId} = lists:keyfind(player_id, 1, Config),
+    true = is_binary(PlayerId),
+    Currency = <<"f5_lock_", (integer_to_binary(erlang:unique_integer([positive])))/binary>>,
+    Start = 100,
+    Price = 10,
+    %% 20 concurrent debits, only 10 should succeed.
+    Workers = 20,
+    {ok, _} = asobi_economy:grant(PlayerId, Currency, Start, #{reason => ~"f5_test"}),
+    Self = self(),
+    Pids = [
+        spawn(fun() ->
+            Result = asobi_economy:debit(PlayerId, Currency, Price, #{reason => ~"f5_test"}),
+            Self ! {result, self(), Result}
+        end)
+     || _ <- lists:seq(1, Workers)
+    ],
+    Results = [
+        receive
+            {result, P, R} -> R
+        after 10000 -> timeout
+        end
+     || P <- Pids
+    ],
+    Successes = length([R || {ok, _} = R <- Results]),
+    Insufficient = length([R || {error, insufficient_funds} = R <- Results]),
+    ?assertEqual(Workers, Successes + Insufficient),
+    ?assertEqual(Start div Price, Successes),
+    {ok, MyWallet} = asobi_economy:get_or_create_wallet(PlayerId, Currency),
+    ?assertEqual(0, maps:get(balance, MyWallet)),
+    Config.
+
+debit_rejects_negative_amount(Config) ->
+    {player_id, PlayerId} = lists:keyfind(player_id, 1, Config),
+    true = is_binary(PlayerId),
+    %% The function-head guard `Amount > 0` should fail-closed for any
+    %% non-positive integer (function_clause crash on the caller side).
+    ?assertError(function_clause, asobi_economy:debit(PlayerId, ~"gold", -1, #{})),
+    ?assertError(function_clause, asobi_economy:debit(PlayerId, ~"gold", 0, #{})),
+    ?assertError(function_clause, asobi_economy:grant(PlayerId, ~"gold", -1, #{})),
     Config.
 
 concurrent_wallet_creation(Config) ->

--- a/test/asobi_matchmaker_api_SUITE.erl
+++ b/test/asobi_matchmaker_api_SUITE.erl
@@ -7,23 +7,43 @@
     add_ticket/1,
     get_ticket/1,
     get_ticket_not_found/1,
-    cancel_ticket/1
+    cancel_ticket/1,
+    party_other_players_dropped/1,
+    other_player_cannot_read_ticket/1,
+    other_player_cannot_cancel_ticket/1
 ]).
 
-all() -> [add_ticket, get_ticket, get_ticket_not_found, cancel_ticket].
+all() ->
+    [
+        add_ticket,
+        get_ticket,
+        get_ticket_not_found,
+        cancel_ticket,
+        party_other_players_dropped,
+        other_player_cannot_read_ticket,
+        other_player_cannot_cancel_ticket
+    ].
 
 init_per_suite(Config) ->
     Config0 = asobi_test_helpers:start(Config),
-    U1 = asobi_test_helpers:unique_username(~"mm_api"),
+    U1 = asobi_test_helpers:unique_username(~"mm_api1"),
+    U2 = asobi_test_helpers:unique_username(~"mm_api2"),
     {ok, R1} = nova_test:post(
         "/api/v1/auth/register",
         #{json => #{~"username" => U1, ~"password" => ~"testpass123"}},
         Config0
     ),
+    {ok, R2} = nova_test:post(
+        "/api/v1/auth/register",
+        #{json => #{~"username" => U2, ~"password" => ~"testpass123"}},
+        Config0
+    ),
     #{~"player_id" := P1Id, ~"session_token" := P1Token} = nova_test:json(R1),
+    #{~"session_token" := P2Token} = nova_test:json(R2),
     [
         {player1_id, P1Id},
-        {player1_token, P1Token}
+        {player1_token, P1Token},
+        {player2_token, P2Token}
         | Config0
     ].
 
@@ -32,6 +52,11 @@ end_per_suite(Config) ->
 
 auth(Config) ->
     {player1_token, Token} = lists:keyfind(player1_token, 1, Config),
+    true = is_binary(Token),
+    [{~"authorization", <<"Bearer ", Token/binary>>}].
+
+auth2(Config) ->
+    {player2_token, Token} = lists:keyfind(player2_token, 1, Config),
     true = is_binary(Token),
     [{~"authorization", <<"Bearer ", Token/binary>>}].
 
@@ -89,6 +114,92 @@ get_ticket_not_found(Config) ->
         Config
     ),
     ?assertStatus(404, Resp),
+    Config.
+
+%% F-7 regression: party entries that aren't the requester are dropped.
+party_other_players_dropped(Config) ->
+    {ok, AddResp} = nova_test:post(
+        "/api/v1/matchmaker",
+        #{
+            headers => auth(Config),
+            json => #{
+                ~"mode" => ~"ranked",
+                ~"party" => [~"someone-else", ~"00000000-0000-0000-0000-000000000001"]
+            }
+        },
+        Config
+    ),
+    #{~"ticket_id" := TicketId} = nova_test:json(AddResp),
+    true = is_binary(TicketId),
+    {ok, GetResp} = nova_test:get(
+        "/api/v1/matchmaker/" ++ binary_to_list(TicketId),
+        #{headers => auth(Config)},
+        Config
+    ),
+    Body = nova_test:json(GetResp),
+    {player1_id, P1Id} = lists:keyfind(player1_id, 1, Config),
+    case Body of
+        #{~"party" := Party} when is_list(Party) ->
+            ?assertEqual([P1Id], Party);
+        _ ->
+            ok
+    end,
+    _ = nova_test:delete(
+        "/api/v1/matchmaker/" ++ binary_to_list(TicketId),
+        #{headers => auth(Config)},
+        Config
+    ),
+    Config.
+
+%% F-8 regression: another player cannot read someone else's ticket.
+other_player_cannot_read_ticket(Config) ->
+    {ok, AddResp} = nova_test:post(
+        "/api/v1/matchmaker",
+        #{headers => auth(Config), json => #{~"mode" => ~"casual"}},
+        Config
+    ),
+    #{~"ticket_id" := TicketId} = nova_test:json(AddResp),
+    true = is_binary(TicketId),
+    {ok, ForbiddenResp} = nova_test:get(
+        "/api/v1/matchmaker/" ++ binary_to_list(TicketId),
+        #{headers => auth2(Config)},
+        Config
+    ),
+    ?assertStatus(403, ForbiddenResp),
+    _ = nova_test:delete(
+        "/api/v1/matchmaker/" ++ binary_to_list(TicketId),
+        #{headers => auth(Config)},
+        Config
+    ),
+    Config.
+
+%% F-8 regression: another player cannot cancel someone else's ticket.
+other_player_cannot_cancel_ticket(Config) ->
+    {ok, AddResp} = nova_test:post(
+        "/api/v1/matchmaker",
+        #{headers => auth(Config), json => #{~"mode" => ~"casual"}},
+        Config
+    ),
+    #{~"ticket_id" := TicketId} = nova_test:json(AddResp),
+    true = is_binary(TicketId),
+    {ok, ForbiddenResp} = nova_test:delete(
+        "/api/v1/matchmaker/" ++ binary_to_list(TicketId),
+        #{headers => auth2(Config)},
+        Config
+    ),
+    ?assertStatus(403, ForbiddenResp),
+    %% The owner can still see / cancel it.
+    {ok, GetResp} = nova_test:get(
+        "/api/v1/matchmaker/" ++ binary_to_list(TicketId),
+        #{headers => auth(Config)},
+        Config
+    ),
+    ?assertStatus(200, GetResp),
+    _ = nova_test:delete(
+        "/api/v1/matchmaker/" ++ binary_to_list(TicketId),
+        #{headers => auth(Config)},
+        Config
+    ),
     Config.
 
 cancel_ticket(Config) ->

--- a/test/asobi_social_api_SUITE.erl
+++ b/test/asobi_social_api_SUITE.erl
@@ -8,8 +8,11 @@
     show_group_not_found/1,
     leave_group/1,
     leave_group_not_member/1,
-    chat_history_empty/1,
-    chat_history_with_messages/1
+    chat_history_unauthorized_arbitrary_channel/1,
+    chat_history_with_messages/1,
+    chat_history_non_member_forbidden/1,
+    chat_history_dm_non_participant_forbidden/1,
+    chat_history_dm_participant_allowed/1
 ]).
 
 all() -> [{group, groups_api}, {group, chat_api}].
@@ -20,7 +23,11 @@ groups() ->
             show_group, show_group_not_found, leave_group, leave_group_not_member
         ]},
         {chat_api, [sequence], [
-            chat_history_empty, chat_history_with_messages
+            chat_history_unauthorized_arbitrary_channel,
+            chat_history_with_messages,
+            chat_history_non_member_forbidden,
+            chat_history_dm_non_participant_forbidden,
+            chat_history_dm_participant_allowed
         ]}
     ].
 
@@ -28,6 +35,7 @@ init_per_suite(Config) ->
     Config0 = asobi_test_helpers:start(Config),
     U1 = asobi_test_helpers:unique_username(~"sapi1_"),
     U2 = asobi_test_helpers:unique_username(~"sapi2_"),
+    U3 = asobi_test_helpers:unique_username(~"sapi3_"),
     {ok, R1} = nova_test:post(
         "/api/v1/auth/register",
         #{json => #{~"username" => U1, ~"password" => ~"testpass123"}},
@@ -40,12 +48,21 @@ init_per_suite(Config) ->
         Config0
     ),
     B2 = nova_test:json(R2),
+    {ok, R3} = nova_test:post(
+        "/api/v1/auth/register",
+        #{json => #{~"username" => U3, ~"password" => ~"testpass123"}},
+        Config0
+    ),
+    B3 = nova_test:json(R3),
     #{~"session_token" := P1Token, ~"player_id" := P1Id} = B1,
     #{~"session_token" := P2Token, ~"player_id" := P2Id} = B2,
+    #{~"session_token" := P3Token, ~"player_id" := P3Id} = B3,
     true = is_binary(P1Id),
     true = is_binary(P2Id),
+    true = is_binary(P3Id),
     true = is_binary(P1Token),
     true = is_binary(P2Token),
+    true = is_binary(P3Token),
     {ok, GR} = nova_test:post(
         "/api/v1/groups",
         #{
@@ -63,9 +80,10 @@ init_per_suite(Config) ->
         #{headers => auth(P2Token), json => #{}},
         Config0
     ),
-    ChannelId = iolist_to_binary([
-        ~"test_chat_api_", integer_to_binary(erlang:unique_integer([positive]))
-    ]),
+    %% F-10: chat history is now membership-gated. Use the actual GroupId
+    %% as the channel_id so P1 (creator) is authorized via asobi_group_member;
+    %% P3 will be a non-member who must be denied.
+    ChannelId = GroupId,
     asobi_chat_channel:join(ChannelId, self()),
     asobi_chat_channel:send_message(ChannelId, P1Id, ~"Hello from p1"),
     asobi_chat_channel:send_message(ChannelId, P2Id, ~"Hello from p2"),
@@ -76,6 +94,8 @@ init_per_suite(Config) ->
         {player1_token, P1Token},
         {player2_id, P2Id},
         {player2_token, P2Token},
+        {player3_id, P3Id},
+        {player3_token, P3Token},
         {group_id, GroupId},
         {channel_id, ChannelId}
         | Config0
@@ -144,7 +164,9 @@ leave_group_not_member(Config) ->
 
 %% --- Chat API ---
 
-chat_history_empty(Config) ->
+%% F-10: arbitrary channel ids that don't correspond to a group the
+%% requester is a member of must return 403, not leak history.
+chat_history_unauthorized_arbitrary_channel(Config) ->
     {player1_token, Token} = lists:keyfind(player1_token, 1, Config),
     true = is_binary(Token),
     {ok, Resp} = nova_test:get(
@@ -152,8 +174,7 @@ chat_history_empty(Config) ->
         #{headers => auth(Token)},
         Config
     ),
-    ?assertStatus(200, Resp),
-    ?assertJson(#{~"messages" := []}, Resp),
+    ?assertStatus(403, Resp),
     Config.
 
 chat_history_with_messages(Config) ->
@@ -170,4 +191,47 @@ chat_history_with_messages(Config) ->
     #{~"messages" := Messages} = nova_test:json(Resp),
     true = is_list(Messages),
     ?assert(length(Messages) >= 3),
+    Config.
+
+%% F-10: a player who is not a member of the group MUST not be able to
+%% read its chat history.
+chat_history_non_member_forbidden(Config) ->
+    {channel_id, ChannelId} = lists:keyfind(channel_id, 1, Config),
+    {player3_token, Token} = lists:keyfind(player3_token, 1, Config),
+    true = is_binary(ChannelId),
+    true = is_binary(Token),
+    {ok, Resp} = nova_test:get(
+        "/api/v1/chat/" ++ binary_to_list(ChannelId) ++ "/history",
+        #{headers => auth(Token)},
+        Config
+    ),
+    ?assertStatus(403, Resp),
+    Config.
+
+%% F-10: DM channels (`dm:A:B`) must only be readable by A or B.
+chat_history_dm_non_participant_forbidden(Config) ->
+    {player1_id, P1Id} = lists:keyfind(player1_id, 1, Config),
+    {player2_id, P2Id} = lists:keyfind(player2_id, 1, Config),
+    {player3_token, EavesdropToken} = lists:keyfind(player3_token, 1, Config),
+    DmChannel = asobi_dm:channel_id(P1Id, P2Id),
+    true = is_binary(DmChannel),
+    {ok, Resp} = nova_test:get(
+        "/api/v1/chat/" ++ binary_to_list(DmChannel) ++ "/history",
+        #{headers => auth(EavesdropToken)},
+        Config
+    ),
+    ?assertStatus(403, Resp),
+    Config.
+
+chat_history_dm_participant_allowed(Config) ->
+    {player1_id, P1Id} = lists:keyfind(player1_id, 1, Config),
+    {player1_token, Token} = lists:keyfind(player1_token, 1, Config),
+    {player2_id, P2Id} = lists:keyfind(player2_id, 1, Config),
+    DmChannel = asobi_dm:channel_id(P1Id, P2Id),
+    {ok, Resp} = nova_test:get(
+        "/api/v1/chat/" ++ binary_to_list(DmChannel) ++ "/history",
+        #{headers => auth(Token)},
+        Config
+    ),
+    ?assertStatus(200, Resp),
     Config.

--- a/test/asobi_store_SUITE.erl
+++ b/test/asobi_store_SUITE.erl
@@ -16,6 +16,7 @@
     consume_insufficient_quantity/1,
     consume_not_found/1,
     consume_other_player/1,
+    consume_negative_quantity/1,
     inventory_empty/1
 ]).
 
@@ -36,7 +37,8 @@ groups() ->
             consume_item_fully,
             consume_insufficient_quantity,
             consume_not_found,
-            consume_other_player
+            consume_other_player,
+            consume_negative_quantity
         ]}
     ].
 
@@ -349,6 +351,61 @@ consume_not_found(Config) ->
         Config
     ),
     ?assertStatus(404, Resp),
+    Config.
+
+%% F-6 regression: a negative `quantity` must not duplicate items.
+consume_negative_quantity(Config) ->
+    {ok, InvResp} = nova_test:get(
+        "/api/v1/inventory",
+        #{headers => auth(Config, player1)},
+        Config
+    ),
+    #{~"items" := Items} = nova_test:json(InvResp),
+    case Items of
+        [#{~"id" := ItemId, ~"quantity" := BeforeQty} | _] ->
+            {ok, NegResp} = nova_test:post(
+                "/api/v1/inventory/consume",
+                #{
+                    headers => auth(Config, player1),
+                    json => #{~"item_id" => ItemId, ~"quantity" => -1000}
+                },
+                Config
+            ),
+            ?assertStatus(400, NegResp),
+            {ok, ZeroResp} = nova_test:post(
+                "/api/v1/inventory/consume",
+                #{
+                    headers => auth(Config, player1),
+                    json => #{~"item_id" => ItemId, ~"quantity" => 0}
+                },
+                Config
+            ),
+            ?assertStatus(400, ZeroResp),
+            {ok, FloatResp} = nova_test:post(
+                "/api/v1/inventory/consume",
+                #{
+                    headers => auth(Config, player1),
+                    json => #{~"item_id" => ItemId, ~"quantity" => 1.5}
+                },
+                Config
+            ),
+            ?assertStatus(400, FloatResp),
+            %% Verify quantity didn't change.
+            {ok, AfterResp} = nova_test:get(
+                "/api/v1/inventory",
+                #{headers => auth(Config, player1)},
+                Config
+            ),
+            #{~"items" := AfterItems} = nova_test:json(AfterResp),
+            true = is_list(AfterItems),
+            ItemAfter = [I || I <- AfterItems, is_map(I), maps:get(~"id", I) =:= ItemId],
+            case ItemAfter of
+                [#{~"quantity" := AfterQty}] -> ?assertEqual(BeforeQty, AfterQty);
+                [] -> ok
+            end;
+        [] ->
+            ok
+    end,
     Config.
 
 consume_other_player(Config) ->

--- a/test/asobi_world_lobby_SUITE.erl
+++ b/test/asobi_world_lobby_SUITE.erl
@@ -20,7 +20,11 @@ tests pin that contract so the bug can never sneak back in unnoticed.
     find_or_create_reuses_existing_world/1,
     find_or_create_creates_new_for_different_mode/1,
     find_or_create_creates_new_when_existing_full/1,
-    find_or_create_concurrent_callers_share_world/1
+    find_or_create_concurrent_callers_share_world/1,
+    create_world_player_cap_blocks_after_limit/1,
+    create_world_player_cap_releases_when_world_dies/1,
+    create_world_global_cap_blocks_at_max/1,
+    create_world_anonymous_bypasses_player_cap/1
 ]).
 
 -define(MODE_HUB, ~"test_hub").
@@ -37,7 +41,11 @@ all() ->
         find_or_create_reuses_existing_world,
         find_or_create_creates_new_for_different_mode,
         find_or_create_creates_new_when_existing_full,
-        find_or_create_concurrent_callers_share_world
+        find_or_create_concurrent_callers_share_world,
+        create_world_player_cap_blocks_after_limit,
+        create_world_player_cap_releases_when_world_dies,
+        create_world_global_cap_blocks_at_max,
+        create_world_anonymous_bypasses_player_cap
     ].
 
 init_per_suite(Config) ->
@@ -220,6 +228,94 @@ find_or_create_concurrent_callers_share_world(_Config) ->
     {ok, _, Info} = asobi_world_lobby:find_or_create(?MODE_HUB),
     FollowupId = maps:get(world_id, Info),
     ?assertEqual(hd(Unique), FollowupId).
+
+%% --- F-9: per-player and global concurrent-world caps ---
+
+create_world_player_cap_blocks_after_limit(_Config) ->
+    %% Drop the per-player cap to a small number for the test.
+    application:set_env(asobi, world_max_per_player, 2),
+    try
+        Player = ~"player_cap_test",
+        {ok, _Pid1, _} = asobi_world_lobby:create_world(?MODE_HUB, Player),
+        {ok, _Pid2, _} = asobi_world_lobby:create_world(?MODE_HUB, Player),
+        ?assertEqual(
+            {error, player_world_limit_reached},
+            asobi_world_lobby:create_world(?MODE_HUB, Player)
+        ),
+        %% A different player must still be able to create.
+        ?assertMatch(
+            {ok, _, _},
+            asobi_world_lobby:create_world(?MODE_HUB, ~"other_player")
+        )
+    after
+        application:unset_env(asobi, world_max_per_player)
+    end.
+
+create_world_player_cap_releases_when_world_dies(_Config) ->
+    application:set_env(asobi, world_max_per_player, 1),
+    try
+        Player = ~"player_release_test",
+        {ok, Pid, _} = asobi_world_lobby:create_world(?MODE_HUB, Player),
+        ?assertEqual(
+            {error, player_world_limit_reached},
+            asobi_world_lobby:create_world(?MODE_HUB, Player)
+        ),
+        %% Killing the world must release the slot via pg.
+        Ref = monitor(process, Pid),
+        exit(Pid, kill),
+        receive
+            {'DOWN', Ref, process, Pid, _} -> ok
+        after 2000 -> ct:fail("world process did not die")
+        end,
+        wait_until_player_count(Player, 0, 50),
+        ?assertMatch(
+            {ok, _, _},
+            asobi_world_lobby:create_world(?MODE_HUB, Player)
+        )
+    after
+        application:unset_env(asobi, world_max_per_player)
+    end.
+
+create_world_global_cap_blocks_at_max(_Config) ->
+    application:set_env(asobi, world_max, 1),
+    try
+        {ok, _Pid, _} = asobi_world_lobby:create_world(?MODE_HUB, ~"p_global_a"),
+        ?assertEqual(
+            {error, world_capacity_reached},
+            asobi_world_lobby:create_world(?MODE_HUB, ~"p_global_b")
+        ),
+        %% Anonymous create also blocked by the global cap.
+        ?assertEqual(
+            {error, world_capacity_reached},
+            asobi_world_lobby:create_world(?MODE_HUB)
+        )
+    after
+        application:unset_env(asobi, world_max)
+    end.
+
+create_world_anonymous_bypasses_player_cap(_Config) ->
+    %% Anonymous (PlayerId = undefined) creates are internal callers and
+    %% should not be subject to the per-player cap. The global cap still
+    %% applies and is covered above.
+    application:set_env(asobi, world_max_per_player, 1),
+    try
+        {ok, _Pid1, _} = asobi_world_lobby:create_world(?MODE_HUB),
+        {ok, _Pid2, _} = asobi_world_lobby:create_world(?MODE_HUB),
+        {ok, _Pid3, _} = asobi_world_lobby:create_world(?MODE_HUB)
+    after
+        application:unset_env(asobi, world_max_per_player)
+    end.
+
+wait_until_player_count(_Player, _Target, 0) ->
+    ct:fail("player owned-world count never reached target");
+wait_until_player_count(Player, Target, N) ->
+    case asobi_world_lobby:player_owned_world_count(Player) of
+        Target ->
+            ok;
+        _ ->
+            timer:sleep(20),
+            wait_until_player_count(Player, Target, N - 1)
+    end.
 
 %% --- helpers ---
 


### PR DESCRIPTION
## Summary

Continues #93 (Criticals F-1..F-4). Closes the remaining 30 findings from the 2026-04-30 audit. Stacked on `fix/security-criticals-2026-04-30` — merge order is #93 → this.

### Highs (F-5..F-11)

- **F-5/F-22**: `pg_advisory_xact_lock` around wallet debit + flatten the nested transaction in `asobi_economy:purchase/2`.
- **F-6**: cap inventory consume quantity at 1,000,000.
- **F-7**: matchmaker drops party entries that aren't the requester.
- **F-8**: matchmaker `get_ticket` / `remove` require ownership.
- **F-9**: per-player + global world creation cap via pg groups (`world_max_per_player`, `world_max` env).
- **F-10**: chat history membership check (DM participants, world joiners, group members).
- **F-11**: DM content cap 2000 bytes; reject empty/non-binary.

### Mediums (F-12..F-23)

- **F-12**: `join_group` enforces `open` flag and `max_members`.
- **F-13**: cloud-save 256 KB body cap + 10-slot/player cap.
- **F-14**: storage `read_perm` / `write_perm` whitelist.
- **F-15**: centralised `asobi_qs:integer/3,5` (parse-fail-safe + clamp); replaces 8 duplicated `qs_integer` helpers.
- **F-16**: WS `chat.join` namespaced (`dm:`, `world:`, `zone:`, `prox:`, `room:`); per-conn cap of 32 channels; chat-channel idle timeout.
- **F-17**: group description length validation.
- **F-18**: hex-validate Steam tickets; `uri_string:quote/1` every dynamic URL component.
- **F-19**: per-route auth/iap/api Seki limiters via path-based selection.
- **F-20**: vote history match-participant check + hidden-visibility strip.
- **F-21**: leaderboard `top` / `around` limit clamps.
- **F-23**: friend self-add reject + idempotent duplicate handling.

### Lows (F-24..F-29)

- **F-24**: `register/1` binary guards.
- **F-25**: log `player_stats` insert errors (auth + oauth).
- **F-26**: stop echoing client-supplied `type` in WS error replies.
- **F-27**: `erl_crash.dump` in `.gitignore`.
- **F-28**: world reconnect now runs in the supervised player session, not an unsupervised `spawn`.
- **F-29**: `world.list` filter values type-checked.

### Info (F-30..F-33)

- **F-30**: vm.args dist-localhost / TLS-dist guidance.
- **F-31**: UUIDv7 timestamp leak documented in `asobi_id` moduledoc.
- **F-32**: `asobi_match_server` game-module trust boundary documented.
- **F-33**: `asobi_world_sup` public-ETS trust assumption documented.

### Security docs as first class

- `SECURITY.md` trimmed to vuln-reporting policy + pointer.
- New `guides/security-threat-model.md` — trust model, BEAM dist, public ETS, UUIDv7.
- New `guides/security-auth.md` — bearer tokens, Apple JWS chain, Steam ticket validation, per-route rate limits, per-call upper-bound table, test coverage map.
- New `guides/security-known-limitations.md` — game-module trust, dist defaults, OS-level resource bounds.
- ex_doc `Security` extras group wired up.

## Test plan

- [x] `rebar3 fmt --check` clean
- [x] `rebar3 xref` clean
- [x] `rebar3 dialyzer` 0 warnings
- [x] `~/bin/elp eqwalize-all` 0 errors
- [x] `~/bin/elp lint` no new warnings
- [x] `rebar3 eunit` 249/249
- [x] `rebar3 ct` 231/232 (single failure is the pre-existing `register_player` username-uniqueness flake unrelated to this PR — passes in isolation)
- [x] `rebar3 ex_doc` no new warnings