### PR TITLE
docs: correct + enrich 8 guides as single sources for asobi.dev

### DIFF
--- a/guides/configuration.md
+++ b/guides/configuration.md
@@ -2,6 +2,14 @@
 
 Asobi supports two configuration paths depending on how you use it.
 
+> #### Do you even need this file? {: .info}
+>
+> On Asobi Cloud (`asobi deploy`) and the `asobi_lua` Docker image you write
+> no config file at all - the platform supplies sane defaults and you tune the
+> few knobs that matter through environment variables. You only edit
+> `sys.config` when you build the release from source and embed asobi as an
+> Erlang dependency.
+
 ## Lua (Docker)
 
 For Lua game developers using the Docker image, configuration lives in
@@ -126,13 +134,16 @@ Per-route-group rate limits using sliding window algorithm via
 
 ```erlang
 {rate_limits, #{
-    auth => #{limit => 10, window => 60000},    %% 10 req/min for auth
-    iap  => #{limit => 300, window => 1000},    %% 300 req/sec for IAP
+    auth => #{limit => 5, window => 1000},      %% 5 req/sec for login/refresh
+    iap  => #{limit => 10, window => 1000},     %% 10 req/sec for IAP
     api  => #{limit => 300, window => 1000}     %% 300 req/sec for API
 }}
 ```
 
-Default: 300 requests per second for all groups.
+Each route group has its own per-IP default (window in ms): `auth` 5/1000,
+`register` 3/1000, `iap` 10/1000, `api` 300/1000, `ws_connect` 60/1000, and the
+global (not per-IP) guest-create bound `guest_global` 100/1000. Override any
+group under `rate_limits`; unset groups keep their default.
 
 ## CORS
 
@@ -191,6 +202,14 @@ Optional multi-node clustering via Erlang distribution.
 }}
 ```
 
+`base_url` is the public origin asobi uses to build OAuth/OIDC redirect URIs
+(defaults to `~"http://localhost:8082"`). Set it to your deployed URL so the
+redirect that providers call back to matches what you registered:
+
+```erlang
+{base_url, ~"https://mygame.com"}
+```
+
 ### Steam
 
 ```erlang
@@ -202,9 +221,50 @@ Optional multi-node clustering via Erlang distribution.
 
 ```erlang
 {apple_bundle_id, ~"com.example.mygame"},
+{apple_root_cert_path, ~"/path/to/AppleRootCA-G3.pem"},
 {google_package_name, ~"com.example.mygame"},
 {google_service_account_key, ~"/path/to/service-account.json"}
 ```
+
+`apple_root_cert_path` points at the Apple Root CA (PEM or DER) that
+`asobi_iap:verify_apple/1` validates the StoreKit 2 receipt chain against.
+Without it Apple receipt verification is refused.
+
+## Guest (anonymous) auth
+
+Guest auth lets a device create a throwaway player without credentials and
+upgrade it to a real account later. It is **opt-in and fails closed**: the
+guest endpoints return `404 guest_auth_disabled` until `guest_auth` is `true`
+**and** a `guest_verifier_pepper` is set.
+
+```erlang
+{guest_auth, true},
+%% Required. A key-id -> pepper map (>= 32 bytes each). Keep old key ids for the
+%% guest retention window so existing guests can still resume after rotation.
+{guest_verifier_pepper, #{~"v1" => ~"a-32-byte-or-longer-secret......"}},
+{guest_verifier_key_id, ~"v1"},
+
+%% Optional abuse control: max unclaimed guests, or `infinity`.
+{guest_unlinked_cap, 100000},
+
+%% Optional retention. Unset = permanent guests (never reaped). Seconds after
+%% which unclaimed guests are deleted by the reaper.
+{guest_reap_after, 2592000}
+```
+
+| Key | Default | Description |
+|-----|---------|-------------|
+| `guest_auth` | `false` | Master switch. Both this and a pepper are required |
+| `guest_verifier_pepper` | none | Key-id -> pepper map (each pepper >= 32 bytes) or a single >= 32-byte binary |
+| `guest_verifier_key_id` | `~"v1"` | Which pepper key id to use when minting new verifiers |
+| `guest_unlinked_cap` | `100000` | Soft ceiling on unclaimed guests, or `infinity` |
+| `guest_reap_after` | unset | Seconds; unset disables the reaper (guests are permanent) |
+
+The pepper is a server-side secret kept **outside** the database - store it in
+an env var or secret manager, never in source. To rotate, add a new key id and
+point `guest_verifier_key_id` at it; keep the old key ids for at least the
+retention window so existing guests can still resume. Guest creation is bounded
+by the per-IP auth limiter plus the global `guest_global` create limit.
 
 ## Vote Templates
 
