### PR TITLE
feat(ws): connect-rate cap and idle-auth timeout on the WebSocket

### DIFF
--- a/src/asobi_peer.erl
+++ b/src/asobi_peer.erl
@@ -1,0 +1,27 @@
+-module(asobi_peer).
+-moduledoc """
+Client-IP extraction shared across HTTP and WebSocket entry points.
+
+Reads `cowboy_req:peer/1` and renders the address as a binary. Returns
+`~"unknown"` for any unexpected shape so callers can use the result as
+a rate-limiter key without crashing the request.
+
+This module deliberately does **not** honor `X-Forwarded-For` today —
+trusting `XFF` blindly lets any client choose its own rate-limit key,
+which defeats the limiter. Honoring `XFF` correctly requires a
+deployer-configured CIDR trust list and is a follow-up.
+""".
+
+-export([client_ip/1]).
+
+-spec client_ip(cowboy_req:req() | map()) -> binary().
+client_ip(Req) ->
+    try cowboy_req:peer(Req) of
+        {IP, _Port} ->
+            case inet:ntoa(IP) of
+                Addr when is_list(Addr) -> list_to_binary(Addr);
+                _ -> ~"unknown"
+            end
+    catch
+        _:_ -> ~"unknown"
+    end.

--- a/src/asobi_sup.erl
+++ b/src/asobi_sup.erl
@@ -111,10 +111,15 @@ register_limiters() ->
     %% Brute-force resistance: 5 auth requests/sec was the historical
     %% setting and is reasonable for honest UX; iap is per-purchase so
     %% 10/sec is plenty. The general-purpose api limiter stays at 300.
+    %% ws_connect protects the WebSocket upgrade path: 60/sec/IP is
+    %% high enough for legitimate mobile reconnect storms (carrier-NAT
+    %% means many real users share one IP) but low enough to bound a
+    %% single-IP flood of fresh connections.
     Defaults = #{
         auth => #{algorithm => sliding_window, limit => 5, window => 1000},
         iap => #{algorithm => sliding_window, limit => 10, window => 1000},
