### PR TITLE
refactor: remove the dead matchmaker party surface

### DIFF
--- a/guides/matchmaking.md
+++ b/guides/matchmaking.md
@@ -5,7 +5,7 @@ groups tickets into matches using a per-mode strategy module.
 
 ## How It Works
 
-1. Player submits a matchmaking ticket with a mode, optional properties, and an optional party.
+1. Player submits a matchmaking ticket with a mode and optional properties.
 2. Matchmaker ticks periodically (default every 1 second).
 3. Each tick groups tickets by mode, and the mode's strategy module decides which tickets form a match.
 4. When a group is formed, a match is spawned.
@@ -44,7 +44,7 @@ curl -X POST http://localhost:8084/api/v1/matchmaker \
 ```
 <!-- /tabs -->
 
-A ticket currently supports `mode`, `properties`, and `party`. A
+A ticket supports `mode` and `properties`. A
 query-language extension (numeric ranges, required keys, automatic skill
 window expansion) is on the roadmap but not shipped — do that filtering
 inside your strategy module instead.
@@ -108,20 +108,21 @@ Wire it up per mode:
 ]}
 ```
 
-## Party Support
+## Playing With Friends
 
-Players can queue as a party. All party members are placed in the same match:
+The matchmaker has no party grouping. It queues individual players, and a
+ticket cannot bring other players with it.
 
