### PR TITLE
fix: verify TLS peer on outbound Steam/Google calls (#171)

### DIFF
--- a/src/auth/asobi_iap.erl
+++ b/src/auth/asobi_iap.erl
@@ -265,7 +265,7 @@ do_verify_google(PackageName, ProductId, PurchaseToken) ->
                 httpc:request(
                     get,
                     {binary_to_list(Url), Headers},
-                    [{timeout, 10000}],
+                    asobi_tls_client:http_options(),
                     [{body_format, binary}]
                 )
             of
@@ -379,7 +379,7 @@ exchange_jwt_for_token(Jwt) ->
         httpc:request(
             post,
             {Url, [], ContentType, Body},
-            [{timeout, 10000}],
+            asobi_tls_client:http_options(),
             [{body_format, binary}]
         )
     of

--- a/src/auth/asobi_steam.erl
+++ b/src/auth/asobi_steam.erl
@@ -66,7 +66,9 @@ do_validate_ticket(ApiKey, AppId, Ticket) ->
         identity_param()
     ]),
     case
-        httpc:request(get, {binary_to_list(Url), []}, [{timeout, 10000}], [{body_format, binary}])
+        httpc:request(
+            get, {binary_to_list(Url), []}, asobi_tls_client:http_options(), [{body_format, binary}]
+        )
     of
         {ok, {{_, 200, _}, _, Body}} when is_binary(Body) ->
             parse_auth_response(Body);
@@ -134,7 +136,9 @@ fetch_player_summary(SteamId) ->
             ]),
             case
                 httpc:request(
-                    get, {binary_to_list(Url), []}, [{timeout, 10000}], [{body_format, binary}]
+                    get, {binary_to_list(Url), []}, asobi_tls_client:http_options(), [
+                        {body_format, binary}
+                    ]
                 )
             of
                 {ok, {{_, 200, _}, _, Body}} when is_binary(Body) ->

--- a/src/auth/asobi_tls_client.erl
+++ b/src/auth/asobi_tls_client.erl
@@ -1,0 +1,54 @@
+-module(asobi_tls_client).
+
+-export([http_options/0, http_options/1, ssl_options/0]).
+
+-define(DEFAULT_TIMEOUT, 10000).
+-define(CONNECT_TIMEOUT, 5000).
+
+%% Explicit TLS options for outbound calls to fixed high-trust endpoints
+%% (Steam, Google). Without these, httpc falls back to ssl defaults that on
+%% older OTP do not verify the peer, so a MITM or mis-issued cert would
+%% silently validate a forged receipt/token. We verify against the OS trust
+%% store and enforce the https hostname check; leaf/CA pinning is deliberately
+%% omitted because these providers rotate certificates and a stale pin is a
+%% self-inflicted outage.
+-type http_option() ::
+    {timeout, timeout()} | {connect_timeout, timeout()} | {ssl, [ssl:tls_option()]}.
+
+-spec http_options() -> [http_option()].
+http_options() ->
+    http_options(?DEFAULT_TIMEOUT).
+
+-spec http_options(timeout()) -> [http_option()].
+http_options(Timeout) ->
+    [
+        {timeout, Timeout},
+        {connect_timeout, ?CONNECT_TIMEOUT},
+        {ssl, ssl_options()}
+    ].
+
+-spec ssl_options() -> [ssl:tls_option()].
+ssl_options() ->
+    [
+        {verify, verify_peer},
+        {cacerts, cacerts()},
+        {depth, 4},
+        {versions, ['tlsv1.3', 'tlsv1.2']},
+        {customize_hostname_check, [
+            {match_fun, public_key:pkix_verify_hostname_match_fun(https)}
+        ]}
+    ].
+
+%% cacerts_get/0 re-parses the OS trust store on every call and raises when the
+%% image ships without one. Load once and cache so an auth request neither pays
+%% the re-parse nor crashes mid-flight on a misconfigured host.
+-spec cacerts() -> dynamic().
+cacerts() ->
+    case persistent_term:get({?MODULE, cacerts}, undefined) of
+        undefined ->
+            Certs = public_key:cacerts_get(),
+            persistent_term:put({?MODULE, cacerts}, Certs),
+            Certs;
+        Certs when is_list(Certs) ->
+            Certs
+    end.

--- a/test/asobi_steam_tests.erl
+++ b/test/asobi_steam_tests.erl
@@ -5,7 +5,8 @@ steam_test_() ->
     {foreach, fun setup/0, fun cleanup/1, [
         fun ok_ticket_returns_claims/0,
         fun publisher_banned_rejected/0,
-        fun identity_param_included_when_configured/0
+        fun identity_param_included_when_configured/0,
+        fun outbound_call_sets_tls_options/0
     ]}.
 
 setup() ->
@@ -43,6 +44,22 @@ identity_param_included_when_configured() ->
     _ = asobi_steam:validate_ticket(~"deadbeef"),
     receive
         {url, Url} -> ?assert(binary:match(Url, ~"&identity=asobi-prod") =/= nomatch)
