### PR TITLE
test: silence telemetry-handler warnings in property test setups

### DIFF
--- a/src/asobi.app.src
+++ b/src/asobi.app.src
@@ -7,6 +7,7 @@
     {applications, [
         kernel,
         stdlib,
+        telemetry,
         nova,
         kura,
         nova_auth,

--- a/test/prop_chat_zone_routing.erl
+++ b/test/prop_chat_zone_routing.erl
@@ -28,6 +28,7 @@ chat_zone_routing_test_() ->
     ]}.
 
 setup() ->
+    {ok, _} = application:ensure_all_started(telemetry),
     case whereis(nova_scope) of
         undefined -> pg:start(nova_scope);
         _ -> ok

--- a/test/prop_input_never_dropped.erl
+++ b/test/prop_input_never_dropped.erl
@@ -42,6 +42,7 @@ input_never_dropped_test_() ->
     end}.
 
 setup() ->
+    {ok, _} = application:ensure_all_started(telemetry),
     case whereis(nova_scope) of
         undefined -> pg:start(nova_scope);
         _ -> ok

--- a/test/prop_reconnect_lifecycle.erl
+++ b/test/prop_reconnect_lifecycle.erl
@@ -44,6 +44,7 @@ reconnect_lifecycle_test_() ->
     end}.
 
 setup() ->
+    {ok, _} = application:ensure_all_started(telemetry),
     case whereis(nova_scope) of
         undefined -> pg:start(nova_scope);
         _ -> ok

--- a/test/prop_zone_invariants.erl
+++ b/test/prop_zone_invariants.erl
@@ -44,6 +44,7 @@ zone_invariants_test_() ->
     end}.
 
 setup() ->
+    {ok, _} = application:ensure_all_started(telemetry),
     %% Use pg:start (not start_link) so pg outlives the setup process —
     %% the world supervisor itself is unlinked, but its init pg:join calls
     %% will fail if pg dies between setup and test body.


### PR DESCRIPTION
## Summary

- `telemetry:execute/3` warns when called before the `telemetry` app is started; production OTP processes emit telemetry, so prop tests that exercise them log a warning per event.
- This drowned PropEr's shrunk counterexample in nightly issue #119 (`prop_input_never_dropped` failed at `PROPER_NUMTESTS=1000`, output unreadable).
- Adds `telemetry` to `asobi.app.src` so CT suites that go through `nova_test:start(asobi)` get it transitively, and starts it explicitly in the four EUnit prop test setups that build OTP processes directly.

## Test plan

- [x] `rebar3 fmt --check` clean
- [x] `rebar3 xref` clean
- [x] `rebar3 dialyzer` clean
- [x] `rebar3 eunit` — 263 tests, 0 failures
- [x] `PROPER_NUMTESTS=25 rebar3 eunit --module=prop_input_never_dropped` — 25 tests pass with no telemetry warnings observed in output

Refs: #119