### PR TITLE
feat(world): build per-zone state in the zone process

### DIFF
--- a/examples/world-spawns/README.md
+++ b/examples/world-spawns/README.md
@@ -1,0 +1,73 @@
+# Spawns — entity templates and `game.zone.spawn`
+
+A reference world script for server-authoritative entity spawning. It
+shows the two halves of the spawn API: defining a **template registry**
+with `spawn_templates`, and creating entities from it with
+`game.zone.spawn`.
+
+If you want NPCs, resource nodes, loot, or anything the server owns
+(not a connected player), this is the pattern.
+
+## How it works
+
+### 1. Define templates
+
+`spawn_templates(config)` returns a table keyed by template id. Each
+entry has a `type`, a `base_state` table, and an optional `respawn`
+rule:
+
+```lua
+function spawn_templates(config)
+    return {
+        goblin = {
+            type       = "npc",
+            base_state = { health = 100, ai = "patrol" },
+            respawn    = { delay = 5000, jitter = 1000 },
+        },
+    }
+end
+```
+
+- `type` defaults to `"npc"`.
+- `base_state` is the entity's starting fields.
+- `respawn` schedules a timed respawn after the entity is removed. Omit
+  `max_respawns` for unlimited respawns; omit the whole `respawn` key
+  for a one-shot entity that never comes back. The only strategy is
+  `timer`, so you supply `delay`/`jitter`/`max_respawns` (milliseconds
+  and counts), not a strategy name.
+
+The registry lives in the zone's state, not a database or config file.
+
+### 2. Spawn from a template
+
+```lua
+game.zone.spawn(template_id, x, y)             -- returns true
+game.zone.spawn(template_id, x, y, overrides)  -- overrides merged over base_state
+game.zone.despawn(entity_id)
+```
+
+`overrides` is a table merged over the template's `base_state`
+(overrides win); `x`, `y`, and `type` are then set from the call and
+template.
+
+## Two gotchas
+
+- **Zone context only.** `game.zone.spawn`/`despawn` work inside
+  per-zone callbacks (`zone_tick`, `handle_input`) where the zone
+  process is running. Calling them from `init`/`join` returns an error,
+  because there is no zone yet.
+- **The call is an async cast.** An unknown `template_id` fails
+  server-side (`{error, unknown_template}` in the zone), not as a Lua
+  return value, so a typo in a template id will not raise in your
+  script. The entity simply will not appear.
+
+## Run the server
+
+```bash
+docker compose up
+```
+
+Asobi reads `lua/config.lua`, sees `spawns = "world.lua"`, and
+registers `spawns` as a world mode. On the first zone tick the script
+seeds a goblin, an ore node, and a chest; connect any client that
+speaks the asobi WebSocket protocol to watch them appear.

--- a/examples/world-spawns/docker-compose.yml
+++ b/examples/world-spawns/docker-compose.yml
@@ -1,0 +1,29 @@
+services:
+  postgres:
+    image: postgres:17
+    environment:
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: postgres
+      POSTGRES_DB: spawns
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U postgres"]
+      interval: 5s
+      timeout: 5s
+      retries: 5
+
+  asobi:
+    image: ghcr.io/widgrensit/asobi_lua:latest
+    depends_on:
+      postgres:
+        condition: service_healthy
+    ports:
+      - "8080:8080"
+    environment:
+      ASOBI_PORT: "8080"
+      ASOBI_DB_HOST: postgres
+      ASOBI_DB_NAME: spawns
+      ASOBI_DB_USER: postgres
+      ASOBI_DB_PASSWORD: postgres
+      ASOBI_CORS_ORIGINS: "*"
+    volumes:
+      - ./lua:/app/game

--- a/examples/world-spawns/lua/config.lua
+++ b/examples/world-spawns/lua/config.lua
@@ -1,0 +1,3 @@
+return {
+    spawns = "world.lua",
+}

