### PR TITLE
chore(otp): build on OTP 29

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,5 +27,8 @@ jobs:
       # by previous runs survive and get executed by rebar3 eunit/ct. That's
       # how asobi_lua_SUITE.beam (removed in #59) keeps reappearing in CT
       # and crashing on `luerl:init/0` undef. Force-fresh project test tree.
-      pre-test-command: 'rm -rf _build/default/lib/asobi/test _build/test/lib/asobi/test'
+      # meck is a test-only dep (not in rebar.lock) so the cache key never
+      # reflects its version; a stale OTP-28-era meck gets restored and fails
+      # to compile on OTP 29 (deprecated catch). Drop it so it re-resolves.
+      pre-test-command: 'rm -rf _build/default/lib/asobi/test _build/test/lib/asobi/test _build/test/lib/meck'
     secrets: inherit

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,9 @@ jobs:
       pull-requests: write
     with:
       version-file: '.tool-versions'
+      # version-file drives the analysis jobs; the eunit/ct matrix uses
+      # otp-matrix (else it falls back to the otp-version default of 28).
+      otp-matrix: '["29.0.2"]'
       enable-audit: true
       enable-ct: true
       extra-services-compose: 'docker-compose.yml'

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,2 @@
-erlang 28.0.1
+erlang 29.0.2
 rebar 3.27.0

--- a/rebar.config
+++ b/rebar.config
@@ -12,7 +12,7 @@
 
 {deps, [
     nova,
-    {kura, {git, "https://github.com/Taure/kura.git", {tag, "v2.0.4"}}},
+    {kura, {git, "https://github.com/Taure/kura.git", {tag, "v2.0.8"}}},
     {kura_postgres, {git, "https://github.com/Taure/kura_postgres.git", {tag, "v0.4.2"}}},
     {nova_auth, "~> 0.1"},
     {nova_auth_oidc, "~> 0.1"},
@@ -39,10 +39,19 @@
         ]}
     ]},
     {test, [
-        {erl_opts, [nowarn_export_all, nowarn_missing_spec, warnings_as_errors, {i, "test"}]},
+        %% nowarn_deprecated_catch: OTP 29 deprecates the `catch Expr` form; test
+        %% teardown uses it for fire-and-forget cleanup (catch exit/2, meck:unload).
+        %% Suppress in tests only - src is catch-free. (Migrate to try/catch later.)
+        {erl_opts, [
+            nowarn_export_all,
+            nowarn_missing_spec,
+            nowarn_deprecated_catch,
+            warnings_as_errors,
+            {i, "test"}
+        ]},
         {deps, [
             {nova_test, {git, "https://github.com/novaframework/nova_test.git", {branch, "main"}}},
-            {meck, "~> 0.9"},
+            {meck, "~> 1.2"},
             {proper, "~> 1.4"}
         ]},
         {ct_opts, [{sys_config, "./config/dev_sys.config.src"}]},

--- a/rebar.lock
+++ b/rebar.lock
@@ -7,7 +7,7 @@
  {<<"jose">>,{pkg,<<"jose">>,<<"1.11.12">>},2},
  {<<"kura">>,
   {git,"https://github.com/Taure/kura.git",
-       {ref,"64c487a02596e082ee0968f7f14b5ac8090ebc02"}},
+       {ref,"fdb1abc5fdc0cc48c34b7d33fd8e0d6748c4a7d1"}},
   0},
  {<<"kura_postgres">>,
   {git,"https://github.com/Taure/kura_postgres.git",
@@ -25,7 +25,7 @@
  {<<"routing_tree">>,{pkg,<<"routing_tree">>,<<"1.0.11">>},1},
  {<<"seki">>,{pkg,<<"seki">>,<<"0.4.3">>},0},
  {<<"shigoto">>,{pkg,<<"shigoto">>,<<"1.2.2">>},0},
- {<<"telemetry">>,{pkg,<<"telemetry">>,<<"1.4.1">>},1},
+ {<<"telemetry">>,{pkg,<<"telemetry">>,<<"1.4.2">>},1},
  {<<"telemetry_registry">>,{pkg,<<"telemetry_registry">>,<<"0.3.2">>},2},
  {<<"thoas">>,{pkg,<<"thoas">>,<<"1.2.1">>},1}]}.
 [
@@ -48,7 +48,7 @@
  {<<"routing_tree">>, <<"72ACEF2095F0EC804F7AFD07EF781DDE5009425A1CA0A28F0706B1DB334A4812">>},
  {<<"seki">>, <<"3A9209AD6154DA08084E8409C8F97586C79855450A748D989EDF23483B90B8B8">>},
  {<<"shigoto">>, <<"7DAA82CD28FDAD50CDEF227B4B4BEE301EAA1F9CC1F5ED585EC756763178EABF">>},
- {<<"telemetry">>, <<"AB6DE178E2B29B58E8256B92B382EA3F590A47152CA3651EA857A6CAE05AC423">>},
+ {<<"telemetry">>, <<"A0CB522801DFFB1C49FE6E30561BADFFC7B6D0E180DB1300DF759FAA22062855">>},
  {<<"telemetry_registry">>, <<"701576890320BE6428189BFF963E865E8F23E0FF3615EADE8F78662BE0FC003C">>},
  {<<"thoas">>, <<"19A25F31177A17E74004D4840F66D791D4298C5738790FA2CC73731EB911F195">>}]},
 {pkg_hash_ext,[
@@ -70,7 +70,7 @@
  {<<"routing_tree">>, <<"85982C7AC502892C5179CD2A591331003BACD2D2A71723640BA7D23F45408E6E">>},
  {<<"seki">>, <<"5493BAC387329DE722AC5BCB967364CACECC104AE3E6ED143863453263DC6DB4">>},
  {<<"shigoto">>, <<"32BC87B8127507F31F2F007CB5B947C3AF4E3D1C9EC73059E72564E2F649A0DC">>},
- {<<"telemetry">>, <<"2172E05A27531D3D31DD9782841065C50DD5C3C7699D95266B2EDD54C2DAFA1C">>},
+ {<<"telemetry">>, <<"928F6495066506077862C0D1646609EED891A4326BEE3126BA54B60AF61FEBB1">>},
  {<<"telemetry_registry">>, <<"E7ED191EB1D115A3034AF8E1E35E4E63D5348851D556646D46CA3D1B4E16BAB9">>},
  {<<"thoas">>, <<"E38697EDFFD6E91BD12CEA41B155115282630075C2A727E7A6B2947F5408B86A">>}]}
 ].


### PR DESCRIPTION
OTP 29 deprecates the `catch Expr` form; under `warnings_as_errors` that breaks the build.

- `.tool-versions`: erlang 29.0.2 (also drives CI via `version-file`)
- kura `v2.0.4` → `v2.0.8` (v2.0.4 failed to compile on OTP 29 — Taure/kura#126)
- meck `~> 0.9` → `~> 1.2` (0.9 failed on OTP 29)
- test profile: `nowarn_deprecated_catch` (test teardown uses `catch exit/2` + `meck:unload`; src is catch-free)

Green on OTP 29.0.2: fmt, xref, dialyzer, eunit 276/0, ct 237/0. (eqwalize omitted — ELP has no otp-29 build yet. Pre-existing ex_doc link warnings are unrelated.)