### PR TITLE
fix(storage): split unique index by player_id (#122)

### DIFF
--- a/src/migrations/m20260514133500_fix_storage_unique_index.erl
+++ b/src/migrations/m20260514133500_fix_storage_unique_index.erl
@@ -1,0 +1,43 @@
+-module(m20260514133500_fix_storage_unique_index).
+-moduledoc false.
+-behaviour(kura_migration).
+-include_lib("kura/include/kura.hrl").
+-export([up/0, down/0]).
+
+%% Split the storage unique index so player-scoped rows can coexist with
+%% the same (collection, key) across different player_id values.
+%%
+%% The original `(collection, key)` index was created before
+%% `player_id` existed on the table and was never widened. As a result
+%% `game.storage.player_set(p1, "inventory", "gold", ...)` and
+%% `game.storage.player_set(p2, "inventory", "gold", ...)` collide:
+%% the second insert silently fails the unique constraint.
+%%
+%% Replace it with two partial indexes:
+%% - global rows (player_id IS NULL) remain unique on (collection, key)
+%% - per-player rows (player_id IS NOT NULL) are unique on
+%%   (collection, key, player_id)
+%%
+%% Postgres treats two NULL `player_id` values as distinct in a normal
+%% unique index, so a single combined index wouldn't catch duplicate
+%% global rows. Partial indexes give us the right uniqueness in each
+%% scope.
+
+-spec up() -> [kura_migration:operation()].
+up() ->
+    [
+        {drop_index, ~"storage_collection_key_index"},
+        {create_index, ~"storage_collection_key_index", ~"storage", [collection, key], [
+            unique, {where, ~"player_id IS NULL"}
+        ]},
+        {create_index, ~"storage_collection_key_player_id_index", ~"storage",
+            [collection, key, player_id], [unique, {where, ~"player_id IS NOT NULL"}]}
+    ].
+
+-spec down() -> [kura_migration:operation()].
+down() ->
+    [
+        {drop_index, ~"storage_collection_key_index"},
+        {drop_index, ~"storage_collection_key_player_id_index"},
+        {create_index, ~"storage", [collection, key], #{unique => true}}
+    ].

--- a/src/storage/asobi_storage.erl
+++ b/src/storage/asobi_storage.erl
@@ -36,6 +36,9 @@ associations() ->
 -spec indexes() -> [{[atom()], map()}].
 indexes() ->
     [
-        {[collection, key], #{unique => true}},
+        {[collection, key], #{unique => true, where => ~"player_id IS NULL"}},
+        {[collection, key, player_id], #{
+            unique => true, where => ~"player_id IS NOT NULL"
+        }},
         {[player_id], #{}}
     ].

--- a/test/asobi_storage_SUITE.erl
+++ b/test/asobi_storage_SUITE.erl
@@ -16,7 +16,8 @@
     list_storage/1,
     list_storage_filters_owner_perm/1,
     delete_storage/1,
-    storage_owner_permission/1
+    storage_owner_permission/1,
+    put_storage_per_player_keys_dont_collide/1
 ]).
 
 all() -> [{group, cloud_saves}, {group, generic_storage}].
@@ -32,7 +33,8 @@ groups() ->
             list_storage,
             list_storage_filters_owner_perm,
             delete_storage,
-            storage_owner_permission
+            storage_owner_permission,
+            put_storage_per_player_keys_dont_collide
         ]}
     ].
 
@@ -250,4 +252,54 @@ storage_owner_permission(Config) ->
         Config
     ),
     ?assertStatus(403, Resp),
+    Config.
+
+%% Regression for https://github.com/widgrensit/asobi/issues/122:
+%% the storage unique index used to be `(collection, key)` without
+%% `player_id`, so two players writing the same (collection, key) with
+%% different player_id values would silently collide on insert. The
+%% HTTP /storage path is single-row-per-(collection, key) by design
+%% (it uses ownership-perm semantics), so this test exercises the
+%% schema directly via kura — that's the path `asobi_lua_api`'s
+%% `game.storage.player_set` follows for per-player rows.
+put_storage_per_player_keys_dont_collide(Config) ->
+    Suffix = integer_to_binary(erlang:unique_integer([positive])),
+    Col = <<"shared_", Suffix/binary>>,
+    Key = <<"counter_", Suffix/binary>>,
+    {player1_id, P1} = lists:keyfind(player1_id, 1, Config),
+    %% Register a fresh second player whose id we can capture here.
+    U2 = asobi_test_helpers:unique_username(~"index_collide_p2"),
+    {ok, R2} = nova_test:post(
+        "/api/v1/auth/register",
+        #{json => #{~"username" => U2, ~"password" => ~"testpass123"}},
+        Config
+    ),
+    #{~"player_id" := P2} = nova_test:json(R2),
+    Insert = fun(PlayerId, Value) ->
+        Params = #{
+            collection => Col,
+            key => Key,
+            player_id => PlayerId,
+            value => Value,
+            version => 1,
+            read_perm => ~"owner",
+            write_perm => ~"owner",
+            updated_at => calendar:universal_time()
+        },
+        CS = kura_changeset:cast(asobi_storage, #{}, Params, maps:keys(Params)),
+        asobi_repo:insert(CS)
+    end,
+    ?assertMatch({ok, _}, Insert(P1, #{~"n" => 1})),
+    ?assertMatch({ok, _}, Insert(P2, #{~"n" => 2})),
+    %% Read each back via a player-scoped query and verify isolation.
+    Read = fun(PlayerId) ->
+        Q0 = kura_query:from(asobi_storage),
+        Q1 = kura_query:where(Q0, {collection, Col}),
+        Q2 = kura_query:where(Q1, {key, Key}),
+        Q3 = kura_query:where(Q2, {player_id, PlayerId}),
+        {ok, [Doc]} = asobi_repo:all(Q3),
+        maps:get(value, Doc)
+    end,
+    ?assertEqual(#{~"n" => 1}, Read(P1)),
+    ?assertEqual(#{~"n" => 2}, Read(P2)),
     Config.


### PR DESCRIPTION
## Summary
- Closes #122.
- The `(collection, key)` unique index predated `player_id` and was never widened, so two players writing the same `(collection, key)` collided on insert. Replaced with two partial unique indexes scoped by whether `player_id IS NULL` or not.
- Schema `indexes/0` updated to match.
- Adds a regression test that inserts the same `(collection, key)` for two different players via the kura path (the HTTP storage path is single-row-per-key by design, so the schema is exercised directly).

## Test plan
- [x] `rebar3 fmt --check`
- [x] `rebar3 xref`
- [x] `rebar3 eunit` (263 tests, 0 failures)
- [x] `asobi_storage_SUITE` (12/12 incl. new regression test)
- [x] Verified `\\d storage` shows both partial indexes after migration