### PR TITLE
fix(deps): pin rebar3_kura to v0.15.4 (fixes nightly #172)

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -68,7 +68,7 @@
 
 {project_plugins, [
     {rebar3_nova, {git, "https://github.com/Taure/rebar3_nova.git", {branch, "feat/unified-gen"}}},
-    {rebar3_kura, {git, "https://github.com/Taure/rebar3_kura.git", {branch, "main"}}},
+    {rebar3_kura, {git, "https://github.com/Taure/rebar3_kura.git", {tag, "v0.15.4"}}},
     {rebar3_audit, {git, "https://github.com/Taure/rebar3_audit.git", {tag, "v0.2.7"}}},
     {rebar3_sbom,
         {git, "https://github.com/Taure/rebar3_sbom.git", {branch, "feat/include-otp-components"}}},


### PR DESCRIPTION
## Problem
Nightly #172 (2026-07-15) failed at dependency compile, not in the property tests:

\`\`\`
===> Compiling _build/default/lib/kura/src/kura_dialect_pg.erl failed
 11 │  -behaviour(kura_dialect).
     │   ╰── undefined callback function delete/3 (behaviour 'kura_dialect')
\`\`\`

`rebar.config` pinned `rebar3_kura` to `{branch, "main"}` — a moving target. rebar3_kura bundles its own kura via its dep declaration. When main pointed at a commit pulling an older kura (v2.6.0), that kura's `kura_dialect` behaviour requires `delete/3` and shadowed asobi's kura 2.17.1 `kura_dialect_pg` (which implements `delete/2`), breaking the compile. Regular CI stayed green off cached `_build`; the nightly's fresh fetch hit it.

## Fix
Pin to the latest tag **v0.15.4**, which declares `{kura, "~> 2.17"}` — the same kura line asobi uses, so no foreign dialect behaviour shadows the compile.

## Verification
Wiped `rebar3_kura` + `kura` + `kura_postgres` from `_build` (mimicking the nightly's clean fetch), then:
- `rebar3 compile` — green
- `rebar3 as test compile` — green (the exact path that broke)

Closes #172.