### PR TITLE
feat(world): persist and restore entity timers across zone reap

### DIFF
--- a/src/timers/asobi_entity_timer.erl
+++ b/src/timers/asobi_entity_timer.erl
@@ -1,13 +1,22 @@
 -module(asobi_entity_timer).
 
+-include_lib("kernel/include/logger.hrl").
+
 %% Per-entity timers for zone-level objects (crafting, decay, cooldowns).
 %%
 %% Designed for scale: no individual erlang:send_after per entity.
 %% The zone server calls `tick/2` each zone tick, which checks all
 %% active timers against wall-clock time. Expired timers fire events.
+%%
+%% Timers survive zone snapshots via serialise/1 + deserialise/1. `end_at`
+%% is absolute wall-clock, so a timer that expired while the zone was reaped
+%% fires on the first tick after restore. `on_complete` is persisted as-is and
+%% so must be JSON-safe (binary / number / boolean / null / map / list); a
+%% tuple or atom will not round-trip through the jsonb column.
 
 -export([new/0, start_timer/2, cancel_timer/3, tick/2]).
 -export([get_timers/2, active_count/1, info/1]).
+-export([serialise/1, deserialise/1]).
 
 -export_type([state/0, entity_timer_event/0]).
 
@@ -132,3 +141,129 @@ active_count(#{timers := Timers}) ->
 -spec info(state()) -> map().
 info(State) ->
     #{active_timers => active_count(State)}.
+
+%% -------------------------------------------------------------------
+%% Serialisation (for zone snapshots)
+%% -------------------------------------------------------------------
+
+-spec serialise(state()) -> map().
+serialise(#{timers := Timers}) ->
+    #{
+        ~"timers" => maps:map(
+            fun(_EntityId, EntityTimers) ->
+                maps:map(fun(_TimerId, Entry) -> serialise_entry(Entry) end, EntityTimers)
+            end,
+            Timers
+        )
+    }.
+
+-spec deserialise(map()) -> state().
+deserialise(#{~"timers" := Timers}) when is_map(Timers) ->
+    #{
+        timers => maps:fold(
+            fun(EntityId, EntityTimers, Acc) ->
+                Decoded = deserialise_entity_timers(EntityTimers),
+                case map_size(Decoded) of
+                    0 -> Acc;
+                    _ -> Acc#{EntityId => Decoded}
+                end
+            end,
+            #{},
+            Timers
+        )
+    };
+deserialise(_) ->
+    %% Pre-persistence snapshots stored only an active-timer count; nothing to
+    %% restore.
+    new().
+
+deserialise_entity_timers(EntityTimers) when is_map(EntityTimers) ->
+    maps:fold(
+        fun(TimerId, Entry, Acc) ->
+            case deserialise_entry(Entry) of
+                skip -> Acc;
+                Decoded -> Acc#{TimerId => Decoded}
+            end
+        end,
+        #{},
+        EntityTimers
+    );
+deserialise_entity_timers(_) ->
+    #{}.
+
+serialise_entry(#{
+    timer_id := TimerId,
+    entity_id := EntityId,
+    owner := Owner,
+    end_at := EndAt,
+    on_complete := OnComplete,
+    category := Category,
+    pause_when_offline := PauseWhenOffline,
+    paused := Paused
+}) ->
+    #{
+        ~"timer_id" => TimerId,
+        ~"entity_id" => EntityId,
+        ~"owner" => owner_to_json(Owner),
+        ~"end_at" => EndAt,
+        ~"on_complete" => json_safe(OnComplete),
+        ~"category" => atom_to_binary(Category, utf8),
+        ~"pause_when_offline" => PauseWhenOffline,
+        ~"paused" => Paused
+    }.
+
+deserialise_entry(
+    #{
+        ~"timer_id" := TimerId,
+        ~"entity_id" := EntityId,
+        ~"end_at" := EndAt
+    } = Entry
+) when is_number(EndAt) ->
+    #{
+        timer_id => TimerId,
+        entity_id => EntityId,
+        owner => owner_from_json(maps:get(~"owner", Entry, null)),
+        end_at => to_int(EndAt),
+        on_complete => maps:get(~"on_complete", Entry, undefined),
+        category => category_from_json(maps:get(~"category", Entry, ~"general")),
+        pause_when_offline => maps:get(~"pause_when_offline", Entry, false),
+        paused => maps:get(~"paused", Entry, false)
+    };
+deserialise_entry(Entry) ->
+    %% A truncated/corrupt row must not abort the whole zone's restore.
+    ?LOG_WARNING(#{event => entity_timer_skipped_bad_entry, entry => Entry}),
+    skip.
+
+%% on_complete is delivered to game code as-is and persisted verbatim, so it
+%% must survive jsonb. Anything json:encode/1 rejects (tuples, pids, refs,
+%% funs) is dropped to null rather than crashing the snapshot write.
+json_safe(Value) ->
+    try
+        _ = json:encode(Value),
+        Value
+    catch
+        _:_ ->
+            ?LOG_WARNING(#{event => timer_on_complete_not_json_safe, value => Value}),
+            null
+    end.
+
+owner_to_json(undefined) -> null;
+owner_to_json(Owner) -> Owner.
+
+owner_from_json(null) -> undefined;
+owner_from_json(Owner) when is_binary(Owner) -> Owner;
+owner_from_json(_) -> undefined.
+
+%% Never create atoms from persisted data (atom-table exhaustion). A category
+%% in use already exists as an atom; an unknown one falls back to `general`.
+category_from_json(Bin) when is_binary(Bin) ->
+    try
+        binary_to_existing_atom(Bin, utf8)
+    catch
+        error:badarg -> general
+    end;
+category_from_json(_) ->
+    general.
+
+to_int(N) when is_integer(N) -> N;
+to_int(N) when is_float(N) -> trunc(N).

--- a/src/world/asobi_zone.erl
+++ b/src/world/asobi_zone.erl
@@ -212,6 +212,9 @@ maybe_restore_from_snapshot(
             State#{
                 zone_state => maps:get(zone_state, Snapshot, #{}),
                 spawner => restore_spawner(maps:get(spawner_state, Snapshot, #{}), Templates),
+                entity_timers => asobi_entity_timer:deserialise(
+                    maps:get(entity_timers, Snapshot, #{})
+                ),
                 tick => restore_tick(maps:get(tick, Snapshot, 0))
             };
         not_found ->
@@ -506,7 +509,7 @@ do_tick(
                 coords => Coords,
                 entities => snapshot_entities(Entities4),
                 zone_state => call_optional(GameMod, dump_zone_state, [ZoneState1], ZoneState1),
-                entity_timers => asobi_entity_timer:info(ET1),
+                entity_timers => asobi_entity_timer:serialise(ET1),
                 spawner_state => asobi_zone_spawner:serialise(Spawner1),
                 tick => TickN
             });
@@ -682,7 +685,7 @@ maybe_final_snapshot(#{persistence := true} = State) ->
             coords => Coords,
             entities => snapshot_entities(Entities),
             zone_state => call_optional(GameMod, dump_zone_state, [ZoneState], ZoneState),
-            entity_timers => asobi_entity_timer:info(ET),
+            entity_timers => asobi_entity_timer:serialise(ET),
             spawner_state => asobi_zone_spawner:serialise(Spawner),
             tick => Tick
         })

--- a/src/world/asobi_zone_snapshotter.erl
+++ b/src/world/asobi_zone_snapshotter.erl
@@ -1,6 +1,8 @@
 -module(asobi_zone_snapshotter).
 -behaviour(gen_server).
 
+-include_lib("kernel/include/logger.hrl").
+
 %% Batched async DB writer for zone entity snapshots.
 %% Deduplicates per zone key, flushes every 1s.
 
@@ -77,7 +79,7 @@ init([]) ->
 
 -spec handle_call(term(), gen_server:from(), map()) -> {reply, term(), map()}.
 handle_call({snapshot_sync, Data}, _From, State) ->
-    write_snapshot(Data),
+    safe_write_snapshot(Data),
     {reply, ok, State};
 handle_call(_Request, _From, State) ->
     {reply, {error, unknown_request}, State}.
@@ -94,13 +96,32 @@ handle_cast(_Msg, State) ->
 
 -spec handle_info(term(), map()) -> {noreply, map()}.
 handle_info(flush, #{pending := Pending} = State) ->
-    maps:foreach(fun(_Key, Data) -> write_snapshot(Data) end, Pending),
+    maps:foreach(fun(_Key, Data) -> safe_write_snapshot(Data) end, Pending),
     erlang:send_after(?FLUSH_INTERVAL, self(), flush),
     {noreply, State#{pending => #{}}};
 handle_info(_Info, State) ->
     {noreply, State}.
 
 %% --- Internal ---
+
+%% One poison zone (e.g. a game_state term jsonb cannot encode) must not crash
+%% the snapshotter or drop every other zone in the same flush. Isolate each
+%% write; a failure costs only that zone's snapshot this round.
+safe_write_snapshot(Data) ->
+    try
+        write_snapshot(Data)
+    catch
+        Class:Reason:Stacktrace ->
+            ?LOG_WARNING(#{
+                event => zone_snapshot_write_crashed,
+                world_id => maps:get(world_id, Data, undefined),
+                coords => maps:get(coords, Data, undefined),
+                class => Class,
+                reason => Reason,
+                stacktrace => Stacktrace
+            }),
+            ok
+    end.
 
 write_snapshot(#{world_id := WorldId, coords := {ZX, ZY}} = Data) ->
     Entities = maps:get(entities, Data, #{}),
@@ -152,7 +173,7 @@ write_snapshot(#{world_id := WorldId, coords := {ZX, ZY}} = Data) ->
         {ok, _} ->
             ok;
         {error, Reason} ->
-            logger:warning(#{msg => ~"zone snapshot write failed", reason => Reason}),
+            ?LOG_WARNING(#{event => zone_snapshot_write_failed, reason => Reason}),
             ok
     end.
 
@@ -162,6 +183,6 @@ do_delete_world(WorldId) ->
         {ok, _} ->
             ok;
         {error, Reason} ->
-            logger:warning(#{msg => ~"zone snapshot cleanup failed", reason => Reason}),
+            ?LOG_WARNING(#{event => zone_snapshot_cleanup_failed, reason => Reason}),
             ok
     end.

--- a/test/asobi_entity_timer_tests.erl
+++ b/test/asobi_entity_timer_tests.erl
@@ -117,3 +117,97 @@ info_test() ->
     ),
     Info = asobi_entity_timer:info(S1),
     ?assertEqual(1, maps:get(active_timers, Info)).
+
+serialise_round_trip_test() ->
+    S0 = asobi_entity_timer:new(),
+    S1 = asobi_entity_timer:start_timer(
+        #{
+            entity_id => ~"furnace_1",
+            timer_id => ~"smelt",
+            duration => 5000,
+            owner => ~"player_1",
+            on_complete => #{~"type" => ~"craft", ~"item" => ~"iron_ingot"},
+            category => crafting,
+            pause_when_offline => true
+        },
+        S0
+    ),
+    Restored = round_trip(S1),
+    ?assertEqual(1, asobi_entity_timer:active_count(Restored)),
+    [Timer] = asobi_entity_timer:get_timers(~"furnace_1", Restored),
+    ?assertEqual(~"smelt", maps:get(timer_id, Timer)),
+    ?assertEqual(~"player_1", maps:get(owner, Timer)),
+    ?assertEqual(crafting, maps:get(category, Timer)),
+    ?assertEqual(true, maps:get(pause_when_offline, Timer)),
+    ?assertEqual(#{~"type" => ~"craft", ~"item" => ~"iron_ingot"}, maps:get(on_complete, Timer)).
+
+serialise_undefined_owner_test() ->
+    S0 = asobi_entity_timer:new(),
+    S1 = asobi_entity_timer:start_timer(
+        #{entity_id => ~"e1", timer_id => ~"t1", duration => 5000, on_complete => ~"x"},
+        S0
+    ),
+    [Timer] = asobi_entity_timer:get_timers(~"e1", round_trip(S1)),
+    ?assertEqual(undefined, maps:get(owner, Timer)).
+
+deserialise_legacy_count_is_empty_test() ->
+    %% Pre-persistence snapshots stored #{active_timers => N}; deserialise must
+    %% treat that (no "timers" key) as empty rather than crash.
+    Restored = asobi_entity_timer:deserialise(#{~"active_timers" => 3}),
+    ?assertEqual(0, asobi_entity_timer:active_count(Restored)).
+
+serialise_preserves_expiry_test() ->
+    %% end_at is absolute, so a timer that lapsed during downtime fires on the
+    %% first tick after restore.
+    S0 = asobi_entity_timer:new(),
+    S1 = asobi_entity_timer:start_timer(
+        #{entity_id => ~"e1", timer_id => ~"t1", duration => 1, on_complete => ~"ping"},
+        S0
+    ),
+    Restored = round_trip(S1),
+    {Events, _} = asobi_entity_timer:tick(erlang:system_time(millisecond) + 1000, Restored),
+    ?assertMatch([{entity_timer_expired, ~"e1", ~"t1", ~"ping"}], Events).
+
+serialise_tuple_on_complete_is_json_safe_test() ->
+    %% A tuple on_complete cannot survive jsonb. serialise must drop it to null
+    %% rather than emit a term json:encode/1 rejects, which would crash the
+    %% snapshot write and take down the whole flush batch.
+    S0 = asobi_entity_timer:new(),
+    S1 = asobi_entity_timer:start_timer(
+        #{
+            entity_id => ~"furnace_1",
+            timer_id => ~"smelt",
+            duration => 5000,
+            on_complete => {craft_complete, ~"iron_ingot", 10}
+        },
+        S0
+    ),
+    Serialised = asobi_entity_timer:serialise(S1),
+    ?assertMatch(Bin when is_binary(Bin), iolist_to_binary(json:encode(Serialised))),
+    [Timer] = asobi_entity_timer:get_timers(~"furnace_1", round_trip(S1)),
+    ?assertEqual(null, maps:get(on_complete, Timer)).
+
+deserialise_malformed_entry_is_skipped_test() ->
+    %% A truncated/corrupt entry (no end_at) must be skipped, not abort the whole
+    %% zone's restore.
+    Snapshot = #{
+        ~"timers" => #{
+            ~"furnace_1" => #{
+                ~"good" => #{
+                    ~"timer_id" => ~"good",
+                    ~"entity_id" => ~"furnace_1",
+                    ~"end_at" => erlang:system_time(millisecond) + 5000
+                },
+                ~"bad" => #{~"timer_id" => ~"bad", ~"entity_id" => ~"furnace_1"}
+            }
+        }
+    },
+    Restored = asobi_entity_timer:deserialise(Snapshot),
+    ?assertEqual(1, asobi_entity_timer:active_count(Restored)),
+    [Timer] = asobi_entity_timer:get_timers(~"furnace_1", Restored),
+    ?assertEqual(~"good", maps:get(timer_id, Timer)).
+
+round_trip(State) ->
+    asobi_entity_timer:deserialise(
+        json:decode(iolist_to_binary(json:encode(asobi_entity_timer:serialise(State))))
+    ).

--- a/test/asobi_zone_snapshot_recovery_tests.erl
+++ b/test/asobi_zone_snapshot_recovery_tests.erl
@@ -81,6 +81,7 @@ cold_start_restores() ->
     Snapshot = #{
         zone_state => #{~"saved" => true},
         spawner_state => SpawnerState,
+        entity_timers => timer_state(),
         tick => 42
     },
     meck:new(asobi_zone_snapshotter, [passthrough]),
@@ -96,6 +97,7 @@ cold_start_restores() ->
         ?assertEqual(42, maps:get(tick, State)),
         Spawner = maps:get(spawner, State),
         ?assertEqual(1, maps:get(pending_respawns, asobi_zone_spawner:info(Spawner))),
+        ?assertEqual(1, asobi_entity_timer:active_count(maps:get(entity_timers, State))),
         gen_server:stop(Pid)
     after
         meck:unload(asobi_zone_snapshotter)
@@ -164,6 +166,21 @@ goblin_templates() ->
             respawn => #{strategy => timer, delay => 1000, max_respawns => infinity, jitter => 0}
         }
     }.
+
+timer_state() ->
+    %% A tuple on_complete + a non-general category exercise json_safe/1 and the
+    %% binary_to_existing_atom category round-trip through the real restore path.
+    S = asobi_entity_timer:start_timer(
+        #{
+            entity_id => ~"furnace_1",
+            timer_id => ~"smelt",
+            duration => 60000,
+            on_complete => {craft_complete, ~"iron_ingot"},
+            category => crafting
+        },
+        asobi_entity_timer:new()
+    ),
+    json:decode(iolist_to_binary(json:encode(asobi_entity_timer:serialise(S)))).
 
 pending_respawn_spawner_state(Templates) ->
     S0 = asobi_zone_spawner:new(Templates),


### PR DESCRIPTION
## What

Entity timers were dropped on idle reap: zone snapshots wrote only an active-timer *count*, so a crafting/decay/cooldown timer mid-flight vanished when the zone was restored.

This makes the timer set durable across reap, mirroring the spawner's snapshot path.

## Changes

- `asobi_entity_timer:serialise/1` + `deserialise/1` round-trip the timer set through jsonb. `end_at` stays absolute, so a timer that lapsed during downtime fires on the first tick after restore.
- `category` decodes via `binary_to_existing_atom` (never creates atoms from persisted data), falling back to `general`. Old count-shaped snapshots deserialise to empty.
- Zone snapshots now write `serialise/1` instead of `info/1`; the cold restore path (`handle_continue`) restores timers alongside `zone_state`, spawner and tick.

## Safety (review findings)

- **`on_complete` must survive jsonb.** It is delivered to game code as-is and persisted verbatim. `serialise` drops anything `json:encode/1` rejects (tuples, pids, refs, funs) to `null` rather than emitting a term that would crash the snapshot write.
- **Corrupt entries don't abort restore.** A truncated entry (e.g. missing `end_at`) is skipped, not function-clause-crashed.
- **Blast-radius backstop.** `asobi_zone_snapshotter` isolates each per-zone write in a `try`, so one poison zone can no longer crash the snapshotter or drop every other zone in the same flush.

## Tests

- Timer serialise/deserialise round-trip, undefined owner, legacy count-shape, expiry preservation, tuple `on_complete` -> null, malformed-entry skip.
- Recovery suite restores a real timer through the full cold-start path, now with a tuple `on_complete` + non-`general` category exercising `json_safe/1` and the atom round-trip.

## Verification

fmt --check, xref, dialyzer, `elp eqwalize` (changed modules: NO ERRORS), elp lint (no new warnings), full eunit (276 tests, 0 failures).

Closes #134.