### PR TITLE
feat: add live match discovery

### DIFF
--- a/guides/websocket-protocol.md
+++ b/guides/websocket-protocol.md
@@ -54,13 +54,40 @@ Keep-alive ping. Send periodically to prevent timeout.
 
 ## Matches
 
+### `match.list`
+
+Browse live, joinable matches. Filters are optional.
+
+```json
+{"type": "match.list", "payload": {"mode": "arena", "has_capacity": true}}
+```
+
+Reply payload is `{"matches": [...]}`, each entry carrying `match_id`,
+`mode`, `status`, `player_count` and `max_players`. The roster is not
+included; see [World Server](world-server.md) for why discovery and
+membership are separate surfaces.
+
+**Matches are unlisted by default.** A matchmaker-spawned match is already
+assigned to its players, so it has no reason to appear in a browser. A mode
+opts in with `listed => true`. This is the inverse of worlds, which default
+to listed.
+
+Distinct from `GET /api/v1/matches`, which reads the match *record* table
+(finished matches, an audit trail). `GET /api/v1/matches/live` is the REST
+equivalent of this message.
+
 ### `match.join`
 
-Join a match (after being matched via matchmaker or direct invite).
+Join a match (after being matched via matchmaker, discovered via
+`match.list`, or a direct invite).
 
 ```json
 {"type": "match.join", "payload": {"match_id": "..."}}
 ```
+
+Joining is WebSocket-only by design: the join binds the match to your
+session so subsequent `match.input` is routed. There is no REST join, the
+same as for worlds.
 
 ### `match.input`
 

--- a/priv/protocol/fixtures/match.list.json
+++ b/priv/protocol/fixtures/match.list.json
@@ -1,0 +1,1 @@
+{"type":"match.list","cid":"21","payload":{"matches":[{"match_id":"01j8x000000000000000000001","mode":"demo","status":"waiting","player_count":1,"max_players":4}]}}

--- a/src/asobi_discovery.erl
+++ b/src/asobi_discovery.erl
@@ -1,0 +1,76 @@
+-module(asobi_discovery).
+-moduledoc """
+Shared enumeration for the discovery surfaces.
+
+Worlds and matches both register as `{ServerMod, Id}` in the `nova_scope`
+pg scope and both expose `get_info/1` plus `listing_info/1`, so browsing
+either is the same walk: enumerate the live processes, apply the caller's
+filter to the full info, and return the listing projection.
+
+Enumeration is a pull, not a push. Worlds churn on *attributes* — the set
+of worlds is near-static while occupancy changes constantly — so a delta
+stream would fan out at a rate set by other players' behaviour, with no
+ceiling. The 500ms cache in front of this is a hard ceiling of two
+refreshes per second regardless of load. See `asobi_world_lobby`.
+""".
+
+-export([enumerate/3, cache_lookup/2]).
+
+-define(PG_SCOPE, nova_scope).
+-define(LIST_CACHE_TAB, asobi_world_lobby_cache).
+
+-doc """
+List live `ServerMod` processes whose info satisfies `FilterFun`, each as
+its `ServerMod:listing_info/1` projection.
+
+`ServerMod` is both the pg group tag and the module supplying `get_info/1`
+and `listing_info/1`. A process that dies mid-enumeration, or whose
+`get_info/1` fails, is skipped rather than failing the whole listing.
+""".
+-spec enumerate(module(), map(), fun((map(), map()) -> boolean())) -> [map()].
+enumerate(ServerMod, Filters, FilterFun) ->
+    Pids = [
+        Pid
+     || {Mod, _Id} = Group <- pg:which_groups(?PG_SCOPE),
+        Mod =:= ServerMod,
+        Pid <- take_first(pg:get_members(?PG_SCOPE, Group))
+    ],
+    lists:filtermap(
+        fun(Pid) ->
+            try ServerMod:get_info(Pid) of
+                Info when is_map(Info) ->
+                    case FilterFun(Info, Filters) of
+                        true -> {true, ServerMod:listing_info(Info)};
+                        false -> false
+                    end;
+                _ ->
+                    false
+            catch
+                _:_ -> false
+            end
+        end,
+        Pids
+    ).
+
+-doc """
+Read a cached listing, or `miss` if absent or expired.
+
+The table is owned and written by `asobi_world_lobby_server`; reads are
+direct (the table is protected) so a browse costs no round-trip.
+`badarg` before the owner has started is a miss, not a crash.
+""".
+-spec cache_lookup(term(), integer()) -> {hit, [map()]} | miss.
+cache_lookup(Key, Now) ->
+    try ets:lookup(?LIST_CACHE_TAB, Key) of
+        [{_, Listing, ExpiresAt}] when ExpiresAt > Now -> {hit, Listing};
+        _ -> miss
+    catch
+        error:badarg -> miss
+    end.
+
+%% A pg group holds one pid per world/match; extra members would mean a
+%% duplicate registration, and listing the same world twice is worse than
+%% ignoring the duplicate.
+-spec take_first([pid()]) -> [pid()].
+take_first([Pid | _]) -> [Pid];
+take_first([]) -> [].

