### PR TITLE
docs(guest): document anonymous guest auth in the backend guides

### DIFF
--- a/guides/authentication.md
+++ b/guides/authentication.md
@@ -1,9 +1,14 @@
 # Authentication
 
 Asobi supports multiple authentication methods: username/password, OAuth/OIDC
-social login (Google, Apple, Microsoft, Discord), Steam, and device-based auth.
+social login (Google, Apple, Microsoft, Discord), Steam, and anonymous
+[guest](#guest-anonymous) accounts that a player can later upgrade to a real one.
 
 Players can link multiple providers to a single account.
+
+> Auth endpoints return an `access_token` (short-lived) and a `refresh_token`
+> (used against `/auth/refresh`). The `session_token` shown in the shorthand
+> examples below is the access token; use it as the `Bearer` credential.
 
 ## Username & Password
 
@@ -135,6 +140,127 @@ display name from their Steam profile.
 ```
 
 Get your API key from the [Steam Partner site](https://partner.steamgames.com/).
+
+## Guest (Anonymous)
+
+Guest auth lets a player start playing immediately - no email, no password, no
+social sign-in - and claim a real account later without losing progress. It is
+the "device-based auth" option: the client generates a secret once, stores it on
+the device, and presents it to resume the same account on every launch.
+
+Guest auth is **opt-in** and disabled by default. Enable it in `sys.config`
+(see [Configuration](#configuration-2)) before the endpoints respond.
+
+### How it works
+
+1. On first launch the client generates a random `device_secret` (>= 32 bytes
+   from a CSPRNG) and a stable `device_id`, and stores both on the device
+   (Keychain on iOS, Keystore on Android, etc.).
+2. The client posts them to `POST /api/v1/auth/guest`. Asobi creates a player
+   and stores only a **salted, peppered HMAC** of the secret - never the secret
+   itself - then returns a token pair.
+3. On later launches the client posts the same `device_id` + `device_secret`.
+   Asobi verifies the HMAC and resumes the **same** player (create-or-resume).
+4. When the player is ready, they call `POST /api/v1/auth/guest/upgrade` with a
+   username and password. The account becomes a normal password account and the
+   device secret is revoked.
+
+The client must treat `device_secret` like a password: generate it with a
+cryptographic RNG, store it in secure device storage, and never log or transmit
+it anywhere but this endpoint. A guest account is only as safe as that secret,
+so it is low-assurance until upgraded.
+
+### Create or resume
+
+```bash
+curl -X POST http://localhost:8080/api/v1/auth/guest \
+  -H 'Content-Type: application/json' \
+  -d '{"device_id": "b64-device-id", "device_secret": "b64-32-random-bytes"}'
+```
+
+First call (new account):
+
+```json
+{
+  "player_id": "...",
+  "access_token": "...",
+  "refresh_token": "...",
+  "username": "guest_019f615cbc4a",
+  "created": true,
+  "guest": true
+}
+```
+
+Later calls with the same credentials resume the same player and omit `created`.
+A wrong secret for a known `device_id` returns `401 invalid_device_secret` and
+never creates a second account.
+
+### Upgrade to a real account
+
+Requires the guest's own session (the token from the create-or-resume call).
+Only an unclaimed guest may upgrade - a password account, or an account with a
+non-guest provider, is refused.
+
+```bash
+curl -X POST http://localhost:8080/api/v1/auth/guest/upgrade \
+  -H 'Authorization: Bearer <access_token>' \
+  -H 'Content-Type: application/json' \
+  -d '{"username": "player1", "password": "secret123"}'
+```
+
+```json
+{
+  "player_id": "...",
+  "access_token": "...",
+  "refresh_token": "...",
+  "username": "player1",
+  "upgraded": true
+}
+```
+
+Upgrade revokes every token the guest held (a fresh pair is returned) and
+deletes the device verifier, so the old device secret can no longer sign in.
+Player id, progress, wallets, and inventory are preserved.
+
+### Errors
+
+| Status | `error` | Meaning |
+|--------|---------|---------|
+| `404`  | `guest_auth_disabled`     | Guest auth is not enabled in config |
+| `400`  | `missing_required_fields` | `device_id` / `device_secret` (or `username` / `password` on upgrade) absent |
+| `400`  | `weak_device_secret`      | Secret decodes to fewer than 32 bytes (or exceeds the size cap) |
+| `400`  | `invalid_device_id`       | `device_id` empty or over 255 bytes |
+| `401`  | `invalid_device_secret`   | Wrong secret for a known device |
+| `401`  | `guest_revoked`           | The device verifier was revoked |
+| `401`  | `guest_upgraded`          | The account was already claimed; log in with its real credentials |
+| `409`  | `not_an_unclaimed_guest`  | Upgrade target is not an unclaimed guest |
+| `409`  | `username_taken`          | Upgrade username is already in use |
+| `422`  | `validation_failed`       | Upgrade fields invalid (see `fields`) |
+| `503`  | `guest_capacity_reached`  | Global create limit or the unlinked-guest cap was hit |
+
+### Configuration
+
+```erlang
+{asobi, [
+    {guest_auth, true},
+    %% Required. A key-id -> pepper map (>= 32 bytes each). Keep old keys for the
+    %% guest retention window so existing guests can still resume after rotation.
+    {guest_verifier_pepper, #{<<"v1">> => <<"a-32-byte-or-longer-secret......">>}},
+    {guest_verifier_key_id, <<"v1">>},
+
+    %% Optional abuse controls.
+    {guest_unlinked_cap, 100000},        %% max unclaimed guests, or `infinity`
+
+    %% Optional retention. Unset = permanent guests (never reaped). Set to a
+    %% number of seconds to delete unclaimed guests older than that.
+    {guest_reap_after, 2592000}          %% e.g. 30 days
+]}
+```
+
+The pepper is a server-side secret that makes a stolen database of verifiers
+useless without it - store it like any other secret (env/secret manager), not in
+source. Guest creation is additionally bounded by a global rate limiter and the
+per-IP auth limiter.
 
 ## Linking Providers
 

--- a/guides/comparison.md
+++ b/guides/comparison.md
@@ -8,6 +8,7 @@ How Asobi compares to other open-source game backend platforms.
 |---------|:-----:|:------:|:--------:|:-------:|
 | **Runtime** | BEAM (Erlang/OTP) | Go | Node.js | Cloud |
 | **Authentication** | Built-in | Built-in | Plugin | Built-in |
+| **Anonymous / Guest Auth** | Built-in (upgradeable) | Built-in | Manual | Built-in |
 | **Player Management** | Built-in | Built-in | Manual | Built-in |
 | **Real-Time Multiplayer** | WebSocket | WebSocket | WebSocket | WebSocket |
 | **Server-Authoritative Game Loop** | Built-in (tick-based) | Lua scripting | Room-based | CloudScript |

--- a/guides/migrate-from-nakama.md
+++ b/guides/migrate-from-nakama.md
@@ -65,7 +65,8 @@ Nakama and asobi agree on most of the vocabulary:
 | **Notifications** | Notifications (`/api/v1/notifications`) | Plus WS push. |
 | **Wallets** | Economy wallets (`/api/v1/wallets`) | Multi-currency ledgers. |
 | **Purchases** | Economy store (`/api/v1/store/purchase`) | Integrates with IAP verification. |
-| **Authentication (Custom / Device / Email)** | `/api/v1/auth/register` + `/login` | Username + password (you generate creds client-side for "custom" flows). |
+| **Authentication (Device / Custom)** | `/api/v1/auth/guest` | Create-or-resume anonymous accounts from a device-held secret; upgrade later with `/auth/guest/upgrade`. Maps directly to `AuthenticateDevice`/`AuthenticateCustom`. |
+| **Authentication (Email)** | `/api/v1/auth/register` + `/login` | Username + password. |
 | **Authentication (Google / Apple / Steam / ...)** | `/api/v1/auth/oauth` | OAuth/OIDC. |
 | **RPC endpoints** | Nova controllers (Erlang) or Lua callbacks | For per-match logic, use Lua in `match.lua`. For cross-match workflows, write a Nova controller. |
 | **Hooks (`before_authenticate`, `after_friendAdd`)** | Nova plugins + match lifecycle callbacks | Pre- and post-request middleware in Nova. |
@@ -191,9 +192,9 @@ var session = await client.AuthenticateCustomAsync(deviceId);
 var socket = client.NewSocket();
 await socket.ConnectAsync(session);
 
-// After (asobi)
+// After (asobi) - guest auth is the direct AuthenticateCustom/Device equivalent
 var client = new AsobiClient("https://api.my-game.com");
-await client.Auth.RegisterAsync(deviceId, localPassword);   // or LoginAsync
+await client.Auth.GuestAsync(deviceId, deviceSecret);   // POST /auth/guest, create-or-resume
 await client.WebSocket.ConnectAsync();
 client.WebSocket.SendSessionConnect(client.Session.Token);
 ```

--- a/guides/migrate-from-playfab.md
+++ b/guides/migrate-from-playfab.md
@@ -114,21 +114,24 @@ curl localhost:8080/api/v1/auth/register \
 
 PlayFab auth paths map 1:1:
 
+`LoginWithCustomID` maps directly to guest auth - Asobi handles create-or-resume
+server-side, so there is no client-generated password to persist:
+
 ```csharp
 // Before (PlayFab)
 PlayFabClientAPI.LoginWithCustomID(new LoginWithCustomIDRequest {
   CustomId = deviceId, CreateAccount = true
 }, OnSuccess, OnError);
 
-// After (asobi) — generate creds once, persist locally, then login
+// After (asobi) — anonymous guest, create-or-resume from a device-held secret
 var client = new AsobiClient("https://api.my-game.com");
-if (!PlayerPrefs.HasKey("asobi_pw")) {
-  PlayerPrefs.SetString("asobi_pw", Guid.NewGuid().ToString("N"));
-  await client.Auth.RegisterAsync(deviceId, PlayerPrefs.GetString("asobi_pw"));
-} else {
-  await client.Auth.LoginAsync(deviceId, PlayerPrefs.GetString("asobi_pw"));
-}
+await client.Auth.GuestAsync(deviceId, deviceSecret);   // POST /auth/guest
+// later, when the player signs up for real:
+// await client.Auth.UpgradeGuestAsync(username, password);
 ```
+
+Store `deviceSecret` (>= 32 random bytes) in secure device storage; see the
+[Authentication guide](authentication.md#guest-anonymous).
 
 OAuth providers (Google, Apple, Steam) go through
 `POST /api/v1/auth/oauth` — same as PlayFab's `LoginWithGoogleAccount` etc.

--- a/guides/rest-api.md
+++ b/guides/rest-api.md
@@ -19,12 +19,14 @@ Authenticated endpoints require the `Authorization: Bearer <session_token>` head
 ## Auth
 
 ```
-POST   /api/v1/auth/register     Register a new player
-POST   /api/v1/auth/login        Login, returns session token
-POST   /api/v1/auth/refresh      Refresh session token
-POST   /api/v1/auth/oauth        OAuth / Steam token validation
-POST   /api/v1/auth/link         Link a provider to the current account
-DELETE /api/v1/auth/unlink       Unlink a provider
+POST   /api/v1/auth/register        Register a new player
+POST   /api/v1/auth/login           Login, returns session token
+POST   /api/v1/auth/refresh         Refresh session token
+POST   /api/v1/auth/oauth           OAuth / Steam token validation
+POST   /api/v1/auth/guest           Create or resume an anonymous guest
+POST   /api/v1/auth/guest/upgrade   Claim a guest account (username + password)
+POST   /api/v1/auth/link            Link a provider to the current account
+DELETE /api/v1/auth/unlink          Unlink a provider
 ```
 
 ### Register
@@ -49,6 +51,25 @@ curl -X POST /api/v1/auth/login \
 
 ```json
 {"player_id": "...", "session_token": "...", "username": "player1"}
+```
+
+### Guest
+
+Anonymous device-based auth, opt-in via config. `POST /auth/guest` creates a
+player on first call and resumes the same one on later calls; `/auth/guest/upgrade`
+(authenticated) claims it with a username and password. See the
+[Authentication guide](authentication.md#guest-anonymous) for the device-secret
+contract, config, and error codes.
+
+```bash
+curl -X POST /api/v1/auth/guest \
+  -H 'Content-Type: application/json' \
+  -d '{"device_id": "b64-device-id", "device_secret": "b64-32-random-bytes"}'
+```
+
+```json
+{"player_id": "...", "access_token": "...", "refresh_token": "...",
+ "username": "guest_019f615cbc4a", "created": true, "guest": true}
 ```
 
 ## Players


### PR DESCRIPTION
Documents the guest-auth feature (#164) across the backend guides. Backend-only; the per-SDK `guest()`/`upgrade()` client methods + quickstarts are the next phase.

## What changed
- **authentication.md** — new `Guest (Anonymous)` section: create-or-resume model, the device-secret contract (client-generated CSPRNG secret, secure storage, never logged), the upgrade flow, a full error table, and config keys (`guest_auth`, `guest_verifier_pepper`, cap, retention).
- **rest-api.md** — `POST /auth/guest` and `/auth/guest/upgrade` routes + a summary block.
- **comparison.md** — an *upgradeable* guest-auth row in the feature matrix (the differentiator vs Nakama/PlayFab, which have device auth but not a clean upgrade path).
- **migrate-from-nakama / migrate-from-playfab** — map `AuthenticateDevice`/`AuthenticateCustom` and `LoginWithCustomID` to guest auth, replacing the old client-generated-password workaround.
- Clarifies that auth endpoints return an `access_token`/`refresh_token` pair (the `session_token` shorthand is the access token).

## Notes
- All response shapes and error codes are traced from `asobi_guest_controller` on main, not invented.
- The migrate-guide C# snippets reference `Auth.GuestAsync` / `Auth.UpgradeGuestAsync` — these name the target SDK methods the per-SDK phase will implement.
- `rebar3 ex_doc` clean; `#guest-anonymous` and `#configuration-2` anchors verified in the generated HTML.