### PR TITLE
chore(chat): eager-create chat_registry ETS in supervisor init

### DIFF
--- a/src/social/asobi_chat_channel.erl
+++ b/src/social/asobi_chat_channel.erl
@@ -52,7 +52,6 @@ get_history(ChannelId, Limit) when is_integer(Limit) ->
 
 -spec init({binary(), binary()}) -> {ok, map(), pos_integer()}.
 init({ChannelId, ChannelType}) ->
-    ensure_registry(),
     ets:insert(?REGISTRY, {ChannelId, self()}),
     process_flag(trap_exit, true),
     {ok,
@@ -151,19 +150,9 @@ start_new_channel(ChannelId) ->
     end.
 
 lookup(ChannelId) ->
-    ensure_registry(),
     case ets:lookup(?REGISTRY, ChannelId) of
         [{_, Pid}] -> {ok, Pid};
         [] -> error
-    end.
-
-ensure_registry() ->
-    case ets:whereis(?REGISTRY) of
-        undefined ->
-            _ = ets:new(?REGISTRY, [named_table, public, set, {read_concurrency, true}]),
-            ok;
-        _ ->
-            ok
     end.
 
 %% --- Persistence ---

--- a/src/social/asobi_chat_sup.erl
+++ b/src/social/asobi_chat_sup.erl
@@ -4,6 +4,8 @@
 -export([start_link/0, start_channel/1, start_channel/2]).
 -export([init/1]).
 
+-define(REGISTRY, asobi_chat_registry).
+
 -spec start_link() -> supervisor:startlink_ret().
 start_link() ->
     supervisor:start_link({local, ?MODULE}, ?MODULE, []).
@@ -18,6 +20,24 @@ start_channel(ChannelId, ChannelType) ->
 
 -spec init([]) -> {ok, {supervisor:sup_flags(), [supervisor:child_spec()]}}.
 init([]) ->
+    %% Owned by the supervisor process so the table outlives every
+    %% channel restart. Eager-creating here removes the lazy
+    %% ets:whereis/ets:new check from the lookup hot path and the race
+    %% where two simultaneous `start_channel` callers both saw the
+    %% table missing.
+    case ets:whereis(?REGISTRY) of
+        undefined ->
+            ?REGISTRY = ets:new(?REGISTRY, [
+                named_table,
+                public,
+                set,
+                {read_concurrency, true},
+                {write_concurrency, true}
+            ]),
+            ok;
+        _ ->
+            ok
+    end,
     SupFlags = #{
         strategy => simple_one_for_one,
         intensity => 5,


### PR DESCRIPTION
## Summary
- Move \`asobi_chat_registry\` ETS creation from the per-lookup hot path into \`asobi_chat_sup:init/1\` so it's owned by the long-lived supervisor and exists before any channel can be started.
- Removes the race where two concurrent \`start_channel\` callers both saw the table missing.
- Adds \`write_concurrency\` since the registry sees an insert per new channel and a delete per channel termination.

## Test plan
- [x] \`rebar3 fmt --check\`, \`xref\`, \`dialyzer\` clean
- [x] \`~/bin/elp eqwalize-all\` clean
- [x] \`rebar3 eunit\` passes (254 tests)