### PR TITLE
fix(world): snapshot and restore per-zone state across idle reap

### DIFF
--- a/src/world/asobi_zone.erl
+++ b/src/world/asobi_zone.erl
@@ -1,7 +1,7 @@
 -module(asobi_zone).
 -behaviour(gen_server).
 
--export([start_link/1]).
+-export([start_link/1, reap/1]).
 -export([tick/2, player_input/3, add_entity/3, remove_entity/2]).
 -export([spawn_entity/3, spawn_entity/4, spawn_entities/2, despawn_entity/2]).
 -export([subscribe/2, unsubscribe/2]).
@@ -10,6 +10,8 @@
 -export([query_radius/3, query_rect/3]).
 -export([init/1, handle_call/3, handle_cast/2, handle_continue/2, handle_info/2, terminate/2]).
 
+-include_lib("kernel/include/logger.hrl").
+
 -define(PG_SCOPE, nova_scope).
 
 %% --- Public API ---
@@ -17,6 +19,14 @@
 -spec start_link(map()) -> gen_server:start_ret().
 start_link(Config) ->
     gen_server:start_link(?MODULE, Config, []).
+
+%% Stop the zone gracefully so terminate/2 runs a final snapshot. The zone
+%% child is `transient`, so a normal stop does not respawn. Used by the zone
+%% manager when reaping idle zones - unlike a supervisor kill, this preserves
+%% the zone's gameplay state.
+-spec reap(pid()) -> ok.
+reap(Pid) ->
+    gen_server:cast(Pid, reap).
 
 -spec tick(pid(), non_neg_integer()) -> ok.
 tick(Pid, TickN) ->
@@ -137,6 +147,7 @@ init(Config) ->
             game_module => GameModule,
             game_config => GameConfig,
             world_server_pid => WorldServerPid,
+            spawn_templates => Templates,
             zone_manager_pid => ZoneManagerPid,
             terrain_store_pid => TerrainStorePid,
             entities => RecoveredEntities,
@@ -159,8 +170,8 @@ init(Config) ->
 %% to self()), regardless of how the zone was created — pre-spawned, lazy, or
 %% recovered. Game modules without the callback keep their zone_state as-is.
 -spec handle_continue(init_zone_state, map()) -> {noreply, map()}.
-handle_continue(
-    init_zone_state,
+handle_continue(init_zone_state, State0) ->
+    State = maybe_restore_from_snapshot(State0),
     #{
         game_module := GameMod,
         world_id := WorldId,
@@ -168,8 +179,7 @@ handle_continue(
         game_config := GameConfig,
         world_server_pid := WorldServerPid,
         zone_state := ZoneState
-    } = State
-) ->
+    } = State,
     ZoneConfig = #{
         world_id => WorldId,
         coords => Coords,
