### PR TITLE
docs: move to port 8084, hand the Lua guides to asobi_lua

### DIFF
--- a/docker-compose.example.yml
+++ b/docker-compose.example.yml
@@ -10,11 +10,11 @@ services:
   asobi:
     image: ghcr.io/widgrensit/asobi_lua:latest
     ports:
-      - "8080:8080"
+      - "8084:8084"
     volumes:
       - ./game:/app/game
     environment:
-      ASOBI_PORT: 8080
+      ASOBI_PORT: 8084
       ASOBI_DB_HOST: db
       ASOBI_DB_NAME: my_game
       ASOBI_DB_USER: postgres

--- a/examples/erlang-match/README.md
+++ b/examples/erlang-match/README.md
@@ -16,10 +16,10 @@ rebar3 shell              # pulls deps, runs migrations, boots asobi
 ```
 
 You'll see `Nova application started` once asobi is listening on
-`localhost:8080`. Verify:
+`localhost:8084`. Verify:
 
 ```bash
-curl -s localhost:8080/api/v1/auth/register \
+curl -s localhost:8084/api/v1/auth/register \
   -H 'content-type: application/json' \
   -d '{"username":"alice","password":"hunter-2026"}' | jq
 ```

--- a/examples/erlang-match/config/sys.config
+++ b/examples/erlang-match/config/sys.config
@@ -4,7 +4,7 @@
         {dev_mode, true},
         {bootstrap_application, asobi},
         {json_lib, json},
-        {cowboy_configuration, #{port => 8080}},
+        {cowboy_configuration, #{port => 8084}},
         {plugins, [
             {pre_request, nova_request_plugin, #{
                 decode_json_body => true,

--- a/examples/hotreload-demo/nginx.conf
+++ b/examples/hotreload-demo/nginx.conf
@@ -11,7 +11,7 @@ server {
 
     # REST — proxy to asobi container
     location /api/ {
-        proxy_pass http://asobi:8080;
+        proxy_pass http://asobi:8084;
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
@@ -19,7 +19,7 @@ server {
 
     # WebSocket — upgrade headers required
     location /ws {
-        proxy_pass http://asobi:8080;
+        proxy_pass http://asobi:8084;
         proxy_http_version 1.1;
         proxy_set_header Upgrade $http_upgrade;
         proxy_set_header Connection "upgrade";

--- a/examples/world-spawns/docker-compose.yml
+++ b/examples/world-spawns/docker-compose.yml
@@ -17,9 +17,9 @@ services:
       postgres:
         condition: service_healthy
     ports:
-      - "8080:8080"
+      - "8084:8084"
     environment:
-      ASOBI_PORT: "8080"
+      ASOBI_PORT: "8084"
       ASOBI_DB_HOST: postgres
       ASOBI_DB_NAME: spawns
       ASOBI_DB_USER: postgres

--- a/examples/world-terrain/config/sys.config
+++ b/examples/world-terrain/config/sys.config
@@ -4,7 +4,7 @@
         {dev_mode, true},
         {bootstrap_application, asobi},
         {json_lib, json},
-        {cowboy_configuration, #{port => 8080}},
+        {cowboy_configuration, #{port => 8084}},
         {plugins, [
             {pre_request, nova_request_plugin, #{
                 decode_json_body => true,

--- a/examples/world-walkers/defold-client/walkers.script
+++ b/examples/world-walkers/defold-client/walkers.script
@@ -13,7 +13,7 @@ local asobi = require("asobi.client")
 local SPEED       = 200       -- units per second
 local SEND_HZ     = 20        -- inputs/sec sent to the server
 local SERVER_HOST = "localhost"
-local SERVER_PORT = 8080
+local SERVER_PORT = 8084
 
 local client
 local state = {

--- a/examples/world-walkers/docker-compose.yml
+++ b/examples/world-walkers/docker-compose.yml
@@ -17,9 +17,9 @@ services:
       postgres:
         condition: service_healthy
     ports:
-      - "8080:8080"
+      - "8084:8084"
     environment:
-      ASOBI_PORT: "8080"
+      ASOBI_PORT: "8084"
       ASOBI_DB_HOST: postgres
       ASOBI_DB_NAME: walkers
       ASOBI_DB_USER: postgres

--- a/guides/authentication.md
+++ b/guides/authentication.md
@@ -15,7 +15,7 @@ Players can link multiple providers to a single account.
 The simplest method. Register and login to receive a session token:
 
 ```bash
