### PR TITLE
docs: reference-guide corrections + websocket raw-reference banner

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -3,6 +3,13 @@
 This document describes Asobi's internal architecture, supervision trees,
 data model, and protocol design.
 
+> This is an internal design document. It is not published to HexDocs and is not
+> the API reference. For the canonical, maintained references see the
+> [Architecture guide](../guides/architecture.md) (supervision, lifecycles,
+> deployment models), the [REST API guide](../guides/rest-api.md) (every HTTP
+> endpoint and status code), and the
+> [WebSocket protocol guide](../guides/websocket-protocol.md) (the message catalogue).
+
 ## Stack
 
 | Layer | Technology |
@@ -10,7 +17,6 @@ data model, and protocol design.
 | HTTP / REST | Nova (Cowboy) |
 | WebSocket | Nova WebSocket (Cowboy) |
 | Database / ORM | Kura (PostgreSQL via pgo) |
-| Real-time UI / Admin | Arizona Core + arizona_nova |
 | Authentication | nova_auth |
 | Background Jobs | Shigoto |
 | Pub/Sub / Presence | `pg` module + Nova PubSub |
@@ -30,7 +36,7 @@ data model, and protocol design.
 │                      Nova Router                        │
 │  ┌──────────────┐  ┌──────────────┐  ┌──────────────┐ │
 │  │ REST API     │  │ WebSocket    │  │ Admin        │ │
-│  │ Controllers  │  │ Handler      │  │ (Arizona)    │ │
+│  │ Controllers  │  │ Handler      │  │ (ext. repo)  │ │
 │  └──────┬───────┘  └──────┬───────┘  └──────┬───────┘ │
 └─────────┼─────────────────┼─────────────────┼──────────┘
           │                 │                 │
@@ -447,34 +453,10 @@ Single WebSocket connection per client. JSON message envelope:
 
 ### Message Types
 
-**Connection:**
-- `session.connect` → authenticate WebSocket, start player session
-- `session.heartbeat` → keep-alive ping/pong
-
-**Matches:**
-- `match.join` → join a match
-- `match.leave` → leave current match
-- `match.input` → send game input to match server
-- `match.state` → server pushes state updates (delta)
-- `match.started` → server notification: match began
-- `match.finished` → server notification: match ended with results
-
-**Matchmaking:**
-- `matchmaker.add` → submit matchmaking ticket
-- `matchmaker.remove` → cancel ticket
-- `matchmaker.matched` → server notification: match found
-
-**Chat:**
-- `chat.join` → join a channel
-- `chat.leave` → leave a channel
-- `chat.send` → send message to channel
-- `chat.message` → server pushes new message
-- `chat.history` → request message history
-
-**Social:**
-- `presence.update` → update own status
-- `presence.changed` → server pushes friend status change
-- `notification.new` → server pushes notification
+The authoritative message catalogue is the
+[WebSocket protocol guide](../guides/websocket-protocol.md). The handler
+(`asobi_ws_handler`) routes each `type` to the owning service; the client sends
+input, the server decides and broadcasts state deltas.
 
 ### WebSocket Handler (`asobi_ws_handler`)
 
@@ -496,111 +478,21 @@ route_message(~"chat.send", Payload, State) ->
 
 ## REST API
 
