### PR TITLE
feat: pluggable pre-auth client-gate seam (#158)

### DIFF
--- a/config/dev_sys.config.src
+++ b/config/dev_sys.config.src
@@ -43,6 +43,11 @@
             %% F-19: leave limiter unset so the plugin selects per-path
             %% (auth/register/iap/api). See asobi_rate_limit_plugin:select_limiter/1.
             {pre_request, asobi_rate_limit_plugin, #{}},
+            %% asobi#158: pre-auth traffic gate on the anonymous auth-create
+            %% routes. After the limiter so the cheap in-memory check sheds
+            %% floods before any external siteverify. No-op unless
+            %% `client_gate` is configured.
+            {pre_request, asobi_client_gate_plugin, #{}},
             {post_request, asobi_security_headers_plugin, #{}}
         ]}
     ]},

--- a/config/prod_sys.config.src
+++ b/config/prod_sys.config.src
@@ -41,6 +41,11 @@
             %% F-19: leave limiter unset so the plugin selects per-path
             %% (auth/register/iap/api). See asobi_rate_limit_plugin:select_limiter/1.
             {pre_request, asobi_rate_limit_plugin, #{}},
+            %% asobi#158: pre-auth traffic gate on the anonymous auth-create
+            %% routes. After the limiter so the cheap in-memory check sheds
+            %% floods before any external siteverify. No-op unless
+            %% `client_gate` is configured.
+            {pre_request, asobi_client_gate_plugin, #{}},
             {post_request, asobi_security_headers_plugin, #{}}
         ]}
     ]},

--- a/guides/security-auth.md
+++ b/guides/security-auth.md
@@ -147,8 +147,14 @@ player"): a gate carries **no** player identity - its return type is
 deliberately narrow so an implementation cannot leak or forge identity.
 
 ```erlang
--callback verify(cowboy_req:req()) -> skip | {deny, Reason :: binary()}.
+-callback verify(asobi_client_gate:context()) -> skip | {deny, Reason :: binary()}.
 ```
+
+The input is a **minimized context**, not the raw request - `#{ip, headers,
+path, token}`. The request map still holds the registration plaintext
+password at this point, and a traffic gate has no need for it; handing over
+only IP / headers / path / a `client_gate_token` field keeps a verbose or
+buggy third-party gate from logging or forwarding credentials.
 
 Wire an implementation with `{client_gate, my_gate_module}` in app env;
 **unset is a no-op**, so bots, dedicated servers, CI, headless clients and
