### PR TITLE
feat(match): wire reconnect grace period — match-side disconnect handling

### DIFF
--- a/src/matches/asobi_match_server.erl
+++ b/src/matches/asobi_match_server.erl
@@ -19,6 +19,7 @@ the place to put callback hardening.
 -behaviour(gen_statem).
 
 -export([start_link/1, join/2, leave/2, handle_input/3, get_info/1, pause/1, resume/1, cancel/1]).
+-export([reconnect/2]).
 -export([whereis/1]).
 
 -define(PG_SCOPE, nova_scope).
@@ -78,6 +79,13 @@ resume(Pid) ->
 -spec cancel(pid()) -> ok.
 cancel(Pid) ->
     gen_statem:cast(Pid, cancel).
+
+-spec reconnect(pid(), binary()) -> ok | {error, term()}.
+reconnect(Pid, PlayerId) when is_binary(PlayerId) ->
+    case gen_statem:call(Pid, {reconnect, PlayerId}) of
+        ok -> ok;
+        {error, _} = Err -> Err
+    end.
 
 -spec start_vote(pid(), map()) -> {ok, pid()} | {error, term()}.
 start_vote(Pid, VoteConfig) ->
@@ -245,6 +253,31 @@ running(cast, {leave, PlayerId}, State) ->
     handle_leave(PlayerId, State);
 running(cast, cancel, State) ->
     {next_state, finished, State#{result => #{status => ~"cancelled"}}};
+running(
+    info, {'DOWN', _MonRef, process, DownPid, _Reason}, #{reconnect_state := undefined} = State
+) ->
+    %% No reconnect policy active — a session DOWN is treated as an explicit
+    %% leave (player removed from match; match shuts down if empty).
+    case find_player_by_pid(DownPid, State) of
+        {ok, PlayerId} -> handle_leave(PlayerId, State);
+        none -> keep_state_and_data
+    end;
+running(info, {'DOWN', _MonRef, process, DownPid, _Reason}, #{reconnect_state := RS} = State) ->
+    %% Reconnect policy active — start the grace timer instead of removing
+    %% the player. asobi_reconnect:tick/2 (called every match tick by
+    %% tick_reconnect/2) will fire grace_expired if the player doesn't come
+    %% back in time.
+    case find_player_by_pid(DownPid, State) of
+        {ok, PlayerId} ->
+            Now = erlang:system_time(millisecond),
+            {Events, RS1} = asobi_reconnect:disconnect(PlayerId, Now, RS),
+            State1 = handle_reconnect_events(Events, State#{reconnect_state => RS1}),
+            {keep_state, State1};
+        none ->
+            keep_state_and_data
+    end;
+running({call, From}, {reconnect, PlayerId}, State) when is_binary(PlayerId) ->
+    handle_reconnect_call(From, PlayerId, State);
 running({call, From}, pause, State) ->
     {next_state, paused, State, [{reply, From, ok}]};
 running({call, From}, resume, _State) ->
@@ -435,8 +468,17 @@ handle_join(
         false ->
             case Mod:join(PlayerId, GS) of
                 {ok, GS1} ->
+                    %% Monitor the player session so we can run reconnect grace
+                    %% (or immediate cleanup) when the WS process dies. Mirrors
+                    %% asobi_world_server's handle_join monitor setup.
+                    SessionPid = find_player_pid(PlayerId),
+                    MonRef = erlang:monitor(process, SessionPid),
                     Players1 = Players#{
-                        PlayerId => #{joined_at => erlang:system_time(millisecond)}
+                        PlayerId => #{
+                            joined_at => erlang:system_time(millisecond),
+                            session_pid => SessionPid,
+                            monitor_ref => MonRef
+                        }
                     },
                     VetoTokens = maps:get(veto_tokens, State),
                     VetoCount = maps:get(veto_tokens_per_player, State),
@@ -469,6 +511,12 @@ handle_leave(PlayerId, #{players := Players, game_module := Mod, game_state := G
             keep_state_and_data;
         true ->
             asobi_telemetry:match_player_left(maps:get(match_id, State), PlayerId),
+            %% Demonitor the player session if we set one up at join time so
+            %% a stale 'DOWN' message can't trigger a second leave path.
+            case maps:get(monitor_ref, maps:get(PlayerId, Players, #{}), undefined) of
+                undefined -> ok;
+                MonRef -> erlang:demonitor(MonRef, [flush])
+            end,
             {ok, GS1} = Mod:leave(PlayerId, GS),
             Players1 = maps:remove(PlayerId, Players),
             case map_size(Players1) of
@@ -733,6 +781,55 @@ tick_reconnect(DeltaMs, #{reconnect_state := RS} = State) ->
     {Events, RS1} = asobi_reconnect:tick(DeltaMs, RS),
     State1 = State#{reconnect_state => RS1},
     handle_reconnect_events(Events, State1).
+
+handle_reconnect_call(From, PlayerId, #{players := Players, reconnect_state := RS} = State) when
+    RS =/= undefined
+->
+    case maps:is_key(PlayerId, Players) of
+        false ->
+            {keep_state_and_data, [{reply, From, {error, not_in_match}}]};
+        true ->
+            {_Events, RS1} = asobi_reconnect:reconnect(PlayerId, RS),
+            %% Re-monitor: the new session pid is whoever is currently
+            %% registered as the WS owner for this player_id.
+            PlayerMeta0 = maps:get(PlayerId, Players),
+            case maps:get(monitor_ref, PlayerMeta0, undefined) of
+                undefined -> ok;
+                OldRef -> erlang:demonitor(OldRef, [flush])
+            end,
+            NewSessionPid = find_player_pid(PlayerId),
+            NewMonRef = erlang:monitor(process, NewSessionPid),
+            PlayerMeta1 = PlayerMeta0#{
+                session_pid => NewSessionPid,
+                monitor_ref => NewMonRef
+            },
+            Players1 = Players#{PlayerId => PlayerMeta1},
+            {keep_state, State#{reconnect_state => RS1, players => Players1}, [
+                {reply, From, ok}
+            ]}
+    end;
+handle_reconnect_call(From, _PlayerId, _State) ->
+    {keep_state_and_data, [{reply, From, {error, no_reconnect_policy}}]}.
+
+-spec find_player_pid(binary()) -> pid().
+find_player_pid(PlayerId) ->
+    case pg:get_members(?PG_SCOPE, {player, PlayerId}) of
+        [Pid | _] -> Pid;
+        [] -> self()
+    end.
+
+-spec find_player_by_pid(pid(), map()) -> {ok, binary()} | none.
+find_player_by_pid(Pid, #{players := Players}) ->
+    maps:fold(
+        fun
+            (PlayerId, #{session_pid := SPid}, none) when SPid =:= Pid ->
+                {ok, PlayerId};
+            (_, _, Acc) ->
+                Acc
+        end,
+        none,
+        Players
+    ).
 
 handle_reconnect_events([], State) ->
     State;

--- a/src/matches/asobi_match_server.erl
+++ b/src/matches/asobi_match_server.erl
@@ -207,20 +207,12 @@ running(state_timeout, tick, #{game_module := Mod, game_state := GS, input_queue
                     State1 = State#{game_state => GS2, input_queue => []},
                     State2 = maybe_start_vote(Mod, State1),
                     State3 = tick_reconnect(TickRate, tick_phases(TickRate, State2)),
-                    case maps:get(phase_state, State3) of
-                        PS when is_map(PS) ->
-                            case asobi_phase:info(PS) of
-                                #{status := complete} ->
-                                    {next_state, finished, State3#{
-                                        result => #{status => ~"phases_complete"}
-                                    }};
-                                _ ->
-                                    broadcast_state(State3),
-                                    {keep_state, State3, [
-                                        {state_timeout, TickRate, tick}
-                                    ]}
-                            end;
-                        _ ->
+                    case asobi_phase:is_complete(maps:get(phase_state, State3)) of
+                        true ->
+                            {next_state, finished, State3#{
+                                result => #{status => ~"phases_complete"}
+                            }};
+                        false ->
                             broadcast_state(State3),
                             {keep_state, State3, [{state_timeout, TickRate, tick}]}
                     end;
@@ -231,18 +223,12 @@ running(state_timeout, tick, #{game_module := Mod, game_state := GS, input_queue
             State1 = State#{game_state => GS1, input_queue => []},
             State2 = maybe_start_vote(Mod, State1),
             State3 = tick_phases(TickRate, State2),
-            case maps:get(phase_state, State3) of
-                PS when is_map(PS) ->
-                    case asobi_phase:info(PS) of
-                        #{status := complete} ->
-                            {next_state, finished, State3#{
-                                result => #{status => ~"phases_complete"}
-                            }};
-                        _ ->
-                            broadcast_state(State3),
-                            {keep_state, State3, [{state_timeout, TickRate, tick}]}
-                    end;
-                _ ->
+            case asobi_phase:is_complete(maps:get(phase_state, State3)) of
+                true ->
+                    {next_state, finished, State3#{
+                        result => #{status => ~"phases_complete"}
+                    }};
+                false ->
                     broadcast_state(State3),
                     {keep_state, State3, [{state_timeout, TickRate, tick}]}
             end
@@ -255,14 +241,16 @@ running(cast, cancel, State) ->
     {next_state, finished, State#{result => #{status => ~"cancelled"}}};
 running(
     info, {'DOWN', _MonRef, process, DownPid, _Reason}, #{reconnect_state := undefined} = State
-) ->
+) when is_pid(DownPid) ->
     %% No reconnect policy active — a session DOWN is treated as an explicit
     %% leave (player removed from match; match shuts down if empty).
     case find_player_by_pid(DownPid, State) of
         {ok, PlayerId} -> handle_leave(PlayerId, State);
         none -> keep_state_and_data
     end;
-running(info, {'DOWN', _MonRef, process, DownPid, _Reason}, #{reconnect_state := RS} = State) ->
+running(info, {'DOWN', _MonRef, process, DownPid, _Reason}, #{reconnect_state := RS} = State) when
+    is_pid(DownPid)
+->
     %% Reconnect policy active — start the grace timer instead of removing
     %% the player. asobi_reconnect:tick/2 (called every match tick by
     %% tick_reconnect/2) will fire grace_expired if the player doesn't come

--- a/src/timers/asobi_phase.erl
+++ b/src/timers/asobi_phase.erl
@@ -9,7 +9,7 @@
 
 -export([init/1, tick/2]).
 -export([notify/2, pause/1, resume/1]).
--export([current/1, remaining/1, config/1, timers_info/1, info/1]).
+-export([current/1, remaining/1, config/1, timers_info/1, info/1, is_complete/1]).
 
 -export_type([phase_state/0, phase_def/0, phase_event/0]).
 
@@ -189,6 +189,11 @@ config(PS) ->
 -spec timers_info(phase_state()) -> #{binary() => map()}.
 timers_info(#{active_timers := Timers}) ->
     maps:map(fun(_Id, T) -> asobi_timer:info(T) end, Timers).
+
+-spec is_complete(undefined | phase_state() | map()) -> boolean().
+is_complete(undefined) -> false;
+is_complete(#{complete := true}) -> true;
+is_complete(_) -> false.
 
 -spec info(phase_state()) -> map().
 info(#{complete := true}) ->

--- a/test/asobi_match_server_tests.erl
+++ b/test/asobi_match_server_tests.erl
@@ -58,7 +58,11 @@ match_server_test_() ->
         {timeout, 70, {"waiting timeout stops match", fun waiting_timeout/0}},
         {"get_info works in all states", fun get_info_all_states/0},
         {"state backup and recovery", fun state_backup_recovery/0},
-        {"generate_id produces valid uuidv7", fun generate_id_format/0}
+        {"generate_id produces valid uuidv7", fun generate_id_format/0},
+        {"disconnect with reconnect policy starts grace", fun disconnect_starts_grace/0},
+        {"disconnect without policy is immediate leave", fun disconnect_no_policy_leaves/0},
+        {"reconnect within grace keeps player", fun reconnect_within_grace_keeps/0},
+        {"reconnect with no policy returns error", fun reconnect_no_policy_errors/0}
     ]}.
 
 %% --- Tests ---
@@ -277,7 +281,104 @@ generate_id_format() ->
     ),
     ?assertEqual(<<"7">>, binary:part(Id, 14, 1)).
 
+%% --- Reconnect tests ---
+
+disconnect_starts_grace() ->
+    %% With a reconnect policy, killing the player session must NOT remove
+    %% the player from the match — the grace timer holds them in place
+    %% until reconnect/2 returns or grace expires.
+    Pid = start_match(#{
+        min_players => 1,
+        max_players => 2,
+        reconnect => #{
+            grace_period => 30_000,
+            during_grace => idle,
+            on_reconnect => resume,
+            on_expire => remove,
+            pause_match => false,
+            max_offline_total => infinity
+        }
+    }),
+    SessionPid = fake_session(~"p1"),
+    ok = asobi_match_server:join(Pid, ~"p1"),
+    timer:sleep(50),
+    %% Match transitioned to running; player count is 1.
+    ?assertEqual(1, maps:get(player_count, asobi_match_server:get_info(Pid))),
+
+    exit(SessionPid, kill),
+    timer:sleep(50),
+    %% Player still counted — grace is active.
+    ?assertEqual(1, maps:get(player_count, asobi_match_server:get_info(Pid))),
+    stop(Pid).
+
+disconnect_no_policy_leaves() ->
+    %% Without a reconnect policy, session DOWN goes through handle_leave —
+    %% same as an explicit leave/2.
+    Pid = start_match(#{min_players => 1, max_players => 2}),
+    unlink(Pid),
+    PidRef = monitor(process, Pid),
+    SessionPid = fake_session(~"p1"),
+    ok = asobi_match_server:join(Pid, ~"p1"),
+    timer:sleep(50),
+
+    exit(SessionPid, kill),
+    %% Single-player match shuts down on last leave.
+    receive
+        {'DOWN', PidRef, process, Pid, {shutdown, empty}} -> ok
+    after 2000 ->
+        ?assert(false)
+    end.
+
+reconnect_within_grace_keeps() ->
+    %% Disconnect → reconnect inside the grace window leaves the player
+    %% counted and re-monitors the new session.
+    Pid = start_match(#{
+        min_players => 1,
+        max_players => 2,
+        reconnect => #{
+            grace_period => 30_000,
+            during_grace => idle,
+            on_reconnect => resume,
+            on_expire => remove,
+            pause_match => false,
+            max_offline_total => infinity
+        }
+    }),
+    SessionPid1 = fake_session(~"p1"),
+    ok = asobi_match_server:join(Pid, ~"p1"),
+    timer:sleep(50),
+
+    exit(SessionPid1, kill),
+    timer:sleep(30),
+    %% Replace the registered session with a fresh fake.
+    catch pg:leave(nova_scope, {player, ~"p1"}, SessionPid1),
+    _SessionPid2 = fake_session(~"p1"),
+    ?assertEqual(ok, asobi_match_server:reconnect(Pid, ~"p1")),
+    timer:sleep(30),
+    ?assertEqual(1, maps:get(player_count, asobi_match_server:get_info(Pid))),
+    stop(Pid).
+
+reconnect_no_policy_errors() ->
+    Pid = start_match(#{min_players => 1, max_players => 2}),
+    _SessionPid = fake_session(~"p1"),
+    ok = asobi_match_server:join(Pid, ~"p1"),
+    timer:sleep(50),
+    ?assertMatch({error, no_reconnect_policy}, asobi_match_server:reconnect(Pid, ~"p1")),
+    stop(Pid).
+
 %% --- Helpers ---
+
+fake_session(PlayerId) ->
+    %% Spawn a tiny process and register it as the player's session in the
+    %% nova_scope pg group so asobi_match_server:find_player_pid/1 returns it.
+    Pid = spawn(fun L() ->
+        receive
+            stop -> ok;
+            _ -> L()
+        end
+    end),
+    ok = pg:join(nova_scope, {player, PlayerId}, Pid),
+    Pid.
 
 stop(Pid) ->
     case is_process_alive(Pid) of


### PR DESCRIPTION
## Summary
- Match server now monitors player session pids on join and demonitors on leave.
- Adds DOWN-message handlers for both reconnect-policy and no-policy paths: with policy, the grace timer fires; without, the player is removed (and the match shuts down if empty).
- Public `reconnect/2` API + `running({call, From}, {reconnect, ...})` clause re-monitor the new session pid and call into the existing `asobi_reconnect` state.
- Added `asobi_phase:is_complete/1` and replaced the `is_map(PS)`-guarded info call at the tick check; the guard was stripping the opaque type and dialyzer flagged it once the player metadata map widened.

## Test plan
- [x] `rebar3 eunit` passes (254 tests, including 4 new reconnect-bridge tests)
- [x] `rebar3 dialyzer` clean
- [x] `~/bin/elp eqwalize-all` clean
- [x] `rebar3 fmt --check` clean