### PR TITLE
ci: cancel superseded runs and skip docs-only changes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,8 +3,14 @@ name: CI
 on:
   push:
     branches: [main]
+    paths-ignore: ['**.md', 'docs/**', 'LICENSE']
   pull_request:
     branches: [main]
+    paths-ignore: ['**.md', 'docs/**', 'LICENSE']
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
 
 jobs:
   ci:

--- a/.github/workflows/docs-drift.yml
+++ b/.github/workflows/docs-drift.yml
@@ -27,6 +27,10 @@ on:
       - 'scripts/check-error-drift.sh'
       - '.github/workflows/docs-drift.yml'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   drift:
     runs-on: ubuntu-24.04

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,6 +9,10 @@ on:
       - 'guides/**'
       - 'LICENSE'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   release:
     uses: Taure/erlang-ci/.github/workflows/release.yml@v2.1.4


### PR DESCRIPTION
Cut Actions minutes (org is on the 3000/mo budget): add `concurrency` (cancel-in-progress) so a burst of pushes to a PR costs one run not N, and skip the pipeline on docs-only changes (`**.md`, `docs/**`). Mirrors asobi_saas.