### PR TITLE
docs: fix the wrong answers and the missing REST reference

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -270,7 +270,7 @@ One process per connected player. Manages WebSocket state, presence, and acts as
 Client ←→ WebSocket Handler ←→ Player Session Process
                                     │
                                     ├── pg groups: presence, player-specific topics
-                                    ├── Tracks: current match, party, chat channels
+                                    ├── Tracks: current match, world, chat channels
                                     └── Handles: heartbeat, disconnect cleanup
 ```
 
@@ -347,23 +347,24 @@ Game developers implement the `asobi_match` behaviour to define their game:
 
 ### Matchmaker (`asobi_matchmaker` — gen_server)
 
-Runs periodic matching ticks via Shigoto. Query-based matching with expanding windows.
+Runs periodic matching ticks. Strategy modules group tickets; the shipped
+strategies are `fill` (FCFS) and `skill_based` (expanding window).
 
-**Ticket:**
+**Ticket** (`asobi_matchmaker:add/2`):
 ```erlang
 #{
+    id => binary(),
     player_id => binary(),
-    properties => #{
-        skill => integer(),
-        region => binary(),
-        mode => binary()
-    },
-    query => binary(),          %% match query expression
-    party => [binary()],        %% party member IDs
+    mode => binary(),
+    properties => map(),        %% game-defined, read by your strategy
     submitted_at => integer(),
-    expansion_level => integer()
+    status => pending
 }
 ```
+
+There is no query expression and no party field. Ticket filtering beyond
+`mode` happens inside your strategy module against `properties`. See
+[Matchmaking](../guides/matchmaking.md).
 
 **Algorithm (each tick):**
 1. Load all active tickets from ETS

--- a/guides/configuration.md
+++ b/guides/configuration.md
@@ -112,6 +112,8 @@ Shorthand (Erlang module only):
 | `skill_window` | `200` | Initial skill difference allowed (skill_based only) |
 | `skill_expand_rate` | `50` | Window expansion per 5 seconds (skill_based only) |
 | `bots` | `#{}` | Bot configuration. Read by [asobi_lua](https://github.com/widgrensit/asobi_lua), not by asobi — see [Bots](lua-bots.md) |
