### PR TITLE
fix: correct protocol fixture shapes and pin them to the projections

### DIFF
--- a/priv/protocol/fixtures/match.joined.json
+++ b/priv/protocol/fixtures/match.joined.json
@@ -1,1 +1,1 @@
-{"type":"match.joined","cid":"3","payload":{"match_id":"01j8x000000000000000000001","mode":"demo","players":["01j8x000000000000000000000"]}}
+{"type":"match.joined","cid":"3","payload":{"match_id":"01j8x000000000000000000001","mode":"demo","status":"waiting","player_count":1,"max_players":4,"players":["01j8x000000000000000000000"],"listed":false}}

--- a/priv/protocol/fixtures/world.joined.json
+++ b/priv/protocol/fixtures/world.joined.json
@@ -1,1 +1,1 @@
-{"type":"world.joined","cid":"14","payload":{"world_id":"01j8x000000000000000000007","mode":"village"}}
+{"type":"world.joined","cid":"14","payload":{"world_id":"01j8x000000000000000000007","mode":"village","status":"running","player_count":3,"max_players":16,"players":["01j8x000000000000000000000"],"grid_size":10,"started_at":1750000000000}}

--- a/priv/protocol/fixtures/world.list.json
+++ b/priv/protocol/fixtures/world.list.json
@@ -1,1 +1,1 @@
-{"type":"world.list","cid":"13","payload":{"worlds":[{"id":"01j8x000000000000000000007","mode":"village","capacity":16,"size":3}]}}
+{"type":"world.list","cid":"13","payload":{"worlds":[{"world_id":"01j8x000000000000000000007","mode":"village","status":"running","player_count":3,"max_players":16,"grid_size":10,"started_at":1750000000000}]}}

--- a/test/asobi_protocol_coverage_tests.erl
+++ b/test/asobi_protocol_coverage_tests.erl
@@ -158,3 +158,56 @@ extract_captures(Bin, Re) ->
         {match, Matches} -> [B || [B] <- Matches];
         nomatch -> []
     end.
+
+%% The existence and envelope checks above cannot catch a fixture whose
+%% payload has the wrong KEYS. world.list.json shipped for a long time with
+%% `id`/`capacity`/`size` while the server emits
+%% `world_id`/`max_players`/`player_count`. SDKs treat these fixtures as
+%% ground truth for dispatch tests, so a wrong-shaped fixture teaches every
+%% client the wrong contract and nothing fails.
+%%
+%% The two listing events have a pure projection function to compare
+%% against, so pin them exactly.
+listing_fixtures_match_the_projection_test() ->
+    WorldKeys = projection_keys(fun asobi_world_server:listing_info/1, #{
+        world_id => ~"w",
+        status => running,
+        player_count => 1,
+        max_players => 2,
+        mode => ~"m",
+        grid_size => 1,
+        started_at => 0,
+        players => [~"p"]
+    }),
+    ?assertEqual(
+        WorldKeys,
+        fixture_entry_keys("world.list", ~"worlds"),
+        "world.list fixture must match asobi_world_server:listing_info/1"
+    ),
+
+    MatchKeys = projection_keys(fun asobi_match_server:listing_info/1, #{
+        match_id => ~"m",
+        status => waiting,
+        player_count => 1,
+        max_players => 2,
+        mode => ~"m",
+        players => [~"p"],
+        listed => true
+    }),
+    ?assertEqual(
+        MatchKeys,
+        fixture_entry_keys("match.list", ~"matches"),
+        "match.list fixture must match asobi_match_server:listing_info/1"
+    ).
+
+projection_keys(Fun, Sample) ->
+    lists:sort([atom_to_binary(K) || K <- maps:keys(Fun(Sample))]).
+
+fixture_entry_keys(Event, ListKey) ->
+    {ok, Bin} = file:read_file(?FIXTURE_DIR ++ "/" ++ Event ++ ".json"),
+    #{~"payload" := #{ListKey := [Entry | _]}} = json:decode(Bin),
+    entry_keys(Entry).
+
+%% Guard narrows json:decode_value() to a map for eqwalizer.
+entry_keys(Entry) when is_map(Entry) ->
+    lists:sort(maps:keys(Entry)).


### PR DESCRIPTION
Blocks the SDK sync — fixtures are what the SDKs are synced *against*, so this has to land first or the wrong shape gets baked into seven clients.

## The drift

`world.list.json` declared:

```json
{"id":"...","mode":"village","capacity":16,"size":3}
```

The server emits `world_id`, `status`, `player_count`, `max_players`, `mode`, `grid_size`, `started_at`. Three of four keys were wrong, and had been for a long time — this predates the current work.

`priv/protocol/fixtures/` is ground truth for SDK dispatch tests, so a wrong-shaped fixture teaches every client the wrong contract and nothing fails anywhere. The existing coverage tests check that a fixture **exists** (`every_emitted_event_has_a_fixture_test`) and that its envelope is valid — never that its payload keys are real.

`world.joined` and `match.joined` were valid but incomplete subsets; filled out to what the server actually sends.

## The guard

`listing_fixtures_match_the_projection_test` compares the `world.list` and `match.list` fixture keys against `asobi_world_server:listing_info/1` and `asobi_match_server:listing_info/1` directly — the projection functions are pure, so the test calls them rather than restating the key list.

I verified it **fails on the old fixture** rather than passing vacuously:

```
expected: [<<"grid_size">>,<<"max_players">>,<<"mode">>,
           <<"player_count">>,<<"started_at">>,<<"status">>,<<"world_id">>]
     got: [<<"capacity">>,<<"id">>,<<"mode">>,<<"size">>]
```

Only the two listing events are pinned this way, since they are the ones with a pure projection to compare against. The rest still rely on existence plus envelope checks.

## Note for follow-up

`match.joined` carries `listed`, a server-side discovery flag that has no reason to be on the wire. The fixture reflects reality rather than hiding it. Tidying that is a separate change — it means splitting `match_info/2` between what `matches_filters/2` reads and what a client sees.

## Verification

`fmt --check`, `xref`, `dialyzer` clean. `eunit` 351/0. `elp eqwalize-all` 36, identical to `main` — the new test initially added one (`json:decode_value()` not narrowed to a map), fixed with a guard rather than a fixme.