### PR TITLE
docs(examples): add world-walkers — two players in one shared room

### DIFF
--- a/examples/world-walkers/README.md
+++ b/examples/world-walkers/README.md
@@ -1,0 +1,103 @@
+# Walkers — two players in one shared room
+
+The simplest possible world demo. One persistent world, any number of
+players, everyone walks around and sees each other. No matchmaking, no
+zones to debug, no terrain provider, no phases.
+
+If you're trying to build something on top of asobi and just want to
+see "two avatars on a screen", **start here**.
+
+## Run the server
+
+```bash
+docker compose up
+```
+
+That brings up Postgres + asobi_lua. Asobi reads `lua/config.lua`,
+sees `walkers = "world.lua"`, and registers `walkers` as a world mode.
+
+## Connect two clients
+
+Use any client that speaks the asobi WebSocket protocol. The two
+canonical paths:
+
+- **Defold** — see [`defold-client/`](./defold-client/) for a
+  ~120-line `.script` you can drop into a Defold project that already
+  has the [asobi-defold](https://github.com/widgrensit/asobi-defold)
+  SDK installed.
+- **Browser / Node / your-game-engine** — the protocol is six message
+  types. Register, connect WebSocket, send `session.connect`, send
+  `world.find_or_create`, send `world.input` on each move, render the
+  `world.tick` updates.
+
+## The full protocol used here
+
+Client → server:
+
+| `type`                    | `payload`                                  |
+|---------------------------|--------------------------------------------|
+| `session.connect`         | `{ token: <session_token> }`               |
+| `world.find_or_create`    | `{ mode: "walkers" }`                      |
+| `world.input`             | `{ kind: "move", x: 600.0, y: 480.0 }`     |
+| `world.leave`             | `{}`                                       |
+
+Server → client:
+
+| `type`           | `payload`                                                                  |
+|------------------|----------------------------------------------------------------------------|
+| `session.connected` | `{ player_id, username }`                                               |
+| `world.joined`   | `{ world_id, mode, ... }` (full world info)                                |
+| `world.tick`     | `{ tick: N, updates: [{ op, id, x, y, type, ... }] }`                      |
+| `world.left`     | `{ success: true }`                                                        |
+| `world.finished` | `{ ... }`                                                                  |
+| `error`          | `{ reason: "..." }`                                                        |
+
+`updates` is a list of entity deltas. `op` is `"a"` (added — full
+state), `"u"` (updated — diff), or `"r"` (removed — id only). The first
+`world.tick` you receive after joining is `tick = 0` and contains an
+`"a"` for every entity already in the zone.
+
+## What `world.lua` does
+
+- Declares one world mode (`game_type = "world"`).
+- One zone. The whole "room" is 1200×1200 units. `view_radius = 0`
+  means a player only subscribes to their own zone — and since there's
+  only one zone, everyone always sees everyone.
+- 20 Hz tick (`tick_rate = 50` ms).
+- `handle_input` accepts `{ kind = "move", x, y }` and writes the
+  player's entity into the zone's entities map. The zone diffs that
+  against the previous tick and broadcasts deltas as `world.tick`.
+
+That's it. Roughly 30 lines of actual logic.
+
+## Common pitfalls
+
+1. **`type = "world"` is silently ignored.** The Lua loader reads
+   `game_type`. If you write `type = "world"`, your script registers as
+   a *match* mode, and `world.find_or_create` returns `mode_not_found`.
+
+2. **`view_radius = 1` (the default) is too narrow for "see each other"
+   demos.** With default `zone_size = 200`, two random spawns are very
+   often outside each other's 3×3 interest window. The walkers world
+   sidesteps this by using a single zone (`grid_size = 1`,
+   `view_radius = 0`).
+
+3. **Register your `world_tick` handler before sending
+   `world.find_or_create`.** The first snapshot arrives as a `world.tick`
+   immediately after `world.joined`. If your handler isn't registered
+   yet, you miss it and the client looks empty until the next entity
+   moves.
+
+4. **`empty_grace_ms = 0` (the default) tears the world down the
+   instant the last player leaves.** If you're testing two clients and
+   one drops a frame, the other gets `world.finished`. The walkers world
+   sets `empty_grace_ms = 10000`.
+
+## Adapting Barrow
+
+Barrow's `hub.lua` already follows this exact shape — `game_type =
+"world"`, single zone, `handle_input` writes a `move` entity. The
+difference is barrow's hub uses `grid_size = 1` implicitly (no
+`generate_world` table beyond `"0,0"`) and `empty_grace_ms = 900000`.
+Use this example as the reference and Barrow's hub.lua as a
+working production-shaped derivative.

--- a/examples/world-walkers/defold-client/README.md
+++ b/examples/world-walkers/defold-client/README.md
@@ -1,0 +1,43 @@
+# Walkers — Defold client
+
+The smallest possible Defold client for the `walkers` world. Two players
+connect, walk with WASD, see each other.
+
+## Project layout you need
+
+- A Defold project with the [asobi-defold](https://github.com/widgrensit/asobi-defold)
+  SDK added as a project dependency (`game.project` → Dependencies).
+- One game object that owns this script (your local player).
+- One *factory* component at `/avatars#avatar_factory` whose prototype is
+  a separate `.go` with a sprite — this is what gets spawned for *other*
+  players.
+- Input bindings for `key_w`, `key_a`, `key_s`, `key_d` in
+  `input/game.input_binding`.
+
+## Running two clients
+
+1. Start the backend:
+
+   ```bash
+   cd ../  # examples/world-walkers/
+   docker compose up
+   ```
+
+2. In Defold, *Project → Build* twice (or Build + a HTML5 bundle in a
+   browser tab) to launch two windows. Each gets a unique guest username
+   (`walker_<timestamp>`), so they appear as separate players.
+
+3. Both clients are now in the same world. Walk around with WASD — each
+   client sees the other moving.
+
+## What the script does
+
+- Registers a guest account, then `realtime.connect()`s.
+- On `connected`, calls `find_or_create_world("walkers")`. The first
+  client spawns the world, the second joins it.
+- Listens for `world.tick` and renders other players. Updates carry
+  `op = "a"` on add, `"u"` on update, `"r"` on remove.
+- Sends `world.input` at 20 Hz with the local player's predicted
+  position.
+
+That's the whole protocol. No matchmaker, no chat, no votes.

--- a/examples/world-walkers/defold-client/walkers.script
+++ b/examples/world-walkers/defold-client/walkers.script
@@ -1,0 +1,143 @@
+-- examples/world-walkers/defold-client/walkers.script
+--
+-- Drop this on a game object in your Defold collection. Bind WASD to
+-- input actions named `key_w`, `key_a`, `key_s`, `key_d`.
+--
+-- Other players are drawn by spawning instances from a factory at
+-- `/avatars#avatar_factory`. The simplest setup: a single sprite go,
+-- saved as a separate .go, referenced by a factory component on
+-- /avatars. (The local player is *this* go.)
+
+local asobi = require("asobi.client")
+
+local SPEED       = 200       -- units per second
+local SEND_HZ     = 20        -- inputs/sec sent to the server
+local SERVER_HOST = "localhost"
+local SERVER_PORT = 8080
+
+local client
+local state = {
+    self_id   = nil,
+    pos       = vmath.vector3(600, 600, 0),
+    others    = {},  -- player_id -> { go_id, pos }
+    input     = { up = false, down = false, left = false, right = false },
+    last_send = 0,
+    connected = false,
+    joined    = false,
+}
+
+local function ensure_other(player_id)
+    if state.others[player_id] then return state.others[player_id] end
+    local id = factory.create("/avatars#avatar_factory", vmath.vector3(0, 0, 0))
+    state.others[player_id] = { go_id = id, pos = vmath.vector3(0, 0, 0) }
+    return state.others[player_id]
+end
+
+local function remove_other(player_id)
+    local o = state.others[player_id]
+    if not o then return end
+    go.delete(o.go_id)
+    state.others[player_id] = nil
+end
+
+-- world.tick payload: { tick = N, updates = [ {op, id, ...fields} ] }
+-- op values: "a" = added (full state), "u" = updated (diff), "r" = removed
+local function on_world_tick(payload)
+    for _, u in ipairs(payload.updates or {}) do
+        if u.id == state.self_id then
+            -- We render ourselves locally; ignore server echo.
+        elseif u.op == "r" then
+            remove_other(u.id)
+        else
+            local o = ensure_other(u.id)
+            if u.x then o.pos.x = u.x end
+            if u.y then o.pos.y = u.y end
+            go.set_position(o.pos, o.go_id)
+        end
+    end
+end
+
+local function join_world()
+    client.realtime.find_or_create_world("walkers", function(payload, err)
+        if err then
+            print("find_or_create_world failed: " .. tostring(err))
+            return
+        end
+        state.joined = true
+        print("joined world: " .. tostring(payload.world_id))
+    end)
+end
+
+local function on_connected()
+    state.connected = true
+    join_world()
+end
+
+function init(self)
+    msg.post(".", "acquire_input_focus")
+
+    client = asobi.create(SERVER_HOST, SERVER_PORT)
+
+    -- Unique guest username per launch so two clients don't clash.
+    local username = "walker_" .. tostring(math.floor(socket.gettime() * 1000))
+
+    client.auth.register(client, username, "secret123", function(data, err)
+        if err then
+            print("register failed: " .. tostring(err.error))
+            return
+        end
+        state.self_id = data.player_id
+        print("registered as " .. data.username .. " (" .. data.player_id .. ")")
+
+        client.realtime.on("connected",      on_connected)
+        client.realtime.on("world_tick",     on_world_tick)
+        client.realtime.on("world_finished", function() print("world finished") end)
+        client.realtime.on("error",          function(p) print("ws error: " .. tostring(p.reason)) end)
+
+        client.realtime.connect()
+    end)
+end
+
+function update(self, dt)
+    if not state.joined then return end
+
+    -- Local prediction: move our own avatar immediately.
+    local dx, dy = 0, 0
+    if state.input.up    then dy = dy + 1 end
+    if state.input.down  then dy = dy - 1 end
+    if state.input.left  then dx = dx - 1 end
+    if state.input.right then dx = dx + 1 end
+    if dx ~= 0 or dy ~= 0 then
+        local len = math.sqrt(dx * dx + dy * dy)
+        state.pos.x = state.pos.x + (dx / len) * SPEED * dt
+        state.pos.y = state.pos.y + (dy / len) * SPEED * dt
+        go.set_position(state.pos)
+    end
+
+    -- Send our position to the server at SEND_HZ.
+    state.last_send = state.last_send + dt
+    if state.last_send >= 1 / SEND_HZ then
+        state.last_send = 0
+        client.realtime.send_world_input({
+            kind = "move",
+            x    = state.pos.x,
+            y    = state.pos.y,
+        })
+    end
+end
+
+function on_input(self, action_id, action)
+    if action_id == hash("key_w") then state.input.up    = not action.released end
+    if action_id == hash("key_s") then state.input.down  = not action.released end
+    if action_id == hash("key_a") then state.input.left  = not action.released end
+    if action_id == hash("key_d") then state.input.right = not action.released end
+end
+
+function final(self)
+    if client and state.joined then
+        client.realtime.leave_world()
+    end
+    if client and state.connected then
+        client.realtime.disconnect()
+    end
+end

--- a/examples/world-walkers/docker-compose.yml
+++ b/examples/world-walkers/docker-compose.yml
@@ -1,0 +1,29 @@
+services:
+  postgres:
+    image: postgres:17
+    environment:
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: postgres
+      POSTGRES_DB: walkers
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U postgres"]
+      interval: 5s
+      timeout: 5s
+      retries: 5
+
+  asobi:
+    image: ghcr.io/widgrensit/asobi_lua:latest
+    depends_on:
+      postgres:
+        condition: service_healthy
+    ports:
+      - "8080:8080"
+    environment:
+      ASOBI_PORT: "8080"
+      ASOBI_DB_HOST: postgres
+      ASOBI_DB_NAME: walkers
+      ASOBI_DB_USER: postgres
+      ASOBI_DB_PASSWORD: postgres
+      ASOBI_CORS_ORIGINS: "*"
+    volumes:
+      - ./lua:/app/game

--- a/examples/world-walkers/lua/config.lua
+++ b/examples/world-walkers/lua/config.lua
@@ -1,0 +1,4 @@
+-- Map mode names to the Lua scripts that implement them.
+return {
+    walkers = "world.lua",
+}

--- a/examples/world-walkers/lua/world.lua
+++ b/examples/world-walkers/lua/world.lua
@@ -1,0 +1,84 @@
+-- Two players walking around in one shared room.
+--
+-- The minimum world.lua: one zone, no terrain, no phases, no votes.
+-- Everything else in asobi (matchmaking, chat, persistence) is *off* by
+-- default — this file only shows the world callbacks.
+
+-- IMPORTANT: the global must be `game_type` (not `type`). The Lua
+-- config loader reads `game_type`; setting `type = "world"` is silently
+-- ignored and the script registers as a *match* mode instead.
+game_type      = "world"
+
+-- match_size is required by the Lua config loader for *every* mode,
+-- including worlds. Worlds don't gate on a minimum player count, so
+-- `1` is the correct value here — it just satisfies the loader check.
+match_size     = 1
+max_players    = 8
+tick_rate      = 50          -- ms (20 Hz)
+
+-- Single zone covering the entire room. With grid_size=1, view_radius=0
+-- is the only sensible value: every player is always in zone (0,0) and
+-- always sees every other player. No interest-set debugging.
+grid_size      = 1
+zone_size      = 1200
+view_radius    = 0
+
+-- Keep the room alive for 10s after the last player leaves so a brief
+-- network blip doesn't tear down the world between two test clients.
+empty_grace_ms = 10000
+
+local function log(msg)
+    if game and game.log then game.log("info", "[walkers] " .. tostring(msg), {}) end
+end
+
+function init(config)
+    log("init")
+    return { tick = 0 }
+end
+
+function generate_world(seed, config)
+    -- One zone at (0,0). No tiles, no mobs.
+    return { ["0,0"] = {} }
+end
+
+function spawn_position(player_id, state)
+    -- Spread spawns around the centre so two players don't stack.
+    math.randomseed(#player_id + (state.tick or 0))
+    local angle = math.random() * math.pi * 2
+    return {
+        x = 600 + math.cos(angle) * 80,
+        y = 600 + math.sin(angle) * 80,
+    }
+end
+
+function join(player_id, state)
+    log("join " .. player_id)
+    return state
+end
+
+function leave(player_id, state)
+    log("leave " .. player_id)
+    return state
+end
+
+-- Inputs from `world.input` arrive here. Update the entity for this
+-- player and return the new entities table for the zone.
+function handle_input(player_id, input, entities)
+    if not input or input.kind ~= "move" then return entities end
+    entities[player_id] = {
+        type  = "player",
+        x     = tonumber(input.x) or 0,
+        y     = tonumber(input.y) or 0,
+        color = input.color, -- optional vanity field
+    }
+    return entities
+end
+
+function zone_tick(entities, zone_state)
+    return entities, zone_state
+end
+
+function post_tick(tick_n, state)
+    state.tick = tick_n
+    return state
+end


### PR DESCRIPTION
## Summary

The simplest possible world demo: one persistent world, single zone, players walk around with WASD and see each other. No matchmaker, no zones to debug, no terrain provider, no phases.

This closes a concrete onboarding gap. Today, every example and the getting-started guide point developers at *matches*. Building "two avatars on a screen" required reading `guides/world-server.md` (~470 lines) and synthesising the WS protocol from `asobi_ws_handler.erl`. This example is the missing copy-pasteable starting point.

## Layout

```
examples/world-walkers/
├── README.md                        protocol reference + four common pitfalls
├── docker-compose.yml               postgres + asobi_lua, ready to compose up
├── lua/
│   ├── config.lua                   walkers = "world.lua"
│   └── world.lua                    ~75 lines, the actual world logic
└── defold-client/
    ├── README.md                    Defold project setup
    └── walkers.script               ~120 lines: register → connect → join → walk
```

## Pitfalls documented

The README calls out the four traps that block this exact use case:

1. `type = "world"` is silently ignored — the loader reads `game_type`.
2. `view_radius = 1` (the default) is too narrow for "see each other" demos with random spawns.
3. The first `world.tick` after `world.joined` is the initial snapshot — register your handler **before** `world.find_or_create`.
4. `empty_grace_ms = 0` (the default) tears the world down on the first dropped frame.

## Dependency

Requires widgrensit/asobi_lua#29 to be released for the world dimension globals (`grid_size = 1`, `view_radius = 0`, `zone_size = 1200`) in `world.lua` to take effect. With older asobi_lua those are no-ops and the world falls through to the default 10×10 grid — so this PR can land before that release, but the demo only fully works once a new asobi_lua image is published.

## Test plan

- [x] `luac -p` on all three Lua files
- [x] `docker compose config -q` validates the compose file
- [ ] `docker compose up` brings up postgres + asobi_lua (manual, after asobi_lua#29 ships)
- [ ] Two browser tabs / Defold instances see each other walking (manual)