### PR TITLE
ci: remove dependency audit from CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,6 @@ jobs:
       pull-requests: write
     with:
       version-file: '.tool-versions'
-      enable-audit: true
       enable-ct: true
       extra-services-compose: 'docker-compose.yml'
       enable-dependency-submission: true


### PR DESCRIPTION
Removes `enable-audit` from the erlang-ci workflow. Dependency-submission, CT, SBOM/summary and the rest of the pipeline stay as-is.