### PR TITLE
docs: add Next steps to the threat-model guide

### DIFF
--- a/guides/security-threat-model.md
+++ b/guides/security-threat-model.md
@@ -77,3 +77,8 @@ an obviously broken game module cannot keep churning silently.
 `asobi_world_lobby_server` serializes `find_or_create/1` to close a
 documented TOCTOU race (two concurrent `find_or_create` for the same
 mode no longer spawn duplicate worlds).
+
+## Next steps
+
+- [Auth & rate limiting](security-auth.md) - how clients are authenticated and the brute-force surface is bounded.
+- [Known limitations](security-known-limitations.md) - the sharp edges this design accepts.


### PR DESCRIPTION
Small prep for single-sourcing the asobi.dev Threat model page (ADR 0003). Pairs with widgrensit/asobi_site's threat-model generation PR.

The guide and the hand-written site page are already parity in content. The only site-only element was a "Where next?" nav footer, so this adds an equivalent `## Next steps` section (auth + known-limitations) — which benefits hexdocs readers too. The site's lua-sandbox link is dropped: it's an asobi_lua concern with no asobi guide to link to.