### PR TITLE
fix(ci): stop the nightly restoring a stale _build cache

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -50,10 +50,22 @@ jobs:
           path: _build
           # rebar.config is hashed too: test-profile deps (meck, proper) are not
           # written to rebar.lock, so a lock-only key never busts when they bump.
-          # The -v2- prefix retires the poisoned pre-OTP-29 caches (stale meck 0.9).
-          key: nightly-prop-v2-${{ hashFiles('rebar.config', 'rebar.lock') }}
-          restore-keys: |
-            nightly-prop-v2-
+          # The -v3- prefix retires the caches poisoned by the kura shadow below.
+          #
+          # No restore-keys, deliberately. A prefix fallback restores SOME cache
+          # even when rebar.lock changed, so _build arrives holding an older
+          # dep set. rebar3 then "Upgrading kura ..." and recompiles it, and
+          # that recompile picks up the kura bundled inside the rebar3_kura
+          # plugin instead of the dep, which declares kura_dialect with
+          # delete/2 where the dep implements delete/3:
+          #
+          #   Compiling _build/default/lib/kura/src/kura_dialect_pg.erl failed
+          #     undefined callback function delete/3 (behaviour 'kura_dialect')
+          #
+          # That failed every nightly from 2026-07-16 to 2026-07-20. A key miss
+          # costs one clean build; a stale restore costs a red nightly nobody
+          # can reproduce locally, because a local _build is already consistent.
+          key: nightly-prop-v3-${{ hashFiles('rebar.config', 'rebar.lock') }}
 
       - name: Run property tests at high numtests
         run: |


### PR DESCRIPTION
The property-test job has failed **every night since 2026-07-16** — #174, #175, #185, #190, #207. Five auto-opened issues, one cause.

## It was never a property regression

The job dies **3.4 seconds** after the command echoes, across four different SHAs (`9e74246`, `d7b7a77`, `d664fd5`, `eb24fa3`). Seven property modules at `PROPER_NUMTESTS: 1000`, several of which start a world per iteration, cannot run in 3 seconds. No property ever executed, so the shrunk counterexample everyone would go looking for does not exist.

The `prop_zone_snapshot_roundtrip` regression already tracked separately is also unaffected — it runs in a later CT step that is never reached.

## The actual error

Only visible in the raw job log via the API; `gh run view --log-failed` has the postgres service-container output interleaved over it, which is a large part of why this sat undiagnosed:

```
===> Verifying dependencies...
===> Upgrading kura v2.17.1
===> Upgrading kura_postgres v0.7.2
===> Compiling _build/default/lib/kura/src/kura_dialect_pg.erl failed
 11 │  -behaviour(kura_dialect).
    │   ╰── undefined callback function delete/3 (behaviour 'kura_dialect')
```

**"Upgrading" is the tell.** `rebar.lock` pins kura 2.17.1, so a clean build has nothing to upgrade. The `restore-keys: nightly-prop-v2-` fallback restores *some* cache with that prefix even when `rebar.lock` has changed, so `_build` arrives holding an older dep set. rebar3 upgrades it in place, and the recompile resolves `kura_dialect` against a different kura than the one `kura_dialect_pg` was compiled for. The dep's own `kura_dialect` declares `delete/2`; the behaviour in scope during that compile wanted `delete/3`.

## The fix

Drop `restore-keys`, bump the prefix to `-v3-` to retire the poisoned caches.

A key miss costs one clean build. A stale restore costs a red nightly that **nobody can reproduce locally**, because a local `_build` is already consistent — I ran the exact command locally and it passed in 1.4s. That asymmetry is why this ran five days without a diagnosis.

The `-v2-` prefix in the current key exists because this same class of bug bit once before with stale meck. Prefix bumps treat the symptom; removing the fallback treats the cause.

## Verification

The workflow has `workflow_dispatch`, so this is provable rather than a wait-and-see: I'll trigger a manual run once this is on `main` and confirm the job goes green before closing the five issues.

## Follow-up worth doing separately

The nightly opens a **new issue per failure** rather than reopening or commenting on an existing one. Five issues for one cause is noise that made the problem look bigger and newer than it was. Worth a dedupe on `.github/workflows/nightly.yml:110`.