+    after 1000 -> ?assert(false)
+    end.
+
+%% The outbound call must go through asobi_tls_client, so verify_peer TLS
+%% options reach httpc rather than the fail-open default (#171).
+outbound_call_sets_tls_options() ->
+    Self = self(),
+    meck:expect(httpc, request, fun(get, {_Url, _H}, Opts, _P) ->
+        Self ! {opts, Opts},
+        {ok, {{"HTTP/1.1", 200, "OK"}, [], auth_body(#{~"result" => ~"OK", ~"steamid" => ~"1"})}}
+    end),
+    _ = asobi_steam:validate_ticket(~"deadbeef"),
+    receive
+        {opts, Opts} ->
+            {ssl, Ssl} = lists:keyfind(ssl, 1, Opts),
+            ?assertEqual(verify_peer, proplists:get_value(verify, Ssl))
     after 1000 -> ?assert(false)
     end.
 

--- a/test/asobi_tls_client_tests.erl
+++ b/test/asobi_tls_client_tests.erl
@@ -1,0 +1,31 @@
+-module(asobi_tls_client_tests).
+
+-include_lib("eunit/include/eunit.hrl").
+
+verifies_peer_test() ->
+    Ssl = asobi_tls_client:ssl_options(),
+    ?assertEqual(verify_peer, proplists:get_value(verify, Ssl)).
+
+uses_system_trust_store_test() ->
+    Ssl = asobi_tls_client:ssl_options(),
+    CaCerts = proplists:get_value(cacerts, Ssl),
+    ?assert(is_list(CaCerts)),
+    ?assert(length(CaCerts) > 0).
+
+checks_hostname_test() ->
+    Ssl = asobi_tls_client:ssl_options(),
+    Customize = proplists:get_value(customize_hostname_check, Ssl),
+    ?assertMatch([{match_fun, F}] when is_function(F, 2), Customize).
+
+restricts_to_modern_tls_test() ->
+    Ssl = asobi_tls_client:ssl_options(),
+    ?assertEqual(['tlsv1.3', 'tlsv1.2'], proplists:get_value(versions, Ssl)).
+
+http_options_carry_ssl_test() ->
+    Opts = asobi_tls_client:http_options(),
+    ?assertEqual(asobi_tls_client:ssl_options(), proplists:get_value(ssl, Opts)),
+    ?assertEqual(10000, proplists:get_value(timeout, Opts)),
+    ?assert(is_integer(proplists:get_value(connect_timeout, Opts))).
+
+http_options_honours_timeout_test() ->
+    ?assertEqual(2500, proplists:get_value(timeout, asobi_tls_client:http_options(2500))).


### PR DESCRIPTION
Closes #171 (M6 from the 2026-05-19 audit).

## Problem
Outbound `httpc` calls to the Steam Web API and Google Play/OAuth endpoints set no `ssl` options, so on older OTP httpc used defaults that do not verify the peer certificate. A MITM or mis-issued cert could silently validate a forged receipt/token. asobi is a consumed library, so it must not depend on an implicit, version-dependent OTP default.

## Change
- New `asobi_tls_client` with `http_options/0,1` + `ssl_options/0`: `verify_peer`, OS trust store via `public_key:cacerts_get/0` (cached in a `persistent_term`), https hostname check, TLS 1.2/1.3, depth 4.
- Routes all four outbound call sites (Steam ticket-auth, Steam player-summary, Google androidpublisher, Google OAuth2 token) through it.
- A call-site test asserts the `{ssl, _}` options actually reach `httpc`.

Apple's IAP path needs no change: it validates the StoreKit JWS chain locally against an operator-configured root and makes no outbound call (effectively pinned to Apple).

## Deliberate decisions
- **No leaf/CA pinning.** These providers rotate certificates; a stale pin is a self-inflicted outage. Both the architecture guardian and security reviewer agreed this is defensible; documented as a residual.
- **`persistent_term` cache** for the trust store: avoids a per-request re-parse and an uncaught crash on a trust-store-less image.

## Review gate
- asobi-architecture-guardian: ACCEPT (correct home, shared module, no warp; prompted the `asobi_tls_client` name).
- beam-security-reviewer: correct, no fail-open; verified empirically on OTP 29.0.2 (badssl corpus rejects bad certs, real endpoints connect on TLS 1.2 and 1.3). 0 Critical.
  - One Medium raised is **out of scope** for this Steam/IAP fix: the OIDC social-login JWKS/discovery fetch (via the transitive `oidcc` dep) also relies on the httpc default and needs a `nova_auth_oidc` change to thread TLS opts. Tracked in #220 (asobi) + novaframework/nova_auth_oidc#6. Not currently exploitable on the pinned OTP 29 (default verifies).

## Checklist
fmt / xref / dialyzer / eqwalize (3 modules, NO ERRORS) / elp lint / eunit (10/10) all green.

Held for human merge per the security-lib gate.
