### PR TITLE
ci: skip release on docs-only changes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,6 +3,11 @@ name: Release
 on:
   push:
     branches: [main]
+    paths-ignore:
+      - '**.md'
+      - 'docs/**'
+      - 'guides/**'
+      - 'LICENSE'
 
 jobs:
   release:


### PR DESCRIPTION
Docs-only merges to main currently cut a release. Add `paths-ignore` (`**.md`, `docs/**`, `guides/**`, `LICENSE`) to the release trigger so a pure-docs merge no longer tags/publishes a release. Mixed code+docs merges still release normally.

This is a prerequisite for the upcoming docs restructure so README/guide edits do not spam releases.