--- a/examples/world-spawns/lua/world.lua
+++ b/examples/world-spawns/lua/world.lua
@@ -1,0 +1,66 @@
+game_type      = "world"
+match_size     = 1
+max_players    = 8
+tick_rate      = 50
+grid_size      = 1
+zone_size      = 1200
+view_radius    = 0
+empty_grace_ms = 10000
+
+function spawn_templates(config)
+    return {
+        goblin = {
+            type       = "npc",
+            base_state = { health = 100, ai = "patrol" },
+            respawn    = { delay = 5000, jitter = 1000 },
+        },
+        ore = {
+            type       = "resource",
+            base_state = { quantity = 5 },
+            respawn    = { delay = 3000, max_respawns = 2 },
+        },
+        chest = {
+            type       = "object",
+            base_state = { loot = "common" },
+        },
+    }
+end
+
+function init(config)
+    return { tick = 0 }
+end
+
+function generate_world(seed, config)
+    return { ["0,0"] = {} }
+end
+
+function spawn_position(player_id, state)
+    return { x = 600, y = 600 }
+end
+
+function join(player_id, state)  return state end
+function leave(player_id, state) return state end
+
+function zone_tick(entities, zone_state)
+    zone_state = zone_state or {}
+    if not zone_state.seeded then
+        game.zone.spawn("goblin", 500, 500)
+        game.zone.spawn("ore", 700, 650)
+        game.zone.spawn("chest", 620, 600, { loot = "rare" })
+        zone_state.seeded = true
+    end
+    return entities, zone_state
+end
+
+function handle_input(player_id, input, entities)
+    if input and input.kind == "drop_chest" then
+        game.zone.spawn("chest", tonumber(input.x) or 0, tonumber(input.y) or 0)
+    end
+    entities[player_id] = { type = "player", x = input.x, y = input.y }
+    return entities
+end
+
+function post_tick(tick_n, state)
+    state.tick = tick_n
+    return state
+end

--- a/src/world/asobi_world.erl
+++ b/src/world/asobi_world.erl
@@ -57,6 +57,17 @@
 -callback on_zone_unloaded(Coords :: {integer(), integer()}, GameState :: term()) ->
     {ok, GameState1 :: term()}.
 
+%% Build this zone's zone_state in the zone process, from the zone Config and
+%% any plain gameplay state restored from a snapshot. This is where a game
+%% module that holds a per-zone runtime (e.g. a Lua VM) constructs it, bound to
+%% the zone process. Runs once, after init, via handle_continue.
+-callback init_zone_state(Config :: map(), ZoneState :: map()) -> map().
+
+%% Reduce zone_state to a JSON-safe map for snapshotting: drop any live runtime
+%% (e.g. a VM that cannot be serialised) and decode engine-held gameplay state
+%% to plain terms. The inverse of init_zone_state's restore path.
+-callback dump_zone_state(ZoneState :: map()) -> map().
+
 -optional_callbacks([
     generate_world/2,
     get_state/2,
@@ -67,5 +78,7 @@
     spawn_templates/1,
     terrain_provider/1,
     on_zone_loaded/2,
-    on_zone_unloaded/2
+    on_zone_unloaded/2,
+    init_zone_state/2,
+    dump_zone_state/1
 ]).

