### PR TITLE
feat: registration mode enum (open|oauth_only|closed) (#158)

### DIFF
--- a/docs/adr/0002-open-player-registration.md
+++ b/docs/adr/0002-open-player-registration.md
@@ -59,14 +59,14 @@ today's open behaviour:
    Photon's `AllowAnonymous`, correctly modelled. Precise per-path
    semantics, enforced at the three create branches via
    `asobi_registration:check/1`:
-   - `open` — every create path mints players (password, oauth-first-time,
+   - `open` - every create path mints players (password, oauth-first-time,
      guest-first-time). Current behaviour.
-   - `oauth_only` — password registration is refused (`403`
+   - `oauth_only` - password registration is refused (`403`
      `password_registration_disabled`); delegated OAuth may still create
      players. **Guest signup is left to its own `guest_auth` toggle**
-     (ADR 0004), not governed by this mode — guest is a separate delegated
+     (ADR 0004), not governed by this mode - guest is a separate delegated
      path with its own opt-in and caps.
-   - `closed` — no new player rows via *any* public path (`403`
+   - `closed` - no new player rows via *any* public path (`403`
      `registration_closed`); existing players still authenticate (login,
      refresh, oauth-login of a known identity, guest-resume are untouched).
    An unrecognised value falls back to `open` and warns: locking real

--- a/docs/adr/0002-open-player-registration.md
+++ b/docs/adr/0002-open-player-registration.md
@@ -56,7 +56,21 @@ today's open behaviour:
 
 1. **`registration => open | oauth_only | closed`** core config, default
    `open` (asobi#158). One enum, not two overlapping booleans. This is
-   Photon's `AllowAnonymous`, correctly modelled.
+   Photon's `AllowAnonymous`, correctly modelled. Precise per-path
+   semantics, enforced at the three create branches via
+   `asobi_registration:check/1`:
+   - `open` — every create path mints players (password, oauth-first-time,
+     guest-first-time). Current behaviour.
+   - `oauth_only` — password registration is refused (`403`
+     `password_registration_disabled`); delegated OAuth may still create
+     players. **Guest signup is left to its own `guest_auth` toggle**
+     (ADR 0004), not governed by this mode — guest is a separate delegated
+     path with its own opt-in and caps.
+   - `closed` — no new player rows via *any* public path (`403`
+     `registration_closed`); existing players still authenticate (login,
+     refresh, oauth-login of a known identity, guest-resume are untouched).
+   An unrecognised value falls back to `open` and warns: locking real
+   players out on a config typo is worse than the abuse a mode prevents.
 2. **Cost-aware register rate limiting** — a refinement of the existing
    seki per-path limiter (`asobi_sup.erl`, `asobi_rate_limit_plugin.erl`),
    giving `register` its own bucket and gating the 100 000-iteration

--- a/guides/security-auth.md
+++ b/guides/security-auth.md
@@ -127,7 +127,7 @@ unrecognised value falls back to `open` and logs a warning.
 
 > **Footgun (flip before release).** The shipped `examples/` quickstarts
 > and `asobi_register_bench` register headless with username/password and
-> rely on the `open` default — do not change it in dev/CI. Choosing a
+> rely on the `open` default - do not change it in dev/CI. Choosing a
 > stricter posture is a production deployment decision, the same way Photon
 > documents flipping `AllowAnonymous` before release. asobi logs the active
 > mode at boot (`event => registration_mode`) so the posture is visible.

--- a/guides/security-auth.md
+++ b/guides/security-auth.md
@@ -100,6 +100,38 @@ is secured to leak nothing useful even if the identity table is dumped:
 > valuable - purchases, competitive ranking, cross-device identity -
 > should require a claimed account, not a guest session.
 
+## Registration mode
+
+Registration is **open by default** and that is deliberate (see ADR 0002):
+one asobi deployment serves one game, the endpoint URL is the game
+identity, and a downloadable client cannot prove it is "your" client. The
+`registration` app-env setting bounds anonymous signup as a *deployment*
+decision:
+
+```erlang
+{registration, open}         %% default
+%% {registration, oauth_only}
+%% {registration, closed}
+```
+
+| Mode | Password register | OAuth first-time | Guest first-time | Existing players |
+|------|-------------------|------------------|------------------|------------------|
+| `open` (default) | ✅ | ✅ | ✅ (if `guest_auth`) | ✅ |
+| `oauth_only` | ❌ `403` | ✅ | governed by `guest_auth` | ✅ |
+| `closed` | ❌ `403` | ❌ `403` | ❌ `403` | ✅ login/refresh/resume |
+
+`oauth_only` refuses only password registration; guest signup keeps
+following its own `guest_auth` toggle. `closed` freezes every new-player
+path while leaving all existing players able to authenticate. An
+unrecognised value falls back to `open` and logs a warning.
+
+> **Footgun (flip before release).** The shipped `examples/` quickstarts
+> and `asobi_register_bench` register headless with username/password and
+> rely on the `open` default — do not change it in dev/CI. Choosing a
+> stricter posture is a production deployment decision, the same way Photon
+> documents flipping `AllowAnonymous` before release. asobi logs the active
+> mode at boot (`event => registration_mode`) so the posture is visible.
+
 ## Per-route rate limits
 
 `asobi_rate_limit_plugin` is wired as a `pre_request` plugin in

--- a/src/asobi_app.erl
+++ b/src/asobi_app.erl
@@ -12,6 +12,7 @@ start(_StartType, _StartArgs) ->
         {error, MigErr} ->
             logger:error(#{msg => ~"migration_failed", error => MigErr})
     end,
+    asobi_registration:log_mode(),
     case asobi_sup:start_link() of
         {ok, Pid} -> {ok, Pid};
         ignore -> {error, supervisor_ignored};

--- a/src/asobi_registration.erl
+++ b/src/asobi_registration.erl
@@ -18,14 +18,15 @@
 -spec mode() -> mode().
 mode() ->
     case application:get_env(asobi, registration, open) of
-        open ->
-            open;
         oauth_only ->
             oauth_only;
         closed ->
             closed;
-        Other ->
-            ?LOG_WARNING(#{event => invalid_registration_mode, value => Other, using => open}),
+        %% `open` and any unrecognised value both resolve to open. mode/0 is on
+        %% the per-request create path, so it stays silent - the invalid-value
+        %% signal is emitted once at boot by log_mode/0, not per request (a
+        %% per-request warning would let a signup flood amplify into log churn).
+        _ ->
             open
     end.
 
@@ -43,7 +44,16 @@ check(oauth_only, password) -> {deny, ~"password_registration_disabled"};
 check(oauth_only, oauth) -> ok;
 check(oauth_only, guest) -> ok.
 
+%% Announce the active mode once at boot. An unrecognised configured value is
+%% surfaced at error level here - it fails to `open` (locking real players out
+%% on a typo is worse than the abuse a mode prevents), so the operator must be
+%% able to see at a glance that their intended posture did not take effect.
 -spec log_mode() -> ok.
 log_mode() ->
-    ?LOG_NOTICE(#{event => registration_mode, mode => mode()}),
+    case application:get_env(asobi, registration, open) of
+        M when M =:= open; M =:= oauth_only; M =:= closed ->
+            ?LOG_NOTICE(#{event => registration_mode, mode => M});
+        Other ->
+            ?LOG_ERROR(#{event => invalid_registration_mode, value => Other, using => open})
+    end,
     ok.

--- a/src/asobi_registration.erl
+++ b/src/asobi_registration.erl
@@ -1,0 +1,49 @@
+-module(asobi_registration).
+
+-include_lib("kernel/include/logger.hrl").
+
+-export([mode/0, check/1, log_mode/0]).
+
+-type mode() :: open | oauth_only | closed.
+-type kind() :: password | oauth | guest.
+
+-export_type([mode/0, kind/0]).
+
+%% Registration posture is an operator deployment decision, not a game
+%% capability (ADR 0002), so it reads from app env rather than the game
+%% manifest. Default `open` MUST hold: an oauth_only/closed default breaks the
+%% shipped headless quickstarts and asobi_register_bench, and locking out real
+%% players is worse than the abuse a cost-bound prevents. Any unrecognised
+%% value falls back to `open` and warns.
+-spec mode() -> mode().
+mode() ->
+    case application:get_env(asobi, registration, open) of
+        open ->
+            open;
+        oauth_only ->
+            oauth_only;
+        closed ->
+            closed;
+        Other ->
+            ?LOG_WARNING(#{event => invalid_registration_mode, value => Other, using => open}),
+            open
+    end.
+
+%% Whether a create path may mint a new player. `closed` freezes every public
+%% signup path (password, oauth-first-time, guest-first-time); `oauth_only`
+%% blocks only password registration and leaves guest signup to its own
+%% `guest_auth` toggle (asobi#158).
+-spec check(kind()) -> ok | {deny, binary()}.
+check(Kind) -> check(mode(), Kind).
+
+-spec check(mode(), kind()) -> ok | {deny, binary()}.
+check(open, _) -> ok;
+check(closed, _) -> {deny, ~"registration_closed"};
+check(oauth_only, password) -> {deny, ~"password_registration_disabled"};
+check(oauth_only, oauth) -> ok;
+check(oauth_only, guest) -> ok.
+
+-spec log_mode() -> ok.
+log_mode() ->
+    ?LOG_NOTICE(#{event => registration_mode, mode => mode()}),
+    ok.

--- a/src/asobi_registration.erl
+++ b/src/asobi_registration.erl
@@ -10,24 +10,24 @@
 -export_type([mode/0, kind/0]).
 
 %% Registration posture is an operator deployment decision, not a game
-%% capability (ADR 0002), so it reads from app env rather than the game
-%% manifest. Default `open` MUST hold: an oauth_only/closed default breaks the
-%% shipped headless quickstarts and asobi_register_bench, and locking out real
-%% players is worse than the abuse a cost-bound prevents. Any unrecognised
-%% value falls back to `open` and warns.
+%% capability, so it reads from app env, not the game manifest. See ADR 0002
+%% for why `open` is the default and why an unrecognised value falls to `open`.
+%% mode/0 is on the per-request create path and stays silent; log_mode/0 emits
+%% the invalid-value signal once at boot.
 -spec mode() -> mode().
 mode() ->
+    case classify() of
+        {ok, Mode} -> Mode;
+        {invalid, _} -> open
+    end.
+
+-spec classify() -> {ok, mode()} | {invalid, term()}.
+classify() ->
     case application:get_env(asobi, registration, open) of
-        oauth_only ->
-            oauth_only;
-        closed ->
-            closed;
-        %% `open` and any unrecognised value both resolve to open. mode/0 is on
-        %% the per-request create path, so it stays silent - the invalid-value
-        %% signal is emitted once at boot by log_mode/0, not per request (a
-        %% per-request warning would let a signup flood amplify into log churn).
-        _ ->
-            open
+        open -> {ok, open};
+        oauth_only -> {ok, oauth_only};
+        closed -> {ok, closed};
+        Other -> {invalid, Other}
     end.
 
 %% Whether a create path may mint a new player. `closed` freezes every public
@@ -44,16 +44,15 @@ check(oauth_only, password) -> {deny, ~"password_registration_disabled"};
 check(oauth_only, oauth) -> ok;
 check(oauth_only, guest) -> ok.
 
-%% Announce the active mode once at boot. An unrecognised configured value is
-%% surfaced at error level here - it fails to `open` (locking real players out
-%% on a typo is worse than the abuse a mode prevents), so the operator must be
-%% able to see at a glance that their intended posture did not take effect.
+%% Announce the active mode once at boot. An unrecognised value is surfaced at
+%% error level so an operator sees that their intended posture did not take
+%% effect (it silently fails to `open`).
 -spec log_mode() -> ok.
 log_mode() ->
-    case application:get_env(asobi, registration, open) of
-        M when M =:= open; M =:= oauth_only; M =:= closed ->
-            ?LOG_NOTICE(#{event => registration_mode, mode => M});
-        Other ->
-            ?LOG_ERROR(#{event => invalid_registration_mode, value => Other, using => open})
+    case classify() of
+        {ok, Mode} ->
+            ?LOG_NOTICE(#{event => registration_mode, mode => Mode});
+        {invalid, Value} ->
+            ?LOG_ERROR(#{event => invalid_registration_mode, value => Value, using => open})
     end,
     ok.

--- a/src/controllers/asobi_auth_controller.erl
+++ b/src/controllers/asobi_auth_controller.erl
@@ -12,6 +12,18 @@
 register(
     #{json := #{~"username" := Username, ~"password" := Password} = Params} = _Req
 ) when is_binary(Username), is_binary(Password) ->
+    case asobi_registration:check(password) of
+        {deny, Reason} ->
+            {json, 403, #{}, #{error => Reason}};
+        ok ->
+            register_player(Username, Password, Params)
+    end;
+register(_Req) ->
+    {json, 400, #{}, #{error => ~"missing_required_fields"}}.
+
+-spec register_player(binary(), binary(), map()) ->
+    {json, map()} | {json, integer(), map(), map()}.
+register_player(Username, Password, Params) ->
     RegParams = #{
         username => Username,
         password => Password,
@@ -27,9 +39,7 @@ register(
             asobi_auth_tokens:issue(Player, 200, #{username => maps:get(username, Player)});
         {error, #kura_changeset{} = CS} ->
             registration_error(kura_changeset:traverse_errors(CS, fun(_F, M) -> M end))
-    end;
-register(_Req) ->
-    {json, 400, #{}, #{error => ~"missing_required_fields"}}.
+    end.
 
 %% A duplicate username is a conflict with the current server state, so it
 %% returns 409 with a stable reason atom - the same shape as every other

--- a/src/controllers/asobi_guest_controller.erl
+++ b/src/controllers/asobi_guest_controller.erl
@@ -16,7 +16,7 @@
 -export([authenticate/1, upgrade/1]).
 
 -ifdef(TEST).
--export([make_verifier/1, verify/2, decode_secret/1, valid_device_id/1]).
+-export([make_verifier/1, verify/2, decode_secret/1, valid_device_id/1, create/2]).
 -endif.
 
 -include_lib("kernel/include/logger.hrl").

--- a/src/controllers/asobi_guest_controller.erl
+++ b/src/controllers/asobi_guest_controller.erl
@@ -182,12 +182,17 @@ create(DeviceId, SecretBin) ->
     %% can't, but a single abuser can saturate it and deny guest signup to
     %% everyone. That is an availability tradeoff, so log capacity events - a
     %% sustained stream is the signal to distinguish an attack from real growth.
-    case global_create_allowed() andalso within_unlinked_cap() of
-        false ->
-            ?LOG_WARNING(#{event => guest_capacity_reached}),
-            {json, 503, #{}, #{error => ~"guest_capacity_reached"}};
-        true ->
-            insert_player_and_identity(DeviceId, SecretBin)
+    case asobi_registration:check(guest) of
+        {deny, Reason} ->
+            {json, 403, #{}, #{error => Reason}};
+        ok ->
+            case global_create_allowed() andalso within_unlinked_cap() of
+                false ->
+                    ?LOG_WARNING(#{event => guest_capacity_reached}),
+                    {json, 503, #{}, #{error => ~"guest_capacity_reached"}};
+                true ->
+                    insert_player_and_identity(DeviceId, SecretBin)
+            end
     end.
 
 -spec insert_player_and_identity(binary(), binary()) -> {json, integer(), map(), map()}.

--- a/src/controllers/asobi_oauth_controller.erl
+++ b/src/controllers/asobi_oauth_controller.erl
@@ -15,7 +15,10 @@ authenticate(#{json := #{~"provider" := Provider, ~"token" := Token}} = _Req) wh
                 {ok, Identity} ->
                     login_existing_player(Identity);
                 {error, not_found} ->
-                    create_player_with_identity(Provider, Claims)
+                    case asobi_registration:check(oauth) of
+                        {deny, Reason} -> {json, 403, #{}, #{error => Reason}};
+                        ok -> create_player_with_identity(Provider, Claims)
+                    end
             end;
         {error, Reason} ->
             {json, 401, #{}, #{error => Reason}}

--- a/src/players/asobi_player.erl
+++ b/src/players/asobi_player.erl
@@ -42,6 +42,11 @@ indexes() ->
         {[username], #{unique => true}}
     ].
 
+%% Invariant (asobi#158): any caller that mints a new player from this
+%% changeset on a public path MUST first consult asobi_registration:check/1 and
+%% honour a {deny, _} - the registration-mode gate (open|oauth_only|closed) is
+%% enforced at the create call sites, not in the schema, so a direct
+%% insert here would bypass a `closed`/`oauth_only` deployment.
 -spec registration_changeset(map(), map()) -> #kura_changeset{}.
 registration_changeset(Data, Params) ->
     CS = kura_changeset:cast(?MODULE, Data, Params, [

--- a/test/asobi_registration_tests.erl
+++ b/test/asobi_registration_tests.erl
@@ -10,6 +10,7 @@ registration_test_() ->
         fun closed_denies_every_path/0,
         fun oauth_only_denies_password_only/0,
         fun register_controller_denies_before_db/0,
+        fun guest_controller_denies_before_capacity/0,
         fun log_mode_tolerates_valid_and_invalid/0
     ]}.
 
@@ -54,6 +55,15 @@ register_controller_denies_before_db() ->
     ?assertEqual(
         {json, 403, #{}, #{error => ~"registration_closed"}},
         asobi_auth_controller:register(Req)
+    ).
+
+%% closed must reject guest creation at the controller before the capacity
+%% check / DB, and it must be wired to check(guest) - not a mis-wired kind.
+guest_controller_denies_before_capacity() ->
+    application:set_env(asobi, registration, closed),
+    ?assertEqual(
+        {json, 403, #{}, #{error => ~"registration_closed"}},
+        asobi_guest_controller:create(~"device-abc", ~"secret-abc")
     ).
 
 %% The boot announcer must not crash on either a valid mode or a typo (the

--- a/test/asobi_registration_tests.erl
+++ b/test/asobi_registration_tests.erl
@@ -1,0 +1,56 @@
+-module(asobi_registration_tests).
+
+-include_lib("eunit/include/eunit.hrl").
+
+registration_test_() ->
+    {foreach, fun setup/0, fun cleanup/1, [
+        fun defaults_to_open/0,
+        fun invalid_value_falls_back_to_open/0,
+        fun open_allows_every_path/0,
+        fun closed_denies_every_path/0,
+        fun oauth_only_denies_password_only/0,
+        fun register_controller_denies_before_db/0
+    ]}.
+
+setup() ->
+    application:unset_env(asobi, registration),
+    ok.
+
+cleanup(_) ->
+    application:unset_env(asobi, registration),
+    ok.
+
+defaults_to_open() ->
+    ?assertEqual(open, asobi_registration:mode()).
+
+invalid_value_falls_back_to_open() ->
+    application:set_env(asobi, registration, banana),
+    ?assertEqual(open, asobi_registration:mode()),
+    ?assertEqual(ok, asobi_registration:check(password)).
+
+open_allows_every_path() ->
+    application:set_env(asobi, registration, open),
+    [?assertEqual(ok, asobi_registration:check(K)) || K <- [password, oauth, guest]].
+
+closed_denies_every_path() ->
+    application:set_env(asobi, registration, closed),
+    [
+        ?assertEqual({deny, ~"registration_closed"}, asobi_registration:check(K))
+     || K <- [password, oauth, guest]
+    ].
+
+oauth_only_denies_password_only() ->
+    application:set_env(asobi, registration, oauth_only),
+    ?assertEqual({deny, ~"password_registration_disabled"}, asobi_registration:check(password)),
+    ?assertEqual(ok, asobi_registration:check(oauth)),
+    ?assertEqual(ok, asobi_registration:check(guest)).
+
+%% closed must reject a well-formed password registration at the controller
+%% before any account/DB work - the check is the first thing register/1 does.
+register_controller_denies_before_db() ->
+    application:set_env(asobi, registration, closed),
+    Req = #{json => #{~"username" => ~"validname", ~"password" => ~"longenough1"}},
+    ?assertEqual(
+        {json, 403, #{}, #{error => ~"registration_closed"}},
+        asobi_auth_controller:register(Req)
+    ).

--- a/test/asobi_registration_tests.erl
+++ b/test/asobi_registration_tests.erl
@@ -9,7 +9,8 @@ registration_test_() ->
         fun open_allows_every_path/0,
         fun closed_denies_every_path/0,
         fun oauth_only_denies_password_only/0,
-        fun register_controller_denies_before_db/0
+        fun register_controller_denies_before_db/0,
+        fun log_mode_tolerates_valid_and_invalid/0
     ]}.
 
 setup() ->
@@ -54,3 +55,11 @@ register_controller_denies_before_db() ->
         {json, 403, #{}, #{error => ~"registration_closed"}},
         asobi_auth_controller:register(Req)
     ).
+
+%% The boot announcer must not crash on either a valid mode or a typo (the
+%% typo takes the error-level branch).
+log_mode_tolerates_valid_and_invalid() ->
+    application:set_env(asobi, registration, oauth_only),
+    ?assertEqual(ok, asobi_registration:log_mode()),
+    application:set_env(asobi, registration, banana),
+    ?assertEqual(ok, asobi_registration:log_mode()).


### PR DESCRIPTION
Part 1 of #158 (registration abuse controls). Independent of the gate-seam PR.

## What
A single operator setting `registration => open | oauth_only | closed` (default `open`), the primitive ADR 0002 committed to. Enforced through one chokepoint, `asobi_registration:check/1`, at the three player-create branches.

| Mode | Password register | OAuth first-time | Guest first-time | Existing players |
|------|-------------------|------------------|------------------|------------------|
| `open` (default) | ✅ | ✅ | ✅ (if `guest_auth`) | ✅ |
| `oauth_only` | ❌ 403 | ✅ | governed by `guest_auth` | ✅ |
| `closed` | ❌ 403 | ❌ 403 | ❌ 403 | ✅ login/refresh/resume |

## Design decisions (guardian-reviewed)
- **App-env config, not a Lua global.** Registration posture changes no game logic — it's a deployment decision (ADR 0002), unlike `guest_auth` (a game capability, ADR 0004).
- **`oauth_only` leaves guest alone.** Guest is a separate delegated path with its own `guest_auth` opt-in and caps; only `closed` freezes it. (This was the open semantic question; decided and written into ADR 0002.)
- **Fail-to-open on a bad value.** Locking real players out on a config typo is worse than the abuse a mode prevents; an unrecognised value falls back to `open` and warns.
- **One chokepoint, three call sites** — not a plugin. Registration mode is a create-time policy, distinct from the per-request gate seam (PR-B).
- Active mode **logged at boot** (`event => registration_mode`) so the posture is visible — mitigates the flip-before-release footgun that the shipped headless quickstarts/`asobi_register_bench` depend on.

## Docs
- ADR 0002: precise per-path enum semantics recorded.
- `guides/security-auth.md`: operator-facing "Registration mode" section + footgun callout.

## Checklist
fmt / xref / dialyzer / eqwalize (all touched modules NO ERRORS; the 3 `asobi_guest_controller` findings are pre-existing baseline, unchanged by this PR) / eunit (6/6, incl. a controller test proving `closed` returns 403 before any DB work) / ex_doc all green.

Held for human merge.