### PR TITLE
fix: return 403 not 404 when guest auth is disabled

### DIFF
--- a/guides/authentication.md
+++ b/guides/authentication.md
@@ -255,7 +255,7 @@ Player id, progress, wallets, and inventory are preserved.
 | `401`  | `invalid_device_secret`   | Wrong secret for a known device |
 | `401`  | `guest_revoked`           | The device verifier was revoked |
 | `401`  | `guest_upgraded`          | The account was already claimed; log in with its real credentials |
-| `404`  | `guest_auth_disabled`     | Guest auth is not enabled in config |
+| `403`  | `guest_auth_disabled`     | Guest auth is not enabled in config |
 | `404`  | `player_not_found`        | The upgrade token resolves to no player |
 | `409`  | `device_already_registered` | Two creates for the same device raced; retry - the retry resumes the existing guest |
 | `409`  | `not_an_unclaimed_guest`  | Upgrade target is not an unclaimed guest |

--- a/guides/configuration.md
+++ b/guides/configuration.md
@@ -234,7 +234,7 @@ Without it Apple receipt verification is refused.
 
 Guest auth lets a device create a throwaway player without credentials and
 upgrade it to a real account later. It is **opt-in and fails closed**: the
-guest endpoints return `404 guest_auth_disabled` until `guest_auth` is `true`
+guest endpoints return `403 guest_auth_disabled` until `guest_auth` is `true`
 **and** a `guest_verifier_pepper` is set.
 
 ```erlang

--- a/guides/security-auth.md
+++ b/guides/security-auth.md
@@ -62,7 +62,7 @@ is secured to leak nothing useful even if the identity table is dumped:
 
 - **Fails closed.** The controller serves guest routes only when
   `guest_auth` is `true` **and** a `guest_verifier_pepper` is
-  configured; otherwise every guest endpoint returns `404
+  configured; otherwise every guest endpoint returns `403
   guest_auth_disabled`.
 - **The device secret is never stored.** The database holds a
   *verifier*, not the secret. On creation the server draws a 16-byte

--- a/src/controllers/asobi_guest_controller.erl
+++ b/src/controllers/asobi_guest_controller.erl
@@ -37,7 +37,10 @@ authenticate(#{json := #{~"device_id" := DeviceId, ~"device_secret" := Secret}} 
 ->
     case guest_enabled() of
         false ->
-            {json, 404, #{}, #{error => ~"guest_auth_disabled"}};
+            {json, 403, #{}, #{
+                error => ~"guest_auth_disabled",
+                message => ~"Guest authentication is not enabled for this deployment."
+            }};
         true ->
             case decode_secret(Secret) of
                 {ok, SecretBin} ->

--- a/test/asobi_guest_controller_tests.erl
+++ b/test/asobi_guest_controller_tests.erl
@@ -59,6 +59,19 @@ decode_secret_upper_bound_test() ->
         error, asobi_guest_controller:decode_secret(binary:copy(~"A", 4096))
     ).
 
+authenticate_disabled_returns_403_test() ->
+    application:unset_env(asobi, guest_auth),
+    Req = #{
+        json => #{
+            ~"device_id" => ~"dev-abc",
+            ~"device_secret" => base64:encode(crypto:strong_rand_bytes(32))
+        }
+    },
+    ?assertMatch(
+        {json, 403, _, #{error := ~"guest_auth_disabled", message := _}},
+        asobi_guest_controller:authenticate(Req)
+    ).
+
 valid_device_id_test() ->
     ?assert(asobi_guest_controller:valid_device_id(base64:encode(crypto:strong_rand_bytes(16)))),
     ?assertNot(asobi_guest_controller:valid_device_id(~"")),


### PR DESCRIPTION
The guest routes are always registered and `authenticate/1` gates internally on `guest_enabled/0` (flag AND pepper). Returning **404** for a disabled-but-present endpoint overloaded 404's "route not found" meaning - and the 404 body already carried `guest_auth_disabled`, so it hid nothing.

Now returns:
```json
403 { "error": "guest_auth_disabled", "message": "Guest authentication is not enabled for this deployment." }
```

- **403** = the endpoint exists but is off for this deployment (semantically correct for an always-registered route).
- The `message` stops a dev from hunting for a "missing" URL.
- **No information leak**: the response is undifferentiated - it never reveals which half of the two-key gate (flag vs pepper) is missing. beam-security-reviewer: clean, no findings.

Client-contract change (404 -> 403); guides updated here, asobi_site docs + the godot SDK test updated in companion PRs.

Adds a unit test for the disabled -> 403 path.