### PR TITLE
feat: opt-in WebSocket Origin allowlist (#160)

### DIFF
--- a/guides/configuration.md
+++ b/guides/configuration.md
@@ -166,6 +166,18 @@ When set, a browser upgrade whose `Origin` is not listed is closed with
 `1008 origin_rejected` and emits `[asobi, ws, origin_rejected]`. Leaving it
 unset (or empty) keeps the open default.
 
+Match is **exact** against the value the browser sends, so copy that verbatim:
+scheme + host + non-default port only — **no trailing slash, no path, all
+lowercase, punycode (`xn--...`) for internationalised domains**, and each
+entry a binary (`~"..."`), not a string. A trailing slash, an explicit `:443`,
+or an uppercase host silently matches nothing and locks out real users. A
+value that is not a list of binaries is treated as a misconfiguration and
+**fails closed** (rejects everything) with a logged error, rather than
+silently reverting to allow-all.
+
+This is independent of [CORS](#cors): CORS governs XHR/fetch, not the WebSocket
+handshake, so configuring one does not affect the other.
+
 Native clients (Defold, Unity, Unreal, etc.) send no `Origin` header and are
 never affected — an absent `Origin` always passes, since a non-browser client
 cannot be a CSWSH vector. The socket also does nothing until it presents a

--- a/guides/configuration.md
+++ b/guides/configuration.md
@@ -147,6 +147,31 @@ Each route group has its own per-IP default (window in ms): `auth` 5/1000,
 global (not per-IP) guest-create bound `guest_global` 100/1000. Override any
 group under `rate_limits`; unset groups keep their default.
 
+## WebSocket Origin allowlist
+
+By default the `/ws` upgrade accepts any `Origin` — web builds are served from
+arbitrary studio and hosting domains, so a strict default would break them.
+
+To harden a deployment against cross-site WebSocket hijacking, set an
+allowlist:
+
+```erlang
+{ws_allowed_origins, [
+    ~"https://play.yourgame.com",
+    ~"https://yourstudio.itch.io"
+]}
+```
+
+When set, a browser upgrade whose `Origin` is not listed is closed with
+`1008 origin_rejected` and emits `[asobi, ws, origin_rejected]`. Leaving it
+unset (or empty) keeps the open default.
+
+Native clients (Defold, Unity, Unreal, etc.) send no `Origin` header and are
+never affected — an absent `Origin` always passes, since a non-browser client
+cannot be a CSWSH vector. The socket also does nothing until it presents a
+valid token in the first `session.connect` frame, so this is defence in depth,
+not the primary auth gate.
+
 ## CORS
 
 CORS is handled by `nova_cors_plugin` in the Nova plugin chain — configure

--- a/src/asobi_telemetry.erl
+++ b/src/asobi_telemetry.erl
@@ -13,7 +13,8 @@
     ws_message_out/1,
     ws_connect_rate_limited/1,
     join_rate_limited/1,
-    ws_idle_auth_timeout/0
+    ws_idle_auth_timeout/0,
+    ws_origin_rejected/0
 ]).
 -export([anticheat_violation/3]).
 -export([economy_transaction/4, store_purchase/3]).