-curl -X POST http://localhost:8080/api/v1/auth/register \
+curl -X POST http://localhost:8084/api/v1/auth/register \
   -H 'Content-Type: application/json' \
   -d '{"username": "player1", "password": "secret123"}'
 ```
@@ -52,7 +52,7 @@ POST /api/v1/auth/oauth
 ### Example
 
 ```bash
-curl -X POST http://localhost:8080/api/v1/auth/oauth \
+curl -X POST http://localhost:8084/api/v1/auth/oauth \
   -H 'Content-Type: application/json' \
   -d '{"provider": "google", "token": "eyJhbGciOiJSUzI1NiIs..."}'
 ```
@@ -122,7 +122,7 @@ Steam uses session tickets instead of OIDC. The game client obtains a ticket
 via `ISteamUser::GetAuthSessionTicket` and sends the hex-encoded ticket.
 
 ```bash
-curl -X POST http://localhost:8080/api/v1/auth/oauth \
+curl -X POST http://localhost:8084/api/v1/auth/oauth \
   -H 'Content-Type: application/json' \
   -d '{"provider": "steam", "token": "14000000..."}'
 ```
@@ -173,7 +173,7 @@ so it is low-assurance until upgraded.
 ### Create or resume
 
 ```bash
-curl -X POST http://localhost:8080/api/v1/auth/guest \
+curl -X POST http://localhost:8084/api/v1/auth/guest \
   -H 'Content-Type: application/json' \
   -d '{"device_id": "b64-device-id", "device_secret": "b64-32-random-bytes"}'
 ```
@@ -202,7 +202,7 @@ Only an unclaimed guest may upgrade - a password account, or an account with a
 non-guest provider, is refused.
 
 ```bash
-curl -X POST http://localhost:8080/api/v1/auth/guest/upgrade \
+curl -X POST http://localhost:8084/api/v1/auth/guest/upgrade \
   -H 'Authorization: Bearer <access_token>' \
   -H 'Content-Type: application/json' \
   -d '{"username": "player1", "password": "secret123"}'
@@ -273,7 +273,7 @@ the same player).
 Requires an authenticated session.
 
 ```bash
-curl -X POST http://localhost:8080/api/v1/auth/link \
+curl -X POST http://localhost:8084/api/v1/auth/link \
   -H 'Authorization: Bearer <session_token>' \
   -H 'Content-Type: application/json' \
   -d '{"provider": "discord", "token": "eyJhbGciOi..."}'
@@ -288,7 +288,7 @@ curl -X POST http://localhost:8080/api/v1/auth/link \
 Asobi prevents unlinking the last auth method to avoid locking the player out.
 
 ```bash
-curl -X DELETE http://localhost:8080/api/v1/auth/unlink \
+curl -X DELETE http://localhost:8084/api/v1/auth/unlink \
   -H 'Authorization: Bearer <session_token>' \
   -H 'Content-Type: application/json' \
   -d '{"provider": "discord"}'

--- a/guides/clustering.md
+++ b/guides/clustering.md
@@ -152,8 +152,8 @@ metadata:
 ```
 backend asobi
     balance roundrobin
-    server node1 10.0.0.1:8080 check
-    server node2 10.0.0.2:8080 check
+    server node1 10.0.0.1:8084 check
+    server node2 10.0.0.2:8084 check
 ```
 
 ## Matchmaking Across Nodes