-        api => #{algorithm => sliding_window, limit => 300, window => 1000}
+        api => #{algorithm => sliding_window, limit => 300, window => 1000},
+        ws_connect => #{algorithm => sliding_window, limit => 60, window => 1000}
     },
     Configured =
         case application:get_env(asobi, rate_limits, #{}) of
@@ -138,7 +143,8 @@ register_limiters() ->
 
 limiter_name(auth) -> asobi_auth_limiter;
 limiter_name(iap) -> asobi_iap_limiter;
-limiter_name(api) -> asobi_api_limiter.
+limiter_name(api) -> asobi_api_limiter;
+limiter_name(ws_connect) -> asobi_ws_connect_limiter.
 
 cluster_spec() ->
     #{

--- a/src/asobi_telemetry.erl
+++ b/src/asobi_telemetry.erl
@@ -6,7 +6,14 @@
 -export([world_phase_changed/3]).
 -export([matchmaker_queued/2, matchmaker_removed/2, matchmaker_formed/3]).
 -export([session_connected/1, session_disconnected/2]).
--export([ws_connected/0, ws_disconnected/0, ws_message_in/1, ws_message_out/1]).
+-export([
+    ws_connected/0,
+    ws_disconnected/0,
+    ws_message_in/1,
+    ws_message_out/1,
+    ws_connect_rate_limited/1,
+    ws_idle_auth_timeout/0
+]).
 -export([anticheat_violation/3]).
 -export([economy_transaction/4, store_purchase/3]).
 -export([chat_message_sent/2]).
@@ -157,6 +164,16 @@ ws_connected() ->
 -spec ws_disconnected() -> ok.
 ws_disconnected() ->
     telemetry:execute([asobi, ws, disconnected], #{count => 1}, #{}).
+
+-spec ws_connect_rate_limited(binary()) -> ok.
+ws_connect_rate_limited(PeerIp) ->
+    telemetry:execute(
+        [asobi, ws, connect_rate_limited], #{count => 1}, #{peer_ip => PeerIp}
+    ).
+
+-spec ws_idle_auth_timeout() -> ok.
+ws_idle_auth_timeout() ->
+    telemetry:execute([asobi, ws, idle_auth_timeout], #{count => 1}, #{}).
 
 -spec anticheat_violation(binary(), atom(), map()) -> ok.
 anticheat_violation(PlayerId, Type, Details) ->

--- a/src/plugins/asobi_rate_limit_plugin.erl
+++ b/src/plugins/asobi_rate_limit_plugin.erl
@@ -59,18 +59,10 @@ rate_limit_key(Req) ->
         <<"Bearer ", _/binary>> ->
             case maps:get(auth_data, Req, undefined) of
                 #{player_id := Id} when is_binary(Id) -> Id;
-                _ -> peer_ip(Req)
+                _ -> asobi_peer:client_ip(Req)
             end;
         _ ->
-            peer_ip(Req)
-    end.
-
--spec peer_ip(cowboy_req:req()) -> binary().
-peer_ip(Req) ->
-    {IP, _Port} = cowboy_req:peer(Req),
-    case inet:ntoa(IP) of
-        Addr when is_list(Addr) -> list_to_binary(Addr);
-        _ -> ~"unknown"
+            asobi_peer:client_ip(Req)
     end.
 
 -spec select_limiter(cowboy_req:req()) -> atom().

--- a/src/ws/asobi_ws_handler.erl
+++ b/src/ws/asobi_ws_handler.erl
@@ -10,18 +10,52 @@
 -define(MAX_JOINED_CHANNELS_PER_CONN, 32).
 -define(MAX_CHANNEL_ID_BYTES, 256).
 
--spec init(map()) -> {ok, map()}.
-init(State) ->
-    {ok, State#{session => undefined}}.
+%% Default time a freshly-connected WS has to send `session.connect`
+%% before we close it. Mobile TLS handshake on poor networks can be
+%% several seconds; 10s gives margin without leaving idle sockets
+%% holding cowboy acceptors. Override via `asobi.ws_idle_auth_timeout_ms`.
+-define(DEFAULT_IDLE_AUTH_TIMEOUT_MS, 10000).
 
--spec websocket_init(map()) -> {ok, map()}.
+-spec init(map()) -> {ok, map()}.
+init(#{req := Req} = State) ->
+    %% Capture peer IP before the upgrade so websocket_init can run the
+    %% per-IP connect-rate check without re-parsing the req.
+    PeerIp = asobi_peer:client_ip(Req),
+    {ok, State#{session => undefined, peer_ip => PeerIp}};
+init(State) ->
+    {ok, State#{session => undefined, peer_ip => ~"unknown"}}.
+
+-spec websocket_init(map()) -> {ok, map()} | {reply, {close, 1008, binary()}, map()}.
+websocket_init(#{peer_ip := PeerIp} = State) ->
+    case seki:check(asobi_ws_connect_limiter, PeerIp) of
+        {allow, _} ->
+            start_authenticated_session(State);
+        {deny, _} ->
+            asobi_telemetry:ws_connect_rate_limited(PeerIp),
+            {reply, {close, 1008, ~"rate_limited"}, State}
+    end;
 websocket_init(State) ->
+    %% No peer_ip — init/1 ran in a path without a req map. Skip the
+    %% connect-rate gate but still install the idle-auth timer.
+    start_authenticated_session(State).
+
+start_authenticated_session(State) ->
     asobi_telemetry:ws_connected(),
+    Now = erlang:system_time(millisecond),
+    TimeoutMs = idle_auth_timeout_ms(),
+    TimerRef = erlang:send_after(TimeoutMs, self(), idle_auth_timeout),
     {ok, State#{
-        connected_at => erlang:system_time(millisecond),
+        connected_at => Now,
         ws_msg_count => 0,
-        ws_msg_window_start => erlang:system_time(millisecond)
+        ws_msg_window_start => Now,
+        idle_auth_timer => TimerRef
     }}.
+
+idle_auth_timeout_ms() ->
+    case application:get_env(asobi, ws_idle_auth_timeout_ms) of
+        {ok, Ms} when is_integer(Ms), Ms > 0 -> Ms;
+        _ -> ?DEFAULT_IDLE_AUTH_TIMEOUT_MS
+    end.
 
 -spec websocket_handle({text | binary, binary()}, map()) ->
     {ok, map()} | {reply, {text, binary()}, map()}.
@@ -56,7 +90,10 @@ websocket_handle(_Frame, State) ->
     {ok, State}.
 
 -spec websocket_info(term(), map()) ->
-    {ok, map()} | {reply, {text, binary()}, map()} | {stop, map()}.
+    {ok, map()}
+    | {reply, {text, binary()}, map()}
+    | {reply, {close, non_neg_integer(), binary()}, map()}
+    | {stop, map()}.
 websocket_info({asobi_message, {match_state, MatchState}}, State) ->
     Reply = encode_reply(undefined, ~"match.state", MatchState),
     {reply, {text, Reply}, State};
@@ -91,6 +128,16 @@ websocket_info({asobi_message, {notification, Notif}}, State) ->
 websocket_info({session_revoked, Reason}, State) ->
     logger:notice(#{msg => ~"session_revoked", reason => Reason}),
     {stop, State#{session => undefined}};
+websocket_info(idle_auth_timeout, #{session := undefined} = State) ->
+    %% Client opened the WS and never sent session.connect within the
+    %% configured window. Close so the cowboy acceptor isn't held by an
+    %% idle peer that may never authenticate.
+    asobi_telemetry:ws_idle_auth_timeout(),
+    {reply, {close, 1008, ~"idle_auth_timeout"}, State};
+websocket_info(idle_auth_timeout, State) ->
+    %% Race: the timer fired but session.connect already succeeded.
+    %% Ignore.
+    {ok, State};
 websocket_info(_Info, State) ->
     {ok, State}.
 
@@ -121,7 +168,8 @@ handle_message(#{~"type" := ~"session.connect", ~"payload" := Payload} = Msg, St
                     ok
             end,
             Reply = encode_reply(Cid, ~"session.connected", #{player_id => PlayerId}),
-            {reply, {text, Reply}, State#{session => SessionPid, player_id => PlayerId}};
+            State1 = cancel_idle_auth_timer(State),
+            {reply, {text, Reply}, State1#{session => SessionPid, player_id => PlayerId}};
         {error, Reason} ->
             Reply = encode_reply(Cid, ~"error", #{reason => Reason}),
             {reply, {text, Reply}, State}
@@ -522,6 +570,12 @@ current_player_world(PlayerId) ->
     end.
 
 %% --- Internal ---
+
+cancel_idle_auth_timer(#{idle_auth_timer := Ref} = State) when is_reference(Ref) ->
+    _ = erlang:cancel_timer(Ref, [{async, true}, {info, false}]),
+    maps:remove(idle_auth_timer, State);
+cancel_idle_auth_timer(State) ->
+    State.
 
 authenticate(#{~"token" := Token}) ->
     case nova_auth_session:get_user_by_session_token(asobi_auth, Token) of

--- a/test/asobi_ws_SUITE.erl
+++ b/test/asobi_ws_SUITE.erl
@@ -6,10 +6,11 @@
 -export([
     ws_connect_invalid_token/1,
     ws_heartbeat/1,
-    ws_unknown_type/1
+    ws_unknown_type/1,
+    ws_idle_auth_timeout_closes/1
 ]).
 
-all() -> [ws_connect_invalid_token, ws_heartbeat, ws_unknown_type].
+all() -> [ws_connect_invalid_token, ws_heartbeat, ws_unknown_type, ws_idle_auth_timeout_closes].
 
 init_per_suite(Config) ->
     asobi_test_helpers:start(Config).
@@ -59,4 +60,20 @@ ws_unknown_type(Config) ->
     {ok, Resp} = nova_test_ws:recv_json(Conn),
     ?assertMatch(#{~"type" := ~"error", ~"payload" := #{~"reason" := ~"unknown_type"}}, Resp),
     nova_test_ws:close(Conn),
+    Config.
+
+%% A WS that opens and never sends `session.connect` must be closed by
+%% the server with code 1008 once the idle-auth window elapses.
+ws_idle_auth_timeout_closes(Config) ->
+    Old = application:get_env(asobi, ws_idle_auth_timeout_ms),
+    application:set_env(asobi, ws_idle_auth_timeout_ms, 200),
+    try
+        {ok, Conn} = nova_test_ws:connect("/ws", Config),
+        ?assertEqual({error, {closed, 1008}}, nova_test_ws:recv(Conn, 2000))
+    after
+        case Old of
+            {ok, V} -> application:set_env(asobi, ws_idle_auth_timeout_ms, V);
+            undefined -> application:unset_env(asobi, ws_idle_auth_timeout_ms)
+        end
+    end,
     Config.


### PR DESCRIPTION
## Summary

Two complementary protections for the public WS endpoint:

- **Per-IP connect-rate limit** — new \`asobi_ws_connect_limiter\` (60/sec/IP sliding window) checked in \`websocket_init/1\` before any session work. Over-limit clients get a close 1008 \`rate_limited\`. Configurable via \`asobi.rate_limits\`. 60/sec is generous for legitimate mobile reconnect storms behind carrier-NAT.
- **Idle-auth timeout** — a freshly-connected WS that doesn't send \`session.connect\` within \`asobi.ws_idle_auth_timeout_ms\` (default 10s) is closed with 1008. Stops idle peers from holding cowboy acceptors.

Peer-IP extraction is factored into a shared \`asobi_peer:client_ip/1\` reused by the WS path and the existing rate-limit plugin. XFF trust is deferred — honoring XFF without a deployer-configured CIDR allowlist defeats the limiter.

## Test plan
- [x] New CT \`ws_idle_auth_timeout_closes/1\` connects, waits, asserts close 1008
- [x] \`rebar3 fmt --check\`, \`xref\`, \`dialyzer\` clean
- [x] \`~/bin/elp eqwalize-all\` clean
- [x] \`rebar3 eunit\` 254 tests pass
- [x] \`rebar3 ct --suite test/asobi_ws_SUITE\` 4 tests pass