### PR TITLE
feat: add listed and quick_play visibility flags to world modes

### DIFF
--- a/guides/world-server.md
+++ b/guides/world-server.md
@@ -352,6 +352,30 @@ Register your world mode in `sys.config`:
 | `zone_idle_timeout` | 30000 | Milliseconds an empty zone lingers before it is released |
 | `empty_grace_ms` | 0 | Milliseconds a world with no players lingers before it finishes (0 = finish immediately) |
 | `snapshot_interval` | 600 | Ticks between zone snapshots (see [Snapshots](#snapshots)) |
+| `listed` | `true` | Whether worlds of this mode appear in `world.list` / `GET /api/v1/worlds` |
+| `quick_play` | `true` | Whether `world.find_or_create` may place a player into an existing world of this mode |
+
+### Visibility
+
+`listed` and `quick_play` are independent axes, so a mode can be browsable
+but out of quick-play rotation, or reachable by quick-play while hidden from
+the browser.
+
+```erlang
+~"tutorial" => #{
+    type => world,
+    module => my_tutorial,
+    listed => false,      %% never shows up in the browser
+    quick_play => false   %% and never absorbs a quick-play request
+}
+```
+
+Neither flag gates joining. A client that already knows a `world_id` can
+still `world.join` it. Both flags control discovery only.
+
+With `quick_play => false`, `world.find_or_create` returns
+`quick_play_disabled` rather than creating a world, since it could never
+find the one it just made.
 
 ### Procedural Generation
 

--- a/src/asobi_game_modes.erl
+++ b/src/asobi_game_modes.erl
@@ -41,7 +41,9 @@ world_config(Mode) ->
                 zone_size => maps:get(zone_size, ModeConfig, 200),
                 tick_rate => maps:get(tick_rate, ModeConfig, 50),
                 view_radius => maps:get(view_radius, ModeConfig, 1),
-                persistent => maps:get(persistent, ModeConfig, false)
+                persistent => maps:get(persistent, ModeConfig, false),
+                listed => maps:get(listed, ModeConfig, true),
+                quick_play => maps:get(quick_play, ModeConfig, true)
             },
             {ok, forward_optional(ModeConfig, [empty_grace_ms, player_ttl_ms], Base)};
         {error, _} = Err ->

--- a/src/world/asobi_world_lobby.erl
+++ b/src/world/asobi_world_lobby.erl
@@ -72,7 +72,7 @@ list_worlds_cached(Filters) ->
             {hit, Worlds} ->
                 Worlds;
             miss ->
-                Worlds = list_worlds(#{has_capacity => HasCapacity}),
+                Worlds = list_worlds(#{has_capacity => HasCapacity, listed => true}),
                 asobi_world_lobby_server:cache_worlds(
                     HasCapacity, Worlds, Now + ?LIST_CACHE_TTL_MS
                 ),
@@ -122,7 +122,25 @@ find_or_create_unsafe(Mode) ->
 -spec find_or_create_unsafe(binary(), binary() | undefined) ->
     {ok, pid(), map()} | {error, term()}.
 find_or_create_unsafe(Mode, PlayerId) ->
-    Worlds = list_worlds(#{mode => Mode, has_capacity => true}),
+    case mode_quick_play(Mode) of
+        true -> do_find_or_create(Mode, PlayerId);
+        false -> {error, quick_play_disabled}
+    end.
+
+%% Without this guard a `quick_play => false` mode would never match the
+%% filter below and so would spawn a fresh world on every call, up to the
+%% global cap.
+-spec mode_quick_play(binary()) -> boolean().
+mode_quick_play(Mode) ->
+    case asobi_game_modes:world_config(Mode) of
+        {ok, Config} -> maps:get(quick_play, Config, true);
+        {error, _} -> true
+    end.
+
+-spec do_find_or_create(binary(), binary() | undefined) ->
+    {ok, pid(), map()} | {error, term()}.
+do_find_or_create(Mode, PlayerId) ->
+    Worlds = list_worlds(#{mode => Mode, has_capacity => true, quick_play => true}),
     case Worlds of
         [#{world_id := WorldId} = First | _] ->
             case asobi_world_server:whereis(WorldId) of
@@ -272,7 +290,19 @@ matches_filters(Info, Filters) ->
     %% spawned their own world because neither saw the in-flight one.
     Status = maps:get(status, Info, undefined),
     StatusOk = Status =:= running orelse Status =:= loading,
-    ModeOk andalso CapOk andalso StatusOk.
+    ModeOk andalso CapOk andalso StatusOk andalso flag_ok(listed, Info, Filters) andalso
+        flag_ok(quick_play, Info, Filters).
+
+%% A visibility flag only constrains the paths that ask for it: the browser
+%% filters on `listed`, quick-play on `quick_play`. Neither filters on the
+%% other, so a world can be browsable but out of quick-play rotation, or
+%% reachable by quick-play while hidden from the browser.
+-spec flag_ok(atom(), map(), map()) -> boolean().
+flag_ok(Flag, Info, Filters) ->
+    case maps:find(Flag, Filters) of
+        {ok, Want} -> maps:get(Flag, Info, true) =:= Want;
+        error -> true
+    end.
 
 -spec take_first([pid()]) -> [pid()].
 take_first([Pid | _]) -> [Pid];

--- a/src/world/asobi_world_server.erl
+++ b/src/world/asobi_world_server.erl
@@ -174,6 +174,8 @@ init(Config) ->
         frustration_bonus => FrustrationBonus,
         active_votes => #{},
         persistent => Persistent,
+        listed => maps:get(listed, Config, true),
+        quick_play => maps:get(quick_play, Config, true),
         empty_grace_ms => EmptyGraceMs,
         player_ttl_ms => maps:get(player_ttl_ms, Config, 0),
         reconnect_state => init_reconnect(Config),
@@ -1032,7 +1034,9 @@ world_info(Status, #{world_id := WorldId, players := Players} = State) ->
         players => maps:keys(Players),
         mode => maps:get(mode, State, undefined),
         grid_size => maps:get(grid_size, State),
-        started_at => maps:get(started_at, State, undefined)
+        started_at => maps:get(started_at, State, undefined),
+        listed => maps:get(listed, State, true),
+        quick_play => maps:get(quick_play, State, true)
     },
     case maps:get(phase_state, State, undefined) of
         undefined -> Base;

--- a/test/asobi_world_lobby_SUITE.erl
+++ b/test/asobi_world_lobby_SUITE.erl
@@ -24,12 +24,19 @@ tests pin that contract so the bug can never sneak back in unnoticed.
     create_world_player_cap_blocks_after_limit/1,
     create_world_player_cap_releases_when_world_dies/1,
     create_world_global_cap_blocks_at_max/1,
-    create_world_anonymous_bypasses_player_cap/1
+    create_world_anonymous_bypasses_player_cap/1,
+    unlisted_world_hidden_from_browser/1,
+    unlisted_world_hidden_from_cached_browser/1,
+    unlisted_world_still_reachable_by_quick_play/1,
+    no_quick_play_world_hidden_from_find_or_create/1,
+    no_quick_play_world_still_browsable/1
 ]).
 
 -define(MODE_HUB, ~"test_hub").
 -define(MODE_ARENA, ~"test_arena").
 -define(MODE_SOLO, ~"test_solo").
+-define(MODE_UNLISTED, ~"test_unlisted").
+-define(MODE_NO_QUICK_PLAY, ~"test_no_quick_play").
 
 all() ->
     [
@@ -45,7 +52,12 @@ all() ->
         create_world_player_cap_blocks_after_limit,
         create_world_player_cap_releases_when_world_dies,
         create_world_global_cap_blocks_at_max,
-        create_world_anonymous_bypasses_player_cap
+        create_world_anonymous_bypasses_player_cap,
+        unlisted_world_hidden_from_browser,
+        unlisted_world_hidden_from_cached_browser,
+        unlisted_world_still_reachable_by_quick_play,
+        no_quick_play_world_hidden_from_find_or_create,
+        no_quick_play_world_still_browsable
     ].
 
 init_per_suite(Config) ->
@@ -74,6 +86,24 @@ init_per_suite(Config) ->
             grid_size => 1,
             zone_size => 100,
             tick_rate => 50
+        },
+        ?MODE_UNLISTED => #{
+            type => world,
+            module => asobi_test_world_game,
+            max_players => 4,
+            grid_size => 1,
+            zone_size => 100,
+            tick_rate => 50,
+            listed => false
+        },
+        ?MODE_NO_QUICK_PLAY => #{
+            type => world,
+            module => asobi_test_world_game,
+            max_players => 4,
+            grid_size => 1,
+            zone_size => 100,
+            tick_rate => 50,
+            quick_play => false
         }
     }),
     Config1.