-All REST endpoints under `/api/v1`. JSON request/response.
+The HTTP endpoint reference is the [REST API guide](../guides/rest-api.md). It is
+the single source of truth for paths, methods, and status codes; this document does
+not repeat it. All endpoints sit under `/api/v1` and exchange JSON. Routing lives in
+`asobi_router.erl`; the controllers are the `*_controller` modules under
+[Project Structure](#project-structure).
 
-### Auth (nova_auth)
-```
-POST   /api/v1/auth/register          Register with email/password
-POST   /api/v1/auth/login             Login, returns session token
-POST   /api/v1/auth/link              Link additional provider
-POST   /api/v1/auth/refresh           Refresh session token
-POST   /api/v1/auth/device            Device ID authentication
-POST   /api/v1/auth/apple             Apple Game Center auth
-POST   /api/v1/auth/google            Google Play Games auth
-```
+The client sends intent over these endpoints, the server decides, and the server
+persists and broadcasts the result.
 
-### Players
-```
-GET    /api/v1/players/:id            Get player profile
-PUT    /api/v1/players/:id            Update own profile
-GET    /api/v1/players/:id/stats      Get player stats
-```
+## Admin
 
-### Social
-```
-GET    /api/v1/friends                List friends
-POST   /api/v1/friends                Send friend request
-PUT    /api/v1/friends/:id            Accept/reject/block
-DELETE /api/v1/friends/:id            Remove friend
-
-POST   /api/v1/groups                 Create group
-GET    /api/v1/groups/:id             Get group
-PUT    /api/v1/groups/:id             Update group
-POST   /api/v1/groups/:id/join        Join group
-POST   /api/v1/groups/:id/leave       Leave group
-PUT    /api/v1/groups/:id/members/:pid Update member role
-```
-
-### Economy
-```
-GET    /api/v1/wallets                List player wallets
-GET    /api/v1/wallets/:currency/history  Transaction history
-
-GET    /api/v1/store                  List store catalog
-POST   /api/v1/store/purchase         Purchase item
-
-POST   /api/v1/iap/apple/verify       Validate Apple receipt
-POST   /api/v1/iap/google/verify      Validate Google receipt
-```
-
-### Inventory
-```
-GET    /api/v1/inventory              List player items
-POST   /api/v1/inventory/consume      Consume item
-POST   /api/v1/inventory/equip        Equip/unequip item
-```
-
-### Leaderboards
-```
-GET    /api/v1/leaderboards/:id              Top N entries
-GET    /api/v1/leaderboards/:id/around/:pid  Around player
-POST   /api/v1/leaderboards/:id              Submit score
-```
-
-### Tournaments
-```
-GET    /api/v1/tournaments            List active tournaments
-GET    /api/v1/tournaments/:id        Get tournament details
-POST   /api/v1/tournaments/:id/join   Join tournament
-```
-
-### Storage
-```
-GET    /api/v1/storage/:collection/:key        Read object
-PUT    /api/v1/storage/:collection/:key        Write object (with version for OCC)
-DELETE /api/v1/storage/:collection/:key        Delete object
-GET    /api/v1/storage/:collection             List objects in collection
-```
-
-### Cloud Saves
-```
-GET    /api/v1/saves                  List save slots
-GET    /api/v1/saves/:slot            Get save data
-PUT    /api/v1/saves/:slot            Write save (with version)
-```
-
-### Notifications
-```
-GET    /api/v1/notifications          List notifications (paginated)
-PUT    /api/v1/notifications/:id/read Mark as read
-DELETE /api/v1/notifications/:id      Delete notification
-```
-
-## Admin Dashboard (Arizona)
-
-Arizona LiveView admin console at `/admin`. Real-time updates via Arizona PubSub.
-
-### Views
-
-- **Dashboard** — online players, active matches, server stats (ETS counters)
-- **Players** — search, view profile, ban/unban, edit metadata, view transactions
-- **Matches** — live match list, spectate match state, force-end
-- **Economy** — grant/revoke currency, edit store listings, transaction audit
-- **Leaderboards** — view boards, manual entry management, trigger reset
-- **Groups** — view groups, moderate, edit
-- **Chat** — monitor channels, moderate messages
-- **Tournaments** — create/edit tournaments, view standings
-- **Config** — remote config key-value editor, feature flags
+This node ships no admin console. The dashboard is a separate project,
+[asobi_admin](https://github.com/widgrensit/asobi_admin), which reads the same
+database. There is no `/admin` route in `asobi_router.erl`, and asobi no longer
+depends on Arizona.
 
 ## Background Jobs (Shigoto)
 
@@ -834,20 +726,11 @@ asobi/
 ].
 ```
 
-## Dependencies (rebar.config)
+## Dependencies
 
-```erlang
-{deps, [
-    {nova, {git, "https://github.com/novaframework/nova.git", {branch, "main"}}},
-    {kura, {git, "https://github.com/Taure/kura.git", {branch, "main"}}},
-    {arizona_core, {git, "https://github.com/novaframework/arizona_core.git", {branch, "main"}}},
-    {arizona_nova, {git, "https://github.com/novaframework/arizona_nova.git", {branch, "main"}}},
-    {nova_auth, {git, "https://github.com/novaframework/nova_auth.git", {branch, "main"}}},
-    {shigoto, {git, "https://github.com/Taure/shigoto.git", {branch, "main"}}},
-    {nova_test, {git, "https://github.com/novaframework/nova_test.git", {branch, "main"}}},
-    {opentelemetry_kura, {git, "https://github.com/novaframework/opentelemetry_kura.git", {branch, "main"}}}
-]}.
-```
+`rebar.config` is the authoritative list. asobi builds on Nova, Kura (with
+kura_postgres), nova_auth, nova_auth_oidc, nova_resilience, seki, and Shigoto. It
+does not depend on Arizona.
 
 ## Build Phases
 

--- a/guides/large-worlds.md
+++ b/guides/large-worlds.md
@@ -3,46 +3,52 @@
 Scale the world server to handle massive tile-based maps with lazy zone
 loading, terrain data serving, and configurable zone lifecycle management.
 
+Everything here is game logic and config. It is written once and runs the same
+whether you deploy to managed Cloud (`asobi deploy`, console.asobi.dev) or
+self-host your own release of asobi + asobi_lua. The one exception - shipping a
+custom terrain generator - is called out under [Terrain Data](#terrain-data).
+
 ## Lazy Zone Loading
 
 By default, all zones in a world are spawned at startup. For large worlds
-(thousands of zones), enable lazy loading so zones are created on demand
-when a player enters.
+(thousands of zones), enable lazy loading so zones are created on demand when a
+player enters. The config keys are globals at the top of your world script.
 
 <!-- tabs -->
 **Lua**
 ```lua
 -- world.lua
 game_type         = "world"
-grid_size         = 2000       -- 2000x2000 zone grid
-zone_size         = 64         -- 64 tiles per zone
-lazy_zones        = true       -- auto-true when grid_size > 100
-zone_idle_timeout = 30000      -- reap idle zones after 30s
-max_active_zones  = 10000      -- cap concurrent zone processes
+grid_size         = 2000
+zone_size         = 64
+lazy_zones        = true
+zone_idle_timeout = 30000
+max_active_zones  = 10000
 ```
 
 **Erlang**
 ```erlang
 Config = #{
     game_module => my_world,
-    grid_size => 2000,          %% 2000x2000 zone grid
-    zone_size => 64,            %% 64 tiles per zone
-    lazy_zones => true,         %% auto-true when grid_size > 100
-    zone_idle_timeout => 30000, %% reap idle zones after 30s
-    max_active_zones => 10000   %% cap concurrent zone processes
+    grid_size => 2000,
+    zone_size => 64,
+    lazy_zones => true,
+    zone_idle_timeout => 30000,
+    max_active_zones => 10000
 }.
 ```
 <!-- /tabs -->
 
-With `lazy_zones => true`:
+With `lazy_zones` on:
 
-- Zones are created when a player joins or moves into them
-- Interest zones (adjacent to the player) only subscribe if already loaded
-- Idle zones are snapshotted to the database and terminated after `zone_idle_timeout`
-- The `max_active_zones` cap prevents runaway memory usage
+- Zones are created when a player joins or moves into them.
+- Interest zones (adjacent to the player) only subscribe if already loaded.
+- Idle zones are snapshotted to the database and terminated after `zone_idle_timeout`.
+- `max_active_zones` caps concurrent zone processes and prevents runaway memory.
 
-For small worlds (`grid_size =< 100`), all zones are pre-warmed at startup
-regardless of the `lazy_zones` setting.
+`lazy_zones` auto-enables when `grid_size > 100`. For small worlds
+(`grid_size <= 100`) all zones are pre-warmed at startup regardless of the
+setting.
 
 ## Zone Lifecycle
 
@@ -55,47 +61,71 @@ Each zone follows this lifecycle:
      +---<---snapshot + terminate---<---reap---<--------------+
 ```
 
