### PR TITLE
docs(terrain): document and exemplify terrain providers

### DIFF
--- a/examples/world-terrain/README.md
+++ b/examples/world-terrain/README.md
@@ -1,0 +1,92 @@
+# world-terrain
+
+A terrain provider for the asobi world server: how you tell Asobi what data
+it is chunking.
+
+## The mental model
+
+Asobi does not define what terrain is. It asks a provider you write for the
+bytes of the chunk at a `{X, Y}` coordinate, caches that blob in
+`asobi_terrain_store`, and ships it to clients on zone entry. The payload is
+whatever your provider returns. Asobi never looks inside it; the client
+decodes it.
+
+So "the data Asobi is chunking" is the data your provider hands back. You
+choose the format. This example uses the built-in tile format, but a binary
+your client understands works just as well.
+
+```
+client enters zone (X,Y)
+        |
+        v
+asobi_terrain_store:get_chunk(Store, {X,Y})
+        |  cache miss
+        v
+provider:load_chunk({X,Y}, S)   --> {error, not_found}
+        |  fall back
+        v
+provider:generate_chunk({X,Y}, Seed, S) --> {ok, <<compressed tiles>>, S}
+        |  cache + ship verbatim
+        v
+client decompresses + decodes the bytes
+```
+
+## The provider behaviour
+
+Implement `asobi_terrain_provider` (see `src/heightmap_terrain_provider.erl`):
+
+- `init(Args)` once at startup; returns the state threaded through later calls.
+- `load_chunk({X,Y}, State)` returns a stored chunk, or `{error, not_found}`
+  to fall back to `generate_chunk/3`.
+- `generate_chunk({X,Y}, Seed, State)` (optional) builds a chunk procedurally.
+
+The `asobi_terrain` helpers build the built-in payload: a chunk is a grid of
+`{TileId, Flags, Elevation}` tiles, `encode_chunk/1` packs it (4 bytes/tile,
+64x64 by default), `compress_chunk/1` zlib-compresses it. The client mirrors
+`decompress_chunk/1` then `decode_chunk/1`.
+
+## Wiring it to a world
+
+Export `terrain_provider/1` from your `asobi_world` game module
+(`src/world_terrain_game.erl`):
+
+```erlang
+terrain_provider(_Config) ->
+    {heightmap_terrain_provider, #{}}.
+```
+
+That is the whole handshake. Asobi starts a terrain store with the module and
+args you return.
+
+### From Lua
+
+A Lua game can return a provider too, but only an **allowlisted** Erlang
+module (terrain logic cannot be written in Lua):
+
+```lua
+function terrain_provider(config)
+    return { module = "heightmap_terrain_provider", args = {} }
+end
+```
+
+The module must be listed in `asobi_lua`'s `terrain_providers` env, or it is
+rejected with `terrain_provider_not_allowed`.
+
+## Run it
+
+The terrain flow is verified by a test that drives a real `asobi_terrain_store`
+through the provider and decodes the result:
+
+```
+rebar3 eunit
+```
+
+To run the full world server, start Postgres and a shell:
+
+```
+docker compose up -d
+rebar3 shell
+```
+
+The `overworld` mode in `config/sys.config` is served by
+`world_terrain_game`, which supplies the heightmap provider.

