### PR TITLE
chore(deps): bump kura to v2.0.4

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -12,7 +12,7 @@
 
 {deps, [
     nova,
-    {kura, {git, "https://github.com/Taure/kura.git", {tag, "v2.0.0"}}},
+    {kura, {git, "https://github.com/Taure/kura.git", {tag, "v2.0.4"}}},
     {kura_postgres, {git, "https://github.com/Taure/kura_postgres.git", {tag, "v0.4.2"}}},
     {nova_auth, "~> 0.1"},
     {nova_auth_oidc, "~> 0.1"},

--- a/rebar.lock
+++ b/rebar.lock
@@ -7,7 +7,7 @@
  {<<"jose">>,{pkg,<<"jose">>,<<"1.11.12">>},2},
  {<<"kura">>,
   {git,"https://github.com/Taure/kura.git",
-       {ref,"78f71e2e954e11c2f1cf49112dc8123c8dd8cf95"}},
+       {ref,"64c487a02596e082ee0968f7f14b5ac8090ebc02"}},
   0},
  {<<"kura_postgres">>,
   {git,"https://github.com/Taure/kura_postgres.git",


### PR DESCRIPTION
## Summary
- Picks up Taure/kura#118 — `cast/dump/load(jsonb, ...)` accept JSON scalars.
- Unblocks dropping the `#{<<"n">> => N}` wrapper in asobi_lua / barrow when writing scalar storage values.

## Test plan
- [x] `rebar3 fmt --check`
- [x] `rebar3 xref`
- [x] `rebar3 eunit` (263 tests, 0 failures)