### PR TITLE
docs: complete the guest auth error table, and guard it in CI

### DIFF
--- a/.github/workflows/docs-drift.yml
+++ b/.github/workflows/docs-drift.yml
@@ -1,0 +1,38 @@
+name: Docs drift
+
+# Fails if a guide's error table no longer matches the controller it describes:
+# an atom the controller returns but the table omits, or a table row no source
+# backs. The guest table listed 11 of 15 atoms until #176, one of the missing
+# being the retryable 409 device_already_registered.
+#
+# Separate from ci.yml because that delegates wholesale to the erlang-ci
+# reusable workflow and takes no extra steps. Guides and controllers live in
+# this repo, so nothing needs cloning - unlike asobi_site, which runs the same
+# check against its own hand-written docs and must fetch this repo first.
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'guides/authentication.md'
+      - 'src/controllers/asobi_guest_controller.erl'
+      - 'src/asobi_auth_error.erl'
+      - 'scripts/check-error-drift.sh'
+      - '.github/workflows/docs-drift.yml'
+  pull_request:
+    branches: [main]
+    paths:
+      - 'guides/authentication.md'
+      - 'src/controllers/asobi_guest_controller.erl'
+      - 'src/asobi_auth_error.erl'
+      - 'scripts/check-error-drift.sh'
+      - '.github/workflows/docs-drift.yml'
+
+jobs:
+  drift:
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+      - name: Check error-table-vs-controller drift
+        run: scripts/check-error-drift.sh

--- a/guides/authentication.md
+++ b/guides/authentication.md
@@ -226,16 +226,20 @@ Player id, progress, wallets, and inventory are preserved.
 
 | Status | `error` | Meaning |
 |--------|---------|---------|
-| `404`  | `guest_auth_disabled`     | Guest auth is not enabled in config |
 | `400`  | `missing_required_fields` | `device_id` / `device_secret` (or `username` / `password` on upgrade) absent |
 | `400`  | `weak_device_secret`      | Secret decodes to fewer than 32 bytes (or exceeds the size cap) |
 | `400`  | `invalid_device_id`       | `device_id` empty or over 255 bytes |
 | `401`  | `invalid_device_secret`   | Wrong secret for a known device |
 | `401`  | `guest_revoked`           | The device verifier was revoked |
 | `401`  | `guest_upgraded`          | The account was already claimed; log in with its real credentials |
+| `404`  | `guest_auth_disabled`     | Guest auth is not enabled in config |
+| `404`  | `player_not_found`        | The upgrade token resolves to no player |
+| `409`  | `device_already_registered` | Two creates for the same device raced; retry - the retry resumes the existing guest |
 | `409`  | `not_an_unclaimed_guest`  | Upgrade target is not an unclaimed guest |
 | `409`  | `username_taken`          | Upgrade username is already in use |
 | `422`  | `validation_failed`       | Upgrade fields invalid (see `fields`) |
+| `500`  | `guest_create_failed`     | The player row could not be created |
+| `500`  | `guest_player_missing`    | The device resolves to an identity whose player no longer exists |
 | `503`  | `guest_capacity_reached`  | Global create limit or the unlinked-guest cap was hit |
 
 ### Configuration

