### PR TITLE
fix: bound world and match joins per player

### DIFF
--- a/guides/configuration.md
+++ b/guides/configuration.md
@@ -297,6 +297,27 @@ Bounds on persistent world creation, enforced as a DoS backstop:
 {world_max, 1000}            %% default 1000
 ```
 
+## Join rate
+
+Joins are bounded per player, not per IP:
+
+```erlang
+{rate_limits, #{
+    join => #{algorithm => sliding_window, limit => 10, window => 60000}
+}}
+```
+
+Joining is how a client reaches a world's roster and leaving is free, so an
+unbounded join rate lets one account enumerate every live world by joining,
+reading `world.joined`, and leaving. The default (10 per minute) is generous
+for real play and turns a sweep of a full deployment from seconds into hours
+per identity. Exceeding it returns `join_rate_limited` and emits
+`[asobi, join, rate_limited]`.
+
+This bounds the cost of a sweep; it does not make worlds private. For that,
+implement `join/3` in your game module and reject unauthorised joins - see
+[WebSocket Protocol](websocket-protocol.md).
+
 A player at the per-player cap gets `429`; once the global cap is reached
 further creates get `503`.
 

--- a/src/asobi_sup.erl
+++ b/src/asobi_sup.erl
@@ -140,6 +140,14 @@ register_limiters() ->
         iap => #{algorithm => sliding_window, limit => 10, window => 1000},
         api => #{algorithm => sliding_window, limit => 300, window => 1000},
         ws_connect => #{algorithm => sliding_window, limit => 60, window => 1000},
+        %% Per-player bound on world/match joins (asobi#193). Joining is how a
+        %% client reaches a roster, and leaving is free, so an unbounded join
+        %% rate lets one account sweep every live world by joining, reading
+        %% `world.joined`, and leaving. Keyed on player_id, not IP: the cost we
+        %% are bounding is per-identity, and identities are what an attacker
+        %% would rotate. Generous for real play - a player browsing worlds joins
+        %% a handful of times a minute, not ten times a second.
+        join => #{algorithm => sliding_window, limit => 10, window => 60000},
         %% Global (not per-IP) bound on guest-create throughput. Guest rows are
         %% minted unauthenticated and cheaply, so a per-IP limit alone lets a
         %% botnet spam rows; this caps the total rate. Keyed on a constant.
@@ -170,6 +178,7 @@ limiter_name(register) -> asobi_register_limiter;
 limiter_name(iap) -> asobi_iap_limiter;
 limiter_name(api) -> asobi_api_limiter;
 limiter_name(ws_connect) -> asobi_ws_connect_limiter;
+limiter_name(join) -> asobi_join_limiter;
 limiter_name(guest_global) -> asobi_guest_global_limiter.
 
 cluster_spec() ->

--- a/src/asobi_telemetry.erl
+++ b/src/asobi_telemetry.erl
@@ -12,6 +12,7 @@
     ws_message_in/1,
     ws_message_out/1,
     ws_connect_rate_limited/1,
+    join_rate_limited/1,
     ws_idle_auth_timeout/0
 ]).
 -export([anticheat_violation/3]).
@@ -165,6 +166,13 @@ ws_connected() ->
 -spec ws_disconnected() -> ok.
 ws_disconnected() ->
     telemetry:execute([asobi, ws, disconnected], #{count => 1}, #{}).
+
+-doc "asobi#193: a player hit the per-identity join rate cap.".
+-spec join_rate_limited(binary()) -> ok.
+join_rate_limited(PlayerId) ->
+    telemetry:execute(
+        [asobi, join, rate_limited], #{count => 1}, #{player_id => PlayerId}
+    ).
 
 -spec ws_connect_rate_limited(binary()) -> ok.
 ws_connect_rate_limited(PeerIp) ->

--- a/src/ws/asobi_ws_handler.erl
+++ b/src/ws/asobi_ws_handler.erl
@@ -346,19 +346,17 @@ handle_message(
             Reply = encode_reply(Cid, ~"error", #{reason => ~"match_not_found"}),
             {reply, {text, Reply}, State};
         {ok, MatchPid} ->
-            case asobi_join_ctx:parse(maps:get(~"payload", Msg, #{})) of
-                {error, CtxErr} ->
-                    Reply = encode_reply(Cid, ~"error", #{reason => CtxErr}),
+            case check_join_rate(PlayerId) of
+                denied ->
+                    Reply = encode_reply(Cid, ~"error", #{reason => ~"join_rate_limited"}),
                     {reply, {text, Reply}, State};
-                {ok, Ctx} ->
-                    case asobi_match_server:join(MatchPid, PlayerId, Ctx) of
-                        ok ->
-                            Info = asobi_match_server:get_info(MatchPid),
-                            Reply = encode_reply(Cid, ~"match.joined", Info),
+                allowed ->
+                    case asobi_join_ctx:parse(maps:get(~"payload", Msg, #{})) of
+                        {error, CtxErr} ->
+                            Reply = encode_reply(Cid, ~"error", #{reason => CtxErr}),
                             {reply, {text, Reply}, State};
-                        {error, Reason} ->
-                            Reply = encode_reply(Cid, ~"error", #{reason => Reason}),
-                            {reply, {text, Reply}, State}
+                        {ok, Ctx} ->
+                            join_match_and_reply(Cid, MatchPid, PlayerId, Ctx, State)
                     end
             end
     end;
@@ -496,12 +494,18 @@ handle_message(
             Reply = encode_reply(Cid, ~"error", #{reason => ~"world_not_found"}),
             {reply, {text, Reply}, State};
         {ok, WorldPid} ->
-            case asobi_join_ctx:parse(maps:get(~"payload", Msg, #{})) of
-                {error, CtxErr} ->
-                    Reply = encode_reply(Cid, ~"error", #{reason => CtxErr}),
+            case check_join_rate(PlayerId) of
+                denied ->
+                    Reply = encode_reply(Cid, ~"error", #{reason => ~"join_rate_limited"}),
                     {reply, {text, Reply}, State};
-                {ok, Ctx} ->
-                    join_and_reply(Cid, WorldPid, PlayerId, Ctx, State)
+                allowed ->
+                    case asobi_join_ctx:parse(maps:get(~"payload", Msg, #{})) of
+                        {error, CtxErr} ->
+                            Reply = encode_reply(Cid, ~"error", #{reason => CtxErr}),
+                            {reply, {text, Reply}, State};
+                        {ok, Ctx} ->
+                            join_and_reply(Cid, WorldPid, PlayerId, Ctx, State)
+                    end
             end
     end;
 handle_message(
@@ -580,6 +584,31 @@ reply_error(Msg, Reason, State) ->
     Cid = maps:get(~"cid", Msg, undefined),
     Reply = encode_reply(Cid, ~"error", #{reason => Reason}),
     {reply, {text, Reply}, State}.
+
+%% asobi#193: joining is how a client reaches a roster and leaving is free,
+%% so an unbounded join rate lets one account sweep every live world. Keyed
+%% on player_id because identity, not IP, is the unit an attacker rotates.
+%% `world.create`/`world.find_or_create` route through join_and_reply too, so
+%% they are covered by the same bucket.
+check_join_rate(PlayerId) ->
+    case seki:check(asobi_join_limiter, PlayerId) of
+        {allow, _} ->
+            allowed;
+        {deny, _} ->
+            asobi_telemetry:join_rate_limited(PlayerId),
+            denied
+    end.
+
+join_match_and_reply(Cid, MatchPid, PlayerId, Ctx, State) ->
+    case asobi_match_server:join(MatchPid, PlayerId, Ctx) of
+        ok ->
+            Info = asobi_match_server:get_info(MatchPid),
+            Reply = encode_reply(Cid, ~"match.joined", Info),
+            {reply, {text, Reply}, State};
+        {error, Reason} ->
+            Reply = encode_reply(Cid, ~"error", #{reason => Reason}),
+            {reply, {text, Reply}, State}
+    end.
 
 join_and_reply(Cid, WorldPid, PlayerId, State) ->
     join_and_reply(Cid, WorldPid, PlayerId, #{}, State).

--- a/test/asobi_join_limiter_tests.erl
+++ b/test/asobi_join_limiter_tests.erl
@@ -1,0 +1,46 @@
+-module(asobi_join_limiter_tests).
+-include_lib("eunit/include/eunit.hrl").
+
+%% asobi#193: the join bucket is what bounds a roster sweep. These pin that
+%% the limiter exists, is keyed per player, and actually refuses - a
+%% misconfigured or absent bucket would silently restore the unbounded join
+%% rate with nothing failing.
+
+-define(LIMITER, asobi_join_limiter).
+
+setup() ->
+    application:ensure_all_started(seki),
+    catch seki:new_limiter(?LIMITER, #{algorithm => sliding_window, limit => 3, window => 60000}),
+    ok.
+
+cleanup(_) ->
+    ok.
+
+join_limiter_test_() ->
+    {setup, fun setup/0, fun cleanup/1, [
+        {"allows up to the limit then denies", fun denies_past_limit/0},
+        {"buckets are per player", fun per_player_buckets/0}
+    ]}.
+
+denies_past_limit() ->
+    P = unique_player(),
+    [?assertMatch({allow, _}, seki:check(?LIMITER, P)) || _ <- lists:seq(1, 3)],
+    ?assertMatch(
+        {deny, _},
+        seki:check(?LIMITER, P),
+        "an unbounded join rate is what makes a roster sweep cheap"
+    ).
+
+per_player_buckets() ->
+    A = unique_player(),
+    B = unique_player(),
+    [?assertMatch({allow, _}, seki:check(?LIMITER, A)) || _ <- lists:seq(1, 3)],
+    ?assertMatch({deny, _}, seki:check(?LIMITER, A)),
+    ?assertMatch(
+        {allow, _},
+        seki:check(?LIMITER, B),
+        "one player exhausting the bucket must not lock everyone out"
+    ).
+
+unique_player() ->
+    integer_to_binary(erlang:unique_integer([positive])).


### PR DESCRIPTION
The remaining half of the roster-harvest problem tracked in issue 193.

## What the attack actually is

A joiner is a **legitimate member** while joined, so reading the roster is not unauthorised access. The defect was that membership was unbounded and free: join any world by id, read `world.joined`, leave, repeat. A full deployment could be swept in seconds by one account.

That framing rules out the two obvious "fixes". Projecting the roster out of `world.joined` breaks members rendering who is in their world, across seven SDKs. A core-level join gate collapses the visibility/authorisation split that every backend surveyed keeps deliberately separate.

## What this does

A `join` seki bucket, 10 per minute, keyed on **player_id rather than IP** — identity is the unit an attacker rotates, and the cost being bounded is per-identity. `world.create` and `world.find_or_create` route through `join_and_reply` so they share the bucket.

Refuses with `join_rate_limited` and emits `[asobi, join, rate_limited]` so operators can see sweeps.

10/min is generous for real play (a player browsing worlds joins a handful of times a minute) and turns a sweep of a 1000-world deployment from seconds into roughly one work-day per identity.

## Honest limits

This **bounds** the cost of a sweep; it does not eliminate it. A determined attacker with many identities still enumerates slowly, and where guest auth is enabled identities are cheap. Two things keep that acceptable:

- The data is player ids and occupancy, not credentials or PII.
- Games that need worlds genuinely restricted now have `join/3` (#198) and can reject outright.

Together — games can restrict, core bounds what an unrestricted game exposes — I think this closes issue 193. If the residual is unacceptable for a given deployment, the lever is `rate_limits.join`, plus `join/3`.

## Verification

`fmt --check`, `xref`, `dialyzer`, `ex_doc` clean. `eunit` 350/0 including 2 new limiter cases (denies past limit; buckets are per player, so one player exhausting the bucket cannot lock everyone out). `ct --suite asobi_world_lobby_SUITE` 20/20. `elp eqwalize-all` 36, identical to `main`.

Docs: a Join rate section in `guides/configuration.md`, explicit that this bounds a sweep and does not make worlds private.

Docker unavailable locally so DB-backed CT suites did not run; CI covers them.