### PR TITLE
feat(auth): cache session-token resolution to elide DB hits per WS connect

### DIFF
--- a/src/asobi_sup.erl
+++ b/src/asobi_sup.erl
@@ -17,6 +17,7 @@ init([]) ->
     },
     Children = [
         rate_limit_spec(),
+        auth_cache_spec(),
         cluster_spec(),
         player_session_sup(),
         match_sup(),
@@ -150,6 +151,12 @@ cluster_spec() ->
     #{
         id => asobi_cluster,
         start => {asobi_cluster, start_link, []}
+    }.
+
+auth_cache_spec() ->
+    #{
+        id => asobi_auth_cache,
+        start => {asobi_auth_cache, start_link, []}
     }.
 
 season_manager_spec() ->

--- a/src/asobi_telemetry.erl
+++ b/src/asobi_telemetry.erl
@@ -18,6 +18,7 @@
 -export([economy_transaction/4, store_purchase/3]).
 -export([chat_message_sent/2]).
 -export([vote_started/2, vote_cast/2, vote_resolved/3]).
+-export([auth_cache_hit/1, auth_cache_miss/1, auth_cache_sweep/0]).
 -export([handle_event/4]).
 
 -spec setup() -> ok.
@@ -232,6 +233,20 @@ vote_resolved(VoteId, DurationMs, Result) ->
     telemetry:execute([asobi, vote, resolved], #{duration_ms => DurationMs, count => 1}, #{
         vote_id => VoteId, result => Result
     }).