--- a/src/world/asobi_world_server.erl
+++ b/src/world/asobi_world_server.erl
@@ -421,6 +421,8 @@ configure_zone_manager(
         world_id => WorldId,
         ticker_pid => TickerPid,
         game_module => GameMod,
+        game_config => maps:get(game_config, Config, #{}),
+        world_server_pid => self(),
         spawn_templates => Templates,
         persistence => Persistence,
         snapshot_interval => maps:get(snapshot_interval, Config, 600),

--- a/src/world/asobi_zone.erl
+++ b/src/world/asobi_zone.erl
@@ -8,7 +8,7 @@
 -export([get_entities/1, get_subscriber_count/1]).
 -export([start_entity_timer/2, cancel_entity_timer/3]).
 -export([query_radius/3, query_rect/3]).
--export([init/1, handle_call/3, handle_cast/2, handle_info/2, terminate/2]).
+-export([init/1, handle_call/3, handle_cast/2, handle_continue/2, handle_info/2, terminate/2]).
 
 -define(PG_SCOPE, nova_scope).
 
@@ -97,12 +97,14 @@ narrow_id_pos_list([{Id, {X, Y}} | Rest]) when
 
 %% --- gen_server callbacks ---
 
--spec init(map()) -> {ok, map()}.
+-spec init(map()) -> {ok, map(), {continue, init_zone_state}}.
 init(Config) ->
     WorldId = maps:get(world_id, Config),
     Coords = maps:get(coords, Config),
     TickerPid = maps:get(ticker_pid, Config),
     GameModule = maps:get(game_module, Config),
+    GameConfig = maps:get(game_config, Config, #{}),
+    WorldServerPid = maps:get(world_server_pid, Config, undefined),
     ZoneState = maps:get(zone_state, Config, #{}),
     ZoneManagerPid = maps:get(zone_manager_pid, Config, undefined),
     TerrainStorePid = maps:get(terrain_store_pid, Config, undefined),
@@ -127,27 +129,64 @@ init(Config) ->
             undefined -> undefined;
             CellSize -> asobi_spatial_grid:new(CellSize)
         end,
-    {ok, #{
+    {ok,
+        #{
+            world_id => WorldId,
+            coords => Coords,
+            ticker_pid => TickerPid,
+            game_module => GameModule,
+            game_config => GameConfig,
+            world_server_pid => WorldServerPid,
+            zone_manager_pid => ZoneManagerPid,
+            terrain_store_pid => TerrainStorePid,
+            entities => RecoveredEntities,
+            prev_entities => #{},
+            broadcast_entities => #{},
+            broadcast_interval => maps:get(broadcast_interval, Config, 3),
+            subscribers => #{},
+            zone_state => ZoneState,
+            input_queue => [],
+            entity_timers => asobi_entity_timer:new(),
+            spawner => Spawner,
+            persistence => Persistence,
+            snapshot_interval => SnapshotInterval,
+            spatial_grid => SpatialGrid,
+            tick => 0
+        },
+        {continue, init_zone_state}}.
+
+%% Build the zone's runtime state in the zone process (so a per-zone VM binds
+%% to self()), regardless of how the zone was created — pre-spawned, lazy, or
+%% recovered. Game modules without the callback keep their zone_state as-is.
+-spec handle_continue(init_zone_state, map()) -> {noreply, map()}.
+handle_continue(
+    init_zone_state,
+    #{
+        game_module := GameMod,
+        world_id := WorldId,
+        coords := Coords,
+        game_config := GameConfig,
+        world_server_pid := WorldServerPid,
+        zone_state := ZoneState
+    } = State
+) ->
+    ZoneConfig = #{
         world_id => WorldId,
         coords => Coords,
-        ticker_pid => TickerPid,
-        game_module => GameModule,
-        zone_manager_pid => ZoneManagerPid,
-        terrain_store_pid => TerrainStorePid,
-        entities => RecoveredEntities,
-        prev_entities => #{},
-        broadcast_entities => #{},
-        broadcast_interval => maps:get(broadcast_interval, Config, 3),
-        subscribers => #{},
-        zone_state => ZoneState,
-        input_queue => [],
-        entity_timers => asobi_entity_timer:new(),
-        spawner => Spawner,
-        persistence => Persistence,
-        snapshot_interval => SnapshotInterval,
-        spatial_grid => SpatialGrid,
-        tick => 0
-    }}.
+        game_module => GameMod,
+        game_config => GameConfig,
+        world_server_pid => WorldServerPid
+    },
+    ZoneState1 = call_optional(GameMod, init_zone_state, [ZoneConfig, ZoneState], ZoneState),
+    {noreply, State#{zone_state => ZoneState1}}.
+
+-spec call_optional(module(), atom(), [term()], term()) -> term().
+call_optional(GameMod, Fun, Args, Default) ->
+    _ = code:ensure_loaded(GameMod),
+    case erlang:function_exported(GameMod, Fun, length(Args)) of
+        true -> apply(GameMod, Fun, Args);
+        false -> Default
+    end.
 
 -spec handle_call(term(), gen_server:from(), map()) -> {reply, term(), map()}.
 handle_call(get_entities, _From, #{entities := Entities} = State) ->
@@ -386,7 +425,7 @@ do_tick(
                 world_id => WorldId,
                 coords => Coords,
                 entities => snapshot_entities(Entities4),
-                zone_state => ZoneState1,
+                zone_state => call_optional(GameMod, dump_zone_state, [ZoneState1], ZoneState1),
                 entity_timers => asobi_entity_timer:info(ET1),
                 spawner_state => asobi_zone_spawner:serialise(Spawner1),
                 tick => TickN
@@ -550,6 +589,7 @@ maybe_final_snapshot(#{persistence := true} = State) ->
     #{
         world_id := WorldId,
         coords := Coords,
+        game_module := GameMod,
         entities := Entities,
         zone_state := ZoneState,
         entity_timers := ET,
@@ -561,7 +601,7 @@ maybe_final_snapshot(#{persistence := true} = State) ->
             world_id => WorldId,
             coords => Coords,
             entities => snapshot_entities(Entities),
-            zone_state => ZoneState,
+            zone_state => call_optional(GameMod, dump_zone_state, [ZoneState], ZoneState),
             entity_timers => asobi_entity_timer:info(ET),
             spawner_state => asobi_zone_spawner:serialise(Spawner),
             tick => Tick

--- a/test/asobi_zone_ctx_test_game.erl
+++ b/test/asobi_zone_ctx_test_game.erl
@@ -1,0 +1,37 @@
+-module(asobi_zone_ctx_test_game).
+-behaviour(asobi_world).
+
+-export([init/1, join/2, leave/2, spawn_position/2]).
+-export([zone_tick/2, handle_input/3, post_tick/2]).
+-export([init_zone_state/2, dump_zone_state/1]).
+
+init(_Config) ->
+    {ok, #{}}.
+
+join(_PlayerId, State) ->
+    {ok, State}.
+
+leave(_PlayerId, State) ->
+    {ok, State}.
+
+spawn_position(_PlayerId, _State) ->
+    {ok, {0.0, 0.0}}.
+
+zone_tick(Entities, ZoneState) ->
+    {Entities, ZoneState}.
+
+handle_input(_PlayerId, _Input, Entities) ->
+    {ok, Entities}.
+
+post_tick(TickN, State) ->
+    {ok, State#{tick => TickN}}.
+
+init_zone_state(Config, ZoneState) ->
+    ZoneState#{
+        built_by => init_zone_state,
+        coords => maps:get(coords, Config),
+        runtime => make_ref()
+    }.
+
+dump_zone_state(ZoneState) ->
+    maps:remove(runtime, ZoneState).

--- a/test/asobi_zone_lifecycle_tests.erl
+++ b/test/asobi_zone_lifecycle_tests.erl
@@ -1,0 +1,76 @@
+-module(asobi_zone_lifecycle_tests).
+-include_lib("eunit/include/eunit.hrl").
+
+%% The zone builds its runtime zone_state in its own process via the optional
+%% init_zone_state/2 callback (handle_continue), for every creation path. Game
+%% modules that don't export it are unaffected.
+
+setup() ->
+    case whereis(nova_scope) of
+        undefined -> pg:start_link(nova_scope);
+        _ -> ok
+    end,
+    ok.
+
+cleanup(_) ->
+    ok.
+
+start_zone(GameMod, Overrides) ->
+    Config = maps:merge(
+        #{
+            world_id => ~"lifecycle_world",
+            coords => {2, 3},
+            ticker_pid => self(),
+            game_module => GameMod,
+            zone_state => #{}
+        },
+        Overrides
+    ),
+    {ok, Pid} = asobi_zone:start_link(Config),
+    Pid.
+
+zone_lifecycle_test_() ->
+    {setup, fun setup/0, fun cleanup/1, [
+        {"init_zone_state runs via handle_continue", fun init_zone_state_runs/0},
+        {"game module without the callback is unaffected", fun no_callback_unaffected/0},
+        {"dump_zone_state strips the runtime before snapshot", fun dump_zone_state_strips_runtime/0}
+    ]}.
+
+init_zone_state_runs() ->
+    Pid = start_zone(asobi_zone_ctx_test_game, #{}),
+    ZoneState = maps:get(zone_state, sys:get_state(Pid)),
+    ?assertEqual(init_zone_state, maps:get(built_by, ZoneState)),
+    ?assertEqual({2, 3}, maps:get(coords, ZoneState)),
+    ?assert(is_reference(maps:get(runtime, ZoneState))),
+    gen_server:stop(Pid).
+
+no_callback_unaffected() ->
+    %% asobi_test_world_game exports no init_zone_state; zone_state stays as given.
+    Pid = start_zone(asobi_test_world_game, #{zone_state => #{seeded => true}}),
+    ?assertEqual(#{seeded => true}, maps:get(zone_state, sys:get_state(Pid))),
+    gen_server:stop(Pid).
+
+dump_zone_state_strips_runtime() ->
+    %% The motivating bug: a live runtime in zone_state cannot survive jsonb.
+    %% Snapshots must route through dump_zone_state, which drops it. Drive the
+    %% real terminate snapshot path; no DB needed.
+    meck:new(asobi_zone_snapshotter, [passthrough]),
+    Self = self(),
+    meck:expect(asobi_zone_snapshotter, snapshot_sync, fun(Data) ->
+        Self ! {snapshot, Data},
+        ok
+    end),
+    try
+        Pid = start_zone(asobi_zone_ctx_test_game, #{persistence => true}),
+        gen_server:stop(Pid),
+        receive
+            {snapshot, Data} ->
+                ZoneState = maps:get(zone_state, Data),
+                ?assertNot(maps:is_key(runtime, ZoneState)),
+                ?assertEqual(init_zone_state, maps:get(built_by, ZoneState))
+        after 1000 ->
+            ?assert(false)
+        end
+    after
+        meck:unload(asobi_zone_snapshotter)
+    end.


### PR DESCRIPTION
## Problem

Per-zone game callbacks (`zone_tick`, `handle_input`) only ran for **pre-spawned** zones. For a Lua-backed world they were silently dead on:

- **Lazy zones** (`lazy_zones=true`, the default when `grid_size > 100`) — `spawn_zones/1` is skipped, so no per-zone runtime was ever stitched in.
- **Snapshot-recovered / idle-reaped-then-reloaded zones** — `zone_state` persists as jsonb, and a Luerl VM (opaque closures) can't round-trip it.

So large or persistent Lua worlds had per-zone scripting that did nothing, with no error.

## Fix

Each zone now builds its own runtime state **in its own process**, regardless of how it was created.

Two optional `asobi_world` callbacks:

- `init_zone_state/2` — builds the zone's `zone_state` (including any per-zone runtime, e.g. a Lua VM bound to the zone pid) from config + any plain gameplay state restored from a snapshot. Runs once after `init`, via `handle_continue`.
- `dump_zone_state/1` — reduces `zone_state` to a JSON-safe map for snapshotting (drops the non-serialisable runtime, decodes engine-held gameplay state to plain terms).

Both are optional with **identity defaults**, so non-Lua world modules (`sc_game`, etc.) are unchanged. `BaseZoneConfig` now carries `game_config` + `world_server_pid` (the single wiring point reaching every zone-creation path), and both snapshot writes route `zone_state` through `dump_zone_state`.

This is the `asobi`-side half. The `asobi_lua` implementation of the two callbacks (which makes `game.zone.spawn` actually work on every zone path) lands in a follow-up PR there, pinned to this once merged.

## Tests

- `asobi_zone_lifecycle_tests` — `init_zone_state` runs via `handle_continue`; a module without the callback is unaffected; `dump_zone_state` strips the runtime before snapshot (driven through the real terminate path via meck, no DB).
- All existing zone/world eunit suites green.

## Docs

`examples/world-spawns/` — reference world documenting `spawn_templates` + `game.zone.spawn`.

## Follow-ups (separate)

- Lazy-respawn DB reload so reaped Lua zones round-trip their gameplay state (`snapshot_before_reap` currently hardcodes `zone_state => #{}`).
- `kura` v2.0.4 fails to build on OTP 29 (`catch` deprecation); local dev needs OTP 28. CI runs 28, so unaffected.
