### PR TITLE
fix(ci): one nightly issue per outage, not one per night

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -113,14 +113,41 @@ jobs:
       issues: write
     steps:
       - uses: actions/github-script@v9
+        env:
+          PROPERTY_RESULT: ${{ needs.property-soak.result }}
+          SOAK_RESULT: ${{ needs.soak.result }}
         with:
           script: |
-            const title = `Nightly failure: ${new Date().toISOString().slice(0,10)}`;
-            const url = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
-            await github.rest.issues.create({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              title,
-              body: `Nightly workflow failed.\n\nRun: ${url}\n\nThis issue is auto-opened by \`.github/workflows/nightly.yml\`.`,
-              labels: ['nightly-regression']
+            // One open issue per outage, not one per night. A recurring
+            // failure used to mint a fresh date-stamped issue every run, so
+            // a single cause (a stale _build cache, #211) accumulated five
+            // issues over five days and read as five separate regressions.
+            const { owner, repo } = context.repo;
+            const today = new Date().toISOString().slice(0, 10);
+            const url = `${context.serverUrl}/${owner}/${repo}/actions/runs/${context.runId}`;
+            const failed = [
+              ['Property Tests', process.env.PROPERTY_RESULT],
+              ['Soak', process.env.SOAK_RESULT]
+            ].filter(([, r]) => r === 'failure').map(([n]) => n).join(', ') || 'unknown job';
+
+            const open = await github.rest.issues.listForRepo({
+              owner, repo, state: 'open', labels: 'nightly-regression', per_page: 100
             });
+            // listForRepo returns PRs as issues; a labelled PR must not absorb the report.
+            const existing = open.data.find(i => !i.pull_request);
+
+            if (existing) {
+              await github.rest.issues.createComment({
+                owner, repo, issue_number: existing.number,
+                body: `Still failing on ${today} (${failed}).\n\nRun: ${url}`
+              });
+              core.notice(`Commented on #${existing.number} rather than opening a duplicate.`);
+            } else {
+              const created = await github.rest.issues.create({
+                owner, repo,
+                title: `Nightly failure: ${today}`,
+                body: `Nightly workflow failed (${failed}).\n\nRun: ${url}\n\nAuto-opened by \`.github/workflows/nightly.yml\`. While this stays open, subsequent failures are added as comments rather than new issues, so the comment count is how long the outage has run.`,
+                labels: ['nightly-regression']
+              });
+              core.notice(`Opened #${created.data.number}.`);
+            }


### PR DESCRIPTION
Follow-up from #211.

## The problem

The failure handler called `issues.create` unconditionally with a date-stamped title:

```js
const title = `Nightly failure: ${new Date().toISOString().slice(0,10)}`;
await github.rest.issues.create({ ... });
```

So every failing night minted a new issue by construction. One cause — the stale `_build` cache fixed in #211 — produced **five issues over five days** (#174, #175, #185, #190, #207). That made a four-day-old problem look like five separate regressions, and it's why it read as newer and larger than it was in triage.

## The fix

Look for an open `nightly-regression` issue. Comment on it if one exists, create only if none does. The comment count then tells you how long the outage has run, which is the number you actually want.

Two details that matter:

**PRs are filtered out.** `listForRepo` returns pull requests as issues, so a PR carrying the `nightly-regression` label would silently absorb every failure report. `!i.pull_request` guards that.

**The report now names the failing job.** All five of those issues said only "Nightly workflow failed", so triage started by opening the run just to find out which job it was. It now reads `Nightly workflow failed (Property Tests)`.

Behaviour when the issue is closed is unchanged: a later failure opens a fresh one, which is right — a closed issue means someone believed it fixed, and a new outage deserves a new thread.

## Verification

`workflow_dispatch` runs skip this job entirely (`if: failure() && github.event_name == 'schedule'`), so it cannot be exercised by a manual trigger. Instead I validated it directly: YAML parses, `node --check` on the extracted script passes, and I ran both branches against a stubbed `github` client —

- existing open issue → `commented on: 99 | created: null`
- only a labelled PR present → `commented on: null | created: true`

`needs.property-soak.result` and `needs.soak.result` match the actual job ids (`property-soak`, `soak`).