+
+%% --- Auth Cache Events ---
+
+-spec auth_cache_hit(positive | negative) -> ok.
+auth_cache_hit(Kind) ->
+    telemetry:execute([asobi, auth_cache, hit], #{count => 1}, #{kind => Kind}).
+
+-spec auth_cache_miss(positive | negative) -> ok.
+auth_cache_miss(Kind) ->
+    telemetry:execute([asobi, auth_cache, miss], #{count => 1}, #{kind => Kind}).
+
+-spec auth_cache_sweep() -> ok.
+auth_cache_sweep() ->
+    telemetry:execute([asobi, auth_cache, sweep], #{count => 1}, #{}).
 
 %% --- Internal ---
 

--- a/src/auth/asobi_auth_cache.erl
+++ b/src/auth/asobi_auth_cache.erl
@@ -1,0 +1,203 @@
+-module(asobi_auth_cache).
+-moduledoc """
+In-memory cache for session-token → player resolution.
+
+The WS connect path and every authenticated HTTP request hit
+`nova_auth_session:get_user_by_session_token/2`, which costs two
+kura queries (one for the token row, one for the user). Under
+mobile-reconnect storms this is the dominant per-connect cost. The
+cache turns a hit into one ETS lookup.
+
+## Lifetime and freshness
+
+Entries TTL after `asobi.auth_cache_ttl_ms` (default 60_000ms) so a
+revoked token's fallout is bounded. Invalidation must be wired into
+every code path that deletes or replaces a token; see `invalidate/1`.
+
+Negative results (token not found, expired) are also cached but with
+a much shorter TTL (`asobi.auth_cache_negative_ttl_ms`, default
+5_000ms) so a fresh-token race doesn't keep returning errors after
+the token actually exists.
+
+## Process model
+
+A single named gen_server owns the ETS table. Lookups are direct ETS
+reads from any process; writes go through the gen_server only for
+expiry-sweep coordination — `put/2,3` and `invalidate/1` write
+directly via `public` ETS for latency. The gen_server runs a
+periodic sweep (every TTL/2) that removes expired rows so the table
+doesn't grow unbounded under attack.
+""".
+
+-behaviour(gen_server).
+
+-export([start_link/0]).
+-export([resolve_token/1, invalidate/1, put_positive/2, put_negative/1, clear/0, info/0]).
+
+-export([init/1, handle_call/3, handle_cast/2, handle_info/2]).
+
+-define(TABLE, asobi_auth_cache_tab).
+-define(DEFAULT_TTL_MS, 60_000).
+-define(DEFAULT_NEGATIVE_TTL_MS, 5_000).
+
+-spec start_link() -> gen_server:start_ret().
+start_link() ->
+    gen_server:start_link({local, ?MODULE}, ?MODULE, [], []).
+
+%% Single chokepoint helper: cache hit returns immediately, miss falls
+%% back to nova_auth_session and populates the cache. Both call sites
+%% (`asobi_ws_handler:authenticate/1` and `asobi_auth_plugin:verify/1`)
+%% should call this rather than nova_auth_session directly.
+-spec resolve_token(binary()) -> {ok, map()} | {error, term()}.
+resolve_token(Token) when is_binary(Token) ->
+    Now = erlang:system_time(millisecond),
+    case ets:lookup(?TABLE, Token) of
+        [{_, {ok, Player}, ExpiresAt}] when ExpiresAt > Now ->
+            asobi_telemetry:auth_cache_hit(positive),
+            {ok, Player};
+        [{_, {error, Reason}, ExpiresAt}] when ExpiresAt > Now ->
+            asobi_telemetry:auth_cache_hit(negative),
+            {error, Reason};
+        _ ->
+            miss(Token)
+    end;
+resolve_token(_) ->
+    {error, invalid_token}.
+
+-spec invalidate(binary()) -> ok.
+invalidate(Token) when is_binary(Token) ->
+    case ets:whereis(?TABLE) of
+        undefined ->
+            ok;
+        _ ->
+            ets:delete(?TABLE, Token),
+            ok
+    end;
+invalidate(_) ->
+    ok.
+
+-spec put_positive(binary(), map()) -> ok.
+put_positive(Token, Player) when is_binary(Token), is_map(Player) ->
+    ExpiresAt = erlang:system_time(millisecond) + ttl_ms(),
+    insert(Token, {ok, Player}, ExpiresAt).
+
+-spec put_negative(binary()) -> ok.
+put_negative(Token) when is_binary(Token) ->
+    ExpiresAt = erlang:system_time(millisecond) + negative_ttl_ms(),
+    insert(Token, {error, not_found}, ExpiresAt).
+
+-spec clear() -> ok.
+clear() ->
+    case ets:whereis(?TABLE) of
+        undefined ->
+            ok;
+        _ ->
+            ets:delete_all_objects(?TABLE),
+            ok
+    end.
+
+-spec info() -> #{size := non_neg_integer(), memory_words := non_neg_integer()}.
+info() ->
+    #{
+        size => to_count(ets:info(?TABLE, size)),
+        memory_words => to_count(ets:info(?TABLE, memory))
+    }.
+
+-spec to_count(non_neg_integer() | undefined | term()) -> non_neg_integer().
+to_count(N) when is_integer(N), N >= 0 -> N;
+to_count(_) -> 0.
+
+%% --- gen_server callbacks ---
+
+-spec init([]) -> {ok, map()}.
+init([]) ->
+    case ets:whereis(?TABLE) of
+        undefined ->
+            ?TABLE = ets:new(?TABLE, [
+                named_table,
+                public,
+                set,
+                {read_concurrency, true},
+                {write_concurrency, true},
+                {decentralized_counters, true}
+            ]);
+        _ ->
+            ok
+    end,
+    schedule_sweep(),
+    {ok, #{}}.
+
+-spec handle_call(term(), gen_server:from(), map()) -> {reply, ok, map()}.
+handle_call(_Req, _From, State) ->
+    {reply, ok, State}.
+
+-spec handle_cast(term(), map()) -> {noreply, map()}.
+handle_cast(_Msg, State) ->
+    {noreply, State}.
+
+-spec handle_info(term(), map()) -> {noreply, map()}.
+handle_info(sweep, State) ->
+    sweep_expired(),
+    schedule_sweep(),
+    {noreply, State};
+handle_info(_Info, State) ->
+    {noreply, State}.
+
+%% --- Internal ---
+
+miss(Token) ->
+    case nova_auth_session:get_user_by_session_token(asobi_auth, Token) of
+        {ok, Player} = OK ->
+            asobi_telemetry:auth_cache_miss(positive),
+            put_positive(Token, Player),
+            OK;
+        {error, _} = Err ->
+            asobi_telemetry:auth_cache_miss(negative),
+            put_negative(Token),
+            Err
+    end.
+
+insert(Token, Value, ExpiresAt) ->
+    case ets:whereis(?TABLE) of
+        undefined ->
+            %% Cache not yet running (test harness, app startup) —
+            %% silently skip; the real lookup will go to the DB.
+            ok;
+        _ ->
+            ets:insert(?TABLE, {Token, Value, ExpiresAt}),
+            ok
+    end.
+
+-spec schedule_sweep() -> reference().
+schedule_sweep() ->
+    Half = ttl_ms() div 2,
+    Interval =
+        case Half >= 1000 of
+            true -> Half;
+            false -> 1000
+        end,
+    erlang:send_after(Interval, self(), sweep).
+
+sweep_expired() ->
+    Now = erlang:system_time(millisecond),
+    %% Match every row with an ExpiresAt <= Now and delete it. Using a
+    %% match-spec avoids dragging the whole table through the
+    %% gen_server.
+    MS = [{{'_', '_', '$1'}, [{'=<', '$1', Now}], [true]}],
+    _ = ets:select_delete(?TABLE, MS),
+    asobi_telemetry:auth_cache_sweep(),
+    ok.
+
+-spec ttl_ms() -> non_neg_integer().
+ttl_ms() ->
+    case application:get_env(asobi, auth_cache_ttl_ms) of
+        {ok, N} when is_integer(N), N >= 0 -> N;
+        _ -> ?DEFAULT_TTL_MS
+    end.
+
+-spec negative_ttl_ms() -> non_neg_integer().
+negative_ttl_ms() ->
+    case application:get_env(asobi, auth_cache_negative_ttl_ms) of
+        {ok, N} when is_integer(N), N >= 0 -> N;
+        _ -> ?DEFAULT_NEGATIVE_TTL_MS
+    end.

--- a/src/controllers/asobi_auth_controller.erl
+++ b/src/controllers/asobi_auth_controller.erl
@@ -53,6 +53,7 @@ refresh(#{json := #{~"session_token" := OldToken}} = _Req) when is_binary(OldTok
     case nova_auth_session:get_user_by_session_token(asobi_auth, OldToken) of
         {ok, Player} ->
             nova_auth_session:delete_session_token(asobi_auth, OldToken),
+            asobi_auth_cache:invalidate(OldToken),
             {ok, NewToken} = nova_auth_session:generate_session_token(asobi_auth, Player),
             {json, 200, #{}, #{
                 player_id => maps:get(id, Player),

--- a/src/plugins/asobi_auth_plugin.erl
+++ b/src/plugins/asobi_auth_plugin.erl
@@ -8,7 +8,7 @@ verify(Req) ->
         undefined ->
             false;
         <<"Bearer ", Token/binary>> ->
-            case nova_auth_session:get_user_by_session_token(asobi_auth, Token) of
+            case asobi_auth_cache:resolve_token(Token) of
                 {ok, Player} ->
                     {true, #{player_id => maps:get(id, Player)}};
                 {error, _} ->

--- a/src/ws/asobi_ws_handler.erl
+++ b/src/ws/asobi_ws_handler.erl
@@ -577,13 +577,15 @@ cancel_idle_auth_timer(#{idle_auth_timer := Ref} = State) when is_reference(Ref)
 cancel_idle_auth_timer(State) ->
     State.
 
-authenticate(#{~"token" := Token}) ->
-    case nova_auth_session:get_user_by_session_token(asobi_auth, Token) of
+authenticate(#{~"token" := Token}) when is_binary(Token) ->
+    case asobi_auth_cache:resolve_token(Token) of
         {ok, Player} ->
             {ok, maps:get(id, Player)};
         {error, _} ->
             {error, ~"invalid_token"}
-    end.
+    end;
+authenticate(_) ->
+    {error, ~"invalid_token"}.
 
 check_ws_rate_limit(#{ws_msg_count := Count, ws_msg_window_start := WindowStart} = State) ->
     Now = erlang:system_time(millisecond),

--- a/test/asobi_auth_cache_tests.erl
+++ b/test/asobi_auth_cache_tests.erl
@@ -1,0 +1,58 @@
+-module(asobi_auth_cache_tests).
+-include_lib("eunit/include/eunit.hrl").
+
+cache_test_() ->
+    {setup, fun setup/0, fun teardown/1, [
+        {"resolve_token returns cached positive without DB", fun positive_hit/0},
+        {"resolve_token caches negative with shorter TTL", fun negative_hit/0},
+        {"invalidate clears the entry", fun invalidate_clears/0},
+        {"expired entries are not returned", fun expired_skipped/0}
+    ]}.
+
+setup() ->
+    application:set_env(asobi, auth_cache_ttl_ms, 60_000),
+    application:set_env(asobi, auth_cache_negative_ttl_ms, 5_000),
+    {ok, Pid} = asobi_auth_cache:start_link(),
+    Pid.
+
+teardown(Pid) ->
+    asobi_auth_cache:clear(),
+    gen_server:stop(Pid),
+    application:unset_env(asobi, auth_cache_ttl_ms),
+    application:unset_env(asobi, auth_cache_negative_ttl_ms),
+    ok.
+
+positive_hit() ->
+    Token = ~"tok-positive",
+    Player = #{id => ~"player-1", username => ~"alice"},
+    asobi_auth_cache:put_positive(Token, Player),
+    ?assertEqual({ok, Player}, asobi_auth_cache:resolve_token(Token)).
+
+negative_hit() ->
+    Token = ~"tok-negative",
+    asobi_auth_cache:put_negative(Token),
+    ?assertEqual({error, not_found}, asobi_auth_cache:resolve_token(Token)).
+
+invalidate_clears() ->
+    Token = ~"tok-invalidate",
+    Player = #{id => ~"player-2"},
+    asobi_auth_cache:put_positive(Token, Player),
+    ?assertEqual({ok, Player}, asobi_auth_cache:resolve_token(Token)),
+    asobi_auth_cache:invalidate(Token),
+    %% After invalidate the cache no longer holds the entry; resolve_token
+    %% would fall back to nova_auth_session, but with the asobi_auth ets
+    %% configuration not set up in eunit it will surface as an error.
+    ?assertMatch({error, _}, asobi_auth_cache:resolve_token(Token)).
+
+%% A short-TTL setup confirms expired rows are not served.
+expired_skipped() ->
+    application:set_env(asobi, auth_cache_ttl_ms, 1),
+    try
+        Token = ~"tok-expire",
+        Player = #{id => ~"player-3"},
+        asobi_auth_cache:put_positive(Token, Player),
+        timer:sleep(10),
+        ?assertMatch({error, _}, asobi_auth_cache:resolve_token(Token))
+    after
+        application:set_env(asobi, auth_cache_ttl_ms, 60_000)
+    end.


### PR DESCRIPTION
## Summary

A new \`asobi_auth_cache\` module: single named gen_server owning a public ETS, caching token → player resolutions for the WS connect path and every authenticated HTTP request. Both call sites (\`asobi_ws_handler:authenticate/1\` and \`asobi_auth_plugin:verify/1\`) now go through one chokepoint helper, \`asobi_auth_cache:resolve_token/1\`.

- **TTLs**: 60s hits, 5s negatives, both configurable (\`asobi.auth_cache_ttl_ms\`, \`asobi.auth_cache_negative_ttl_ms\`).
- **Negative caching** stops a flood of bad-token attempts from hammering kura.
- **Invalidation** is wired into \`asobi_auth_controller:refresh\` so revocation propagates immediately rather than waiting for TTL.
- **Telemetry**: \`[asobi, auth_cache, hit|miss|sweep]\` events for observability.
- **Periodic sweep** removes expired rows so the table stays bounded under attack.
- ETS uses \`read_concurrency\` + \`write_concurrency\` + \`decentralized_counters\` because every WS connect reads it.

## Test plan
- [x] New \`asobi_auth_cache_tests\`: positive hit, negative hit, invalidate, expiry (4 tests)
- [x] \`rebar3 fmt --check\`, \`xref\`, \`dialyzer\` clean
- [x] \`~/bin/elp eqwalize-all\` clean
- [x] \`rebar3 eunit\` 258 tests pass (+4 new)