### PR TITLE
feat(match): encode-once shared-state broadcast

### DIFF
--- a/guides/architecture.md
+++ b/guides/architecture.md
@@ -105,7 +105,8 @@ Matchmaker              Match Sup            Match Server          Players (via 
 **Server-authoritative:** The match process owns all game state. Clients send
 inputs, the server applies them each tick, and broadcasts the resulting state.
 The game module (`asobi_match` behaviour) provides `init/1`, `join/2`,
-`handle_input/3`, `tick/1`, and `get_state/2`.
+`handle_input/3`, `tick/1`, and either `get_state/2` (per-player) or
+`get_state/1` (shared, broadcast-once — see [Performance Tuning](performance-tuning.md)).
 
 ## Database & Migrations
 

--- a/guides/performance-tuning.md
+++ b/guides/performance-tuning.md
@@ -44,6 +44,27 @@ This is automatic -- no configuration needed. Subscribers receive
 `zone_delta_raw` messages containing pre-encoded JSON, which the
 WebSocket handler forwards directly without re-encoding.
 
+## Match State Broadcast (Shared vs. Per-Player)
+
+By default the match server calls `Mod:get_state(PlayerId, GameState)`
+once per player per tick and JSON-encodes each result. For games where
+every player sees the same world (FFA shooters, racing, party games),
+implement the optional `get_state/1` callback instead:
+
+```erlang
+-callback get_state(GameState) -> SharedState.
+```
+
+When the match server detects `get_state/1` is exported, it calls it once
+per tick, JSON-encodes once, and broadcasts the same pre-encoded binary
+to every player. At 200 players / 10 ticks/sec this drops 2000 encodes/sec
+to 10. Games that need per-player filtering (fog of war, hidden hand)
+keep `get_state/2` and pay the per-player cost.
+
+Lua match scripts opt in by declaring `state_strategy = "shared"` and
+defining a one-arg `get_state(state)`. The asobi_lua bridge then routes
+through `asobi_lua_match_shared`, which exports `get_state/1`.
+
 ## Adaptive Tick Rates
 
 Zones with no subscribers tick at a reduced rate to save CPU:

--- a/src/asobi_game_modes.erl
+++ b/src/asobi_game_modes.erl
@@ -16,6 +16,8 @@ resolve_game_module(Mode) ->
     case mode_config(Mode) of
         #{type := world, module := {lua, Script}} ->
             {ok, asobi_lua_world, #{lua_script => Script}};
+        #{module := {lua, Script}, state_strategy := shared} ->
+            {ok, asobi_lua_match_shared, #{lua_script => Script}};
         #{module := {lua, Script}} ->
             {ok, asobi_lua_match, #{lua_script => Script}};
         #{module := Mod} when is_atom(Mod) ->

--- a/src/matches/asobi_match.erl
+++ b/src/matches/asobi_match.erl
@@ -30,6 +30,12 @@
 -callback get_state(PlayerId :: binary(), GameState :: term()) ->
     StateForPlayer :: map().
 
+%% Shared-payload variant. Avoids the per-player encode cost when every
+%% player sees the same world. Mutually exclusive with get_state/2 — export
+%% exactly one.
+-callback get_state(GameState :: term()) ->
+    SharedState :: map().
+
 -callback vote_requested(GameState :: term()) ->
     {ok, VoteConfig :: map()} | none.
 
@@ -46,6 +52,8 @@
 
 -optional_callbacks([
     tick/1,
+    get_state/1,
+    get_state/2,
     vote_requested/1,
     vote_resolved/3,
     phases/1,

--- a/src/matches/asobi_match_server.erl
+++ b/src/matches/asobi_match_server.erl
@@ -539,6 +539,25 @@ broadcast_match_event(Event, Payload, #{players := Players}) ->
     ).
 
 broadcast_state(#{players := Players, game_module := Mod, game_state := GS}) ->
+    case erlang:function_exported(Mod, get_state, 1) of
+        true ->
+            broadcast_shared_state(Mod, GS, Players);
+        false ->
+            broadcast_per_player_state(Mod, GS, Players)
+    end.
+
+broadcast_shared_state(Mod, GS, Players) ->
+    SharedState = Mod:get_state(GS),
+    Payload = #{~"type" => ~"match.state", ~"payload" => SharedState},
+    PreEncoded = iolist_to_binary(json:encode(Payload)),
+    maps:foreach(
+        fun(PlayerId, _Meta) ->
+            asobi_presence:send(PlayerId, {match_state_raw, PreEncoded})
+        end,
+        Players
+    ).
+
+broadcast_per_player_state(Mod, GS, Players) ->
     maps:foreach(
         fun(PlayerId, _Meta) ->
             PlayerState = Mod:get_state(PlayerId, GS),

--- a/src/matches/asobi_matchmaker.erl
+++ b/src/matches/asobi_matchmaker.erl
@@ -264,6 +264,8 @@ resolve_game_module(Mode) ->
     case mode_config(Mode) of
         #{type := world, module := {lua, Script}} ->
             {ok, asobi_lua_world, #{lua_script => Script}};
+        #{module := {lua, Script}, state_strategy := shared} ->
+            {ok, asobi_lua_match_shared, #{lua_script => Script}};
         #{module := {lua, Script}} ->
             {ok, asobi_lua_match, #{lua_script => Script}};
         #{module := Mod} when is_atom(Mod) ->

--- a/src/ws/asobi_ws_handler.erl
+++ b/src/ws/asobi_ws_handler.erl
@@ -97,6 +97,8 @@ websocket_handle(_Frame, State) ->
 websocket_info({asobi_message, {match_state, MatchState}}, State) ->
     Reply = encode_reply(undefined, ~"match.state", MatchState),
     {reply, {text, Reply}, State};
+websocket_info({asobi_message, {match_state_raw, PreEncoded}}, State) when is_binary(PreEncoded) ->
+    {reply, {text, PreEncoded}, State};
 websocket_info({asobi_message, {match_event, Event, Payload}}, State) when is_atom(Event) ->
     Type = iolist_to_binary([~"match.", atom_to_binary(Event)]),
     Reply = encode_reply(undefined, Type, Payload),

--- a/test/asobi_match_broadcast_tests.erl
+++ b/test/asobi_match_broadcast_tests.erl
@@ -1,0 +1,106 @@
+-module(asobi_match_broadcast_tests).
+-include_lib("eunit/include/eunit.hrl").
+
+%% Verifies the broadcast_state/1 dispatch in asobi_match_server: when the
+%% game module exports get_state/1, the match server encodes once and sends
+%% the same pre-encoded binary to every player. When only get_state/2 is
+%% exported, the legacy per-player path runs.
+
+-define(SENT_TAB, asobi_match_broadcast_tests_sent).
+
+setup() ->
+    case ets:whereis(asobi_match_state) of
+        undefined -> ets:new(asobi_match_state, [named_table, public, set]);
+        _ -> ok
+    end,
+    case ets:whereis(?SENT_TAB) of
+        undefined -> ets:new(?SENT_TAB, [named_table, public, duplicate_bag]);
+        _ -> ets:delete_all_objects(?SENT_TAB)
+    end,
+    case whereis(nova_scope) of
+        undefined -> pg:start_link(nova_scope);
+        _ -> ok
+    end,
+    meck:new(asobi_repo, [no_link]),
+    meck:expect(asobi_repo, insert, fun(_CS) -> {ok, #{}} end),
+    meck:expect(asobi_repo, insert, fun(_CS, _Opts) -> {ok, #{}} end),
+    meck:new(asobi_presence, [non_strict, no_link]),
+    meck:expect(asobi_presence, send, fun(PlayerId, Msg) ->
+        ets:insert(?SENT_TAB, {PlayerId, Msg}),
+        ok
+    end),
+    ok.
+
+cleanup(_) ->
+    meck:unload(asobi_presence),
+    meck:unload(asobi_repo),
+    ok.
+
+broadcast_test_() ->
+    {setup, fun setup/0, fun cleanup/1, [
+        {"per-player path delivers match_state per player", fun per_player_path/0},
+        {"shared path delivers match_state_raw with same binary", fun shared_path/0}
+    ]}.
+
+per_player_path() ->
+    ets:delete_all_objects(?SENT_TAB),
+    Pid = start_match(asobi_test_game),
+    ok = asobi_match_server:join(Pid, ~"p1"),
+    ok = asobi_match_server:join(Pid, ~"p2"),
+    timer:sleep(200),
+    Sent = ets:tab2list(?SENT_TAB),
+    PerPlayer = [X || X = {_, {match_state, _}} <- Sent],
+    Raw = [X || X = {_, {match_state_raw, _}} <- Sent],
+    ?assert(length(PerPlayer) >= 1),
+    ?assertEqual([], Raw),
+    stop(Pid).
+
+shared_path() ->
+    ets:delete_all_objects(?SENT_TAB),
+    Pid = start_match(asobi_test_game_shared),
+    ok = asobi_match_server:join(Pid, ~"p1"),
+    ok = asobi_match_server:join(Pid, ~"p2"),
+    timer:sleep(200),
+    Sent = ets:tab2list(?SENT_TAB),
+    PerPlayer = [X || X = {_, {match_state, _}} <- Sent],
+    Raw = [{P, B} || {P, {match_state_raw, B}} <- Sent, is_binary(B)],
+    ?assertEqual([], PerPlayer),
+    ?assert(length(Raw) >= 2),
+    %% In any single tick the binary is identical for every player. Pick
+    %% the most-recent binary delivered to each player and compare them.
+    LastByPlayer = #{P => B || {P, B} <- Raw},
+    case maps:values(LastByPlayer) of
+        [B1, B2 | _] ->
+            ?assertEqual(B1, B2),
+            Decoded = json:decode(B1),
+            ?assertMatch(#{~"type" := ~"match.state", ~"payload" := _}, Decoded);
+        _ ->
+            ?assert(false)
+    end,
+    stop(Pid).
+
+%% --- Helpers ---
+
+start_match(GameModule) ->
+    Config = #{
+        game_module => GameModule,
+        min_players => 2,
+        max_players => 4,
+        tick_rate => 30
+    },
+    {ok, Pid} = asobi_match_server:start_link(Config),
+    Pid.
+
+stop(Pid) ->
+    case is_process_alive(Pid) of
+        true ->
+            unlink(Pid),
+            Ref = monitor(process, Pid),
+            exit(Pid, shutdown),
+            receive
+                {'DOWN', Ref, process, Pid, _} -> ok
+            after 5000 -> ok
+            end;
+        false ->
+            ok
+    end.

--- a/test/asobi_test_game_shared.erl
+++ b/test/asobi_test_game_shared.erl
@@ -1,0 +1,28 @@
+-module(asobi_test_game_shared).
+-behaviour(asobi_match).
+
+-export([init/1, join/2, leave/2, handle_input/3, tick/1, get_state/1]).
+
+-spec init(map()) -> {ok, map()}.
+init(_Config) ->
+    {ok, #{players => #{}, tick_count => 0, world => #{npcs => 0}}}.
+
+-spec join(binary(), map()) -> {ok, map()}.
+join(PlayerId, #{players := Players} = State) ->
+    {ok, State#{players => Players#{PlayerId => #{score => 0}}}}.
+
+-spec leave(binary(), map()) -> {ok, map()}.
+leave(PlayerId, #{players := Players} = State) ->
+    {ok, State#{players => maps:remove(PlayerId, Players)}}.
+
+-spec handle_input(binary(), map(), map()) -> {ok, map()}.
+handle_input(_PlayerId, _Input, State) ->
+    {ok, State}.
+
+-spec tick(map()) -> {ok, map()}.
+tick(#{tick_count := Count} = State) ->
+    {ok, State#{tick_count => Count + 1}}.
+
+-spec get_state(map()) -> map().
+get_state(#{world := World, tick_count := Tc}) ->
+    #{~"world" => World, ~"tick" => Tc}.


### PR DESCRIPTION
## Summary

- Adds optional `get_state/1` callback to `asobi_match` for shared-payload games
- `asobi_match_server:broadcast_state/1` branches at runtime: when `get_state/1` is exported, JSON-encode once per tick and ship the same pre-encoded binary to every player; otherwise the legacy per-player path runs
- New `{match_state_raw, Bin}` WS message type wires through `asobi_ws_handler`
- `state_strategy => shared` in mode config dispatches Lua matches to `asobi_lua_match_shared` (companion PR in [asobi_lua](https://github.com/widgrensit/asobi_lua))

## Why

At 200 players / 10 Hz we were paying 2000 `get_state/2 + json:encode/1` calls per second on the match path. Mirrors the `zone_delta_raw` optimization that the world-server zone path has had for a while. Architecture-guardian flagged this as fix #1 of four; expected p99 improvement ~5-10x at 200 players.

## What's NOT in scope

- The `resolve_game_module/1` duplication between `asobi_game_modes` and `asobi_matchmaker` is pre-existing; this PR edits both copies in lockstep but leaves deduplication for a follow-up.
- Pre-existing 2 eqwalizer warnings in `test/asobi_world_lobby_ws_SUITE.erl` are unrelated to this change.

## Test plan

- [x] `rebar3 fmt --check` clean
- [x] `rebar3 xref` clean
- [x] `rebar3 dialyzer` clean
- [x] `~/bin/elp eqwalize-all` zero new errors
- [x] `~/bin/elp lint` zero new warnings on changed files
- [x] `rebar3 eunit` 263/263 green (includes new `asobi_match_broadcast_tests` covering both paths via meck on `asobi_presence`)
- [ ] After merge: re-bench against asobi-bench to confirm p99 improvement, then move on to fix #2 (match-level delta broadcast)