-Active zones call `touch_zone` each tick when they have subscribers,
-resetting the idle timer. When subscribers drop to zero and the zone has
-no tickable entities, it enters Erlang hibernation to reduce memory.
+A zone with subscribers resets its idle timer each tick. When subscribers drop
+to zero and the zone has no tickable entities, it enters BEAM hibernation to
+reduce memory, then is snapshotted and reaped once `zone_idle_timeout` expires.
 
 ## Terrain Data
 
-Terrain is separate from entities. Tile chunks are served as compressed
-binary blobs when a player subscribes to a zone -- not through the
-tick/delta loop.
+Terrain is separate from entities. Tile chunks are served as compressed binary
+blobs when a player subscribes to a zone, not through the tick/delta loop.
 
-Asobi does not define what terrain is. You implement a provider that returns
-the bytes of the chunk at a `{X, Y}` coordinate; Asobi caches that blob in
-the terrain store and ships it to clients verbatim. The payload is whatever
-your provider produces -- "the data Asobi chunks" is the data you hand back.
-The `asobi_terrain` helpers below give you a compact tile format, but any
-binary your client can decode works. A complete, runnable provider lives in
+Asobi does not define what terrain is. A provider returns the bytes of the chunk
+at a `{X, Y}` coordinate; Asobi caches that blob in the terrain store and ships
+it to clients verbatim. The payload is whatever your provider produces. A
+complete, runnable provider lives in
 [`examples/world-terrain`](https://github.com/widgrensit/asobi/tree/main/examples/world-terrain).
 
-### Selecting a Provider (Lua)
+The split is: Lua selects a provider, Erlang implements one.
 
-A Lua world names its provider from `terrain_provider`, returning the module
-and its args:
+### Selecting a Provider
 
+Your world script names its provider from `terrain_provider`, returning the
+module name and its args as a keyed table.
+
+<!-- tabs -->
+**Lua**
 ```lua
 -- world.lua
 function terrain_provider(config)
-	return {"asobi_terrain_perlin", {seed = 42}}
+    return { module = "asobi_terrain_perlin", args = { seed = 42 } }
 end
 ```
 
-Two providers ship built in: `asobi_terrain_flat` and
-`asobi_terrain_perlin`. The name is checked against an allowlist rather than
-resolved as an arbitrary module, so a script cannot name `gen_server` or any
-other loaded module. Operators extend the allowlist via env.
+**Erlang**
+```erlang
+terrain_provider(Config) ->
+    {asobi_terrain_perlin, #{seed => maps:get(seed, Config, 42)}}.
+```
+<!-- /tabs -->
 
-**Writing a new provider is Erlang only** - the same split as matchmaker
-strategies. Lua selects; Erlang implements.
+Return `nil` (Lua) or `none` (Erlang) for a world with no terrain.
+
+Two providers ship built in: `asobi_terrain_flat` and `asobi_terrain_perlin`.
+The name is checked against an allowlist rather than resolved as an arbitrary
+module, so a script cannot name `gen_server` or any other loaded module. A name
+that is not on the list is rejected with `terrain_provider_not_allowed`.
+
+**Cloud:** the two built-in providers are available with no configuration.
+
+**Self-hosted:** extend the allowlist to admit your own provider. This is an
+`asobi_lua` key, set in sys.config - see
+[Terrain provider allowlist](configuration.md#terrain-provider-allowlist):
+
+```erlang
+{asobi_lua, [
+    {terrain_providers, [asobi_terrain_flat, asobi_terrain_perlin, my_terrain]}
+]}
+```
+
+A custom provider is a compiled Erlang module, so shipping one means running
+your own release: it is a self-hosted feature. On managed Cloud, stick to the
+built-ins.
 
 ### Terrain Provider Behaviour (Erlang)
 
-Implement `asobi_terrain_provider` to supply terrain data:
+Implement `asobi_terrain_provider` to supply terrain data. This is Erlang only,
+the same split as matchmaker strategies.
 
 ```erlang
 -module(my_terrain).
@@ -106,68 +136,60 @@ init(Config) ->
     {ok, Config}.
 
 load_chunk({X, Y}, State) ->
-    %% Load from file, database, etc.
-    {error, not_found}.  %% Falls back to generate_chunk/3
+    {error, not_found}.
 
 generate_chunk({X, Y}, Seed, State) ->
-    %% Procedural generation
     Tiles = generate_tiles(X, Y, Seed),
-    Bin = asobi_terrain:compress_chunk(
-        asobi_terrain:encode_chunk(Tiles)
-    ),
+    Bin = asobi_terrain:compress_chunk(asobi_terrain:encode_chunk(Tiles)),
     {ok, Bin, State}.
 ```
 
-### Connecting to the World
+`load_chunk/2` loads from file or database; returning `{error, not_found}` falls
+back to `generate_chunk/3` for procedural generation.
 
-Add `terrain_provider/1` to your world game module:
-
-```erlang
--module(my_world).
--behaviour(asobi_world).
-
-terrain_provider(Config) ->
-    {my_terrain, #{seed => maps:get(seed, Config, 42)}}.
-```
-
-When a player subscribes to a zone, they receive a `world.terrain` message
-with the compressed chunk data (base64-encoded in JSON).
+When a player subscribes to a zone, they receive a `world.terrain` message with
+the compressed chunk data (base64-encoded in JSON).
 
 ### Terrain Encoding
 
 `asobi_terrain` encodes tiles as compact binaries:
 
-- Default format: 4 bytes per tile (2B tile_id, 1B flags, 1B elevation)
-- 64x64 chunk = 16KB raw, typically 2-4KB compressed
-- Custom formats via the `format` parameter
+- Default format: 4 bytes per tile (2B tile_id, 1B flags, 1B elevation).
+- 64x64 chunk = 16KB raw, typically 2-4KB compressed.
+- Custom formats via the `format` parameter.
 
 ```erlang
 Tiles = [{0, 0, 1, 0, 10}, {3, 5, 200, 15, 255}],
 Bin = asobi_terrain:encode_chunk(Tiles),
-Compressed = asobi_terrain:compress_chunk(Bin),
-%% Compressed is typically 75-85% smaller
+Compressed = asobi_terrain:compress_chunk(Bin).
 ```
 
 ### Terrain Store
 
 The terrain store is an ETS-backed cache that lazy-loads chunks from the
-provider. It is started automatically when the game module returns a
-terrain provider. Chunks are cached after first load.
+provider. It starts automatically when the game returns a terrain provider.
+Chunks are cached after first load.
 
-## Configuration Reference
+## Zone Lifecycle Callbacks
 
-| Key | Default | Description |
-|-----|---------|-------------|
-| `lazy_zones` | `grid_size > 100` | Enable on-demand zone loading |
-| `zone_idle_timeout` | `30000` | Milliseconds before idle zones are reaped |
-| `max_active_zones` | `10000` | Maximum concurrent zone processes |
-| `grid_size` | `10` | Zones per dimension |
-| `zone_size` | `200` | World units per zone |
+A world script can react to zones loading and unloading. Both callbacks are
+optional.
 
-## New Behaviour Callbacks
+<!-- tabs -->
+**Lua**
+```lua
+-- world.lua
+function on_zone_loaded(cx, cy, state)
+    local zone_state = { biome = "plains" }
+    return zone_state, state
+end
 
-These optional callbacks are available on `asobi_world`:
+function on_zone_unloaded(cx, cy, state)
+    return state
+end
+```
 
+**Erlang**
 ```erlang
 -callback terrain_provider(Config :: map()) ->
     {Module :: module(), ProviderArgs :: map()} | none.
@@ -178,15 +200,49 @@ These optional callbacks are available on `asobi_world`:
 -callback on_zone_unloaded(Coords :: {integer(), integer()}, GameState :: term()) ->
     {ok, GameState1 :: term()}.
 ```
+<!-- /tabs -->
+
+## Configuration Reference
+
+| Key | Default | Description |
+|-----|---------|-------------|
+| `grid_size` | `10` | Zones per dimension |
+| `zone_size` | `200` | World units per zone |
+| `lazy_zones` | `grid_size > 100` | Enable on-demand zone loading |
+| `zone_idle_timeout` | `30000` | Milliseconds before idle zones are reaped |
+| `max_active_zones` | `10000` | Maximum concurrent zone processes |
 
 ## Scaling Guidelines
+
+Asobi is single-node by design. These figures are per node.
 
 | Map Size | Zones | Recommended Config |
 |----------|-------|--------------------|
 | Small (1K x 1K) | 100 | Default (eager loading) |
-| Medium (10K x 10K) | 10,000 | `lazy_zones => true` |
+| Medium (10K x 10K) | 10,000 | `lazy_zones = true` |
 | Large (128K x 128K) | 4,000,000 | Lazy + terrain provider + tuned idle timeout |
 
-For large worlds, expect 200-500 concurrent zone processes per node with
-typical player clustering. The BEAM handles this efficiently -- the
-bottleneck is serialisation and network I/O, not process count.
+For large worlds, expect 200-500 concurrent zone processes per node with typical
+player clustering. The BEAM handles this efficiently; the bottleneck is
+serialisation and network I/O, not process count.
+
+## Checkpoint
+
+1. Set `game_type = "world"`, `grid_size = 2000` and `lazy_zones = true` in
+   `world.lua`, then start your world (Cloud: `asobi deploy`; self-hosted: your
+   release).
+2. Connect a client and move into a zone. On the server, confirm only a handful
+   of zones are active, not four million:
+
+   ```
+   Active zones climb as players spread out, and idle zones vanish after
+   zone_idle_timeout - not all grid_size^2 zones at once.
+   ```
+3. If you named a `terrain_provider`, the subscribing client receives a
+   `world.terrain` message with a non-empty base64 chunk. An empty chunk or a
+   `terrain_provider_not_allowed` log means the name is not on the allowlist.
+
+## Next
+
+[Performance Tuning](performance-tuning.md) - spatial-grid indexing, adaptive
+tick rates, and shared-state broadcast for busy zones.

--- a/guides/performance-tuning.md
+++ b/guides/performance-tuning.md
@@ -1,33 +1,38 @@
 # Performance Tuning
 
-Optimisation features for high-throughput world servers. These are all
-opt-in and backward compatible -- existing configurations work unchanged.
+Optimisation features for high-throughput world and match servers. All are
+opt-in and backward compatible; existing configurations work unchanged.
+
+Every feature here is game config or logic. It is identical on managed Cloud
+(`asobi deploy`, console.asobi.dev) and on a self-hosted release - the same
+script, the same globals. Only the base server URL your client SDK points at
+differs, and that is covered in [Getting Started](getting-started.md).
 
 ## Spatial Grid Index
 
-By default, spatial queries (`query_radius`, `query_rect`) scan all
-entities in a zone via `maps:fold` -- O(n). For zones with many entities,
-enable the cell-based spatial grid for O(1) cell lookup + local scan.
+By default, spatial queries scan all entities in a zone (O(n)). For zones with
+many entities, enable the cell-based spatial grid for O(1) cell lookup plus a
+local scan. Set the cell size as a global in your world script.
 
 <!-- tabs -->
 **Lua**
 ```lua
 -- world.lua
 game_type              = "world"
-spatial_grid_cell_size = 16   -- units per cell
+spatial_grid_cell_size = 16
 ```
 
 **Erlang**
 ```erlang
 Config = #{
     game_module => my_world,
-    spatial_grid_cell_size => 16  %% units per cell
+    spatial_grid_cell_size => 16
 }.
 ```
 <!-- /tabs -->
 
-The grid is maintained automatically as entities are added, removed, or
-moved during ticks. Query through the zone API:
+The grid is maintained automatically as entities are added, removed, or moved
+during ticks. Query it through the `game.spatial` namespace:
 
 <!-- tabs -->
 **Lua**
@@ -36,74 +41,86 @@ moved during ticks. Query through the zone API:
 local hits = game.spatial.query_radius(100, 200, 50)
 ```
 
-`game.spatial` also offers `query_rect`, `nearest`, `in_range` and
-`distance`. The zone-based forms need a zone in scope; the entity-list
-forms (`game.spatial.query_radius(entities, x, y, radius)`) work anywhere.
-
 **Erlang**
 ```erlang
 Results = asobi_zone:query_radius(ZonePid, {100.0, 200.0}, 50.0).
-%% Returns [{EntityId, {X, Y}}, ...]
 ```
 <!-- /tabs -->
 
-When no `spatial_grid_cell_size` is configured, the zone falls back to
-the brute-force scan (existing behaviour).
+`game.spatial` also offers `query_rect`, `nearest`, `in_range` and `distance`.
+Only `query_radius` and `query_rect` have zone-based forms and need a zone in
+scope; `nearest`, `in_range` and `distance` are entity-list forms
+(`game.spatial.query_radius(entities, x, y, radius)`) and work anywhere.
+
+When no `spatial_grid_cell_size` is configured, the zone falls back to the
+brute-force scan.
 
 ### Cell Size Guidelines
 
 | Entity Density | Recommended Cell Size |
 |---------------|----------------------|
-| Sparse (< 50/zone) | Don't enable (overhead not worth it) |
+| Sparse (< 50/zone) | Do not enable (overhead not worth it) |
 | Medium (50-200/zone) | 32-64 units |
 | Dense (200+/zone) | 8-16 units |
 
 ## Broadcast Batching
 
-Zone deltas are JSON-encoded once and the pre-encoded binary is sent to
-all subscribers. This replaces N `json:encode` calls with exactly 1.
+Zone deltas are JSON-encoded once and the pre-encoded binary is sent to all
+subscribers, replacing N `json:encode` calls with exactly 1. This is automatic;
+no configuration needed. Subscribers receive `zone_delta_raw` messages that the
+WebSocket handler forwards without re-encoding.
 
-This is automatic -- no configuration needed. Subscribers receive
-`zone_delta_raw` messages containing pre-encoded JSON, which the
-WebSocket handler forwards directly without re-encoding.
+## Match State Broadcast (Shared vs Per-Player)
 
-## Match State Broadcast (Shared vs. Per-Player)
+By default the match server calls `get_state(player_id, state)` once per player
+per tick and JSON-encodes each result. For games where every player sees the
+same world (FFA shooters, racing, party games), opt into a single shared encode:
+the server calls the state function once per tick, encodes once, and broadcasts
+the same binary to everyone. At 200 players and 10 ticks/sec this drops 2000
+encodes/sec to 10.
 
-By default the match server calls `Mod:get_state(PlayerId, GameState)`
-once per player per tick and JSON-encodes each result. For games where
-every player sees the same world (FFA shooters, racing, party games),
-implement the optional `get_state/1` callback instead:
+Opt in from your match script by declaring `state_strategy = "shared"` and
+defining a one-arg state function. Games that need per-player filtering (fog of
+war, hidden hand) keep the two-arg form and pay the per-player cost.
 
+<!-- tabs -->
+**Lua**
+```lua
+-- match.lua
+state_strategy = "shared"
+
+function get_state(state)
+    return state
+end
+```
+
+**Erlang**
 ```erlang
 -callback get_state(GameState) -> SharedState.
 ```
+<!-- /tabs -->
 
-When the match server detects `get_state/1` is exported, it calls it once
-per tick, JSON-encodes once, and broadcasts the same pre-encoded binary
-to every player. At 200 players / 10 ticks/sec this drops 2000 encodes/sec
-to 10. Games that need per-player filtering (fog of war, hidden hand)
-keep `get_state/2` and pay the per-player cost.
-
-Lua match scripts opt in by declaring `state_strategy = "shared"` and
-defining a one-arg `get_state(state)`. The asobi_lua bridge then routes
-through `asobi_lua_match_shared`, which exports `get_state/1`.
+The asobi_lua bridge routes a shared script through `asobi_lua_match_shared`,
+which exports `get_state/1`. In Erlang, export exactly one of `get_state/1` or
+`get_state/2`; the match server detects which and switches broadcast strategy.
+For multi-mode games, declare `state_strategy` in the mode's config, not in a
+shared file - see [Configuration](configuration.md).
 
 ## Adaptive Tick Rates
 
-Zones with no subscribers tick at a reduced rate to save CPU:
+Zones with no subscribers tick at a reduced rate to save CPU. Set the divisor as
+a global.
 
 <!-- tabs -->
 **Lua**
 ```lua
 -- world.lua
-cold_tick_divisor = 10   -- cold zones tick 10x less often (default)
+cold_tick_divisor = 10
 ```
 
 **Erlang**
 ```erlang
-Config = #{
-    cold_tick_divisor => 10  %% cold zones tick 10x less often (default)
-}.
+Config = #{cold_tick_divisor => 10}.
 ```
 <!-- /tabs -->
 
@@ -113,22 +130,16 @@ Config = #{
 | Cold | 1/N (every Nth tick) | Entities but no subscribers |
 | Empty | Not ticked | No entities, no subscribers |
 
-The ticker provides manual controls:
-
-```erlang
-asobi_world_ticker:promote_zone(TickerPid, ZonePid).  %% → hot
-asobi_world_ticker:demote_zone(TickerPid, ZonePid).   %% → cold
-asobi_world_ticker:remove_zone(TickerPid, ZonePid).   %% → stop ticking
-```
-
-Zone promotion/demotion is typically handled automatically by the zone
-manager based on subscriber presence.
+Promotion and demotion between hot and cold are handled automatically by the
+zone manager based on subscriber presence, so a game script never manages tick
+state directly.
 
 ## Binary Protocol
 
-For maximum throughput, clients can negotiate binary WebSocket frames
-instead of JSON. Set `binary_protocol: true` in the `session.connect`
-payload.
+For maximum throughput, a client can negotiate binary WebSocket frames instead
+of JSON. This is a client-side choice, identical on Cloud and self-hosted: set
+`binary_protocol: true` in the `session.connect` payload. JSON remains the
+default; binary is opt-in per connection.
 
 Binary frames use a Tag-Length-Value format:
 
@@ -136,24 +147,30 @@ Binary frames use a Tag-Length-Value format:
 [type:u8][length:u32be][payload:bytes]
 ```
 
-### Message Types
-
 | Tag | Type | Payload |
 |-----|------|---------|
 | 0x01 | Terrain chunk | coords (2x i32) + compressed data |
 | 0x02 | Entity deltas | tick (u64) + counted delta list |
 | 0x03 | Match state | Reserved |
 
-### Size Savings
+Terrain chunks save ~25% versus JSON+base64; entity deltas save 15-30% depending
+on field count. Frame encoding and decoding is handled by the server and SDKs -
+see the [WebSocket protocol](websocket-protocol.md) guide.
 
-Terrain chunks save ~25% vs JSON+base64 encoding. Entity deltas save
-varies based on field count but typically 15-30%.
+## Checkpoint
 
-Use `asobi_ws_binary` for encoding/decoding:
+1. Add `spatial_grid_cell_size = 16` to a busy `world.lua`, redeploy (Cloud:
+   `asobi deploy`; self-hosted: your release), and call
+   `game.spatial.query_radius(x, y, r)` from `zone_tick`. It returns the same
+   hits as before, now backed by the grid rather than a full scan.
+2. In a match where everyone shares one view, set `state_strategy = "shared"`
+   and a one-arg `get_state(state)`. With 100+ players connected, server encode
+   count per tick should drop from once-per-player to once total.
+3. Leave a zone with no subscribers. Confirm it ticks at roughly
+   `1 / cold_tick_divisor` of the hot rate, and that an empty zone stops ticking
+   entirely.
 
-```erlang
-Bin = asobi_ws_binary:encode_terrain_chunk({5, 10}, CompressedData).
-{{5, 10}, Data} = asobi_ws_binary:decode_terrain_chunk(Bin).
-```
+## Next
 
-JSON remains the default protocol. Binary is opt-in per connection.
+[Large Worlds](large-worlds.md) - lazy zone loading, terrain providers, and the
+zone lifecycle these tuning knobs sit on top of.

--- a/guides/phases.md
+++ b/guides/phases.md
@@ -1,0 +1,244 @@
+# Phases and seasons
+
+Two clocks, different scopes.
+
+A **phase** is a stage in one session's lifecycle - lobby, then play, then
+results - inside a single match or world. It starts and ends with that
+session and is authored in the game script.
+
+A **season** is a wall-clock window across the whole deployment - a
+fortnight of ranked play, a themed event - shared by every session. It
+lives in the database and is read by game logic.
+
+They do not interact. This guide covers both because a reader who sees
+`phase` on a `world.list` response, or hears "season", lands here.
+
+## Phases
+
+### Declare them in your game script
+
+Phases are a list. The engine walks it in order: the first phase starts,
+runs for its `duration`, ends, and the next begins.
+
+```lua
+-- king_of_the_hill.lua
+function phases(config)
+  return {
+    { name = "warmup",  duration = 10000 },
+    { name = "combat",  duration = 120000 },
+    { name = "results", duration = 8000 },
+  }
+end
+```
+
+`duration` is milliseconds. When the last phase ends the session's phase
+state is complete; a match reports `phases_complete` and finishes.
+
+This is game logic. It runs identically whether you deploy to the managed
+cloud or self-host - nothing here touches deployment, secrets, or the
+database. Every phase example below is written once and is the same on both.
+
+### Start conditions
+
+By default each phase starts when the previous one ends (`prev_ended`). A
+phase can instead wait for a condition:
+
+```lua
+function phases(config)
+  return {
+    { name = "lobby",  start = { players = 4 } },
+    { name = "combat", duration = 120000 },
+    { name = "results", duration = 8000 },
+  }
+end
+```
+
+Start conditions you can declare from Lua:
+
+| `start` value        | Meaning                                  |
+|----------------------|------------------------------------------|
+| `"prev_ended"`       | when the previous phase ends (default)   |
+| `{ players = N }`    | when the Nth player has joined           |
+| `{ timer = Ms }`     | after Ms of waiting, whatever else       |
+| `Ms` (a bare number) | shorthand for `{ timer = Ms }`           |
+| `"all_ready"`        | when the game signals every player ready |
+
+A waiting phase has no duration clock; it holds until its condition fires.
+
+### React to transitions
+
+Two optional callbacks fire as phases begin and end. Use them to reset
+scores, open a gate, freeze input. The client sends intent; the server
+decides the phase; the server broadcasts the result.
+
+```lua
+function on_phase_started(phase_name, state)
+  if phase_name == "combat" then
+    state.scores = {}
+    game.broadcast("round_start", { phase = phase_name })
+  end
+  return state
+end
+
+function on_phase_ended(phase_name, state)
+  if phase_name == "combat" then
+    game.broadcast("round_over", { winner = leader(state) })
+  end
+  return state
+end
+```
+
+`game.broadcast` is how the phase reaches your own clients with your own
+shape. See the callback reference for the full callback list.
+
+### What the client sees on the wire
+
+A **world** pushes `world.phase_changed` on every transition and again
+roughly every three seconds while a phase runs. The payload is the phase
+info block:
+
+```json
+{
+  "type": "world.phase_changed",
+  "payload": {
+    "status": "active",
+    "phase": "combat",
+    "remaining_ms": 118400,
+    "config": {},
+    "world_id": "..."
+  }
+}
+```
+
+A **match** does not push a phase event. The match server runs the phase
+clock and your callbacks, but the client learns the phase by reading the
+`phase` block on the listing and join reply - `status`, `phase`,
+`remaining_ms` and the pending `start_condition`. Broadcast anything richer
+yourself from `on_phase_started`.
+
+See [WebSocket protocol](websocket-protocol.md#worldphase_changed-server-push)
+for the frame envelope and [Lobbies](lobbies.md) for `game.broadcast`.
+
+### Erlang games
+
+An Erlang match or world module implements the same three callbacks and has
+the full phase feature set, including per-phase `timers`, an `end_condition`
+predicate, and the `players_ratio` and `event` start conditions that the Lua
+decoder does not expose.
+
+```erlang
+phases(_Config) ->
+    [
+        #{name => ~"warmup", duration => 10000},
+        #{name => ~"combat", duration => 120000,
+          timers => [#{id => ~"suddendeath", type => countdown, duration => 100000}]},
+        #{name => ~"results", duration => 8000}
+    ].
+
+on_phase_started(~"combat", GameState) ->
+    {ok, GameState#{scores => #{}}};
+on_phase_started(_Name, GameState) ->
+    {ok, GameState}.
+```
+
+### Limits when authoring in Lua
+
+The Lua `phases()` decoder reads `name`, `duration`, `start` and `config`
+only. From Lua you cannot declare per-phase `timers`, an `end_condition`
+function, or the `players_ratio` and `event` start conditions - those need
+an Erlang game module. If a phase needs a timer, drive it from your own tick
+logic and `game.broadcast`, or move that game to Erlang.
+
+## Seasons
+
+A season is a named, dated window stored in the `seasons` table. A
+background manager checks the clock once a minute and moves each season
+`upcoming -> active -> ended` as its `starts_at` and `ends_at` pass. Exactly
+the parts of a game you want gated on "the current event" - a ranked ladder,
+a reward set - key off the active season.
+
+Seasons are a server-side primitive today. There is no Lua binding, no
+WebSocket event and no REST endpoint. You seed a season row into the
+database and read it from Erlang game logic.
+
+### Seed a season
+
+A season is one row. `starts_at` and `ends_at` are millisecond epochs.
+
+```erlang
+Now = erlang:system_time(millisecond),
+CS = kura_changeset:cast(asobi_season, #{}, #{
+    name      => ~"Spring Ladder",
+    starts_at => Now,
+    ends_at   => Now + 14 * 24 * 60 * 60 * 1000,
+    status    => ~"active",
+    config    => #{theme => ~"spring"},
+    rewards   => #{top10 => ~"gold_frame"}
+}, [name, starts_at, ends_at, status, config, rewards]),
+{ok, _} = asobi_repo:insert(CS).
+```
+
+Where that row goes differs by deployment:
+
+**Cloud.** The per-project database is provisioned for you and the `seasons`
+table already exists. Open a console against your project
+(`console.asobi.dev`) and insert the row - or run the snippet above from a
+release remote shell attached to your project's node.
+
+**Self-hosted.** Point `ASOBI_*` at your own Postgres, apply migrations so
+the `seasons` table exists (`rebar3 kura migrate`), then insert the row from
+your release's remote shell. See [Configuration](configuration.md) for the
+`ASOBI_*` database variables.
+
+Once the row exists the season manager runs the same on both: it flips
+`status` by wall clock with no further action from you.
+
+### Read the active season from game logic
+
+```erlang
+case asobi_season:current() of
+    {ok, #{name := Name, rewards := Rewards}} ->
+        %% gate ranked play, pick the reward table, etc.
+        {ranked, Name, Rewards};
+    {error, no_active_season} ->
+        casual
+end.
+```
+
+Other queries: `asobi_season:config(Key)` pulls one key from the active
+season's `config`; `upcoming/0` and `history/0` list scheduled and past
+seasons; `time_remaining/0` returns milliseconds left in the active season
+(or `infinity` if none is active).
+
+To surface the season to players, read it in your game module and put it in
+the state you already send - there is no season frame to subscribe to.
+
+## Checkpoint
+
+Phases, with a Lua world game running locally:
+
+1. Add a `phases()` returning `warmup` (5000) then `active` (10000) to your
+   world script.
+2. Join the world over the WebSocket and watch the frames. Within a few
+   seconds you see `world.phase_changed` with `"phase": "warmup"`, then
+   after five seconds another with `"phase": "active"`.
+3. Call `world.list`; the entry carries a `phase` block with the live
+   `phase` and `remaining_ms`.
+
+Seasons:
+
+1. Insert a season row with `status = "active"` and an `ends_at` a minute
+   out (cloud console, or self-hosted remote shell as above).
+2. From a remote shell, `asobi_season:current()` returns `{ok, Season}` and
+   `asobi_season:time_remaining()` counts down.
+3. Wait past `ends_at`; within a minute the manager logs `season_ended` and
+   `current()` returns `{error, no_active_season}`.
+
+If the phase frames never arrive, confirm the game is a **world** (matches
+run phases but do not push them) and that `phases()` returns a list. A
+non-list logs a warning and is ignored.
+
+## Next
+
+[Voting](voting.md) - run a vote inside a phase to let players pick what
+happens in the next one.

--- a/guides/websocket-protocol.md
+++ b/guides/websocket-protocol.md
@@ -3,6 +3,13 @@
 Asobi uses a single WebSocket connection per client at `/ws`. All messages
 are JSON with a common envelope format.
 
+> **You probably do not call this directly.** This page is the raw wire reference.
+> Every official SDK (Defold, Godot, Unity, Unreal, Dart/Flame, JavaScript, LÖVE)
+> wraps this protocol: each message you *send* is a function, each message the
+> server *pushes* is a callback you register. Reach for this page only to write a
+> client from scratch or to debug what is on the wire. For the calls in your
+> language, see the realtime section of your [SDK quickstart](https://asobi.dev/docs).
+
 ## Message Format
 
 ### Client to Server
@@ -53,6 +60,10 @@ Keep-alive ping. Send periodically to prevent timeout.
 ```
 
 ## Matches
+
+> The `match.input` (client -> server) and `match.state` (server -> all clients)
+> pair below is the core real-time loop. In an SDK these are one send function and
+> one receive callback - see the realtime section of your [SDK quickstart](https://asobi.dev/docs).
 
 ### `match.list`
 
@@ -348,11 +359,20 @@ membership without a per-frame registry lookup.
 
 | Prefix   | Used for                                  | Membership rule |
 |----------|-------------------------------------------|-----------------|
-| `dm:`    | Direct messages                           | Both participants only. |
+| `dm:`    | Direct messages                           | The two named participants only. |
 | `world:` | World-wide chat                           | Players currently joined to the world. |
-| `zone:`  | A specific zone within a world            | Players currently inside that zone. |
-| `prox:`  | Proximity chat (radius around a position) | Players within the configured radius. |
-| `room:`  | Group / lobby / custom rooms              | Group members, or open join per room policy. |
+| `zone:`  | A specific zone within a world            | Players currently joined to the world. |
+| `prox:`  | Proximity chat (radius around a position) | Players currently joined to the world. |
+| `room:`  | App-defined group chat                    | Members of the group whose id equals the channel id. Not open-join. |
+
+There is no open-join room policy and no `match:` scheme. `room:` is authorised
+as a group membership check: the runtime treats the full channel id as the group
+id, so a player must already belong to a group with that exact id. For pre-game
+lobby chat, gate on world membership with `world:<world_id>`, or use
+`game.broadcast`; see the [Lobbies](lobbies.md) guide.
+
+The worked examples below use a `world:` channel, which authorises on world
+membership you already hold after `world.join`.
 
 A single connection may join at most **32 channels** at once; a 33rd is rejected
 with `too_many_channels`. Idle channels with no members stop after 60s; rejoining
@@ -367,7 +387,7 @@ History (`GET /api/v1/chat/:channel_id/history`) requires membership and clamps
 Join a chat channel. The channel id must be namespaced.
 
 ```json
-{"type": "chat.join", "payload": {"channel_id": "room:lobby"}}
+{"type": "chat.join", "payload": {"channel_id": "world:w_ancient_ruins"}}
 ```
 
 ### `chat.send`
@@ -375,7 +395,7 @@ Join a chat channel. The channel id must be namespaced.
 Send a message to a channel.
 
 ```json
-{"type": "chat.send", "payload": {"channel_id": "room:lobby", "content": "Hello!"}}
+{"type": "chat.send", "payload": {"channel_id": "world:w_ancient_ruins", "content": "Hello!"}}
 ```
 
 ### `chat.message` (server push)
@@ -386,7 +406,7 @@ A new message in a joined channel.
 {
   "type": "chat.message",
   "payload": {
-    "channel_id": "room:lobby",
+    "channel_id": "world:w_ancient_ruins",
     "sender_id": "...",
     "content": "Hello!",
     "sent_at": "2025-01-15T10:30:00Z"
@@ -399,7 +419,7 @@ A new message in a joined channel.
 Leave a chat channel.
 
 ```json
-{"type": "chat.leave", "payload": {"channel_id": "room:lobby"}}
+{"type": "chat.leave", "payload": {"channel_id": "world:w_ancient_ruins"}}
 ```
 
 ## Voting

--- a/rebar.config
+++ b/rebar.config
@@ -105,13 +105,13 @@
         <<"guides/economy.md">>,
         <<"guides/comparison.md">>,
         <<"guides/clustering.md">>,
-        <<"docs/ARCHITECTURE.md">>,
         <<"guides/authentication.md">>,
         <<"guides/iap.md">>,
         <<"guides/voting.md">>,
         <<"guides/world-server.md">>,
         <<"guides/large-worlds.md">>,
         <<"guides/performance-tuning.md">>,
+        <<"guides/phases.md">>,
         <<"guides/security-threat-model.md">>,
         <<"guides/security-auth.md">>,
         <<"guides/security-known-limitations.md">>,
@@ -146,16 +146,14 @@
             <<"guides/voting.md">>,
             <<"guides/world-server.md">>,
             <<"guides/large-worlds.md">>,
-            <<"guides/performance-tuning.md">>
+            <<"guides/performance-tuning.md">>,
+            <<"guides/phases.md">>
         ]},
         {<<"Security">>, [
             <<"guides/security-threat-model.md">>,
             <<"guides/security-auth.md">>,
             <<"guides/security-known-limitations.md">>,
             <<"SECURITY.md">>
-        ]},
-        {<<"Reference">>, [
-            <<"docs/ARCHITECTURE.md">>
         ]}
     ]},
     {groups_for_modules, [


### PR DESCRIPTION
Closes #209, #205, #213, #203.

## Changes
- **#209 chat docs** - correct the `## Chat` membership table in `websocket-protocol.md`: `room:` is an app-defined group-membership check (not open-join), and `zone:`/`prox:` authorise on world membership. Worked examples now use a `world:` channel. Verified against `asobi_chat_acl`.
- **#205 Lua-first** - `large-worlds.md` and `performance-tuning.md` now lead every example with Lua (Erlang secondary only where the surface is genuinely Erlang, e.g. the terrain-provider behaviour). Also fixes a broken terrain-provider table example (positional -> keyed `module`/`args`).
- **#213 phases + seasons** - new `guides/phases.md` documenting both timing primitives, honest about the Lua limits (no `players_ratio`/`event` starts from Lua; seasons are a server-side Erlang primitive with no client API). Added to ex_doc extras.
- **#203 stale ARCHITECTURE** - de-list `docs/ARCHITECTURE.md` from ex_doc and stub its duplicate REST / admin / dependencies / message-catalogue sections with cross-links to the canonical guides, so it can't masquerade as the API reference again.
- **Banner** - a 'you probably do not call this directly' note at the top of `websocket-protocol.md` pointing SDK users at the realtime helpers.

## Verified
`rebar3 ex_doc` builds with **no warnings**; the published output no longer contains the stale endpoints or the phantom Arizona admin; `phases` is published; no em dashes in the changed guides.

## Follow-up (coupled, ADR 0003)
A matching `asobi_site` PR will regenerate the `websocket` and `large-worlds` views and wire the new `phases` page (manifest + route + sidebar). It lands right after this merges, per the guide+regen split.