### PR TITLE
fix(auth): harden Steam ticket validation

### DIFF
--- a/src/auth/asobi_steam.erl
+++ b/src/auth/asobi_steam.erl
@@ -62,7 +62,8 @@ do_validate_ticket(ApiKey, AppId, Ticket) ->
         ~"&appid=",
         url_encode(AppId),
         ~"&ticket=",
-        url_encode(Ticket)
+        url_encode(Ticket),
+        identity_param()
     ]),
     case
         httpc:request(get, {binary_to_list(Url), []}, [{timeout, 10000}], [{body_format, binary}])
@@ -80,22 +81,34 @@ do_validate_ticket(ApiKey, AppId, Ticket) ->
 -spec parse_auth_response(binary()) -> {ok, map()} | {error, binary()}.
 parse_auth_response(Body) ->
     case json:decode(Body) of
-        #{~"response" := #{~"params" := #{~"result" := ~"OK", ~"steamid" := SteamId}}} when
+        #{~"response" := #{~"params" := #{~"result" := ~"OK", ~"steamid" := SteamId} = Params}} when
             is_binary(SteamId)
         ->
-            maybe_fetch_profile(SteamId);
+            check_bans(SteamId, Params);
         #{~"response" := #{~"error" := #{~"errordesc" := Desc}}} when is_binary(Desc) ->
             {error, Desc};
         _ ->
             {error, ~"invalid_steam_response"}
     end.
 
--spec maybe_fetch_profile(binary()) -> {ok, map()}.
-maybe_fetch_profile(SteamId) ->
+%% Reject tickets banned from THIS app. `ownersteamid` differing from
+%% `steamid` means Family Sharing (borrowed copy) — surfaced in the claims so
+%% game policy can decide, not hard-rejected here.
+-spec check_bans(binary(), map()) -> {ok, map()} | {error, binary()}.
+check_bans(SteamId, Params) ->
+    case maps:get(~"publisherbanned", Params, false) of
+        true -> {error, ~"publisher_banned"};
+        _ -> maybe_fetch_profile(SteamId, Params)
+    end.
+
+-spec maybe_fetch_profile(binary(), map()) -> {ok, map()}.
+maybe_fetch_profile(SteamId, Params) ->
     Claims = #{
         provider_uid => SteamId,
         provider_email => undefined,
-        provider_display_name => undefined
+        provider_display_name => undefined,
+        owner_steamid => maps:get(~"ownersteamid", Params, SteamId),
+        vac_banned => maps:get(~"vacbanned", Params, false)
     },
     case fetch_player_summary(SteamId) of
         {ok, Summary} ->
@@ -148,6 +161,16 @@ steam_app_id() ->
     case application:get_env(asobi, steam_app_id, ~"0") of
         V when is_binary(V) -> V;
         _ -> ~"0"
+    end.
+
+%% Optional `identity` string binding the ticket to this service. When the game
+%% client passes the same identity to GetAuthSessionTicket, Steam rejects a
+%% ticket minted for a different service — blunting cross-service replay.
+-spec identity_param() -> binary().
+identity_param() ->
+    case application:get_env(asobi, steam_identity, undefined) of
+        V when is_binary(V), V =/= <<>> -> <<"&identity=", (url_encode(V))/binary>>;
+        _ -> <<>>
     end.
 
 -spec url_encode(binary()) -> binary().

--- a/test/asobi_steam_tests.erl
+++ b/test/asobi_steam_tests.erl
@@ -1,0 +1,61 @@
+-module(asobi_steam_tests).
+-include_lib("eunit/include/eunit.hrl").
+
+steam_test_() ->
+    {foreach, fun setup/0, fun cleanup/1, [
+        fun ok_ticket_returns_claims/0,
+        fun publisher_banned_rejected/0,
+        fun identity_param_included_when_configured/0
+    ]}.
+
+setup() ->
+    application:set_env(asobi, steam_api_key, ~"test-key"),
+    application:set_env(asobi, steam_app_id, ~"480"),
+    application:unset_env(asobi, steam_identity),
+    meck:new(httpc, [unstick, no_link]),
+    ok.
+
+cleanup(_) ->
+    meck:unload(httpc),
+    application:unset_env(asobi, steam_api_key),
+    application:unset_env(asobi, steam_app_id),
+    application:unset_env(asobi, steam_identity),
+    ok.
+
+ok_ticket_returns_claims() ->
+    stub_steam(#{~"result" => ~"OK", ~"steamid" => ~"123", ~"ownersteamid" => ~"123"}),
+    {ok, Claims} = asobi_steam:validate_ticket(~"deadbeef"),
+    ?assertEqual(~"123", maps:get(provider_uid, Claims)),
+    ?assertEqual(~"123", maps:get(owner_steamid, Claims)),
+    ?assertEqual(false, maps:get(vac_banned, Claims)).
+
+publisher_banned_rejected() ->
+    stub_steam(#{~"result" => ~"OK", ~"steamid" => ~"123", ~"publisherbanned" => true}),
+    ?assertEqual({error, ~"publisher_banned"}, asobi_steam:validate_ticket(~"deadbeef")).
+
+identity_param_included_when_configured() ->
+    application:set_env(asobi, steam_identity, ~"asobi-prod"),
+    Self = self(),
+    meck:expect(httpc, request, fun(get, {Url, _H}, _O, _P) ->
+        Self ! {url, list_to_binary(Url)},
+        {ok, {{"HTTP/1.1", 200, "OK"}, [], auth_body(#{~"result" => ~"OK", ~"steamid" => ~"1"})}}
+    end),
+    _ = asobi_steam:validate_ticket(~"deadbeef"),
+    receive
+        {url, Url} -> ?assert(binary:match(Url, ~"&identity=asobi-prod") =/= nomatch)
+    after 1000 -> ?assert(false)
+    end.
+
+%% Route both Steam calls (ticket auth + optional profile fetch) to canned bodies.
+stub_steam(Params) ->
+    meck:expect(httpc, request, fun(get, {Url, _H}, _O, _P) ->
+        Body =
+            case binary:match(list_to_binary(Url), ~"GetPlayerSummaries") of
+                nomatch -> auth_body(Params);
+                _ -> ~"{\"response\":{\"players\":[]}}"
+            end,
+        {ok, {{"HTTP/1.1", 200, "OK"}, [], Body}}
+    end).
+
+auth_body(Params) ->
+    iolist_to_binary(json:encode(#{~"response" => #{~"params" => Params}})).


### PR DESCRIPTION
From the SDK-access security review (HIGH). Steam ticket validation only checked `result == "OK"` + `steamid`.

- **Ticket→service binding:** optional `steam_identity` passed as the AuthenticateUserTicket `identity` param — when the client sets the same identity on `GetAuthSessionTicket`, Steam rejects a ticket minted for another service (blunts cross-service replay). *(Coordinated: the SDK must send the matching identity; no-op until configured.)*
- **`publisherbanned` → rejected** (banned from this app).
- **`ownersteamid`** (Family Sharing: owner ≠ player) and **`vacbanned`** surfaced in claims for game-policy use.

Tests (mock `httpc`): OK ticket → claims incl. owner/vac; publisher-banned → error; identity param present when configured. eunit 3/0, fmt/xref clean.

Follow-up (MEDIUM): short-window ticket dedup cache.