### PR TITLE
fix(ci): bust stale nightly _build cache holding pre-OTP-29 meck

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -48,9 +48,12 @@ jobs:
         uses: actions/cache@v4
         with:
           path: _build
-          key: nightly-prop-${{ hashFiles('rebar.lock') }}
+          # rebar.config is hashed too: test-profile deps (meck, proper) are not
+          # written to rebar.lock, so a lock-only key never busts when they bump.
+          # The -v2- prefix retires the poisoned pre-OTP-29 caches (stale meck 0.9).
+          key: nightly-prop-v2-${{ hashFiles('rebar.config', 'rebar.lock') }}
           restore-keys: |
-            nightly-prop-
+            nightly-prop-v2-
 
       - name: Run property tests at high numtests
         run: |


### PR DESCRIPTION
## Problem
Nightly `Property Tests` has failed every night since #138 (OTP 29 build). The failure is a **compile error in `meck`**, not a property test:

```
===> Compiling _build/test/lib/meck/src/meck_matcher.erl failed
 76 │  (catch erlang:apply(hamcrest, assert_that, [Value, HamcrestMatcher])) == true;
    │   ╰── 'catch ...' is deprecated; please use 'try ... catch ... end' instead.
##[error]Process completed with exit code 1.
```

The property tests never run — so the real bugs behind #128 and #119 are currently masked.

## Root cause
#138 bumped `{meck, "~> 0.9"}` → `"~> 1.2"`. meck **1.2.0 already fixed** the bare `catch` (upstream #260, `try...catch`), so a **clean** build is fine — verified locally: `rebar3 as test compile` resolves meck 1.2.0 and compiles clean on OTP 29.

The nightly never got a clean build. Its cache key is `hashFiles('rebar.lock')`, but **meck and proper are test-profile deps that rebar3 never writes to `rebar.lock`**. So the key didn't change across the bump, and `restore-keys: nightly-prop-` blindly restored the old `_build` still holding **meck 0.9.x** (bare `catch`, fatal under OTP 29 because 0.9's own rebar.config sets `warnings_as_errors`). rebar3 recompiled the stale source instead of fetching 1.2.0.

## Fix
- Hash `rebar.config` in the cache key so test-profile dep bumps bust it.
- Bump the prefix to `nightly-prop-v2-` so `restore-keys` can't resurrect the poisoned pre-OTP-29 caches.

No source or dependency change — main's config was already correct.

## Follow-up (not in this PR)
Once green, the two masked real PropEr failures resurface: `prop_zone_snapshot_roundtrip` (#128) and `prop_input_never_dropped` (#119).