### PR TITLE
fix: cap player metadata (#169) and generic-storage value (#170) size

### DIFF
--- a/src/controllers/asobi_storage_controller.erl
+++ b/src/controllers/asobi_storage_controller.erl
@@ -111,6 +111,22 @@ put_storage(
     WritePerm0 = maps:get(~"write_perm", Params, ~"owner"),
     ReadPerm = ensure_binary_perm(ReadPerm0),
     WritePerm = ensure_binary_perm(WritePerm0),
+    %% M5: the generic-storage path had no per-row cap, only the 1 MiB global
+    %% body cap. Mirror the save-data limit so one row cannot persist an
+    %% arbitrary blob under the global ceiling.
+    case data_within_limit(Value) of
+        false ->
+            {json, 413, #{}, #{error => ~"storage_value_too_large"}};
+        true ->
+            put_storage_checked(Col, Key, PlayerId, Value, ReadPerm, WritePerm)
+    end;
+put_storage(_Req) ->
+    {status, 400}.
+
+-spec put_storage_checked(
+    dynamic(), dynamic(), dynamic(), dynamic(), binary(), binary()
+) -> {json, map()} | {json, integer(), map(), map()} | {status, integer()}.
+put_storage_checked(Col, Key, PlayerId, Value, ReadPerm, WritePerm) ->
     case valid_perm(ReadPerm) andalso valid_perm(WritePerm) of
         false ->
             {json, 400, #{}, #{error => ~"invalid_perm"}};

--- a/src/players/asobi_player.erl
+++ b/src/players/asobi_player.erl
@@ -51,7 +51,13 @@ registration_changeset(Data, Params) ->
     CS2 = kura_changeset:validate_length(CS1, username, [{min, 3}, {max, 32}]),
     CS3 = kura_changeset:validate_format(CS2, username, ~"^[a-zA-Z0-9_-]+$"),
     CS4 = kura_changeset:validate_length(CS3, password, [{min, 8}, {max, 128}]),
-    maybe_hash_password(CS4).
+    %% M3 (#169): registration casts metadata too. No in-tree caller feeds it,
+    %% but registration_changeset is a library entry point (asobi_engine,
+    %% self-hosters) on the unauthenticated path, so the cap travels with the
+    %% schema rather than the controller. Placed before maybe_hash_password so
+    %% an oversized blob fails the changeset and skips the pbkdf2 cost (#157).
+    CS5 = kura_changeset:validate_change(CS4, metadata, fun metadata_within_limit/1),
+    maybe_hash_password(CS5).
 
 %% Only pay the pbkdf2 cost for a changeset that will actually be inserted -
 %% hashing an invalid one is wasted work and an unauthenticated-DoS lever (#157).

--- a/src/players/asobi_player.erl
+++ b/src/players/asobi_player.erl
@@ -75,7 +75,23 @@ hash_password(CS) ->
             kura_changeset:put_change(CS, hashed_password, Hashed)
     end.
 
+-define(MAX_METADATA_BYTES, 16384).
+
 -spec update_changeset(map(), map()) -> #kura_changeset{}.
 update_changeset(Data, Params) ->
     CS = kura_changeset:cast(?MODULE, Data, Params, [display_name, avatar_url, metadata]),
-    kura_changeset:validate_length(CS, display_name, [{max, 64}]).
+    CS1 = kura_changeset:validate_length(CS, display_name, [{max, 64}]),
+    %% M3: `metadata` is unbounded jsonb - any authenticated player could
+    %% PUT a huge blob and persist it. Cap the encoded size. Only runs when
+    %% metadata is in the change; the global body cap is 1 MiB, this bounds
+    %% the per-row blob well under it.
+    kura_changeset:validate_change(CS1, metadata, fun metadata_within_limit/1).
+
+-spec metadata_within_limit(dynamic()) -> ok | {error, binary()}.
+metadata_within_limit(Metadata) ->
+    try iolist_size(json:encode(Metadata)) =< ?MAX_METADATA_BYTES of
+        true -> ok;
+        false -> {error, ~"must be 16 KB or less"}
+    catch
+        _:_ -> {error, ~"is not encodable"}
+    end.

--- a/test/asobi_player_tests.erl
+++ b/test/asobi_player_tests.erl
@@ -18,3 +18,25 @@ valid_changeset_hashes_password_test() ->
     }),
     ?assert(CS#kura_changeset.valid),
     ?assertMatch(H when is_binary(H), kura_changeset:get_change(CS, hashed_password)).
+
+%% M3 (#169): metadata is unbounded jsonb; the changeset now caps the encoded
+%% size so a PUT cannot persist an arbitrary blob under the 1 MiB body cap.
+metadata_within_limit_passes_test() ->
+    CS = asobi_player:update_changeset(#{}, #{~"metadata" => #{~"level" => 7}}),
+    ?assert(CS#kura_changeset.valid).
+
+metadata_over_limit_is_rejected_test() ->
+    Big = #{~"blob" => binary:copy(~"x", 20000)},
+    CS = asobi_player:update_changeset(#{}, #{~"metadata" => Big}),
+    ?assertNot(CS#kura_changeset.valid).
+
+metadata_absent_is_not_checked_test() ->
+    %% A profile update that does not touch metadata must not fail the cap.
+    CS = asobi_player:update_changeset(#{}, #{~"display_name" => ~"Alice"}),
+    ?assert(CS#kura_changeset.valid).
+
+metadata_at_the_limit_passes_test() ->
+    %% ~16 KB of encodable content sits under the 16384-byte ceiling.
+    Ok = #{~"blob" => binary:copy(~"x", 16000)},
+    CS = asobi_player:update_changeset(#{}, #{~"metadata" => Ok}),
+    ?assert(CS#kura_changeset.valid).

--- a/test/asobi_player_tests.erl
+++ b/test/asobi_player_tests.erl
@@ -40,3 +40,17 @@ metadata_at_the_limit_passes_test() ->
     Ok = #{~"blob" => binary:copy(~"x", 16000)},
     CS = asobi_player:update_changeset(#{}, #{~"metadata" => Ok}),
     ?assert(CS#kura_changeset.valid).
+
+%% The cap travels with the schema: registration_changeset caps metadata too,
+%% and an oversized blob must fail before the pbkdf2 hash is computed (#157).
+registration_metadata_over_limit_is_rejected_test() ->
+    Big = #{~"blob" => binary:copy(~"x", 20000)},
+    CS = asobi_player:registration_changeset(#{}, #{
+        ~"username" => ~"validname", ~"password" => ~"longenough1", ~"metadata" => Big
+    }),
+    ?assertNot(CS#kura_changeset.valid),
+    ?assertEqual(
+        undefined,
+        kura_changeset:get_change(CS, hashed_password),
+        "an oversized-metadata registration must not pay the pbkdf2 cost"
+    ).

--- a/test/asobi_storage_SUITE.erl
+++ b/test/asobi_storage_SUITE.erl
@@ -12,6 +12,7 @@
     save_version_conflict/1,
     %% Generic storage
     put_storage/1,
+    put_storage_rejects_oversized_value/1,
     get_storage/1,
     list_storage/1,
     list_storage_filters_owner_perm/1,
@@ -29,6 +30,7 @@ groups() ->
         ]},
         {generic_storage, [sequence], [
             put_storage,
+            put_storage_rejects_oversized_value,
             get_storage,
             list_storage,
             list_storage_filters_owner_perm,
@@ -149,6 +151,22 @@ put_storage(Config) ->
     ?assertStatus(200, Resp),
     Body = nova_test:json(Resp),
     ?assertMatch(#{~"version" := 1, ~"collection" := ~"settings"}, Body),
+    Config.
+
+%% M5 (#169/#170): the generic-storage path now mirrors the save-data cap.
+%% The 413 is returned before any DB query, so this exercises the cap itself.
+put_storage_rejects_oversized_value(Config) ->
+    Big = binary:copy(~"x", 300000),
+    {ok, Resp} = nova_test:put(
+        "/api/v1/storage/settings/huge",
+        #{
+            headers => auth(Config, player1),
+            json => #{~"value" => #{~"blob" => Big}}
+        },
+        Config
+    ),
+    ?assertStatus(413, Resp),
+    ?assertMatch(#{~"error" := ~"storage_value_too_large"}, nova_test:json(Resp)),
     Config.
 
 get_storage(Config) ->


### PR DESCRIPTION
Closes #169 and #170 (M3 + M5 from the 2026-05-19 audit). Both are per-row size caps: the 1 MiB global body cap (H2) already exists, these bound the persisted blob well under it.

## #169 — player metadata

`metadata` is unbounded jsonb, cast in `update_changeset/2` with no size check, so any authenticated player could `PUT /api/v1/players/:id` a huge blob and persist it. Adds a `validate_change` on the encoded metadata, capped at 16 KB, surfacing as **422** (kura rejects the invalid changeset before the write). Only runs when metadata is in the change.

**Security review caught an asymmetry:** the sibling `registration_changeset/2` casts `metadata` too, uncapped. No in-tree caller feeds it, but it's an exported library entry point (`asobi_engine`, self-hosters) on the *unauthenticated* registration path — a consumer wiring signup metadata would reintroduce #169 with the cap silently absent. Capped there too, before `maybe_hash_password` so an oversized blob fails the changeset and skips the pbkdf2 cost (ties into #157).

## #170 — generic storage

`put_storage/1` had no per-row cap on `value`, unlike `put_save/1` which already gates on `data_within_limit/1`. Routes the value through the same helper (256 KB), returning **413 before any DB query**. Split `put_storage/1` into the cap check plus `put_storage_checked/6` to keep the happy path flat — the review confirmed all four DB branches and the perm-check are preserved verbatim, and the new `_Req -> {status, 400}` fallback replaces a prior `function_clause` → 500 on a malformed request (which was itself a small amplification lever).

## Review verdict

No High or Medium; both caps complete for every HTTP-reachable path. It also confirmed the things I was unsure about: no bypass write path, the `json:encode`-to-measure cost is negligible (body already ≤1 MiB and decoded), the try/catch is genuinely fail-closed, and encoded size is the right proxy for jsonb cost with no DB off-by-one.

## Follow-ups filed

- #216 — the same unbounded-jsonb-`metadata` pattern recurs across ~10 other schemas; needs a deliberate client-writable-vs-server-only pass, and a shared `within_limit` helper once there are three copies of the idiom.

## Tests

`metadata` over/under/at-limit/absent and registration-over-limit-skips-hashing (pure changeset, eunit). Oversized-storage 413 (CT, exercises the pre-DB cap — runs in CI, needs Docker Postgres).

`fmt --check`, `xref`, `dialyzer` clean. `eunit` 361/0. `elp eqwalize-all` 36, identical to `main`.