--- a/scripts/check-error-drift.sh
+++ b/scripts/check-error-drift.sh
@@ -1,0 +1,112 @@
+#!/usr/bin/env bash
+# Guards the guides' error tables against the controllers they describe.
+#
+# An error table is a contract a client acts on: the guest table here listed 11
+# of the 15 atoms asobi_guest_controller returns, and one of the four missing
+# was the retryable 409 device_already_registered - a client reading the guide
+# would treat it as fatal and fail a launch a retry resolves (#176). Both
+# directions are checked: every atom the source returns is documented, and every
+# atom documented is reachable.
+#
+# The sibling asobi_site runs the same check against its own hand-written docs
+# (asobi_site#90). Two surfaces describe these endpoints, so both need guarding.
+#
+# Usage: scripts/check-error-drift.sh
+set -uo pipefail
+
+repo_root="$(cd "$(dirname "$0")/.." && pwd)"
+fail=0
+
+# Every "<status> <atom>" pair a module returns. Newlines are flattened and runs
+# of spaces squeezed first, so erlfmt reflowing a return across lines can never
+# hide it from the regex.
+src_pairs() {
+	tr '\n' ' ' <"$1" | tr -s ' ' |
+		grep -oE '\{json, ?[0-9]+, ?#\{\}, ?#\{ ?error => ~"[a-z_]+"' |
+		sed -E 's/.*\{json, ?([0-9]+).*error => ~"([a-z_]+)"/\1 \2/'
+}
+
+# Every "<status> <atom>" row of the markdown error table inside one guide
+# section. Scoped to the section so an unrelated table added elsewhere in the
+# same guide cannot bleed in and fail this spuriously.
+doc_pairs() {
+	# SC2016: the backticks are literal markdown, not command substitution -
+	# single quotes are what keeps them literal.
+	# shellcheck disable=SC2016
+	awk -v heading="$2" '$0 == heading {f=1; next} /^## /{f=0} f' "$1" |
+		grep -oE '^\| `[0-9]{3}` *\| `[a-z_]+`' |
+		sed -E 's/^\| `([0-9]{3})` *\| `([a-z_]+)`/\1 \2/'
+}
+
+indent() {
+	local line
+	while IFS= read -r line; do printf '        %s\n' "$line"; done
+}
+
+# check_table <label> <guide> <section-heading> <module...>
+#
+# Every listed module is authoritative: the table must document exactly the
+# union of what they return, no more and no less. asobi_auth_error is shared
+# with register/login, but every atom it can return on this path is one the
+# endpoint genuinely can return, so it earns the same exactness as the
+# controller. A new atom there failing this check is the point - a human should
+# look, not let the table drift silently.
+check_table() {
+	local label="$1" guide="$2" heading="$3"
+	shift 3
+	local f
+	for f in "$guide" "$@"; do
+		if [ ! -f "$f" ]; then
+			echo "  !!  $label - $f not found"
+			fail=1
+			return
+		fi
+	done
+
+	local documented returned missing extra m
+	documented=$(doc_pairs "$guide" "$heading" | sort -u)
+	returned=$(
+		for m in "$@"; do src_pairs "$m"; done | sort -u
+	)
+
+	if [ -z "$documented" ]; then
+		echo "  !!  $label - no error table found under '$heading' in $(basename "$guide")"
+		fail=1
+		return
+	fi
+
+	missing=$(comm -23 <(echo "$returned") <(echo "$documented"))
+	extra=$(comm -13 <(echo "$returned") <(echo "$documented"))
+
+	if [ -n "$missing" ]; then
+		echo "  !!  $label - returned by source, undocumented:"
+		echo "$missing" | indent
+		fail=1
+	fi
+	if [ -n "$extra" ]; then
+		echo "  !!  $label - documented, but no source returns it:"
+		echo "$extra" | indent
+		fail=1
+	fi
+	if [ -z "$missing$extra" ]; then
+		echo "  OK  $label - $(echo "$documented" | wc -l) rows match source"
+	fi
+}
+
+echo "== Guest auth =="
+check_table "guest error table" \
+	"$repo_root/guides/authentication.md" \
+	'## Guest (Anonymous)' \
+	"$repo_root/src/controllers/asobi_guest_controller.erl" \
+	"$repo_root/src/asobi_auth_error.erl"
+
+# Add a check_table line above as other exhaustive error tables are written. A
+# table that is deliberately partial ("common errors") must not be listed here -
+# this guard reads every table it is given as a complete contract.
+
+echo
+if [ "$fail" -ne 0 ]; then
+	echo "DRIFT: a guide's error table no longer matches the controller it describes."
+	exit 1
+fi
+echo "OK: every documented error atom matches source."


### PR DESCRIPTION
Found while documenting guest auth on asobi.dev (asobi_site#90): the error table in `guides/authentication.md` listed 11 of the 15 error atoms `asobi_guest_controller` actually returns. This fixes the table and adds a CI guard so it cannot drift again.

## The missing rows

| Status | `error` | Why it happens |
|---|---|---|
| `404` | `player_not_found` | The upgrade token resolves to no player (`asobi_guest_controller.erl:79`) |
| `409` | `device_already_registered` | Two creates for the same device raced the unique `{provider, device_id}` index; the loser deletes its just-created player and returns this. The retry resumes the existing guest (`:211`) |
| `500` | `guest_create_failed` | The player row could not be created (`:214`) |
| `500` | `guest_player_missing` | The device resolves to an identity whose player no longer exists (`:233`) |

`409 device_already_registered` is the one that matters for clients: it is transient and retryable, and a client that treats it as fatal would fail a launch a retry would resolve.

Rows are now sorted by status code.

## The guard

`scripts/check-error-drift.sh` extracts `(status, atom)` pairs from the table and from the modules behind it, and requires an exact match in **both** directions - nothing the controller returns is undocumented, nothing documented is unreachable. Status codes are compared too, so a right-atom-wrong-code row fails.

Verified each failure mode actually fails rather than passing quietly:

| Mode | Result |
|---|---|
| Dropped row (the bug this PR fixes) | fails, names the atom |
| Fictional atom documented | fails, both directions |
| Right atom, wrong status code | fails |
| Section heading renamed (parses to zero rows) | fails, does not pass empty |
| Referenced module missing | fails |

Unlike asobi_site's copy, which must tolerate an absent clone of this repo, every input here is in-repo, so a missing file is a hard failure and cannot mask a false pass.

It lives outside `ci.yml` because that delegates wholesale to the erlang-ci reusable workflow and takes no extra steps. No `schedule:` - both inputs are in this repo, so there is no cross-repo drift to catch on a timer (the site's copy does need one).

## Why both surfaces need this

These endpoints are documented twice: here (ex_doc -> hexdocs) and again in asobi_site, which hand-writes its docs as Erlang views rather than generating from `guides/`. Nothing couples them, which is why guest auth shipped fully documented here and entirely absent from asobi.dev. Both tables now match source exactly and both are guarded, but the duplication itself remains the underlying problem.