### PR TITLE
feat(telemetry): add game_error/1,2 event

### DIFF
--- a/src/asobi_telemetry.erl
+++ b/src/asobi_telemetry.erl
@@ -17,6 +17,12 @@
     ws_origin_rejected/0
 ]).
 -export([anticheat_violation/3]).
+-export([game_error/1, game_error/2]).
+
+%% Categories of game-code error. A fixed literal set on purpose - never derive
+%% Kind from untrusted input (atom-table exhaustion). Extend as categories arise.
+-type game_error_kind() :: lua_error.
+-export_type([game_error_kind/0]).
 -export([economy_transaction/4, store_purchase/3]).
 -export([chat_message_sent/2]).
 -export([vote_started/2, vote_cast/2, vote_resolved/3]).
@@ -197,6 +203,26 @@ anticheat_violation(PlayerId, Type, Details) ->
         #{count => 1},
         #{player_id => PlayerId, type => Type, details => Details}
     ).
+
+-doc """
+Emit `[asobi, error]` for a game-code error - the game author's logic failing,
+e.g. a Lua callback raising. `count => 1`, metadata `#{kind, details}`.
+
+`details` is passed verbatim to every attached handler (which may log or export
+it), so emitters MUST keep it bounded and free of sensitive data: no raw player
+input, secrets, PII, or file-system paths, and no unbounded values (truncate a
+message, classify the reason - never pass a raw luerl/error term, which can
+embed interpolated player input). Consumers should aggregate on `kind` only, not
+on `details` (this event can fire at high frequency).
+""".
+-spec game_error(game_error_kind(), map()) -> ok.
+game_error(Kind, Details) ->
+    telemetry:execute([asobi, error], #{count => 1}, #{kind => Kind, details => Details}).
+
+-doc "Emit `[asobi, error]` with no extra context. See `game_error/2`.".
+-spec game_error(game_error_kind()) -> ok.
+game_error(Kind) ->
+    game_error(Kind, #{}).
 
 -spec ws_message_in(binary()) -> ok.
 ws_message_in(Type) ->

--- a/test/asobi_telemetry_tests.erl
+++ b/test/asobi_telemetry_tests.erl
@@ -1,0 +1,32 @@
+-module(asobi_telemetry_tests).
+
+-include_lib("eunit/include/eunit.hrl").
+
+game_error_emits_single_event_test() ->
+    {ok, _} = application:ensure_all_started(telemetry),
+    Self = self(),
+    Ref = make_ref(),
+    telemetry:attach(
+        Ref, [asobi, error], fun(_Event, M, Meta, _) -> Self ! {ev, M, Meta} end, []
+    ),
+    try
+        asobi_telemetry:game_error(lua_error, #{callback => post_tick}),
+        receive
+            {ev, M, Meta} ->
+                ?assertEqual(1, maps:get(count, M)),
+                ?assertEqual(lua_error, maps:get(kind, Meta)),
+                ?assertEqual(#{callback => post_tick}, maps:get(details, Meta))
+        after 1000 -> ?assert(false)
+        end,
+        %% arity-1 keeps count/kind and defaults details to an empty map.
+        asobi_telemetry:game_error(lua_error),
+        receive
+            {ev, M2, Meta2} ->
+                ?assertEqual(1, maps:get(count, M2)),
+                ?assertEqual(lua_error, maps:get(kind, Meta2)),
+                ?assertEqual(#{}, maps:get(details, Meta2))
+        after 1000 -> erlang:error(no_event)
+        end
+    after
+        telemetry:detach(Ref)
+    end.


### PR DESCRIPTION
Adds a public `[asobi, error]` telemetry event for game-code errors - the game author's logic failing (e.g. a Lua callback raising). First of a 3-repo game-error-rate chain (asobi_lua emits it, the engine counts it into a per-env rate, the saas dashboard shows it).

## What
`asobi_telemetry:game_error/1,2` -> `telemetry:execute([asobi, error], #{count => 1}, #{kind, details})`. `game_error/1` defaults details to `#{}`.

## Contract (security-reviewed)
`kind` is a fixed literal (`game_error_kind() :: lua_error`) - never derive it from untrusted input (atom-exhaustion). `details` is passed verbatim to every attached handler, so emitters MUST keep it bounded and PII-free: no raw player input, secrets, or paths; classify + truncate, never a raw luerl/error term. Documented on the export.

## Gated
asobi-architecture-guardian ruled the design (single event, kind in metadata, defined here / emitted from asobi_lua). beam-security-reviewer (contract: narrowed kind type + details doc applied) + erlang-code-reviewer (0 blockers). fmt/xref/dialyzer clean, eqwalize NO ERRORS, 1 eunit test (both arities).

Merge this FIRST - asobi_lua pins asobi@main and calls game_error, so it can't build until this lands.