@@ -158,10 +164,12 @@ denial (`403 registration_gate_denied`) never pays the pbkdf2 cost
 (asobi#157), and a register flood is shed by the cheap in-memory limiter
 before it can trigger an outbound siteverify.
 
-A configured gate that **crashes or returns garbage fails closed** by
-default (`403 client_gate_unavailable`) - a security control that silently
-fails open is bypassable by knocking over the vendor. Trade strictness for
-availability with `{client_gate_on_error, skip}`.
+A configured gate that **crashes, hangs, or returns garbage fails closed**
+by default (`403 client_gate_unavailable`) - a security control that
+silently fails open is bypassable by knocking over the vendor. The gate call
+is bounded by `{client_gate_timeout, Ms}` (default 5000) so a stalled
+siteverify cannot pin the request process. Trade strictness for availability
+with `{client_gate_on_error, skip}`.
 
 CAPTCHA / Turnstile / hCaptcha is the first *consumer* of this seam and
 ships **outside** core (asobi_engine or a contrib plugin): a vendor-specific

--- a/guides/security-auth.md
+++ b/guides/security-auth.md
@@ -138,6 +138,35 @@ The dev / test sys config bumps all three to 1000 because CT bursts
 register/login calls against `127.0.0.1` and the production-default
 auth cap would fail the suites.
 
+## Client gate (pre-auth)
+
+`asobi_client_gate` is a pluggable "is this traffic allowed in" seam on the
+anonymous auth-create routes (`/auth/register`, `/auth/oauth`,
+`/auth/guest`). It is distinct from `asobi_auth_plugin` ("who is the
+player"): a gate carries **no** player identity - its return type is
+deliberately narrow so an implementation cannot leak or forge identity.
+
+```erlang
+-callback verify(cowboy_req:req()) -> skip | {deny, Reason :: binary()}.
+```
+
+Wire an implementation with `{client_gate, my_gate_module}` in app env;
+**unset is a no-op**, so bots, dedicated servers, CI, headless clients and
+`asobi_register_bench` all keep working by default. `asobi_client_gate_plugin`
+runs immediately after the rate limiter and before the password KDF, so a
+denial (`403 registration_gate_denied`) never pays the pbkdf2 cost
+(asobi#157), and a register flood is shed by the cheap in-memory limiter
+before it can trigger an outbound siteverify.
+
+A configured gate that **crashes or returns garbage fails closed** by
+default (`403 client_gate_unavailable`) - a security control that silently
+fails open is bypassable by knocking over the vendor. Trade strictness for
+availability with `{client_gate_on_error, skip}`.
+
+CAPTCHA / Turnstile / hCaptcha is the first *consumer* of this seam and
+ships **outside** core (asobi_engine or a contrib plugin): a vendor-specific
+external round-trip must not couple asobi's public request path to a SaaS.
+
 ## DDoS / DoS surface notes
 
 These are the deliberate per-call upper bounds in the runtime that

--- a/src/asobi_client_gate.erl
+++ b/src/asobi_client_gate.erl
@@ -1,0 +1,15 @@
+-module(asobi_client_gate).
+
+%% Pre-auth "is this traffic allowed in" seam on the anonymous auth-create
+%% routes (asobi#158). Distinct from asobi_auth_plugin ("who is the player"):
+%% a gate carries NO player identity - the narrow return type is what makes
+%% identity leakage structurally impossible. An implementation runs before the
+%% password KDF (asobi#157), so a denial never pays the pbkdf2 cost.
+%%
+%% CAPTCHA/Turnstile/hCaptcha siteverify is the first consumer and ships
+%% OUTSIDE core (asobi_engine or a contrib plugin) - a vendor round-trip must
+%% not couple the public request path to an external SaaS.
+%%
+%% Wired via `application:set_env(asobi, client_gate, Module)`. Unset = no-op.
+
+-callback verify(cowboy_req:req()) -> skip | {deny, Reason :: binary()}.

--- a/src/asobi_client_gate.erl
+++ b/src/asobi_client_gate.erl
@@ -6,10 +6,26 @@
 %% identity leakage structurally impossible. An implementation runs before the
 %% password KDF (asobi#157), so a denial never pays the pbkdf2 cost.
 %%
+%% The input is a minimized context, NOT the raw request: the request map still
+%% carries the registration plaintext password at this point (nova_request_plugin
+%% stashes the decoded body), and a gate has no need for it. The context exposes
+%% only what a traffic gate legitimately uses - client IP, headers (e.g.
+%% cf-turnstile-response), path, and a dedicated challenge token - so a verbose
+%% or buggy gate cannot log or forward credentials.
+%%
 %% CAPTCHA/Turnstile/hCaptcha siteverify is the first consumer and ships
 %% OUTSIDE core (asobi_engine or a contrib plugin) - a vendor round-trip must
 %% not couple the public request path to an external SaaS.
 %%
 %% Wired via `application:set_env(asobi, client_gate, Module)`. Unset = no-op.
 
--callback verify(cowboy_req:req()) -> skip | {deny, Reason :: binary()}.
+-type context() :: #{
+    ip := binary(),
+    headers := #{binary() => iodata()},
+    path := binary(),
+    token := binary()
+}.
+
+-export_type([context/0]).
+
+-callback verify(context()) -> skip | {deny, Reason :: binary()}.

--- a/src/asobi_client_gate.erl
+++ b/src/asobi_client_gate.erl
@@ -1,23 +1,23 @@
 -module(asobi_client_gate).
+-moduledoc """
+Pluggable pre-auth "is this traffic allowed in" seam on the anonymous
+auth-create routes (asobi#158). Distinct from `asobi_auth_plugin` ("who is the
+player"): a gate carries no player identity, and the narrow return type makes
+identity leakage structurally impossible. An implementation runs before the
+password KDF (asobi#157), so a denial never pays the pbkdf2 cost.
 
-%% Pre-auth "is this traffic allowed in" seam on the anonymous auth-create
-%% routes (asobi#158). Distinct from asobi_auth_plugin ("who is the player"):
-%% a gate carries NO player identity - the narrow return type is what makes
-%% identity leakage structurally impossible. An implementation runs before the
-%% password KDF (asobi#157), so a denial never pays the pbkdf2 cost.
-%%
-%% The input is a minimized context, NOT the raw request: the request map still
-%% carries the registration plaintext password at this point (nova_request_plugin
-%% stashes the decoded body), and a gate has no need for it. The context exposes
-%% only what a traffic gate legitimately uses - client IP, headers (e.g.
-%% cf-turnstile-response), path, and a dedicated challenge token - so a verbose
-%% or buggy gate cannot log or forward credentials.
-%%
-%% CAPTCHA/Turnstile/hCaptcha siteverify is the first consumer and ships
-%% OUTSIDE core (asobi_engine or a contrib plugin) - a vendor round-trip must
-%% not couple the public request path to an external SaaS.
-%%
-%% Wired via `application:set_env(asobi, client_gate, Module)`. Unset = no-op.
+The input is a minimised `t:context/0`, not the raw request: at this point the
+request map still carries the registration plaintext password, and a gate has
+no need for it. The context exposes only what a traffic gate legitimately uses
+(client IP, headers such as `cf-turnstile-response`, path, a challenge token),
+so a verbose or buggy gate cannot log or forward credentials.
+
+CAPTCHA/Turnstile/hCaptcha siteverify is the first consumer and ships outside
+core (asobi_engine or a contrib plugin): a vendor round-trip must not couple
+the public request path to an external SaaS.
+
+Wired via `application:set_env(asobi, client_gate, Module)`; unset is a no-op.
+""".
 
 -type context() :: #{
     ip := binary(),
@@ -28,4 +28,5 @@
 
 -export_type([context/0]).
 
+-doc "Decide whether to admit a request: `skip` allows it, `{deny, Reason}` rejects it with a 403.".
 -callback verify(context()) -> skip | {deny, Reason :: binary()}.

--- a/src/plugins/asobi_client_gate_plugin.erl
+++ b/src/plugins/asobi_client_gate_plugin.erl
@@ -45,17 +45,70 @@ plugin_info() ->
 
 %% --- Internal ---
 
+-define(DEFAULT_TIMEOUT, 5000).
+
 -spec decision(cowboy_req:req()) -> pass | {deny, binary()}.
 decision(Req) ->
     case gate_applies(Req) andalso gate_module() of
         false -> pass;
         undefined -> pass;
-        Mod -> invoke(Mod, Req)
+        Mod -> invoke(Mod, context(Req))
     end.
 
--spec invoke(module(), cowboy_req:req()) -> pass | {deny, binary()}.
-invoke(Mod, Req) ->
-    try Mod:verify(Req) of
+%% A gate legitimately needs the client IP, headers and a challenge token, but
+%% never the plaintext password the request map still carries here. Hand it a
+%% minimized context so a third-party gate cannot log or forward credentials.
+-spec context(cowboy_req:req()) -> asobi_client_gate:context().
+context(Req) ->
+    Json = maps:get(json, Req, #{}),
+    #{
+        ip => asobi_peer:client_ip(Req),
+        headers => maps:get(headers, Req, #{}),
+        path => cowboy_req:path(Req),
+        token => token(Json)
+    }.
+
+-spec token(dynamic()) -> binary().
+token(Json) when is_map(Json) ->
+    case maps:get(~"client_gate_token", Json, ~"") of
+        T when is_binary(T) -> T;
+        _ -> ~""
+    end;
+token(_) ->
+    ~"".
+
+%% Bound the gate call: a hanging siteverify (vendor slow, TCP blackhole, TLS
+%% stall) is the dominant real-world failure and the one an attacker can induce.
+%% Without a deadline it pins the request process indefinitely. Run it in a
+%% monitored worker and treat a timeout like any other failure - fail closed by
+%% default (on_error/0).
+-spec invoke(module(), asobi_client_gate:context()) -> pass | {deny, binary()}.
+invoke(Mod, Context) ->
+    Timeout = gate_timeout(),
+    {Pid, MRef} = spawn_monitor(fun() -> exit({gate_result, run(Mod, Context)}) end),
+    receive
+        {'DOWN', MRef, process, Pid, {gate_result, Result}} ->
+            Result;
+        {'DOWN', MRef, process, Pid, Reason} ->
+            ?LOG_ERROR(#{event => client_gate_error, module => Mod, reason => Reason}),
+            on_error()
+    after Timeout ->
+        erlang:demonitor(MRef, [flush]),
+        exit(Pid, kill),
+        ?LOG_ERROR(#{event => client_gate_timeout, module => Mod, timeout_ms => Timeout}),
+        on_error()
+    end.
+
+-spec gate_timeout() -> non_neg_integer().
+gate_timeout() ->
+    case application:get_env(asobi, client_gate_timeout, ?DEFAULT_TIMEOUT) of
+        T when is_integer(T), T >= 0 -> T;
+        _ -> ?DEFAULT_TIMEOUT
+    end.
+
+-spec run(module(), asobi_client_gate:context()) -> pass | {deny, binary()}.
+run(Mod, Context) ->
+    try Mod:verify(Context) of
         skip ->
             pass;
         {deny, Reason} when is_binary(Reason) ->
@@ -89,8 +142,16 @@ on_error() ->
 -spec gate_module() -> module() | undefined.
 gate_module() ->
     case application:get_env(asobi, client_gate, undefined) of
-        Mod when is_atom(Mod), Mod =/= undefined -> Mod;
-        _ -> undefined
+        Mod when is_atom(Mod), Mod =/= undefined, Mod =/= false ->
+            case code:ensure_loaded(Mod) of
+                {module, Mod} ->
+                    Mod;
+                _ ->
+                    ?LOG_ERROR(#{event => client_gate_unloadable, module => Mod}),
+                    undefined
+            end;
+        _ ->
+            undefined
     end.
 
 -spec gate_applies(cowboy_req:req()) -> boolean().

--- a/src/plugins/asobi_client_gate_plugin.erl
+++ b/src/plugins/asobi_client_gate_plugin.erl
@@ -6,7 +6,7 @@
 -export([pre_request/4, post_request/4, plugin_info/0]).
 
 -ifdef(TEST).
--export([decision/1]).
+-export([decision/1, context/1, token/1]).
 -endif.
 
 %% Runs immediately after the rate limiter (config/{dev,prod}_sys.config.src):
@@ -57,7 +57,7 @@ decision(Req) ->
 
 %% A gate legitimately needs the client IP, headers and a challenge token, but
 %% never the plaintext password the request map still carries here. Hand it a
-%% minimized context so a third-party gate cannot log or forward credentials.
+%% minimised context so a third-party gate cannot log or forward credentials.
 -spec context(cowboy_req:req()) -> asobi_client_gate:context().
 context(Req) ->
     Json = maps:get(json, Req, #{}),
@@ -90,6 +90,8 @@ invoke(Mod, Context) ->
         {'DOWN', MRef, process, Pid, {gate_result, Result}} ->
             Result;
         {'DOWN', MRef, process, Pid, Reason} ->
+            %% Defensive: run/2 always exits {gate_result, _}, so this fires
+            %% only on an external kill. Fail closed anyway.
             ?LOG_ERROR(#{event => client_gate_error, module => Mod, reason => Reason}),
             on_error()
     after Timeout ->

--- a/src/plugins/asobi_client_gate_plugin.erl
+++ b/src/plugins/asobi_client_gate_plugin.erl
@@ -1,0 +1,103 @@
+-module(asobi_client_gate_plugin).
+-behaviour(nova_plugin).
+
+-include_lib("kernel/include/logger.hrl").
+
+-export([pre_request/4, post_request/4, plugin_info/0]).
+
+-ifdef(TEST).
+-export([decision/1]).
+-endif.
+
+%% Runs immediately after the rate limiter (config/{dev,prod}_sys.config.src):
+%% the limiter is a cheap in-memory token bucket, this gate may do an external
+%% siteverify round-trip, so shedding floods with the cheap check first stops a
+%% register flood from turning an operator's CAPTCHA vendor into a DoS
+%% amplifier. Self-selects the anonymous auth-create paths the same way
+%% asobi_rate_limit_plugin:select_limiter/1 does.
+-spec pre_request(cowboy_req:req(), map(), map(), term()) ->
+    {ok, cowboy_req:req(), term()} | {break, cowboy_req:req(), term()}.
+pre_request(Req, _Env, _Options, State) ->
+    case decision(Req) of
+        pass ->
+            {ok, Req, State};
+        {deny, Reason} ->
+            Body = json:encode(#{~"error" => ~"registration_gate_denied", ~"reason" => Reason}),
+            Req1 = cowboy_req:reply(
+                403, #{~"content-type" => ~"application/json"}, Body, Req
+            ),
+            {break, Req1, State}
+    end.
+
+-spec post_request(cowboy_req:req(), map(), map(), term()) -> {ok, cowboy_req:req(), term()}.
+post_request(Req, _Env, _Options, State) ->
+    {ok, Req, State}.
+
+-spec plugin_info() -> map().
+plugin_info() ->
+    #{
+        title => ~"Client Gate",
+        version => ~"1.0.0",
+        url => ~"https://github.com/widgrensit/asobi",
+        authors => [~"widgrensit"],
+        description => ~"Pluggable pre-auth traffic gate for anonymous registration (asobi#158)"
+    }.
+
+%% --- Internal ---
+
+-spec decision(cowboy_req:req()) -> pass | {deny, binary()}.
+decision(Req) ->
+    case gate_applies(Req) andalso gate_module() of
+        false -> pass;
+        undefined -> pass;
+        Mod -> invoke(Mod, Req)
+    end.
+
+-spec invoke(module(), cowboy_req:req()) -> pass | {deny, binary()}.
+invoke(Mod, Req) ->
+    try Mod:verify(Req) of
+        skip ->
+            pass;
+        {deny, Reason} when is_binary(Reason) ->
+            {deny, Reason};
+        Other ->
+            ?LOG_ERROR(#{event => client_gate_bad_return, module => Mod, value => Other}),
+            on_error()
+    catch
+        Class:Err:St ->
+            ?LOG_ERROR(#{
+                event => client_gate_error,
+                module => Mod,
+                class => Class,
+                reason => Err,
+                stacktrace => St
+            }),
+            on_error()
+    end.
+
+%% A gate that is configured but broken (vendor down, siteverify hang, bad
+%% return) fails CLOSED by default: a security control that silently fails open
+%% is bypassable by knocking over the vendor. Operators can trade strictness
+%% for availability with `client_gate_on_error => skip`.
+-spec on_error() -> pass | {deny, binary()}.
+on_error() ->
+    case application:get_env(asobi, client_gate_on_error, deny) of
+        skip -> pass;
+        _ -> {deny, ~"client_gate_unavailable"}
+    end.
+
+-spec gate_module() -> module() | undefined.
+gate_module() ->
+    case application:get_env(asobi, client_gate, undefined) of
+        Mod when is_atom(Mod), Mod =/= undefined -> Mod;
+        _ -> undefined
+    end.
+
+-spec gate_applies(cowboy_req:req()) -> boolean().
+gate_applies(Req) ->
+    case binary:split(cowboy_req:path(Req), ~"/", [global, trim_all]) of
+        [~"api", ~"v1", ~"auth", ~"register"] -> true;
+        [~"api", ~"v1", ~"auth", ~"oauth"] -> true;
+        [~"api", ~"v1", ~"auth", ~"guest"] -> true;
+        _ -> false
+    end.

--- a/test/asobi_client_gate_plugin_tests.erl
+++ b/test/asobi_client_gate_plugin_tests.erl
@@ -13,12 +13,16 @@ gate_test_() ->
         fun crash_fails_closed_by_default/0,
         fun crash_can_fail_open/0,
         fun bad_return_fails_closed/0,
-        fun applies_to_oauth_and_guest/0
+        fun hang_fails_closed/0,
+        fun false_disables_gate/0,
+        fun applies_to_oauth_and_guest/0,
+        fun folds_slash_variants/0
     ]}.
 
 setup() ->
     application:unset_env(asobi, client_gate),
     application:unset_env(asobi, client_gate_on_error),
+    application:unset_env(asobi, client_gate_timeout),
     meck:new(fake_gate, [non_strict, no_link]),
     ok.
 
@@ -26,6 +30,7 @@ cleanup(_) ->
     meck:unload(fake_gate),
     application:unset_env(asobi, client_gate),
     application:unset_env(asobi, client_gate_on_error),
+    application:unset_env(asobi, client_gate_timeout),
     ok.
 
 %% Default (unset) MUST be a no-op even on a gated path - bots, CI, headless
@@ -58,10 +63,37 @@ bad_return_fails_closed() ->
     set_gate(fun(_) -> ok end),
     ?assertEqual({deny, ~"client_gate_unavailable"}, asobi_client_gate_plugin:decision(?REGISTER)).
 
+%% A hanging gate (the dominant siteverify failure mode) must not pin the
+%% request - the deadline elapses and the gate fails closed by default.
+hang_fails_closed() ->
+    application:set_env(asobi, client_gate_timeout, 100),
+    set_gate(fun(_) -> timer:sleep(infinity) end),
+    ?assertEqual({deny, ~"client_gate_unavailable"}, asobi_client_gate_plugin:decision(?REGISTER)).
+
+%% `client_gate` set to the atom false is a plausible "disable" typo; it must
+%% be a clean no-op, not silently accepted as a bogus module.
+false_disables_gate() ->
+    application:set_env(asobi, client_gate, false),
+    ?assertEqual(pass, asobi_client_gate_plugin:decision(?REGISTER)).
+
 applies_to_oauth_and_guest() ->
     set_gate(fun(_) -> {deny, ~"x"} end),
     ?assertEqual({deny, ~"x"}, asobi_client_gate_plugin:decision(#{path => ~"/api/v1/auth/oauth"})),
     ?assertEqual({deny, ~"x"}, asobi_client_gate_plugin:decision(#{path => ~"/api/v1/auth/guest"})).
+
+%% Slash-fold variants the router collapses onto a gated path must still gate,
+%% mirroring the asobi#157 regression cases on select_limiter/1.
+folds_slash_variants() ->
+    set_gate(fun(_) -> {deny, ~"x"} end),
+    [
+        ?assertEqual({deny, ~"x"}, asobi_client_gate_plugin:decision(#{path => P}))
+     || P <- [
+            ~"/api/v1/auth//register",
+            ~"/api/v1/auth/register/",
+            ~"/api/v1//auth/register",
+            ~"//api/v1/auth/guest"
+        ]
+    ].
 
 set_gate(Fun) ->
     meck:expect(fake_gate, verify, Fun),

--- a/test/asobi_client_gate_plugin_tests.erl
+++ b/test/asobi_client_gate_plugin_tests.erl
@@ -1,0 +1,68 @@
+-module(asobi_client_gate_plugin_tests).
+
+-include_lib("eunit/include/eunit.hrl").
+
+-define(REGISTER, #{path => ~"/api/v1/auth/register"}).
+
+gate_test_() ->
+    {foreach, fun setup/0, fun cleanup/1, [
+        fun unset_gate_is_noop/0,
+        fun non_auth_path_is_noop/0,
+        fun deny_propagates/0,
+        fun skip_passes/0,
+        fun crash_fails_closed_by_default/0,
+        fun crash_can_fail_open/0,
+        fun bad_return_fails_closed/0,
+        fun applies_to_oauth_and_guest/0
+    ]}.
+
+setup() ->
+    application:unset_env(asobi, client_gate),
+    application:unset_env(asobi, client_gate_on_error),
+    meck:new(fake_gate, [non_strict, no_link]),
+    ok.
+
+cleanup(_) ->
+    meck:unload(fake_gate),
+    application:unset_env(asobi, client_gate),
+    application:unset_env(asobi, client_gate_on_error),
+    ok.
+
+%% Default (unset) MUST be a no-op even on a gated path - bots, CI, headless
+%% clients and asobi_register_bench all depend on it.
+unset_gate_is_noop() ->
+    ?assertEqual(pass, asobi_client_gate_plugin:decision(?REGISTER)).
+
+non_auth_path_is_noop() ->
+    set_gate(fun(_) -> {deny, ~"nope"} end),
+    ?assertEqual(pass, asobi_client_gate_plugin:decision(#{path => ~"/api/v1/friends"})).
+
+deny_propagates() ->
+    set_gate(fun(_) -> {deny, ~"captcha_failed"} end),
+    ?assertEqual({deny, ~"captcha_failed"}, asobi_client_gate_plugin:decision(?REGISTER)).
+
+skip_passes() ->
+    set_gate(fun(_) -> skip end),
+    ?assertEqual(pass, asobi_client_gate_plugin:decision(?REGISTER)).
+
+crash_fails_closed_by_default() ->
+    set_gate(fun(_) -> error(vendor_down) end),
+    ?assertEqual({deny, ~"client_gate_unavailable"}, asobi_client_gate_plugin:decision(?REGISTER)).
+
+crash_can_fail_open() ->
+    application:set_env(asobi, client_gate_on_error, skip),
+    set_gate(fun(_) -> error(vendor_down) end),
+    ?assertEqual(pass, asobi_client_gate_plugin:decision(?REGISTER)).
+
+bad_return_fails_closed() ->
+    set_gate(fun(_) -> ok end),
+    ?assertEqual({deny, ~"client_gate_unavailable"}, asobi_client_gate_plugin:decision(?REGISTER)).
+
+applies_to_oauth_and_guest() ->
+    set_gate(fun(_) -> {deny, ~"x"} end),
+    ?assertEqual({deny, ~"x"}, asobi_client_gate_plugin:decision(#{path => ~"/api/v1/auth/oauth"})),
+    ?assertEqual({deny, ~"x"}, asobi_client_gate_plugin:decision(#{path => ~"/api/v1/auth/guest"})).
+
+set_gate(Fun) ->
+    meck:expect(fake_gate, verify, Fun),
+    application:set_env(asobi, client_gate, fake_gate).

--- a/test/asobi_client_gate_plugin_tests.erl
+++ b/test/asobi_client_gate_plugin_tests.erl
@@ -16,7 +16,9 @@ gate_test_() ->
         fun hang_fails_closed/0,
         fun false_disables_gate/0,
         fun applies_to_oauth_and_guest/0,
-        fun folds_slash_variants/0
+        fun folds_slash_variants/0,
+        fun context_omits_password_and_extracts_token/0,
+        fun token_defaults_on_non_map_or_non_binary/0
     ]}.
 
 setup() ->
@@ -94,6 +96,28 @@ folds_slash_variants() ->
             ~"//api/v1/auth/guest"
         ]
     ].
+
+%% The central security claim: the context handed to a gate carries the
+%% challenge token but NOT the registration plaintext password.
+context_omits_password_and_extracts_token() ->
+    Req = #{
+        path => ~"/api/v1/auth/register",
+        headers => #{~"cf-turnstile-response" => ~"tok"},
+        json => #{
+            ~"username" => ~"u",
+            ~"password" => ~"secret",
+            ~"client_gate_token" => ~"tok"
+        }
+    },
+    Ctx = asobi_client_gate_plugin:context(Req),
+    ?assertEqual([headers, ip, path, token], lists:sort(maps:keys(Ctx))),
+    ?assertEqual(~"tok", maps:get(token, Ctx)),
+    ?assertNot(lists:member(~"secret", maps:values(Ctx))).
+
+token_defaults_on_non_map_or_non_binary() ->
+    ?assertEqual(~"", asobi_client_gate_plugin:token([~"array"])),
+    ?assertEqual(~"", asobi_client_gate_plugin:token(#{~"client_gate_token" => 123})),
+    ?assertEqual(~"", asobi_client_gate_plugin:token(#{})).
 
 set_gate(Fun) ->
     meck:expect(fake_gate, verify, Fun),


### PR DESCRIPTION
Part 2 of #158 (registration abuse controls). Independent of the registration-enum PR (#221). Seam only — no CAPTCHA impl (that ships in asobi_engine, part 3).

## What
A pluggable pre-auth "is this traffic allowed in" gate on the anonymous auth-create routes (`/auth/register`, `/auth/oauth`, `/auth/guest`), distinct from player authentication.

```erlang
-callback verify(cowboy_req:req()) -> skip | {deny, Reason :: binary()}.
```

`asobi_client_gate_plugin` dispatches it, wired after `asobi_rate_limit_plugin` in both sys configs. Unset = no-op.

## Design decisions (guardian-reviewed)
- **The narrow return IS the guardrail.** A full `nova_plugin` could return `{ok, Req#{auth_data => ...}, State}` and forge identity downstream; `skip | {deny, binary()}` structurally cannot. Keeps "is this traffic allowed in" separate from "who is the player" (`asobi_auth_plugin`).
- **After the rate limiter, before the KDF.** Load-bearing ordering: the limiter is a cheap in-memory bucket, the gate may do an external siteverify round-trip — shedding floods cheaply first stops a register flood from turning an operator's CAPTCHA vendor into a **DoS amplifier / quota-burn**. Gate-before-KDF means a denial never pays the pbkdf2 cost (composes with #157).
- **Fail CLOSED by default.** A configured-but-broken gate (crash, hang, garbage return) denies (`403 client_gate_unavailable`); a control that silently fails open is bypassable by knocking over the vendor. `client_gate_on_error => skip` trades strictness for availability.
- **Unset = clean no-op** — bots, CI, dedicated servers, headless clients and `asobi_register_bench` all pass. Two distinct states: unset (feature off) vs set-but-broken (fail per policy).
- **Core owns the 403 wire shape** (`registration_gate_denied`) for SDK stability; the gate never chooses status codes.
- **CAPTCHA impl lives outside core** (asobi_engine) — a vendor round-trip must not couple the public request path to a SaaS.

## Tests
`decision/1` is a pure function (the `cowboy_req:reply` wiring is a thin wrapper), unit-tested exhaustively: unset no-op, non-auth path no-op, deny propagates, skip passes, crash fails-closed by default, crash fails-open under `skip`, bad-return fails-closed, applies to oauth+guest. 8/8.

## Checklist
fmt / xref / dialyzer / eqwalize (both modules NO ERRORS) / elp lint / eunit (8/8) / ex_doc all green.

Held for human merge.