+| `listed` | `false` for matches, `true` for worlds | Whether instances of this mode appear in discovery (`match.list` / `world.list`). **Matches are unlisted by default** — a matchmaker-spawned match is already assigned to its players, so opt in explicitly. |
+| `quick_play` | `true` | Worlds only. Whether `world.find_or_create` may place a player into an existing world of this mode. Independent of `listed` — see [World Server](world-server.md#visibility). |
 
 ## Matchmaker
 

--- a/guides/migrate-from-hathora.md
+++ b/guides/migrate-from-hathora.md
@@ -119,12 +119,12 @@ that to be you again.
 | Lobby | Matchmaker ticket + Match in "waiting" phase | Players hit `/matchmaker/tickets`; when `match_size` is reached the match transitions to "running". |
 | Region | Deployment location | Deploy one container per region. No region abstraction baked in — you pick where to run the container. |
 | Matchmaker (2.0) | `asobi_matchmaker` | Pluggable strategies (`fill`, `skill_based`); custom via `asobi_matchmaker_strategy` behaviour. |
-| `HathoraClient.loginAnonymous` | `POST /api/v1/auth/register` with `username` + `password` | **No anonymous flag today.** You generate a random username/password in the client and persist it locally (or use OAuth). Response fields: `player_id`, `session_token`, `username`. |
+| `HathoraClient.loginAnonymous` | `POST /api/v1/auth/guest` | Device-backed anonymous auth: pass `device_id` + `device_secret`, get a real player back. Opt-in - the game declares `guest_auth` and the operator sets a pepper. Claim the account later with `POST /api/v1/auth/guest/upgrade`. See [Authentication](authentication.md). |
 | `HathoraClient.loginGoogle` | `POST /api/v1/auth/oauth` | OAuth/OIDC flow. |
 | `createLobby` / `createRoom` / queue | `POST /api/v1/matchmaker` body `{"mode":"default","properties":{}}` | Response: `{"ticket_id":"...","status":"pending"}`. |
 | Ticket poll | `GET /api/v1/matchmaker/:ticket_id` | |
 | Cancel | `DELETE /api/v1/matchmaker/:ticket_id` | |
-| `listActivePublicLobbies` | `GET /api/v1/matches` | Query params filter results. |
+| `listActivePublicLobbies` | `GET /api/v1/matches/live` | Live, joinable matches. Filter with `mode` and `has_capacity`. Matches are **unlisted by default** - a mode opts in with `listed => true`. Not to be confused with `GET /api/v1/matches`, which reads the match record table (finished matches, an audit trail). |
 | `getConnectionInfo(roomId)` | WebSocket upgrade on `GET /ws` | See [§ WebSocket handshake](#websocket-handshake) — first frame must authenticate. |
 | `ping` region API | *(none)* | If you need client-side region selection, probe each deployment endpoint yourself. |
 | Hathora SDK | asobi SDKs | [asobi-unity](https://github.com/widgrensit/asobi-unity), [asobi-unreal](https://github.com/widgrensit/asobi-unreal), [asobi-js](https://github.com/widgrensit/asobi-js), [asobi-godot](https://github.com/widgrensit/asobi-godot), [asobi-defold](https://github.com/widgrensit/asobi-defold), [asobi-dart](https://github.com/widgrensit/asobi-dart), [flame_asobi](https://github.com/widgrensit/flame_asobi). |

--- a/guides/rest-api.md
+++ b/guides/rest-api.md
@@ -85,6 +85,50 @@ GET /api/v1/players/:id        Get player profile
 PUT /api/v1/players/:id        Update own profile
 ```
 
+## Worlds
+
+```
+GET  /api/v1/worlds         Browse live worlds
+GET  /api/v1/worlds/:id     Get one world
+POST /api/v1/worlds         Create a world
+```
+
+`GET /api/v1/worlds` accepts `mode` (ignored above 64 bytes) and
+`has_capacity=true`. Only worlds whose mode sets `listed` (the default) are
+returned. Results are cached for 500ms.
+
+`POST /api/v1/worlds` returns **201** with the world info, **429** when the
+player is at their per-player cap (`player_world_limit_reached`), and **503**
+when the global cap is reached (`world_capacity_reached`). See
+[World capacity](configuration.md#world-capacity).
+
+`GET /api/v1/worlds/:id` returns **404** for an unknown id.
+
+None of these return the player roster - see [World Server](world-server.md).
+There is no REST join: joining binds the world to your WebSocket session, so
+it is `world.join` over WS.
+
+## Matches
+
+```
+GET /api/v1/matches         Match history (finished matches)
+GET /api/v1/matches/live    Live, joinable matches
+GET /api/v1/matches/:id     Get one match record
+```
+
+**These read different data sources, and it is the most confusing thing in
+this API.** `GET /api/v1/matches` queries the match *record* table: finished
+matches, an audit trail, nothing you can join. It accepts `mode`, `status`
+and `limit` (1-200, default 50), newest first.
+
+`GET /api/v1/matches/live` enumerates running match processes and is what a
+lobby browser wants. It accepts `mode` and `has_capacity=true`. Matches are
+**unlisted by default** - a mode opts in with `listed => true` - so an empty
+result usually means no mode has opted in yet.
+
+Neither returns the player roster. As with worlds, joining is `match.join`
+over WS.
+
 ## Social
 
 ```

--- a/guides/websocket-protocol.md
+++ b/guides/websocket-protocol.md
@@ -98,9 +98,26 @@ to your game module untouched:
 {"type": "match.join", "payload": {"match_id": "...", "ctx": {"code": "AB12"}}}
 ```
 
-Asobi never interprets, echoes, or logs it. It reaches your game's
-`join/3` callback, which decides whether to accept. Games that implement
-only `join/2` are unaffected and a supplied `ctx` is ignored.
+Asobi never interprets, echoes, or logs it. It reaches your game's join
+callback, which decides whether to accept.
+
+In Lua, declare a third parameter:
+
+```lua
+function join(player_id, state, ctx)
+	if ctx.code ~= state.room_code then
+		return state              -- refuse: player is not added
+	end
+	state.players[player_id] = true
+	return state
+end
+```
+
+In Erlang, export `join/3` (`join(PlayerId, Ctx, GameState)`) alongside or
+instead of `join/2`.
+
+Either way a game that takes only `(player_id, state)` is unaffected and a
+supplied `ctx` is ignored.
 
 This is how you build join codes, invites, passwords and party checks:
 without it there is no channel from a client to your game before

--- a/guides/world-server.md
+++ b/guides/world-server.md
@@ -194,6 +194,7 @@ end
 |----------|----------|-------------|
 | `init(config)` | yes | Return initial global game state |
 | `join(player_id, state)` | yes | Handle player join, return state |
+| `join(player_id, state, ctx)` | no | Same, plus the client's join context. Declare the third parameter and it is used instead — see [Join context](websocket-protocol.md#join-context) |
 | `leave(player_id, state)` | yes | Handle player leave, return state |
 | `spawn_position(player_id, state)` | yes | Return `{x=N, y=N}` table |
 | `post_tick(tick, state)` | yes | Global tick logic. Set `_finished`/`_result` or `_vote` on state |


### PR DESCRIPTION
From a docs audit of the lobby/discovery batch (#192, #195-#201). Three of these gave readers a **wrong** answer rather than no answer, which is the class worth fixing first.

## Wrong

**`migrate-from-hathora.md`** mapped `listActivePublicLobbies` → `GET /api/v1/matches`. That reads the match *record* table — finished matches, an audit trail, nothing joinable. A Hathora migrant follows that row, gets a list of dead matches, and concludes browsing is broken. Now points at `/matches/live` with the distinction spelled out.

The same guide said **"No anonymous flag today"** and told people to hand-roll random credentials. Guest auth shipped months ago. That is the worst kind of doc error: it tells someone to build what you already built for them.

**`docs/ARCHITECTURE.md`** is in the ex_doc `extras` list, so it publishes to HexDocs as a second API reference. Its documented ticket shape still carried the `party` field removed in #200 — the one place my sweep missed — plus a `query` expression and `expansion_level` that have **never** existed. Corrected against `asobi_matchmaker:add/2`.

## Missing

**`rest-api.md` had no Worlds and no Matches sections.** Six routes absent, including the `/matches/live` I added last week. So the REST reference could not answer the question that started this whole batch — "how do I browse games?" — even after we built it.

Both sections added, carrying the things that only existed in source: `POST /api/v1/worlds` returns 201, **429** on `player_world_limit_reached`, **503** on `world_capacity_reached`; the `mode` filter is ignored above 64 bytes; and an explicit warning that `index` and `live` read different data sources.

## Undiscoverable

- `listed` / `quick_play` were not in `configuration.md`'s Mode Options table. Someone whose match never appears in `match.list` had no reason to suspect an opt-in flag existed — matches default to unlisted.
- `join/3` was missing from the `world-server.md` callback table.
- The join context was documented **Erlang-only**, against a Lua-first mandate. Now leads with Lua, which is only honest as of widgrensit/asobi_lua#86 — before that the Lua bridge had no `join/3` and silently discarded the context.

## Not fixed here

`docs/ARCHITECTURE.md` has further pre-existing drift the audit found: phantom endpoints (`/auth/device`, `/auth/apple`, `/players/:id/stats`, `/inventory/equip`, wrong IAP paths), no Worlds section, and an "Admin Dashboard (Arizona)" section describing a console that lives in a separate repo. I fixed only what this batch made wrong. Tracking the rest separately — the real question is whether that file should be in `extras` at all.

## Verification

`rebar3 ex_doc` clean (0 warnings), `fmt --check` clean. Site views regenerate separately per ADR 0003.