### PR TITLE
feat: add optional join context to the game join callback

### DIFF
--- a/guides/websocket-protocol.md
+++ b/guides/websocket-protocol.md
@@ -89,6 +89,33 @@ Joining is WebSocket-only by design: the join binds the match to your
 session so subsequent `match.input` is routed. There is no REST join, the
 same as for worlds.
 
+#### Join context
+
+Both `match.join` and `world.join` accept an optional `ctx`, passed through
+to your game module untouched:
+
+```json
+{"type": "match.join", "payload": {"match_id": "...", "ctx": {"code": "AB12"}}}
+```
+
+Asobi never interprets, echoes, or logs it. It reaches your game's
+`join/3` callback, which decides whether to accept. Games that implement
+only `join/2` are unaffected and a supplied `ctx` is ignored.
+
+This is how you build join codes, invites, passwords and party checks:
+without it there is no channel from a client to your game before
+membership exists, so `join/2` can implement an allowlist but never a code.
+
+Bounded at the server: a flat object, at most 8 keys, keys up to 64 bytes,
+string values up to 256 bytes, plus integers and booleans. No nesting.
+Violations are rejected with `invalid_join_ctx`, `join_ctx_too_many_keys`,
+`join_ctx_key_too_long`, `join_ctx_value_too_long`, or
+`invalid_join_ctx_value`.
+
+**A join context does not make a world private.** Only a game that
+implements `join/3` and rejects unauthorised joins restricts entry; a game
+that ignores it stays open to anyone holding a `world_id`.
+
 ### `match.input`
 
 Send game input to the match server.

--- a/src/asobi_game_join.erl
+++ b/src/asobi_game_join.erl
@@ -1,0 +1,25 @@
+-module(asobi_game_join).
+-moduledoc """
+Dispatch to a game module's join callback, preferring the context-carrying
+`join/3` when the module exports it.
+
+Shared by `asobi_match_server` and `asobi_world_server` so the two cannot
+drift on which arity wins.
+""".
+
+-export([invoke/4]).
+
+-doc """
+Call `Mod:join/3` if exported, otherwise `Mod:join/2`.
+
+The export check runs per join rather than being cached at init: a module
+can gain or lose `join/3` across a hot code upgrade, and a cached decision
+would keep calling the arity that no longer exists.
+""".
+-spec invoke(module(), binary(), map(), term()) ->
+    {ok, term()} | {error, term()}.
+invoke(Mod, PlayerId, Ctx, GameState) when is_map(Ctx) ->
+    case erlang:function_exported(Mod, join, 3) of
+        true -> Mod:join(PlayerId, Ctx, GameState);
+        false -> Mod:join(PlayerId, GameState)
+    end.

