### PR TITLE
fix(test): scale EUnit timeout to PROPER_NUMTESTS on fixture-heavy props

### DIFF
--- a/test/prop_chat_zone_routing.erl
+++ b/test/prop_chat_zone_routing.erl
@@ -18,14 +18,14 @@
 -define(PROX_RADIUS, 1).
 
 chat_zone_routing_test_() ->
-    {timeout, 60,
-        {setup, fun setup/0, fun cleanup/1, [
+    {setup, fun setup/0, fun cleanup/1, [
+        {timeout, max(60, ?NUMTESTS div 2),
             ?_assert(
                 proper:quickcheck(prop_chat_zone_routing(), [
                     {numtests, ?NUMTESTS}, {to_file, user}
                 ])
-            )
-        ]}}.
+            )}
+    ]}.
 
 setup() ->
     case whereis(nova_scope) of

--- a/test/prop_input_never_dropped.erl
+++ b/test/prop_input_never_dropped.erl
@@ -30,16 +30,16 @@
 }).
 
 input_never_dropped_test_() ->
-    {timeout, 120,
-        {setup, fun setup/0, fun cleanup/1, fun(Ctx) ->
-            [
+    {setup, fun setup/0, fun cleanup/1, fun(Ctx) ->
+        [
+            {timeout, max(60, ?NUMTESTS div 2),
                 ?_assert(
                     proper:quickcheck(prop_input_never_dropped(Ctx), [
                         {numtests, ?NUMTESTS}, {to_file, user}
                     ])
-                )
-            ]
-        end}}.
+                )}
+        ]
+    end}.
 
 setup() ->
     case whereis(nova_scope) of

--- a/test/prop_reconnect_lifecycle.erl
+++ b/test/prop_reconnect_lifecycle.erl
@@ -32,16 +32,16 @@
 }).
 
 reconnect_lifecycle_test_() ->
-    {timeout, 120,
-        {setup, fun setup/0, fun cleanup/1, fun(Ctx) ->
-            [
+    {setup, fun setup/0, fun cleanup/1, fun(Ctx) ->
+        [
+            {timeout, max(60, ?NUMTESTS div 2),
                 ?_assert(
                     proper:quickcheck(prop_reconnect_lifecycle(Ctx), [
                         {numtests, ?NUMTESTS}, {to_file, user}
                     ])
-                )
-            ]
-        end}}.
+                )}
+        ]
+    end}.
 
 setup() ->
     case whereis(nova_scope) of

--- a/test/prop_zone_invariants.erl
+++ b/test/prop_zone_invariants.erl
@@ -32,16 +32,16 @@
 }).
 
 zone_invariants_test_() ->
-    {timeout, 120,
-        {setup, fun setup/0, fun cleanup/1, fun(Ctx) ->
-            [
+    {setup, fun setup/0, fun cleanup/1, fun(Ctx) ->
+        [
+            {timeout, max(60, ?NUMTESTS div 2),
                 ?_assert(
                     proper:quickcheck(prop_zone_invariants(Ctx), [
                         {numtests, ?NUMTESTS}, {to_file, user}
                     ])
-                )
-            ]
-        end}}.
+                )}
+        ]
+    end}.
 
 setup() ->
     %% Use pg:start (not start_link) so pg outlives the setup process —


### PR DESCRIPTION
## Summary
- Closes #100. Nightly at `PROPER_NUMTESTS=1000` cancelled four prop tests stuck in `timer:sleep` fixtures (`reset_world`, `wait_for_observation`, `cleanup_world`, `check`). Properties themselves were not failing — they were getting cancelled.
- Root cause: `{timeout, N, {setup, ..., [?_assert(...)]}}` doesn't cascade the timeout into the inner `?_assert` primitives. Each runs with EUnit's default per-test timeout instead of the wrapper's `120` / `60` seconds.
- Fix: move the `{timeout, ...}` inside the setup body so it directly wraps each `?_assert(...)`, and scale it as `max(60, ?NUMTESTS div 2)` — default `25` keeps a 60s floor, nightly's `1000` gets 500s.

## Test plan
- [x] `PROPER_NUMTESTS=25 rebar3 eunit --module=prop_zone_invariants,prop_input_never_dropped,prop_reconnect_lifecycle,prop_chat_zone_routing` — 4 tests, 0 failures, 4.5s
- [x] `PROPER_NUMTESTS=200 rebar3 eunit ...same...` — 4 tests, 0 failures, 35.5s
- [x] `PROPER_NUMTESTS=1000 rebar3 eunit ...same...` (matches nightly) — 4 tests, 0 failures, **177.8s**
- [x] `rebar3 fmt --check` clean
- [x] `rebar3 xref` clean
- [x] `rebar3 dialyzer` clean
- [x] `elp eqwalize-all` NO ERRORS
- [x] `elp lint` — no warnings on the four changed files