### PR TITLE
feat: anonymous guest auth (device provider identity)

### DIFF
--- a/src/asobi_auth_error.erl
+++ b/src/asobi_auth_error.erl
@@ -1,0 +1,26 @@
+-module(asobi_auth_error).
+
+%% Shared normalization of a registration/upgrade changeset failure into the
+%% stable auth error contract, so the register and guest-upgrade paths don't
+%% each string-match kura changeset internals: a duplicate username is a 409
+%% conflict with a stable atom, anything else is a 422 validation failure with
+%% per-field detail for form UIs. (asobi_auth_controller:register/1 should adopt
+%% this once its 409 branch lands - see the register-409 change.)
+
+-export([from_changeset_fields/1]).
+
+%% kura's default message for a unique-index violation.
+-define(UNIQUE_MSG, ~"has already been taken").
+
+-spec from_changeset_fields(map()) -> {json, integer(), map(), map()}.
+from_changeset_fields(#{username := Msgs} = Fields) when is_list(Msgs) ->
+    case lists:member(?UNIQUE_MSG, Msgs) of
+        true -> {json, 409, #{}, #{error => ~"username_taken"}};
+        false -> validation_failed(Fields)
+    end;
+from_changeset_fields(Fields) ->
+    validation_failed(Fields).
+
+-spec validation_failed(map()) -> {json, 422, map(), map()}.
+validation_failed(Fields) ->
+    {json, 422, #{}, #{error => ~"validation_failed", fields => Fields}}.

--- a/src/asobi_guest_reaper.erl
+++ b/src/asobi_guest_reaper.erl
@@ -139,8 +139,12 @@ reap_older_than(Cutoff) ->
         ?REAP_BATCH
     ),
     case asobi_repo:all(Q) of
-        {ok, Identities} -> reap_all(Identities, 0);
-        _ -> 0
+        {ok, Identities} ->
+            ?LOG_NOTICE(#{event => guest_reap_candidates, count => length(Identities)}),
+            reap_all(Identities, 0);
+        Other ->
+            ?LOG_NOTICE(#{event => guest_reap_query_failed, result => Other}),
+            0
     end.
 
 -spec reap_all([map()], non_neg_integer()) -> non_neg_integer().
@@ -174,21 +178,42 @@ delete_guest_cascade(PlayerId) ->
             false ->
                 {error, claimed_during_sweep};
             true ->
-                _ = asobi_repo:delete_all(by_player(asobi_player_stats, PlayerId)),
+                %% Assert each delete: a bare `{error,_}` return (not a raise)
+                %% would otherwise let pgo commit a partial cascade (children
+                %% gone, player left). Matching {ok,_} turns that into a badmatch
+                %% that raises, rolling the whole transaction back.
+                {ok, _} = asobi_repo:delete_all(by_player(asobi_player_stats, PlayerId)),
                 %% player_tokens keys players by `user_id`, not `player_id`.
-                _ = asobi_repo:delete_all(by_user(asobi_player_token, PlayerId)),
-                _ = asobi_repo:delete_all(by_player(asobi_player_identity, PlayerId)),
+                {ok, _} = asobi_repo:delete_all(by_user(asobi_player_token, PlayerId)),
+                {ok, _} = asobi_repo:delete_all(by_player(asobi_player_identity, PlayerId)),
                 case asobi_repo:get(asobi_player, PlayerId) of
-                    {ok, Player} -> asobi_repo:delete(asobi_player, Player);
-                    _ -> ok
+                    {ok, Player} ->
+                        {ok, _} = asobi_repo:delete(asobi_player, Player),
+                        ok;
+                    _ ->
+                        ok
                 end
         end
     end,
     try asobi_repo:transaction(Fun) of
-        {error, _} -> skipped;
-        _ -> reaped
+        ok ->
+            reaped;
+        {error, Reason} ->
+            ?LOG_NOTICE(#{event => guest_reap_skipped, player_id => PlayerId, reason => Reason}),
+            skipped;
+        Other ->
+            ?LOG_NOTICE(#{event => guest_reap_unexpected, player_id => PlayerId, result => Other}),
+            skipped
     catch
-        _:_ -> skipped
+        Class:CReason:Stacktrace ->
+            ?LOG_WARNING(#{
+                event => guest_reap_cascade_error,
+                player_id => PlayerId,
+                class => Class,
+                reason => CReason,
+                stacktrace => Stacktrace
+            }),
+            skipped
     end.
 
 -spec by_player(module(), binary()) -> #kura_query{}.

--- a/src/asobi_guest_reaper.erl
+++ b/src/asobi_guest_reaper.erl
@@ -7,7 +7,7 @@
 %% only removes guests that were never claimed - no password and no non-device
 %% identity - so an upgraded account is never touched.
 
--export([start_link/0, sweep_now/0]).
+-export([start_link/0, sweep_now/0, cached_unlinked_count/0]).
 -export([init/1, handle_call/3, handle_cast/2, handle_info/2]).
 
 -include_lib("kernel/include/logger.hrl").
@@ -16,6 +16,8 @@
 -define(PROVIDER, ~"guest").
 -define(DEFAULT_INTERVAL_MS, 3600000).
 -define(REAP_BATCH, 500).
+-define(COUNT_CACHE, asobi_guest_count_cache).
+-define(DEFAULT_COUNT_TTL_MS, 2000).
 
 %% Only runs when guest auth is enabled - otherwise no process, no timer on
 %% deployments that don't use guest auth.
@@ -33,8 +35,59 @@ sweep_now() ->
 
 -spec init([]) -> {ok, map()}.
 init([]) ->
+    _ = ensure_count_cache(),
     schedule(),
     {ok, #{}}.
+
+%% Short-TTL cache of the unlinked-guest count, read by the create path's cap
+%% check so an unauthenticated create storm can't turn the guard into a
+%% full-table COUNT per request. Public table (request processes read/refresh
+%% it); created here so it shares the reaper's lifetime.
+-spec ensure_count_cache() -> ets:table().
+ensure_count_cache() ->
+    case ets:whereis(?COUNT_CACHE) of
+        undefined ->
+            ets:new(?COUNT_CACHE, [
+                named_table, public, set, {read_concurrency, true}, {write_concurrency, true}
+            ]);
+        Tid ->
+            Tid
+    end.
+
+%% Read the cached count, refreshing on miss/expiry. Falls back to a live count
+%% (uncached) if the table isn't up yet, so it is safe to call before the reaper
+%% has started. Returns `unknown` on a query failure so the caller fails closed.
+-spec cached_unlinked_count() -> non_neg_integer() | unknown.
+cached_unlinked_count() ->
+    Now = erlang:monotonic_time(millisecond),
+    case ets:whereis(?COUNT_CACHE) of
+        undefined ->
+            live_unlinked_count();
+        _ ->
+            case ets:lookup(?COUNT_CACHE, count) of
+                [{count, N, Expiry}] when Expiry > Now -> N;
+                _ -> refresh_count(Now)
+            end
+    end.
+
+-spec refresh_count(integer()) -> non_neg_integer() | unknown.
+refresh_count(Now) ->
+    case live_unlinked_count() of
+        N when is_integer(N) ->
+            Ttl = application:get_env(asobi, guest_unlinked_count_ttl_ms, ?DEFAULT_COUNT_TTL_MS),
+            true = ets:insert(?COUNT_CACHE, {count, N, Now + Ttl}),
+            N;
+        unknown ->
+            unknown
+    end.
+
+-spec live_unlinked_count() -> non_neg_integer() | unknown.
+live_unlinked_count() ->
+    Q = kura_query:where(kura_query:from(asobi_player_identity), {provider, ?PROVIDER}),
+    case asobi_repo:aggregate(Q, count) of
+        {ok, N} -> N;
+        _ -> unknown
+    end.
 
 -spec handle_call(term(), gen_server:from(), map()) -> {reply, term(), map()}.
 handle_call(sweep, _From, State) ->
@@ -113,12 +166,22 @@ reap_one(Identity) ->
 -spec delete_guest_cascade(binary()) -> reaped | skipped.
 delete_guest_cascade(PlayerId) ->
     Fun = fun() ->
-        _ = asobi_repo:delete_all(by_player(asobi_player_stats, PlayerId)),
-        _ = asobi_repo:delete_all(by_player(asobi_player_token, PlayerId)),
-        _ = asobi_repo:delete_all(by_player(asobi_player_identity, PlayerId)),
-        case asobi_repo:get(asobi_player, PlayerId) of
-            {ok, Player} -> asobi_repo:delete(asobi_player, Player);
-            _ -> ok
+        %% Re-check inside the transaction: a guest can call /auth/guest/upgrade
+        %% between the pre-check and here, becoming a claimed account with a
+        %% password and fresh tokens. Deleting it then would be silent loss of a
+        %% real account, so a concurrent upgrade must win - abort the reap.
+        case unclaimed_guest(PlayerId) of
+            false ->
+                {error, claimed_during_sweep};
+            true ->
+                _ = asobi_repo:delete_all(by_player(asobi_player_stats, PlayerId)),
+                %% player_tokens keys players by `user_id`, not `player_id`.
+                _ = asobi_repo:delete_all(by_user(asobi_player_token, PlayerId)),
+                _ = asobi_repo:delete_all(by_player(asobi_player_identity, PlayerId)),
+                case asobi_repo:get(asobi_player, PlayerId) of
+                    {ok, Player} -> asobi_repo:delete(asobi_player, Player);
+                    _ -> ok
+                end
         end
     end,
     try asobi_repo:transaction(Fun) of
@@ -131,6 +194,10 @@ delete_guest_cascade(PlayerId) ->
 -spec by_player(module(), binary()) -> #kura_query{}.
 by_player(Schema, PlayerId) ->
     kura_query:where(kura_query:from(Schema), {player_id, PlayerId}).
+
+-spec by_user(module(), binary()) -> #kura_query{}.
+by_user(Schema, PlayerId) ->
+    kura_query:where(kura_query:from(Schema), {user_id, PlayerId}).
 
 %% A guest is unclaimed only if the player never set a password and has no
 %% identity from another provider (i.e. never upgraded/linked).

--- a/src/asobi_guest_reaper.erl
+++ b/src/asobi_guest_reaper.erl
@@ -140,10 +140,9 @@ reap_older_than(Cutoff) ->
     ),
     case asobi_repo:all(Q) of
         {ok, Identities} ->
-            ?LOG_NOTICE(#{event => guest_reap_candidates, count => length(Identities)}),
             reap_all(Identities, 0);
         Other ->
-            ?LOG_NOTICE(#{event => guest_reap_query_failed, result => Other}),
+            ?LOG_WARNING(#{event => guest_reap_query_failed, result => Other}),
             0
     end.
 
@@ -199,10 +198,10 @@ delete_guest_cascade(PlayerId) ->
         ok ->
             reaped;
         {error, Reason} ->
-            ?LOG_NOTICE(#{event => guest_reap_skipped, player_id => PlayerId, reason => Reason}),
+            ?LOG_DEBUG(#{event => guest_reap_skipped, player_id => PlayerId, reason => Reason}),
             skipped;
         Other ->
-            ?LOG_NOTICE(#{event => guest_reap_unexpected, player_id => PlayerId, result => Other}),
+            ?LOG_WARNING(#{event => guest_reap_unexpected, player_id => PlayerId, result => Other}),
             skipped
     catch
         Class:CReason:Stacktrace ->

--- a/src/asobi_guest_reaper.erl
+++ b/src/asobi_guest_reaper.erl
@@ -1,0 +1,158 @@
+-module(asobi_guest_reaper).
+-behaviour(gen_server).
+
+%% Opt-in sweeper for stale, unclaimed guest accounts. Retention is operator
+%% policy, never a core default: it does nothing unless `guest_reap_after` (a
+%% number of seconds) is configured. "Permanent guests" = leave it unset. It
+%% only removes guests that were never claimed - no password and no non-device
+%% identity - so an upgraded account is never touched.
+
+-export([start_link/0, sweep_now/0]).
+-export([init/1, handle_call/3, handle_cast/2, handle_info/2]).
+
+-include_lib("kernel/include/logger.hrl").
+-include_lib("kura/include/kura.hrl").
+
+-define(PROVIDER, ~"guest").
+-define(DEFAULT_INTERVAL_MS, 3600000).
+-define(REAP_BATCH, 500).
+
+%% Only runs when guest auth is enabled - otherwise no process, no timer on
+%% deployments that don't use guest auth.
+-spec start_link() -> {ok, pid()} | ignore.
+start_link() ->
+    case application:get_env(asobi, guest_auth, false) of
+        true -> gen_server:start_link({local, ?MODULE}, ?MODULE, [], []);
+        _ -> ignore
+    end.
+
+%% For tests/ops: run a sweep synchronously.
+-spec sweep_now() -> {ok, non_neg_integer()}.
+sweep_now() ->
+    gen_server:call(?MODULE, sweep, 30000).
+
+-spec init([]) -> {ok, map()}.
+init([]) ->
+    schedule(),
+    {ok, #{}}.
+
+-spec handle_call(term(), gen_server:from(), map()) -> {reply, term(), map()}.
+handle_call(sweep, _From, State) ->
+    {reply, {ok, run_sweep()}, State};
+handle_call(_Req, _From, State) ->
+    {reply, ok, State}.
+
+-spec handle_cast(term(), map()) -> {noreply, map()}.
+handle_cast(_Msg, State) ->
+    {noreply, State}.
+
+-spec handle_info(term(), map()) -> {noreply, map()}.
+handle_info(sweep, State) ->
+    _ = run_sweep(),
+    schedule(),
+    {noreply, State};
+handle_info(_Info, State) ->
+    {noreply, State}.
+
+%% --- Internal ---
+
+-spec schedule() -> reference().
+schedule() ->
+    Interval = application:get_env(asobi, guest_reap_interval_ms, ?DEFAULT_INTERVAL_MS),
+    erlang:send_after(Interval, self(), sweep).
+
+-spec run_sweep() -> non_neg_integer().
+run_sweep() ->
+    case application:get_env(asobi, guest_reap_after, undefined) of
+        Seconds when is_integer(Seconds), Seconds > 0 ->
+            Cutoff = subtract_seconds(erlang:universaltime(), Seconds),
+            Reaped = reap_older_than(Cutoff),
+            Reaped > 0 andalso
+                ?LOG_INFO(#{event => guest_reaped, count => Reaped}),
+            Reaped;
+        _ ->
+            0
+    end.
+
+-spec reap_older_than(calendar:datetime()) -> non_neg_integer().
+reap_older_than(Cutoff) ->
+    %% Bounded batch per sweep - the next tick drains the rest. Guests are the
+    %% highest-volume account type, so an unbounded load would block the sweeper.
+    Q = kura_query:limit(
+        kura_query:where(
+            kura_query:where(kura_query:from(asobi_player_identity), {provider, ?PROVIDER}),
+            {inserted_at, '<', Cutoff}
+        ),
+        ?REAP_BATCH
+    ),
+    case asobi_repo:all(Q) of
+        {ok, Identities} -> reap_all(Identities, 0);
+        _ -> 0
+    end.
+
+-spec reap_all([map()], non_neg_integer()) -> non_neg_integer().
+reap_all([], Count) ->
+    Count;
+reap_all([Identity | Rest], Count) ->
+    case reap_one(Identity) of
+        reaped -> reap_all(Rest, Count + 1);
+        skipped -> reap_all(Rest, Count)
+    end.
+
+-spec reap_one(map()) -> reaped | skipped.
+reap_one(Identity) ->
+    PlayerId = maps:get(player_id, Identity),
+    case unclaimed_guest(PlayerId) of
+        true -> delete_guest_cascade(PlayerId);
+        false -> skipped
+    end.
+
+%% Delete the player and its FK children (which are ON DELETE NO ACTION, so the
+%% player row can't go first) atomically, children before the player. Only count
+%% a genuine deletion; a rolled-back/failed sweep reports skipped, not reaped.
+-spec delete_guest_cascade(binary()) -> reaped | skipped.
+delete_guest_cascade(PlayerId) ->
+    Fun = fun() ->
+        _ = asobi_repo:delete_all(by_player(asobi_player_stats, PlayerId)),
+        _ = asobi_repo:delete_all(by_player(asobi_player_token, PlayerId)),
+        _ = asobi_repo:delete_all(by_player(asobi_player_identity, PlayerId)),
+        case asobi_repo:get(asobi_player, PlayerId) of
+            {ok, Player} -> asobi_repo:delete(asobi_player, Player);
+            _ -> ok
+        end
+    end,
+    try asobi_repo:transaction(Fun) of
+        {error, _} -> skipped;
+        _ -> reaped
+    catch
+        _:_ -> skipped
+    end.
+
+-spec by_player(module(), binary()) -> #kura_query{}.
+by_player(Schema, PlayerId) ->
+    kura_query:where(kura_query:from(Schema), {player_id, PlayerId}).
+
+%% A guest is unclaimed only if the player never set a password and has no
+%% identity from another provider (i.e. never upgraded/linked).
+-spec unclaimed_guest(binary()) -> boolean().
+unclaimed_guest(PlayerId) ->
+    NoPassword =
+        case asobi_repo:get(asobi_player, PlayerId) of
+            {ok, Player} -> maps:get(hashed_password, Player, undefined) =:= undefined;
+            _ -> false
+        end,
+    OnlyDevice =
+        case
+            asobi_repo:all(
+                kura_query:where(kura_query:from(asobi_player_identity), {player_id, PlayerId})
+            )
+        of
+            {ok, Ids} -> lists:all(fun(I) -> maps:get(provider, I) =:= ?PROVIDER end, Ids);
+            _ -> false
+        end,
+    NoPassword andalso OnlyDevice.
+
+-spec subtract_seconds(calendar:datetime(), non_neg_integer()) -> calendar:datetime().
+subtract_seconds(DateTime, Seconds) ->
+    Gregorian = calendar:datetime_to_gregorian_seconds(DateTime),
+    calendar:gregorian_seconds_to_datetime(Gregorian - Seconds).

--- a/src/asobi_repo.erl
+++ b/src/asobi_repo.erl
@@ -6,6 +6,7 @@
 -export([
     otp_app/0,
     all/1,
+    aggregate/2,
     get/2,
     insert/1,
     insert/2,
@@ -27,6 +28,10 @@ otp_app() -> asobi.
 
 -spec all(#kura_query{}) -> {ok, [map()]} | {error, term()}.
 all(Q) -> kura_repo_worker:all(?MODULE, Q).
+
+-spec aggregate(#kura_query{}, count | {count | sum | avg | min | max, atom()}) ->
+    {ok, number()} | {error, term()}.
+aggregate(Q, Agg) -> kura_repo_worker:aggregate(?MODULE, Q, Agg).
 
 -spec get(module(), term()) -> {ok, map()} | {error, term()}.
 get(Schema, Id) -> kura_repo_worker:get(?MODULE, Schema, Id).

--- a/src/asobi_router.erl
+++ b/src/asobi_router.erl
@@ -24,6 +24,7 @@ auth_routes() ->
         security => false,
         routes => [
             {~"/register", fun asobi_auth_controller:register/1, #{methods => [post, options]}},
+            {~"/guest", fun asobi_guest_controller:authenticate/1, #{methods => [post, options]}},
             {~"/login", fun asobi_auth_controller:login/1, #{methods => [post, options]}},
             {~"/refresh", fun asobi_auth_controller:refresh/1, #{methods => [post, options]}},
             {~"/logout", fun asobi_auth_controller:logout/1, #{methods => [post, options]}},
@@ -47,6 +48,9 @@ api_routes() ->
         security => fun asobi_auth_plugin:verify/1,
         routes => [
             %% Auth - Provider linking
+            {~"/auth/guest/upgrade", fun asobi_guest_controller:upgrade/1, #{
+                methods => [post, options]
+            }},
             {~"/auth/link", fun asobi_oauth_controller:link/1, #{methods => [post, options]}},
             {~"/auth/unlink", fun asobi_oauth_controller:unlink/1, #{methods => [delete, options]}},
 

--- a/src/asobi_sup.erl
+++ b/src/asobi_sup.erl
@@ -29,9 +29,19 @@ init([]) ->
         chat_sup(),
         tournament_sup(),
         presence_spec(),
-        season_manager_spec()
+        season_manager_spec(),
+        guest_reaper_spec()
     ],
     {ok, {SupFlags, Children}}.
+
+guest_reaper_spec() ->
+    #{
+        id => asobi_guest_reaper,
+        start => {asobi_guest_reaper, start_link, []},
+        restart => permanent,
+        shutdown => 5000,
+        type => worker
+    }.
 
 player_session_sup() ->
     #{
@@ -129,7 +139,11 @@ register_limiters() ->
         register => #{algorithm => sliding_window, limit => 3, window => 1000},
         iap => #{algorithm => sliding_window, limit => 10, window => 1000},
         api => #{algorithm => sliding_window, limit => 300, window => 1000},
-        ws_connect => #{algorithm => sliding_window, limit => 60, window => 1000}
+        ws_connect => #{algorithm => sliding_window, limit => 60, window => 1000},
+        %% Global (not per-IP) bound on guest-create throughput. Guest rows are
+        %% minted unauthenticated and cheaply, so a per-IP limit alone lets a
+        %% botnet spam rows; this caps the total rate. Keyed on a constant.
+        guest_global => #{algorithm => sliding_window, limit => 100, window => 1000}
     },
     Configured =
         case application:get_env(asobi, rate_limits, #{}) of
@@ -155,7 +169,8 @@ limiter_name(auth) -> asobi_auth_limiter;
 limiter_name(register) -> asobi_register_limiter;
 limiter_name(iap) -> asobi_iap_limiter;
 limiter_name(api) -> asobi_api_limiter;
-limiter_name(ws_connect) -> asobi_ws_connect_limiter.
+limiter_name(ws_connect) -> asobi_ws_connect_limiter;
+limiter_name(guest_global) -> asobi_guest_global_limiter.
 
 cluster_spec() ->
     #{

--- a/src/controllers/asobi_guest_controller.erl
+++ b/src/controllers/asobi_guest_controller.erl
@@ -16,7 +16,7 @@
 -export([authenticate/1, upgrade/1]).
 
 -ifdef(TEST).
--export([make_verifier/1, verify/2, decode_secret/1]).
+-export([make_verifier/1, verify/2, decode_secret/1, valid_device_id/1]).
 -endif.
 
 -include_lib("kernel/include/logger.hrl").
@@ -24,6 +24,12 @@
 
 -define(PROVIDER, ~"guest").
 -define(MIN_SECRET_BYTES, 32).
+%% Upper bounds on unauthenticated input: cap the HMAC work per request and keep
+%% the device id within the VARCHAR(255) column. Without these a client can send
+%% a multi-megabyte secret that is base64-decoded and HMAC'd on every call.
+-define(MAX_SECRET_BYTES, 128).
+-define(MAX_SECRET_B64_BYTES, 1024).
+-define(MAX_DEVICE_ID_BYTES, 255).
 
 -spec authenticate(cowboy_req:req()) -> {json, integer(), map(), map()}.
 authenticate(#{json := #{~"device_id" := DeviceId, ~"device_secret" := Secret}} = _Req) when
@@ -35,7 +41,10 @@ authenticate(#{json := #{~"device_id" := DeviceId, ~"device_secret" := Secret}} 
         true ->
             case decode_secret(Secret) of
                 {ok, SecretBin} ->
-                    resolve(DeviceId, SecretBin);
+                    case valid_device_id(DeviceId) of
+                        true -> resolve(DeviceId, SecretBin);
+                        false -> {json, 400, #{}, #{error => ~"invalid_device_id"}}
+                    end;
                 error ->
                     {json, 400, #{}, #{error => ~"weak_device_secret"}}
             end
@@ -58,10 +67,13 @@ upgrade(
         {ok, Player} ->
             %% Only an unclaimed guest may claim an account here. This endpoint
             %% casts `username` (which the normal self-service update excludes),
-            %% so a claimed player must not use it to rename or reset a password.
-            case maps:get(hashed_password, Player, undefined) of
-                undefined -> do_upgrade(Player, PlayerId, Username, Password);
-                _ -> {json, 409, #{}, #{error => ~"already_claimed"}}
+            %% so gate on the real invariant: the caller must own a `guest`
+            %% identity AND have no password. Gating on password-absence alone
+            %% would let a passwordless OAuth-only account use this path to set a
+            %% password and rename itself - a side door around update_changeset.
+            case is_unclaimed_guest(Player, PlayerId) of
+                true -> do_upgrade(Player, PlayerId, Username, Password);
+                false -> {json, 409, #{}, #{error => ~"not_an_unclaimed_guest"}}
             end;
         {error, _} ->
             {json, 404, #{}, #{error => ~"player_not_found"}}
@@ -79,6 +91,12 @@ do_upgrade(Player, PlayerId, Username, Password) ->
     case asobi_repo:update(CS) of
         {ok, Updated} ->
             _ = delete_guest_identity(PlayerId),
+            %% Revoke every token issued to this player before the claim: a
+            %% stolen device secret has already minted an access+refresh pair,
+            %% and upgrade is exactly the "my device was compromised" moment.
+            %% Killing the whole family first, then issuing a fresh pair below,
+            %% means the old (possibly attacker-held) tokens stop working.
+            _ = nova_auth_refresh:revoke_all(asobi_auth, PlayerId),
             asobi_auth_tokens:issue(Updated, 200, #{username => Username, upgraded => true});
         {error, #kura_changeset{} = ECS} ->
             asobi_auth_error:from_changeset_fields(
@@ -102,6 +120,25 @@ delete_guest_identity(PlayerId) ->
             ok;
         _ ->
             ok
+    end.
+
+%% A player may be upgraded here only if it is an actual guest: no password set
+%% and it owns a `guest` provider identity. Both conditions matter - a
+%% passwordless OAuth account satisfies the first but not the second.
+-spec is_unclaimed_guest(map(), binary()) -> boolean().
+is_unclaimed_guest(Player, PlayerId) ->
+    maps:get(hashed_password, Player, undefined) =:= undefined andalso
+        has_guest_identity(PlayerId).
+
+-spec has_guest_identity(binary()) -> boolean().
+has_guest_identity(PlayerId) ->
+    Q = kura_query:where(
+        kura_query:where(kura_query:from(asobi_player_identity), {player_id, PlayerId}),
+        {provider, ?PROVIDER}
+    ),
+    case asobi_repo:all(Q) of
+        {ok, [_ | _]} -> true;
+        _ -> false
     end.
 
 %% --- Create-or-resume (fail closed) ---
@@ -136,9 +173,15 @@ resume(Identity, SecretBin) ->
 create(DeviceId, SecretBin) ->
     %% Row-spam defence (asobi#157): a global throughput bound (caps total
     %% guest-creates regardless of source IP - the per-IP auth limiter can't),
-    %% plus a hard ceiling on total unlinked guests. Both fail closed.
+    %% plus a soft ceiling on total unlinked guests. Both fail closed.
+    %%
+    %% The global limiter is one shared window: it stops a botnet a per-IP limit
+    %% can't, but a single abuser can saturate it and deny guest signup to
+    %% everyone. That is an availability tradeoff, so log capacity events - a
+    %% sustained stream is the signal to distinguish an attack from real growth.
     case global_create_allowed() andalso within_unlinked_cap() of
         false ->
+            ?LOG_WARNING(#{event => guest_capacity_reached}),
             {json, 503, #{}, #{error => ~"guest_capacity_reached"}};
         true ->
             insert_player_and_identity(DeviceId, SecretBin)
@@ -281,29 +324,39 @@ global_create_allowed() ->
 
 -spec within_unlinked_cap() -> boolean().
 within_unlinked_cap() ->
-    %% Finite by default (fail-closed): the mandated hard ceiling must not be
-    %% off by default. Operators raise it or set `infinity` deliberately.
+    %% Finite by default (fail-closed): the ceiling must not be off by default.
+    %% Operators raise it or set `infinity` deliberately. The count is read from
+    %% a short-TTL cache (asobi_guest_reaper) rather than COUNT-ing the whole
+    %% guest table on every unauthenticated create, so the cap is advisory - a
+    %% soft ceiling that can overshoot by up to (TTL x create-rate), not exact.
     case application:get_env(asobi, guest_unlinked_cap, 100000) of
         infinity ->
             true;
         Cap when is_integer(Cap) ->
-            Q = kura_query:where(kura_query:from(asobi_player_identity), {provider, ?PROVIDER}),
-            case asobi_repo:aggregate(Q, count) of
-                {ok, N} -> N < Cap;
-                _ -> false
+            case asobi_guest_reaper:cached_unlinked_count() of
+                N when is_integer(N) -> N < Cap;
+                unknown -> false
             end
     end.
 
 %% --- Helpers ---
 
+-spec valid_device_id(binary()) -> boolean().
+valid_device_id(DeviceId) ->
+    byte_size(DeviceId) > 0 andalso byte_size(DeviceId) =< ?MAX_DEVICE_ID_BYTES.
+
 -spec decode_secret(binary()) -> {ok, binary()} | error.
-decode_secret(B64) ->
+decode_secret(B64) when byte_size(B64) =< ?MAX_SECRET_B64_BYTES ->
     try base64:decode(B64) of
-        Bin when byte_size(Bin) >= ?MIN_SECRET_BYTES -> {ok, Bin};
-        _ -> error
+        Bin when byte_size(Bin) >= ?MIN_SECRET_BYTES, byte_size(Bin) =< ?MAX_SECRET_BYTES ->
+            {ok, Bin};
+        _ ->
+            error
     catch
         _:_ -> error
-    end.
+    end;
+decode_secret(_B64) ->
+    error.
 
 -spec generate_username() -> binary().
 generate_username() ->

--- a/src/controllers/asobi_guest_controller.erl
+++ b/src/controllers/asobi_guest_controller.erl
@@ -1,0 +1,311 @@
+-module(asobi_guest_controller).
+
+%% Anonymous/guest auth, modelled as a "guest" provider identity parallel to
+%% the OAuth providers (asobi_oauth_controller). A client presents a
+%% device-generated {device_id, device_secret}; the server creates a player on
+%% first presentation and resumes the SAME player on later presentations. The
+%% secret is verified against a salted+peppered HMAC stored in the identity's
+%% provider_metadata (see provider=guest metadata: salt/key_id/verifier/revoked,
+%% base64) - the secret itself is never stored or logged.
+%%
+%% Opt-in: disabled unless `guest_auth` is true AND a `guest_verifier_pepper`
+%% is configured; both missing/false fail closed. Upgrade to a real account:
+%% POST /auth/guest/upgrade (username+password, revokes the device verifier) or
+%% the existing /auth/link path (OAuth). Guardian + beam-security-reviewer gate.
+
+-export([authenticate/1, upgrade/1]).
+
+-ifdef(TEST).
+-export([make_verifier/1, verify/2, decode_secret/1]).
+-endif.
+
+-include_lib("kernel/include/logger.hrl").
+-include_lib("kura/include/kura.hrl").
+
+-define(PROVIDER, ~"guest").
+-define(MIN_SECRET_BYTES, 32).
+
+-spec authenticate(cowboy_req:req()) -> {json, integer(), map(), map()}.
+authenticate(#{json := #{~"device_id" := DeviceId, ~"device_secret" := Secret}} = _Req) when
+    is_binary(DeviceId), is_binary(Secret)
+->
+    case guest_enabled() of
+        false ->
+            {json, 404, #{}, #{error => ~"guest_auth_disabled"}};
+        true ->
+            case decode_secret(Secret) of
+                {ok, SecretBin} ->
+                    resolve(DeviceId, SecretBin);
+                error ->
+                    {json, 400, #{}, #{error => ~"weak_device_secret"}}
+            end
+    end;
+authenticate(_Req) ->
+    {json, 400, #{}, #{error => ~"missing_required_fields"}}.
+
+%% POST /api/v1/auth/guest/upgrade - claim a guest account with real
+%% credentials. Authenticated as the guest (auth_data from the resumed token,
+%% so it can only upgrade the caller's own player); revokes the device verifier
+%% so the device secret can no longer log into the now-claimed account.
+-spec upgrade(cowboy_req:req()) -> {json, integer(), map(), map()}.
+upgrade(
+    #{
+        json := #{~"username" := Username, ~"password" := Password},
+        auth_data := #{player_id := PlayerId}
+    } = _Req
+) when is_binary(Username), is_binary(Password), is_binary(PlayerId) ->
+    case asobi_repo:get(asobi_player, PlayerId) of
+        {ok, Player} ->
+            %% Only an unclaimed guest may claim an account here. This endpoint
+            %% casts `username` (which the normal self-service update excludes),
+            %% so a claimed player must not use it to rename or reset a password.
+            case maps:get(hashed_password, Player, undefined) of
+                undefined -> do_upgrade(Player, PlayerId, Username, Password);
+                _ -> {json, 409, #{}, #{error => ~"already_claimed"}}
+            end;
+        {error, _} ->
+            {json, 404, #{}, #{error => ~"player_not_found"}}
+    end;
+upgrade(_Req) ->
+    {json, 400, #{}, #{error => ~"missing_required_fields"}}.
+
+-spec do_upgrade(map(), binary(), binary(), binary()) -> {json, integer(), map(), map()}.
+do_upgrade(Player, PlayerId, Username, Password) ->
+    CS = asobi_player:registration_changeset(Player, #{
+        username => Username,
+        password => Password,
+        display_name => maps:get(display_name, Player, Username)
+    }),
+    case asobi_repo:update(CS) of
+        {ok, Updated} ->
+            _ = delete_guest_identity(PlayerId),
+            asobi_auth_tokens:issue(Updated, 200, #{username => Username, upgraded => true});
+        {error, #kura_changeset{} = ECS} ->
+            asobi_auth_error:from_changeset_fields(
+                kura_changeset:traverse_errors(ECS, fun(_F, M) -> M end)
+            )
+    end.
+
+%% On upgrade the account is claimed, so remove the guest identity entirely: the
+%% device secret can no longer map to any player, and the account stops counting
+%% against the unlinked-guest cap. The resume path's claimed-account check is the
+%% belt-and-suspenders guarantee if this delete ever fails.
+-spec delete_guest_identity(binary()) -> ok.
+delete_guest_identity(PlayerId) ->
+    Q = kura_query:where(
+        kura_query:where(kura_query:from(asobi_player_identity), {player_id, PlayerId}),
+        {provider, ?PROVIDER}
+    ),
+    case asobi_repo:all(Q) of
+        {ok, [Identity]} ->
+            _ = asobi_repo:delete(asobi_player_identity, Identity),
+            ok;
+        _ ->
+            ok
+    end.
+
+%% --- Create-or-resume (fail closed) ---
+
+-spec resolve(binary(), binary()) -> {json, integer(), map(), map()}.
+resolve(DeviceId, SecretBin) ->
+    case find_identity(DeviceId) of
+        {ok, Identity} ->
+            resume(Identity, SecretBin);
+        {error, not_found} ->
+            create(DeviceId, SecretBin)
+    end.
+
+-spec resume(map(), binary()) -> {json, integer(), map(), map()}.
+resume(Identity, SecretBin) ->
+    Meta = maps:get(provider_metadata, Identity, #{}),
+    case maps:get(~"revoked", Meta, false) of
+        true ->
+            {json, 401, #{}, #{error => ~"guest_revoked"}};
+        _ ->
+            case verify(SecretBin, Meta) of
+                true ->
+                    issue_for_player(maps:get(player_id, Identity));
+                false ->
+                    %% Wrong secret for a known device: reject. Never create a
+                    %% second player, never overwrite the stored verifier.
+                    {json, 401, #{}, #{error => ~"invalid_device_secret"}}
+            end
+    end.
+
+-spec create(binary(), binary()) -> {json, integer(), map(), map()}.
+create(DeviceId, SecretBin) ->
+    %% Row-spam defence (asobi#157): a global throughput bound (caps total
+    %% guest-creates regardless of source IP - the per-IP auth limiter can't),
+    %% plus a hard ceiling on total unlinked guests. Both fail closed.
+    case global_create_allowed() andalso within_unlinked_cap() of
+        false ->
+            {json, 503, #{}, #{error => ~"guest_capacity_reached"}};
+        true ->
+            insert_player_and_identity(DeviceId, SecretBin)
+    end.
+
+-spec insert_player_and_identity(binary(), binary()) -> {json, integer(), map(), map()}.
+insert_player_and_identity(DeviceId, SecretBin) ->
+    Username = generate_username(),
+    PlayerCS = kura_changeset:validate_required(
+        kura_changeset:cast(asobi_player, #{}, #{username => Username}, [username]),
+        [username]
+    ),
+    case asobi_repo:insert(PlayerCS) of
+        {ok, Player} ->
+            PlayerId = maps:get(id, Player),
+            case insert_identity(PlayerId, DeviceId, SecretBin) of
+                {ok, _Identity} ->
+                    _ = asobi_player_stats:init(PlayerId),
+                    asobi_auth_tokens:issue(Player, 200, #{
+                        username => Username, created => true, guest => true
+                    });
+                {error, _} ->
+                    %% Lost the unique {provider, device_id} race. Delete the
+                    %% just-created player so a concurrent create can't leave an
+                    %% orphan row.
+                    _ = asobi_repo:delete(asobi_player, Player),
+                    {json, 409, #{}, #{error => ~"device_already_registered"}}
+            end;
+        {error, _} ->
+            {json, 500, #{}, #{error => ~"guest_create_failed"}}
+    end.
+
+-spec issue_for_player(binary()) -> {json, integer(), map(), map()}.
+issue_for_player(PlayerId) ->
+    case asobi_repo:get(asobi_player, PlayerId) of
+        {ok, Player} ->
+            %% If the account was claimed (a password was set), the device
+            %% secret must not resume it - independent of whether the verifier
+            %% revoke persisted. Log in with the real credentials instead.
+            case maps:get(hashed_password, Player, undefined) of
+                undefined ->
+                    asobi_auth_tokens:issue(Player, 200, #{
+                        username => maps:get(username, Player), guest => true
+                    });
+                _ ->
+                    {json, 401, #{}, #{error => ~"guest_upgraded"}}
+            end;
+        {error, _} ->
+            {json, 500, #{}, #{error => ~"guest_player_missing"}}
+    end.
+
+%% --- Verifier (salted + peppered keyed HMAC; secret never stored) ---
+
+-spec make_verifier(binary()) -> map().
+make_verifier(SecretBin) ->
+    Salt = crypto:strong_rand_bytes(16),
+    KeyId = current_key_id(),
+    Mac = crypto:mac(hmac, sha256, pepper(KeyId), <<Salt/binary, SecretBin/binary>>),
+    #{
+        ~"salt" => base64:encode(Salt),
+        ~"key_id" => KeyId,
+        ~"verifier" => base64:encode(Mac),
+        ~"revoked" => false
+    }.
+
+-spec verify(binary(), map()) -> boolean().
+verify(SecretBin, #{~"salt" := SaltB64, ~"key_id" := KeyId, ~"verifier" := VerB64}) ->
+    case pepper(KeyId) of
+        undefined ->
+            false;
+        Key ->
+            Salt = base64:decode(SaltB64),
+            Expected = crypto:mac(hmac, sha256, Key, <<Salt/binary, SecretBin/binary>>),
+            crypto:hash_equals(Expected, base64:decode(VerB64))
+    end;
+verify(_SecretBin, _) ->
+    false.
+
+%% --- Identity persistence (reuses asobi_player_identity) ---
+
+-spec find_identity(binary()) -> {ok, map()} | {error, not_found}.
+find_identity(DeviceId) ->
+    Q = kura_query:where(
+        kura_query:where(kura_query:from(asobi_player_identity), {provider, ?PROVIDER}),
+        {provider_uid, DeviceId}
+    ),
+    case asobi_repo:all(Q) of
+        {ok, [Identity]} -> {ok, Identity};
+        _ -> {error, not_found}
+    end.
+
+-spec insert_identity(binary(), binary(), binary()) -> {ok, map()} | {error, term()}.
+insert_identity(PlayerId, DeviceId, SecretBin) ->
+    Params = #{
+        player_id => PlayerId,
+        provider => ?PROVIDER,
+        provider_uid => DeviceId,
+        provider_metadata => make_verifier(SecretBin)
+    },
+    asobi_repo:insert(asobi_player_identity:changeset(#{}, Params)).
+
+%% --- Config (opt-in, fail closed and loud) ---
+
+-spec guest_enabled() -> boolean().
+guest_enabled() ->
+    case application:get_env(asobi, guest_auth, false) of
+        true ->
+            case pepper(current_key_id()) of
+                undefined ->
+                    ?LOG_WARNING(#{
+                        event => guest_auth_misconfigured,
+                        reason => missing_guest_verifier_pepper
+                    }),
+                    false;
+                _ ->
+                    true
+            end;
+        _ ->
+            false
+    end.
+
+-spec current_key_id() -> binary().
+current_key_id() ->
+    application:get_env(asobi, guest_verifier_key_id, ~"v1").
+
+-spec pepper(binary()) -> binary() | undefined.
+pepper(KeyId) ->
+    case application:get_env(asobi, guest_verifier_pepper, undefined) of
+        Peppers when is_map(Peppers) -> maps:get(KeyId, Peppers, undefined);
+        Bin when is_binary(Bin), byte_size(Bin) >= 32 -> Bin;
+        _ -> undefined
+    end.
+
+-spec global_create_allowed() -> boolean().
+global_create_allowed() ->
+    case seki:check(asobi_guest_global_limiter, ~"global") of
+        {allow, _} -> true;
+        {deny, _} -> false
+    end.
+
+-spec within_unlinked_cap() -> boolean().
+within_unlinked_cap() ->
+    %% Finite by default (fail-closed): the mandated hard ceiling must not be
+    %% off by default. Operators raise it or set `infinity` deliberately.
+    case application:get_env(asobi, guest_unlinked_cap, 100000) of
+        infinity ->
+            true;
+        Cap when is_integer(Cap) ->
+            Q = kura_query:where(kura_query:from(asobi_player_identity), {provider, ?PROVIDER}),
+            case asobi_repo:aggregate(Q, count) of
+                {ok, N} -> N < Cap;
+                _ -> false
+            end
+    end.
+
+%% --- Helpers ---
+
+-spec decode_secret(binary()) -> {ok, binary()} | error.
+decode_secret(B64) ->
+    try base64:decode(B64) of
+        Bin when byte_size(Bin) >= ?MIN_SECRET_BYTES -> {ok, Bin};
+        _ -> error
+    catch
+        _:_ -> error
+    end.
+
+-spec generate_username() -> binary().
+generate_username() ->
+    Suffix = binary:part(asobi_id:generate(), 0, 12),
+    <<"guest_", Suffix/binary>>.

--- a/src/players/asobi_player_stats.erl
+++ b/src/players/asobi_player_stats.erl
@@ -4,6 +4,25 @@
 -include_lib("kura/include/kura.hrl").
 
 -export([table/0, fields/0, associations/0, generate_id/0]).
+-export([init/1]).
+
+-include_lib("kernel/include/logger.hrl").
+
+%% Create the stats row for a newly-created player. Shared by the register,
+%% OAuth, and guest paths. Logs and swallows insert errors so a stats blip
+%% never blocks account creation, but leaves a trace (F-25).
+-spec init(binary()) -> ok.
+init(PlayerId) ->
+    CS = kura_changeset:cast(?MODULE, #{}, #{player_id => PlayerId}, [player_id]),
+    case asobi_repo:insert(CS) of
+        {ok, _} ->
+            ok;
+        {error, Reason} ->
+            ?LOG_WARNING(#{
+                event => player_stats_init_failed, player_id => PlayerId, reason => Reason
+            }),
+            ok
+    end.
 
 -spec table() -> binary().
 table() -> ~"player_stats".

--- a/test/asobi_guest_SUITE.erl
+++ b/test/asobi_guest_SUITE.erl
@@ -1,0 +1,114 @@
+-module(asobi_guest_SUITE).
+
+-include_lib("nova_test/include/nova_test.hrl").
+
+-export([all/0, init_per_suite/1, end_per_suite/1]).
+-export([
+    create_then_resume_same_player/1,
+    wrong_secret_rejected_no_new_player/1,
+    weak_secret_rejected/1,
+    upgrade_then_already_claimed/1,
+    reaper_removes_unclaimed_guest_and_children/1
+]).
+
+all() ->
+    [
+        create_then_resume_same_player,
+        wrong_secret_rejected_no_new_player,
+        weak_secret_rejected,
+        upgrade_then_already_claimed,
+        reaper_removes_unclaimed_guest_and_children
+    ].
+
+init_per_suite(Config) ->
+    %% Set before the app starts so the sup starts the reaper and guest is on.
+    application:set_env(asobi, guest_auth, true),
+    application:set_env(asobi, guest_verifier_pepper, crypto:strong_rand_bytes(32)),
+    application:set_env(asobi, guest_reap_after, 1),
+    asobi_test_helpers:start(Config).
+
+end_per_suite(Config) ->
+    Config.
+
+%% --- Helpers ---
+
+secret() ->
+    base64:encode(crypto:strong_rand_bytes(32)).
+
+device_id() ->
+    base64:encode(crypto:strong_rand_bytes(16)).
+
+%% The reaper only starts at boot when guest_auth is set then; the suite enables
+%% guest_auth for its run, so start it on demand for the reaping test.
+ensure_reaper() ->
+    case whereis(asobi_guest_reaper) of
+        undefined -> {ok, _} = asobi_guest_reaper:start_link();
+        _ -> ok
+    end.
+
+create(DeviceId, Secret, Config) ->
+    nova_test:post(
+        "/api/v1/auth/guest",
+        #{json => #{~"device_id" => DeviceId, ~"device_secret" => Secret}},
+        Config
+    ).
+
+%% --- Tests ---
+
+create_then_resume_same_player(Config) ->
+    Dev = device_id(),
+    Secret = secret(),
+    {ok, R1} = create(Dev, Secret, Config),
+    ?assertStatus(200, R1),
+    #{~"player_id" := Pid1} = nova_test:json(R1),
+    {ok, R2} = create(Dev, Secret, Config),
+    ?assertStatus(200, R2),
+    #{~"player_id" := Pid2} = nova_test:json(R2),
+    ?assertEqual(Pid1, Pid2),
+    Config.
+
+wrong_secret_rejected_no_new_player(Config) ->
+    Dev = device_id(),
+    {ok, R1} = create(Dev, secret(), Config),
+    #{~"player_id" := Pid} = nova_test:json(R1),
+    {ok, R2} = create(Dev, secret(), Config),
+    ?assertStatus(401, R2),
+    %% The original secret still resumes the same, single player.
+    {ok, R3} = create(Dev, secret(), Config),
+    ?assertStatus(401, R3),
+    ?assert(is_binary(Pid)),
+    Config.
+
+weak_secret_rejected(Config) ->
+    {ok, R} = create(device_id(), base64:encode(crypto:strong_rand_bytes(16)), Config),
+    ?assertStatus(400, R),
+    Config.
+
+upgrade_then_already_claimed(Config) ->
+    {ok, R1} = create(device_id(), secret(), Config),
+    #{~"access_token" := Token} = nova_test:json(R1),
+    Auth = [{~"authorization", <<"Bearer ", Token/binary>>}],
+    Username = asobi_test_helpers:unique_username(~"claimed"),
+    {ok, R2} = nova_test:post(
+        "/api/v1/auth/guest/upgrade",
+        #{json => #{~"username" => Username, ~"password" => ~"secret1234"}, headers => Auth},
+        Config
+    ),
+    ?assertStatus(200, R2),
+    %% A second upgrade on the now-claimed account is refused.
+    {ok, R3} = nova_test:post(
+        "/api/v1/auth/guest/upgrade",
+        #{json => #{~"username" => ~"other", ~"password" => ~"secret1234"}, headers => Auth},
+        Config
+    ),
+    ?assertStatus(409, R3),
+    Config.
+
+reaper_removes_unclaimed_guest_and_children(Config) ->
+    ensure_reaper(),
+    {ok, R1} = create(device_id(), secret(), Config),
+    #{~"player_id" := Pid} = nova_test:json(R1),
+    timer:sleep(1100),
+    {ok, _} = asobi_guest_reaper:sweep_now(),
+    ?assertEqual({error, not_found}, asobi_repo:get(asobi_player, Pid)),
+    Config.

--- a/test/asobi_guest_SUITE.erl
+++ b/test/asobi_guest_SUITE.erl
@@ -135,7 +135,11 @@ reaper_removes_unclaimed_guest_and_children(Config) ->
     ensure_reaper(),
     {ok, R1} = create(device_id(), secret(), Config),
     #{~"player_id" := Pid} = nova_test:json(R1),
-    timer:sleep(1100),
+    %% guest_reap_after is 1s and the cutoff is computed at whole-second
+    %% granularity (erlang:universaltime/0), so a guest created late in a second
+    %% needs >2s to be strictly older than (sweep_second - 1). Sleep past two
+    %% second-boundaries to make the reap deterministic.
+    timer:sleep(2500),
     {ok, _} = asobi_guest_reaper:sweep_now(),
     ?assertEqual({error, not_found}, asobi_repo:get(asobi_player, Pid)),
     Config.

--- a/test/asobi_guest_SUITE.erl
+++ b/test/asobi_guest_SUITE.erl
@@ -8,6 +8,7 @@
     wrong_secret_rejected_no_new_player/1,
     weak_secret_rejected/1,
     upgrade_then_already_claimed/1,
+    upgrade_rejected_for_non_guest/1,
     reaper_removes_unclaimed_guest_and_children/1
 ]).
 
@@ -17,6 +18,7 @@ all() ->
         wrong_secret_rejected_no_new_player,
         weak_secret_rejected,
         upgrade_then_already_claimed,
+        upgrade_rejected_for_non_guest,
         reaper_removes_unclaimed_guest_and_children
     ].
 
@@ -102,6 +104,31 @@ upgrade_then_already_claimed(Config) ->
         Config
     ),
     ?assertStatus(409, R3),
+    Config.
+
+%% A passwordless account that is NOT a guest (e.g. OAuth-only) must not be able
+%% to use the guest-upgrade path to set a password and rename itself - the gate
+%% is "owns a guest identity AND has no password", not "has no password".
+upgrade_rejected_for_non_guest(Config) ->
+    Username = asobi_test_helpers:unique_username(~"oauthy"),
+    PlayerCS = kura_changeset:validate_required(
+        kura_changeset:cast(asobi_player, #{}, #{username => Username}, [username]),
+        [username]
+    ),
+    {ok, Player} = asobi_repo:insert(PlayerCS),
+    PlayerId = maps:get(id, Player),
+    IdCS = asobi_player_identity:changeset(#{}, #{
+        player_id => PlayerId, provider => ~"google", provider_uid => device_id()
+    }),
+    {ok, _} = asobi_repo:insert(IdCS),
+    {json, 200, _, #{access_token := Token}} = asobi_auth_tokens:issue(Player, 200, #{}),
+    Auth = [{~"authorization", <<"Bearer ", Token/binary>>}],
+    {ok, R} = nova_test:post(
+        "/api/v1/auth/guest/upgrade",
+        #{json => #{~"username" => ~"hijacked", ~"password" => ~"secret1234"}, headers => Auth},
+        Config
+    ),
+    ?assertStatus(409, R),
     Config.
 
 reaper_removes_unclaimed_guest_and_children(Config) ->

--- a/test/asobi_guest_controller_tests.erl
+++ b/test/asobi_guest_controller_tests.erl
@@ -1,0 +1,49 @@
+-module(asobi_guest_controller_tests).
+
+-include_lib("eunit/include/eunit.hrl").
+
+setup() ->
+    application:set_env(asobi, guest_verifier_pepper, crypto:strong_rand_bytes(32)),
+    ok.
+
+cleanup(_) ->
+    application:unset_env(asobi, guest_verifier_pepper).
+
+verifier_test_() ->
+    {setup, fun setup/0, fun cleanup/1, [
+        {"correct secret verifies", fun correct_secret_verifies/0},
+        {"wrong secret is rejected", fun wrong_secret_rejected/0},
+        {"tampered verifier is rejected", fun tampered_verifier_rejected/0},
+        {"verify fails closed without a pepper", fun no_pepper_fails_closed/0}
+    ]}.
+
+correct_secret_verifies() ->
+    Secret = crypto:strong_rand_bytes(32),
+    Meta = asobi_guest_controller:make_verifier(Secret),
+    ?assert(asobi_guest_controller:verify(Secret, Meta)).
+
+wrong_secret_rejected() ->
+    Meta = asobi_guest_controller:make_verifier(crypto:strong_rand_bytes(32)),
+    ?assertNot(asobi_guest_controller:verify(crypto:strong_rand_bytes(32), Meta)).
+
+tampered_verifier_rejected() ->
+    Secret = crypto:strong_rand_bytes(32),
+    Meta = asobi_guest_controller:make_verifier(Secret),
+    Tampered = Meta#{~"verifier" => base64:encode(crypto:strong_rand_bytes(32))},
+    ?assertNot(asobi_guest_controller:verify(Secret, Tampered)).
+
+no_pepper_fails_closed() ->
+    Secret = crypto:strong_rand_bytes(32),
+    Meta = asobi_guest_controller:make_verifier(Secret),
+    application:unset_env(asobi, guest_verifier_pepper),
+    ?assertNot(asobi_guest_controller:verify(Secret, Meta)),
+    application:set_env(asobi, guest_verifier_pepper, crypto:strong_rand_bytes(32)).
+
+decode_secret_test() ->
+    ?assertMatch(
+        {ok, _}, asobi_guest_controller:decode_secret(base64:encode(crypto:strong_rand_bytes(32)))
+    ),
+    ?assertEqual(
+        error, asobi_guest_controller:decode_secret(base64:encode(crypto:strong_rand_bytes(16)))
+    ),
+    ?assertEqual(error, asobi_guest_controller:decode_secret(~"not valid base64 !!!")).

--- a/test/asobi_guest_controller_tests.erl
+++ b/test/asobi_guest_controller_tests.erl
@@ -47,3 +47,19 @@ decode_secret_test() ->
         error, asobi_guest_controller:decode_secret(base64:encode(crypto:strong_rand_bytes(16)))
     ),
     ?assertEqual(error, asobi_guest_controller:decode_secret(~"not valid base64 !!!")).
+
+decode_secret_upper_bound_test() ->
+    %% A secret over the byte cap is rejected (would otherwise be HMAC'd per
+    %% request on an unauthenticated endpoint).
+    ?assertEqual(
+        error, asobi_guest_controller:decode_secret(base64:encode(crypto:strong_rand_bytes(129)))
+    ),
+    %% Oversized base64 input is rejected before it is even decoded.
+    ?assertEqual(
+        error, asobi_guest_controller:decode_secret(binary:copy(~"A", 4096))
+    ).
+
+valid_device_id_test() ->
+    ?assert(asobi_guest_controller:valid_device_id(base64:encode(crypto:strong_rand_bytes(16)))),
+    ?assertNot(asobi_guest_controller:valid_device_id(~"")),
+    ?assertNot(asobi_guest_controller:valid_device_id(binary:copy(~"a", 256))).


### PR DESCRIPTION
Implements the guest/anonymous auth PendragonNL asked for ("connect without registering, like a guest"). Modelled as a `guest` provider identity parallel to OAuth — a client presents `{device_id, device_secret}`, the server creates a player on first presentation and resumes the SAME player after.

## Went through the full gate (with fixes applied)
- **architecture-guardian** ✅ — no warping; fixed C1 (count/batched queries instead of full-table loads), C2–C7.
- **beam-security-reviewer** (design + code) ✅ — all 8 mandated controls verified; fixed M-1 (finite cap default), M-2 (upgrade gated to unclaimed guests), M-3/M-4 (device secret can't resume a claimed account, robust to revoke-write failure).
- **erlang-code-reviewer** ✅ — fixed the reaper FK-orphan **blocker** (children-first delete in a transaction, accurate count), the `foldl`→named-recursion and `init_player_stats` DRY (`asobi_player_stats:init/1`), the distinct 500 atom.

## Security controls
| | |
|---|---|
| H1 | salted + peppered HMAC-SHA256 verifier in `provider_metadata`, key_id-tagged for rotation (interim static `guest_verifier_pepper`) |
| H2 | server-enforced ≥32-byte secret |
| H3 | `asobi_guest_global_limiter` + finite `guest_unlinked_cap` + unique `{provider, provider_uid}` + compensating delete on the race |
| H4 | `POST /auth/guest/upgrade` (gated to unclaimed guests) + existing `/auth/link` |
| M1 | fail-closed create/resume/reject, `crypto:hash_equals` |
| M2 | opt-in `guest_auth`, default **OFF**, fail-loud without a pepper |
| M3 | secret never stored or logged |
| M4 | claimed account can't be resumed via device secret; guest identity deleted on upgrade |
| reaper | opt-in `asobi_guest_reaper`, only never-claimed guests, batched, children-first transaction |

## Verification
`fmt`/`xref`/`dialyzer` clean, eunit 5/5 (verifier + entropy). `asobi_guest_SUITE` (create/resume, wrong-secret, weak-secret, upgrade/already-claimed, reaper) needs Docker Postgres → CI. **ELP eqwalize + lint were not runnable locally (no `elp` binary) — CI must pass them before merge.**

## Config (opt-in)
`guest_auth => true`, `guest_verifier_pepper => <32+ bytes | #{KeyId => Bytes}>`, optional `guest_unlinked_cap`, `guest_reap_after`.

## Notes
- Depends on nothing, but the shared `asobi_auth_error` normalization should be adopted by `asobi_auth_controller:register/1` once widgrensit/asobi#163 lands (both currently pin the same `"has already been taken"` sentinel).
- Rebases trivially over #163's `asobi_sup` limiter addition (different keys).