### PR TITLE
docs: correct matchmaker push event name to match.matched

### DIFF
--- a/guides/matchmaking.md
+++ b/guides/matchmaking.md
@@ -9,7 +9,7 @@ groups tickets into matches using a per-mode strategy module.
 2. Matchmaker ticks periodically (default every 1 second).
 3. Each tick groups tickets by mode, and the mode's strategy module decides which tickets form a match.
 4. When a group is formed, a match is spawned.
-5. Players are notified via WebSocket (`matchmaker.matched`).
+5. Players are notified via WebSocket (`match.matched`).
 
 ## Submitting a Ticket
 

--- a/guides/websocket-protocol.md
+++ b/guides/websocket-protocol.md
@@ -120,13 +120,18 @@ Cancel a matchmaking ticket.
 {"type": "matchmaker.remove", "payload": {"ticket_id": "..."}}
 ```
 
-### `matchmaker.matched` (server push)
+### `match.matched` (server push)
 
-Notification that a match was found.
+Notification that the matchmaker paired you into a match.
 
 ```json
-{"type": "matchmaker.matched", "payload": {"match_id": "...", "players": [...]}}
+{"type": "match.matched", "payload": {"match_id": "...", "players": [...]}}
 ```
+
+> Note: distinct from `match.joined`, which is the server's reply to a
+> client-initiated `match.join` message. Both signal "you're in a match
+> and `match.state` will follow," but only `match.matched` is fired
+> spontaneously by the matchmaker.
 
 ## Worlds
 


### PR DESCRIPTION
## Summary

\`guides/websocket-protocol.md\` and \`guides/matchmaking.md\` said the server pushes \`matchmaker.matched\` on a successful match. The server has always emitted \`match.matched\` — see \`src/ws/asobi_ws_handler.erl\` line 101 (\`iolist_to_binary([~\"match.\", atom_to_binary(Event)])\`). The docs lied.

This documentation drift is what caused asobi-defold's author to wire the SDK against \`matchmaker.matched\`, producing a callback that silently never fired — the bug that motivated this entire workstream (#111 fixture corpus + per-SDK dispatch tests).

## Changes

- \`guides/websocket-protocol.md\` — section \`matchmaker.matched\` renamed to \`match.matched\` with corrected payload example. Adds a note explaining the distinction from \`match.joined\` (server reply to client-initiated \`match.join\`), since they look similar and SDK authors have conflated them.
- \`guides/matchmaking.md\` — the one-line reference to \`matchmaker.matched\` updated to \`match.matched\`.

## Verification

\`\`\`
\$ grep -rn 'matchmaker\.matched' guides/ examples/ README.md
(no output — all references corrected)
\`\`\`

## Test plan

- [x] Grep confirms zero remaining \`matchmaker.matched\` references in user-facing docs
- [x] Server source-of-truth (\`asobi_ws_handler.erl:101\`) and the fixture corpus (\`priv/protocol/fixtures/match.matched.json\`) are now consistent with the docs