### PR TITLE
fix(rate-limit): honor X-Forwarded-For from trusted proxies

### DIFF
--- a/src/asobi_peer.erl
+++ b/src/asobi_peer.erl
@@ -1,21 +1,40 @@
 -module(asobi_peer).
 -moduledoc """
-Client-IP extraction shared across HTTP and WebSocket entry points.
+Client-IP extraction shared across HTTP and WebSocket entry points, used as
+the rate-limiter key.
 
-Reads `cowboy_req:peer/1` and renders the address as a binary. Returns
-`~"unknown"` for any unexpected shape so callers can use the result as
-a rate-limiter key without crashing the request.
+By default this returns `cowboy_req:peer/1` (the socket peer). When the engine
+runs behind a trusted reverse proxy (Traefik/ingress/LB), the socket peer is
+the proxy, so every client collapses into one rate-limit bucket. Configure the
+proxy's address range so the real client is read from `X-Forwarded-For`:
 
-This module deliberately does **not** honor `X-Forwarded-For` today —
-trusting `XFF` blindly lets any client choose its own rate-limit key,
-which defeats the limiter. Honoring `XFF` correctly requires a
-deployer-configured CIDR trust list and is a follow-up.
+    {asobi, [{trusted_proxies, [~"10.0.0.0/8", ~"::1/128"]}]}
+
+`X-Forwarded-For` is honored ONLY when the socket peer is itself within a
+configured trusted range; otherwise it is ignored (an untrusted client must
+not be able to choose its own rate-limit key). With no `trusted_proxies`
+configured, behavior is identical to reading the socket peer directly.
 """.
 
 -export([client_ip/1]).
 
 -spec client_ip(cowboy_req:req() | map()) -> binary().
 client_ip(Req) ->
+    Peer = peer_ip(Req),
+    case parsed_trusted_proxies() of
+        [] ->
+            Peer;
+        Cidrs ->
+            case ip_in_any(Peer, Cidrs) of
+                true -> forwarded_client(Req, Cidrs, Peer);
+                false -> Peer
+            end
+    end.
+
+%% --- Internal ---
+
+-spec peer_ip(cowboy_req:req() | map()) -> binary().
+peer_ip(Req) ->
     try cowboy_req:peer(Req) of
         {IP, _Port} ->
             case inet:ntoa(IP) of
@@ -25,3 +44,103 @@ client_ip(Req) ->
     catch
         _:_ -> ~"unknown"
     end.
+
+%% Peer is a trusted proxy: the real client is the right-most X-Forwarded-For
+%% entry that is not itself a trusted proxy (walk right-to-left, strip our own
+%% proxy hops). Falls back to the peer if XFF is absent or all-trusted.
+-spec forwarded_client(cowboy_req:req() | map(), [cidr()], binary()) -> binary().
+forwarded_client(Req, Cidrs, Peer) ->
+    case cowboy_req:header(~"x-forwarded-for", Req) of
+        Xff when is_binary(Xff), Xff =/= <<>> ->
+            Hops = lists:reverse([trim(P) || P <- binary:split(Xff, ~",", [global])]),
+            case first_untrusted(Hops, Cidrs) of
+                {ok, Ip} -> Ip;
+                none -> Peer
+            end;
+        _ ->
+            Peer
+    end.
+
+-spec first_untrusted([binary()], [cidr()]) -> {ok, binary()} | none.
+first_untrusted([], _Cidrs) ->
+    none;
+first_untrusted([Ip | Rest], Cidrs) ->
+    case is_ip(Ip) andalso not ip_in_any(Ip, Cidrs) of
+        true -> {ok, Ip};
+        false -> first_untrusted(Rest, Cidrs)
+    end.
+
+-type cidr() :: {inet:ip_address(), non_neg_integer()}.
+
+-spec parsed_trusted_proxies() -> [cidr()].
+parsed_trusted_proxies() ->
+    Raw = application:get_env(asobi, trusted_proxies, []),
+    lists:filtermap(fun parse_cidr/1, to_list(Raw)).
+
+-spec parse_cidr(binary() | string()) -> {true, cidr()} | false.
+parse_cidr(C0) ->
+    case binary:split(to_bin(C0), ~"/") of
+        [AddrB, BitsB] ->
+            case {inet:parse_address(binary_to_list(AddrB)), to_int(BitsB)} of
+                {{ok, IP}, Bits} when is_integer(Bits), Bits >= 0 -> {true, {IP, Bits}};
+                _ -> false
+            end;
+        [AddrB] ->
+            case inet:parse_address(binary_to_list(AddrB)) of
+                {ok, IP} -> {true, {IP, width(IP)}};
+                _ -> false
+            end
+    end.
+
+-spec ip_in_any(binary(), [cidr()]) -> boolean().
+ip_in_any(IpBin, Cidrs) ->
+    case inet:parse_address(binary_to_list(IpBin)) of
+        {ok, IP} -> lists:any(fun(C) -> ip_in_cidr(IP, C) end, Cidrs);
+        _ -> false
+    end.
+
+-spec ip_in_cidr(inet:ip_address(), cidr()) -> boolean().
+ip_in_cidr(IP, {Net, Bits}) when tuple_size(IP) =:= tuple_size(Net) ->
+    Width = width(IP),
+    Shift = Width - min(Bits, Width),
+    (ip_to_int(IP) bsr Shift) =:= (ip_to_int(Net) bsr Shift);
+ip_in_cidr(_IP, _Cidr) ->
+    false.
+
+-spec ip_to_int(inet:ip_address()) -> non_neg_integer().
+ip_to_int(IP) ->
+    ElemBits = elem_bits(IP),
+    lists:foldl(fun(E, Acc) -> (Acc bsl ElemBits) bor E end, 0, tuple_to_list(IP)).
+
+-spec width(inet:ip_address()) -> 32 | 128.
+width(IP) -> tuple_size(IP) * elem_bits(IP).
+
+-spec elem_bits(inet:ip_address()) -> 8 | 16.
+elem_bits(IP) when tuple_size(IP) =:= 4 -> 8;
+elem_bits(_IP) -> 16.
+
+-spec is_ip(binary()) -> boolean().
+is_ip(Bin) ->
+    case inet:parse_address(binary_to_list(Bin)) of
+        {ok, _} -> true;
+        _ -> false
+    end.
+
+-spec to_list(term()) -> list().
+to_list(L) when is_list(L) -> L;
+to_list(_) -> [].
+
+-spec to_bin(binary() | string()) -> binary().
+to_bin(B) when is_binary(B) -> B;
+to_bin(L) when is_list(L) -> list_to_binary(L).
+
+-spec to_int(binary()) -> integer() | error.
+to_int(B) ->
+    try
+        binary_to_integer(B)
+    catch
+        _:_ -> error
+    end.
+
+-spec trim(binary()) -> binary().
+trim(B) -> string:trim(B).