--- a/src/asobi_router.erl
+++ b/src/asobi_router.erl
@@ -65,6 +65,7 @@ api_routes() ->
 
             %% Matches
             {~"/matches", fun asobi_match_controller:index/1, #{methods => [get, options]}},
+            {~"/matches/live", fun asobi_match_controller:live/1, #{methods => [get, options]}},
             {~"/matches/:id", fun asobi_match_controller:show/1, #{methods => [get, options]}},
 
             %% Matchmaker

--- a/src/controllers/asobi_match_controller.erl
+++ b/src/controllers/asobi_match_controller.erl
@@ -1,6 +1,6 @@
 -module(asobi_match_controller).
 
--export([show/1, index/1]).
+-export([show/1, index/1, live/1]).
 
 -doc """
 Projection of a persisted match record for callers who were not in it.
@@ -15,6 +15,28 @@ summaries. A game that puts per-player data there is choosing to publish it.
 -spec public_record(map()) -> map().
 public_record(Record) ->
     maps:with([id, mode, status, result, started_at, finished_at, inserted_at], Record).
+
+-doc """
+Live, joinable matches. `index/1` reads the record table, which is
+finished-match history; this enumerates running match processes.
+""".
+-spec live(cowboy_req:req()) -> {json, map()}.
+live(#{qs := Qs} = _Req) when is_binary(Qs) ->
+    Params = cow_qs:parse_qs(Qs),
+    Filters0 = #{},
+    Filters1 =
+        case proplists:get_value(~"mode", Params) of
+            undefined -> Filters0;
+            Mode -> Filters0#{mode => Mode}
+        end,
+    Filters =
+        case proplists:get_value(~"has_capacity", Params) of
+            ~"true" -> Filters1#{has_capacity => true};
+            _ -> Filters1
+        end,
+    {json, #{matches => asobi_match_lobby:list_matches_cached(Filters)}};
+live(_Req) ->
+    {json, #{matches => asobi_match_lobby:list_matches_cached(#{})}}.
 
 -spec show(cowboy_req:req()) -> {json, map()} | {status, integer()}.
 show(#{bindings := #{~"id" := MatchId}} = _Req) ->

--- a/src/matches/asobi_match_lobby.erl
+++ b/src/matches/asobi_match_lobby.erl
@@ -1,0 +1,83 @@
+-module(asobi_match_lobby).
+-moduledoc """
+Discovery for live matches.
+
+`GET /api/v1/matches` reads the `asobi_match_record` table: finished
+matches, an audit trail, nothing a player can join. This module enumerates
+the running `asobi_match_server` processes instead, which is what a client
+choosing a match actually needs.
+
+Matches are **unlisted by default**. A match spawned by the matchmaker is
+already assigned to its players and has no reason to appear in a browser,
+so a mode opts in with `listed => true`. This is the inverse of worlds,
+which default to listed because their browser already shipped.
+""".
+
+-export([list_matches/0, list_matches/1, list_matches_cached/1]).
+
+-define(LIST_CACHE_TTL_MS, 500).
+
+-doc "List live matches. Unfiltered - callers that serve clients want `list_matches/1`.".
+-spec list_matches() -> [map()].
+list_matches() ->
+    list_matches(#{}).
+
+-doc """
+List live matches with optional filters: `mode`, `has_capacity`, `listed`.
+
+Only `waiting` and `running` matches are returned; a `finished` match is
+history and a `paused` one cannot be joined.
+""".
+-spec list_matches(map()) -> [map()].
+list_matches(Filters) ->
+    asobi_discovery:enumerate(asobi_match_server, Filters, fun matches_filters/2).
+
+-doc """
+Cached `list_matches/1` for request paths, mirroring
+`asobi_world_lobby:list_worlds_cached/1`.
+
+Each uncached call issues one `gen_statem:call` per live match. That cost
+is paid even when every match is unlisted and the result is empty, so a
+flood of `match.list` messages would stall every match's mailbox. Keyed on
+`has_capacity` only - `mode` is client-controlled and unbounded, so keying
+on it would miss on every request and grow the table without bound.
+""".
+-spec list_matches_cached(map()) -> [map()].
+list_matches_cached(Filters) ->
+    HasCapacity = maps:get(has_capacity, Filters, false),
+    Now = erlang:monotonic_time(millisecond),
+    Key = {asobi_match_server, HasCapacity},
+    All =
+        case asobi_discovery:cache_lookup(Key, Now) of
+            {hit, Matches} ->
+                Matches;
+            miss ->
+                Matches = list_matches(#{has_capacity => HasCapacity, listed => true}),
+                asobi_world_lobby_server:cache_listing(Key, Matches, Now + ?LIST_CACHE_TTL_MS),
+                Matches
+        end,
+    case maps:get(mode, Filters, undefined) of
+        undefined -> All;
+        Mode -> [M || M <- All, maps:get(mode, M, undefined) =:= Mode]
+    end.
+
+-spec matches_filters(map(), map()) -> boolean().
+matches_filters(Info, Filters) ->
+    ModeOk =
+        case maps:find(mode, Filters) of
+            {ok, Mode} -> maps:get(mode, Info, undefined) =:= Mode;
+            error -> true
+        end,
+    CapOk =
+        case maps:get(has_capacity, Filters, false) of
+            true -> maps:get(player_count, Info, 0) < maps:get(max_players, Info, 0);
+            false -> true
+        end,
+    ListedOk =
+        case maps:find(listed, Filters) of
+            {ok, Want} -> maps:get(listed, Info, false) =:= Want;
+            error -> true
+        end,
+    Status = maps:get(status, Info, undefined),
+    StatusOk = Status =:= waiting orelse Status =:= running,
+    ModeOk andalso CapOk andalso ListedOk andalso StatusOk.

--- a/src/matches/asobi_match_server.erl
+++ b/src/matches/asobi_match_server.erl
@@ -20,6 +20,7 @@ the place to put callback hardening.
 
 -export([start_link/1, join/2, leave/2, handle_input/3, get_info/1, pause/1, resume/1, cancel/1]).
 -export([reconnect/2]).
+-export([listing_info/1]).
 -export([whereis/1]).
 
 -define(PG_SCOPE, nova_scope).
@@ -161,6 +162,7 @@ init(Config) ->
                 tick_rate => maps:get(tick_rate, Config, ?DEFAULT_TICK_RATE),
                 min_players => maps:get(min_players, Config, ?DEFAULT_MIN_PLAYERS),
                 max_players => maps:get(max_players, Config, ?DEFAULT_MAX_PLAYERS),
+                listed => maps:get(listed, Config, false),
                 started_at => undefined,
                 vote_frustration => #{},
                 veto_tokens => #{},
@@ -602,11 +604,30 @@ match_info(Status, #{match_id := MatchId, players := Players} = State) ->
         status => Status,
         player_count => map_size(Players),
         players => maps:keys(Players),
-        mode => maps:get(mode, State, undefined)
+        mode => maps:get(mode, State, undefined),
+        max_players => maps:get(max_players, State, ?DEFAULT_MAX_PLAYERS),
+        listed => maps:get(listed, State, false)
     },
     case maps:get(phase_state, State, undefined) of
         undefined -> Base;
         PS -> Base#{phase => asobi_phase:info(PS)}
+    end.
+
+-doc """
+Projection of `get_info/1` for callers who are not in the match.
+
+Mirrors `asobi_world_server:listing_info/1`. `get_info/1` carries the full
+`players` roster and the server-side `listed` flag; neither reaches a
+browsing client.
+""".
+-spec listing_info(map()) -> map().
+listing_info(Info) ->
+    Base = maps:with([match_id, status, player_count, max_players, mode], Info),
+    case maps:get(phase, Info, undefined) of
+        Phase when is_map(Phase) ->
+            Base#{phase => maps:with([status, phase, remaining_ms, start_condition], Phase)};
+        _ ->
+            Base
     end.
 
 maybe_start_vote(Mod, #{game_state := GS} = State) ->

--- a/src/matches/asobi_matchmaker.erl
+++ b/src/matches/asobi_matchmaker.erl
@@ -308,7 +308,8 @@ spawn_match(Mode, ModeConfig, PlayerIds, Group, Rest, Failed) ->
                 game_module => GameMod,
                 game_config => ExtraConfig,
                 min_players => MatchSize,
-                max_players => MaxPlayers
+                max_players => MaxPlayers,
+                listed => maps:get(listed, ModeConfig, false)
             },
             case asobi_match_sup:start_match(Config) of
                 {ok, MatchPid} when is_pid(MatchPid) ->

--- a/src/world/asobi_world_lobby.erl
+++ b/src/world/asobi_world_lobby.erl
@@ -18,30 +18,10 @@
 list_worlds() ->
     list_worlds(#{}).
 
--doc "List running worlds with optional filters: mode, has_capacity.".
+-doc "List running worlds with optional filters: mode, has_capacity, listed, quick_play.".
 -spec list_worlds(map()) -> [map()].
 list_worlds(Filters) ->
-    Groups = pg:which_groups(?PG_SCOPE),
-    WorldGroups = [
-        {WorldId, Pid}
-     || {asobi_world_server, WorldId} = Group <- Groups,
-        Pid <- take_first(pg:get_members(?PG_SCOPE, Group))
-    ],
-    Worlds = lists:filtermap(
-        fun({_WorldId, Pid}) ->
-            try asobi_world_server:get_info(Pid) of
-                Info when is_map(Info) ->
-                    case matches_filters(Info, Filters) of
-                        true -> {true, asobi_world_server:listing_info(Info)};
-                        false -> false
-                    end
-            catch
-                _:_ -> false
-            end
-        end,
-        WorldGroups
-    ),
-    Worlds.
+    asobi_discovery:enumerate(asobi_world_server, Filters, fun matches_filters/2).
 
 -doc """
 H3 (2026-05-19): cached variant of `list_worlds/1` for request paths that
@@ -68,28 +48,19 @@ list_worlds_cached(Filters) ->
     HasCapacity = maps:get(has_capacity, Filters, false),
     Now = erlang:monotonic_time(millisecond),
     All =
-        case cache_lookup(HasCapacity, Now) of
+        case asobi_discovery:cache_lookup({asobi_world_server, HasCapacity}, Now) of
             {hit, Worlds} ->
                 Worlds;
             miss ->
                 Worlds = list_worlds(#{has_capacity => HasCapacity, listed => true}),
-                asobi_world_lobby_server:cache_worlds(
-                    HasCapacity, Worlds, Now + ?LIST_CACHE_TTL_MS
+                asobi_world_lobby_server:cache_listing(
+                    {asobi_world_server, HasCapacity}, Worlds, Now + ?LIST_CACHE_TTL_MS
                 ),
                 Worlds
         end,
     case maps:get(mode, Filters, undefined) of
         undefined -> All;
         Mode -> [W || W <- All, maps:get(mode, W, undefined) =:= Mode]
-    end.
-
--spec cache_lookup(boolean(), integer()) -> {hit, [map()]} | miss.
-cache_lookup(Key, Now) ->
-    try ets:lookup(?LIST_CACHE_TAB, Key) of
-        [{_, Worlds, ExpiresAt}] when ExpiresAt > Now -> {hit, Worlds};
-        _ -> miss
-    catch
-        error:badarg -> miss
     end.
 
 -doc """
@@ -303,10 +274,6 @@ flag_ok(Flag, Info, Filters) ->
         {ok, Want} -> maps:get(Flag, Info, true) =:= Want;
         error -> true
     end.
-
--spec take_first([pid()]) -> [pid()].
-take_first([Pid | _]) -> [Pid];
-take_first([]) -> [].
 
 -spec wait_for_world_server(pid(), non_neg_integer()) -> pid() | undefined.
 wait_for_world_server(_InstancePid, 0) ->

--- a/src/world/asobi_world_lobby_server.erl
+++ b/src/world/asobi_world_lobby_server.erl
@@ -18,13 +18,13 @@ Calls are sequential, but `create_world/1` is the slowest step and
 takes <100ms in practice; for the small number of distinct modes a
 typical deployment supports, the queue stays empty.
 
-It also owns the protected ETS table backing
-`asobi_world_lobby:list_worlds_cached/1`. Callers read the table
-directly (protected reads); only this server writes, via `cache_worlds/3`.
+It also owns the protected ETS table backing the cached discovery
+listings for both worlds and matches. Callers read the table directly
+(protected reads); only this server writes, via `cache_listing/3`.
 """.
 -behaviour(gen_server).
 
--export([start_link/0, find_or_create/1, find_or_create/2, cache_worlds/3]).
+-export([start_link/0, find_or_create/1, find_or_create/2, cache_listing/3]).
 -export([init/1, handle_call/3, handle_cast/2]).
 
 -define(CALL_TIMEOUT, 30000).
@@ -53,13 +53,20 @@ find_or_create(Mode, PlayerId) ->
     end.
 
 -doc """
-Store a computed world list against a bounded key (`has_capacity`
-boolean) with an absolute expiry. Async: the caller keeps the value it
-already computed; this only seeds the shared cache for the next reader.
+Store a computed listing against a bounded key with an absolute expiry.
+Async: the caller keeps the value it already computed; this only seeds the
+shared cache for the next reader.
+
+The key is `{ServerMod, HasCapacity}` - four keys total across worlds and
+matches. It must stay bounded and free of client-controlled values: keying
+on `mode` would let a client cycle distinct modes to miss on every request
+and grow the table without bound.
 """.
--spec cache_worlds(boolean(), [map()], integer()) -> ok.
-cache_worlds(HasCapacity, Worlds, ExpiresAt) when is_boolean(HasCapacity) ->
-    gen_server:cast(?MODULE, {cache_worlds, HasCapacity, Worlds, ExpiresAt}).
+-spec cache_listing({module(), boolean()}, [map()], integer()) -> ok.
+cache_listing({Mod, HasCapacity} = Key, Listing, ExpiresAt) when
+    is_atom(Mod), is_boolean(HasCapacity)
+->
+    gen_server:cast(?MODULE, {cache_listing, Key, Listing, ExpiresAt}).
 
 %%--------------------------------------------------------------------
 %% gen_server
@@ -93,10 +100,10 @@ handle_call(_Other, _From, State) ->
     {reply, {error, unknown_request}, State}.
 
 -spec handle_cast(term(), map()) -> {noreply, map()}.
-handle_cast({cache_worlds, HasCapacity, Worlds, ExpiresAt}, State) when
-    is_boolean(HasCapacity), is_list(Worlds), is_integer(ExpiresAt)
+handle_cast({cache_listing, Key, Listing, ExpiresAt}, State) when
+    is_tuple(Key), is_list(Listing), is_integer(ExpiresAt)
 ->
-    ets:insert(?LIST_CACHE_TAB, {HasCapacity, Worlds, ExpiresAt}),
+    ets:insert(?LIST_CACHE_TAB, {Key, Listing, ExpiresAt}),
     {noreply, State};
 handle_cast(_Msg, State) ->
     {noreply, State}.

--- a/src/ws/asobi_ws_handler.erl
+++ b/src/ws/asobi_ws_handler.erl
@@ -430,13 +430,27 @@ handle_message(
     Cid = maps:get(~"cid", Msg, undefined),
     %% F-29: validate filter values rather than silently degrading on
     %% bad types.
-    case build_world_filters(Payload) of
+    case build_listing_filters(Payload) of
         {ok, Filters} ->
             %% H3 (2026-05-19): cached variant absorbs the per-world
             %% get_info fan-out so a flood of world.list messages cannot
             %% stall every world's mailbox.
             Worlds = asobi_world_lobby:list_worlds_cached(Filters),
             Reply = encode_reply(Cid, ~"world.list", #{worlds => Worlds}),
+            {reply, {text, Reply}, State};
+        {error, Reason} ->
+            Reply = encode_reply(Cid, ~"error", #{reason => Reason}),
+            {reply, {text, Reply}, State}
+    end;
+handle_message(
+    #{~"type" := ~"match.list", ~"payload" := Payload} = Msg,
+    #{player_id := _PlayerId} = State
+) when is_map(Payload) ->
+    Cid = maps:get(~"cid", Msg, undefined),
+    case build_listing_filters(Payload) of
+        {ok, Filters} ->
+            Matches = asobi_match_lobby:list_matches_cached(Filters),
+            Reply = encode_reply(Cid, ~"match.list", #{matches => Matches}),
             {reply, {text, Reply}, State};
         {error, Reason} ->
             Reply = encode_reply(Cid, ~"error", #{reason => Reason}),
@@ -652,9 +666,9 @@ valid_channel_prefix(<<"prox:", _/binary>>) -> true;
 valid_channel_prefix(<<"room:", _/binary>>) -> true;
 valid_channel_prefix(_) -> false.
 
-%% F-29: world.list filter values must be the right type or we reject the
-%% request rather than silently returning unfiltered results.
-build_world_filters(Payload) ->
+%% F-29: world.list/match.list filter values must be the right type or we
+%% reject the request rather than silently returning unfiltered results.
+build_listing_filters(Payload) ->
     Acc1 =
         case maps:find(~"mode", Payload) of
             error ->

--- a/test/asobi_match_lobby_tests.erl
+++ b/test/asobi_match_lobby_tests.erl
@@ -1,0 +1,107 @@
+-module(asobi_match_lobby_tests).
+-include_lib("eunit/include/eunit.hrl").
+
+-define(GAME, asobi_test_game).
+-define(BASE_CONFIG, #{game_module => ?GAME, min_players => 2, max_players => 4, tick_rate => 50}).
+
+setup() ->
+    case ets:whereis(asobi_match_state) of
+        undefined -> ets:new(asobi_match_state, [named_table, public, set]);
+        _ -> ok
+    end,
+    case whereis(nova_scope) of
+        undefined -> pg:start_link(nova_scope);
+        _ -> ok
+    end,
+    meck:new(asobi_repo, [no_link]),
+    meck:expect(asobi_repo, insert, fun(_CS) -> {ok, #{}} end),
+    meck:expect(asobi_repo, insert, fun(_CS, _Opts) -> {ok, #{}} end),
+    meck:new(asobi_presence, [non_strict, no_link]),
+    meck:expect(asobi_presence, send, fun(_PlayerId, _Msg) -> ok end),
+    ok.
+
+cleanup(_) ->
+    meck:unload(asobi_presence),
+    meck:unload(asobi_repo),
+    ok.
+
+start_match(Overrides) ->
+    {ok, Pid} = asobi_match_server:start_link(maps:merge(?BASE_CONFIG, Overrides)),
+    Pid.
+
+stop_match(Pid) ->
+    unlink(Pid),
+    exit(Pid, kill),
+    wait_gone(Pid, 50).
+
+wait_gone(_Pid, 0) ->
+    ok;
+wait_gone(Pid, N) ->
+    case is_process_alive(Pid) of
+        false ->
+            ok;
+        true ->
+            timer:sleep(10),
+            wait_gone(Pid, N - 1)
+    end.
+
+match_lobby_test_() ->
+    {setup, fun setup/0, fun cleanup/1, [
+        {"matches are unlisted by default", fun unlisted_by_default/0},
+        {"listed => true opts a match into discovery", fun listed_opts_in/0},
+        {"listing drops the roster and the flag", fun listing_drops_roster/0},
+        {"filters by mode", fun filters_by_mode/0},
+        {"has_capacity excludes a full match", fun filters_by_capacity/0}
+    ]}.
+
+unlisted_by_default() ->
+    Pid = start_match(#{mode => ~"unlisted_mode"}),
+    ?assertEqual(
+        [],
+        asobi_match_lobby:list_matches(#{listed => true, mode => ~"unlisted_mode"}),
+        "a matchmaker-spawned match must not appear in a browser by default"
+    ),
+    ?assertEqual(1, length(asobi_match_lobby:list_matches(#{mode => ~"unlisted_mode"}))),
+    stop_match(Pid).
+
+listed_opts_in() ->
+    Pid = start_match(#{mode => ~"listed_mode", listed => true}),
+    [M] = asobi_match_lobby:list_matches(#{listed => true, mode => ~"listed_mode"}),
+    ?assertEqual(~"listed_mode", maps:get(mode, M)),
+    ?assertEqual(waiting, maps:get(status, M)),
+    stop_match(Pid).
+
+listing_drops_roster() ->
+    Pid = start_match(#{mode => ~"roster_mode", listed => true}),
+    ok = asobi_match_server:join(Pid, ~"p1"),
+    [M] = asobi_match_lobby:list_matches(#{listed => true, mode => ~"roster_mode"}),
+    ?assertEqual(
+        lists:sort([match_id, status, player_count, max_players, mode]),
+        lists:sort(maps:keys(M)),
+        "listing key set is a security contract - widen it deliberately"
+    ),
+    ?assertEqual(1, maps:get(player_count, M)),
+    ?assert(maps:is_key(players, asobi_match_server:get_info(Pid))),
+    stop_match(Pid).
+
+filters_by_mode() ->
+    A = start_match(#{mode => ~"mode_a", listed => true}),
+    B = start_match(#{mode => ~"mode_b", listed => true}),
+    [MA] = asobi_match_lobby:list_matches(#{listed => true, mode => ~"mode_a"}),
+    ?assertEqual(~"mode_a", maps:get(mode, MA)),
+    stop_match(A),
+    stop_match(B).
+
+filters_by_capacity() ->
+    Pid = start_match(#{mode => ~"cap_mode", listed => true, min_players => 1, max_players => 1}),
+    ok = asobi_match_server:join(Pid, ~"p1"),
+    ?assertEqual(
+        [],
+        asobi_match_lobby:list_matches(#{
+            listed => true, mode => ~"cap_mode", has_capacity => true
+        })
+    ),
+    ?assertEqual(
+        1, length(asobi_match_lobby:list_matches(#{listed => true, mode => ~"cap_mode"}))
+    ),
+    stop_match(Pid).

--- a/test/asobi_world_lobby_cache_tests.erl
+++ b/test/asobi_world_lobby_cache_tests.erl
@@ -13,6 +13,9 @@
 
 -define(TAB, asobi_world_lobby_cache).
 -define(TTL_MS, 500).
+%% The cache is shared with match discovery, so the key is namespaced by
+%% the server module that produced the listing.
+-define(KEY(HasCapacity), {asobi_world_server, HasCapacity}).
 
 cache_test_() ->
     {foreach, fun setup/0, fun teardown/1, [
@@ -43,7 +46,7 @@ returns_cached_entry_within_ttl() ->
     %% rather than recomputed from pg. Default key is has_capacity=false.
     Fake = #{world_id => ~"cached-world-id", mode => ~"barrow"},
     Now = erlang:monotonic_time(millisecond),
-    ets:insert(?TAB, {false, [Fake], Now + ?TTL_MS}),
+    ets:insert(?TAB, {?KEY(false), [Fake], Now + ?TTL_MS}),
     ?assertEqual([Fake], asobi_world_lobby:list_worlds_cached(#{})).
 
 mode_filtered_in_memory() ->
@@ -52,7 +55,7 @@ mode_filtered_in_memory() ->
     Now = erlang:monotonic_time(millisecond),
     A = #{world_id => ~"a", mode => ~"barrow"},
     B = #{world_id => ~"b", mode => ~"corsairs"},
-    ets:insert(?TAB, {false, [A, B], Now + ?TTL_MS}),
+    ets:insert(?TAB, {?KEY(false), [A, B], Now + ?TTL_MS}),
     ?assertEqual([A], asobi_world_lobby:list_worlds_cached(#{mode => ~"barrow"})),
     ?assertEqual([B], asobi_world_lobby:list_worlds_cached(#{mode => ~"corsairs"})),
     ?assertEqual([], asobi_world_lobby:list_worlds_cached(#{mode => ~"nonexistent"})).
@@ -62,7 +65,7 @@ distinct_modes_do_not_grow_table() ->
     %% served from the single has_capacity=false row, never inserting new keys.
     Now = erlang:monotonic_time(millisecond),
     A = #{world_id => ~"a", mode => ~"barrow"},
-    ets:insert(?TAB, {false, [A], Now + ?TTL_MS}),
+    ets:insert(?TAB, {?KEY(false), [A], Now + ?TTL_MS}),
     lists:foreach(
         fun(N) ->
             Mode = integer_to_binary(N),
@@ -76,8 +79,8 @@ has_capacity_keyed_separately() ->
     Now = erlang:monotonic_time(millisecond),
     All = #{world_id => ~"all", mode => ~"barrow"},
     OpenOnly = #{world_id => ~"open", mode => ~"barrow"},
-    ets:insert(?TAB, {false, [All], Now + ?TTL_MS}),
-    ets:insert(?TAB, {true, [OpenOnly], Now + ?TTL_MS}),
+    ets:insert(?TAB, {?KEY(false), [All], Now + ?TTL_MS}),
+    ets:insert(?TAB, {?KEY(true), [OpenOnly], Now + ?TTL_MS}),
     ?assertEqual([All], asobi_world_lobby:list_worlds_cached(#{})),
     ?assertEqual([OpenOnly], asobi_world_lobby:list_worlds_cached(#{has_capacity => true})).
 
@@ -87,7 +90,7 @@ ignores_expired_entry() ->
     %% as a miss by inspecting the row's expiry against "now".
     Fake = #{world_id => ~"stale", mode => ~"barrow"},
     Past = erlang:monotonic_time(millisecond) - 1,
-    ets:insert(?TAB, {false, [Fake], Past}),
-    [{_K, _W, Expires}] = ets:lookup(?TAB, false),
+    ets:insert(?TAB, {?KEY(false), [Fake], Past}),
+    [{_K, _W, Expires}] = ets:lookup(?TAB, ?KEY(false)),
     Now = erlang:monotonic_time(millisecond),
     ?assert(Expires =< Now).


### PR DESCRIPTION
Items 3 and 4 of the lobby sequence, together — item 3 alone is an abstraction with one consumer.

This is the change that answers the original question. A player could authenticate and then either blind-queue or nothing; matches had no discovery at all. `GET /api/v1/matches` reads the `asobi_match_record` table (finished matches, an audit trail, nothing joinable) and `match.join` required an id the client had no supported way to obtain.

## Item 3: shared enumeration

`asobi_discovery:enumerate/3`. Worlds and matches already register as `{ServerMod, Id}` in `nova_scope` and both expose `get_info/1` plus `listing_info/1`, so the module name doubles as the group tag and browsing either is one walk: enumerate live processes, filter on full info, return the listing projection.

`asobi_world_lobby:list_worlds/1` becomes a call into it. Behaviour-preserving — the world suite passes 20/20 unchanged.

Pull, not push, per the earlier architecture review: worlds churn on *attributes* (occupancy) while the set stays near-static, so a delta stream would fan out at a rate set by other players' behaviour with no ceiling, where the 500ms cache is a hard two-refreshes-per-second ceiling.

## Item 4: match discovery

`asobi_match_lobby`, `GET /api/v1/matches/live`, WS `match.list`. Filters: `mode`, `has_capacity`.

**Matches are unlisted by default.** A matchmaker-spawned match is already assigned to its players and has no reason to appear in a browser, so a mode opts in with `listed => true`. Inverse of worlds, which default to listed because their browser already shipped. This also matches the field: PlayFab requires the owner to set search properties before a lobby is findable, i.e. discovery is opt-in.

The listing cache is now shared and keyed `{ServerMod, HasCapacity}`. Matches need it as much as worlds: enumeration costs one `gen_statem:call` per live match *even when every match is unlisted and the result is empty*.

## Deviation from the plan

The sequence called for "plus the missing REST join". I did not add one. Joining binds the match to the WS session so subsequent `match.input` is routed; a REST join could not do that and would be a footgun. Worlds have no REST join either (`POST /api/v1/worlds` creates, joining is `world.join`), so matches lacking one is consistent rather than a gap.

## Notes

`/matches/live` is registered before `/matches/:id` so the literal wins.

`match_info/2` gained `max_players` (needed for capacity filtering) and `listed`. Both are dropped by `listing_info/1`; `max_players` is additive on `match.joined`.

## Verification

`fmt --check`, `xref`, `dialyzer`, `ex_doc` clean. `eunit` 335/0 including 5 new match-lobby cases. `ct --suite asobi_world_lobby_SUITE` 20/20. `elp eqwalize-all` 36 errors, identical to `main`.

Two existing tests needed updating and both were right to fail: `asobi_protocol_coverage_tests` caught that `match.list` had no protocol fixture (added), and `asobi_world_lobby_cache_tests` pinned the old bare-boolean cache key.

Docker unavailable locally so DB-backed CT suites did not run; CI covers them.