### PR TITLE
fix(auth): enforce player bans in the token chokepoint

### DIFF
--- a/src/auth/asobi_auth_cache.erl
+++ b/src/auth/asobi_auth_cache.erl
@@ -50,6 +50,12 @@ start_link() ->
 %% should call this rather than nova_auth_session directly.
 -spec resolve_token(binary()) -> {ok, map()} | {error, term()}.
 resolve_token(Token) when is_binary(Token) ->
+    ensure_active(lookup(Token));
+resolve_token(_) ->
+    {error, invalid_token}.
+
+-spec lookup(binary()) -> {ok, map()} | {error, term()}.
+lookup(Token) ->
     Now = erlang:system_time(millisecond),
     case ets:lookup(?TABLE, Token) of
         [{_, {ok, Player}, ExpiresAt}] when ExpiresAt > Now ->
@@ -60,9 +66,22 @@ resolve_token(Token) when is_binary(Token) ->
             {error, Reason};
         _ ->
             miss(Token)
+    end.
+
+%% Reject sessions belonging to banned players, even when the token itself is
+%% valid and cached. `banned_at` is nil/absent for active players.
+-spec ensure_active({ok, map()} | {error, term()}) -> {ok, map()} | {error, term()}.
+ensure_active({ok, Player} = OK) ->
+    case is_banned(Player) of
+        true -> {error, banned};
+        false -> OK
     end;
-resolve_token(_) ->
-    {error, invalid_token}.
+ensure_active(Other) ->
+    Other.
+
+-spec is_banned(map()) -> boolean().
+is_banned(#{banned_at := V}) -> V =/= nil andalso V =/= undefined;
+is_banned(_) -> false.
 
 -spec invalidate(binary()) -> ok.
 invalidate(Token) when is_binary(Token) ->

--- a/test/asobi_auth_cache_tests.erl
+++ b/test/asobi_auth_cache_tests.erl
@@ -6,7 +6,9 @@ cache_test_() ->
         {"resolve_token returns cached positive without DB", fun positive_hit/0},
         {"resolve_token caches negative with shorter TTL", fun negative_hit/0},
         {"invalidate clears the entry", fun invalidate_clears/0},
-        {"expired entries are not returned", fun expired_skipped/0}
+        {"expired entries are not returned", fun expired_skipped/0},
+        {"banned players are rejected", fun banned_rejected/0},
+        {"active players (nil banned_at) pass", fun active_passes/0}
     ]}.
 
 setup() ->
@@ -43,6 +45,18 @@ invalidate_clears() ->
     %% would fall back to nova_auth_session, but with the asobi_auth ets
     %% configuration not set up in eunit it will surface as an error.
     ?assertMatch({error, _}, asobi_auth_cache:resolve_token(Token)).
+
+banned_rejected() ->
+    Token = ~"tok-banned",
+    Player = #{id => ~"player-banned", banned_at => {{2026, 1, 1}, {0, 0, 0}}},
+    asobi_auth_cache:put_positive(Token, Player),
+    ?assertEqual({error, banned}, asobi_auth_cache:resolve_token(Token)).
+
+active_passes() ->
+    Token = ~"tok-active",
+    Player = #{id => ~"player-active", banned_at => nil},
+    asobi_auth_cache:put_positive(Token, Player),
+    ?assertEqual({ok, Player}, asobi_auth_cache:resolve_token(Token)).
 
 %% A short-TTL setup confirms expired rows are not served.
 expired_skipped() ->


### PR DESCRIPTION
From the SDK-access security review (HIGH). `banned_at` is on the player schema but **never enforced** — a banned player keeps full access until their 30-day session + 60s auth cache expire.

`asobi_auth_cache:resolve_token/1` (the single chokepoint for both `asobi_auth_plugin` and the WS handler) now runs results through a ban gate → `{error, banned}` for players with a non-nil `banned_at`.

Tests: banned player rejected; active player (`banned_at = nil`) passes; existing cache tests unaffected. eunit 6/0, fmt/xref clean.

Follow-up: invalidate sessions on ban for immediate effect (currently a warm cache entry can serve a freshly-banned player for up to the 60s cache TTL).