### PR TITLE
docs(worlds): document game_type vs type and add Worlds section to ws protocol

### DIFF
--- a/guides/websocket-protocol.md
+++ b/guides/websocket-protocol.md
@@ -128,6 +128,141 @@ Notification that a match was found.
 {"type": "matchmaker.matched", "payload": {"match_id": "...", "players": [...]}}
 ```
 
+## Worlds
+
+The world server runs persistent shared spaces with zoned interest
+management. See [World server](world-server.md) for the model and
+[Large worlds](large-worlds.md) for tuning.
+
+### `world.list`
+
+List running worlds. Optional filters: `mode` (string), `has_capacity`
+(bool — only worlds that aren't full).
+
+```json
+{"type": "world.list", "payload": {"mode": "walkers", "has_capacity": true}}
+```
+
+Response:
+
+```json
+{"type": "world.list", "payload": {"worlds": [{"world_id": "...", "mode": "walkers", "player_count": 1, "max_players": 8}]}}
+```
+
+### `world.create`
+
+Create a new world for the given mode. Refuses with
+`world_capacity_reached` (global cap hit) or `player_world_limit_reached`
+(per-player cap hit). On success the caller is auto-joined.
+
+```json
+{"type": "world.create", "payload": {"mode": "walkers"}}
+```
+
+### `world.find_or_create`
+
+Atomic find-or-create: returns the first non-full world for the mode,
+or creates one if none exists. The caller is auto-joined. **This is the
+right call for "drop me into a shared room" flows.**
+
+```json
+{"type": "world.find_or_create", "payload": {"mode": "walkers"}}
+```
+
+### `world.join`
+
+Join a specific world by id (e.g. one returned from `world.list`).
+
+```json
+{"type": "world.join", "payload": {"world_id": "..."}}
+```
+
+### `world.input`
+
+Send game input to your zone. The `payload` IS the input map — there is
+no inner `data` wrapper. Field names are entirely up to your game; the
+server only forwards the map verbatim to your `handle_input/3` callback.
+
+```json
+{"type": "world.input", "payload": {"kind": "move", "x": 600, "y": 480}}
+```
+
+The server routes the message to whichever zone owns your player
+entity — clients don't specify zone coordinates.
+
+### `world.leave`
+
+Leave the current world.
+
+```json
+{"type": "world.leave", "payload": {}}
+```
+
+### `world.joined` (server push)
+
+Sent in response to a successful `world.create`, `world.find_or_create`,
+or `world.join`. The `payload` is the full world info (mode, world_id,
+player_count, grid_size, max_players, …).
+
+```json
+{"type": "world.joined", "payload": {"world_id": "...", "mode": "walkers", "grid_size": 1, "max_players": 8, "player_count": 1, "status": "running"}}
+```
+
+### `world.tick` (server push)
+
+Per-zone delta broadcast. The first `world.tick` after `world.joined` is
+the **initial snapshot** for every entity in the zone — register your
+handler before sending the join message or you miss it.
+
+```json
+{"type": "world.tick", "payload": {"tick": 42, "updates": [{"op": "a", "id": "01HX...", "x": 600, "y": 480, "type": "player"}]}}
+```
+
+`updates` is a list of entity deltas. `op` values:
+
+| `op` | Meaning | Fields |
+|------|---------|--------|
+| `"a"` | Added — full state | id + every field on the entity |
+| `"u"` | Updated — diff | id + only changed fields |
+| `"r"` | Removed | id only |
+
+### `world.terrain` (server push)
+
+Sent on zone subscription when the world has a terrain provider. The
+chunk data is base64-encoded compressed binary; see
+[Large worlds](large-worlds.md) for the encoding.
+
+```json
+{"type": "world.terrain", "payload": {"coords": [3, 5], "data": "eJw..."}}
+```
+
+### `world.left` (server push)
+
+Confirmation that the leave completed (or that the client was already
+out of any world).
+
+```json
+{"type": "world.left", "payload": {"success": true}}
+```
+
+### `world.finished` (server push)
+
+The world ended (e.g. last player left and the empty grace expired, or
+the game module returned `{finished, Result, State}` from `post_tick`).
+
+```json
+{"type": "world.finished", "payload": {"world_id": "...", "result": {}}}
+```
+
+### `world.phase_changed` (server push)
+
+Phase transition for worlds that declare phases. Payload mirrors the
+match `match.phase_changed` event.
+
+```json
+{"type": "world.phase_changed", "payload": {"phase": "combat", "duration_ms": 60000}}
+```
+
 ## Chat
 
 ### `chat.join`

--- a/guides/world-server.md
+++ b/guides/world-server.md
@@ -216,14 +216,22 @@ Each zone receives its state via the `zone_state` field in `zone_tick/2`.
 ## Lua Implementation
 
 World scripts follow the same pattern as match scripts but with
-zone-specific callbacks. Set `type = "world"` in your mode config.
+zone-specific callbacks. Set `game_type = "world"` in your mode globals.
+
+> **Gotcha**: the global is **`game_type`**, not `type`. The Erlang
+> `sys.config` form (above) uses the key `type`, but the Lua loader
+> reads `game_type`. A Lua script that sets `type = "world"` is
+> silently ignored — the script registers as a *match* mode and
+> `world.find_or_create` returns `mode_not_found`.
 
 ```lua
 -- lua/world.lua
 
 -- World mode config
-type        = "world"
-match_size  = 10
+game_type   = "world"
+match_size  = 10            -- required by the loader for every mode,
+                            -- including worlds. Use 1 for worlds that
+                            -- don't gate on a minimum player count.
 max_players = 500
 grid_size   = 5
 zone_size   = 400


### PR DESCRIPTION
## Summary

Closes the two doc holes the architecture-guardian flagged after #97 landed:

1. **`guides/world-server.md` told Lua devs to set `type = "world"`** — but the loader reads `game_type`. A Lua script that follows the docs verbatim silently registers as a *match* mode, and `world.find_or_create` returns `mode_not_found`. The Erlang `sys.config` form continues to use `type` (correct — that's the key the Erlang side reads); only the Lua section was wrong. Adds a Gotcha callout pointing at the asymmetry, fixes the example, and surfaces the loader's `match_size` requirement (worlds still need to declare it; `1` is the right value).

2. **`guides/websocket-protocol.md` had zero coverage of the `world.*` namespace.** Anyone not copying from `examples/world-walkers/` couldn't construct `world.find_or_create` or `world.input` from the protocol reference. Adds a Worlds section covering all seven client→server messages (`list`, `create`, `find_or_create`, `join`, `input`, `leave`) and the six server→client pushes (`joined`, `tick`, `terrain`, `left`, `finished`, `phase_changed`). Pins the canonical `world.input` payload shape (no inner `data` wrapper — the `payload` IS the input map) and the `world.tick` `op` codes (`a`/`u`/`r`).

Together with widgrensit/asobi_lua#29 and #97 (already merged), this closes the four remaining blockers from the audit:

- ✅ `type` vs `game_type` mismatch (this PR)
- ✅ `world.*` undocumented in protocol reference (this PR)
- ⚠️ asobi-defold README hides world support — separate PR incoming
- ✅ `world.input` payload shape inconsistency — pinned in protocol doc

## Test plan

- [x] `rebar3 fmt --check`
- [x] `rebar3 xref`
- [x] All cross-references in the new section resolve to existing docs (`world-server.md`, `large-worlds.md`)