### PR TITLE
fix: hash the auth-cache key and stop caching the full player row (#168)

### DIFF
--- a/src/auth/asobi_auth_cache.erl
+++ b/src/auth/asobi_auth_cache.erl
@@ -57,7 +57,7 @@ resolve_token(_) ->
 -spec lookup(binary()) -> {ok, map()} | {error, term()}.
 lookup(Token) ->
     Now = erlang:system_time(millisecond),
-    case ets:lookup(?TABLE, Token) of
+    case ets:lookup(?TABLE, key(Token)) of
         [{_, {ok, Player}, ExpiresAt}] when ExpiresAt > Now ->
             asobi_telemetry:auth_cache_hit(positive),
             {ok, Player};
@@ -89,7 +89,7 @@ invalidate(Token) when is_binary(Token) ->
         undefined ->
             ok;
         _ ->
-            ets:delete(?TABLE, Token),
+            ets:delete(?TABLE, key(Token)),
             ok
     end;
 invalidate(_) ->
@@ -183,9 +183,24 @@ insert(Token, Value, ExpiresAt) ->
             %% silently skip; the real lookup will go to the DB.
             ok;
         _ ->
-            ets:insert(?TABLE, {Token, Value, ExpiresAt}),
+            ets:insert(?TABLE, {key(Token), Value, ExpiresAt}),
             ok
     end.
+
+-doc """
+Derive the ETS key from a token.
+
+The token itself is never stored - only its SHA-256. A crash dump,
+`observer`, or a hot-loaded debugger reading the table yields hashes, not
+usable session tokens. asobi is single-tenant so there is no untrusted Lua,
+but the dump/observer/debugger surface is real; this closes it (asobi#168).
+
+The stored `Value` holds the player map, which contains no token, so the
+row as a whole leaks nothing that resolves to a session.
+""".
+-spec key(binary()) -> binary().
+key(Token) ->
+    crypto:hash(sha256, Token).
 
 -spec schedule_sweep() -> reference().
 schedule_sweep() ->

--- a/src/auth/asobi_auth_cache.erl
+++ b/src/auth/asobi_auth_cache.erl
@@ -98,7 +98,17 @@ invalidate(_) ->
 -spec put_positive(binary(), map()) -> ok.
 put_positive(Token, Player) when is_binary(Token), is_map(Player) ->
     ExpiresAt = erlang:system_time(millisecond) + ttl_ms(),
-    insert(Token, {ok, Player}, ExpiresAt).
+    insert(Token, {ok, cacheable(Player)}, ExpiresAt).
+
+%% Cache only the fields the auth path consumes. The full player row from
+%% nova_auth_refresh carries `hashed_password` (pbkdf2); parking that in a
+%% `public` ETS table reopens the exact crash-dump/observer surface #168
+%% closes for tokens - a per-session offline-cracking target. Both consumers
+%% (asobi_ws_handler, asobi_auth_plugin) read only `id`; `is_banned/1` reads
+%% only `banned_at`.
+-spec cacheable(map()) -> map().
+cacheable(Player) ->
+    maps:with([id, banned_at], Player).
 
 -spec put_negative(binary()) -> ok.
 put_negative(Token) when is_binary(Token) ->
@@ -195,8 +205,9 @@ The token itself is never stored - only its SHA-256. A crash dump,
 usable session tokens. asobi is single-tenant so there is no untrusted Lua,
 but the dump/observer/debugger surface is real; this closes it (asobi#168).
 
-The stored `Value` holds the player map, which contains no token, so the
-row as a whole leaks nothing that resolves to a session.
+The stored `Value` holds only `id` and `banned_at` (see `cacheable/1`) -
+never the token, never `hashed_password` - so the row as a whole leaks
+nothing that resolves to a session or a credential.
 """.
 -spec key(binary()) -> binary().
 key(Token) ->

--- a/test/asobi_auth_cache_tests.erl
+++ b/test/asobi_auth_cache_tests.erl
@@ -8,7 +8,8 @@ cache_test_() ->
         {"invalidate clears the entry", fun invalidate_clears/0},
         {"expired entries are not returned", fun expired_skipped/0},
         {"banned players are rejected", fun banned_rejected/0},
-        {"active players (nil banned_at) pass", fun active_passes/0}
+        {"active players (nil banned_at) pass", fun active_passes/0},
+        {"the raw token never appears as an ETS key", fun token_not_stored_raw/0}
     ]}.
 
 setup() ->
@@ -57,6 +58,22 @@ active_passes() ->
     Player = #{id => ~"player-active", banned_at => nil},
     asobi_auth_cache:put_positive(Token, Player),
     ?assertEqual({ok, Player}, asobi_auth_cache:resolve_token(Token)).
+
+token_not_stored_raw() ->
+    %% asobi#168: a crash dump / observer read of the cache table must not
+    %% yield a usable session token. The key is the SHA-256 of the token, so
+    %% the raw token appears nowhere in the row.
+    Token = ~"tok-secret-value",
+    asobi_auth_cache:put_positive(Token, #{id => ~"p"}),
+    Rows = ets:tab2list(asobi_auth_cache_tab),
+    Keys = [K || {K, _V, _E} <- Rows],
+    ?assert(lists:member(crypto:hash(sha256, Token), Keys)),
+    ?assertNot(
+        lists:member(Token, Keys),
+        "the raw token is stored as an ETS key - a dump would leak it"
+    ),
+    %% And it is genuinely still resolvable through the hash chokepoint.
+    ?assertEqual({ok, #{id => ~"p"}}, asobi_auth_cache:resolve_token(Token)).
 
 %% A short-TTL setup confirms expired rows are not served.
 expired_skipped() ->

--- a/test/asobi_auth_cache_tests.erl
+++ b/test/asobi_auth_cache_tests.erl
@@ -9,7 +9,8 @@ cache_test_() ->
         {"expired entries are not returned", fun expired_skipped/0},
         {"banned players are rejected", fun banned_rejected/0},
         {"active players (nil banned_at) pass", fun active_passes/0},
-        {"the raw token never appears as an ETS key", fun token_not_stored_raw/0}
+        {"the raw token never appears as an ETS key", fun token_not_stored_raw/0},
+        {"hashed_password is never cached", fun hashed_password_not_cached/0}
     ]}.
 
 setup() ->
@@ -29,7 +30,10 @@ positive_hit() ->
     Token = ~"tok-positive",
     Player = #{id => ~"player-1", username => ~"alice"},
     asobi_auth_cache:put_positive(Token, Player),
-    ?assertEqual({ok, Player}, asobi_auth_cache:resolve_token(Token)).
+    %% The cache projects to the fields the auth path uses; `username` and any
+    %% other row field (incl. hashed_password) are dropped, so the id is what
+    %% comes back.
+    ?assertEqual({ok, #{id => ~"player-1"}}, asobi_auth_cache:resolve_token(Token)).
 
 negative_hit() ->
     Token = ~"tok-negative",
@@ -57,7 +61,9 @@ active_passes() ->
     Token = ~"tok-active",
     Player = #{id => ~"player-active", banned_at => nil},
     asobi_auth_cache:put_positive(Token, Player),
-    ?assertEqual({ok, Player}, asobi_auth_cache:resolve_token(Token)).
+    ?assertEqual(
+        {ok, #{id => ~"player-active", banned_at => nil}}, asobi_auth_cache:resolve_token(Token)
+    ).
 
 token_not_stored_raw() ->
     %% asobi#168: a crash dump / observer read of the cache table must not
@@ -74,6 +80,22 @@ token_not_stored_raw() ->
     ),
     %% And it is genuinely still resolvable through the hash chokepoint.
     ?assertEqual({ok, #{id => ~"p"}}, asobi_auth_cache:resolve_token(Token)).
+
+hashed_password_not_cached() ->
+    %% asobi#168: the full player row carries hashed_password (pbkdf2). Parking
+    %% it in the public cache table reopens the crash-dump surface for a
+    %% credential, so put_positive/2 projects the row before storing.
+    Token = ~"tok-with-secret",
+    Player = #{id => ~"p", banned_at => nil, hashed_password => ~"$pbkdf2-sha256$secret"},
+    asobi_auth_cache:put_positive(Token, Player),
+    %% Look up by the hashed key rather than assuming a single-row table -
+    %% the setup/0 table is shared across tests.
+    [{_, {ok, Cached}, _}] = ets:lookup(asobi_auth_cache_tab, crypto:hash(sha256, Token)),
+    ?assertNot(
+        maps:is_key(hashed_password, Cached),
+        "hashed_password is in the cached row - a dump would leak a crackable credential"
+    ),
+    ?assertEqual(#{id => ~"p", banned_at => nil}, Cached).
 
 %% A short-TTL setup confirms expired rows are not served.
 expired_skipped() ->


### PR DESCRIPTION
Closes #168 (M1 from the 2026-05-19 audit).

## The finding, as stated

`asobi_auth_cache` stored raw access tokens as ETS keys in a `public` named table. A crash dump, `observer`, or a hot-loaded debugger reading that table yields usable session tokens. asobi is single-tenant so there's no untrusted Lua, but that dump/observer/debugger surface is real.

## First cut: hash the key

A `key/1` chokepoint SHA-256s the token; `lookup`, `invalidate`, and `insert` all key on it. Tokens are `base64(strong_rand_bytes(32))` = 256-bit, so a bare unsalted hash is right — no rainbow table or brute force is feasible, and a salt would break the recompute-key-from-token requirement. The sweep match-spec is position-based, so unaffected.

## Second cut: the review caught the real hole

The `beam-security-reviewer` flagged that hashing the token was **only half the fix**. On a miss, the cache stored the full `nova_auth_refresh:get_user_by_access_token/2` player row — and `asobi_player:fields/0` includes a non-virtual `hashed_password` (pbkdf2, 600k iters). That full map went verbatim into the public table.

So the exact crash-dump surface #168 exists to close stayed **open for a per-session, offline-crackable credential**. The finding was relocated, not removed — and my own new docstring claimed *"the row as a whole leaks nothing that resolves to a session,"* which was false the moment you look past the token.

Fixed by projecting the row to `id` + `banned_at` at the `put_positive` chokepoint — the only fields the two consumers (`asobi_ws_handler:666`, `asobi_auth_plugin:13`) and `is_banned/1` actually read. Docstring corrected.

## Tests

`token_not_stored_raw` — the raw token appears nowhere as a key.
`hashed_password_not_cached` — a cached row is exactly `#{id, banned_at}`, no credential.
The existing round-trip tests updated to the projected shape (they now assert `#{id => ...}` comes back, which incidentally proves the projection is applied).

## Follow-up worth a separate check

The reviewer noted the cache is only as fresh as its ≤60s TTL, so **every revocation path** (logout, ban, `nova_auth_refresh:revoke_family`) must call `asobi_auth_cache:invalidate/1` or a revoked token stays valid for up to a minute. Only the one wired caller (`asobi_auth_tokens:42`) was in scope here. Filing separately.

## Verification

`fmt --check`, `xref`, `dialyzer` clean. `eunit` 356/0. `elp eqwalize-all` 36, identical to `main`.