### PR TITLE
docs: make the large-worlds and performance-tuning guides Lua-first

### DIFF
--- a/guides/large-worlds.md
+++ b/guides/large-worlds.md
@@ -9,6 +9,19 @@ By default, all zones in a world are spawned at startup. For large worlds
 (thousands of zones), enable lazy loading so zones are created on demand
 when a player enters.
 
+<!-- tabs -->
+**Lua**
+```lua
+-- world.lua
+game_type         = "world"
+grid_size         = 2000       -- 2000x2000 zone grid
+zone_size         = 64         -- 64 tiles per zone
+lazy_zones        = true       -- auto-true when grid_size > 100
+zone_idle_timeout = 30000      -- reap idle zones after 30s
+max_active_zones  = 10000      -- cap concurrent zone processes
+```
+
+**Erlang**
 ```erlang
 Config = #{
     game_module => my_world,
@@ -19,6 +32,7 @@ Config = #{
     max_active_zones => 10000   %% cap concurrent zone processes
 }.
 ```
+<!-- /tabs -->
 
 With `lazy_zones => true`:
 
@@ -59,7 +73,27 @@ The `asobi_terrain` helpers below give you a compact tile format, but any
 binary your client can decode works. A complete, runnable provider lives in
 [`examples/world-terrain`](https://github.com/widgrensit/asobi/tree/main/examples/world-terrain).
 
-### Terrain Provider Behaviour
+### Selecting a Provider (Lua)
+
+A Lua world names its provider from `terrain_provider`, returning the module
+and its args:
+
+```lua
+-- world.lua
+function terrain_provider(config)
+	return {"asobi_terrain_perlin", {seed = 42}}
+end
+```
+
+Two providers ship built in: `asobi_terrain_flat` and
+`asobi_terrain_perlin`. The name is checked against an allowlist rather than
+resolved as an arbitrary module, so a script cannot name `gen_server` or any
+other loaded module. Operators extend the allowlist via env.
+
+**Writing a new provider is Erlang only** - the same split as matchmaker
+strategies. Lua selects; Erlang implements.
+
+### Terrain Provider Behaviour (Erlang)
 
 Implement `asobi_terrain_provider` to supply terrain data:
 

--- a/guides/performance-tuning.md
+++ b/guides/performance-tuning.md
@@ -9,20 +9,43 @@ By default, spatial queries (`query_radius`, `query_rect`) scan all
 entities in a zone via `maps:fold` -- O(n). For zones with many entities,
 enable the cell-based spatial grid for O(1) cell lookup + local scan.
 
+<!-- tabs -->
+**Lua**
+```lua
+-- world.lua
+game_type              = "world"
+spatial_grid_cell_size = 16   -- units per cell
+```
+
+**Erlang**
 ```erlang
 Config = #{
     game_module => my_world,
     spatial_grid_cell_size => 16  %% units per cell
 }.
 ```
+<!-- /tabs -->
 
 The grid is maintained automatically as entities are added, removed, or
 moved during ticks. Query through the zone API:
 
+<!-- tabs -->
+**Lua**
+```lua
+-- inside zone_tick or handle_input, where the zone is in scope
+local hits = game.spatial.query_radius(100, 200, 50)
+```
+
+`game.spatial` also offers `query_rect`, `nearest`, `in_range` and
+`distance`. The zone-based forms need a zone in scope; the entity-list
+forms (`game.spatial.query_radius(entities, x, y, radius)`) work anywhere.
+
+**Erlang**
 ```erlang
 Results = asobi_zone:query_radius(ZonePid, {100.0, 200.0}, 50.0).
 %% Returns [{EntityId, {X, Y}}, ...]
 ```
+<!-- /tabs -->
 
 When no `spatial_grid_cell_size` is configured, the zone falls back to
 the brute-force scan (existing behaviour).
@@ -69,11 +92,20 @@ through `asobi_lua_match_shared`, which exports `get_state/1`.
 
 Zones with no subscribers tick at a reduced rate to save CPU:
 
+<!-- tabs -->
+**Lua**
+```lua
+-- world.lua
+cold_tick_divisor = 10   -- cold zones tick 10x less often (default)
+```
+
+**Erlang**
 ```erlang
 Config = #{
     cold_tick_divisor => 10  %% cold zones tick 10x less often (default)
 }.
 ```
+<!-- /tabs -->
 
 | Zone State | Tick Rate | When |
 |-----------|-----------|------|


### PR DESCRIPTION
Closes the follow-up from #204. Both guides showed world configuration as an Erlang `Config = #{...}` map with no Lua at all.

## Verified before writing

The issue warned explicitly not to write Lua examples on assumption, since that failure mode has bitten three times recently. So each key was checked against `asobi_lua_config` first:

- `grid_size`, `zone_size`, `lazy_zones`, `zone_idle_timeout`, `max_active_zones`, `spatial_grid_cell_size`, `cold_tick_divisor` — all confirmed script globals
- `game.spatial.query_radius(x, y, radius)` — confirmed present, along with `query_rect`, `nearest`, `in_range`, `distance`
- `terrain_provider` — confirmed, returns `{module, args}` from Lua

Nothing here is documented on the assumption that it works.

## The two open questions the issue raised

**Does `game.spatial` cover `query_radius`?** Yes. The zone-based form needs a zone in scope; the entity-list form works anywhere. Both documented.

**Does `terrain_provider` accept a Lua script?** No, and this turned out to be the same split as matchmaker strategies. Lua *names* a provider (`return {"asobi_terrain_perlin", {seed = 42}}`); writing one is Erlang. The section is now titled **Terrain Provider Behaviour (Erlang)** so the boundary shows in the table of contents.

## One undocumented security property, now stated

The provider name is checked against an allowlist (`asobi_terrain_flat`, `asobi_terrain_perlin`, extensible via env) rather than resolved as an arbitrary module — the source comment notes this exists so a script cannot name `gen_server`, `rpc` or `application`. That is a real hardening decision and it was documented nowhere. Now in the guide.

## Verification

`rebar3 ex_doc` clean. Site views regenerate separately per ADR 0003.