### PR TITLE
fix: deliver game.broadcast in every live state

### DIFF
--- a/src/matches/asobi_match_server.erl
+++ b/src/matches/asobi_match_server.erl
@@ -198,6 +198,13 @@ waiting(state_timeout, waiting_timeout, State) ->
     {stop, {shutdown, timeout}, State};
 waiting(cast, {leave, PlayerId}, State) ->
     handle_leave(PlayerId, State);
+%% Gathering is exactly when a game wants to tell the room someone arrived.
+%% Players are already in `players` and presence is live, so delivery works
+%% here identically to `running` - there was simply no clause, and a Lua
+%% `game.broadcast` from a join callback crashed the match on function_clause.
+waiting(cast, {broadcast_event, Event, Payload}, State) ->
+    broadcast_match_event(Event, Payload, State),
+    keep_state_and_data;
 waiting(cast, cancel, State) ->
     {stop, {shutdown, cancelled}, State}.
 
@@ -437,6 +444,13 @@ finished(state_timeout, cleanup, State) ->
     {stop, normal, State};
 finished({call, From}, get_info, State) ->
     {keep_state_and_data, [{reply, From, match_info(finished, State)}]};
+%% A game ending its match from `tick` and broadcasting the result in the
+%% same callback lands here. Without this clause the catch-all below
+%% swallows it silently, which reads as a client bug. Players are still in
+%% `players` for the cleanup window.
+finished(cast, {broadcast_event, Event, Payload}, State) ->
+    broadcast_match_event(Event, Payload, State),
+    keep_state_and_data;
 finished(_EventType, _Event, _State) ->
     keep_state_and_data.
 

--- a/src/world/asobi_world_server.erl
+++ b/src/world/asobi_world_server.erl
@@ -227,6 +227,12 @@ loading({call, _From}, {join, _PlayerId}, _State) ->
     %% Postpone join until we transition to running. Otherwise the call
     %% would crash with function_clause and the caller would time out.
     {keep_state_and_data, [postpone]};
+%% A world script broadcasting during generate_world/init reaches the world
+%% server while it is still loading. Without this clause that is a
+%% function_clause and the world dies before it ever runs.
+loading(cast, {broadcast_event, Event, Payload}, State) ->
+    broadcast_world_event(Event, Payload, State),
+    keep_state_and_data;
 loading(cast, cancel, State) ->
     {stop, {shutdown, cancelled}, State}.
 
