### PR TITLE
docs: align guest-auth guides with ADR 0004; document world + matchmaker behaviours

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ your release.
 - **`asobi_world_server`** — persistent worlds with lazy zones, spatial grid indexing, terrain chunk serving, adaptive tick rates.
 - **`asobi_vote_server`** — plurality, ranked choice, approval, weighted. Fixed / ready-up / hybrid / adaptive windows. Spectator voting, veto tokens, majority-tyranny mitigations.
 - **`asobi_phase`, `asobi_season_manager`, `asobi_timer`** — phase engine, season lifecycles, five timer primitives.
+- **Auth** — email/password, Google / Apple / Steam sign-in, and **guest (anonymous) play** with device-based create-or-resume and upgrade-to-account (game-declared, operator-peppered).
 - **Rate limiting** via `seki` (sliding window, per route group), **sessions** cached in ETS, **presence** via `pg`, **chat / social / economy / inventory / storage / tournaments / notifications** as Nova controllers.
 - **Client SDKs** for Godot, Defold, Unity, Unreal, JS/TS, Dart, Flame — [see below](#client-sdks).
 

--- a/guides/authentication.md
+++ b/guides/authentication.md
@@ -171,8 +171,10 @@ social sign-in - and claim a real account later without losing progress. It is
 the "device-based auth" option: the client generates a secret once, stores it on
 the device, and presents it to resume the same account on every launch.
 
-Guest auth is **opt-in** and disabled by default. Enable it in `sys.config`
-(see [Configuration](#configuration-2)) before the endpoints respond.
+Guest auth is **opt-in** and disabled by default. It turns on only when two
+independent parties agree (see [Configuration](#configuration-2)): the **game**
+declares `guest_auth = true` in its Lua config, and the **operator** supplies a
+verifier pepper. Either one alone leaves the endpoints returning `403`.
 
 ### How it works
 
@@ -255,7 +257,7 @@ Player id, progress, wallets, and inventory are preserved.
 | `401`  | `invalid_device_secret`   | Wrong secret for a known device |
 | `401`  | `guest_revoked`           | The device verifier was revoked |
 | `401`  | `guest_upgraded`          | The account was already claimed; log in with its real credentials |
-| `403`  | `guest_auth_disabled`     | Guest auth is not enabled in config |
+| `403`  | `guest_auth_disabled`     | Guest auth is off - the game did not declare `guest_auth`, or no pepper is present |
 | `404`  | `player_not_found`        | The upgrade token resolves to no player |
 | `409`  | `device_already_registered` | Two creates for the same device raced; retry - the retry resumes the existing guest |
 | `409`  | `not_an_unclaimed_guest`  | Upgrade target is not an unclaimed guest |
@@ -267,9 +269,24 @@ Player id, progress, wallets, and inventory are preserved.
 
 ### Configuration
 
+Guest auth is on **iff both** halves below are satisfied; either alone fails
+closed with `403 guest_auth_disabled`. The toggle belongs to the game, the pepper
+to the operator (ADR 0004: guest auth is declared by the game, peppered by the
+operator).
+
+**1. The game declares the toggle.** `guest_auth` is a boolean game global,
+declared like `match_size` or `bots` - in `match.lua` for a single-mode game, or
+`config.lua` for a multi-mode game:
+
+```lua
+guest_auth = true
+```
+
+**2. The operator supplies the pepper** (and any abuse controls). The pepper is
+the one value that must never live in a bundle:
+
 ```erlang
 {asobi, [
-    {guest_auth, true},
     %% Required. A key-id -> pepper map (>= 32 bytes each). Keep old keys for the
     %% guest retention window so existing guests can still resume after rotation.
     {guest_verifier_pepper, #{<<"v1">> => <<"a-32-byte-or-longer-secret......">>}},
@@ -283,6 +300,11 @@ Player id, progress, wallets, and inventory are preserved.
     {guest_reap_after, 2592000}          %% e.g. 30 days
 ]}
 ```
+
+There is no `ASOBI_GUEST_AUTH` env var. A self-hoster owns both sides: set
+`guest_auth = true` in Lua and provide the pepper via
+`ASOBI_GUEST_VERIFIER_PEPPER`. On managed cloud the pepper is provisioned per
+environment, so the same bundle is off in dev (no pepper) and on in prod.
 
 The pepper is a server-side secret that makes a stolen database of verifiers
 useless without it - store it like any other secret (env/secret manager), not in

--- a/guides/authentication.md
+++ b/guides/authentication.md
@@ -7,8 +7,8 @@ social login (Google, Apple, Microsoft, Discord), Steam, and anonymous
 Players can link multiple providers to a single account.
 
 > Auth endpoints return an `access_token` (short-lived) and a `refresh_token`
-> (used against `/auth/refresh`). The `session_token` shown in the shorthand
-> examples below is the access token; use it as the `Bearer` credential.
+> (used against `/auth/refresh`). Use the `access_token` as the `Bearer`
+> credential.
 
 > #### Windows {: .info}
 >
@@ -18,7 +18,7 @@ Players can link multiple providers to a single account.
 
 ## Username & Password
 
-The simplest method. Register and login to receive a session token:
+The simplest method. Register and login to receive a token pair:
 
 ```bash
 curl -X POST http://localhost:8084/api/v1/auth/register \
@@ -27,13 +27,13 @@ curl -X POST http://localhost:8084/api/v1/auth/register \
 ```
 
 ```json
-{"player_id": "...", "session_token": "...", "username": "player1"}
+{"player_id": "...", "access_token": "...", "refresh_token": "...", "username": "player1"}
 ```
 
-Use the session token in subsequent requests:
+Use the access token in subsequent requests:
 
 ```
-Authorization: Bearer <session_token>
+Authorization: Bearer <access_token>
 ```
 
 ## Refresh & Rotation
@@ -85,7 +85,8 @@ First-time response (new account created):
 ```json
 {
   "player_id": "...",
-  "session_token": "...",
+  "access_token": "...",
+  "refresh_token": "...",
   "username": "google_abc12345_4821",
   "created": true
 }
@@ -96,7 +97,8 @@ Returning player response:
 ```json
 {
   "player_id": "...",
-  "session_token": "...",
+  "access_token": "...",
+  "refresh_token": "...",
   "username": "player1"
 }
 ```
@@ -323,7 +325,7 @@ Requires an authenticated session.
 
 ```bash
 curl -X POST http://localhost:8084/api/v1/auth/link \
-  -H 'Authorization: Bearer <session_token>' \
+  -H 'Authorization: Bearer <access_token>' \
   -H 'Content-Type: application/json' \
   -d '{"provider": "discord", "token": "eyJhbGciOi..."}'
 ```
@@ -338,7 +340,7 @@ Asobi prevents unlinking the last auth method to avoid locking the player out.
 
 ```bash
 curl -X DELETE http://localhost:8084/api/v1/auth/unlink \
-  -H 'Authorization: Bearer <session_token>' \
+  -H 'Authorization: Bearer <access_token>' \
   -H 'Content-Type: application/json' \
   -d '{"provider": "discord"}'
 ```
@@ -349,13 +351,13 @@ curl -X DELETE http://localhost:8084/api/v1/auth/unlink \
 
 ## WebSocket Authentication
 
-After obtaining a session token (from any auth method), connect to the
+After obtaining an access token (from any auth method), connect to the
 WebSocket and authenticate:
 
 ```json
 {
   "type": "session.connect",
-  "payload": {"token": "<session_token>"}
+  "payload": {"token": "<access_token>"}
 }
 ```
 
@@ -364,7 +366,7 @@ The token works the same regardless of which provider was used to obtain it.
 ## SDK Integration
 
 The same Google sign-in flow across the SDKs. The platform SDK returns an ID
-token; hand it to Asobi and the session token is stored internally.
+token; hand it to Asobi and the access token is stored internally.
 
 <!-- tabs -->
 **Unity (C#)**

--- a/guides/configuration.md
+++ b/guides/configuration.md
@@ -233,12 +233,14 @@ Without it Apple receipt verification is refused.
 ## Guest (anonymous) auth
 
 Guest auth lets a device create a throwaway player without credentials and
-upgrade it to a real account later. It is **opt-in and fails closed**: the
-guest endpoints return `403 guest_auth_disabled` until `guest_auth` is `true`
-**and** a `guest_verifier_pepper` is set.
+upgrade it to a real account later. It is **opt-in and fails closed**: the guest
+endpoints return `403 guest_auth_disabled` until the **game** declares
+`guest_auth = true` in its Lua config **and** the **operator** sets a
+`guest_verifier_pepper` (ADR 0004). The toggle is a game global, not a
+`sys.config` key - see [Authentication](authentication.md#guest-anonymous). This
+page covers the operator half: the pepper and abuse controls.
 
 ```erlang
-{guest_auth, true},
 %% Required. A key-id -> pepper map (>= 32 bytes each). Keep old key ids for the
 %% guest retention window so existing guests can still resume after rotation.
 {guest_verifier_pepper, #{~"v1" => ~"a-32-byte-or-longer-secret......"}},
@@ -254,8 +256,7 @@ guest endpoints return `403 guest_auth_disabled` until `guest_auth` is `true`
 
 | Key | Default | Description |
 |-----|---------|-------------|
-| `guest_auth` | `false` | Master switch. Both this and a pepper are required |
-| `guest_verifier_pepper` | none | Key-id -> pepper map (each pepper >= 32 bytes) or a single >= 32-byte binary |
+| `guest_verifier_pepper` | none | Key-id -> pepper map (each pepper >= 32 bytes) or a single >= 32-byte binary. Presence is the operator's on switch |
 | `guest_verifier_key_id` | `~"v1"` | Which pepper key id to use when minting new verifiers |
 | `guest_unlinked_cap` | `100000` | Soft ceiling on unclaimed guests, or `infinity` |
 | `guest_reap_after` | unset | Seconds; unset disables the reaper (guests are permanent) |

--- a/src/matches/asobi_matchmaker_strategy.erl
+++ b/src/matches/asobi_matchmaker_strategy.erl
@@ -1,13 +1,18 @@
 -module(asobi_matchmaker_strategy).
-
--doc """
+-moduledoc """
 Behaviour for matchmaking strategies.
 
-Implement `match/2` to define how tickets are grouped into matches.
-Return `{Matched, Unmatched}` where Matched is a list of groups
-(each group is a list of tickets that form a match) and Unmatched
-is the remaining tickets that couldn't be matched.
+Implement `match/2` to define how tickets are grouped into matches. Asobi ships
+`fill` and `skill_based`; provide your own by implementing this behaviour and
+pointing the matchmaker at your module.
 """.
 
+-doc """
+Group pending tickets into matches.
+
+Return `{Matched, Unmatched}` where `Matched` is a list of groups (each group a
+list of tickets that form one match) and `Unmatched` is the tickets that could
+not be matched this pass.
+""".
 -callback match(Tickets :: [map()], Config :: map()) ->
     {Matched :: [[map()]], Unmatched :: [map()]}.

--- a/src/world/asobi_world.erl
+++ b/src/world/asobi_world.erl
@@ -1,71 +1,96 @@
 -module(asobi_world).
+-moduledoc """
+Behaviour for large-session world game modules.
 
-%% Behaviour for large-session world game modules.
-%%
-%% Unlike `asobi_match`, world games are spatially partitioned into zones.
-%% The game module provides zone-level tick logic and global post-tick events.
+Unlike `asobi_match`, world games are spatially partitioned into zones. The game
+module provides zone-level tick logic and global post-tick events. Only `init/1`,
+`join/2`, `leave/2`, `spawn_position/2`, `zone_tick/2`, `handle_input/3`,
+`post_tick/2`, `init_zone_state/2`, and `dump_zone_state/1` are required; the rest
+are optional hooks (see `-optional_callbacks`).
+""".
 
+-doc "Initialise global game state from the match config.".
 -callback init(Config :: map()) ->
     {ok, GameState :: term()}.
 
+-doc "A player joins the world.".
 -callback join(PlayerId :: binary(), GameState :: term()) ->
     {ok, GameState1 :: term()} | {error, Reason :: term()}.
 
+-doc "A player leaves the world.".
 -callback leave(PlayerId :: binary(), GameState :: term()) ->
     {ok, GameState1 :: term()}.
 
+-doc "Where a joining player spawns.".
 -callback spawn_position(PlayerId :: binary(), GameState :: term()) ->
     {ok, {X :: number(), Y :: number()}}.
 
+-doc "Per-zone tick: advance the entities in one zone from its zone_state.".
 -callback zone_tick(Entities :: map(), ZoneState :: term()) ->
     {Entities1 :: map(), ZoneState1 :: term()}.
 
+-doc "Apply a player input to a zone's entities.".
 -callback handle_input(PlayerId :: binary(), Input :: map(), Entities :: map()) ->
     {ok, Entities1 :: map()} | {error, Reason :: term()}.
 
+-doc "Global post-tick hook: continue, trigger a vote, or finish the world.".
 -callback post_tick(Tick :: non_neg_integer(), GameState :: term()) ->
     {ok, GameState1 :: term()}
     | {vote, VoteConfig :: map(), GameState1 :: term()}
     | {finished, Result :: map(), GameState1 :: term()}.
 
+-doc "Optional: seed the initial zone states from a world seed.".
 -callback generate_world(Seed :: integer(), Config :: map()) ->
     {ok, ZoneStates :: #{{integer(), integer()} => term()}}.
 
+-doc "Optional: project the world to the state one player should see.".
 -callback get_state(PlayerId :: binary(), GameState :: term()) ->
     StateForPlayer :: map().
 
+-doc "Optional: declare the world's phases.".
 -callback phases(Config :: map()) -> [asobi_phase:phase_def()].
 
+-doc "Optional: a phase started.".
 -callback on_phase_started(PhaseName :: binary(), GameState :: term()) ->
     {ok, GameState1 :: term()}.
 
+-doc "Optional: a phase ended.".
 -callback on_phase_ended(PhaseName :: binary(), GameState :: term()) ->
     {ok, GameState1 :: term()}.
 
+-doc "Optional: the world was recovered from snapshots after a crash.".
 -callback on_world_recovered(Snapshots :: map(), GameState :: term()) ->
     {ok, GameState1 :: term()}.
 
+-doc "Optional: named entity spawn templates for zone spawners.".
 -callback spawn_templates(Config :: map()) ->
     #{binary() => asobi_zone_spawner:spawn_template()}.
 
+-doc "Optional: the terrain provider module + args, or `none`.".
 -callback terrain_provider(Config :: map()) ->
     {Module :: module(), ProviderArgs :: map()} | none.
 
+-doc "Optional: a zone was lazily loaded.".
 -callback on_zone_loaded(Coords :: {integer(), integer()}, GameState :: term()) ->
     {ok, ZoneState :: map(), GameState1 :: term()}.
 
+-doc "Optional: a zone was unloaded.".
 -callback on_zone_unloaded(Coords :: {integer(), integer()}, GameState :: term()) ->
     {ok, GameState1 :: term()}.
 
-%% Build this zone's zone_state in the zone process, from the zone Config and
-%% any plain gameplay state restored from a snapshot. This is where a game
-%% module that holds a per-zone runtime (e.g. a Lua VM) constructs it, bound to
-%% the zone process. Runs once, after init, via handle_continue.
+-doc """
+Build this zone's zone_state in the zone process, from the zone Config and any
+plain gameplay state restored from a snapshot. This is where a game module that
+holds a per-zone runtime (e.g. a Lua VM) constructs it, bound to the zone
+process. Runs once, after init, via handle_continue.
+""".
 -callback init_zone_state(Config :: map(), ZoneState :: map()) -> map().
 
-%% Reduce zone_state to a JSON-safe map for snapshotting: drop any live runtime
-%% (e.g. a VM that cannot be serialised) and decode engine-held gameplay state
-%% to plain terms. The inverse of init_zone_state's restore path.
+-doc """
+Reduce zone_state to a JSON-safe map for snapshotting: drop any live runtime
+(e.g. a VM that cannot be serialised) and decode engine-held gameplay state to
+plain terms. The inverse of `init_zone_state`'s restore path.
+""".
 -callback dump_zone_state(ZoneState :: map()) -> map().
 
 -optional_callbacks([


### PR DESCRIPTION
Docs audit (2026-07-19) found the guest-auth guides still teach the **removed** operator `sys.config` toggle, contradicting ADR 0004 in this same repo. Following them literally yields a `403`, because `asobi_lua_config:apply_guest_auth/1` clobbers any `sys.config` value on bundle load.

## Changes
**CRITICAL - guest-auth model (ADR 0004)**
- `guides/authentication.md`: `guest_auth = true` is declared in the game's Lua (`match.lua`/`config.lua`); operator supplies only the pepper; auth is on iff both agree; dropped `{guest_auth, true}` from the operator config block; `403` row clarified. No `ASOBI_GUEST_AUTH` env var.
- `guides/configuration.md`: same - the toggle is a game global, not a config key; the operator half is just the pepper + abuse controls.

**HIGH - undocumented surface**
- `README.md`: guest/anonymous auth added to Features.
- `src/world/asobi_world.erl`: `-moduledoc` + `-doc` on all 19 callbacks (was a plain `%%` header that does not render on HexDocs).
- `src/matches/asobi_matchmaker_strategy.erl`: `-moduledoc` added; `match/2` gets its own `-doc`.

Docs-only + moduledoc. `rebar3 compile`, `fmt --check`, and `ex_doc` (no warnings) all clean.