@@ -138,6 +168,66 @@ list_worlds_filters_by_capacity(_Config) ->
     ?assertEqual(
         1, length(asobi_world_lobby:list_worlds())
     ).
+
+%% --- visibility flags ---
+
+unlisted_world_hidden_from_browser(_Config) ->
+    {ok, _Pid, Info} = asobi_world_lobby:create_world(?MODE_UNLISTED),
+    wait_until_running(maps:get(world_id, Info)),
+
+    ?assertEqual(
+        [],
+        asobi_world_lobby:list_worlds(#{listed => true}),
+        "the browser filter must not surface an unlisted world"
+    ),
+    ?assertEqual(
+        1,
+        length(asobi_world_lobby:list_worlds()),
+        "the raw enumerator is unfiltered - the flag is applied per caller"
+    ).
+
+unlisted_world_hidden_from_cached_browser(_Config) ->
+    %% list_worlds_cached/1 is what every production browser call hits, so
+    %% pin that it injects `listed => true` itself. The ETS cache is
+    %% process-owned and protected, so the only way to a clean read is to
+    %% outlive the TTL.
+    timer:sleep(600),
+    {ok, _Pid, Info} = asobi_world_lobby:create_world(?MODE_UNLISTED),
+    wait_until_running(maps:get(world_id, Info)),
+    ?assertEqual([], asobi_world_lobby:list_worlds_cached()).
+
+unlisted_world_still_reachable_by_quick_play(_Config) ->
+    %% listed and quick_play are independent axes: hidden from the browser
+    %% does not mean out of quick-play rotation.
+    {ok, Pid, Info} = asobi_world_lobby:create_world(?MODE_UNLISTED),
+    wait_until_running(maps:get(world_id, Info)),
+
+    {ok, FoundPid, _} = asobi_world_lobby:find_or_create(?MODE_UNLISTED),
+    ?assertEqual(Pid, FoundPid, "quick_play must reuse the unlisted world"),
+    ?assertEqual([], asobi_world_lobby:list_worlds(#{listed => true})).
+
+no_quick_play_world_hidden_from_find_or_create(_Config) ->
+    {ok, _Pid, Info} = asobi_world_lobby:create_world(?MODE_NO_QUICK_PLAY),
+    wait_until_running(maps:get(world_id, Info)),
+
+    %% Must refuse rather than spawn a second world it can never find again.
+    ?assertEqual(
+        {error, quick_play_disabled},
+        asobi_world_lobby:find_or_create(?MODE_NO_QUICK_PLAY)
+    ),
+    ?assertEqual(
+        1,
+        length(asobi_world_lobby:list_worlds()),
+        "a refused find_or_create must not have created a world"
+    ).
+
+no_quick_play_world_still_browsable(_Config) ->
+    {ok, _Pid, Info} = asobi_world_lobby:create_world(?MODE_NO_QUICK_PLAY),
+    WorldId = maps:get(world_id, Info),
+    wait_until_running(WorldId),
+
+    [Listed] = asobi_world_lobby:list_worlds(#{listed => true}),
+    ?assertEqual(WorldId, maps:get(world_id, Listed)).
 
 %% --- find_or_create ---
 


### PR DESCRIPTION
Item 2 of the lobby sequence. Discovery had no visibility control at all: every running world appeared in the browser and was eligible for quick-play.

## Two flags, not one

Game-mode declared, both default `true`, so existing modes are unchanged.

| Flag | Filters |
|---|---|
| `listed` | `world.list` / `GET /api/v1/worlds` |
| `quick_play` | `world.find_or_create` |

They are **independent axes**: a mode can be browsable but out of quick-play rotation, or reachable by quick-play while hidden from the browser. One flag cannot express either.

The reason asobi needs two is that it has three world entry points — browse, quick-play, join-by-id — and they are separately reachable. Colyseus has `private` and `unlisted` on its room cache, but they are **not** orthogonal there: `LobbyRoom` queries `matchMaker.query({ private: false, unlisted: false })` (`rooms/LobbyRoom.ts:102`), so `private` excludes a room from the lobby listing as well as from `joinOrCreate`. That is a hierarchy, not two axes. asobi's entry ops make the fourth quadrant genuinely reachable, so the flags stay independent here.

```erlang
~"tutorial" => #{
    type => world,
    module => my_tutorial,
    listed => false,
    quick_play => false
}
```

## What this deliberately does not do

**Neither flag gates joining.** A client holding a `world_id` can still `world.join` it. Both are discovery-tier, matching Colyseus, where `locked` is the separate join gate.

So this does not close #193. It narrows the discovery surface feeding that attack; it does not remove it. Join authorisation belongs with the `Mod:join/3` join context.

**Both flags are properties of the mode, not of a world instance**, so a player cannot host a private world at runtime. That is the use case the naming suggests, so it is called out explicitly in the guide to stop someone building a privacy feature on a static mode property.

## One guard worth noting

`find_or_create` on a `quick_play => false` mode returns `{error, quick_play_disabled}` rather than falling through to create. Without it the filter could never match, so every call would spawn a fresh world up to the global cap.

## Verification

`fmt --check`, `xref`, `dialyzer`, `ex_doc` clean. `eunit` 330/0. `ct --suite asobi_world_lobby_SUITE` 20/20. `elp eqwalize-all` 36 errors, identical to `main`.

Tests: five suite cases covering both flags in both directions plus the `quick_play_disabled` guard, and `listing_info_omits_visibility_flags` pinning that the flags stay off the wire (they ride in `world_info/2` so `matches_filters/2` can read them).

Main merged in, so this is verified against the post-#192/#196 tree.