--- a/examples/world-terrain/config/sys.config
+++ b/examples/world-terrain/config/sys.config
@@ -1,0 +1,46 @@
+[
+    {nova, [
+        {environment, dev},
+        {dev_mode, true},
+        {bootstrap_application, asobi},
+        {json_lib, json},
+        {cowboy_configuration, #{port => 8080}},
+        {plugins, [
+            {pre_request, nova_request_plugin, #{
+                decode_json_body => true,
+                parse_qs => true
+            }},
+            {pre_request, nova_cors_plugin, #{allow_origins => ~"*"}},
+            {pre_request, nova_correlation_plugin, #{}}
+        ]}
+    ]},
+    {kura, [
+        {repo, asobi_repo},
+        {backend, kura_backend_postgres},
+        {host, "localhost"},
+        {port, 5432},
+        {database, "world_terrain_dev"},
+        {user, "postgres"},
+        {password, "postgres"},
+        {pool_size, 10}
+    ]},
+    {shigoto, [
+        {pool, asobi_repo},
+        {poll_interval, 500},
+        {queues, [{~"default", 10}]}
+    ]},
+    {asobi, [
+        {game_modes, #{
+            ~"overworld" => #{
+                type => world,
+                module => world_terrain_game,
+                zone_size => 256,
+                grid_size => 64,
+                lazy_zones => true
+            }
+        }},
+        {matchmaker, #{tick_interval => 1000, max_wait_seconds => 60}},
+        {session, #{token_ttl => 900, refresh_ttl => 2592000}}
+    ]},
+    {pg, [{scope, [nova_scope, asobi_presence, asobi_chat]}]}
+].

--- a/examples/world-terrain/docker-compose.yml
+++ b/examples/world-terrain/docker-compose.yml
@@ -1,0 +1,14 @@
+services:
+  postgres:
+    image: postgres:17
+    environment:
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: postgres
+      POSTGRES_DB: world_terrain_dev
+    ports:
+      - "5432:5432"
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U postgres"]
+      interval: 5s
+      timeout: 5s
+      retries: 5

--- a/examples/world-terrain/rebar.config
+++ b/examples/world-terrain/rebar.config
@@ -1,0 +1,10 @@
+{erl_opts, [debug_info]}.
+
+{deps, [
+    {asobi, "~> 0.34"}
+]}.
+
+{shell, [
+    {apps, [world_terrain]},
+    {config, "./config/sys.config"}
+]}.

--- a/examples/world-terrain/src/heightmap_terrain_provider.erl
+++ b/examples/world-terrain/src/heightmap_terrain_provider.erl
@@ -1,0 +1,48 @@
+-module(heightmap_terrain_provider).
+
+-moduledoc """
+Example `m:asobi_terrain_provider`: a procedural heightmap.
+
+Every chunk is generated from its world coordinates and the world seed, so
+there is no stored data: `load_chunk/2` always misses and the world server
+falls back to `generate_chunk/3`. A real provider would serve stored chunks
+from disk or a database in `load_chunk/2` and keep `generate_chunk/3` for
+never-visited coordinates.
+
+The point this example makes: the chunk payload is *your* bytes. Here each
+tile is `{TileId, Flags, Elevation}` and we use the `m:asobi_terrain`
+helpers to pack and zlib-compress the grid. Asobi caches and ships that
+blob verbatim; the client decodes it with the matching format.
+""".
+
+-behaviour(asobi_terrain_provider).
+
+-export([init/1, load_chunk/2, generate_chunk/3]).
+
+-define(TILE_WATER, 1).
+-define(TILE_GRASS, 2).
+-define(SEA_LEVEL, 96).
+
+init(Config) ->
+    {ok, Config}.
+
+load_chunk(_Coords, _State) ->
+    {error, not_found}.
+
+generate_chunk({ChunkX, ChunkY}, Seed, State) ->
+    #{chunk_width := Width, chunk_height := Height} = asobi_terrain:default_format(),
+    Tiles = maps:from_list([
+        tile_at(ChunkX * Width + X, ChunkY * Height + Y, X, Y, Seed)
+     || X <- lists:seq(0, Width - 1), Y <- lists:seq(0, Height - 1)
+    ]),
+    Payload = asobi_terrain:compress_chunk(asobi_terrain:encode_chunk(Tiles)),
+    {ok, Payload, State}.
+
+tile_at(WorldX, WorldY, X, Y, Seed) ->
+    Elevation = erlang:phash2({WorldX div 8, WorldY div 8, Seed}, 256),
+    TileId =
+        case Elevation < ?SEA_LEVEL of
+            true -> ?TILE_WATER;
+            false -> ?TILE_GRASS
+        end,
+    {{X, Y}, {TileId, 0, Elevation}}.

--- a/examples/world-terrain/src/world_terrain.app.src
+++ b/examples/world-terrain/src/world_terrain.app.src
@@ -1,0 +1,13 @@
+{application, world_terrain, [
+    {description, "asobi terrain provider example"},
+    {vsn, "0.1.0"},
+    {registered, []},
+    {mod, {world_terrain_app, []}},
+    {applications, [
+        kernel,
+        stdlib,
+        asobi
+    ]},
+    {env, []},
+    {modules, []}
+]}.

--- a/examples/world-terrain/src/world_terrain_app.erl
+++ b/examples/world-terrain/src/world_terrain_app.erl
@@ -1,0 +1,10 @@
+-module(world_terrain_app).
+-behaviour(application).
+
+-export([start/2, stop/1]).
+
+start(_StartType, _StartArgs) ->
+    world_terrain_sup:start_link().
+
+stop(_State) ->
+    ok.

--- a/examples/world-terrain/src/world_terrain_game.erl
+++ b/examples/world-terrain/src/world_terrain_game.erl
@@ -1,0 +1,49 @@
+-module(world_terrain_game).
+
+-moduledoc """
+Minimal `m:asobi_world` game that wires in a terrain provider.
+
+Everything here is a stub except `terrain_provider/1`: that callback is how
+you tell Asobi which provider produces the world's chunks. Asobi starts a
+terrain store with it and serves the chunks it returns to clients on zone
+entry.
+""".
+
+-behaviour(asobi_world).
+
+-export([
+    init/1,
+    join/2,
+    leave/2,
+    spawn_position/2,
+    zone_tick/2,
+    handle_input/3,
+    post_tick/2,
+    terrain_provider/1
+]).
+
+init(_Config) ->
+    {ok, #{}}.
+
+join(_PlayerId, State) ->
+    {ok, State}.
+
+leave(_PlayerId, State) ->
+    {ok, State}.
+
+spawn_position(_PlayerId, _State) ->
+    {ok, {0.0, 0.0}}.
+
+zone_tick(Entities, ZoneState) ->
+    {Entities, ZoneState}.
+
+handle_input(PlayerId, #{~"x" := X, ~"y" := Y}, Entities) ->
+    {ok, Entities#{PlayerId => #{type => ~"player", x => X, y => Y}}};
+handle_input(_PlayerId, _Input, Entities) ->
+    {ok, Entities}.
+
+post_tick(_Tick, State) ->
+    {ok, State}.
+
+terrain_provider(_Config) ->
+    {heightmap_terrain_provider, #{}}.

--- a/examples/world-terrain/src/world_terrain_sup.erl
+++ b/examples/world-terrain/src/world_terrain_sup.erl
@@ -1,0 +1,10 @@
+-module(world_terrain_sup).
+-behaviour(supervisor).
+
+-export([start_link/0, init/1]).
+
+start_link() ->
+    supervisor:start_link({local, ?MODULE}, ?MODULE, []).
+
+init([]) ->
+    {ok, {#{strategy => one_for_one, intensity => 10, period => 10}, []}}.

--- a/examples/world-terrain/test/heightmap_terrain_provider_tests.erl
+++ b/examples/world-terrain/test/heightmap_terrain_provider_tests.erl
@@ -1,0 +1,42 @@
+-module(heightmap_terrain_provider_tests).
+-include_lib("eunit/include/eunit.hrl").
+
+%% The runnable proof of the terrain flow: start a terrain store with the
+%% example provider, fetch a chunk through it, then decompress and decode the
+%% payload back to tiles - exactly what a client does.
+
+chunk_round_trips_through_the_store_test() ->
+    Store = start_store(42),
+    {ok, Payload} = asobi_terrain_store:get_chunk(Store, {0, 0}),
+    ?assert(is_binary(Payload)),
+    Tiles = asobi_terrain:decode_chunk(asobi_terrain:decompress_chunk(Payload)),
+    #{chunk_width := Width, chunk_height := Height} = asobi_terrain:default_format(),
+    %% The provider fills every tile with a non-zero id, so the whole grid
+    %% survives the decode (zero-id tiles are dropped as empty).
+    ?assertEqual(Width * Height, length(Tiles)),
+    gen_server:stop(Store).
+
+same_seed_and_coords_are_deterministic_test() ->
+    A = start_store(7),
+    B = start_store(7),
+    {ok, ChunkA} = asobi_terrain_store:get_chunk(A, {3, 5}),
+    {ok, ChunkB} = asobi_terrain_store:get_chunk(B, {3, 5}),
+    ?assertEqual(ChunkA, ChunkB),
+    gen_server:stop(A),
+    gen_server:stop(B).
+
+different_seeds_diverge_test() ->
+    A = start_store(1),
+    B = start_store(2),
+    {ok, ChunkA} = asobi_terrain_store:get_chunk(A, {3, 5}),
+    {ok, ChunkB} = asobi_terrain_store:get_chunk(B, {3, 5}),
+    ?assertNotEqual(ChunkA, ChunkB),
+    gen_server:stop(A),
+    gen_server:stop(B).
+
+start_store(Seed) ->
+    {ok, Store} = asobi_terrain_store:start_link(#{
+        provider => {heightmap_terrain_provider, #{}},
+        seed => Seed
+    }),
+    Store.

--- a/guides/large-worlds.md
+++ b/guides/large-worlds.md
@@ -51,6 +51,14 @@ Terrain is separate from entities. Tile chunks are served as compressed
 binary blobs when a player subscribes to a zone -- not through the
 tick/delta loop.
 
+Asobi does not define what terrain is. You implement a provider that returns
+the bytes of the chunk at a `{X, Y}` coordinate; Asobi caches that blob in
+the terrain store and ships it to clients verbatim. The payload is whatever
+your provider produces -- "the data Asobi chunks" is the data you hand back.
+The `asobi_terrain` helpers below give you a compact tile format, but any
+binary your client can decode works. A complete, runnable provider lives in
+[`examples/world-terrain`](https://github.com/widgrensit/asobi/tree/main/examples/world-terrain).
+
 ### Terrain Provider Behaviour
 
 Implement `asobi_terrain_provider` to supply terrain data:

--- a/src/world/asobi_terrain.erl
+++ b/src/world/asobi_terrain.erl
@@ -1,9 +1,25 @@
 -module(asobi_terrain).
 
-%% Pure functional terrain chunk encoding/decoding.
-%%
-%% Encodes tile grids as compact binaries. Default format: 4 bytes per tile
-%% (2B tile_id, 1B flags, 1B elevation). A 64x64 chunk = 16KB raw.
+-moduledoc """
+Pure functional terrain chunk encoding and compression.
+
+Helpers for `m:asobi_terrain_provider` implementations that want a compact
+binary chunk format. A chunk is a grid of tiles; each tile is
+`{TileId, Flags, Elevation}`. The default format packs 4 bytes per tile
+(2B tile id, 1B flags, 1B elevation), so a 64x64 chunk is 16KB raw before
+`compress_chunk/1` (zlib).
+
+A provider typically builds a `t:tile_map/0`, then encodes and compresses:
+
+```erlang
+Tiles = #{{0, 0} => {Grass, 0, 0}, {1, 0} => {Water, 0, 3}},
+Payload = asobi_terrain:compress_chunk(asobi_terrain:encode_chunk(Tiles)),
+```
+
+Using these helpers is optional: a provider may return any binary its
+client knows how to decode. The client mirrors `decompress_chunk/1` then
+`decode_chunk/1` to read tiles back.
+""".
 
 -export([encode_chunk/1, encode_chunk/2]).
 -export([decode_chunk/1, decode_chunk/2]).
@@ -31,14 +47,17 @@
 
 %% --- Public API ---
 
+-doc "The default chunk format: 4 bytes per tile, 64x64 tiles per chunk.".
 -spec default_format() -> format().
 default_format() ->
     #{tile_size => 4, chunk_width => 64, chunk_height => 64}.
 
+-doc "Raw (uncompressed) byte size of a chunk in the given format.".
 -spec chunk_byte_size(format()) -> pos_integer().
 chunk_byte_size(#{tile_size := TS, chunk_width := W, chunk_height := H}) ->
     W * H * TS.
 
+-doc "Encode a tile list (or map) to a raw chunk binary in the default format.".
 -spec encode_chunk([tile()]) -> binary().
 encode_chunk(Tiles) ->
     encode_chunk(Tiles, default_format()).
@@ -57,6 +76,7 @@ encode_chunk(TileMap, #{chunk_width := W, chunk_height := H} = _Fmt) when is_map
 tiles_to_map(Tiles) ->
     maps:from_list([{{X, Y}, {TileId, Flags, Elev}} || {X, Y, TileId, Flags, Elev} <- Tiles]).
 
+-doc "Decode a raw chunk binary back to a tile list. Inverse of `encode_chunk/1`.".
 -spec decode_chunk(binary()) -> [tile()].
 decode_chunk(Bin) ->
     decode_chunk(Bin, default_format()).
@@ -65,10 +85,12 @@ decode_chunk(Bin) ->
 decode_chunk(Bin, #{chunk_width := W} = _Fmt) ->
     decode_tiles(Bin, 0, W, []).
 
+-doc "zlib-compress a raw chunk binary for storage and transport.".
 -spec compress_chunk(binary()) -> binary().
 compress_chunk(Bin) ->
     zlib:compress(Bin).
 
+-doc "Inverse of `compress_chunk/1`. Clients call this before `decode_chunk/1`.".
 -spec decompress_chunk(binary()) -> binary().
 decompress_chunk(Bin) ->
     zlib:uncompress(Bin).

--- a/src/world/asobi_terrain_provider.erl
+++ b/src/world/asobi_terrain_provider.erl
@@ -1,16 +1,67 @@
 -module(asobi_terrain_provider).
 
-%% Behaviour for terrain data providers.
-%%
-%% Game developers implement this to supply terrain chunk data from
-%% files, databases, or procedural generation.
+-moduledoc """
+Behaviour for terrain data providers.
 
+A world server does not define what terrain *is*. It calls a provider you
+implement to fetch the bytes of a chunk at a given `{X, Y}` coordinate,
+caches them in `m:asobi_terrain_store`, and ships them to clients on zone
+entry. Asobi never interprets those bytes: the chunk payload is whatever
+your provider returns, and the client is responsible for decoding it.
+
+Implement this to source terrain from disk, a database, or procedural
+generation. The `m:asobi_terrain` helpers (`asobi_terrain:encode_chunk/1`,
+`asobi_terrain:compress_chunk/1`) build a compact, compressed payload from a
+tile map, but you are free to return any binary your client understands.
+
+```erlang
+-module(my_terrain).
+-behaviour(asobi_terrain_provider).
+-export([init/1, load_chunk/2, generate_chunk/3]).
+
+init(Config) -> {ok, Config}.
+
+%% Return a stored chunk, or {error, not_found} to fall back to
+%% generate_chunk/3.
+load_chunk(_Coords, State) -> {error, not_found}.
+
+%% Procedurally build the chunk: produce a tile map, encode and compress it.
+generate_chunk({CX, CY}, Seed, State) ->
+    Tiles = #{{0, 0} => {tile_id(CX, CY, Seed), 0, 0}},
+    Bin = asobi_terrain:compress_chunk(asobi_terrain:encode_chunk(Tiles)),
+    {ok, Bin, State}.
+```
+
+Wire it into a world by exporting `terrain_provider/1` from your
+`m:asobi_world` game module, returning `{my_terrain, Args}`.
+""".
+
+-doc """
+Called once when the terrain store starts. `Config` is the `Args` map from
+the game module's `terrain_provider/1`. Return the provider state threaded
+through every later call.
+""".
 -callback init(Config :: map()) -> {ok, State :: term()}.
 
+-doc """
+Fetch the chunk at `Coords`. Return `{ok, Payload, NewState}` with the
+chunk bytes, or `{error, not_found}` to fall back to `generate_chunk/3`
+(when exported). Any other `{error, Reason}` propagates to the caller. The
+three-element error forms carry updated provider state.
+""".
 -callback load_chunk(Coords :: {integer(), integer()}, State :: term()) ->
-    {ok, CompressedBinary :: binary(), NewState :: term()} | {error, term()}.
+    {ok, Payload :: binary(), NewState :: term()}
+    | {error, not_found}
+    | {error, not_found, NewState :: term()}
+    | {error, Reason :: term()}
+    | {error, Reason :: term(), NewState :: term()}.
 
+-doc """
+Procedurally produce the chunk at `Coords` from the world `Seed`. Optional:
+the fallback for a `load_chunk/2` miss. Without it, a miss yields
+`{error, not_found}` to the caller.
+""".
 -callback generate_chunk(Coords :: {integer(), integer()}, Seed :: integer(), State :: term()) ->
-    {ok, CompressedBinary :: binary(), NewState :: term()}.
+    {ok, Payload :: binary(), NewState :: term()} | {error, term()}.
 
 -optional_callbacks([generate_chunk/3]).


### PR DESCRIPTION
Reader feedback (relayed): *"An example of how to implement a terrain provider would be helpful. I see Asobi can do chunking, but it is not clear how you tell Asobi the data it is chunking."*

The mechanism already existed but had no worked example and no crisp statement of the mental model. This adds both, and fixes a behaviour-spec inaccuracy found along the way.

## The mental model (now documented)

Asobi doesn't define what terrain is. Your provider returns the **bytes** of the chunk at `{X, Y}`; Asobi caches that blob in `asobi_terrain_store` and ships it to clients **verbatim** — it never interprets it. The client decodes it. "The data Asobi chunks" is the data you hand back.

## Changes

- **`examples/world-terrain/`** — a runnable example:
  - `heightmap_terrain_provider` implements `asobi_terrain_provider` (procedural heightmap; `load_chunk` misses → `generate_chunk` builds + compresses a tile grid).
  - `world_terrain_game` is a minimal `asobi_world` game showing the one-line `terrain_provider/1` wiring.
  - a eunit test drives a **real `asobi_terrain_store`** through the provider and decompresses/decodes the payload (the runnable proof).
  - README spells out the model, the behaviour, the tile helpers, the wiring, and the Lua allowlist constraint.
- **`asobi_terrain_provider`** — added moduledoc + per-callback docs, and **fixed the `load_chunk` spec**: it declared only `{error, term()}`, but the store (and the test provider) use the `{error, Reason, NewState}` / `{error, not_found, NewState}` forms. The spec now matches the real contract.
- **`asobi_terrain`** — moduledoc + function docs for the encode/compress helpers.
- **`guides/large-worlds.md`** — states the provider mental model up front and links the example.

## Verification

Example compiled against local asobi and its eunit test passes (3/3: chunk round-trips through the store, determinism by seed+coords, divergence across seeds). asobi suite: `fmt --check`, `xref`, `dialyzer`, `elp eqwalize` (both terrain modules NO ERRORS), full `eunit` (276/276), `ex_doc` (no new warnings; example files are erlfmt-clean).