-```json
-{
-  "type": "matchmaker.add",
-  "payload": {
-    "mode": "arena",
-    "party": ["player_id_2", "player_id_3"],
-    "properties": {"skill": 1200}
-  }
-}
-```
+To play with someone specific, skip the queue: create a match or world,
+share its id or a join code out of band, and have them join directly. Gate
+entry by implementing `join/3` in your game module and checking the join
+context - see [WebSocket Protocol](websocket-protocol.md#join-context). To
+let friends find your session in a browser instead, see
+[World Server](world-server.md).
+
+Matchmaker-mediated party grouping would mean weighting tickets by party
+size, which changes what `match_size` means for every strategy module. It
+is not shipped, and a `party` field on a ticket is not accepted.
 
 ## Cancelling
 

--- a/guides/migrate-from-hathora.md
+++ b/guides/migrate-from-hathora.md
@@ -39,7 +39,7 @@ They get you unblocked even if the full port takes a week:
    curl -s localhost:8084/api/v1/matchmaker \
      -H 'content-type: application/json' \
      -H 'authorization: Bearer wRqvop92/...' \
-     -d '{"mode":"default","properties":{},"party":["019de3..."]}'
+     -d '{"mode":"default","properties":{}}'
    # → { "status": "pending", "ticket_id": "019de3..." }
    ```
 4. **Join the Discord** [`#migrations` channel](https://discord.gg/vYSfYYyXpu).
@@ -121,7 +121,7 @@ that to be you again.
 | Matchmaker (2.0) | `asobi_matchmaker` | Pluggable strategies (`fill`, `skill_based`); custom via `asobi_matchmaker_strategy` behaviour. |
 | `HathoraClient.loginAnonymous` | `POST /api/v1/auth/register` with `username` + `password` | **No anonymous flag today.** You generate a random username/password in the client and persist it locally (or use OAuth). Response fields: `player_id`, `session_token`, `username`. |
 | `HathoraClient.loginGoogle` | `POST /api/v1/auth/oauth` | OAuth/OIDC flow. |
-| `createLobby` / `createRoom` / queue | `POST /api/v1/matchmaker` body `{"mode":"default","properties":{},"party":[playerId]}` | Response: `{"ticket_id":"...","status":"pending"}`. |
+| `createLobby` / `createRoom` / queue | `POST /api/v1/matchmaker` body `{"mode":"default","properties":{}}` | Response: `{"ticket_id":"...","status":"pending"}`. |
 | Ticket poll | `GET /api/v1/matchmaker/:ticket_id` | |
 | Cancel | `DELETE /api/v1/matchmaker/:ticket_id` | |
 | `listActivePublicLobbies` | `GET /api/v1/matches` | Query params filter results. |

--- a/guides/migrate-from-nakama.md
+++ b/guides/migrate-from-nakama.md
@@ -54,8 +54,8 @@ Nakama and asobi agree on most of the vocabulary:
 | **Match** (authoritative) | Match | Same: a BEAM/goroutine process owning state. |
 | **Match handler** (Lua / TS / Go) | `asobi_match` behaviour / `match.lua` | Callbacks: init, join, leave, handle_input, tick, get_state. |
 | **Match Handler's LoopTick** | `tick(state)` | Same cadence (configurable). |
-| **Parties** | Matchmaker tickets with `party` field | Send a list of player_ids in the ticket body. |
-| **MatchmakerAdd** | `POST /api/v1/matchmaker` | Body: `{mode, properties, party}`. |
+| **Parties** | Not supported | No matchmaker party grouping. Play with friends by sharing a match/world id or a join code and joining directly; gate entry in `join/3`. |
+| **MatchmakerAdd** | `POST /api/v1/matchmaker` | Body: `{mode, properties}`. |
 | **Storage Engine** | `/api/v1/storage/:collection/:key` | Collection+key+owner model is the same. Public/Owner/None permissions. |
 | **Leaderboards** | Leaderboards (`/api/v1/leaderboards/:id`) | Submit/top/around queries. |
 | **Tournaments** | Tournaments (`/api/v1/tournaments`) | Scheduled, entry fees, rewards. |

--- a/guides/security-auth.md
+++ b/guides/security-auth.md
@@ -163,8 +163,10 @@ exist purely to bound the cost of a single hostile request:
 - **Per-player world creation** — capped via pg group; default 5
   worlds per player, 1000 globally. Tunable via `world_max_per_player`
   / `world_max` env.
-- **Matchmaker** — party entries that don't match the requester are
-  silently dropped; ticket reads / cancellations require ownership.
+- **Matchmaker** — ticket reads and cancellations require ownership, so
+  one player cannot read or cancel another's ticket. A ticket carries only
+  the submitting player, so it cannot pull a non-consenting player into a
+  match.
 
 ## Test coverage
 
@@ -174,7 +176,7 @@ Regressions for the items above live under `test/`:
   (bad alg, missing x5c, swapped signature, expired cert, untrusted
   root, …).
 - `asobi_world_lobby_SUITE.erl` — F-9 per-player + global world caps.
-- `asobi_matchmaker_api_SUITE.erl` — F-7/F-8 party consent + ticket
+- `asobi_matchmaker_api_SUITE.erl` — ticket ownership + party-not-accepted
   ownership.
 - `asobi_social_api_SUITE.erl` — F-10 chat history membership (DM,
   group, non-member denial).

--- a/src/controllers/asobi_matchmaker_controller.erl
+++ b/src/controllers/asobi_matchmaker_controller.erl
@@ -8,8 +8,7 @@ add(#{json := Params, auth_data := #{player_id := PlayerId}} = _Req) when
 ->
     MatchParams = #{
         mode => maps:get(~"mode", Params, ~"default"),
-        properties => maps:get(~"properties", Params, #{}),
-        party => maps:get(~"party", Params, [PlayerId])
+        properties => maps:get(~"properties", Params, #{})
     },
     {ok, TicketId} = asobi_matchmaker:add(PlayerId, MatchParams),
     {json, 200, #{}, #{ticket_id => TicketId, status => ~"pending"}}.

--- a/src/matches/asobi_matchmaker.erl
+++ b/src/matches/asobi_matchmaker.erl
@@ -31,7 +31,7 @@ remove(PlayerId, TicketId) ->
     end.
 
 %% Ticket lookup is owner-scoped. F-8: previously any authenticated
-%% caller could read another player's mode/party/properties.
+%% caller could read another player's mode/properties.
 -spec get_ticket(binary(), binary()) ->
     {ok, map()} | {error, not_found | not_owner}.
 get_ticket(PlayerId, TicketId) ->
@@ -86,16 +86,11 @@ handle_call({add, PlayerId, Params}, _From, #{tickets := Tickets} = State) when
             M when is_binary(M) -> M;
             _ -> ~"default"
         end,
-    %% F-7: only the requester themselves is allowed in the party until
-    %% an explicit invite/accept handshake exists. Drop any party
-    %% members the requester didn't pre-clear.
-    SanitisedParty = sanitise_party(maps:get(party, Params, [PlayerId]), PlayerId),
     Ticket = #{
         id => TicketId,
         player_id => PlayerId,
         mode => Mode,
         properties => maps:get(properties, Params, #{}),
-        party => SanitisedParty,
         submitted_at => erlang:system_time(millisecond),
         status => pending
     },
@@ -458,20 +453,6 @@ notify_expired([#{player_id := PlayerId, id := TicketId} | Rest]) ->
 -spec generate_id() -> binary().
 generate_id() ->
     asobi_id:generate().
-
-%% F-7: until a real invite/accept handshake exists, the requester
-%% themselves is the only player allowed in their own party. Strip
-%% anything else and dedupe so the matchmaker can't be tricked into
-%% bringing a non-consenting player into a match.
--spec sanitise_party(term(), binary()) -> [binary()].
-sanitise_party(Party, PlayerId) when is_list(Party) ->
-    Filtered = [P || P <- Party, is_binary(P), P =:= PlayerId],
-    case Filtered of
-        [] -> [PlayerId];
-        _ -> [PlayerId]
-    end;
-sanitise_party(_, PlayerId) ->
-    [PlayerId].
 
 -spec ensure_map(term()) -> #{term() => term()}.
 ensure_map(M) when is_map(M) -> M;

--- a/src/ws/asobi_ws_handler.erl
+++ b/src/ws/asobi_ws_handler.erl
@@ -303,8 +303,7 @@ handle_message(
     Cid = maps:get(~"cid", Msg, undefined),
     {ok, TicketId} = asobi_matchmaker:add(PlayerId, #{
         mode => maps:get(~"mode", Payload, ~"default"),
-        properties => maps:get(~"properties", Payload, #{}),
-        party => maps:get(~"party", Payload, [PlayerId])
+        properties => maps:get(~"properties", Payload, #{})
     }),
     Reply = encode_reply(Cid, ~"matchmaker.queued", #{ticket_id => TicketId, status => ~"pending"}),
     {reply, {text, Reply}, State};

--- a/test/asobi_matchmaker_api_SUITE.erl
+++ b/test/asobi_matchmaker_api_SUITE.erl
@@ -8,7 +8,7 @@
     get_ticket/1,
     get_ticket_not_found/1,
     cancel_ticket/1,
-    party_other_players_dropped/1,
+    supplied_party_is_not_accepted/1,
     other_player_cannot_read_ticket/1,
     other_player_cannot_cancel_ticket/1
 ]).
@@ -19,7 +19,7 @@ all() ->
         get_ticket,
         get_ticket_not_found,
         cancel_ticket,
-        party_other_players_dropped,
+        supplied_party_is_not_accepted,
         other_player_cannot_read_ticket,
         other_player_cannot_cancel_ticket
     ].
@@ -116,8 +116,11 @@ get_ticket_not_found(Config) ->
     ?assertStatus(404, Resp),
     Config.
 
-%% F-7 regression: party entries that aren't the requester are dropped.
-party_other_players_dropped(Config) ->
+%% asobi never supported grouping by a client-supplied party list: the field
+%% was accepted, sanitised and echoed while nothing downstream read it. It is
+%% gone now, and this pins that a supplied `party` is ignored outright rather
+%% than silently accepted - accept-and-do-nothing is worse than rejecting.
+supplied_party_is_not_accepted(Config) ->
     {ok, AddResp} = nova_test:post(
         "/api/v1/matchmaker",
         #{
@@ -137,13 +140,10 @@ party_other_players_dropped(Config) ->
         Config
     ),
     Body = nova_test:json(GetResp),
-    {player1_id, P1Id} = lists:keyfind(player1_id, 1, Config),
-    case Body of
-        #{~"party" := Party} when is_list(Party) ->
-            ?assertEqual([P1Id], Party);
-        _ ->
-            ok
-    end,
+    ?assertNot(
+        maps:is_key(~"party", Body),
+        "a supplied party must not be echoed back as if it did something"
+    ),
     _ = nova_test:delete(
         "/api/v1/matchmaker/" ++ binary_to_list(TicketId),
         #{headers => auth(Config)},


### PR DESCRIPTION
Item 6 of the lobby sequence, which the architecture review turned into a deletion.

## What was actually there

`party` was **dead code with a live API**. It was accepted on `POST /api/v1/matchmaker` and WS `matchmaker.add`, sanitised by `sanitise_party/2`, written to the ticket, and echoed back by `get_ticket` — while nothing downstream ever read it:

- the spawn path takes `player_id` only (`asobi_matchmaker.erl:392`)
- both shipped strategies group by **ticket count**, not player weight (`asobi_matchmaker_fill:group/3` → `split_at(Size, Tickets)`)

So a developer could pass `party`, get a 200, see it reflected in their ticket, and have it silently do nothing. Accept-and-do-nothing is the one state worse than not offering the field.

## The docs promised more than the code

This is the part that decided it. `guides/matchmaking.md` had a **"Party Support"** section stating *"Players can queue as a party. All party members are placed in the same match"*, with a worked example. The Nakama migration guide said *"Send a list of player_ids in the ticket body"*, and the Hathora guide put `"party":[...]` in a copy-pasteable curl. All corrected.

## What this does

Removes the field, `sanitise_party/2`, and the F-7 comment. Rewrites the guides to say party grouping is not supported and to point at the paths that do work: create/discover a session (#197), share its id or a code, gate entry in `join/3` (#198).

The F-7 regression test is **repointed, not deleted** — it now pins that a supplied `party` is ignored outright rather than silently accepted. Its old assertion already tolerated the field being absent, so it would have passed vacuously.

## Why not build it instead

Real party grouping means weighting tickets by party size, which changes what `match_size` means across the public `asobi_matchmaker_strategy` behaviour — every third-party strategy would silently miscount. That is a deliberate decision deserving its own design, not something to leave half-wired. If it is built later, the co-submission shape (each member submits their own ticket carrying a shared key, so consent *is* submission) looks right and needs no party object, leader, or invite/accept handshake.

Worth noting the failure mode was bounded: `asobi_match_server:handle_join/4` checks capacity inside the `gen_statem` call, so even an oversized group would have had surplus players rejected at the door rather than corrupting a match.

## Verification

`fmt --check`, `xref`, `dialyzer`, `ex_doc` clean. `eunit` 350/0. `ct --suite asobi_world_lobby_SUITE` 20/20. `elp eqwalize-all` 36, identical to `main`.

Docker unavailable locally so DB-backed CT suites did not run; CI covers them, including the repointed `asobi_matchmaker_api_SUITE`.