### PR TITLE
fix(zone): apply queued inputs in arrival order

### DIFF
--- a/src/world/asobi_zone.erl
+++ b/src/world/asobi_zone.erl
@@ -348,7 +348,12 @@ do_tick(
     %% the broadcast step runs after both.
     ZoneStateWithTick = ZoneState#{tick => TickN},
     {Entities0, ZoneState1} = GameMod:zone_tick(Entities, ZoneStateWithTick),
-    Entities2 = apply_inputs(GameMod, Queue, Entities0),
+    %% input_queue is built newest-first via [Input | Queue], so reverse it
+    %% before applying so handle_input sees inputs in arrival order. Without
+    %% this, a burst of moves arriving in one tick window collapses to the
+    %% OLDEST input's state — every later move gets overwritten by the
+    %% next-handle_input call walking the list head-first.
+    Entities2 = apply_inputs(GameMod, lists:reverse(Queue), Entities0),
     Now = erlang:system_time(millisecond),
     {TimerEvents, ET1} = asobi_entity_timer:tick(Now, ET),
     Entities3 = apply_timer_events(TimerEvents, Entities2),

--- a/test/asobi_zone_tests.erl
+++ b/test/asobi_zone_tests.erl
@@ -38,6 +38,7 @@ zone_test_() ->
         {"tick processes inputs and broadcasts deltas", fun tick_broadcasts/0},
         {"tick with no changes sends no deltas", fun tick_no_changes/0},
         {"tick acks to ticker", fun tick_acks/0},
+        {"queued inputs apply in arrival order", fun inputs_apply_in_arrival_order/0},
         {"subscriber DOWN cleans up", fun subscriber_down_cleanup/0},
         {"tick touches zone_manager when subscribers present", fun tick_touches_zone_manager/0},
         {"tick hibernates when empty", fun tick_hibernates_when_empty/0},
@@ -105,6 +106,26 @@ tick_broadcasts() ->
     after 100 ->
         ok
     end,
+    gen_server:stop(Pid).
+
+inputs_apply_in_arrival_order() ->
+    %% Regression: when several player_input casts arrive between two
+    %% ticks they used to be processed newest-first, so the OLDEST x
+    %% won and every later move was overwritten. Assert the newest
+    %% input wins instead.
+    Pid = start_zone(),
+    asobi_zone:add_entity(Pid, <<"p1">>, #{x => 0, y => 0, type => ~"player"}),
+    timer:sleep(10),
+    [
+        asobi_zone:player_input(Pid, <<"p1">>, #{
+            ~"action" => ~"move", ~"x" => X, ~"y" => 100
+        })
+     || X <- [10, 20, 30, 40, 50]
+    ],
+    asobi_zone:tick(Pid, 1),
+    timer:sleep(20),
+    Entities = asobi_zone:get_entities(Pid),
+    ?assertMatch(#{x := 50, y := 100}, maps:get(<<"p1">>, Entities)),
     gen_server:stop(Pid).
 
 tick_no_changes() ->


### PR DESCRIPTION
## Summary
- `input_queue` is prepended head-first via `[Input | Queue]`, but `apply_inputs/3` walks the list head-first too — so a burst of inputs in one tick window applies newest-to-oldest, and the **oldest** input ends up winning.
- Reverse the queue before applying, so `handle_input/3` runs in arrival order (newest applies last).
- This is the root cause of "barrow_defold sees only the first move's position when a client fires several inputs back-to-back."

## Why this wasn't caught
Existing tests only fired one input per tick. Property test `prop_input_never_dropped` counts inputs but doesn't assert ordering. Integration tests don't queue multiple inputs between two ticks.

## Test plan
- [x] New eunit `inputs_apply_in_arrival_order` queues 5 moves with x=10..50 between two ticks; asserts entity ends at x=50 (was x=10 before fix).
- [x] Confirmed test fails on `main` and passes on this branch.
- [x] `rebar3 fmt`, `xref`, `dialyzer`, `eunit` (250), `ct` (232), `elp eqwalize-all` all clean.