### PR TITLE
docs: SDK table launch-gate fixes + Hathora 15-minute migration

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,8 +103,8 @@ UDP relay if you need sub-3ms physics.
 |---|---|---|---|
 | **Godot 4.x** (GDScript) | [asobi-godot](https://github.com/widgrensit/asobi-godot) | [Guide](https://asobi.dev/godot) | [Demo](https://github.com/widgrensit/asobi-godot-demo) |
 | **Defold** (Lua) | [asobi-defold](https://github.com/widgrensit/asobi-defold) | [Guide](https://asobi.dev/defold) | [Demo](https://github.com/widgrensit/asobi-defold-demo) |
-| **LÖVE** (Lua) | _asobi-love — ships May 2026_ | — | — |
-| **Phaser** (TypeScript) | _asobi-phaser — ships May 2026_ | — | — |
+| **LÖVE** (Lua) | _planned — [tracking #102](https://github.com/widgrensit/asobi/issues/102)_ | — | — |
+| **Phaser** (TypeScript) | [asobi-js](https://github.com/widgrensit/asobi-js) (browser) | — | _example planned — [#103](https://github.com/widgrensit/asobi/issues/103)_ |
 | **Unity 2021.3+** (C#) | [asobi-unity](https://github.com/widgrensit/asobi-unity) | [Guide](https://asobi.dev/unity) | [Demo](https://github.com/widgrensit/asobi-unity-demo) |
 | **Unreal Engine 5** (C++) | [asobi-unreal](https://github.com/widgrensit/asobi-unreal) | — | — |
 | **TypeScript / JS** (Browser + Node) | [asobi-js](https://github.com/widgrensit/asobi-js) | — | — |

--- a/examples/erlang-match/README.md
+++ b/examples/erlang-match/README.md
@@ -32,11 +32,14 @@ Expected:
 
 ```json
 {
-  "player_id": "01HX...",
-  "session_token": "eyJ...",
-  "username": "alice"
+  "username": "alice",
+  "player_id": "019de3...",
+  "session_token": "wRqvop92/QgNe9immJuUzQrL9jelCYk3D3sB0NK7lmQ="
 }
 ```
+
+> The `session_token` is a base64-encoded random secret (not a JWT). Pass it
+> verbatim in `Authorization: Bearer …` on subsequent calls.
 
 Now connect a WebSocket client (`wscat`, Defold, Godot, etc.) and play
 the `hello` mode. See the full client protocol in

--- a/guides/migrate-from-hathora.md
+++ b/guides/migrate-from-hathora.md
@@ -29,18 +29,18 @@ They get you unblocked even if the full port takes a week:
    ```bash
    curl -s localhost:8080/api/v1/auth/register \
      -H 'content-type: application/json' \
-     -d '{"username":"test","password":"test"}'
-   # → { "token": "eyJ...", "player_id": "01HX..." }
+     -d '{"username":"test","password":"test1234"}'
+   # → { "username": "test", "player_id": "019de3...", "session_token": "wRqvop92/..." }
    ```
-   That `token` is what your client passes in `Authorization: Bearer …` from
-   here on, in place of any Hathora auth token.
+   That `session_token` is what your client passes in `Authorization: Bearer …`
+   from here on, in place of any Hathora auth token.
 3. **Queue for matchmaking** to confirm the matchmaker works end-to-end:
    ```bash
    curl -s localhost:8080/api/v1/matchmaker \
      -H 'content-type: application/json' \
-     -H 'authorization: Bearer eyJ...' \
-     -d '{"mode":"default","properties":{},"party":["01HX..."]}'
-   # → { "ticket_id": "...", "status": "pending" }
+     -H 'authorization: Bearer wRqvop92/...' \
+     -d '{"mode":"default","properties":{},"party":["019de3..."]}'
+   # → { "status": "pending", "ticket_id": "019de3..." }
    ```
 4. **Join the Discord** [`#migrations` channel](https://discord.gg/vYSfYYyXpu).
    Drop your Hathora setup (engine, language, lobby vs matchmaker,

--- a/guides/migrate-from-hathora.md
+++ b/guides/migrate-from-hathora.md
@@ -5,6 +5,55 @@ this with a running game on `hathora.dev` or `hathora.cloud`, this guide walks
 you from "we need a new backend by May" to "we're running on asobi and we
 never have to do this again."
 
+## Today, in 15 minutes
+
+Before you read the rest of this guide, do these five things in this order.
+They get you unblocked even if the full port takes a week:
+
+1. **Stand up a local asobi backend.** Drop this `docker-compose.yml` into an
+   empty directory:
+   ```yaml
+   services:
+     postgres:
+       image: postgres:17
+       environment: { POSTGRES_USER: postgres, POSTGRES_PASSWORD: postgres, POSTGRES_DB: my_game }
+       healthcheck: { test: ["CMD-SHELL", "pg_isready -U postgres"], interval: 5s }
+     asobi:
+       image: ghcr.io/widgrensit/asobi_lua:latest
+       depends_on: { postgres: { condition: service_healthy } }
+       ports: ["8080:8080"]
+       environment: { ASOBI_DB_HOST: postgres, ASOBI_DB_NAME: my_game }
+   ```
+   Then `docker compose up -d`. HTTP is on `:8080`, WebSocket is on `/ws`.
+2. **Register one player** — the asobi equivalent of `HathoraClient.loginAnonymous`:
+   ```bash
+   curl -s localhost:8080/api/v1/auth/register \
+     -H 'content-type: application/json' \
+     -d '{"username":"test","password":"test"}'
+   # → { "token": "eyJ...", "player_id": "01HX..." }
+   ```
+   That `token` is what your client passes in `Authorization: Bearer …` from
+   here on, in place of any Hathora auth token.
+3. **Queue for matchmaking** to confirm the matchmaker works end-to-end:
+   ```bash
+   curl -s localhost:8080/api/v1/matchmaker \
+     -H 'content-type: application/json' \
+     -H 'authorization: Bearer eyJ...' \
+     -d '{"mode":"default","properties":{},"party":["01HX..."]}'
+   # → { "ticket_id": "...", "status": "pending" }
+   ```
+4. **Join the Discord** [`#migrations` channel](https://discord.gg/vYSfYYyXpu).
+   Drop your Hathora setup (engine, language, lobby vs matchmaker,
+   server-authoritative vs P2P) — we will tell you which sections of this
+   guide actually apply to you and which to skip.
+5. **Open a tracking issue** at
+   [github.com/widgrensit/asobi/issues](https://github.com/widgrensit/asobi/issues)
+   so we know you exist. We are prioritising migration help over feature work
+   until 2026-05-05.
+
+That is the panic checklist. You are no longer locked out as of step 1.
+Everything below is the full port.
+
 > **Draft notice.** This guide is a starting point, not a battle-tested
 > playbook — nobody has yet migrated a Hathora game to asobi end-to-end.
 > The asobi-side endpoint and event names below are **verified against the


### PR DESCRIPTION
## Summary
- README LÖVE/Phaser rows now point at concrete tracking issues instead of a placeholder month.
- Hathora migration guide gets a 5-step \"in 15 minutes\" TL;DR with verified docker-compose, register, and matchmaker curl commands.
- Corrected `session_token` field name in expected register response (was wrongly shown as `token`).

## Test plan
- [x] Followed each step against a fresh asobi container; each command exits 0 with the documented response