### PR TITLE
docs: glossary Arena entry no longer points at the private repo

### DIFF
--- a/guides/glossary.md
+++ b/guides/glossary.md
@@ -17,8 +17,9 @@ library with a [Luerl](https://github.com/rvirding/luerl) VM so you can
 write game logic in Lua without knowing Erlang. Ships as a Docker image at
 `ghcr.io/widgrensit/asobi_lua`. Most people start here.
 
-**asobi_arena_lua** — the flagship end-to-end Lua example. Read it to see
-a full game, not a snippet.
+**Arena Shooter** — the flagship end-to-end sample: a full multiplayer game
+(server-authoritative movement and combat, matchmaking with bots, boons,
+round voting, a leaderboard), not a snippet.
 
 ## Client SDKs
 


### PR DESCRIPTION
The glossary sent readers to `asobi_arena_lua` ("read it to see a full game"), but that repo is private. Reframes the entry to describe the Arena Shooter sample - a full end-to-end multiplayer game - without pointing at any repo. Keeps the docs *about* Arena while linking nothing.

Coupled asobi_site regen of the glossary view follows once this merges (ADR 0003).