### PR TITLE
docs: render the Erlang API in ex_doc (-moduledoc/-doc)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,52 @@
+# Contributing to Asobi
+
+Thanks for helping improve Asobi.
+
+## Build
+
+Requires Erlang/OTP 28 or later and rebar3.
+
+```bash
+rebar3 compile
+```
+
+## Tests
+
+```bash
+rebar3 eunit
+rebar3 ct
+```
+
+The Common Test suites exercise the HTTP and WebSocket API against a real
+Postgres; bring one up with Docker before running them.
+
+## Pre-push checklist
+
+Run these before opening a pull request and fix every warning, doc
+warnings included:
+
+```bash
+rebar3 fmt --check
+rebar3 xref
+rebar3 dialyzer
+rebar3 ex_doc
+rebar3 eunit
+rebar3 ct
+```
+
+## Pull requests
+
+- Branch off `main`; do not push to `main` directly.
+- Use conventional commit messages (`feat:`, `fix:`, `docs:`, `refactor:`, ...).
+- Keep changes focused, and add or update tests alongside the code.
+- Public modules use `-moduledoc`/`-doc` attributes so they render in the
+  generated API reference.
+
+## Security
+
+Do not open public issues for vulnerabilities. See [SECURITY.md](SECURITY.md).
+
+## License
+
+By contributing you agree that your contributions are licensed under
+Apache-2.0.

--- a/rebar.config
+++ b/rebar.config
@@ -114,7 +114,16 @@
         <<"guides/security-threat-model.md">>,
         <<"guides/security-auth.md">>,
         <<"guides/security-known-limitations.md">>,