--- a/src/asobi_join_ctx.erl
+++ b/src/asobi_join_ctx.erl
@@ -1,0 +1,62 @@
+-module(asobi_join_ctx).
+-moduledoc """
+Bounds on the client-supplied join context.
+
+The context is opaque to asobi - only the game module interprets it - but
+it is still attacker-controlled input handed to game code, so its shape is
+constrained here: a flat map, binary keys, scalar values, no nesting.
+
+asobi never interprets, echoes, or logs the context. See
+`c:asobi_match:join/3`.
+""".
+
+-export([parse/1]).
+
+-define(MAX_KEYS, 8).
+-define(MAX_KEY_BYTES, 64).
+-define(MAX_VALUE_BYTES, 256).
+
+-doc """
+Extract and validate `ctx` from a request payload.
+
+Absent context is `{ok, #{}}` rather than an error: most joins carry none,
+and a game that requires one rejects the empty map itself.
+
+Takes `term()`, not `map()`: the caller passes a decoded JSON payload, and
+a client is free to send `"payload": "a string"`, so a non-map reaching
+here is untrusted input rather than a caller bug.
+""".
+-spec parse(term()) -> {ok, map()} | {error, binary()}.
+parse(Payload) when is_map(Payload) ->
+    case maps:get(~"ctx", Payload, undefined) of
+        undefined ->
+            {ok, #{}};
+        Ctx when is_map(Ctx), map_size(Ctx) =< ?MAX_KEYS ->
+            validate(maps:to_list(Ctx), #{});
+        Ctx when is_map(Ctx) ->
+            {error, ~"join_ctx_too_many_keys"};
+        _ ->
+            {error, ~"invalid_join_ctx"}
+    end;
+parse(_) ->
+    {ok, #{}}.
+
+-spec validate([{term(), term()}], map()) -> {ok, map()} | {error, binary()}.
+validate([], Acc) ->
+    {ok, Acc};
+validate([{K, V} | Rest], Acc) when is_binary(K), byte_size(K) =< ?MAX_KEY_BYTES ->
+    case validate_value(V) of
+        ok -> validate(Rest, Acc#{K => V});
+        {error, _} = Err -> Err
+    end;
+validate([{K, _} | _], _) when is_binary(K) ->
+    {error, ~"join_ctx_key_too_long"};
+validate(_, _) ->
+    {error, ~"invalid_join_ctx_key"}.
+
+-spec validate_value(term()) -> ok | {error, binary()}.
+validate_value(V) when is_binary(V), byte_size(V) =< ?MAX_VALUE_BYTES -> ok;
+validate_value(V) when is_binary(V) -> {error, ~"join_ctx_value_too_long"};
+validate_value(V) when is_boolean(V) -> ok;
+validate_value(V) when is_integer(V) -> ok;
+validate_value(_) -> {error, ~"invalid_join_ctx_value"}.

--- a/src/matches/asobi_match.erl
+++ b/src/matches/asobi_match.erl
@@ -47,6 +47,24 @@ in progress).
 -callback join(PlayerId :: binary(), GameState :: term()) ->
     {ok, GameState1 :: term()} | {error, Reason :: term()}.
 
+-doc """
+Optional. Same as `join/2`, but also receives the join context the client
+supplied — a flat map of binaries, bounded by the server, that asobi does
+not interpret.
+
+Implement this to gate entry on something the client presents: a join
+code, an invite token, a party id, a password. Without it there is no
+channel from a client to your game before membership exists, so `join/2`
+can implement an allowlist but never a code.
+
+Export `join/3` and it is used instead of `join/2`. asobi never reads the
+context; validate it against your own `GameState` and return
+`{error, Reason}` to refuse. The context is `#{}` when there is no client
+— matchmaker-spawned matches join players with no request behind them.
+""".
+-callback join(PlayerId :: binary(), Ctx :: map(), GameState :: term()) ->
+    {ok, GameState1 :: term()} | {error, Reason :: term()}.
+
 -doc "A player disconnected or was removed. Cannot fail. Use it to release reservations, stop timers, or forfeit.".
 -callback leave(PlayerId :: binary(), GameState :: term()) ->
     {ok, GameState1 :: term()}.
@@ -103,6 +121,7 @@ when every player sees the same world. Mutually exclusive with
     {ok, GameState1 :: term()}.
 
 -optional_callbacks([
+    join/3,
     tick/1,
     get_state/1,
     get_state/2,

--- a/src/matches/asobi_match_server.erl
+++ b/src/matches/asobi_match_server.erl
@@ -18,7 +18,9 @@ the place to put callback hardening.
 """.
 -behaviour(gen_statem).
 
--export([start_link/1, join/2, leave/2, handle_input/3, get_info/1, pause/1, resume/1, cancel/1]).
+-export([
+    start_link/1, join/2, join/3, leave/2, handle_input/3, get_info/1, pause/1, resume/1, cancel/1
+]).
 -export([reconnect/2]).
 -export([listing_info/1]).
 -export([whereis/1]).
@@ -43,7 +45,15 @@ start_link(Config) ->
 
 -spec join(pid(), binary()) -> ok | {error, term()}.
 join(Pid, PlayerId) ->
-    case gen_statem:call(Pid, {join, PlayerId}) of
+    join(Pid, PlayerId, #{}).
+
+-doc """
+Join carrying an opaque join context from the client. asobi does not
+interpret it; it reaches the game module's `join/3` if it exports one.
+""".
+-spec join(pid(), binary(), map()) -> ok | {error, term()}.
+join(Pid, PlayerId, Ctx) when is_map(Ctx) ->
+    case gen_statem:call(Pid, {join, PlayerId, Ctx}) of
         ok -> ok;
         {error, _} = Err -> Err
     end.
@@ -180,8 +190,8 @@ init(Config) ->
     gen_statem:state_enter_result(atom()).
 waiting(enter, _OldState, _State) ->
     {keep_state_and_data, [{state_timeout, ?WAITING_TIMEOUT, waiting_timeout}]};
-waiting({call, From}, {join, PlayerId}, State) ->
-    handle_join(From, PlayerId, State);
+waiting({call, From}, {join, PlayerId, Ctx}, State) ->
+    handle_join(From, PlayerId, Ctx, State);
 waiting({call, From}, get_info, State) ->
     {keep_state_and_data, [{reply, From, match_info(waiting, State)}]};
 waiting(state_timeout, waiting_timeout, State) ->
@@ -274,8 +284,8 @@ running({call, From}, resume, _State) ->
     {keep_state_and_data, [{reply, From, {error, not_paused}}]};
 running({call, From}, get_info, State) ->
     {keep_state_and_data, [{reply, From, match_info(running, State)}]};
-running({call, From}, {join, PlayerId}, State) ->
-    handle_join(From, PlayerId, State);
+running({call, From}, {join, PlayerId, Ctx}, State) ->
+    handle_join(From, PlayerId, Ctx, State);
 running(
     {call, From},
     {start_vote, VoteConfig0},
@@ -450,13 +460,14 @@ terminate(_Reason, StateName, #{match_id := MatchId} = State) ->
 handle_join(
     From,
     PlayerId,
+    Ctx,
     #{players := Players, max_players := Max, game_module := Mod, game_state := GS} = State
 ) ->
     case map_size(Players) >= Max of
         true ->
             {keep_state_and_data, [{reply, From, {error, match_full}}]};
         false ->
-            case Mod:join(PlayerId, GS) of
+            case asobi_game_join:invoke(Mod, PlayerId, Ctx, GS) of
                 {ok, GS1} ->
                     %% Monitor the player session so we can run reconnect grace
                     %% (or immediate cleanup) when the WS process dies. Mirrors

--- a/src/world/asobi_world.erl
+++ b/src/world/asobi_world.erl
@@ -17,6 +17,24 @@ are optional hooks (see `-optional_callbacks`).
 -callback join(PlayerId :: binary(), GameState :: term()) ->
     {ok, GameState1 :: term()} | {error, Reason :: term()}.
 
+-doc """
+Optional. Same as `join/2`, but also receives the join context the client
+supplied — a flat map of binaries, bounded by the server, that asobi does
+not interpret.
+
+Implement this to gate entry on something the client presents: a join
+code, an invite token, a party id, a password. Without it there is no
+channel from a client to your game before membership exists, so `join/2`
+can implement an allowlist but never a code.
+
+Export `join/3` and it is used instead of `join/2`. asobi never reads the
+context; validate it against your own `GameState` and return
+`{error, Reason}` to refuse. The context is `#{}` when there is no client
+behind the join.
+""".
+-callback join(PlayerId :: binary(), Ctx :: map(), GameState :: term()) ->
+    {ok, GameState1 :: term()} | {error, Reason :: term()}.
+
 -doc "A player leaves the world.".
 -callback leave(PlayerId :: binary(), GameState :: term()) ->
     {ok, GameState1 :: term()}.
@@ -94,6 +112,7 @@ plain terms. The inverse of `init_zone_state`'s restore path.
 -callback dump_zone_state(ZoneState :: map()) -> map().
 
 -optional_callbacks([
+    join/3,
     generate_world/2,
     get_state/2,
     phases/1,

--- a/src/world/asobi_world_server.erl
+++ b/src/world/asobi_world_server.erl
@@ -8,7 +8,9 @@ transient matches use `asobi_match_server` instead.
 """.
 -behaviour(gen_statem).
 
--export([start_link/1, join/2, join/3, leave/2, move_player/3, post_tick/2, get_info/1, cancel/1]).
+-export([
+    start_link/1, join/2, join/3, join/4, leave/2, move_player/3, post_tick/2, get_info/1, cancel/1
+]).
 -export([listing_info/1]).
 -export_type([listing/0]).
 -export([spawn_at/3, spawn_at/4]).
@@ -33,7 +35,7 @@ start_link(Config) ->
 
 -spec join(pid(), binary()) -> ok | {error, term()}.
 join(Pid, PlayerId) ->
-    case gen_statem:call(Pid, {join, PlayerId}) of
+    case gen_statem:call(Pid, {join, PlayerId, #{}}) of
         {ok, _ZonePid} -> ok;
         {error, _} = Err -> Err
     end.
@@ -44,7 +46,15 @@ join(Pid, PlayerId) ->
 %% {world_joined,...} notification is still in flight.
 -spec join(pid(), binary(), pid()) -> ok | {error, term()}.
 join(Pid, PlayerId, SessionPid) when is_pid(SessionPid) ->
-    case gen_statem:call(Pid, {join, PlayerId}) of
+    join(Pid, PlayerId, SessionPid, #{}).
+
+-doc """
+As `join/3`, plus an opaque join context from the client. asobi does not
+interpret it; it reaches the game module's `join/3` if it exports one.
+""".
+-spec join(pid(), binary(), pid(), map()) -> ok | {error, term()}.
+join(Pid, PlayerId, SessionPid, Ctx) when is_pid(SessionPid), is_map(Ctx) ->
+    case gen_statem:call(Pid, {join, PlayerId, Ctx}) of
         {ok, ZonePid} when is_pid(ZonePid) ->
             ok = asobi_player_session:set_zone(SessionPid, Pid, ZonePid),
             ok;
@@ -236,8 +246,8 @@ running(
     asobi_world_ticker:set_zone_manager(TickerPid, ZoneManagerPid, self()),
     asobi_telemetry:world_started(WorldId, maps:get(mode, State, undefined)),
     keep_state_and_data;
-running({call, From}, {join, PlayerId}, State) ->
-    handle_join(From, PlayerId, State);
+running({call, From}, {join, PlayerId, Ctx}, State) ->
+    handle_join(From, PlayerId, Ctx, State);
 running(cast, {leave, PlayerId}, State) ->
     handle_leave(PlayerId, State);
 running(cast, {move_player, PlayerId, NewPos}, State) ->
@@ -548,6 +558,7 @@ get_spawn_templates(GameMod, Config) ->
 handle_join(
     From,
     PlayerId,
+    Ctx,
     #{
         world_id := WorldId,
         players := Players,
@@ -560,7 +571,7 @@ handle_join(
         true ->
             {keep_state_and_data, [{reply, From, {error, world_full}}]};
         false ->
-            case Mod:join(PlayerId, GS) of
+            case asobi_game_join:invoke(Mod, PlayerId, Ctx, GS) of
                 {ok, GS1} ->
                     {ok, SpawnPos} = Mod:spawn_position(PlayerId, GS1),
                     State1 = State#{game_state => GS1},

--- a/src/ws/asobi_ws_handler.erl
+++ b/src/ws/asobi_ws_handler.erl
@@ -346,14 +346,20 @@ handle_message(
             Reply = encode_reply(Cid, ~"error", #{reason => ~"match_not_found"}),
             {reply, {text, Reply}, State};
         {ok, MatchPid} ->
-            case asobi_match_server:join(MatchPid, PlayerId) of
-                ok ->
-                    Info = asobi_match_server:get_info(MatchPid),
-                    Reply = encode_reply(Cid, ~"match.joined", Info),
+            case asobi_join_ctx:parse(maps:get(~"payload", Msg, #{})) of
+                {error, CtxErr} ->
+                    Reply = encode_reply(Cid, ~"error", #{reason => CtxErr}),
                     {reply, {text, Reply}, State};
-                {error, Reason} ->
-                    Reply = encode_reply(Cid, ~"error", #{reason => Reason}),
-                    {reply, {text, Reply}, State}
+                {ok, Ctx} ->
+                    case asobi_match_server:join(MatchPid, PlayerId, Ctx) of
+                        ok ->
+                            Info = asobi_match_server:get_info(MatchPid),
+                            Reply = encode_reply(Cid, ~"match.joined", Info),
+                            {reply, {text, Reply}, State};
+                        {error, Reason} ->
+                            Reply = encode_reply(Cid, ~"error", #{reason => Reason}),
+                            {reply, {text, Reply}, State}
+                    end
             end
     end;
 handle_message(
@@ -490,7 +496,13 @@ handle_message(
             Reply = encode_reply(Cid, ~"error", #{reason => ~"world_not_found"}),
             {reply, {text, Reply}, State};
         {ok, WorldPid} ->
-            join_and_reply(Cid, WorldPid, PlayerId, State)
+            case asobi_join_ctx:parse(maps:get(~"payload", Msg, #{})) of
+                {error, CtxErr} ->
+                    Reply = encode_reply(Cid, ~"error", #{reason => CtxErr}),
+                    {reply, {text, Reply}, State};
+                {ok, Ctx} ->
+                    join_and_reply(Cid, WorldPid, PlayerId, Ctx, State)
+            end
     end;
 handle_message(
     #{~"type" := ~"world.leave"} = Msg,
@@ -569,7 +581,10 @@ reply_error(Msg, Reason, State) ->
     Reply = encode_reply(Cid, ~"error", #{reason => Reason}),
     {reply, {text, Reply}, State}.
 
-join_and_reply(Cid, WorldPid, PlayerId, #{session := SessionPid} = State) when
+join_and_reply(Cid, WorldPid, PlayerId, State) ->
+    join_and_reply(Cid, WorldPid, PlayerId, #{}, State).
+
+join_and_reply(Cid, WorldPid, PlayerId, Ctx, #{session := SessionPid} = State) when
     SessionPid =/= undefined
 ->
     case current_player_world(PlayerId) of
@@ -582,7 +597,7 @@ join_and_reply(Cid, WorldPid, PlayerId, #{session := SessionPid} = State) when
             %% join/3 (vs join/2) sets zone_pid synchronously in the player_session
             %% before returning, so a world.input arriving right after world.joined
             %% lands on the right zone instead of being silently dropped.
-            case asobi_world_server:join(WorldPid, PlayerId, SessionPid) of
+            case asobi_world_server:join(WorldPid, PlayerId, SessionPid, Ctx) of
                 ok ->
                     Info = asobi_world_server:get_info(WorldPid),
                     Reply = encode_reply(Cid, ~"world.joined", Info),

--- a/test/asobi_game_join_tests.erl
+++ b/test/asobi_game_join_tests.erl
@@ -1,0 +1,63 @@
+-module(asobi_game_join_tests).
+-include_lib("eunit/include/eunit.hrl").
+
+%% Two fake game modules: one exporting only join/2, one exporting both.
+%% They are defined at the bottom via meck so the dispatch is exercised
+%% against real export tables rather than a stub of function_exported/3.
+
+setup() ->
+    meck:new(join2_only, [non_strict, no_link]),
+    meck:expect(join2_only, join, fun(PlayerId, GS) -> {ok, GS#{joined => PlayerId}} end),
+    meck:new(join3_game, [non_strict, no_link]),
+    meck:expect(join3_game, join, fun(PlayerId, GS) ->
+        {ok, GS#{via => join2, joined => PlayerId}}
+    end),
+    meck:expect(join3_game, join, fun(PlayerId, Ctx, GS) ->
+        case maps:get(~"code", Ctx, undefined) of
+            ~"open-sesame" -> {ok, GS#{via => join3, joined => PlayerId}};
+            _ -> {error, bad_code}
+        end
+    end),
+    ok.
+
+cleanup(_) ->
+    meck:unload(join3_game),
+    meck:unload(join2_only),
+    ok.
+
+join_dispatch_test_() ->
+    {setup, fun setup/0, fun cleanup/1, [
+        {"falls back to join/2 when join/3 is not exported", fun falls_back_to_join2/0},
+        {"prefers join/3 when exported", fun prefers_join3/0},
+        {"join/3 can reject on the context", fun join3_can_reject/0},
+        {"a join/2-only module ignores a supplied context", fun join2_ignores_ctx/0}
+    ]}.
+
+falls_back_to_join2() ->
+    ?assertEqual(
+        {ok, #{joined => ~"p1"}},
+        asobi_game_join:invoke(join2_only, ~"p1", #{}, #{})
+    ).
+
+prefers_join3() ->
+    ?assertEqual(
+        {ok, #{via => join3, joined => ~"p1"}},
+        asobi_game_join:invoke(join3_game, ~"p1", #{~"code" => ~"open-sesame"}, #{})
+    ).
+
+join3_can_reject() ->
+    ?assertEqual(
+        {error, bad_code},
+        asobi_game_join:invoke(join3_game, ~"p1", #{~"code" => ~"wrong"}, #{})
+    ),
+    %% An empty context (matchmaker-spawned join, no client) is rejected by
+    %% THIS game, which is the game's choice - core must not special-case it.
+    ?assertEqual({error, bad_code}, asobi_game_join:invoke(join3_game, ~"p1", #{}, #{})).
+
+join2_ignores_ctx() ->
+    %% A game that has not opted in must be unaffected by a context the
+    %% client supplies - no crash, no behaviour change.
+    ?assertEqual(
+        {ok, #{joined => ~"p1"}},
+        asobi_game_join:invoke(join2_only, ~"p1", #{~"code" => ~"whatever"}, #{})
+    ).

--- a/test/asobi_join_ctx_tests.erl
+++ b/test/asobi_join_ctx_tests.erl
@@ -1,0 +1,59 @@
+-module(asobi_join_ctx_tests).
+-include_lib("eunit/include/eunit.hrl").
+
+absent_ctx_is_empty_test() ->
+    ?assertEqual({ok, #{}}, asobi_join_ctx:parse(#{})),
+    ?assertEqual({ok, #{}}, asobi_join_ctx:parse(#{~"world_id" => ~"w1"})).
+
+not_a_map_payload_is_empty_test() ->
+    ?assertEqual({ok, #{}}, asobi_join_ctx:parse(not_a_map)).
+
+accepts_flat_scalars_test() ->
+    Ctx = #{~"code" => ~"ABCD", ~"party" => 7, ~"spectator" => true},
+    ?assertEqual({ok, Ctx}, asobi_join_ctx:parse(#{~"ctx" => Ctx})).
+
+rejects_non_map_ctx_test() ->
+    ?assertEqual({error, ~"invalid_join_ctx"}, asobi_join_ctx:parse(#{~"ctx" => ~"nope"})),
+    ?assertEqual({error, ~"invalid_join_ctx"}, asobi_join_ctx:parse(#{~"ctx" => [1, 2]})).
+
+rejects_nesting_test() ->
+    %% Nesting is the shape that would let a client hand game code an
+    %% unbounded term through an "opaque" field.
+    ?assertEqual(
+        {error, ~"invalid_join_ctx_value"},
+        asobi_join_ctx:parse(#{~"ctx" => #{~"a" => #{~"b" => ~"c"}}})
+    ),
+    ?assertEqual(
+        {error, ~"invalid_join_ctx_value"},
+        asobi_join_ctx:parse(#{~"ctx" => #{~"a" => [~"b"]}})
+    ).
+
+rejects_too_many_keys_test() ->
+    Big = maps:from_list([{integer_to_binary(N), ~"v"} || N <- lists:seq(1, 9)]),
+    ?assertEqual({error, ~"join_ctx_too_many_keys"}, asobi_join_ctx:parse(#{~"ctx" => Big})),
+    Ok = maps:from_list([{integer_to_binary(N), ~"v"} || N <- lists:seq(1, 8)]),
+    ?assertMatch({ok, _}, asobi_join_ctx:parse(#{~"ctx" => Ok})).
+
+rejects_oversized_key_test() ->
+    Key = binary:copy(~"k", 65),
+    ?assertEqual(
+        {error, ~"join_ctx_key_too_long"},
+        asobi_join_ctx:parse(#{~"ctx" => #{Key => ~"v"}})
+    ),
+    ?assertMatch({ok, _}, asobi_join_ctx:parse(#{~"ctx" => #{binary:copy(~"k", 64) => ~"v"}})).
+
+rejects_oversized_value_test() ->
+    Val = binary:copy(~"v", 257),
+    ?assertEqual(
+        {error, ~"join_ctx_value_too_long"},
+        asobi_join_ctx:parse(#{~"ctx" => #{~"k" => Val}})
+    ),
+    ?assertMatch(
+        {ok, _}, asobi_join_ctx:parse(#{~"ctx" => #{~"k" => binary:copy(~"v", 256)}})
+    ).
+
+rejects_non_binary_key_test() ->
+    ?assertEqual(
+        {error, ~"invalid_join_ctx_key"},
+        asobi_join_ctx:parse(#{~"ctx" => #{atom_key => ~"v"}})
+    ).


### PR DESCRIPTION
Item 5 of the lobby sequence, to the shape the architecture review landed on.

## The gap

There is no channel from a client to a game module before membership exists. `join/2` receives only a player id, so a game can implement an allowlist but never a code, invite, password, or party check. That is irreducible without a new argument.

## Shape

Optional `join/3` on both `asobi_match` and `asobi_world`:

```erlang
join(PlayerId, Ctx, GameState) -> {ok, GameState1} | {error, Reason}.
```

Context sits between the player id and the state, mirroring `handle_input/3`. asobi never interprets, echoes or logs it. Games exporting only `join/2` are unaffected, and a `ctx` they didn't ask for is ignored.

Rejected during review: a separate `authorize_join/3`. `join/2` is already the authorization seam — it already returns `{error, Reason}` — so splitting would double the Lua surface for nothing.

`asobi_game_join:invoke/4` owns dispatch so the two servers can't drift on which arity wins. The export check is **per join, not cached at init**: a module can gain or lose `join/3` across a hot code upgrade, and a cached decision would keep calling an arity that no longer exists.

## Bounds

`asobi_join_ctx:parse/1`: flat map, ≤8 keys, ≤64-byte keys, ≤256-byte string values, plus integers and booleans. No nesting — nesting is the shape that would let a client hand game code an unbounded term through an "opaque" field.

It takes `term()`, not `map()`. The WS handler passes `maps:get(~"payload", Msg, #{})` and a client can send `"payload": "a string"`, so a non-map arriving here is untrusted input rather than a caller bug. eqwalizer caught this via the test.

## Deliberately not claimed

**This does not close #193.** A world is restricted only when its game implements `join/3` and rejects; a game that ignores the callback stays open to anyone holding a `world_id`. Opt-in is still the right call — a core-level gate would collapse the visibility/authorization split that every backend surveyed keeps separate — but the hole stays open until a game opts in, and the guide says so.

(#193 was auto-closed earlier by a merge body reading "Does not close #193" — GitHub matched `close #193` and ignored the negation. Reopened.)

## Notes

Server API arities are asymmetric: world `join/4`, match `join/3`. `asobi_world_server:join/3` already exists and means join-with-session.

Matchmaker-spawned joins pass `#{}` — there is no client behind them. A game requiring a context will reject those, which is the game's choice, not something core special-cases.

## Verification

`fmt --check`, `xref`, `dialyzer`, `ex_doc` clean. `eunit` 348/0 (13 new: 4 dispatch/fallback, 9 bounds). `ct --suite asobi_world_lobby_SUITE` 20/20. `elp eqwalize-all` 36, identical to `main`.

Docker unavailable locally so DB-backed CT suites did not run; CI covers them.