### PR TITLE
docs: make the matchmaking guide Lua-first

### DIFF
--- a/guides/matchmaking.md
+++ b/guides/matchmaking.md
@@ -60,12 +60,25 @@ are built in:
   expanding window (configurable via `skill_window` and
   `skill_expand_rate`).
 
-The built-in strategies map to modules: the default `fill` strategy is
-`asobi_matchmaker_fill` and `skill_based` is `asobi_matchmaker_skill`.
-Strategy is configured per game mode only - there is no top-level
-`matchmaker_strategy` key.
+Select one with the `strategy` global in your mode script:
 
-## Custom Strategies
+```lua
+-- ranked.lua
+match_size = 4
+strategy   = "skill_based"   -- "fill" (default) or "skill_based"
+```
+
+The built-in strategies map to modules: `fill` is `asobi_matchmaker_fill`
+and `skill_based` is `asobi_matchmaker_skill`. Strategy is configured per
+game mode only - there is no top-level `matchmaker_strategy` key.
+
+**Writing a new strategy is Erlang only.** `strategy` takes either a
+built-in name or an Erlang module name, and there is no Lua callback for
+grouping tickets. If your matching rules do not fit `fill` or
+`skill_based`, you need an Erlang module in the release alongside your Lua
+scripts.
+
+## Custom Strategies (Erlang)
 
 Implement `asobi_matchmaker_strategy` (a single `match/2` callback):
 
@@ -85,6 +98,19 @@ match(Tickets, Config) ->
 
 Wire it up per mode:
 
+<!-- tabs -->
+**Lua**
+
+A Lua game declares its mode as script globals. Point `strategy` at your
+Erlang module by name:
+
+```lua
+-- ranked.lua
+match_size = 4
+strategy   = "my_matchmaker"
+```
+
+**Erlang**
 ```erlang
 {asobi, [
     {game_modes, #{
@@ -96,6 +122,7 @@ Wire it up per mode:
     }}
 ]}
 ```
+<!-- /tabs -->
 
 ## Configuration
 


### PR DESCRIPTION
The matchmaking guide had **five Erlang blocks and zero Lua**, against the Lua-first rule. Most game authors write Lua and never touch Erlang, so the guide read as if matchmaking were an Erlang-only feature.

Not every block was wrong, though, so this separates the three cases rather than mechanically adding Lua everywhere.

## Had a Lua equivalent that was missing

**Mode wiring.** A Lua game declares its mode as script globals, not a `sys.config` `game_modes` map. The guide only ever showed the Erlang form:

```lua
-- ranked.lua
match_size = 4
strategy   = "my_matchmaker"
```

**Strategy selection.** Same — `strategy` is a global. Now shown in Lua where the built-ins are introduced, instead of appearing only as an Erlang config key further down.

## Correctly Erlang, but never said so

**Custom strategies are Erlang-only.** `strategy` accepts either a built-in name or an Erlang module, and there is no Lua callback for grouping tickets (`asobi_lua_config:maybe_add_strategy/2` maps `fill`/`skill_based` and passes anything else through as a module name).

A Lua author previously had to infer that from absence. The guide now states it, and the section is renamed **Custom Strategies (Erlang)** so the boundary is visible from the table of contents.

## Correctly Erlang, left alone

Ticket submission stays JSON-first — it is a client action, and the SDKs cover it. Matchmaker tick settings stay Erlang — operator config, not game code.

## Same problem elsewhere

`guides/large-worlds.md` and `guides/performance-tuning.md` both show `Config = #{game_module => my_world, grid_size => ...}` in Erlang, and every one of those keys is a documented Lua global. Tracked separately — `performance-tuning` also uses `asobi_zone:query_radius`, and whether `game.spatial` covers it needs checking before writing a Lua example for it.

`clustering.md`, `iap.md`, `security-auth.md` and `architecture.md` are operator/deployment config and correctly Erlang.

## Verification

`rebar3 ex_doc` clean. Site views regenerate separately per ADR 0003.