@@ -179,6 +189,71 @@ handle_continue(
     },
     ZoneState1 = call_optional(GameMod, init_zone_state, [ZoneConfig, ZoneState], ZoneState),
     {noreply, State#{zone_state => ZoneState1}}.
+
+%% Lazy zones (and idle-reaped ones) start with a blank zone_state. For a
+%% persistent world, recover the last snapshot here, in the zone process, so
+%% the load doesn't block the zone manager. Entities recovered from the ETS
+%% crash backup win (they are fresher), but zone_state/spawner/tick live only
+%% in the DB snapshot, so we load it whenever zone_state is blank. A pre-spawned
+%% zone arrives with a non-blank zone_state from Config and skips the DB.
+%% init_zone_state then rebuilds the runtime from the restored zone_state.
+-spec maybe_restore_from_snapshot(map()) -> map().
+maybe_restore_from_snapshot(
+    #{
+        persistence := true,
+        zone_state := ZoneState,
+        world_id := WorldId,
+        coords := Coords,
+        spawn_templates := Templates
+    } = State
+) when map_size(ZoneState) =:= 0 ->
+    case safe_load_snapshot(WorldId, Coords) of
+        {ok, Snapshot} ->
+            State#{
+                zone_state => maps:get(zone_state, Snapshot, #{}),
+                spawner => restore_spawner(maps:get(spawner_state, Snapshot, #{}), Templates),
+                tick => restore_tick(maps:get(tick, Snapshot, 0))
+            };
+        not_found ->
+            State;
+        {error, Reason} ->
+            %% A persisted zone whose snapshot we cannot read must NOT start
+            %% blank and then overwrite the good row. Suppress persistence for
+            %% this instance so the row survives; a later clean restart retries.
+            ?LOG_ERROR(#{
+                event => zone_snapshot_load_failed,
+                world_id => WorldId,
+                coords => Coords,
+                reason => Reason
+            }),
+            State#{persistence => false}
+    end;
+maybe_restore_from_snapshot(State) ->
+    State.
+
+-spec safe_load_snapshot(binary(), {integer(), integer()}) ->
+    {ok, map()} | not_found | {error, term()}.
+safe_load_snapshot(WorldId, Coords) ->
+    try asobi_zone_snapshotter:load_snapshot(WorldId, Coords) of
+        {ok, _} = Ok -> Ok;
+        {error, not_found} -> not_found;
+        {error, _} = Err -> Err
+    catch
+        Class:Reason -> {error, {Class, Reason}}
+    end.
+
+-spec restore_spawner(map(), map()) -> asobi_zone_spawner:state().
+restore_spawner(SpawnerState, Templates) when is_map(SpawnerState), map_size(SpawnerState) > 0 ->
+    asobi_zone_spawner:set_templates(Templates, asobi_zone_spawner:deserialise(SpawnerState));
+restore_spawner(_, Templates) ->
+    asobi_zone_spawner:new(Templates).
+
+-spec restore_tick(term()) -> non_neg_integer().
+restore_tick(N) when is_integer(N), N >= 0 ->
+    N;
+restore_tick(Other) ->
+    ?LOG_WARNING(#{event => zone_snapshot_bad_tick, value => Other}),
+    0.
 
 -spec call_optional(module(), atom(), [term()], term()) -> term().
 call_optional(GameMod, Fun, Args, Default) ->
@@ -228,7 +303,12 @@ handle_call(
 handle_call(_Request, _From, State) ->
     {reply, {error, unknown_request}, State}.
 
--spec handle_cast(term(), map()) -> {noreply, map()} | {noreply, map(), hibernate}.
+-spec handle_cast(term(), map()) ->
+    {noreply, map()} | {noreply, map(), hibernate} | {stop, normal, map()}.
+handle_cast(reap, State) ->
+    %% Graceful stop so terminate/2 writes a final snapshot. Transient restart
+    %% means a normal stop is not respawned.
+    {stop, normal, State};
 handle_cast({tick, TickN}, State) ->
     State1 = do_tick(TickN, State),
     State2 = transfer_out_of_bounds_npcs(State1),
@@ -641,7 +721,7 @@ clear_zone_backup(WorldId, Coords) ->
     end.
 
 notify_zone_manager_terminated(#{zone_manager_pid := ZMPid, coords := Coords}) when is_pid(ZMPid) ->
-    asobi_zone_manager:zone_terminated(ZMPid, Coords);
+    asobi_zone_manager:zone_terminated(ZMPid, Coords, self());
 notify_zone_manager_terminated(_) ->
     ok.
 

--- a/src/world/asobi_zone_manager.erl
+++ b/src/world/asobi_zone_manager.erl
@@ -14,7 +14,7 @@ Hot-path lookups go through ETS directly, bypassing the gen_server.
 
 -export([start_link/1]).
 -export([ensure_zone/2, get_zone/2, touch_zone/2, release_zone/2]).
--export([get_active_zones/1, zone_terminated/2, pre_warm/1]).
+-export([get_active_zones/1, zone_terminated/3, pre_warm/1]).
 -export([register_zone/3, set_zone_config/2, set_initial_zone_states/2]).
 -export([init/1, handle_call/3, handle_cast/2, handle_info/2, terminate/2]).
 
@@ -69,9 +69,9 @@ narrow_pid_list([]) -> [];
 narrow_pid_list([P | Rest]) when is_pid(P) -> [P | narrow_pid_list(Rest)].
 
 -doc "Called by zone on terminate. Cleans up ETS entry.".
--spec zone_terminated(pid() | atom(), {integer(), integer()}) -> ok.
-zone_terminated(Ref, Coords) ->
-    gen_server:cast(Ref, {zone_terminated, Coords}).
+-spec zone_terminated(pid() | atom(), {integer(), integer()}, pid()) -> ok.
+zone_terminated(Ref, Coords, ZonePid) ->
+    gen_server:cast(Ref, {zone_terminated, Coords, ZonePid}).
 
 -doc "Spawn all zones in grid. Backward compat for small grids.".
 -spec pre_warm(pid() | atom()) -> ok.
@@ -194,8 +194,13 @@ handle_cast({touch_zone, Coords}, State) ->
 handle_cast({release_zone, Coords}, #{zone_last_active := Active, idle_timeout := Timeout} = State) ->
     Stale = erlang:monotonic_time(millisecond) - Timeout - 1,
     {noreply, State#{zone_last_active => Active#{Coords => Stale}}};
-handle_cast({zone_terminated, Coords}, State) ->
-    {noreply, cleanup_zone(Coords, State)};
+handle_cast({zone_terminated, Coords, ZonePid}, #{ets_tab := Tab} = State) ->
+    %% Only clean up if this coords still maps to the pid that terminated -
+    %% a reaped zone's slot may already have been recreated.
+    case ets:lookup(Tab, Coords) of
+        [{Coords, ZonePid}] -> {noreply, cleanup_zone(Coords, State)};
+        _ -> {noreply, State}
+    end;
 handle_cast(_Msg, State) ->
     {noreply, State}.
 
@@ -209,12 +214,22 @@ handle_info({reap_idle, _OldRef}, State) ->
 handle_info(resolve_zone_sup, #{instance_sup := InstanceSup} = State) ->
     ZoneSup = asobi_world_instance:get_child(InstanceSup, asobi_zone_sup),
     {noreply, State#{zone_sup => ZoneSup}};
-handle_info({'DOWN', MonRef, process, _Pid, _Reason}, #{zone_monitors := Monitors} = State) ->
+handle_info(
+    {'DOWN', MonRef, process, Pid, _Reason},
+    #{zone_monitors := Monitors, ets_tab := Tab} = State
+) ->
     case maps:get(MonRef, Monitors, undefined) of
         undefined ->
             {noreply, State};
         Coords ->
-            {noreply, cleanup_zone(Coords, State)}
+            case ets:lookup(Tab, Coords) of
+                [{Coords, Pid}] ->
+                    {noreply, cleanup_zone(Coords, State)};
+                _ ->
+                    %% Stale monitor: the coords was recreated with a new pid.
+                    %% Drop just this monitor mapping, leave the live zone.
+                    {noreply, State#{zone_monitors => maps:remove(MonRef, Monitors)}}
+            end
     end;
 handle_info(_Info, State) ->
     {noreply, State}.
@@ -288,11 +303,9 @@ cleanup_zone(
 
 reap_idle_zones(
     #{
-        world_id := WorldId,
         zone_last_active := Active,
         idle_timeout := Timeout,
-        ets_tab := Tab,
-        zone_sup := ZoneSup
+        ets_tab := Tab
     } = State
 ) ->
     Now = erlang:monotonic_time(millisecond),
@@ -310,10 +323,13 @@ reap_idle_zones(
         fun(Coords, SAcc) ->
             case ets:lookup(Tab, Coords) of
                 [{Coords, Pid}] ->
-                    snapshot_before_reap(WorldId, Coords, Pid),
-                    SAcc1 = cleanup_zone(Coords, SAcc),
-                    _ = terminate_zone(ZoneSup, Pid),
-                    SAcc1;
+                    %% Stop gracefully so the zone writes a final snapshot via
+                    %% terminate/2. Keep the ets slot + monitor until it is
+                    %% actually gone: cleanup runs on the pid-guarded DOWN /
+                    %% zone_terminated, so a request can't recreate the zone
+                    %% (and load a stale snapshot) until the old one finished.
+                    asobi_zone:reap(Pid),
+                    SAcc;
                 [] ->
                     cleanup_zone(Coords, SAcc)
             end
@@ -321,34 +337,6 @@ reap_idle_zones(
         State,
         Expired
     ).
-
-snapshot_before_reap(WorldId, Coords, Pid) ->
-    try
-        Entities = asobi_zone:get_entities(Pid),
-        case map_size(Entities) of
-            0 ->
-                ok;
-            _ ->
-                asobi_zone_snapshotter:snapshot_sync(#{
-                    world_id => WorldId,
-                    coords => Coords,
-                    entities => Entities,
-                    zone_state => #{},
-                    entity_timers => #{},
-                    spawner_state => #{},
-                    tick => 0
-                })
-        end
-    catch
-        _:_ -> ok
-    end.
-
-terminate_zone(ZoneSup, Pid) ->
-    try
-        supervisor:terminate_child(ZoneSup, Pid)
-    catch
-        _:_ -> ok
-    end.
 
 touch(Coords, #{zone_last_active := Active} = State) ->
     Now = erlang:monotonic_time(millisecond),

--- a/src/world/asobi_zone_snapshotter.erl
+++ b/src/world/asobi_zone_snapshotter.erl
@@ -6,7 +6,7 @@
 
 -export([start_link/0]).
 -export([snapshot/1, snapshot_sync/1, delete_world/1]).
--export([load_snapshots/1]).
+-export([load_snapshots/1, load_snapshot/2]).
 -export([init/1, handle_call/3, handle_cast/2, handle_info/2]).
 
 -define(FLUSH_INTERVAL, 1000).
@@ -37,6 +37,29 @@ load_snapshots(WorldId) ->
             {ok, rows_to_map(Rows, #{})};
         {error, _} = Err ->
             Err
+    end.
+
+%% Load a single zone's snapshot. Used on cold (lazy/reaped) zone start so the
+%% load runs in the zone process rather than scanning the whole world.
+-spec load_snapshot(binary(), {integer(), integer()}) ->
+    {ok, map()} | {error, not_found} | {error, term()}.
+load_snapshot(WorldId, {ZX, ZY}) ->
+    Q = kura_query:limit(
+        kura_query:where(
+            kura_query:where(
+                kura_query:where(
+                    kura_query:from(asobi_zone_snapshot), {world_id, WorldId}
+                ),
+                {zone_x, ZX}
+            ),
+            {zone_y, ZY}
+        ),
+        1
+    ),
+    case asobi_repo:all(Q) of
+        {ok, [Row | _]} -> {ok, Row};
+        {ok, []} -> {error, not_found};
+        {error, _} = Err -> Err
     end.
 
 -spec rows_to_map([map()], map()) -> map().

--- a/test/asobi_zone_lifecycle_tests.erl
+++ b/test/asobi_zone_lifecycle_tests.erl
@@ -56,6 +56,7 @@ dump_zone_state_strips_runtime() ->
     %% real terminate snapshot path; no DB needed.
     meck:new(asobi_zone_snapshotter, [passthrough]),
     Self = self(),
+    meck:expect(asobi_zone_snapshotter, load_snapshot, fun(_, _) -> {error, not_found} end),
     meck:expect(asobi_zone_snapshotter, snapshot_sync, fun(Data) ->
         Self ! {snapshot, Data},
         ok

--- a/test/asobi_zone_snapshot_recovery_tests.erl
+++ b/test/asobi_zone_snapshot_recovery_tests.erl
@@ -1,0 +1,173 @@
+-module(asobi_zone_snapshot_recovery_tests).
+-include_lib("eunit/include/eunit.hrl").
+
+%% Idle-reaped zones must snapshot their full state on the way out (graceful
+%% stop -> terminate/2), and cold-(re)started persistent zones must restore it.
+%% These drive the real zone process; the snapshotter is mecked so no DB is
+%% needed.
+
+setup() ->
+    case whereis(nova_scope) of
+        undefined -> pg:start_link(nova_scope);
+        _ -> ok
+    end,
+    ok.
+
+cleanup(_) ->
+    ok.
+
+start_zone(Overrides) ->
+    Config = maps:merge(
+        #{
+            world_id => ~"recovery_world",
+            coords => {1, 1},
+            ticker_pid => self(),
+            game_module => asobi_zone_ctx_test_game,
+            zone_state => #{}
+        },
+        Overrides
+    ),
+    {ok, Pid} = asobi_zone:start_link(Config),
+    Pid.
+
+recovery_test_() ->
+    {setup, fun setup/0, fun cleanup/1, [
+        {"reap snapshots full state and stops the zone", fun reap_snapshots_full_state/0},
+        {"cold start restores game_state, spawner and tick", fun cold_start_restores/0},
+        {"cold start with a load error does not clobber the snapshot",
+            fun cold_start_load_error_suppresses_persistence/0},
+        {"non-persistent zone does not snapshot on reap", fun non_persistent_no_snapshot/0}
+    ]}.
+
+reap_snapshots_full_state() ->
+    meck:new(asobi_zone_snapshotter, [passthrough]),
+    Self = self(),
+    meck:expect(asobi_zone_snapshotter, load_snapshot, fun(_, _) -> {error, not_found} end),
+    meck:expect(asobi_zone_snapshotter, snapshot_sync, fun(Data) ->
+        Self ! {snapshot, Data},
+        ok
+    end),
+    try
+        Pid = start_zone(#{persistence => true}),
+        Ref = monitor(process, Pid),
+        asobi_zone:reap(Pid),
+        receive
+            {snapshot, Data} ->
+                %% The old reap path hardcoded zone_state => #{}; now the game
+                %% module's dump_zone_state runs, so built_by survives.
+                ZoneState = maps:get(zone_state, Data),
+                ?assertEqual(init_zone_state, maps:get(built_by, ZoneState)),
+                ?assert(maps:is_key(spawner_state, Data)),
+                ?assert(maps:is_key(tick, Data))
+        after 1000 ->
+            ?assert(false)
+        end,
+        receive
+            {'DOWN', Ref, process, Pid, normal} -> ok
+        after 1000 ->
+            ?assert(false)
+        end
+    after
+        meck:unload(asobi_zone_snapshotter)
+    end.
+
+cold_start_restores() ->
+    Templates = goblin_templates(),
+    %% Round-trip through json so deserialise sees jsonb-shaped data (binary
+    %% keys, float-coerced numbers), as a real DB row would deliver.
+    SpawnerState = json:decode(
+        iolist_to_binary(json:encode(pending_respawn_spawner_state(Templates)))
+    ),
+    Snapshot = #{
+        zone_state => #{~"saved" => true},
+        spawner_state => SpawnerState,
+        tick => 42
+    },
+    meck:new(asobi_zone_snapshotter, [passthrough]),
+    meck:expect(asobi_zone_snapshotter, load_snapshot, fun(_, _) -> {ok, Snapshot} end),
+    try
+        Pid = start_zone(#{persistence => true, spawn_templates => Templates}),
+        State = sys:get_state(Pid),
+        ZoneState = maps:get(zone_state, State),
+        %% Restored from the snapshot...
+        ?assertEqual(true, maps:get(~"saved", ZoneState)),
+        %% ...and init_zone_state still ran on top of the restored state.
+        ?assertEqual(init_zone_state, maps:get(built_by, ZoneState)),
+        ?assertEqual(42, maps:get(tick, State)),
+        Spawner = maps:get(spawner, State),
+        ?assertEqual(1, maps:get(pending_respawns, asobi_zone_spawner:info(Spawner))),
+        gen_server:stop(Pid)
+    after
+        meck:unload(asobi_zone_snapshotter)
+    end.
+
+cold_start_load_error_suppresses_persistence() ->
+    meck:new(asobi_zone_snapshotter, [passthrough]),
+    Self = self(),
+    meck:expect(asobi_zone_snapshotter, load_snapshot, fun(_, _) -> {error, db_down} end),
+    meck:expect(asobi_zone_snapshotter, snapshot_sync, fun(Data) ->
+        Self ! {snapshot, Data},
+        ok
+    end),
+    try
+        Pid = start_zone(#{persistence => true}),
+        %% Load failed: the zone starts (no crash) but with persistence
+        %% suppressed, so it never overwrites the unreadable-but-present row.
+        ?assertEqual(false, maps:get(persistence, sys:get_state(Pid))),
+        Ref = monitor(process, Pid),
+        asobi_zone:reap(Pid),
+        receive
+            {'DOWN', Ref, process, Pid, normal} -> ok
+        after 1000 ->
+            ?assert(false)
+        end,
+        receive
+            {snapshot, _} -> ?assert(false)
+        after 100 ->
+            ok
+        end
+    after
+        meck:unload(asobi_zone_snapshotter)
+    end.
+
+non_persistent_no_snapshot() ->
+    meck:new(asobi_zone_snapshotter, [passthrough]),
+    Self = self(),
+    meck:expect(asobi_zone_snapshotter, snapshot_sync, fun(Data) ->
+        Self ! {snapshot, Data},
+        ok
+    end),
+    try
+        Pid = start_zone(#{persistence => false}),
+        Ref = monitor(process, Pid),
+        asobi_zone:reap(Pid),
+        receive
+            {'DOWN', Ref, process, Pid, normal} -> ok
+        after 1000 ->
+            ?assert(false)
+        end,
+        receive
+            {snapshot, _} -> ?assert(false)
+        after 100 ->
+            ok
+        end
+    after
+        meck:unload(asobi_zone_snapshotter)
+    end.
+
+goblin_templates() ->
+    #{
+        ~"goblin" => #{
+            template_id => ~"goblin",
+            type => ~"npc",
+            base_state => #{},
+            respawn => #{strategy => timer, delay => 1000, max_respawns => infinity, jitter => 0}
+        }
+    }.
+
+pending_respawn_spawner_state(Templates) ->
+    S0 = asobi_zone_spawner:new(Templates),
+    {ok, {Id, _}, S1} = asobi_zone_spawner:spawn_entity(~"goblin", {1.0, 2.0}, S0),
+    Now = erlang:system_time(millisecond),
+    S2 = asobi_zone_spawner:entity_removed(Id, Now, S1),
+    asobi_zone_spawner:serialise(S2).


### PR DESCRIPTION
Closes #132. Follow-up to #131 (per-zone Lua VM via `init_zone_state`/`dump_zone_state`).

## Problem

Idle-reaped lazy zones lost almost all per-zone state. `asobi_zone` does not `trap_exit`, so the reaper's `supervisor:terminate_child` killed zones **without** running `terminate/2`. The only thing persisted was `snapshot_before_reap`, which hardcoded `zone_state => #{}` (entities only) — so game_state, the spawner respawn-queue/counts, and tick were dropped. Lazy respawn then never reloaded even that.

## Fix

- **Capture via graceful stop.** `asobi_zone:reap/1` casts a stop → `terminate/2` → `maybe_final_snapshot` writes the **full** snapshot (game_state via `dump_zone_state`, spawner_state, tick). The zone child is `transient`, so a normal stop isn't respawned. Deletes the lossy `snapshot_before_reap`/`terminate_zone`.
- **Race-safe reap.** The manager keeps the ets slot + monitor until the zone is actually gone; cleanup runs on a **pid-guarded** `DOWN`/`zone_terminated`. A request can't recreate the zone (and load a stale snapshot) mid-reap, and a recreated slot is never evicted by the old zone's late termination.
- **Restore in the zone process** (`handle_continue`). A cold persistent zone loads its DB snapshot and seeds `zone_state` + `spawner` + `tick` before `init_zone_state` rebuilds the runtime. ETS-recovered entities still win; `zone_state`/`spawner`/`tick` come from the DB. A **load error suppresses persistence** for that instance rather than starting blank and overwriting the good row.
- **Single-zone load.** `asobi_zone_snapshotter:load_snapshot/2` loads one zone, so the load runs per-zone in the zone process, not as a whole-world scan.

Designed via an architecture-guardian pass (graceful-stop capture, zone-side restore) and hardened against a full erlang-review (the reap-recreate race and the cold-start load-error data-loss path were both caught and fixed here).

## Tests

`asobi_zone_snapshot_recovery_tests` (eunit + meck, no DB):
- reap writes a full snapshot (game_state, spawner_state, tick) and stops gracefully;
- cold start restores game_state + spawner respawn-queue + tick, with the spawner state round-tripped through `json` to exercise jsonb-shaped data;
- cold-start load error suppresses persistence (no blank overwrite);
- non-persistent zone doesn't snapshot on reap.

Full eunit 270/0; fmt/xref/dialyzer clean; eqwalize NO ERRORS on the three changed modules.

## Follow-ups
- Entity-timer serialisation: timers still aren't restored (`asobi_entity_timer:info/1` is a metric, not serialisable) — separate issue.
- A CT test for the reap→immediate-recreate race (hard to drive deterministically in eunit).