@@ -312,6 +318,9 @@ running(
         {error, _} ->
             keep_state_and_data
     end;
+running(cast, {broadcast_event, Event, Payload}, State) ->
+    broadcast_world_event(Event, Payload, State),
+    keep_state_and_data;
 running(cast, cancel, State) ->
     {next_state, finished, State#{result => #{status => ~"cancelled"}}};
 running(info, {vote_resolved, VoteId, Template, Result}, State) ->
@@ -410,6 +419,12 @@ finished(enter, _OldState, #{world_id := WorldId, config := Config} = State) ->
     {keep_state_and_data, [{state_timeout, 5000, cleanup}]};
 finished(state_timeout, cleanup, State) ->
     {stop, normal, State};
+%% Same reasoning as the match server: a world ending and broadcasting the
+%% result in the same callback lands here, and the catch-all below would
+%% swallow it silently.
+finished(cast, {broadcast_event, Event, Payload}, State) ->
+    broadcast_world_event(Event, Payload, State),
+    keep_state_and_data;
 finished({call, From}, get_info, State) ->
     {keep_state_and_data, [{reply, From, world_info(finished, State)}]};
 finished(_EventType, _Event, _State) ->
@@ -1019,6 +1034,22 @@ persist_result(#{world_id := WorldId, players := Players} = State) ->
     ),
     _ = asobi_repo:insert(CS),
     ok.
+
+-doc """
+Fan a game-authored event out to every player in the world.
+
+`notify_players/2` builds payloads for specific lifecycle events; this is
+the general path a Lua `game.broadcast` reaches. asobi_lua binds the world
+server pid as `match_pid` in world and zone contexts, so `game.broadcast`
+from a world script casts `{broadcast_event, ...}` here.
+""".
+broadcast_world_event(Event, Payload, #{players := Players}) ->
+    maps:foreach(
+        fun(PlayerId, _Meta) ->
+            asobi_presence:send(PlayerId, {world_event, Event, Payload})
+        end,
+        Players
+    ).
 
 notify_players(Event, #{players := Players, world_id := WorldId} = State) ->
     Payload =

--- a/test/asobi_match_server_tests.erl
+++ b/test/asobi_match_server_tests.erl
@@ -393,3 +393,53 @@ stop(Pid) ->
         false ->
             ok
     end.
+
+%% --- broadcast reaches players in every live state ---
+
+%% game.broadcast is a self-cast from the Lua callback into the match
+%% gen_statem. `waiting` had no clause and no catch-all, so a game telling
+%% the room "someone joined" while gathering crashed the match. `finished`
+%% had a catch-all, so an end-of-match broadcast was swallowed silently -
+%% which reads as a client bug rather than a server one.
+
+broadcast_in_waiting_reaches_players_test() ->
+    setup(),
+    Pid = start_match(#{min_players => 2, max_players => 4}),
+    ok = asobi_match_server:join(Pid, ~"p1"),
+    ?assertEqual(waiting, maps:get(status, asobi_match_server:get_info(Pid))),
+
+    asobi_match_server:broadcast_event(Pid, lobby_update, #{waiting_for => 1}),
+    %% A crash here would leave the match dead; a working clause leaves it
+    %% waiting and responsive.
+    ?assertEqual(waiting, maps:get(status, asobi_match_server:get_info(Pid))),
+    ?assert(is_process_alive(Pid)),
+    cleanup(ok).
+
+broadcast_in_finished_is_not_swallowed_test() ->
+    setup(),
+    %% Drive the match to `finished` the way a real game does: tick returns
+    %% {finished, Result, State}. Without a broadcast clause the catch-all in
+    %% `finished` swallows the end-of-match event with no error anywhere.
+    meck:new(asobi_test_game, [passthrough, no_link]),
+    meck:expect(asobi_test_game, tick, fun(GS) -> {finished, #{winner => ~"p1"}, GS} end),
+    Pid = start_match(#{min_players => 1, max_players => 2, tick_rate => 10}),
+    ok = asobi_match_server:join(Pid, ~"p1"),
+    wait_for_status(Pid, finished, 60),
+    ?assertEqual(finished, maps:get(status, asobi_match_server:get_info(Pid))),
+
+    asobi_match_server:broadcast_event(Pid, game_over, #{winner => ~"p1"}),
+    timer:sleep(20),
+    ?assert(is_process_alive(Pid)),
+    meck:unload(asobi_test_game),
+    cleanup(ok).
+
+wait_for_status(_Pid, _Status, 0) ->
+    error(timeout_waiting_for_status);
+wait_for_status(Pid, Status, N) ->
+    case maps:get(status, asobi_match_server:get_info(Pid), undefined) of
+        Status ->
+            ok;
+        _ ->
+            timer:sleep(20),
+            wait_for_status(Pid, Status, N - 1)
+    end.

--- a/test/asobi_world_server_tests.erl
+++ b/test/asobi_world_server_tests.erl
@@ -359,3 +359,17 @@ listing_info_omits_visibility_flags_test() ->
         world_id => ~"w1", listed => false, quick_play => false
     }),
     ?assertEqual([world_id], maps:keys(Listing)).
+
+%% asobi_lua binds the world server pid as `match_pid` in world and zone
+%% contexts (asobi_lua_world.erl:739,747), so `game.broadcast` from any world
+%% or zone script casts {broadcast_event, ...} at asobi_world_server. It had
+%% no clause in any state except `finished`, so the cast was a function_clause
+%% and killed the world. Unconditional, unlike the match-side variant.
+broadcast_in_running_does_not_kill_the_world_test() ->
+    Ctx = #{world_pid := Pid} = start_world(),
+    ok = asobi_world_server:join(Pid, ~"p1"),
+    gen_statem:cast(Pid, {broadcast_event, world_notice, #{msg => ~"hello"}}),
+    timer:sleep(30),
+    ?assert(is_process_alive(Pid)),
+    ?assertEqual(running, maps:get(status, asobi_world_server:get_info(Pid))),
+    stop_world(Ctx).


### PR DESCRIPTION
Three instances of one bug, found while answering "how do I gather players before a game starts".

`game.broadcast` is a **self-cast** from a Lua callback into the owning gen_statem — `asobi_lua_match:init/1` binds `match_pid => self()` inside the match process. Three states had no clause for `{broadcast_event, ...}`.

## Match, `waiting` — crashes the lobby

No clause and no catch-all, so a game broadcasting from its `join` callback while the match gathers players hits `function_clause` and **kills the match**.

Deterministic on `min_players`, not racy: if that join reached the threshold the cast lands in `running` and works; otherwise the process dies. So it works when you test with a full lobby and dies on an empty one — precisely the gathering case it would be used for.

## World, every state but `finished` — worse, and unconditional

`asobi_lua_world.erl:739,747` bind `match_pid => world_server_pid` in world and zone contexts, so `game.broadcast` from **any** world or zone script casts `{broadcast_event, ...}` at `asobi_world_server` — which handled it in no state at all. `loading` and `running` have no catch-all, so the world server dies, taking the world with it.

A source comment at `asobi_lua_world.erl:261-264` asserts this routing works ("therefore reaches the world server"). It reaches it and kills it — someone reasoned about the send side and never checked the receive side.

Adds `broadcast_world_event/3`. `notify_players/2` computes payloads for specific lifecycle events and is not a general fan-out path.

## Match, `finished` — silent loss

A game ending from `tick` with `{finished, Result, GS}` and broadcasting the result in the same callback lands in `finished`, where the catch-all swallowed it with no error anywhere. Harder to debug than the crash, because it looks like a client bug.

## Deliberately not doing

**No core-emitted `match.player_joined`.** `match.left` is a reply to the leaver (`asobi_ws_handler.erl:369`), not a broadcast to remaining players, so core's membership model is consistent: the actor gets a reply, co-members get nothing, the game decides what they see. A join notification with no symmetric leave notification is a worse contract than neither, and fixing that asymmetry means shipping roster events — which is game policy. Whether a lobby shows arrivals, a bare count, or nothing until full differs per game.

It would also be mandatory wire surface on all 7 SDKs for every match, including ones with `min_players: 1` that have no lobby phase.

**No new catch-alls.** A crash is the better failure mode in a signalling library: supervision restarts and the operator sees it in minutes, where a swallowed message looks like a client bug and costs days. The existing catch-alls in `paused`/`finished` are exactly why the third instance was silent.

## Verification

`fmt --check`, `xref`, `dialyzer` clean. `eunit` 354/0. `ct --suite asobi_world_lobby_SUITE` 20/20. `elp eqwalize-all` 36, identical to `main`.

Three tests, each verified to **fail on the unfixed code** rather than pass vacuously — the match one cascades into cancelled tests and a non-zero exit, the world one fails outright. The first draft of the `finished` test was vacuous (cancel stops the process before reaching that state); it now drives a real `tick`-returns-finished transition via meck.

## Follow-ups worth tickets

Removing the `paused`/`finished` catch-alls (behaviour change, own review); a full cast/state audit table; and documenting that `game.broadcast` reaches a world server in world/zone contexts — `asobi_lua_api.erl:17` still describes it as "broadcast to all match players".