### PR TITLE
DX pre-release sweep: logger macros, protocol doc, SBOM, mutate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,8 @@ jobs:
     with:
       version-file: '.tool-versions'
       enable-audit: true
+      enable-sbom: true
+      enable-sbom-scan: true
       enable-ct: true
       extra-services-compose: 'docker-compose.yml'
       enable-dependency-submission: true

--- a/guides/websocket-protocol.md
+++ b/guides/websocket-protocol.md
@@ -120,12 +120,46 @@ Cancel a matchmaking ticket.
 {"type": "matchmaker.remove", "payload": {"ticket_id": "..."}}
 ```
 
-### `matchmaker.matched` (server push)
+### `match.matched` (server push)
 
-Notification that a match was found.
+Notification that the matchmaker formed a match including this player. Wire
+type is `match.matched` (the matchmaker emits a `{match_event, matched, ...}`
+internally, which the WS handler renders as `match.` + the event atom).
 
 ```json
-{"type": "matchmaker.matched", "payload": {"match_id": "...", "players": [...]}}
+{"type": "match.matched", "payload": {"match_id": "...", "players": [...]}}
+```
+
+> **Note for SDK authors — `match.matched` vs `match.joined`**
+>
+> Both events signal "the client is in a match and `match.state` will follow",
+> but they fire on different paths:
+>
+> - **`match.matched`** is pushed by the matchmaker after a queue forms a match.
+>   The client did not call `match.join`; the server has already placed it.
+> - **`match.joined`** is the reply to a client-initiated `match.join` (e.g.,
+>   joining a friend's match by id, or rejoining after disconnect).
+>
+> SDKs SHOULD subscribe to both and surface them as a single `OnMatchReady`
+> (or equivalent) event so consumers don't have to know which path was taken.
+> A matchmade flow will fire `match.matched` only; a direct-join flow will
+> fire `match.joined` only.
+
+### `match.matchmaker_failed` (server push)
+
+The matchmaker could not form a match for this ticket (e.g. no game module
+configured for the requested mode).
+
+```json
+{"type": "match.matchmaker_failed", "payload": {"reason": "no_game_module"}}
+```
+
+### `match.matchmaker_expired` (server push)
+
+The ticket exceeded the matchmaker's max wait time and was dropped.
+
+```json
+{"type": "match.matchmaker_expired", "payload": {"ticket_id": "..."}}
 ```
 
 ## Worlds

--- a/rebar.config
+++ b/rebar.config
@@ -62,8 +62,14 @@
     {rebar3_audit, {git, "https://github.com/Taure/rebar3_audit.git", {branch, "main"}}},
     {rebar3_sbom,
         {git, "https://github.com/Taure/rebar3_sbom.git", {branch, "feat/include-otp-components"}}},
+    {rebar3_mutate, {git, "https://github.com/Taure/rebar3_mutate.git", {branch, "main"}}},
     rebar3_ex_doc,
     {erlfmt, "~>1.7"}
+]}.
+
+{mutate, [
+    {min_score, 60},
+    {parallel, true}
 ]}.
 
 {hex, [

--- a/src/asobi_app.erl
+++ b/src/asobi_app.erl
@@ -1,4 +1,5 @@
 -module(asobi_app).
+-include_lib("kernel/include/logger.hrl").
 -behaviour(application).
 
 -export([start/2, stop/1]).
@@ -8,9 +9,9 @@ start(_StartType, _StartArgs) ->
     setup_telemetry(),
     case kura_migrator:migrate(asobi_repo) of
         {ok, Applied} ->
-            logger:notice(#{msg => ~"migrations_applied", versions => Applied});
+            ?LOG_NOTICE(#{msg => ~"migrations_applied", versions => Applied});
         {error, MigErr} ->
-            logger:error(#{msg => ~"migration_failed", error => MigErr})
+            ?LOG_ERROR(#{msg => ~"migration_failed", error => MigErr})
     end,
     case asobi_sup:start_link() of
         {ok, Pid} -> {ok, Pid};

--- a/src/asobi_cluster.erl
+++ b/src/asobi_cluster.erl
@@ -1,4 +1,5 @@
 -module(asobi_cluster).
+-include_lib("kernel/include/logger.hrl").
 -behaviour(gen_server).
 
 -export([start_link/0]).
@@ -95,7 +96,8 @@ maybe_connect(Node) ->
         false ->
             case net_adm:ping(Node) of
                 pong ->
-                    logger:info(#{msg => ~"cluster node connected", node => Node});
+                    ?LOG_INFO(#{msg => ~"cluster node connected", node => Node}),
+                    ok;
                 pang ->
                     ok
             end

--- a/src/asobi_telemetry.erl
+++ b/src/asobi_telemetry.erl
@@ -1,4 +1,5 @@
 -module(asobi_telemetry).
+-include_lib("kernel/include/logger.hrl").
 
 -export([setup/0]).
 -export([match_started/2, match_finished/3, match_player_joined/2, match_player_left/2]).
@@ -225,9 +226,10 @@ vote_resolved(VoteId, DurationMs, Result) ->
     telemetry:handler_config()
 ) -> ok.
 handle_event(EventName, Measurements, Metadata, _Config) ->
-    logger:debug(#{
+    ?LOG_DEBUG(#{
         msg => ~"telemetry_event",
         event => EventName,
         measurements => Measurements,
         metadata => Metadata
-    }).
+    }),
+    ok.

--- a/src/auth/asobi_iap.erl
+++ b/src/auth/asobi_iap.erl
@@ -1,4 +1,5 @@
 -module(asobi_iap).
+-include_lib("kernel/include/logger.hrl").
 
 -include_lib("public_key/include/public_key.hrl").
 
@@ -274,10 +275,10 @@ do_verify_google(PackageName, ProductId, PurchaseToken) ->
                 {ok, {{_, 404, _}, _, _}} ->
                     {error, ~"purchase_not_found"};
                 {ok, {{_, Status, _}, _, _}} ->
-                    logger:warning(#{msg => ~"google_iap_api_error", status => Status}),
+                    ?LOG_WARNING(#{msg => ~"google_iap_api_error", status => Status}),
                     {error, ~"google_api_error"};
                 {error, Reason} ->
-                    logger:warning(#{msg => ~"google_iap_request_failed", reason => Reason}),
+                    ?LOG_WARNING(#{msg => ~"google_iap_request_failed", reason => Reason}),
                     {error, ~"google_api_unavailable"}
             end;
         {error, Reason} ->

--- a/src/auth/asobi_steam.erl
+++ b/src/auth/asobi_steam.erl
@@ -1,4 +1,5 @@
 -module(asobi_steam).
+-include_lib("kernel/include/logger.hrl").
 
 -export([validate_ticket/1]).
 
@@ -70,10 +71,10 @@ do_validate_ticket(ApiKey, AppId, Ticket) ->
         {ok, {{_, 200, _}, _, Body}} when is_binary(Body) ->
             parse_auth_response(Body);
         {ok, {{_, Status, _}, _, _}} ->
-            logger:warning(#{msg => ~"steam_api_error", status => Status}),
+            ?LOG_WARNING(#{msg => ~"steam_api_error", status => Status}),
             {error, ~"steam_api_error"};
         {error, Reason} ->
-            logger:warning(#{msg => ~"steam_api_request_failed", reason => Reason}),
+            ?LOG_WARNING(#{msg => ~"steam_api_request_failed", reason => Reason}),
             {error, ~"steam_api_unavailable"}
     end.
 

--- a/src/controllers/asobi_auth_controller.erl
+++ b/src/controllers/asobi_auth_controller.erl
@@ -1,4 +1,5 @@
 -module(asobi_auth_controller).
+-include_lib("kernel/include/logger.hrl").
 
 -export([register/1, login/1, refresh/1]).
 
@@ -76,7 +77,7 @@ init_player_stats(PlayerId) ->
         {ok, _} ->
             ok;
         {error, Reason} ->
-            logger:warning(#{
+            ?LOG_WARNING(#{
                 msg => ~"player_stats_init_failed",
                 player_id => PlayerId,
                 reason => Reason

--- a/src/controllers/asobi_oauth_controller.erl
+++ b/src/controllers/asobi_oauth_controller.erl
@@ -1,4 +1,5 @@
 -module(asobi_oauth_controller).
+-include_lib("kernel/include/logger.hrl").
 
 -export([authenticate/1, link/1, unlink/1]).
 
@@ -232,7 +233,7 @@ init_player_stats(PlayerId) ->
         {ok, _} ->
             ok;
         {error, Reason} ->
-            logger:warning(#{
+            ?LOG_WARNING(#{
                 msg => ~"player_stats_init_failed",
                 player_id => PlayerId,
                 reason => Reason

--- a/src/leaderboards/asobi_leaderboard_server.erl
+++ b/src/leaderboards/asobi_leaderboard_server.erl
@@ -1,4 +1,5 @@
 -module(asobi_leaderboard_server).
+-include_lib("kernel/include/logger.hrl").
 -behaviour(gen_server).
 
 -export([start_link/1, submit/3, top/2, rank/2, around/3]).
@@ -274,7 +275,7 @@ flush_entries(BoardId, Table, {_NegScore, PlayerId} = Key) ->
         {ok, _} ->
             ok;
         {error, FlushErr} ->
-            logger:error(#{
+            ?LOG_ERROR(#{
                 msg => ~"leaderboard flush failed",
                 board_id => BoardId,
                 player_id => PlayerId,

--- a/src/matches/asobi_match_server.erl
+++ b/src/matches/asobi_match_server.erl
@@ -1,4 +1,5 @@
 -module(asobi_match_server).
+-include_lib("kernel/include/logger.hrl").
 -moduledoc """
 Per-match `gen_statem` driving the configured game module.
 
@@ -122,7 +123,7 @@ init(Config) ->
     pg:join(?PG_SCOPE, {asobi_match_server, MatchId}, self()),
     case recover_state(MatchId) of
         {ok, SavedStatus, SavedState} ->
-            logger:notice(#{msg => ~"match recovered", match_id => MatchId, status => SavedStatus}),
+            ?LOG_NOTICE(#{msg => ~"match recovered", match_id => MatchId, status => SavedStatus}),
             {ok, SavedStatus, SavedState};
         none ->
             GameMod = maps:get(game_module, Config),
@@ -486,7 +487,7 @@ apply_inputs(Mod, [{PlayerId, Input} | Rest], GS) ->
         {ok, GS1} ->
             apply_inputs(Mod, Rest, GS1);
         {error, Reason} ->
-            logger:warning(#{
+            ?LOG_WARNING(#{
                 msg => ~"game input rejected",
                 player_id => PlayerId,
                 reason => Reason

--- a/src/matches/asobi_matchmaker.erl
+++ b/src/matches/asobi_matchmaker.erl
@@ -1,4 +1,5 @@
 -module(asobi_matchmaker).
+-include_lib("kernel/include/logger.hrl").
 -behaviour(gen_server).
 
 -export([start_link/0, add/2, remove/2, get_ticket/1, get_ticket/2, get_queue_stats/0]).
@@ -326,7 +327,7 @@ spawn_match(Mode, ModeConfig, PlayerIds, Group, Rest, Failed) ->
                     ),
                     spawn_matches(Rest, Failed);
                 {error, Reason} ->
-                    logger:error(#{
+                    ?LOG_ERROR(#{
                         msg => ~"match spawn failed, re-queuing players",
                         mode => Mode,
                         players => PlayerIds,
@@ -375,7 +376,7 @@ spawn_world(Mode, ModeConfig, PlayerIds, Group, Rest, Failed) ->
                                 of
                                     WP when is_pid(WP) -> WP
                                 end,
-                            logger:notice(#{
+                            ?LOG_NOTICE(#{
                                 msg => ~"world spawn complete",
                                 world_pid => WorldPid,
                                 instance_pid => InstancePid
@@ -385,7 +386,7 @@ spawn_world(Mode, ModeConfig, PlayerIds, Group, Rest, Failed) ->
                             lists:foreach(
                                 fun(PlayerId) when is_binary(PlayerId) ->
                                     JoinResult = asobi_world_server:join(WorldPid, PlayerId),
-                                    logger:notice(#{
+                                    ?LOG_NOTICE(#{
                                         msg => ~"player joined world",
                                         player_id => PlayerId,
                                         result => JoinResult
@@ -402,7 +403,7 @@ spawn_world(Mode, ModeConfig, PlayerIds, Group, Rest, Failed) ->
                                 SpawnPlayerIds
                             );
                         {error, Reason} ->
-                            logger:error(#{
+                            ?LOG_ERROR(#{
                                 msg => ~"world spawn failed",
                                 mode => Mode,
                                 players => SpawnPlayerIds,
@@ -411,7 +412,7 @@ spawn_world(Mode, ModeConfig, PlayerIds, Group, Rest, Failed) ->
                     end
                 catch
                     Class:Reason2:Stack ->
-                        logger:error(#{
+                        ?LOG_ERROR(#{
                             msg => ~"world spawn crashed",
                             mode => Mode,
                             players => SpawnPlayerIds,
@@ -428,7 +429,7 @@ spawn_world(Mode, ModeConfig, PlayerIds, Group, Rest, Failed) ->
     end.
 
 notify_no_game_module(Mode, PlayerIds) ->
-    logger:warning(#{msg => ~"no game module for mode", mode => Mode}),
+    ?LOG_WARNING(#{msg => ~"no game module for mode", mode => Mode}),
     lists:foreach(
         fun(PlayerId) when is_binary(PlayerId) ->
             asobi_presence:send(

--- a/src/players/asobi_player_session.erl
+++ b/src/players/asobi_player_session.erl
@@ -1,4 +1,5 @@
 -module(asobi_player_session).
+-include_lib("kernel/include/logger.hrl").
 -behaviour(gen_server).
 
 -export([start_link/2, stop/1]).
@@ -69,7 +70,7 @@ handle_cast({reconnect_world, WorldPid}, #{player_id := PlayerId} = State) when
         _ -> ok
     catch
         Class:Reason ->
-            logger:debug(#{
+            ?LOG_DEBUG(#{
                 msg => ~"world_reconnect_failed",
                 player_id => PlayerId,
                 class => Class,

--- a/src/timers/asobi_season_manager.erl
+++ b/src/timers/asobi_season_manager.erl
@@ -1,4 +1,5 @@
 -module(asobi_season_manager).
+-include_lib("kernel/include/logger.hrl").
 -behaviour(gen_server).
 
 %% Periodically checks season boundaries and manages transitions.
@@ -58,7 +59,7 @@ activate_upcoming(Now) ->
                                 asobi_season, Season, #{status => ~"active"}, [status]
                             ),
                             _ = asobi_repo:update(CS),
-                            logger:notice(#{
+                            ?LOG_NOTICE(#{
                                 msg => ~"season_activated",
                                 season_id => Id,
                                 name => maps:get(name, Season)
@@ -86,7 +87,7 @@ end_expired(Now) ->
                                 asobi_season, Season, #{status => ~"ended"}, [status]
                             ),
                             _ = asobi_repo:update(CS),
-                            logger:notice(#{
+                            ?LOG_NOTICE(#{
                                 msg => ~"season_ended",
                                 season_id => Id,
                                 name => maps:get(name, Season)

--- a/src/votes/asobi_vote_server.erl
+++ b/src/votes/asobi_vote_server.erl
@@ -1,4 +1,5 @@
 -module(asobi_vote_server).
+-include_lib("kernel/include/logger.hrl").
 -moduledoc """
 Vote lifecycle state machine.
 
@@ -533,7 +534,7 @@ ranked_eliminate(_Votes, [], _TieBreaker) ->
     undefined;
 ranked_eliminate(Votes, Remaining, TieBreaker) ->
     RemainingSet = sets:from_list(Remaining, [{version, 2}]),
-    InitCounts = lists:foldl(fun(Id, Acc) when is_map(Acc) -> Acc#{Id => 0} end, #{}, Remaining),
+    InitCounts = maps:from_keys(Remaining, 0),
     FirstChoicesRaw = maps:fold(
         fun
             (_VoterId, Ranking, Acc) when is_list(Ranking), is_map(Acc) ->
@@ -675,10 +676,10 @@ merge_spectator_result(PlayerResult, SpectatorResult, SpectatorW, Options, TieBr
     }.
 
 init_counts(Options) ->
-    lists:foldl(fun(#{id := Id}, Acc) when is_map(Acc) -> Acc#{Id => 0} end, #{}, Options).
+    maps:from_list([{Id, 0} || #{id := Id} <- Options]).
 
 init_counts_float(Options) ->
-    lists:foldl(fun(#{id := Id}, Acc) when is_map(Acc) -> Acc#{Id => 0.0} end, #{}, Options).
+    maps:from_list([{Id, 0.0} || #{id := Id} <- Options]).
 
 merge_template(Template, Config) ->
     Templates = ensure_map(application:get_env(asobi, vote_templates, #{})),
@@ -843,7 +844,7 @@ persist_vote(#{
         {ok, _} ->
             ok;
         {error, Reason} ->
-            logger:warning(#{msg => ~"failed to persist vote", vote_id => VoteId, reason => Reason}),
+            ?LOG_WARNING(#{msg => ~"failed to persist vote", vote_id => VoteId, reason => Reason}),
             ok
     end.
 

--- a/src/workers/asobi_broadcast_worker.erl
+++ b/src/workers/asobi_broadcast_worker.erl
@@ -1,4 +1,5 @@
 -module(asobi_broadcast_worker).
+-include_lib("kernel/include/logger.hrl").
 -behaviour(shigoto_worker).
 
 -export([perform/1, queue/0, priority/0, max_attempts/1]).
@@ -29,5 +30,5 @@ perform(#{type := ~"notification", player_id := PlayerId} = Payload) ->
 perform(#{type := ~"chat", channel_id := ChannelId, sender_id := SenderId, content := Content}) ->
     asobi_chat_channel:send_message(ChannelId, SenderId, Content);
 perform(#{type := Type}) ->
-    logger:warning(#{msg => ~"unknown_broadcast_type", type => Type}),
+    ?LOG_WARNING(#{msg => ~"unknown_broadcast_type", type => Type}),
     ok.

--- a/src/world/asobi_zone.erl
+++ b/src/world/asobi_zone.erl
@@ -1,4 +1,5 @@
 -module(asobi_zone).
+-include_lib("kernel/include/logger.hrl").
 -behaviour(gen_server).
 
 -export([start_link/1]).
@@ -427,7 +428,7 @@ apply_inputs(GameMod, [{PlayerId, Input} | Rest], Entities) ->
         {ok, Entities1} ->
             apply_inputs(GameMod, Rest, Entities1);
         {error, Reason} ->
-            logger:warning(#{
+            ?LOG_WARNING(#{
                 msg => ~"zone input rejected",
                 player_id => PlayerId,
                 reason => Reason

--- a/src/world/asobi_zone_snapshotter.erl
+++ b/src/world/asobi_zone_snapshotter.erl
@@ -1,4 +1,5 @@
 -module(asobi_zone_snapshotter).
+-include_lib("kernel/include/logger.hrl").
 -behaviour(gen_server).
 
 %% Batched async DB writer for zone entity snapshots.
@@ -129,7 +130,7 @@ write_snapshot(#{world_id := WorldId, coords := {ZX, ZY}} = Data) ->
         {ok, _} ->
             ok;
         {error, Reason} ->
-            logger:warning(#{msg => ~"zone snapshot write failed", reason => Reason}),
+            ?LOG_WARNING(#{msg => ~"zone snapshot write failed", reason => Reason}),
             ok
     end.
 
@@ -139,6 +140,6 @@ do_delete_world(WorldId) ->
         {ok, _} ->
             ok;
         {error, Reason} ->
-            logger:warning(#{msg => ~"zone snapshot cleanup failed", reason => Reason}),
+            ?LOG_WARNING(#{msg => ~"zone snapshot cleanup failed", reason => Reason}),
             ok
     end.

--- a/src/ws/asobi_ws_handler.erl
+++ b/src/ws/asobi_ws_handler.erl
@@ -1,4 +1,5 @@
 -module(asobi_ws_handler).
+-include_lib("kernel/include/logger.hrl").
 -behaviour(nova_websocket).
 
 -export([init/1, websocket_init/1, websocket_handle/2, websocket_info/2, terminate/3]).
@@ -89,7 +90,7 @@ websocket_info({asobi_message, {notification, Notif}}, State) ->
     Reply = encode_reply(undefined, ~"notification.new", Notif),
     {reply, {text, Reply}, State};
 websocket_info({session_revoked, Reason}, State) ->
-    logger:notice(#{msg => ~"session_revoked", reason => Reason}),
+    ?LOG_NOTICE(#{msg => ~"session_revoked", reason => Reason}),
     {stop, State#{session => undefined}};
 websocket_info(_Info, State) ->
     {ok, State}.
@@ -467,7 +468,7 @@ safe_handle_message(Msg, State) ->
         error:{case_clause, _}:_Stack ->
             reply_error(Msg, ~"invalid_payload", State);
         Class:Reason:Stack ->
-            logger:warning(#{
+            ?LOG_WARNING(#{
                 msg => ~"ws_handler_crash",
                 class => Class,
                 reason => Reason,


### PR DESCRIPTION
## Summary

Three loosely-related backend hygiene wins surfaced by the cross-SDK DX sweep:

- **Logger macros**: convert ~30 `logger:*/1` function calls across 17 modules to `?LOG_*` macros. The macro form attaches `mfa`/`line`/`pid` metadata that nova_jsonlogger relies on; the function form silently drops it. Two clause-end sites get an explicit `, ok` since the `?LOG_*` expansion is `term()`-typed and eqWAlizer wants `ok` at those return positions.
- **Trivial foldl cleanup** in `asobi_vote_server`: three map-builders now use `maps:from_list` / `maps:from_keys` instead of `lists:foldl`. Eight other foldl uses in vote_server / matchmaker / match_server / zone_manager are genuinely iterative and deferred — converting them to named recursion is non-trivial and out of scope for this PR.
- **Protocol doc correction**: the wire event the matchmaker pushes is `match.matched`, not `matchmaker.matched` — the WS handler renders `{match_event, matched, ...}` as `match.` + the atom. Multiple SDK implementations were hooking the wrong event and waiting forever on a server push that never came. Adds a SDK-author-facing note explaining `match.matched` (matchmaker push) vs `match.joined` (reply to client `match.join`) and recommends SDKs expose a unified `OnMatchReady` event. Also documents the two related failure events.
- **CI**: enable `enable-sbom` + `enable-sbom-scan` to match the project's standard flag set.
- **rebar3_mutate**: wire it up as a project_plugin so `rebar3 mutate` is available locally and in CI.

Match-event clarification chosen: **Option A** (keep both events on the wire, document the disambiguation, recommend SDK-side unification). Option B (introduce a new `match.ready` server event) was considered and rejected as additive churn — the docs fix lands the same SDK guidance with no protocol change.

## Test plan

- [x] `rebar3 fmt --check`
- [x] `rebar3 xref`
- [x] `rebar3 dialyzer`
- [x] `~/bin/elp eqwalize-all` — `NO ERRORS`
- [x] `~/bin/elp lint` — only pre-existing migration sigil warnings
- [x] `rebar3 eunit` — 250/250 pass
- [ ] `rebar3 ct` — not run locally (Postgres compose not started); expected to pass since changes are mechanical
- [ ] `rebar3 mutate` — plugin freshly added; baseline run pending

## Deferred to follow-up

- Eight non-trivial `lists:foldl` sites that need named recursive helpers (matchmaker, match_server, zone_manager, vote_server iterative folds).
- ELP weak warnings (`W0051` sigil suggestions in auto-generated migrations) — needs a `rebar3_kura` upstream fix to emit sigil syntax.
- `asobi_cluster.erl` `list_to_atom` threat-model documentation.