### PR TITLE
fix: drop persisted match rosters from the public match endpoints

### DIFF
--- a/src/controllers/asobi_match_controller.erl
+++ b/src/controllers/asobi_match_controller.erl
@@ -2,10 +2,24 @@
 
 -export([show/1, index/1]).
 
+-doc """
+Projection of a persisted match record for callers who were not in it.
+
+`asobi_world_server:persist_result/1` and `asobi_match_server` both write
+`players` (the full roster) into the record, and these endpoints are open
+to any authenticated player, so the roster is dropped on the way out.
+
+`result` is game-authored and stays: games use it for public post-match
+summaries. A game that puts per-player data there is choosing to publish it.
+""".
+-spec public_record(map()) -> map().
+public_record(Record) ->
+    maps:with([id, mode, status, result, started_at, finished_at, inserted_at], Record).
+
 -spec show(cowboy_req:req()) -> {json, map()} | {status, integer()}.
 show(#{bindings := #{~"id" := MatchId}} = _Req) ->
     case asobi_repo:get(asobi_match_record, MatchId) of
-        {ok, Record} -> {json, Record};
+        {ok, Record} -> {json, public_record(Record)};
         {error, not_found} -> {status, 404}
     end.
 
@@ -26,4 +40,4 @@ index(#{qs := Qs} = _Req) when is_binary(Qs) ->
     Limit = asobi_qs:integer(~"limit", Params, 50, 1, 200),
     Q3 = kura_query:limit(kura_query:order_by(Q2, [{inserted_at, desc}]), Limit),
     {ok, Records} = asobi_repo:all(Q3),
-    {json, #{matches => Records}}.
+    {json, #{matches => [public_record(R) || R <- Records]}}.

--- a/src/controllers/asobi_world_controller.erl
+++ b/src/controllers/asobi_world_controller.erl
@@ -18,7 +18,7 @@ show(#{bindings := #{~"id" := WorldId}}) ->
     case asobi_world_server:whereis(WorldId) of
         {ok, Pid} ->
             Info = asobi_world_server:get_info(Pid),
-            {json, asobi_world_lobby:listing(Info)};
+            {json, asobi_world_server:listing_info(Info)};
         error ->
             {status, 404}
     end.

--- a/src/world/asobi_world_lobby.erl
+++ b/src/world/asobi_world_lobby.erl
@@ -3,7 +3,7 @@
 -export([
     list_worlds/0, list_worlds/1, find_or_create/1, find_or_create/2, create_world/1, create_world/2
 ]).
--export([list_worlds_cached/0, list_worlds_cached/1, listing/1]).
+-export([list_worlds_cached/0, list_worlds_cached/1]).
 -export([find_or_create_unsafe/1, find_or_create_unsafe/2]).
 -export([player_owned_world_count/1, world_capacity_state/1]).
 
@@ -32,7 +32,7 @@ list_worlds(Filters) ->
             try asobi_world_server:get_info(Pid) of
                 Info when is_map(Info) ->
                     case matches_filters(Info, Filters) of
-                        true -> {true, listing(Info)};
+                        true -> {true, asobi_world_server:listing_info(Info)};
                         false -> false
                     end
             catch
@@ -42,21 +42,6 @@ list_worlds(Filters) ->
         WorldGroups
     ),
     Worlds.
-
--doc """
-Projection of `asobi_world_server:get_info/1` for discovery callers.
-
-`get_info/1` serves the detail view for players already in the world and
-carries the full `players` roster. Discovery is open to any authenticated
-player, so the listing surface exposes only what is needed to choose a
-world: identity, mode, status, capacity and phase.
-""".
--spec listing(map()) -> map().
-listing(Info) ->
-    maps:with(
-        [world_id, status, player_count, max_players, mode, grid_size, started_at, phase],
-        Info
-    ).
 
 -doc """
 H3 (2026-05-19): cached variant of `list_worlds/1` for request paths that
@@ -192,7 +177,7 @@ do_create_world(Mode, PlayerId) ->
                         WorldPid ->
                             register_world_owner(WorldPid, PlayerId),
                             Info = asobi_world_server:get_info(WorldPid),
-                            {ok, WorldPid, listing(Info)}
+                            {ok, WorldPid, asobi_world_server:listing_info(Info)}
                     end;
                 {error, _} = Err ->
                     Err

--- a/src/world/asobi_world_server.erl
+++ b/src/world/asobi_world_server.erl
@@ -9,6 +9,8 @@ transient matches use `asobi_match_server` instead.
 -behaviour(gen_statem).
 
 -export([start_link/1, join/2, join/3, leave/2, move_player/3, post_tick/2, get_info/1, cancel/1]).
+-export([listing_info/1]).
+-export_type([listing/0]).
 -export([spawn_at/3, spawn_at/4]).
 -export([reconnect/2]).
 -export([start_vote/2, cast_vote/4, use_veto/3]).
@@ -1037,6 +1039,42 @@ world_info(Status, #{world_id := WorldId, players := Players} = State) ->
     case maps:get(phase_state, State, undefined) of
         undefined -> Base;
         PS -> Base#{phase => asobi_phase:info(PS)}
+    end.
+
+-doc "What a non-member may see. Every key is optional: `maps:with/2` keeps only what the world set.".
+-type listing() :: #{
+    world_id => binary(),
+    status => atom(),
+    player_count => non_neg_integer(),
+    max_players => pos_integer(),
+    mode => binary() | undefined,
+    grid_size => non_neg_integer(),
+    started_at => integer() | undefined,
+    phase => map()
+}.
+
+-doc """
+Projection of `get_info/1` for callers who are not members of the world.
+
+`get_info/1` carries the full `players` roster. Discovery and the join
+reply are open to any authenticated player, so they get identity, mode,
+status, capacity and phase only.
+
+The projection descends into `phase`: `asobi_phase:info/1` evolves
+independently and its `config` is game-authored, so allowlisting only the
+top level would leak whatever a future phase field happens to carry.
+""".
+-spec listing_info(map()) -> listing().
+listing_info(Info) ->
+    Base = maps:with(
+        [world_id, status, player_count, max_players, mode, grid_size, started_at],
+        Info
+    ),
+    case maps:get(phase, Info, undefined) of
+        Phase when is_map(Phase) ->
+            Base#{phase => maps:with([status, phase, remaining_ms, start_condition], Phase)};
+        _ ->
+            Base
     end.
 
 %% --- Internal: Reconnection ---

--- a/test/asobi_world_lobby_SUITE.erl
+++ b/test/asobi_world_lobby_SUITE.erl
@@ -151,12 +151,17 @@ list_worlds_omits_player_roster(_Config) ->
     ok = asobi_world_server:join(Pid, ~"player2"),
 
     [Listed] = asobi_world_lobby:list_worlds(),
-    ?assertNot(
-        maps:is_key(players, Listed),
-        "discovery must not expose the player roster"
+    ?assertEqual(
+        lists:sort([world_id, status, player_count, max_players, mode, grid_size, started_at]),
+        lists:sort(maps:keys(Listed)),
+        "listing key set is a security contract - widen it deliberately"
     ),
     ?assertEqual(2, maps:get(player_count, Listed)),
     ?assertEqual(WorldId, maps:get(world_id, Listed)),
+
+    %% The cached path is what every production caller actually hits.
+    [Cached] = asobi_world_lobby:list_worlds_cached(),
+    ?assertNot(maps:is_key(players, Cached)),
 
     Detail = asobi_world_server:get_info(Pid),
     ?assertEqual(
@@ -170,7 +175,9 @@ find_or_create_omits_player_roster(_Config) ->
     wait_until_running(maps:get(world_id, Info)),
     ok = asobi_world_server:join(Pid, ~"player1"),
 
-    {ok, _, Found} = asobi_world_lobby:find_or_create(?MODE_HUB),
+    {ok, FoundPid, Found} = asobi_world_lobby:find_or_create(?MODE_HUB),
+    ?assertEqual(Pid, FoundPid, "must reuse the populated world, not create an empty one"),
+    ?assertEqual(1, maps:get(player_count, Found)),
     ?assertNot(maps:is_key(players, Found)),
 
     {ok, _, Created} = asobi_world_lobby:create_world(?MODE_ARENA),

--- a/test/asobi_world_server_tests.erl
+++ b/test/asobi_world_server_tests.erl
@@ -300,3 +300,52 @@ join_three_sets_zone_pid() ->
     ?assertEqual(Pid, maps:get(world_pid, State1)),
     asobi_player_session:stop(SessionPid),
     stop_world(Ctx).
+
+%% --- listing_info/1 (pure projection, no world needed) ---
+
+listing_info_drops_roster_test() ->
+    Info = #{
+        world_id => ~"w1",
+        status => running,
+        player_count => 2,
+        max_players => 4,
+        players => [~"p1", ~"p2"],
+        mode => ~"hub",
+        grid_size => 1,
+        started_at => 123
+    },
+    Listing = asobi_world_server:listing_info(Info),
+    ?assertEqual(
+        lists:sort([world_id, status, player_count, max_players, mode, grid_size, started_at]),
+        lists:sort(maps:keys(Listing))
+    ),
+    ?assertEqual(2, maps:get(player_count, Listing)).
+
+listing_info_drops_unknown_fields_test() ->
+    Listing = asobi_world_server:listing_info(#{
+        world_id => ~"w1", owner_id => ~"p1", spectators => [~"p2"]
+    }),
+    ?assertEqual([world_id], maps:keys(Listing)).
+
+listing_info_projects_nested_phase_test() ->
+    %% asobi_phase:info/1 evolves independently; the projection must not
+    %% pass through whatever it grows next.
+    Listing = asobi_world_server:listing_info(#{
+        world_id => ~"w1",
+        phase => #{
+            status => active,
+            phase => ~"combat",
+            remaining_ms => 500,
+            config => #{answer_key => ~"secret"},
+            timers => [a, b],
+            winner => ~"p1"
+        }
+    }),
+    ?assertEqual(
+        lists:sort([status, phase, remaining_ms]),
+        lists:sort(maps:keys(maps:get(phase, Listing)))
+    ).
+
+listing_info_handles_missing_phase_test() ->
+    ?assertNot(maps:is_key(phase, asobi_world_server:listing_info(#{world_id => ~"w1"}))),
+    ?assertEqual(#{}, asobi_world_server:listing_info(#{})).


### PR DESCRIPTION
Restores work that was lost from #192. That PR was authored as two commits but only the first reached origin, so the squash merged half of it. This is the missing half, cherry-picked onto main and re-verified.

## The leak this closes

`asobi_world_server:persist_result/1` writes the full roster into the `players` column of `asobi_match_record`, and `asobi_match_controller` returned raw records. `GET /api/v1/matches` served the roster of every world that has ever finished, 200 rows per request, ordered `inserted_at desc`, to any authenticated caller.

This is the larger of the two leaks found in review — historical rather than point-in-time — and it is still open on main.

`public_record/1` drops `players` from both match endpoints. `result` stays: it is game-authored and games use it for public post-match summaries, so a game putting per-player data there is choosing to publish it.

## Also included

- Moves the world projection from `asobi_world_lobby:listing/1` to `asobi_world_server:listing_info/1`, next to `world_info/2` so it cannot drift, with a named `listing()` return type.
- The projection now descends into `phase`. `asobi_phase:info/1` evolves independently and carries a game-authored `config` map. Today's phase output has no player data, so this is defence in depth rather than a live leak.
- Four `listing_info/1` unit tests (roster drop, unknown-field drop, nested-phase projection, missing-phase and empty-map edge cases).
- Tightens the two `#192` suite tests: exact key-set assertion instead of `assertNot` (so widening the allowlist by accident fails), and pins that `find_or_create` actually reused the populated world.

## Verification

`fmt --check`, `xref` clean. `eunit` 329/0. `ct --suite asobi_world_lobby_SUITE` 15/15. Docker unavailable locally so DB-backed suites did not run here; CI covers them.