### PR TITLE
docs(adr): ADR convention + retroactive ADR 0001 for encode-once broadcast

### DIFF
--- a/docs/adr/0000-record-architecture-decisions.md
+++ b/docs/adr/0000-record-architecture-decisions.md
@@ -1,0 +1,63 @@
+# ADR 0000: Record architecture decisions
+
+Date: 2026-05-05
+
+## Status
+
+Accepted.
+
+## Context
+
+asobi is changing fast and several decisions have non-obvious trade-offs
+(behaviour API shape, broadcast strategy, sandboxing model). Without a
+durable record, future contributors and our future selves rediscover the
+same arguments and sometimes reverse them on weaker grounds than the
+original choice.
+
+## Decision
+
+Record significant architecture decisions as numbered markdown files in
+`docs/adr/`. One file per decision. Filename: `NNNN-short-slug.md`.
+
+Use Michael Nygard's lightweight ADR template:
+
+- **Title** — `ADR NNNN: short imperative phrase`
+- **Date** — `YYYY-MM-DD`
+- **Status** — `Proposed` | `Accepted` | `Superseded by ADR NNNN` | `Deprecated`
+- **Context** — what's true now that motivates this decision
+- **Decision** — the choice, in one or two short paragraphs
+- **Consequences** — what this enables, what it costs, what it forecloses
+- **Alternatives considered** — options ruled out, with one-line rationale
+
+Keep them short. An ADR is a record, not an essay. If you need more than
+one screen, split it.
+
+What counts as ADR-worthy:
+
+- New behaviour callbacks or wire-format additions to public APIs
+- Changes to how the runtime handles untrusted code (sandbox, timeouts,
+  heap limits)
+- Optimisations that change observable semantics or trade safety for speed
+- Decisions that we know we'll be tempted to reverse later
+
+What does NOT need an ADR:
+
+- Bug fixes
+- Pure refactors
+- Renames
+- Adding tests
+
+## Consequences
+
+- Future readers can recover *why* a thing was done, not just *what*.
+- The discipline forces the author to articulate the alternative they
+  rejected — which is usually where the real argument lives.
+
+## Alternatives considered
+
+- **Inline comments / module docs** — too local; cross-cutting decisions
+  span many files and the comment rots first.
+- **CHANGELOG / git history** — captures *what* changed but not *why we
+  picked this over the obvious alternative*.
+- **A wiki / Notion** — drifts from the code; ADRs in-repo travel with
+  the branch and PRs reference them.