@@ -227,12 +287,56 @@ Define reusable vote configurations:
 
 Templates are merged with per-vote config from your game module.
 
+## World capacity
+
+Bounds on persistent world creation, enforced as a DoS backstop:
+
+```erlang
+{world_max_per_player, 5},   %% default 5
+{world_max, 1000}            %% default 1000
+```
+
+A player at the per-player cap gets `429`; once the global cap is reached
+further creates get `503`.
+
+## Terrain provider allowlist
+
+For Lua large-world games, only allowlisted terrain generators can be named
+from Lua. This is an `asobi_lua` key (not `asobi`):
+
+```erlang
+{asobi_lua, [
+    {terrain_providers, [asobi_terrain_flat, asobi_terrain_perlin]}
+]}
+```
+
+The default allows `asobi_terrain_flat` and `asobi_terrain_perlin`.
+
+## Per-call upper bounds
+
+These runtime limits bound the cost of a single request. They are not
+configurable - they are documented here so you can size clients accordingly:
+
+| Limit | Value |
+|-------|-------|
+| Cloud save body | 256 KB |
+| Save slots per player | 10 |
+| Inventory consume quantity | 1 .. 1000000 |
+| Leaderboard `top` `?limit` | 1 .. 100 |
+| Leaderboard `around` `?range` | 1 .. 50 |
+| Chat history `?limit` | 1 .. 200 |
+| DM content | 2000 bytes |
+| WS chat channels per connection | 32 |
+| Idle channel timeout | 60s |
+| Lua table decode depth | 64 |
+
 ## Database (Kura)
 
 Database configuration is under the `kura` application key:
 
 ```erlang
 {kura, [
+    {backend, kura_backend_postgres},
     {repo, asobi_repo},
     {host, "localhost"},
     {port, 5432},
@@ -256,6 +360,7 @@ Database configuration is under the `kura` application key:
 ```erlang
 [
     {kura, [
+        {backend, kura_backend_postgres},
         {repo, asobi_repo},
         {host, "localhost"},
         {database, "my_game_dev"},
@@ -345,3 +450,9 @@ function think(bot_id, state)
     -- AI logic
 end
 ```
+
+## Next steps
+
+- [Self-hosting](https://github.com/widgrensit/asobi_lua/blob/main/guides/self-hosting.md) - running the image.
+- [Clustering](clustering.md) - multi-node config.
+- [Performance tuning](performance-tuning.md) - the tick and BEAM knobs.

--- a/guides/economy.md
+++ b/guides/economy.md
@@ -3,6 +3,12 @@
 Asobi provides a full virtual economy system: wallets, transactions, item
 definitions, a store catalog, and player inventory.
 
+> #### Windows {: .info}
+>
+> Run the `curl` examples in Git Bash or WSL, or use PowerShell's
+> `Invoke-RestMethod` with the same URL and a JSON `-Body`. Authenticated calls
+> add `-Headers @{ Authorization = 'Bearer <token>' }`.
+
 ## Wallets
 
 Each player can have multiple wallets, one per currency. All balance changes
@@ -21,6 +27,18 @@ curl http://localhost:8084/api/v1/wallets \
   {"id": "...", "currency": "gems", "balance": 50}
 ]
 ```
+
+<!-- tabs -->
+**Lua**
+```lua
+local balance = game.economy.balance(player_id)
+```
+**Erlang**
+```erlang
+{ok, Wallet} = asobi_economy:get_or_create_wallet(PlayerId, <<"coins">>),
+{ok, _} = asobi_economy:debit(PlayerId, <<"coins">>, 50, #{}).
+```
+<!-- /tabs -->
 
 ### Transaction History
 
@@ -96,6 +114,20 @@ curl -X POST http://localhost:8084/api/v1/store/purchase \
   -d '{"listing_id": "..."}'
 ```
 
+<!-- tabs -->
+**Lua**
+```lua
+game.economy.purchase(player_id, "shop:starter_pack")
+```
+**Erlang**
+```erlang
+{ok, _} = asobi_economy:purchase(PlayerId, <<"shop:starter_pack">>).
+```
+<!-- /tabs -->
+
+Items are granted through the store/purchase flow or by writing an
+`asobi_player_item` row via `asobi_repo` - there is no `grant_item/3` helper.
+
 ## Server-Side Operations
 
 For admin or game logic that needs to grant/debit currency or items
@@ -117,3 +149,8 @@ asobi_economy:debit(PlayerId, ~"gold", 50, #{reason => ~"store_purchase"}).
 
 All economy operations use ACID transactions to prevent double-spending
 or inconsistent state.
+
+## Next steps
+
+- [Authentication](authentication.md) - player identity behind wallets and purchases.
+- [REST API](rest-api.md) - the wallet, store, inventory, and IAP endpoints.

--- a/guides/matchmaking.md
+++ b/guides/matchmaking.md
@@ -27,6 +27,8 @@ curl -X POST http://localhost:8084/api/v1/matchmaker \
 
 ### Via WebSocket
 
+<!-- tabs -->
+**WebSocket (JSON)**
 ```json
 {
   "type": "matchmaker.add",
@@ -36,6 +38,11 @@ curl -X POST http://localhost:8084/api/v1/matchmaker \
   }
 }
 ```
+**Erlang**
+```erlang
+{ok, TicketId} = asobi_matchmaker:add(PlayerId, #{mode => <<"arena">>, properties => #{skill => 1200, region => <<"eu-west">>}}).
+```
+<!-- /tabs -->
 
 A ticket currently supports `mode`, `properties`, and `party`. A
 query-language extension (numeric ranges, required keys, automatic skill
@@ -52,6 +59,11 @@ are built in:
 - `skill_based` — sorts tickets by `properties.skill` and pairs within an
   expanding window (configurable via `skill_window` and
   `skill_expand_rate`).
+
+The built-in strategies map to modules: the default `fill` strategy is
+`asobi_matchmaker_fill` and `skill_based` is `asobi_matchmaker_skill`.
+Strategy is configured per game mode only - there is no top-level
+`matchmaker_strategy` key.
 
 ## Custom Strategies
 
@@ -113,9 +125,16 @@ Players can queue as a party. All party members are placed in the same match:
 
 ## Cancelling
 
+<!-- tabs -->
+**WebSocket (JSON)**
 ```json
 {"type": "matchmaker.remove", "payload": {"ticket_id": "..."}}
 ```
+**Erlang**
+```erlang
+asobi_matchmaker:remove(PlayerId, TicketId).
+```
+<!-- /tabs -->
 
 Or via REST:
 
@@ -123,3 +142,8 @@ Or via REST:
 curl -X DELETE http://localhost:8084/api/v1/matchmaker/<ticket_id> \
   -H 'Authorization: Bearer <token>'
 ```
+
+## Next steps
+
+- [WebSocket protocol](websocket-protocol.md) - the `matchmaker.*` and `match.matched` messages.
+- [Configuration](configuration.md) - per-mode matchmaker tuning.

--- a/guides/rest-api.md
+++ b/guides/rest-api.md
@@ -2,7 +2,13 @@
 
 All endpoints are under `/api/v1`. Requests and responses use JSON.
 
-Authenticated endpoints require the `Authorization: Bearer <session_token>` header.
+Authenticated endpoints require the `Authorization: Bearer <access_token>` header.
+
+> #### Real-time flows go over WebSocket {: .info}
+>
+> Use REST for request/response. Matchmaking notifications, chat, votes,
+> presence, and live game state are pushed over the [WebSocket
+> protocol](websocket-protocol.md), not polled here.
 
 > **Windows / PowerShell**: examples below use `curl` (Linux, macOS, Git Bash,
 > WSL). In PowerShell, translate any block by hand once - the shape is the same:
@@ -38,7 +44,7 @@ curl -X POST /api/v1/auth/register \
 ```
 
 ```json
-{"player_id": "...", "session_token": "...", "username": "player1"}
+{"player_id": "...", "access_token": "...", "refresh_token": "...", "username": "player1"}
 ```
 
 ### Login
@@ -50,7 +56,7 @@ curl -X POST /api/v1/auth/login \
 ```
 
 ```json
-{"player_id": "...", "session_token": "...", "username": "player1"}
+{"player_id": "...", "access_token": "...", "refresh_token": "...", "username": "player1"}
 ```
 
 ### Guest
@@ -179,3 +185,9 @@ GET    /api/v1/storage/:collection/:key        Read object
 PUT    /api/v1/storage/:collection/:key        Write object
 DELETE /api/v1/storage/:collection/:key        Delete object
 ```
+
+## Next steps
+
+- [WebSocket protocol](websocket-protocol.md) - the push side of the API.
+- [Authentication](authentication.md) - obtaining and refreshing the bearer token.
+- [Economy & IAP](economy.md) - wallets, the store, and receipt validation.

--- a/guides/security-auth.md
+++ b/guides/security-auth.md
@@ -8,14 +8,16 @@ trust assumptions see [Threat model](security-threat-model.md).
 
 Every authenticated route is gated by `asobi_auth_plugin:verify/1`,
 which expects an `Authorization: Bearer <token>` header. Tokens are
-issued by `nova_auth_session:generate_session_token/2` after a
-successful `register/1`, `login/1`, `refresh/1`, or OAuth flow. The
-plugin attaches `auth_data => #{player_id => Id, ...}` to the request
-map — controllers should pattern-match on that rather than parsing the
-header themselves.
+issued by `nova_auth_refresh:generate_pair/2` (via
+`asobi_auth_tokens:issue/2,3`) after a successful `register/1`,
+`login/1`, `refresh/1`, or OAuth flow. The caller receives an access
+token plus a single-use rotating refresh token. The plugin attaches
+`auth_data => #{player_id => Id, ...}` to the request map — controllers
+should pattern-match on that rather than parsing the header themselves.
 
-Tokens are stored in `asobi_player_token` and revocable via
-`nova_auth_session:delete_session_token/2`.
+On logout the presented access token is revoked via
+`nova_auth_refresh:delete_access_token/2` (wrapped by
+`asobi_auth_tokens:revoke_access/1`) so it cannot outlive the cache TTL.
 
 ## Apple StoreKit 2 JWS verification
 
@@ -27,9 +29,9 @@ verifies it end-to-end:
 2. The `x5c` chain is decoded (DER-encoded certificates, base64'd in
    JWS order: leaf → intermediate → root).
 3. The chain is validated against a configured Apple Root CA via
-   `public_key:pkix_path_validation/3`. Operators ship the root in
-   `priv/apple_root_ca.pem` (or override the path via
-   `application:get_env(asobi, apple_root_ca_path, ...)`).
+   `public_key:pkix_path_validation/3`. The root is not bundled: operators
+   point `apple_root_cert_path` (or `apple_root_certs`) at it, and
+   verification returns `apple_root_cert_not_configured` if neither is set.
 4. The signature on `<header>.<payload>` is verified with the leaf
    cert's public key. A bit-flipped signature, swapped signature, or
    any chain mismatch fails the verification.
@@ -51,6 +53,52 @@ ticket against the Steam Web API:
 
 The ticket validator is invoked from `asobi_oauth_controller` for
 `provider = "steam"` flows.
+
+## Guest device verifiers
+
+Anonymous/guest auth (`asobi_guest_controller`) lets a device create a
+player from a `{device_id, device_secret}` pair without credentials. It
+is secured to leak nothing useful even if the identity table is dumped:
+
+- **Fails closed.** The controller serves guest routes only when
+  `guest_auth` is `true` **and** a `guest_verifier_pepper` is
+  configured; otherwise every guest endpoint returns `404
+  guest_auth_disabled`.
+- **The device secret is never stored.** The database holds a
+  *verifier*, not the secret. On creation the server draws a 16-byte
+  salt from `crypto:strong_rand_bytes/1` and combines it with a
+  server-side pepper (selected by key id) as
+  `crypto:mac(hmac, sha256, Pepper, <<Salt/binary, Secret/binary>>)`.
+  The result is stored in the identity's `provider_metadata`
+  (`salt` / `key_id` / `verifier` / `revoked`, all base64).
+- **Timing-safe comparison.** Resume verifies with
+  `crypto:hash_equals/2` so a wrong secret can't be recovered by
+  timing.
+- **The pepper lives outside the database.** It is a keyed secret
+  (env/secret manager), so a dumped verifier table is useless without
+  it, and it is rotatable: add a new key id, point
+  `guest_verifier_key_id` at it, and keep old key ids for the retention
+  window so existing guests still resume.
+- **Bounded input.** The secret must base64-decode to at least 32 bytes
+  (under a fixed upper cap) and the `device_id` must be non-empty and
+  at most 255 bytes, so an unauthenticated caller can't force
+  multi-megabyte HMAC work.
+- **Upgrade is compromise-recovery.** Claiming a guest
+  (`/auth/guest/upgrade`) calls `nova_auth_refresh:revoke_all/2` to kill
+  the entire token family a stolen device secret may have minted, then
+  deletes the guest identity so the secret can no longer resume the
+  now-claimed account.
+- **Safe reaping.** The optional `asobi_guest_reaper` (off unless
+  `guest_reap_after` is set) re-checks that a guest is still unclaimed
+  *inside* its delete transaction, so a concurrent upgrade wins the
+  race. The unlinked-guest cap reads a short-TTL cached count and fails
+  closed if the count can't be read.
+
+> #### Assurance level {: .warning}
+>
+> Treat guest accounts as low-assurance until they are upgraded. Anything
+> valuable - purchases, competitive ranking, cross-device identity -
+> should require a claimed account, not a guest session.
 
 ## Per-route rate limits
 
@@ -131,5 +179,7 @@ Regressions for the items above live under `test/`:
 - `asobi_social_api_SUITE.erl` — F-10 chat history membership (DM,
   group, non-member denial).
 - `asobi_dm_tests.erl` — F-11 length cap, empty-content rejection.
+- `asobi_guest_SUITE.erl` — guest create-or-resume, wrong-secret
+  rejection, upgrade + token revocation.
 
 Run with `rebar3 ct,eunit`.

--- a/guides/voting.md
+++ b/guides/voting.md
@@ -22,6 +22,14 @@ a vote config to start a vote, or `none`/`nil` to skip. This is the simplest
 approach and works for both Erlang and Lua game modules. Votes can be triggered
 at any point during gameplay - not just between rounds.
 
+<!-- tabs -->
+**Lua**
+```lua
+function vote_requested(state)
+    return { method = "plurality", options = {"map_a", "map_b"}, window_ms = 15000 }
+end
+```
+**Erlang**
 ```erlang
 vote_requested(#{phase := vote_pending} = _GameState) ->
     {ok, #{
@@ -36,6 +44,7 @@ vote_requested(#{phase := vote_pending} = _GameState) ->
 vote_requested(_) ->
     none.
 ```
+<!-- /tabs -->
 
 When a vote starts this way, the optional `vote_started/1` callback is called
 to let the game module update its state (e.g. change phase).
@@ -66,7 +75,7 @@ asobi_match_server:start_vote(MatchPid, #{
 | `options`      | `[map()]`      | required       | List of `#{id, label}` option maps |
 | `template`     | `binary()`     | `"default"`    | Template name (resolved from config) |
 | `window_ms`    | `pos_integer()`| `15000`        | Vote window in milliseconds        |
-| `method`       | `binary()`     | `"plurality"`  | `"plurality"`, `"approval"`, or `"weighted"` |
+| `method`       | `binary()`     | `"plurality"`  | `"plurality"`, `"approval"`, `"weighted"`, or `"ranked"` |
 | `visibility`   | `binary()`     | `"live"`       | `"live"` or `"hidden"`             |
 | `tie_breaker`  | `binary()`     | `"random"`     | `"random"` or `"first"`            |
 | `veto_enabled` | `boolean()`    | `false`        | Allow players to veto              |
@@ -481,3 +490,8 @@ server. Returns `{error, no_veto_tokens}` when exhausted.
 
 Votes arriving within 500ms after the window closes are still accepted to
 compensate for network latency.
+
+## Next steps
+
+- [WebSocket protocol](websocket-protocol.md) - the `match.vote_*` push messages.
+- [Configuration](configuration.md) - vote templates.

--- a/guides/websocket-protocol.md
+++ b/guides/websocket-protocol.md
@@ -270,12 +270,33 @@ match `match.phase_changed` event.
 
 ## Chat
 
+Channel ids are namespaced: every id must start with one of these prefixes, and
+a frame whose channel id is missing or unprefixed is rejected with
+`channel_id_invalid`. The prefix lets the runtime route the message and enforce
+membership without a per-frame registry lookup.
+
+| Prefix   | Used for                                  | Membership rule |
+|----------|-------------------------------------------|-----------------|
+| `dm:`    | Direct messages                           | Both participants only. |
+| `world:` | World-wide chat                           | Players currently joined to the world. |
+| `zone:`  | A specific zone within a world            | Players currently inside that zone. |
+| `prox:`  | Proximity chat (radius around a position) | Players within the configured radius. |
+| `room:`  | Group / lobby / custom rooms              | Group members, or open join per room policy. |
+
+A single connection may join at most **32 channels** at once; a 33rd is rejected
+with `too_many_channels`. Idle channels with no members stop after 60s; rejoining
+is cheap. Message `content` is capped at 2000 bytes and empty or non-binary
+content is rejected with `content_empty` / `content_too_large`.
+
+History (`GET /api/v1/chat/:channel_id/history`) requires membership and clamps
+`?limit` to 200; non-members get `403`.
+
 ### `chat.join`
 
-Join a chat channel.
+Join a chat channel. The channel id must be namespaced.
 
 ```json
-{"type": "chat.join", "payload": {"channel_id": "lobby"}}
+{"type": "chat.join", "payload": {"channel_id": "room:lobby"}}
 ```
 
 ### `chat.send`
@@ -283,7 +304,7 @@ Join a chat channel.
 Send a message to a channel.
 
 ```json
-{"type": "chat.send", "payload": {"channel_id": "lobby", "content": "Hello!"}}
+{"type": "chat.send", "payload": {"channel_id": "room:lobby", "content": "Hello!"}}
 ```
 
 ### `chat.message` (server push)
@@ -294,7 +315,7 @@ A new message in a joined channel.
 {
   "type": "chat.message",
   "payload": {
-    "channel_id": "lobby",
+    "channel_id": "room:lobby",
     "sender_id": "...",
     "content": "Hello!",
     "sent_at": "2025-01-15T10:30:00Z"
@@ -307,7 +328,7 @@ A new message in a joined channel.
 Leave a chat channel.
 
 ```json
-{"type": "chat.leave", "payload": {"channel_id": "lobby"}}
+{"type": "chat.leave", "payload": {"channel_id": "room:lobby"}}
 ```
 
 ## Voting
@@ -428,3 +449,9 @@ A new notification for the player.
   }
 }
 ```
+
+## Next steps
+
+- [REST API](rest-api.md) - the request/response surface alongside this socket protocol.
+- [Authentication](authentication.md) - obtaining the token the socket authenticates with.
+- [Voting](voting.md) - the vote flow whose `match.vote_*` pushes appear above.

--- a/guides/world-server.md
+++ b/guides/world-server.md
@@ -192,6 +192,9 @@ Register your world mode in `sys.config`:
 | `tick_rate` | 50 | Milliseconds between ticks (50 = 20 Hz) |
 | `view_radius` | 1 | Zones visible in each direction from player's zone |
 | `max_players` | 500 | Maximum concurrent players per world |
+| `zone_idle_timeout` | 30000 | Milliseconds an empty zone lingers before it is released |
+| `empty_grace_ms` | 0 | Milliseconds a world with no players lingers before it finishes (0 = finish immediately) |
+| `snapshot_interval` | 600 | Ticks between zone snapshots (see [Snapshots](#snapshots)) |
 
 ### Procedural Generation
 
@@ -365,6 +368,64 @@ function post_tick(tick, state)
     return state
 end
 ```
+
+## Spawn templates
+
+Worlds seed non-player entities (NPCs, resources, objects) from **spawn
+templates**. Implement the optional `spawn_templates/1` callback to return a
+map of template id to template definition.
+
+A template has:
+
+- `type` -- the entity type applied to every spawned instance.
+- `base_state` -- a map merged into every entity spawned from the template.
+- `respawn` -- optional respawn policy: `strategy` (currently `timer`),
+  `delay` (milliseconds), `jitter` (milliseconds of random spread added to
+  the delay), and `max_respawns` (cap, or `infinity`).
+- `persistent` -- whether a spawned entity survives a zone snapshot/restore.
+  Lua entities default to `true`.
+
+At runtime, Lua scripts spawn from a template with
+`game.zone.spawn("goblin", x, y, {overrides})`, where the optional table
+overrides fields from the template's `base_state`.
+
+```lua
+function spawn_templates(config)
+    return {
+        goblin = {
+            type       = "npc",
+            base_state = { health = 100, ai = "patrol" },
+            respawn    = { delay = 5000, jitter = 1000, max_respawns = 3 }
+        },
+        chest = {
+            type       = "object",
+            base_state = { loot = "common" }
+        }
+    }
+end
+
+function zone_tick(entities, zone_state)
+    game.zone.spawn("goblin", 500, 500)
+    game.zone.spawn("chest", 620, 600, { loot = "rare" })
+    return entities, zone_state
+end
+```
+
+See the `examples/world-spawns` demo for a complete world script.
+
+## Snapshots
+
+`asobi_zone_snapshotter` periodically persists each zone's entities and
+restores them on restart, before the zone accepts new subscribers. Tune the
+cadence with the `snapshot_interval` config key (default 600, measured in
+**ticks**, not milliseconds).
+
+## Subscriptions
+
+A player subscribes to the 3x3 neighbourhood of zones around their entity.
+Membership is recomputed as the player moves: entering a zone streams a
+snapshot of that zone's currently-visible entities, and leaving a zone stops
+its updates.
 
 ## WebSocket Protocol
 


### PR DESCRIPTION
Reconciles 8 guides with the shipped code and the hand-written asobi.dev pages ahead of generation (ADR 0003). Pairs with widgrensit/asobi_site#94.

An audit against the backend found **real correctness bugs in the guides (live on hexdocs now)** plus site-only content the guides lacked. Every fix was verified against `src/` before writing:

- **rest-api**: `session_token` → `access_token`+`refresh_token` in login/register responses.
- **configuration**: added `{backend, kura_backend_postgres}`; corrected rate-limit defaults (per-group, not "300 for all"); ported Guest-auth, World-capacity, Terrain-allowlist, Per-call-bounds, `base_url`, `apple_root_cert_path`.
- **security-auth**: `nova_auth_session`→`nova_auth_refresh`; `apple_root_ca_path`→`apple_root_cert_path`; removed the false `priv/apple_root_ca.pem` default; ported the Guest device-verifiers section + assurance callout; kept pbkdf2 (the site's "bcrypt" is wrong).
- **world-server**: added Spawn templates / Snapshots / Subscriptions; corrected `empty_grace_ms` default to `0` and `snapshot_interval` (ticks, not `_ms`).
- **websocket**: `"lobby"` → `room:lobby` (backend rejects unprefixed ids); added namespacing/cap/history/DM notes.
- **matchmaking / economy / voting**: Erlang & Lua API examples as tab groups; added the missing `ranked` vote method.

These correct docs that were wrong regardless of single-sourcing.