### PR TITLE
feat: env-controlled socket_options for kura DB pool

### DIFF
--- a/config/prod_sys.config.src
+++ b/config/prod_sys.config.src
@@ -44,7 +44,8 @@
         {database, "${ASOBI_DB_NAME}"},
         {user, "${ASOBI_DB_USER}"},
         {password, "${ASOBI_DB_PASSWORD}"},
-        {pool_size, 20}
+        {pool_size, 20},
+        {socket_options, [${ASOBI_DB_SOCKET_OPTS}]}
     ]},
     {asobi, [
         {game_dir, "/app/game"},

--- a/guides/configuration.md
+++ b/guides/configuration.md
@@ -49,6 +49,7 @@ Infrastructure settings come from environment variables:
 | `ASOBI_DB_NAME` | `asobi` | Database name |
 | `ASOBI_DB_USER` | `postgres` | Database user |
 | `ASOBI_DB_PASSWORD` | `postgres` | Database password |
+| `ASOBI_DB_SOCKET_OPTS` | `inet` (set by asobi_lua image; empty when consuming asobi directly) | Erlang term fragment spliced into the kura `socket_options` list. Examples: `inet`, `inet6`, `inet, {nodelay, true}`. Set to `inet6` for IPv6-only Postgres networks. |
 | `ASOBI_CORS_ORIGINS` | `*` | Allowed CORS origins |
 | `ASOBI_NODE_HOST` | `127.0.0.1` | Erlang node hostname |
 | `ERLANG_COOKIE` | `asobi_cookie` | Erlang distribution cookie |


### PR DESCRIPTION
## Summary
Exposes `ASOBI_DB_SOCKET_OPTS` as an env var rendered into the kura `socket_options` list. Lets deployments on IPv6-only Postgres networks pass `inet6` without forking `prod_sys.config`. Default is empty (no-op) when asobi is consumed directly; the asobi_lua image will default to `inet`.

kura already reads `socket_options` from app env (`kura_app.erl:42-43`), so this is purely a config exposure.

## Why
On Fly.io and similar IPv6-only Postgres networks, pgo defaults to IPv4 (`gen_tcp:connect/3` defaults to `inet`) and can't reach `.flycast`/`.internal` hostnames. Without this knob, every deployment must overlay its own sys.config.

## Reviews
- ✅ asobi-architecture-guardian: ACCEPT WITH CHANGES (renamed knob to `_SOCKET_OPTS` per recommendation)
- ✅ erlang-code-reviewer (quick): no blockers, doc nits addressed

## Test plan
- [x] `envsubst` rendering verified for `inet`, `inet6`, `inet, {nodelay, true}`, empty
- [ ] CI green
- [ ] Once merged + asobi_lua published with the matching default, the barrow Fly deploy can drop its sed-hack and rely on `flyctl secrets set ASOBI_DB_SOCKET_OPTS=inet6`

## Related
- widgrensit/asobi_lua PR: matching `ENV ASOBI_DB_SOCKET_OPTS=inet` default