### PR TITLE
ci: bump erlang-ci to v2.1.4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   ci:
-    uses: Taure/erlang-ci/.github/workflows/ci.yml@dc560fbe8e4e39898dd808645fc1d3e69d248429  # main as of 2026-03-31, pinned via Dependabot
+    uses: Taure/erlang-ci/.github/workflows/ci.yml@v2.1.4
     permissions:
       contents: write
       pull-requests: write

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,6 +11,6 @@ on:
 
 jobs:
   release:
-    uses: Taure/erlang-ci/.github/workflows/release.yml@main
+    uses: Taure/erlang-ci/.github/workflows/release.yml@v2.1.4
     permissions:
       contents: write


### PR DESCRIPTION
Bumps erlang-ci to the **v2.1.4** tag in both workflows.

- `ci.yml`: was the pinned 2026-03-31 main sha -> `@v2.1.4`.
- `release.yml`: was `@main` (a moving branch) -> `@v2.1.4`.

- **v2.1.3** (Taure/erlang-ci#68): forwards `GITHUB_TOKEN` into the audit step so the advisories API is authenticated (5000/hr vs 60/hr unauthenticated) - the rate-limit behind the flaky Audit job.
- **v2.1.4** (Taure/erlang-ci#69): drops `_build/*/plugins` so a `rebar.config` plugin-pin change is never shadowed by a stale cached plugin.

Both now use an exact release tag, per convention (no moving `@main`).