-        <<"SECURITY.md">>
+        <<"guides/migrate-from-nakama.md">>,
+        <<"guides/migrate-from-playfab.md">>,
+        <<"guides/migrate-from-hathora.md">>,
+        <<"guides/architecture.md">>,
+        <<"guides/benchmarks.md">>,
+        <<"guides/glossary.md">>,
+        <<"guides/exit.md">>,
+        <<"SECURITY.md">>,
+        <<"CONTRIBUTING.md">>,
+        <<"LICENSE">>
     ]},
     {groups_for_extras, [
         {<<"Getting Started">>, [

--- a/src/matches/asobi_match.erl
+++ b/src/matches/asobi_match.erl
@@ -1,52 +1,104 @@
 -module(asobi_match).
+-moduledoc """
+The behaviour a game developer implements to define server-authoritative
+game logic. Each game mode is a module that implements this behaviour;
+Asobi runs one process per match and invokes these callbacks at the right
+moments in the match lifecycle.
 
-%% Behaviour that game developers implement to define their game logic.
-%%
-%% Example:
-%%   -module(my_card_game).
-%%   -behaviour(asobi_match).
-%%   -export([init/1, join/2, leave/2, handle_input/3, tick/1, get_state/2]).
-%%
-%%   init(Config) -> {ok, #{deck => shuffle(Config), players => #{}}}.
-%%   join(PlayerId, State) -> {ok, State#{players => ...}}.
-%%   tick(State) -> {ok, State}.  %% or {finished, Result, State}
+The Lua runtime (`asobi_lua`) implements this behaviour on your behalf, so
+a Lua `match.lua` and an Erlang `asobi_match` module are the same contract
+on two surfaces. Most games are written in Lua; implement this behaviour
+directly when you want behaviour-level control or are embedding Asobi in an
+existing OTP application.
 
+## Example
+
+```erlang
+-module(my_card_game).
+-behaviour(asobi_match).
+-export([init/1, join/2, leave/2, handle_input/3, tick/1, get_state/2]).
+
+init(Config)            -> {ok, #{deck => shuffle(Config), players => #{}}}.
+join(PlayerId, State)   -> {ok, State#{players => add(PlayerId, State)}}.
+leave(_PlayerId, State) -> {ok, State}.
+handle_input(_P, _I, S) -> {ok, S}.
+tick(State)             -> {ok, State}.
+get_state(_PlayerId, S) -> S.
+```
+
+Required: `c:init/1`, `c:join/2`, `c:leave/2`, `c:handle_input/3`, and
+exactly one of `c:get_state/2` or `c:get_state/1`. Every other callback is
+optional (see `optional_callbacks`).
+""".
+
+-doc """
+Called once when the match is created, with the mode config it was started
+with. Returns the initial game state, which is threaded through every other
+callback.
+""".
 -callback init(Config :: map()) ->
     {ok, GameState :: term()}.
 
+-doc """
+A player is joining. Accept and attach them, returning the new state, or
+reject with `{error, Reason}` (for example when the match is already full or
+in progress).
+""".
 -callback join(PlayerId :: binary(), GameState :: term()) ->
     {ok, GameState1 :: term()} | {error, Reason :: term()}.
 
+-doc "A player disconnected or was removed. Cannot fail. Use it to release reservations, stop timers, or forfeit.".
 -callback leave(PlayerId :: binary(), GameState :: term()) ->
     {ok, GameState1 :: term()}.
 
+-doc """
+A player action arrived over the WebSocket. Validate and apply it. Inputs
+are serialised onto the match process, so state can be mutated here without
+races.
+""".
 -callback handle_input(PlayerId :: binary(), Input :: map(), GameState :: term()) ->
     {ok, GameState1 :: term()} | {error, Reason :: term()}.
 
+-doc """
+Called on a fixed interval (default 10 Hz, configurable per mode). Advance
+time, run AI, and check win conditions. Return `{finished, Result, State}`
+to end the match. Optional: omit it if your game has no fixed time step.
+""".
 -callback tick(GameState :: term()) ->
     {ok, GameState1 :: term()}
     | {finished, Result :: map(), GameState1 :: term()}.
 
+-doc """
+Project the full match state into what this player should see. Hide opponent
+hands, out-of-sight positions, and hidden rolls here.
+""".
 -callback get_state(PlayerId :: binary(), GameState :: term()) ->
     StateForPlayer :: map().
 
-%% Shared-payload variant. Avoids the per-player encode cost when every
-%% player sees the same world. Mutually exclusive with get_state/2 — export
-%% exactly one.
+-doc """
+Shared-payload variant of `c:get_state/2`. Avoids the per-player encode cost
+when every player sees the same world. Mutually exclusive with
+`c:get_state/2` - export exactly one.
+""".
 -callback get_state(GameState :: term()) ->
     SharedState :: map().
 
+-doc "Optional. Return a vote configuration to open an in-match vote, or `none`.".
 -callback vote_requested(GameState :: term()) ->
     {ok, VoteConfig :: map()} | none.
 
+-doc "Optional. React to a resolved vote; `Result` carries the winning option.".
 -callback vote_resolved(Template :: binary(), Result :: map(), GameState :: term()) ->
     {ok, GameState1 :: term()}.
 
+-doc "Optional. Declare named, timed phases (lobby, active, results). Supported for Erlang match games and Lua world games.".
 -callback phases(Config :: map()) -> [asobi_phase:phase_def()].
 
+-doc "Optional. Hook invoked when a declared phase begins.".
 -callback on_phase_started(PhaseName :: binary(), GameState :: term()) ->
     {ok, GameState1 :: term()}.
 
+-doc "Optional. Hook invoked when a declared phase ends.".
 -callback on_phase_ended(PhaseName :: binary(), GameState :: term()) ->
     {ok, GameState1 :: term()}.
 

--- a/src/matches/asobi_matchmaker.erl
+++ b/src/matches/asobi_matchmaker.erl
@@ -1,4 +1,10 @@
 -module(asobi_matchmaker).
+-moduledoc """
+The matchmaking queue. Players submit tickets with a mode and property
+constraints (`add/2`); a pluggable strategy groups compatible tickets,
+spawns a match, and pushes `match.matched` to each player. A single
+`gen_server` owns the queue and ticks it on an interval.
+""".
 -behaviour(gen_server).
 
 -export([start_link/0, add/2, remove/2, get_ticket/1, get_ticket/2, get_queue_stats/0]).

--- a/src/world/asobi_spatial.erl
+++ b/src/world/asobi_spatial.erl
@@ -1,7 +1,10 @@
 -module(asobi_spatial).
-
-%% Spatial query primitives for zone entities.
-%% Pure functional — no process, no state. Operates on entity maps.
+-moduledoc """
+Spatial query primitives over zone entities: radius and rectangle queries,
+nearest-neighbour, range and distance helpers. Pure functional - no
+process, no state - operating on entity maps, so `asobi_zone` and game code
+can call it directly.
+""".
 
 -export([query_radius/3, query_radius/4]).
 -export([query_rect/3, query_rect/4]).

--- a/src/world/asobi_world_server.erl
+++ b/src/world/asobi_world_server.erl
@@ -1,4 +1,11 @@
 -module(asobi_world_server).
+-moduledoc """
+A persistent, zoned world: the `gen_statem` behind large session games
+(`game_type = "world"`). It partitions space into a grid of `asobi_zone`
+processes, moves players between zones as they travel, runs a world-level
+`post_tick`, and drives voting. Use it for MMO-style shared spaces; for
+transient matches use `asobi_match_server` instead.
+""".
 -behaviour(gen_statem).
 
 -export([start_link/1, join/2, join/3, leave/2, move_player/3, post_tick/2, get_info/1, cancel/1]).

--- a/src/world/asobi_zone.erl
+++ b/src/world/asobi_zone.erl
@@ -1,4 +1,10 @@
 -module(asobi_zone).
+-moduledoc """
+One spatial partition of an `asobi_world_server`. A `gen_server` that owns
+the entities in its cell of the grid, ticks their simulation, applies
+player input, manages interest (subscribers), and answers spatial queries
+via `asobi_spatial`. Zones are created and reaped lazily as players move.
+""".
 -behaviour(gen_server).
 
 -export([start_link/1, reap/1]).


### PR DESCRIPTION
Phase 2 of the docs restructure. The product docs now point the Erlang-native path at ex_doc (`/docs/erlang/api` → "read them on the asobi repository"), so the generated API reference needs to actually be useful. It wasn't: the key modules documented themselves with old `%%` comments that ex_doc ignores.

## Changes
- **`asobi_match`**: converted to `-moduledoc` + `-doc` on every behaviour callback (init/join/leave/handle_input/tick/get_state/1,2/vote_*/phases/on_phase_*). This is the canonical contract the Lua runtime implements on your behalf.
- **`asobi_matchmaker`, `asobi_world_server`, `asobi_zone`, `asobi_spatial`**: added `-moduledoc` summaries (`asobi_match_server` already had one).
- **ex_doc extras**: added guides that existed on disk but were unlisted (`migrate-from-*`, `architecture`, `benchmarks`, `glossary`, `exit`), plus `LICENSE` and `CONTRIBUTING`. Added a **`CONTRIBUTING.md`** (the README linked a file that didn't exist).

## Verification
- `rebar3 ex_doc` → **0 warnings** (was 20, all pre-existing broken guide/README links).
- `doc/asobi_match.html` renders the behaviour doc + per-callback docs.
- `rebar3 fmt --check` + `rebar3 xref` clean.

## Follow-up
Per-function `-doc` on the non-behaviour modules' public functions (matchmaker `add`/`remove`, world_server `join`/`spawn_at`, zone/spatial queries) is incremental; the module summaries + the fully-documented behaviour cover the load-bearing surface. Publishing to HexDocs would let `/docs/erlang/api` link to `hexdocs.pm/asobi` instead of the repo.