### PR TITLE
docs: ADR 0003 - single-source docs by truth-holder

### DIFF
--- a/docs/adr/0003-docs-single-sourced-by-truth-holder.md
+++ b/docs/adr/0003-docs-single-sourced-by-truth-holder.md
@@ -24,9 +24,13 @@ They disagree, measurably:
   documented 11 of the 15 atoms `asobi_guest_controller` returns (#176). One
   of the four missing was the retryable `409 device_already_registered`,
   which a client reading the docs would treat as fatal.
-- **Three API ports are documented for the same server.** `guides/`
-  says 8080, asobi.dev and all 7 SDK READMEs say 8084, and asobi's own
-  dev config listens on 8082.
+- **Three API ports are documented for the same server.** `guides/` says
+  8080, asobi.dev and all 7 SDK READMEs say 8084, and asobi's own dev
+  config listens on 8082. Note which was right: the published image
+  defaulted to 8080, so `guides/` matched reality and the client-facing
+  surface was the drift. Counting occurrences would have concluded the
+  opposite — 60 uses of 8084 against 29 of 8080 — which is why ownership
+  follows the code that can be wrong, not the majority of copies.
 
 The obvious fix — make `guides/` the single source and generate asobi.dev
 from it — does not survive contact with the boundaries this project
@@ -75,11 +79,17 @@ Corollaries:
 - **Pages with no truth-holder guide stay hand-written.** Writing a guide
   in `asobi` purely so the site can generate from it inverts the
   relationship: it warps the library to serve the website.
-- **Docs examples agree on port 8084.** The port is not a fact to be
-  discovered — prod reads `${ASOBI_PORT}` and each setup path simply chose
-  differently. It is a convention, so the docs pick one. 8084 wins on
-  count: 7 SDK repos across 34 files, plus 26 uses on the site, against
-  29 uses in `guides/` alone.
+- **Docs examples agree on port 8084, and the image moves to meet them.**
+  The port *is* a fact, and this principle located it: `asobi_lua`'s
+  Dockerfile (`EXPOSE 8080`, `ENV ASOBI_PORT=8080`) is the truth-holder,
+  because the published image is what a quickstart actually runs. So 8080
+  was correct and `guides/` was right; asobi.dev and the 7 SDK READMEs
+  were the drift.
+  We move the image to 8084 anyway, as a deliberate breaking change:
+  8080 collides with most other things on a developer's machine, and
+  moving one image beats moving 34 files across 8 client repos. The
+  truth-holder still decides — it is simply being changed on purpose
+  rather than contradicted.
 
 ## Consequences
 

--- a/docs/adr/0003-docs-single-sourced-by-truth-holder.md
+++ b/docs/adr/0003-docs-single-sourced-by-truth-holder.md
@@ -1,0 +1,101 @@
+# ADR 0003: Docs are single-sourced by truth-holder, not by repo
+
+Date: 2026-07-17
+
+## Status
+
+Accepted.
+
+## Context
+
+The same endpoints are documented twice. `asobi/guides/*.md` ships to
+hexdocs.pm/asobi as ex_doc extras. asobi.dev hand-writes its own copy as
+34 Erlang view modules (`asobi_site/src/views/asobi_site_docs_*_view.erl`).
+Nothing couples the two, and nothing notices when they disagree.
+
+They disagree, measurably:
+
+- **A whole feature reached one surface and not the other.** Guest auth
+  shipped 2026-07-14 (backend #164, all 7 SDKs) fully documented in
+  `guides/authentication.md`. asobi.dev carried zero mentions of it across
+  every page until asobi_site#90 — three days later, and only because
+  someone looked.
+- **The error tables drifted from the controller.** `guides/authentication.md`
+  documented 11 of the 15 atoms `asobi_guest_controller` returns (#176). One
+  of the four missing was the retryable `409 device_already_registered`,
+  which a client reading the docs would treat as fatal.
+- **Three API ports are documented for the same server.** `guides/`
+  says 8080, asobi.dev and all 7 SDK READMEs say 8084, and asobi's own
+  dev config listens on 8082.
+
+The obvious fix — make `guides/` the single source and generate asobi.dev
+from it — does not survive contact with the boundaries this project
+already holds:
+
+- **It would put a closed product's docs in a public library.** `/docs/cloud`
+  documents the managed offering (console.asobi.dev), which is developed
+  closed-source on its own release cadence. Hosting its docs in `asobi`'s
+  hexdocs publishes a commercial surface from a public library — one whose
+  own `comparison.md` and `exit.md` sell independence from closed managed
+  clouds.
+- **asobi does not own the Lua docs it already ships.** `asobi` has no
+  luerl dependency and no `luerl` reference in `src/`, yet publishes
+  `lua-scripting.md` and `lua-bots.md` (173 lines) to hexdocs.
+  `asobi_lua` — which actually implements the runtime — carries its own
+  richer set (1,255 lines across six guides). asobi holds a stale copy of
+  docs for a library it does not depend on.
+- **It cannot cover the site anyway.** Only 16 of asobi.dev's 34 doc pages
+  have a `guides/` counterpart. 18 do not, and 9 guides have no site page.
+
+"The docs drifted" is real. "Therefore one repo owns all docs" does not
+follow.
+
+## Decision
+
+Each doc page is generated from the repo whose CI can verify its claims.
+The truth-holder is the repo that would fail a build if the claim became
+false — not the repo that happens to want the page.
+
+| Source repo | Pages it owns |
+|---|---|
+| `asobi` | authentication, configuration, protocols/rest, protocols/websocket, matchmaking, economy, voting, world-server, clustering, performance, quickstart, security/{auth,threat-model,known-limitations} |
+| `asobi_lua` | lua/{api,bots}, security/{lua-sandbox,lua-trust-model,lua-known-limitations}, self-host |
+| `asobi-{unity,godot,defold}` | the matching quickstart/\<engine\> page |
+| `asobi_site` | cloud, samples, tutorials/\*, concepts, errors, leaderboards, lua/{callbacks,cookbook}, security overview |
+
+Corollaries:
+
+- **`asobi` drops its Lua guides.** `lua-scripting.md` and `lua-bots.md`
+  leave asobi's ex_doc extras; asobi links to asobi_lua's hexdocs instead.
+  A library documents what it implements.
+- **`/docs/cloud` is never single-sourced into a public library.** It stays
+  hand-written site-side. The one-line pointers in `glossary.md` and
+  `comparison.md` are the correct register for a public library
+  acknowledging a commercial option.
+- **Pages with no truth-holder guide stay hand-written.** Writing a guide
+  in `asobi` purely so the site can generate from it inverts the
+  relationship: it warps the library to serve the website.
+- **Docs examples agree on port 8084.** The port is not a fact to be
+  discovered — prod reads `${ASOBI_PORT}` and each setup path simply chose
+  differently. It is a convention, so the docs pick one. 8084 wins on
+  count: 7 SDK repos across 34 files, plus 26 uses on the site, against
+  29 uses in `guides/` alone.
+
+## Consequences
+
+- asobi.dev consumes generated content from three repo families rather
+  than one, so the site build fetches from each. More moving parts than a
+  single source, and the price of not violating the boundaries.
+- The 18 site-only pages keep drifting by hand. That is accepted: they
+  have no truth-holder, so there is nothing to generate them from. The
+  drift guards (`scripts/check-error-drift.sh` here and in asobi_site)
+  cover the factual tables regardless of who writes the prose.
+- hexdocs and asobi.dev keep different registers — library users and game
+  developers are different audiences — so generation carries content, not
+  layout. The site keeps its own shell, callouts, and SDK tabs.
+- Two guides in `asobi` become one-line pointers to asobi_lua. Anyone
+  landing on the old hexdocs anchors follows a link instead of reading a
+  stale copy.
+- Reconciling the existing divergences into the owning repos, and fixing
+  the port, are prerequisites. Generating first would propagate whichever
+  copy happened to win.


### PR DESCRIPTION
Records the architecture decision behind the guest-auth docs gap found this week (#176, asobi_site#90).

## The problem

These endpoints are documented twice - `guides/*.md` to hexdocs, and again by hand as 34 Erlang views on asobi.dev - with nothing coupling them. Measured drift:

| Symptom | Evidence |
|---|---|
| A whole feature reached one surface only | Guest auth shipped 2026-07-14 fully documented in `guides/`, **zero** mentions on asobi.dev until asobi_site#90, three days later |
| Error tables drifted from the controller | `guides/authentication.md` listed 11 of 15 atoms (#176), missing the retryable `409 device_already_registered` |
| Three API ports for one server | `guides/` 8080, asobi.dev + all 7 SDK READMEs 8084, asobi dev config 8082 |

## Why not "guides as the single source"

That was the first instinct and it does not survive the boundaries this project already holds:

- **`/docs/cloud` is a closed product's docs.** Hosting it in a public library's hexdocs publishes a commercial surface from a library whose own `comparison.md` and `exit.md` sell independence from closed managed clouds.
- **asobi does not own the Lua docs it already ships.** No luerl dependency, no `luerl` reference in `src/`, yet it publishes `lua-scripting.md` + `lua-bots.md` (173 lines). `asobi_lua` implements the runtime and carries 1,255 lines across six guides. asobi holds the stale copy.
- **It cannot cover the site regardless.** Only 16 of 34 site pages have a guide; 18 do not, and 9 guides have no site page.

## The decision

Each page is generated from the repo whose CI would fail if the claim became false. asobi keeps 13 pages, `asobi_lua` takes the Lua + self-host set, each SDK repo owns its quickstart, and pages with no truth-holder (cloud, samples, tutorials, errors, leaderboards, concepts) stay hand-written rather than warping the library to serve the website.

Two corollaries land as follow-up work: asobi drops its Lua guides in favour of links to asobi_lua's hexdocs, and the docs standardise on port 8084 (7 SDK repos / 34 files / 26 site uses, against 29 uses in `guides/` alone).

## Notes for review

Every figure above was verified against the repos rather than taken from the analysis that proposed it - two claims from that analysis were discarded for not surviving the check. The architecture review that informed this is what caught the Lua ownership inversion, which I had missed entirely.

No code changes; this is the decision record. Implementation is phased and gated on it.