### PR TITLE
fix(iap): dedup receipts and bind them to the player

### DIFF
--- a/src/controllers/asobi_iap_controller.erl
+++ b/src/controllers/asobi_iap_controller.erl
@@ -5,10 +5,12 @@
 %% POST /api/v1/iap/apple
 %% Body: {"signed_transaction": "<JWS string>"}
 -spec verify_apple(cowboy_req:req()) -> {json, integer(), map(), map()}.
-verify_apple(#{json := #{~"signed_transaction" := SignedTxn}} = _Req) when is_binary(SignedTxn) ->
+verify_apple(
+    #{json := #{~"signed_transaction" := SignedTxn}, auth_data := #{player_id := PlayerId}} = _Req
+) when is_binary(SignedTxn), is_binary(PlayerId) ->
     case asobi_iap:verify_apple(SignedTxn) of
         {ok, Result} ->
-            {json, 200, #{}, Result};
+            record(PlayerId, ~"apple", maps:get(transaction_id, Result, undefined), Result);
         {error, Reason} ->
             {json, 422, #{}, #{error => Reason}}
     end;
@@ -18,12 +20,65 @@ verify_apple(_Req) ->
 %% POST /api/v1/iap/google
 %% Body: {"product_id": "...", "purchase_token": "..."}
 -spec verify_google(cowboy_req:req()) -> {json, integer(), map(), map()}.
-verify_google(#{json := Params} = _Req) when is_map(Params) ->
+verify_google(#{json := Params, auth_data := #{player_id := PlayerId}} = _Req) when
+    is_map(Params), is_binary(PlayerId)
+->
     case asobi_iap:verify_google(Params) of
         {ok, Result} ->
-            {json, 200, #{}, Result};
+            record(PlayerId, ~"google", maps:get(order_id, Result, undefined), Result);
         {error, Reason} ->
             {json, 422, #{}, #{error => Reason}}
     end;
 verify_google(_Req) ->
     {json, 400, #{}, #{error => ~"missing_required_fields"}}.
+
+%% --- Internal ---
+
+%% Persist the verified transaction bound to the player, exactly once.
+%% Re-submitting the same receipt is idempotent for the owner (`duplicate` =>
+%% true) and rejected for anyone else — a receipt can be claimed by one player.
+-spec record(binary(), binary(), binary() | undefined, map()) -> {json, integer(), map(), map()}.
+record(_PlayerId, _Provider, undefined, _Result) ->
+    {json, 422, #{}, #{error => ~"missing_transaction_id"}};
+record(PlayerId, Provider, TxnId, Result) when is_binary(TxnId) ->
+    case existing(Provider, TxnId) of
+        {ok, #{player_id := PlayerId}} ->
+            {json, 200, #{}, Result#{duplicate => true}};
+        {ok, _Other} ->
+            {json, 409, #{}, #{error => ~"transaction_already_claimed"}};
+        none ->
+            insert_new(PlayerId, Provider, TxnId, Result)
+    end.
+
+-spec insert_new(binary(), binary(), binary(), map()) -> {json, integer(), map(), map()}.
+insert_new(PlayerId, Provider, TxnId, Result) ->
+    CS = asobi_iap_transaction:changeset(#{}, #{
+        player_id => PlayerId,
+        provider => Provider,
+        transaction_id => TxnId,
+        original_transaction_id => maps:get(original_transaction_id, Result, undefined),
+        product_id => maps:get(product_id, Result, undefined)
+    }),
+    case asobi_repo:insert(CS) of
+        {ok, _} ->
+            {json, 200, #{}, Result#{duplicate => false}};
+        {error, _Reason} ->
+            %% Most likely the unique index firing on a concurrent submit of the
+            %% same receipt. Re-check: if it now exists it was a race, else a
+            %% genuine store failure.
+            case existing(Provider, TxnId) of
+                {ok, _} -> {json, 409, #{}, #{error => ~"transaction_already_claimed"}};
+                none -> {json, 500, #{}, #{error => ~"record_failed"}}
+            end
+    end.
+
+-spec existing(binary(), binary()) -> {ok, map()} | none.
+existing(Provider, TxnId) ->
+    Q = kura_query:where(
+        kura_query:where(kura_query:from(asobi_iap_transaction), {provider, Provider}),
+        {transaction_id, TxnId}
+    ),
+    case asobi_repo:all(Q) of
+        {ok, [Row | _]} -> {ok, Row};
+        _ -> none
+    end.

--- a/src/iap/asobi_iap_transaction.erl
+++ b/src/iap/asobi_iap_transaction.erl
@@ -1,0 +1,41 @@
+-module(asobi_iap_transaction).
+-behaviour(kura_schema).
+
+-include_lib("kura/include/kura.hrl").
+
+-export([table/0, fields/0, associations/0, indexes/0, generate_id/0, changeset/2]).
+
+-spec table() -> binary().
+table() -> ~"iap_transactions".
+
+-spec fields() -> [#kura_field{}].
+fields() ->
+    [
+        #kura_field{name = id, type = uuid, primary_key = true, nullable = false},
+        #kura_field{name = player_id, type = uuid, nullable = false},
+        #kura_field{name = provider, type = string, nullable = false},
+        #kura_field{name = transaction_id, type = string, nullable = false},
+        #kura_field{name = original_transaction_id, type = string},
+        #kura_field{name = product_id, type = string},
+        #kura_field{name = inserted_at, type = utc_datetime, nullable = false}
+    ].
+
+-spec associations() -> [#kura_assoc{}].
+associations() -> [].
+
+-spec indexes() -> [{[atom()], map()}].
+indexes() ->
+    [
+        {[provider, transaction_id], #{unique => true}},
+        {[player_id], #{}}
+    ].
+
+-spec generate_id() -> binary().
+generate_id() -> asobi_id:generate().
+
+-spec changeset(map(), map()) -> #kura_changeset{}.
+changeset(Data, Params) ->
+    CS = kura_changeset:cast(?MODULE, Data, Params, [
+        player_id, provider, transaction_id, original_transaction_id, product_id
+    ]),
+    kura_changeset:validate_required(CS, [player_id, provider, transaction_id]).

--- a/src/migrations/m20260701120000_create_iap_transactions.erl
+++ b/src/migrations/m20260701120000_create_iap_transactions.erl
@@ -1,0 +1,35 @@
+-module(m20260701120000_create_iap_transactions).
+-moduledoc false.
+-behaviour(kura_migration).
+-include_lib("kura/include/kura.hrl").
+-export([up/0, down/0]).
+
+-spec up() -> [kura_migration:operation()].
+up() ->
+    [
+        {create_table, <<"iap_transactions">>, [
+            #kura_column{name = id, type = uuid, primary_key = true, nullable = false},
+            #kura_column{
+                name = player_id,
+                type = uuid,
+                nullable = false,
+                references = {<<"players">>, id},
+                on_delete = no_action
+            },
+            #kura_column{name = provider, type = string, nullable = false},
+            #kura_column{name = transaction_id, type = string, nullable = false},
+            #kura_column{name = original_transaction_id, type = string},
+            #kura_column{name = product_id, type = string},
+            #kura_column{name = inserted_at, type = utc_datetime, nullable = false}
+        ]},
+        %% Unique per provider transaction: the DB backstop against receipt
+        %% replay (a store transaction can be claimed exactly once).
+        {create_index, <<"iap_transactions">>, [provider, transaction_id], #{unique => true}},
+        {create_index, <<"iap_transactions">>, [player_id], #{}}
+    ].
+
+-spec down() -> [kura_migration:operation()].
+down() ->
+    [
+        {drop_table, <<"iap_transactions">>}
+    ].

--- a/test/asobi_iap_controller_tests.erl
+++ b/test/asobi_iap_controller_tests.erl
@@ -1,0 +1,80 @@
+-module(asobi_iap_controller_tests).
+-include_lib("eunit/include/eunit.hrl").
+
+iap_test_() ->
+    {foreach, fun setup/0, fun cleanup/1, [
+        fun first_purchase_recorded/0,
+        fun duplicate_same_player_idempotent/0,
+        fun cross_account_replay_rejected/0,
+        fun unauthenticated_rejected/0,
+        fun verify_failure_surfaced/0,
+        fun google_uses_order_id/0
+    ]}.
+
+setup() ->
+    meck:new(asobi_iap, [no_link]),
+    meck:new(asobi_repo, [no_link]),
+    ok.
+
+cleanup(_) ->
+    meck:unload(asobi_iap),
+    meck:unload(asobi_repo),
+    ok.
+
+first_purchase_recorded() ->
+    stub_apple(#{transaction_id => ~"t1", product_id => ~"coins", original_transaction_id => ~"t1"}),
+    no_existing(),
+    meck:expect(asobi_repo, insert, fun(_CS) -> {ok, #{}} end),
+    {json, 200, _, Body} = asobi_iap_controller:verify_apple(apple_req(~"p1")),
+    ?assertEqual(false, maps:get(duplicate, Body)),
+    ?assert(meck:called(asobi_repo, insert, '_')).
+
+duplicate_same_player_idempotent() ->
+    stub_apple(#{transaction_id => ~"t1", product_id => ~"coins"}),
+    meck:expect(asobi_repo, all, fun(_Q) -> {ok, [#{player_id => ~"p1"}]} end),
+    {json, 200, _, Body} = asobi_iap_controller:verify_apple(apple_req(~"p1")),
+    ?assertEqual(true, maps:get(duplicate, Body)),
+    ?assertNot(meck:called(asobi_repo, insert, '_')).
+
+cross_account_replay_rejected() ->
+    stub_apple(#{transaction_id => ~"t1", product_id => ~"coins"}),
+    meck:expect(asobi_repo, all, fun(_Q) -> {ok, [#{player_id => ~"someone-else"}]} end),
+    ?assertMatch(
+        {json, 409, _, #{error := ~"transaction_already_claimed"}},
+        asobi_iap_controller:verify_apple(apple_req(~"p1"))
+    ).
+
+unauthenticated_rejected() ->
+    Req = #{json => #{~"signed_transaction" => ~"jws"}},
+    ?assertMatch({json, 400, _, _}, asobi_iap_controller:verify_apple(Req)).
+
+verify_failure_surfaced() ->
+    meck:expect(asobi_iap, verify_apple, fun(_) -> {error, ~"bundle_id_mismatch"} end),
+    ?assertMatch(
+        {json, 422, _, #{error := ~"bundle_id_mismatch"}},
+        asobi_iap_controller:verify_apple(apple_req(~"p1"))
+    ).
+
+google_uses_order_id() ->
+    meck:expect(asobi_iap, verify_google, fun(_) ->
+        {ok, #{order_id => ~"GPA.1", product_id => ~"coins"}}
+    end),
+    no_existing(),
+    meck:expect(asobi_repo, insert, fun(_CS) -> {ok, #{}} end),
+    Req = #{
+        json => #{~"product_id" => ~"coins", ~"purchase_token" => ~"tok"},
+        auth_data => #{player_id => ~"p1"}
+    },
+    {json, 200, _, Body} = asobi_iap_controller:verify_google(Req),
+    ?assertEqual(false, maps:get(duplicate, Body)).
+
+%% Helpers
+
+apple_req(PlayerId) ->
+    #{json => #{~"signed_transaction" => ~"jws"}, auth_data => #{player_id => PlayerId}}.
+
+stub_apple(Result) ->
+    meck:expect(asobi_iap, verify_apple, fun(_) -> {ok, Result} end).
+
+no_existing() ->
+    meck:expect(asobi_repo, all, fun(_Q) -> {ok, []} end).


### PR DESCRIPTION
From the SDK-access security review (HIGH — the sharpest fraud vector). IAP endpoints verified receipts but **stored nothing and never bound them to a player** → one valid receipt is replayable forever and submittable across accounts (an entitlement multiplier, especially with cheap anonymous accounts).

## Change
- New **`iap_transactions`** table (migration) with a **UNIQUE `(provider, transaction_id)`** index (the DB replay backstop) + schema module.
- `verify_apple` / `verify_google` now **require the authenticated `player_id`** and key on `transaction_id` (Apple) / `order_id` (Google):
  - first claim → persist bound to player, `duplicate=false`
  - same player re-submits → idempotent `duplicate=true` (no re-grant)
  - **different player → `409 transaction_already_claimed`**
  - concurrent double-submit → unique index fires → re-check → 409

## Tests
Mock `asobi_iap` + `asobi_repo`: first / dup-same-player / cross-account / unauthenticated / verify-error / google-order-id. eunit 282/0, fmt/xref clean.

## ⚠️ Needs live verify
The migration + unique-constraint path run against Postgres in **CI**, not locally. After deploy, confirm the table exists and a cross-account replay returns 409.

Follow-up (from the review): use Apple `appAccountToken` / Google `obfuscatedAccountId` to bind the receipt to the account *before* purchase, and gate IAP behind non-anon accounts.