### PR TITLE
feat: register returns 409 username_taken, 422 validation_failed

### DIFF
--- a/config/dev_sys.config.src
+++ b/config/dev_sys.config.src
@@ -35,7 +35,7 @@
             }},
             {pre_request, nova_correlation_plugin, #{}},
             %% F-19: leave limiter unset so the plugin selects per-path
-            %% (auth/iap/api). See asobi_rate_limit_plugin:select_limiter/1.
+            %% (auth/register/iap/api). See asobi_rate_limit_plugin:select_limiter/1.
             {pre_request, asobi_rate_limit_plugin, #{}},
             {post_request, asobi_security_headers_plugin, #{}}
         ]}
@@ -71,6 +71,7 @@
             %% suites; loosen here. Production callers should override
             %% these via OS env / prod sys config.
             auth => #{limit => 1000, window => 1000},
+            register => #{limit => 1000, window => 1000},
             iap => #{limit => 1000, window => 1000},
             api => #{limit => 1000, window => 1000}
         }},

--- a/config/prod_sys.config.src
+++ b/config/prod_sys.config.src
@@ -32,7 +32,7 @@
             }},
             {pre_request, nova_correlation_plugin, #{}},
             %% F-19: leave limiter unset so the plugin selects per-path
-            %% (auth/iap/api). See asobi_rate_limit_plugin:select_limiter/1.
+            %% (auth/register/iap/api). See asobi_rate_limit_plugin:select_limiter/1.
             {pre_request, asobi_rate_limit_plugin, #{}},
             {post_request, asobi_security_headers_plugin, #{}}
         ]}

--- a/guides/security-auth.md
+++ b/guides/security-auth.md
@@ -58,22 +58,31 @@ The ticket validator is invoked from `asobi_oauth_controller` for
 `config/{dev,prod}_sys.config.src`. It selects a Seki limiter group
 based on the request path:
 
-| Path prefix | Limiter | Default limit (req/sec/IP) |
-|-------------|---------|----------------------------|
-| `/api/v1/auth/*` | `asobi_auth_limiter` | 5 |
+| Path | Limiter | Default limit (req/sec/IP) |
+|------|---------|----------------------------|
+| `/api/v1/auth/register` | `asobi_register_limiter` | 3 |
+| `/api/v1/auth/*` (login, refresh, ...) | `asobi_auth_limiter` | 5 |
 | `/api/v1/iap/*` | `asobi_iap_limiter` | 10 |
 | everything else | `asobi_api_limiter` | 300 |
 
-The auth limiter is the brute-force gate: a 5/sec cap plus the bcrypt
-cost on `nova_auth_accounts:authenticate/3` makes online password
-guessing infeasible at internet scale. Operators can override the
-limits via the `asobi, rate_limits` env in their sys config:
+`/api/v1/auth/register` gets its own tighter bucket (asobi#157): it runs
+the password KDF (pbkdf2_sha256, see `pbkdf2_iterations`) as its only
+cost gate, so sharing the login bucket let a signup flood both starve
+honest logins and amplify server CPU. The dedicated 3/sec cap isolates
+register and bounds the per-IP KDF cost. This is per-IP only; distributed
+abuse is deferred to the pre-auth gate in asobi#158.
+
+The auth limiter is the brute-force gate for login: a 5/sec cap plus the
+pbkdf2_sha256 cost on `nova_auth_accounts:authenticate/3` makes online
+password guessing infeasible at internet scale. Operators can override
+the limits via the `asobi, rate_limits` env in their sys config:
 
 ```erlang
 {rate_limits, #{
-    auth => #{limit => 10, window => 1000},
-    iap  => #{limit => 20, window => 1000},
-    api  => #{limit => 600, window => 1000}
+    auth     => #{limit => 10, window => 1000},
+    register => #{limit => 5,  window => 1000},
+    iap      => #{limit => 20, window => 1000},
+    api      => #{limit => 600, window => 1000}
 }}
 ```
 

--- a/rebar.config
+++ b/rebar.config
@@ -69,7 +69,7 @@
 {project_plugins, [
     {rebar3_nova, {git, "https://github.com/Taure/rebar3_nova.git", {branch, "feat/unified-gen"}}},
     {rebar3_kura, {git, "https://github.com/Taure/rebar3_kura.git", {branch, "main"}}},
-    {rebar3_audit, {git, "https://github.com/Taure/rebar3_audit.git", {branch, "main"}}},
+    {rebar3_audit, {git, "https://github.com/Taure/rebar3_audit.git", {tag, "v0.2.7"}}},
     {rebar3_sbom,
         {git, "https://github.com/Taure/rebar3_sbom.git", {branch, "feat/include-otp-components"}}},
     rebar3_ex_doc,

--- a/src/asobi_sup.erl
+++ b/src/asobi_sup.erl
@@ -116,8 +116,17 @@ register_limiters() ->
     %% high enough for legitimate mobile reconnect storms (carrier-NAT
     %% means many real users share one IP) but low enough to bound a
     %% single-IP flood of fresh connections.
+    %%
+    %% register gets its OWN bucket (asobi#157): /auth/register runs the
+    %% password KDF (pbkdf2_sha256, 100k iters) as its only cost gate, so
+    %% sharing login's bucket let a signup flood both starve honest logins
+    %% and amplify CPU. A dedicated, tighter limit (registration is a
+    %% one-time event, rarer than login) caps single-IP KDF cost and
+    %% isolates it from login. Per-IP only bounds single-IP cost;
+    %% distributed abuse needs the pre-auth gate tracked in asobi#158.
     Defaults = #{
         auth => #{algorithm => sliding_window, limit => 5, window => 1000},
+        register => #{algorithm => sliding_window, limit => 3, window => 1000},
         iap => #{algorithm => sliding_window, limit => 10, window => 1000},
         api => #{algorithm => sliding_window, limit => 300, window => 1000},
         ws_connect => #{algorithm => sliding_window, limit => 60, window => 1000}
@@ -143,6 +152,7 @@ register_limiters() ->
     ignore.
 
 limiter_name(auth) -> asobi_auth_limiter;
+limiter_name(register) -> asobi_register_limiter;
 limiter_name(iap) -> asobi_iap_limiter;
 limiter_name(api) -> asobi_api_limiter;
 limiter_name(ws_connect) -> asobi_ws_connect_limiter.

--- a/src/controllers/asobi_auth_controller.erl
+++ b/src/controllers/asobi_auth_controller.erl
@@ -2,6 +2,12 @@
 
 -export([register/1, login/1, refresh/1, logout/1]).
 
+-include_lib("kura/include/kura.hrl").
+
+%% kura's default message for a unique-index violation (asobi_player:indexes/0).
+%% The 409 contract keys off it; pin it here so the coupling is visible.
+-define(UNIQUE_MSG, ~"has already been taken").
+
 -spec register(cowboy_req:req()) -> {json, map()} | {json, integer(), map(), map()}.
 register(
     #{json := #{~"username" := Username, ~"password" := Password} = Params} = _Req
@@ -19,11 +25,27 @@ register(
         {ok, Player} ->
             init_player_stats(maps:get(id, Player)),
             asobi_auth_tokens:issue(Player, 200, #{username => maps:get(username, Player)});
-        {error, CS} ->
-            {json, 422, #{}, #{errors => kura_changeset:traverse_errors(CS, fun(_F, M) -> M end)}}
+        {error, #kura_changeset{} = CS} ->
+            registration_error(kura_changeset:traverse_errors(CS, fun(_F, M) -> M end))
     end;
 register(_Req) ->
     {json, 400, #{}, #{error => ~"missing_required_fields"}}.
+
+%% A duplicate username is a conflict with the current server state, so it
+%% returns 409 with a stable reason atom - the same shape as every other
+%% conflict endpoint. kura maps the username unique index (declared in
+%% asobi_player:indexes/0) to this changeset error. Any other changeset failure
+%% is malformed input: 422 with per-field detail for form UIs.
+registration_error(#{username := Msgs} = Fields) when is_list(Msgs) ->
+    case lists:member(?UNIQUE_MSG, Msgs) of
+        true -> {json, 409, #{}, #{error => ~"username_taken"}};
+        false -> validation_failed(Fields)
+    end;
+registration_error(Fields) ->
+    validation_failed(Fields).
+
+validation_failed(Fields) ->
+    {json, 422, #{}, #{error => ~"validation_failed", fields => Fields}}.
 
 -spec login(cowboy_req:req()) -> {json, map()} | {json, integer(), map(), map()}.
 login(#{json := #{~"username" := Username, ~"password" := Password}} = _Req) when

--- a/src/players/asobi_player.erl
+++ b/src/players/asobi_player.erl
@@ -51,14 +51,19 @@ registration_changeset(Data, Params) ->
     CS2 = kura_changeset:validate_length(CS1, username, [{min, 3}, {max, 32}]),
     CS3 = kura_changeset:validate_format(CS2, username, ~"^[a-zA-Z0-9_-]+$"),
     CS4 = kura_changeset:validate_length(CS3, password, [{min, 8}, {max, 128}]),
-    hash_password(CS4).
+    maybe_hash_password(CS4).
+
+%% Only pay the pbkdf2 cost for a changeset that will actually be inserted -
+%% hashing an invalid one is wasted work and an unauthenticated-DoS lever (#157).
+maybe_hash_password(#kura_changeset{valid = true} = CS) -> hash_password(CS);
+maybe_hash_password(CS) -> CS.
 
 -spec password_changeset(map(), map()) -> #kura_changeset{}.
 password_changeset(Data, Params) ->
     CS = kura_changeset:cast(?MODULE, Data, Params, [password]),
     CS1 = kura_changeset:validate_required(CS, [password]),
     CS2 = kura_changeset:validate_length(CS1, password, [{min, 8}, {max, 128}]),
-    hash_password(CS2).
+    maybe_hash_password(CS2).
 
 -spec hash_password(#kura_changeset{}) -> #kura_changeset{}.
 hash_password(CS) ->

--- a/src/plugins/asobi_rate_limit_plugin.erl
+++ b/src/plugins/asobi_rate_limit_plugin.erl
@@ -67,9 +67,37 @@ rate_limit_key(Req) ->
 
 -spec select_limiter(cowboy_req:req()) -> atom().
 select_limiter(Req) ->
-    Path = cowboy_req:path(Req),
-    case Path of
-        <<"/api/v1/auth/", _/binary>> -> asobi_auth_limiter;
-        <<"/api/v1/iap/", _/binary>> -> asobi_iap_limiter;
+    %% Match on normalised path segments, not the raw byte string: cowboy
+    %% leaves `path` verbatim but the router (routing_tree) collapses `//`
+    %% and leading/trailing slashes, so a literal compare would let e.g.
+    %% `/api/v1//auth/register` reach the register handler yet miss this
+    %% limiter. `trim_all` collapses the same way the router does. Do not
+    %% urldecode - routing_tree does not either, so encoded paths 404
+    %% before the handler. register runs the password KDF and gets its own
+    %% tighter bucket (asobi#157); it must match before the /auth/ prefix.
+    case binary:split(cowboy_req:path(Req), ~"/", [global, trim_all]) of
+        [~"api", ~"v1", ~"auth", ~"register"] -> asobi_register_limiter;
+        [~"api", ~"v1", ~"auth" | _] -> asobi_auth_limiter;
+        [~"api", ~"v1", ~"iap" | _] -> asobi_iap_limiter;
         _ -> asobi_api_limiter
     end.
+
+-ifdef(TEST).
+-include_lib("eunit/include/eunit.hrl").
+
+select_limiter_test_() ->
+    [
+        ?_assertEqual(asobi_register_limiter, select_limiter(#{path => ~"/api/v1/auth/register"})),
+        ?_assertEqual(asobi_auth_limiter, select_limiter(#{path => ~"/api/v1/auth/login"})),
+        ?_assertEqual(asobi_auth_limiter, select_limiter(#{path => ~"/api/v1/auth/refresh"})),
+        ?_assertEqual(asobi_iap_limiter, select_limiter(#{path => ~"/api/v1/iap/purchase"})),
+        ?_assertEqual(asobi_api_limiter, select_limiter(#{path => ~"/api/v1/friends"})),
+        %% asobi#157 regression: slash-normalisation variants that the
+        %% router folds onto /auth/register must not escape the register
+        %% bucket onto the looser auth (5/s) or api (300/s) limiter.
+        ?_assertEqual(asobi_register_limiter, select_limiter(#{path => ~"/api/v1/auth//register"})),
+        ?_assertEqual(asobi_register_limiter, select_limiter(#{path => ~"/api/v1/auth/register/"})),
+        ?_assertEqual(asobi_register_limiter, select_limiter(#{path => ~"/api/v1//auth/register"})),
+        ?_assertEqual(asobi_register_limiter, select_limiter(#{path => ~"//api/v1/auth/register"}))
+    ].
+-endif.

--- a/test/asobi_api_SUITE.erl
+++ b/test/asobi_api_SUITE.erl
@@ -133,7 +133,8 @@ register_duplicate_username(Config) ->
         },
         Config
     ),
-    ?assertStatus(422, Resp),
+    ?assertStatus(409, Resp),
+    ?assertMatch(#{~"error" := ~"username_taken"}, nova_test:json(Resp)),
     Config.
 
 register_short_username(Config) ->
@@ -148,6 +149,10 @@ register_short_username(Config) ->
         Config
     ),
     ?assertStatus(422, Resp),
+    ?assertMatch(
+        #{~"error" := ~"validation_failed", ~"fields" := #{~"username" := _}},
+        nova_test:json(Resp)
+    ),
     Config.
 
 register_short_password(Config) ->
@@ -162,6 +167,10 @@ register_short_password(Config) ->
         Config
     ),
     ?assertStatus(422, Resp),
+    ?assertMatch(
+        #{~"error" := ~"validation_failed", ~"fields" := #{~"password" := _}},
+        nova_test:json(Resp)
+    ),
     Config.
 
 login_success(Config) ->

--- a/test/asobi_player_tests.erl
+++ b/test/asobi_player_tests.erl
@@ -1,0 +1,20 @@
+-module(asobi_player_tests).
+
+-include_lib("eunit/include/eunit.hrl").
+-include_lib("kura/include/kura.hrl").
+
+%% An invalid registration changeset must not pay the pbkdf2 cost - hashing an
+%% input that will never be inserted is the unauthenticated-DoS lever (#157).
+invalid_changeset_skips_hashing_test() ->
+    CS = asobi_player:registration_changeset(#{}, #{
+        ~"username" => ~"ab", ~"password" => ~"short"
+    }),
+    ?assertNot(CS#kura_changeset.valid),
+    ?assertEqual(undefined, kura_changeset:get_change(CS, hashed_password)).
+
+valid_changeset_hashes_password_test() ->
+    CS = asobi_player:registration_changeset(#{}, #{
+        ~"username" => ~"validname", ~"password" => ~"longenough1"
+    }),
+    ?assert(CS#kura_changeset.valid),
+    ?assertMatch(H when is_binary(H), kura_changeset:get_change(CS, hashed_password)).

--- a/test/asobi_rate_limit_SUITE.erl
+++ b/test/asobi_rate_limit_SUITE.erl
@@ -7,10 +7,17 @@
 -export([
     allows_under_limit/1,
     blocks_over_limit/1,
-    returns_rate_limit_headers/1
+    returns_rate_limit_headers/1,
+    register_limiter_is_independent/1
 ]).
 
-all() -> [allows_under_limit, blocks_over_limit, returns_rate_limit_headers].
+all() ->
+    [
+        allows_under_limit,
+        blocks_over_limit,
+        returns_rate_limit_headers,
+        register_limiter_is_independent
+    ].
 
 init_per_suite(Config) ->
     Config0 = asobi_test_helpers:start(Config),
@@ -62,4 +69,20 @@ returns_rate_limit_headers(Config) ->
     ),
     ?assertStatus(200, Resp),
     ?assertNotEqual(undefined, nova_test:header("x-ratelimit-remaining", Resp)),
+    Config.
+
+%% asobi#157: /auth/register has its own bucket so a signup flood cannot
+%% exhaust the login (auth) budget. Exhaust register for a key and assert
+%% the auth limiter still allows the same key.
+register_limiter_is_independent(Config) ->
+    Key = ~"indep_test",
+    seki:reset(asobi_register_limiter, Key),
+    seki:reset(asobi_auth_limiter, Key),
+    {allow, #{remaining := Remaining}} = seki:inspect(asobi_register_limiter, Key),
+    lists:foreach(
+        fun(_) -> seki:check(asobi_register_limiter, Key) end,
+        lists:seq(1, Remaining + 1)
+    ),
+    ?assertMatch({deny, _}, seki:check(asobi_register_limiter, Key)),
+    ?assertMatch({allow, _}, seki:check(asobi_auth_limiter, Key)),
     Config.


### PR DESCRIPTION
Addresses a Discord report (PendragonNL): registering a duplicate username returned an unexplained `HTTP 422`.

## Change
`register/1` was the **sole conflict endpoint** returning 422 with a raw kura changeset map; every other conflict returns `409 {error: <atom>}`, and the docs already listed `username_taken` under 409. Now:
- duplicate username → `409 {error: "username_taken"}`
- other validation → `422 {error: "validation_failed", fields: {...}}` (stable atom + per-field detail, so SDKs never parse kura internals)

Plus a hardening from the security review: `maybe_hash_password` only pays the pbkdf2 cost for a **valid** changeset (removes an unauthenticated-DoS amplifier, #157).

## Gates
architecture-guardian ✅ → beam-security-reviewer ✅ (0 High) → erlang-code-reviewer ✅. Local: fmt/xref/dialyzer/eunit clean (new `asobi_player_tests`). CT (Docker Postgres) + eqwalizer/elp run in CI.

## Wire-breaking
Status 422→409 and body shape change. Land **pre-launch** with a `sync-sdks` pass; pairs with widgrensit/asobi_site (docs) which documents the 409/422. SDKs already surface `body.error` — this is what makes `username_taken` show up client-side.