--- a/test/asobi_peer_tests.erl
+++ b/test/asobi_peer_tests.erl
@@ -1,0 +1,68 @@
+-module(asobi_peer_tests).
+-include_lib("eunit/include/eunit.hrl").
+
+peer_test_() ->
+    {foreach, fun setup/0, fun cleanup/1, [
+        fun no_trusted_returns_peer/0,
+        fun untrusted_peer_ignores_xff/0,
+        fun trusted_peer_uses_xff/0,
+        fun strips_trusted_hops/0,
+        fun trusted_peer_no_xff_returns_peer/0,
+        fun ipv6_trusted_proxy/0
+    ]}.
+
+setup() ->
+    application:unset_env(asobi, trusted_proxies),
+    ok.
+
+cleanup(_) ->
+    application:unset_env(asobi, trusted_proxies),
+    ok.
+
+no_trusted_returns_peer() ->
+    ?assertEqual(
+        ~"203.0.113.5",
+        asobi_peer:client_ip(req({{203, 0, 113, 5}, 1234}, ~"1.2.3.4"))
+    ).
+
+untrusted_peer_ignores_xff() ->
+    application:set_env(asobi, trusted_proxies, [~"10.0.0.0/8"]),
+    %% Peer is NOT a trusted proxy, so the client-supplied XFF must be ignored.
+    ?assertEqual(
+        ~"203.0.113.5",
+        asobi_peer:client_ip(req({{203, 0, 113, 5}, 1234}, ~"1.2.3.4"))
+    ).
+
+trusted_peer_uses_xff() ->
+    application:set_env(asobi, trusted_proxies, [~"10.0.0.0/8"]),
+    ?assertEqual(
+        ~"203.0.113.9",
+        asobi_peer:client_ip(req({{10, 1, 2, 3}, 1234}, ~"203.0.113.9"))
+    ).
+
+strips_trusted_hops() ->
+    application:set_env(asobi, trusted_proxies, [~"10.0.0.0/8"]),
+    %% Right-most untrusted hop is the real client.
+    ?assertEqual(
+        ~"203.0.113.9",
+        asobi_peer:client_ip(req({{10, 0, 0, 1}, 1234}, ~"203.0.113.9, 10.0.0.5"))
+    ).
+
+trusted_peer_no_xff_returns_peer() ->
+    application:set_env(asobi, trusted_proxies, [~"10.0.0.0/8"]),
+    ?assertEqual(
+        ~"10.0.0.1",
+        asobi_peer:client_ip(req({{10, 0, 0, 1}, 1234}, undefined))
+    ).
+
+ipv6_trusted_proxy() ->
+    application:set_env(asobi, trusted_proxies, [~"::1/128"]),
+    ?assertEqual(
+        ~"2001:db8::1",
+        asobi_peer:client_ip(req({{0, 0, 0, 0, 0, 0, 0, 1}, 1234}, ~"2001:db8::1"))
+    ).
+
+req(Peer, undefined) ->
+    #{peer => Peer, headers => #{}};
+req(Peer, Xff) ->
+    #{peer => Peer, headers => #{~"x-forwarded-for" => Xff}}.


### PR DESCRIPTION
From the SDK-access security review (HIGH). `asobi_peer` keyed rate limits off the socket peer and deliberately ignored `X-Forwarded-For`. Behind Traefik/ingress that means **every client shares one bucket** (global 5/s auth cap); without a proxy, per-IP limits are IP-rotation-bypassable. This undercuts per-IP / per-account / per-key limiting across the board.

`client_ip/1` now derives the real client from `X-Forwarded-For` — but only when the socket peer is itself within a configured `trusted_proxies` range (so an untrusted client can't spoof its key). Right-most non-trusted hop wins. v4 + v6 CIDR matching. Default (no config) = unchanged (socket peer).

Config:
```erlang
{asobi, [{trusted_proxies, [~"10.0.0.0/8", ~"::1/128"]}]}
```

Tests: no-config→peer; untrusted-peer ignores XFF; trusted-peer uses XFF; strips trusted hops; no-XFF→peer; IPv6. eunit 6/0, fmt/xref clean.

**Deploy note:** set `trusted_proxies` to your Traefik/pod CIDR, or per-IP limiting stays collapsed to the ingress IP.