@@ -183,6 +184,11 @@ ws_connect_rate_limited(PeerIp) ->
 -spec ws_idle_auth_timeout() -> ok.
 ws_idle_auth_timeout() ->
     telemetry:execute([asobi, ws, idle_auth_timeout], #{count => 1}, #{}).
+
+-doc "#160: a WS upgrade was rejected by the Origin allowlist.".
+-spec ws_origin_rejected() -> ok.
+ws_origin_rejected() ->
+    telemetry:execute([asobi, ws, origin_rejected], #{count => 1}, #{}).
 
 -spec anticheat_violation(binary(), atom(), map()) -> ok.
 anticheat_violation(PlayerId, Type, Details) ->

--- a/src/ws/asobi_ws_handler.erl
+++ b/src/ws/asobi_ws_handler.erl
@@ -2,6 +2,8 @@
 -behaviour(nova_websocket).
 
 -export([init/1, websocket_init/1, websocket_handle/2, websocket_info/2, terminate/3]).
+%% Exported for tests (pure allowlist predicate), mirroring deployable/1.
+-export([origin_allowed/1]).
 
 -define(WS_MSG_LIMIT, 60).
 -define(WS_MSG_WINDOW_MS, 1000).
@@ -18,26 +20,53 @@
 
 -spec init(map()) -> {ok, map()}.
 init(#{req := Req} = State) ->
-    %% Capture peer IP before the upgrade so websocket_init can run the
-    %% per-IP connect-rate check without re-parsing the req.
+    %% Capture peer IP and Origin before the upgrade so websocket_init can run
+    %% the per-IP connect-rate check and the Origin allowlist without
+    %% re-parsing the req (websocket_init runs post-upgrade, no req available).
     PeerIp = asobi_peer:client_ip(Req),
-    {ok, State#{session => undefined, peer_ip => PeerIp}};
+    Origin = cowboy_req:header(~"origin", Req, undefined),
+    {ok, State#{session => undefined, peer_ip => PeerIp, origin => Origin}};
 init(State) ->
-    {ok, State#{session => undefined, peer_ip => ~"unknown"}}.
+    {ok, State#{session => undefined, peer_ip => ~"unknown", origin => undefined}}.
 
 -spec websocket_init(map()) -> {ok, map()} | {reply, {close, 1008, binary()}, map()}.
 websocket_init(#{peer_ip := PeerIp} = State) ->
-    case seki:check(asobi_ws_connect_limiter, PeerIp) of
-        {allow, _} ->
-            start_authenticated_session(State);
-        {deny, _} ->
-            asobi_telemetry:ws_connect_rate_limited(PeerIp),
-            {reply, {close, 1008, ~"rate_limited"}, State}
+    %% Origin first: a disallowed cross-origin page is rejected before it can
+    %% even spend a connect-rate token. Native clients send no Origin and pass.
+    case origin_allowed(maps:get(origin, State, undefined)) of
+        false ->
+            asobi_telemetry:ws_origin_rejected(),
+            {reply, {close, 1008, ~"origin_rejected"}, State};
+        true ->
+            case seki:check(asobi_ws_connect_limiter, PeerIp) of
+                {allow, _} ->
+                    start_authenticated_session(State);
+                {deny, _} ->
+                    asobi_telemetry:ws_connect_rate_limited(PeerIp),
+                    {reply, {close, 1008, ~"rate_limited"}, State}
+            end
     end;
 websocket_init(State) ->
     %% No peer_ip — init/1 ran in a path without a req map. Skip the
     %% connect-rate gate but still install the idle-auth timer.
     start_authenticated_session(State).
+
+%% CSWSH defence-in-depth (#160). Opt-in and default-open, matching ADR 0002:
+%% with no `ws_allowed_origins` configured every Origin passes (today's
+%% behaviour). When an operator sets an allowlist, only those browser Origins
+%% may open the socket. A missing Origin header is a non-browser client
+%% (Defold/Unity native etc.) - it cannot be a CSWSH vector, so it always
+%% passes regardless of the allowlist.
+-spec origin_allowed(binary() | undefined) -> boolean().
+origin_allowed(undefined) ->
+    true;
+origin_allowed(Origin) when is_binary(Origin) ->
+    case application:get_env(asobi, ws_allowed_origins) of
+        {ok, Allowed} when is_list(Allowed), Allowed =/= [] ->
+            lists:member(Origin, Allowed);
+        _ ->
+            true
+    end.
 
 start_authenticated_session(State) ->
     asobi_telemetry:ws_connected(),

--- a/src/ws/asobi_ws_handler.erl
+++ b/src/ws/asobi_ws_handler.erl
@@ -31,19 +31,22 @@ init(State) ->
 
 -spec websocket_init(map()) -> {ok, map()} | {reply, {close, 1008, binary()}, map()}.
 websocket_init(#{peer_ip := PeerIp} = State) ->
-    %% Origin first: a disallowed cross-origin page is rejected before it can
-    %% even spend a connect-rate token. Native clients send no Origin and pass.
-    case origin_allowed(maps:get(origin, State, undefined)) of
-        false ->
-            asobi_telemetry:ws_origin_rejected(),
-            {reply, {close, 1008, ~"origin_rejected"}, State};
-        true ->
-            case seki:check(asobi_ws_connect_limiter, PeerIp) of
-                {allow, _} ->
-                    start_authenticated_session(State);
-                {deny, _} ->
-                    asobi_telemetry:ws_connect_rate_limited(PeerIp),
-                    {reply, {close, 1008, ~"rate_limited"}, State}
+    %% Per-IP connect limiter FIRST: spending a token IS the flood defence, so
+    %% every connect must count against the budget, including one we are about
+    %% to reject on Origin. Checking Origin first would let an attacker who
+    %% sets any disallowed Origin spawn ws processes without ever touching the
+    %% limiter - each connect upgrades, emits telemetry, and closes, unbounded.
+    case seki:check(asobi_ws_connect_limiter, PeerIp) of
+        {deny, _} ->
+            asobi_telemetry:ws_connect_rate_limited(PeerIp),
+            {reply, {close, 1008, ~"rate_limited"}, State};
+        {allow, _} ->
+            case origin_allowed(maps:get(origin, State, undefined)) of
+                false ->
+                    asobi_telemetry:ws_origin_rejected(),
+                    {reply, {close, 1008, ~"origin_rejected"}, State};
+                true ->
+                    start_authenticated_session(State)
             end
     end;
 websocket_init(State) ->
@@ -62,11 +65,30 @@ origin_allowed(undefined) ->
     true;
 origin_allowed(Origin) when is_binary(Origin) ->
     case application:get_env(asobi, ws_allowed_origins) of
-        {ok, Allowed} when is_list(Allowed), Allowed =/= [] ->
-            lists:member(Origin, Allowed);
-        _ ->
-            true
+        undefined ->
+            true;
+        {ok, []} ->
+            true;
+        {ok, Allowed} when is_list(Allowed) ->
+            %% Set-but-malformed (e.g. a bare binary instead of a list of
+            %% binaries) must fail CLOSED and loud, not silently allow-all -
+            %% otherwise a dropped-bracket typo nullifies the control while the
+            %% operator believes the socket is locked down.
+            case lists:all(fun is_binary/1, Allowed) of
+                true -> lists:member(Origin, Allowed);
+                false -> misconfigured_origins(Allowed)
+            end;
+        {ok, Other} ->
+            misconfigured_origins(Other)
     end.
+
+-spec misconfigured_origins(term()) -> false.
+misconfigured_origins(Value) ->
+    logger:error(#{
+        msg => ~"ws_allowed_origins must be a list of binaries; failing closed",
+        value => Value
+    }),
+    false.
 
 start_authenticated_session(State) ->
     asobi_telemetry:ws_connected(),

--- a/test/asobi_ws_origin_tests.erl
+++ b/test/asobi_ws_origin_tests.erl
@@ -19,7 +19,10 @@ origin_test_() ->
         {"empty allowlist is treated as unset (default-open)", fun empty_is_open/0},
         {"a configured allowlist admits a listed origin", fun listed_passes/0},
         {"a configured allowlist rejects an unlisted origin", fun unlisted_rejected/0},
-        {"a missing Origin (native client) always passes", fun native_passes/0}
+        {"a missing Origin (native client) always passes", fun native_passes/0},
+        {"a malformed allowlist (bare binary, not a list) fails closed",
+            fun malformed_fails_closed/0},
+        {"a non-list term fails closed", fun non_list_fails_closed/0}
     ]}.
 
 default_open() ->
@@ -43,3 +46,15 @@ native_passes() ->
     %% a non-browser client and cannot be a CSWSH vector.
     application:set_env(asobi, ws_allowed_origins, [~"https://game.studio"]),
     ?assert(asobi_ws_handler:origin_allowed(undefined)).
+
+malformed_fails_closed() ->
+    %% The dropped-bracket typo: a bare binary instead of a list. The old code
+    %% fell through to allow-all, silently disabling the control. It must now
+    %% reject rather than quietly open the socket to every origin.
+    application:set_env(asobi, ws_allowed_origins, ~"https://game.studio"),
+    ?assertNot(asobi_ws_handler:origin_allowed(~"https://game.studio")),
+    ?assertNot(asobi_ws_handler:origin_allowed(~"https://evil.example")).
+
+non_list_fails_closed() ->
+    application:set_env(asobi, ws_allowed_origins, all),
+    ?assertNot(asobi_ws_handler:origin_allowed(~"https://anything.example")).

--- a/test/asobi_ws_origin_tests.erl
+++ b/test/asobi_ws_origin_tests.erl
@@ -1,0 +1,45 @@
+-module(asobi_ws_origin_tests).
+-include_lib("eunit/include/eunit.hrl").
+
+%% #160: opt-in Origin allowlist for the /ws upgrade (CSWSH defence-in-depth).
+%% Default-open per ADR 0002; a configured allowlist gates browser Origins;
+%% native clients (no Origin header) always pass.
+
+setup() ->
+    application:unset_env(asobi, ws_allowed_origins),
+    ok.
+
+cleanup(_) ->
+    application:unset_env(asobi, ws_allowed_origins),
+    ok.
+
+origin_test_() ->
+    {setup, fun setup/0, fun cleanup/1, [
+        {"no allowlist configured: every origin passes (default-open)", fun default_open/0},
+        {"empty allowlist is treated as unset (default-open)", fun empty_is_open/0},
+        {"a configured allowlist admits a listed origin", fun listed_passes/0},
+        {"a configured allowlist rejects an unlisted origin", fun unlisted_rejected/0},
+        {"a missing Origin (native client) always passes", fun native_passes/0}
+    ]}.
+
+default_open() ->
+    application:unset_env(asobi, ws_allowed_origins),
+    ?assert(asobi_ws_handler:origin_allowed(~"https://evil.example")).
+
+empty_is_open() ->
+    application:set_env(asobi, ws_allowed_origins, []),
+    ?assert(asobi_ws_handler:origin_allowed(~"https://anything.example")).
+
+listed_passes() ->
+    application:set_env(asobi, ws_allowed_origins, [~"https://game.studio", ~"https://itch.io"]),
+    ?assert(asobi_ws_handler:origin_allowed(~"https://itch.io")).
+
+unlisted_rejected() ->
+    application:set_env(asobi, ws_allowed_origins, [~"https://game.studio"]),
+    ?assertNot(asobi_ws_handler:origin_allowed(~"https://evil.example")).
+
+native_passes() ->
+    %% Even with a strict allowlist, a client that sends no Origin header is
+    %% a non-browser client and cannot be a CSWSH vector.
+    application:set_env(asobi, ws_allowed_origins, [~"https://game.studio"]),
+    ?assert(asobi_ws_handler:origin_allowed(undefined)).


### PR DESCRIPTION
Closes #160. Opt-in CSWSH defence-in-depth for the `/ws` upgrade.

## The gap and its honest severity

The `/ws` upgrade did no `Origin` check, so any browser page could open the socket. The review confirmed the ceiling on severity: **auth is a bearer token in the first `session.connect` frame, not an ambient cookie**, so classic CSWSH isn't exploitable — a cross-origin page can open the socket but can't produce a valid token. This is defence-in-depth and a connect-flood foothold, not a session-riding hole. Documented as such.

## The control

`ws_allowed_origins`, opt-in and default-open per ADR 0002. Unset or `[]` accepts every origin (today's behaviour), so web builds on arbitrary studio/itch.io domains keep working. When set, a browser upgrade whose `Origin` isn't listed is closed `1008 origin_rejected` with `[asobi, ws, origin_rejected]` telemetry.

**A missing `Origin` always passes** — native clients (Defold/Unity/Unreal) send none, and a browser cannot suppress it, so a strict allowlist never breaks non-browser SDKs and a real cross-origin attack always carries a gated Origin.

## Two Mediums the review caught (fixed here)

**M1 — fail-open on a plausible typo.** A dropped-bracket `{ws_allowed_origins, ~"one-origin"}` (a bare binary, not a list) fell through to allow-all, silently nullifying the control while the operator believed the socket was locked. Now: unset/`[]` stay open by design, but a non-list or a list with a non-binary **fails closed and logs loud**.

**M2 — limiter bypass, and my reasoning was backwards.** The Origin check ran *before* the per-IP connect limiter, so an attacker sending any disallowed Origin spawned a ws process and emitted telemetry on every connect without ever spending a rate token — the flood control became a no-op on exactly the hardened deployments. Spending the token *is* the defence; reordered so the limiter runs first.

Plus L1: the doc now spells out the exact Origin form operators must copy (no trailing slash/path, lowercase, non-default ports only, punycode, binaries) and that the allowlist is independent of CORS.

## Not done (noted by review, deliberately out of scope)

A pre-upgrade HTTP 403 (Nova plugin) would avoid the process spawn entirely and is a "real" access control rather than a post-101 close. Low priority given the token model makes the briefly-open socket harmless; worth a follow-up only if this ever needs to be a primary gate.

## Verification

`fmt --check`, `xref`, `dialyzer`, `ex_doc` clean. `eunit` 368/0 — the origin suite covers default-open, empty-open, listed-passes, unlisted-rejected, native-passes, and both fail-closed cases. `elp eqwalize-all` 36, identical to `main`.

Process note: the first commit landed on `main` by mistake (forgot the branch step); the push failed on the branch-name mismatch, and I reset `main` and moved it onto this branch. `origin/main` was never touched.