--- a/guides/configuration.md
+++ b/guides/configuration.md
@@ -44,7 +44,7 @@ Infrastructure settings come from environment variables:
 
 | Variable | Default | Description |
 |----------|---------|-------------|
-| `ASOBI_PORT` | `8080` | HTTP/WebSocket port |
+| `ASOBI_PORT` | `8084` | HTTP/WebSocket port |
 | `ASOBI_DB_HOST` | `db` | PostgreSQL host |
 | `ASOBI_DB_NAME` | `asobi` | Database name |
 | `ASOBI_DB_USER` | `postgres` | Database user |
@@ -103,7 +103,7 @@ Shorthand (Erlang module only):
 | `strategy` | `fill` | Matchmaking strategy: `fill`, `skill_based`, or custom module |
 | `skill_window` | `200` | Initial skill difference allowed (skill_based only) |
 | `skill_expand_rate` | `50` | Window expansion per 5 seconds (skill_based only) |
-| `bots` | `#{}` | Bot configuration (see [Bots](lua-bots.md)) |
+| `bots` | `#{}` | Bot configuration. Read by [asobi_lua](https://github.com/widgrensit/asobi_lua), not by asobi — see [Bots](lua-bots.md) |
 
 ## Matchmaker
 
@@ -315,7 +315,7 @@ services:
     depends_on:
       postgres: { condition: service_healthy }
     ports:
-      - "8080:8080"
+      - "8084:8084"
     volumes:
       - ./lua:/app/game:ro
     environment:

--- a/guides/economy.md
+++ b/guides/economy.md
@@ -11,7 +11,7 @@ are recorded as transactions for a full audit trail.
 ### List Wallets
 
 ```bash
-curl http://localhost:8080/api/v1/wallets \
+curl http://localhost:8084/api/v1/wallets \
   -H 'Authorization: Bearer <token>'
 ```
 
@@ -25,7 +25,7 @@ curl http://localhost:8080/api/v1/wallets \
 ### Transaction History
 
 ```bash
-curl http://localhost:8080/api/v1/wallets/gold/history \
+curl http://localhost:8084/api/v1/wallets/gold/history \
   -H 'Authorization: Bearer <token>'
 ```
 
@@ -48,14 +48,14 @@ Item definitions are global -- they describe what an item is:
 ### Player Inventory
 
 ```bash
-curl http://localhost:8080/api/v1/inventory \
+curl http://localhost:8084/api/v1/inventory \
   -H 'Authorization: Bearer <token>'
 ```
 
 ### Consuming Items
 
 ```bash
-curl -X POST http://localhost:8080/api/v1/inventory/consume \
+curl -X POST http://localhost:8084/api/v1/inventory/consume \
   -H 'Authorization: Bearer <token>' \
   -H 'Content-Type: application/json' \
   -d '{"item_id": "...", "quantity": 1}'
@@ -68,7 +68,7 @@ The store is a catalog of items available for purchase with in-game currency.
 ### Browse Store
 
 ```bash
-curl http://localhost:8080/api/v1/store \
+curl http://localhost:8084/api/v1/store \
   -H 'Authorization: Bearer <token>'
 ```
 
@@ -90,7 +90,7 @@ Purchases are atomic: the wallet is debited and the item is granted in a
 single database transaction via Kura Multi.
 
 ```bash
-curl -X POST http://localhost:8080/api/v1/store/purchase \
+curl -X POST http://localhost:8084/api/v1/store/purchase \
   -H 'Authorization: Bearer <token>' \
   -H 'Content-Type: application/json' \
   -d '{"listing_id": "..."}'

--- a/guides/getting-started.md
+++ b/guides/getting-started.md
@@ -115,7 +115,7 @@ services:
     depends_on:
       postgres: { condition: service_healthy }
     ports:
-      - "8080:8080"
+      - "8084:8084"
     volumes:
       - ./lua:/app/game:ro
     environment:
@@ -130,7 +130,7 @@ docker compose up -d
 ```
 
 Your game backend is running. Asobi reads your Lua scripts, sets up the
-database, and starts listening for WebSocket connections on port 8080.
+database, and starts listening for WebSocket connections on port 8084.
 
 ### 6. Verify it works
 
@@ -139,7 +139,7 @@ Register a player:
 bash (Linux, macOS, Git Bash, WSL):
 
 ```bash
-curl -s localhost:8080/api/v1/auth/register \
+curl -s localhost:8084/api/v1/auth/register \
   -H 'content-type: application/json' \
   -d '{"username":"alice","password":"hunter2"}' | jq
 ```
@@ -147,7 +147,7 @@ curl -s localhost:8080/api/v1/auth/register \
 PowerShell (Windows) - no `curl`/`jq` install needed, `Invoke-RestMethod` parses the response:
 
 ```powershell
-Invoke-RestMethod -Uri http://localhost:8080/api/v1/auth/register `
+Invoke-RestMethod -Uri http://localhost:8084/api/v1/auth/register `
   -Method Post -ContentType application/json `
   -Body '{"username":"alice","password":"hunter2"}'
 ```
@@ -232,7 +232,7 @@ which DB pool to use, and `kura` needs the connection details:
         {dev_mode, true},
         {bootstrap_application, asobi},
         {json_lib, json},
-        {cowboy_configuration, #{port => 8080}},
+        {cowboy_configuration, #{port => 8084}},
         {plugins, [
             {pre_request, nova_request_plugin, #{
                 decode_json_body => true,
@@ -292,7 +292,7 @@ is now listening on the configured port.
 bash (Linux, macOS, Git Bash, WSL):
 
 ```bash
-curl -X POST http://localhost:8080/api/v1/auth/register \
+curl -X POST http://localhost:8084/api/v1/auth/register \
   -H 'Content-Type: application/json' \
   -d '{"username": "player1", "password": "secret123"}'
 ```
@@ -300,7 +300,7 @@ curl -X POST http://localhost:8080/api/v1/auth/register \
 PowerShell (Windows):
 
 ```powershell
-Invoke-RestMethod -Uri http://localhost:8080/api/v1/auth/register `
+Invoke-RestMethod -Uri http://localhost:8084/api/v1/auth/register `
   -Method Post -ContentType application/json `
   -Body '{"username": "player1", "password": "secret123"}'
 ```
@@ -317,7 +317,7 @@ Response:
 
 ## Connect via WebSocket
 
-Connect to `ws://localhost:8080/ws` and authenticate:
+Connect to `ws://localhost:8084/ws` and authenticate:
 
 ```json
 {

--- a/guides/iap.md
+++ b/guides/iap.md
@@ -20,7 +20,7 @@ POST /api/v1/iap/apple
 ### Example
 
 ```bash
-curl -X POST http://localhost:8080/api/v1/iap/apple \
+curl -X POST http://localhost:8084/api/v1/iap/apple \
   -H 'Authorization: Bearer <session_token>' \
   -H 'Content-Type: application/json' \
   -d '{"signed_transaction": "eyJhbGciOi..."}'
@@ -82,7 +82,7 @@ POST /api/v1/iap/google
 ### Example
 
 ```bash
-curl -X POST http://localhost:8080/api/v1/iap/google \
+curl -X POST http://localhost:8084/api/v1/iap/google \
   -H 'Authorization: Bearer <session_token>' \
   -H 'Content-Type: application/json' \
   -d '{

--- a/guides/lua-bots.md
+++ b/guides/lua-bots.md
@@ -1,74 +1,14 @@
 # Bots
 
-Asobi supports AI-controlled bot players that participate in matches and worlds
-alongside real players. Bots are configured per game mode and scripted in Lua
-via the [`asobi_lua`](https://hexdocs.pm/asobi_lua) package.
+Bots are AI-controlled players that join matches and worlds alongside real
+players. They are implemented and scripted by
+[asobi_lua](https://github.com/widgrensit/asobi_lua) — asobi itself has no bot
+code, so asobi_lua's documentation is the reference and this page points to it
+rather than keeping a copy that drifts.
 
-## Configuration
+- [Lua bots](https://github.com/widgrensit/asobi_lua/blob/main/guides/lua-bots.md)
+  — enabling bots per game mode, the `bots` config map, and writing bot scripts
+- [Lua scripting](https://github.com/widgrensit/asobi_lua/blob/main/guides/lua-scripting.md)
+  — the callbacks a bot script implements
 
-Enable bots in your game mode configuration:
-
-```erlang
-{game_modes, #{
-    ~"deathmatch" => #{
-        game_module => my_game,
-        bots => #{
-            enabled => true,
-            count => 4,
-            script => ~"bots/patrol.lua",
-            fill => true
-        }
-    }
-}}
-```
-
-| Option | Default | Description |
-|--------|---------|-------------|
-| `enabled` | `false` | Enable bot spawning |
-| `count` | `0` | Number of bots to spawn |
-| `script` | `undefined` | Path to bot Lua script |
-| `fill` | `false` | Auto-fill empty slots with bots |
-
-## Lua Bot Scripts
-
-Bot scripts implement a top-level `think` callback that runs each bot tick.
-It receives the bot's own ID and the latest match state for that bot and
-returns an input table (or an empty table to skip the tick):
-
-```lua
-function think(bot_id, state)
-    local players = state.players or {}
-    local me = players[bot_id]
-    if not me then return {} end
-
-    -- Find nearest other player
-    local target = nil
-    local min_dist = math.huge
-    for id, p in pairs(players) do
-        if id ~= bot_id then
-            local dx = p.x - me.x
-            local dy = p.y - me.y
-            local dist = math.sqrt(dx * dx + dy * dy)
-            if dist < min_dist then
-                min_dist = dist
-                target = p
-            end
-        end
-    end
-
-    if target then
-        return {
-            right = target.x > me.x,
-            left  = target.x < me.x,
-            up    = target.y < me.y,
-            down  = target.y > me.y,
-        }
-    end
-    return {}
-end
-```
-
-## Further Reading
-
-See the full [`asobi_lua` documentation](https://hexdocs.pm/asobi_lua) for advanced
-bot patterns including state machines, group coordination, and difficulty scaling.
+See also [Lua Scripting](lua-scripting.md) for the runtime itself.

--- a/guides/lua-scripting.md
+++ b/guides/lua-scripting.md
@@ -1,99 +1,29 @@
 # Lua Scripting
 
-Lua scripting support is provided by the [`asobi_lua`](https://hexdocs.pm/asobi_lua) package,
-a standalone runtime that wraps the asobi library with [Luerl](https://github.com/rvirding/luerl)
-for writing game logic in Lua.
+Lua scripting is provided by [asobi_lua](https://github.com/widgrensit/asobi_lua),
+a standalone runtime that wraps this library with
+[Luerl](https://github.com/rvirding/luerl). asobi has no Lua dependency of its
+own, so asobi_lua's own documentation is the reference — this page points to it
+rather than keeping a copy that drifts.
 
-## Quick Start
-
-The fastest way to get started is with the Docker image:
+Start the runtime:
 
 ```bash
-docker run -v ./game:/game -p 8080:8080 ghcr.io/widgrensit/asobi_lua
+docker run -v ./game:/game -p 8084:8084 ghcr.io/widgrensit/asobi_lua
 ```
 
-Place your Lua scripts in the `game/` directory and the runtime picks them up automatically.
+Then read, in asobi_lua:
 
-## Game Callbacks
+- [Lua scripting](https://github.com/widgrensit/asobi_lua/blob/main/guides/lua-scripting.md)
+  — callbacks, match and world modes, script globals, and using it from an
+  Erlang project
+- [Lua bots](https://github.com/widgrensit/asobi_lua/blob/main/guides/lua-bots.md)
+  — AI-controlled players
+- [Self-hosting](https://github.com/widgrensit/asobi_lua/blob/main/guides/self-hosting.md)
+  — running the image
+- [Sandbox](https://github.com/widgrensit/asobi_lua/blob/main/guides/security-sandbox.md),
+  [trust model](https://github.com/widgrensit/asobi_lua/blob/main/guides/security-trust-model.md),
+  and [known limitations](https://github.com/widgrensit/asobi_lua/blob/main/guides/security-known-limitations.md)
+  — what Lua code can and cannot reach
 
-Your Lua scripts implement callbacks that asobi invokes at the right time:
-
-### Match Mode
-
-```lua
-function init(config)
-    return { score = {} }
-end
-
-function join(player_id, state)
-    state.score[player_id] = 0
-    return state
-end
-
-function tick(state)
-    -- To finish the match, set reserved keys on the state and return it:
-    --   state._finished = true
-    --   state._result   = { winner = "..." }
-    return state
-end
-
-function handle_input(player_id, input, state)
-    return state
-end
-```
-
-### World Mode
-
-```lua
-function init(config)
-    return {}
-end
-
-function join(player_id, state)
-    return state
-end
-
-function spawn_position(player_id, state)
-    return { x = 100.0, y = 100.0 }
-end
-
-function zone_tick(entities, zone_state)
-    return entities, zone_state
-end
-
-function handle_input(player_id, input, entities)
-    return entities
-end
-
-function post_tick(tick, state)
-    return state
-end
-```
-
-## Lua API
-
-The `game.*` namespace provides access to engine features from Lua:
-
-| Function | Description |
-|----------|-------------|
-| `game.id()` | Generate a unique ID |
-| `game.broadcast(event, payload)` | Broadcast to all players |
-| `game.send(player_id, message)` | Send to a specific player |
-| `game.economy.grant(player, currency, amount, reason)` | Grant currency |
-| `game.economy.debit(player, currency, amount, reason)` | Debit currency |
-| `game.economy.balance(player_id)` | Return the player's full wallet list |
-| `game.economy.purchase(player, listing_id)` | Purchase store item |
-| `game.leaderboard.submit(board, player, score)` | Submit score |
-| `game.leaderboard.top(board, limit)` | Get top scores |
-| `game.storage.get(collection, key)` | Read storage value |
-| `game.storage.set(collection, key, value)` | Write storage value |
-| `game.chat.send(channel, player, content)` | Send chat message |
-
-## Further Reading
-
-See the full [`asobi_lua` documentation](https://hexdocs.pm/asobi_lua) for:
-
-- Configuration options
-- Bot scripting
-- Advanced patterns
-- Docker deployment
+For what the runtime is configured with, see [Configuration](configuration.md).

--- a/guides/matchmaking.md
+++ b/guides/matchmaking.md
@@ -16,7 +16,7 @@ groups tickets into matches using a per-mode strategy module.
 ### Via REST
 
 ```bash
-curl -X POST http://localhost:8080/api/v1/matchmaker \
+curl -X POST http://localhost:8084/api/v1/matchmaker \
   -H 'Authorization: Bearer <token>' \
   -H 'Content-Type: application/json' \
   -d '{
@@ -120,6 +120,6 @@ Players can queue as a party. All party members are placed in the same match:
 Or via REST:
 
 ```bash
-curl -X DELETE http://localhost:8080/api/v1/matchmaker/<ticket_id> \
+curl -X DELETE http://localhost:8084/api/v1/matchmaker/<ticket_id> \
   -H 'Authorization: Bearer <token>'
 ```

--- a/guides/migrate-from-hathora.md
+++ b/guides/migrate-from-hathora.md
@@ -21,13 +21,13 @@ They get you unblocked even if the full port takes a week:
      asobi:
        image: ghcr.io/widgrensit/asobi_lua:latest
        depends_on: { postgres: { condition: service_healthy } }
-       ports: ["8080:8080"]
+       ports: ["8084:8084"]
        environment: { ASOBI_DB_HOST: postgres, ASOBI_DB_NAME: my_game }
    ```
-   Then `docker compose up -d`. HTTP is on `:8080`, WebSocket is on `/ws`.
+   Then `docker compose up -d`. HTTP is on `:8084`, WebSocket is on `/ws`.
 2. **Register one player** — the asobi equivalent of `HathoraClient.loginAnonymous`:
    ```bash
-   curl -s localhost:8080/api/v1/auth/register \
+   curl -s localhost:8084/api/v1/auth/register \
      -H 'content-type: application/json' \
      -d '{"username":"test","password":"test1234"}'
    # → { "username": "test", "player_id": "019de3...", "session_token": "wRqvop92/..." }
@@ -36,7 +36,7 @@ They get you unblocked even if the full port takes a week:
    from here on, in place of any Hathora auth token.
 3. **Queue for matchmaking** to confirm the matchmaker works end-to-end:
    ```bash
-   curl -s localhost:8080/api/v1/matchmaker \
+   curl -s localhost:8084/api/v1/matchmaker \
      -H 'content-type: application/json' \
      -H 'authorization: Bearer wRqvop92/...' \
      -d '{"mode":"default","properties":{},"party":["019de3..."]}'
@@ -153,7 +153,7 @@ services:
   asobi:
     image: ghcr.io/widgrensit/asobi_lua:latest
     depends_on: [postgres]
-    ports: ["8080:8080"]
+    ports: ["8084:8084"]
     volumes: ["./lua:/app/game:ro"]
     environment:
       ASOBI_DB_HOST: postgres
@@ -166,7 +166,7 @@ up:
 
 ```bash
 docker compose up -d
-curl localhost:8080/api/v1/auth/register \
+curl localhost:8084/api/v1/auth/register \
   -H 'content-type: application/json' \
   -d '{"username":"test","password":"test1234"}'
 # → { "player_id": "01HX...", "session_token": "...", "username": "test" }

--- a/guides/migrate-from-nakama.md
+++ b/guides/migrate-from-nakama.md
@@ -92,7 +92,7 @@ services:
   asobi:
     image: ghcr.io/widgrensit/asobi_lua:latest
     depends_on: [postgres]
-    ports: ["8080:8080"]
+    ports: ["8084:8084"]
     volumes: ["./lua:/app/game:ro"]
     environment:
       ASOBI_DB_HOST: postgres

--- a/guides/migrate-from-playfab.md
+++ b/guides/migrate-from-playfab.md
@@ -95,7 +95,7 @@ services:
   asobi:
     image: ghcr.io/widgrensit/asobi_lua:latest
     depends_on: [postgres]
-    ports: ["8080:8080"]
+    ports: ["8084:8084"]
     volumes: ["./lua:/app/game:ro"]
     environment:
       ASOBI_DB_HOST: postgres
@@ -104,7 +104,7 @@ services:
 
 ```bash
 docker compose up -d
-curl localhost:8080/api/v1/auth/register \
+curl localhost:8084/api/v1/auth/register \
   -H 'content-type: application/json' \
   -d '{"username":"alice","password":"hunter2"}'
 # → { "player_id": "...", "session_token": "...", "username": "alice" }

--- a/guides/rest-api.md
+++ b/guides/rest-api.md
@@ -8,7 +8,7 @@ Authenticated endpoints require the `Authorization: Bearer <session_token>` head
 > WSL). In PowerShell, translate any block by hand once - the shape is the same:
 >
 > ```powershell
-> Invoke-RestMethod -Uri http://localhost:8080/api/v1/auth/register `
+> Invoke-RestMethod -Uri http://localhost:8084/api/v1/auth/register `
 >   -Method Post -ContentType application/json `
 >   -Body '{"username": "player1", "password": "secret123"}'
 > ```

--- a/guides/voting.md
+++ b/guides/voting.md
@@ -386,7 +386,7 @@ A player has vetoed the vote (when `veto_enabled` is true).
 ### List votes for a match
 
 ```bash
-curl http://localhost:8080/api/v1/matches/<match_id>/votes \
+curl http://localhost:8084/api/v1/matches/<match_id>/votes \
   -H 'Authorization: Bearer <token>'
 ```
 
@@ -395,7 +395,7 @@ Returns the most recent 50 votes for the match, ordered by newest first.
 ### Get a single vote
 
 ```bash
-curl http://localhost:8080/api/v1/votes/<vote_id> \
+curl http://localhost:8084/api/v1/votes/<vote_id> \
   -H 'Authorization: Bearer <token>'
 ```
 


### PR DESCRIPTION
The first two implementation steps of ADR 0003 (#177). Both are prerequisites: reconciling the divergences into the owning repos before anything generates from them, so generation doesn't propagate whichever copy happened to win.

## 1. The Lua guides go to asobi_lua

asobi has **no luerl dependency**, no `luerl` reference in `src/`, and **no bot code** (`asobi_bot.erl`, `asobi_bot_spawner.erl`, `asobi_bot_sup.erl` are all in asobi_lua) — yet it shipped `lua-scripting.md` + `lua-bots.md` to hexdocs, 173 lines against asobi_lua's 1,255.

Both are now pointers to asobi_lua's own guides. They stay in ex_doc's `extras` so existing hexdocs anchors and the five internal links (README, getting-started ×2, world-server, configuration) keep resolving.

**They were shipping dead links.** Both pointed at `hexdocs.pm/asobi_lua`, which 404s — asobi_lua was never published to Hex (asobi itself is: 200). The replacements point at GitHub; every one verified 200.

`configuration.md`'s `bots` row now says the key is read by asobi_lua rather than asobi, which is what the code does.

## 2. The port moves to 8084

asobi_lua's Dockerfile is the truth-holder and now defaults to 8084 (asobi_lua#73). These docs said 8080, which the old image default made **correct** — and which that PR makes wrong.

**This was not docs-only.** Three executable artifacts here relied on the old default and would have broken against the new image:

| Artifact | Problem |
|---|---|
| `examples/hotreload-demo` | Runs `asobi_lua:latest` **without setting `ASOBI_PORT`**, so its nginx `proxy_pass http://asobi:8080` would reach nothing |
| `examples/world-walkers` | Defold client hardcoded `SERVER_PORT = 8080` while its own compose published 8084 |
| `examples/erlang-match` | README said 8080; its `sys.config` listens elsewhere |

Zero references to 8080 remain. Postgres 5432, EPMD 4369, and the hotreload demo's nginx on 3000 are untouched — 3000 is that demo's web UI, never an API port.

## Merge order

**Must land with or after asobi_lua#73.** `configuration.md`'s documented `ASOBI_PORT` default of `8080` is true until that PR merges and false after; this PR flips it to 8084.

## A correction to ADR 0003

The ADR justifies 8084 by saying it "wins on count" (34 SDK files + 26 site uses vs 29 in `guides/`). That reasoning was wrong and I'm fixing it in #177: counting occurrences measures popularity, not truth, which is the exact error the truth-holder principle exists to prevent. The image default was 8080, so **8080 was the correct answer on the evidence** — the docs were right and I had it backwards.

8084 is still the outcome, but on different grounds: it was chosen deliberately, accepting a breaking change to the image, because 8080 collides with most other things on a developer's machine and moving one image beats moving 34 files across 8 client repos.