--- a/docs/adr/0001-encode-once-shared-state-broadcast.md
+++ b/docs/adr/0001-encode-once-shared-state-broadcast.md
@@ -1,0 +1,91 @@
+# ADR 0001: Encode-once shared-state match broadcast
+
+Date: 2026-05-05
+
+## Status
+
+Accepted. Shipped in asobi#117.
+
+Retroactive ADR — written after the change merged. The decision was
+worth recording because the API addition (a new optional behaviour
+callback) is one we'll be tempted to extend or replace later.
+
+## Context
+
+`asobi_match_server` broadcasts the per-tick game state by calling
+`Mod:get_state(PlayerId, GameState)` once per player and JSON-encoding
+each result. At 200 players × 10 Hz that is 2000 calls/sec to
+`Mod:get_state/2` plus 2000 `json:encode/1` calls. The zone path
+(`asobi_zone:broadcast_deltas/3`) had already adopted an
+encode-once-and-fanout pattern via `zone_delta_raw`; the match path had
+no equivalent.
+
+Many games — FFA shooters, racing, party games, watching-from-the-stands
+modes — return the same payload to every player. For these, the
+per-player shape is wasted work.
+
+Some games — fog-of-war strategy, hidden-information card games, anything
+with per-player privacy — genuinely need per-player filtering and cannot
+adopt a shared payload without leaking information.
+
+## Decision
+
+Add an optional behaviour callback `get_state/1` to `asobi_match`:
+
+```erlang
+-callback get_state(GameState :: term()) -> SharedState :: map().
+```
+
+`asobi_match_server:broadcast_state/1` checks
+`erlang:function_exported(Mod, get_state, 1)` at runtime per tick. When
+true, it calls `get_state/1` once, JSON-encodes once, and ships the same
+pre-encoded binary to every subscriber via a new `match_state_raw` message
+that the WS handler emits as a text frame without re-encoding.
+
+Both `get_state/1` and `get_state/2` are listed in
+`-optional_callbacks([...])` so a behaviour module may export either —
+not both. This loosens the contract slightly (a misbehaving module could
+export neither and crash at runtime) in exchange for letting bridge
+modules express their semantics naturally.
+
+For Lua scripts the choice is opt-in via `state_strategy = "shared"` in
+the match script's globals. asobi_lua_config propagates this as
+`state_strategy => shared` in mode config; `asobi_game_modes` and
+`asobi_matchmaker` resolve `{lua, Script}` + `state_strategy => shared`
+to a separate bridge module `asobi_lua_match_shared` (see
+`asobi_lua/docs/adr/0001`) instead of `asobi_lua_match`.
+
+## Consequences
+
+- Games whose `get_state` ignores `PlayerId` get an O(N) → O(1) reduction
+  in `Mod:get_state` calls and `json:encode/1` calls per tick (200 → 1
+  at 200 players). Smaller absolute win than expected because Luerl-eval
+  CPU dominates encode CPU at this load — see `asobi_lua/docs/adr/0002`
+  for the follow-up that actually moved the needle on tail latency.
+- Backward compatible: existing modules exporting `get_state/2` keep
+  the per-player path with no changes.
+- Mirrors the existing `zone_delta_raw` pattern in `asobi_zone`. Reduces
+  the number of distinct broadcast strategies a contributor has to learn.
+- Convention is "export exactly one of `get_state/1` or `get_state/2`".
+  The framework only checks `function_exported(Mod, get_state, 1)` and
+  otherwise calls `Mod:get_state(PlayerId, GS)` blindly — a module that
+  exports neither will crash at first tick. Documented in the behaviour
+  module and in `guides/architecture.md`. No compile-time enforcement.
+
+## Alternatives considered
+
+- **Single `get_state/2` with a runtime "want shared" hint in GameState** —
+  rejected because match state is opaque to the framework; reading a
+  framework-defined key from user state breaks the abstraction.
+- **A dedicated `is_shared_state/1` runtime callback** — would have let
+  one bridge module expose both paths. Rejected for asobi as redundant
+  with `function_exported/3`. asobi_lua needed it for a different reason
+  and ended up using a separate bridge module instead (ADR 0001 in
+  asobi_lua).
+- **Always shared, deprecate per-player** — would break every existing
+  game module. Per-player is also a real use case (privacy) that we don't
+  want to push games to work around.
+- **Make the framework compute deltas across ticks** — possible follow-up
+  (the architecture-guardian's "fix #2"); orthogonal to the encode-once
+  question because deltas still need to be encoded per recipient unless
+  ALSO shared. Punted.


### PR DESCRIPTION
## Summary

- ADR 0000 establishes a `docs/adr/` convention for the project (Michael Nygard format, short, in-repo, captures alternatives).
- ADR 0001 retroactively documents the encode-once shared-state broadcast that shipped in #117.

## Why

We've made several non-obvious design decisions in the last few weeks (encode-once, two-bridge Lua dispatch, behaviour-callback shape) and they're worth recording. ADRs in-repo travel with the branch and PRs reference them; that beats a wiki for the kind of "why did we pick this over the obvious alternative" knowledge that future readers actually need.

ADR 0001 is retroactive — written after #117 merged. It accurately reflects the dispatch logic, the `match_state_raw` WS path, and the convention that exactly one of `get_state/{1,2}` should be exported (with the honest caveat that the framework only checks for `/1` and a module exporting neither will crash at first tick).

Companion ADRs land in [asobi_lua](https://github.com/widgrensit/asobi_lua): 0001 (shared-state bridge module retroactive) + 0002 (skip bounded_eval for handle_input).

## Test plan

- [x] No code changes; doc-only.
- [x] `rebar3 fmt --check` clean (no .erl touched).
- [x] Reviewer pass via erlang-code-reviewer agent — accuracy of retroactive ADR vs shipped code, contract framing.