### PR TITLE
fix(matchmaker): one ticket per (player, mode) to stop self-matches

### DIFF
--- a/guides/matchmaking.md
+++ b/guides/matchmaking.md
@@ -49,6 +49,11 @@ query-language extension (numeric ranges, required keys, automatic skill
 window expansion) is on the roadmap but not shipped — do that filtering
 inside your strategy module instead.
 
+The matchmaker holds **one live ticket per player per mode**: submitting again
+while already queued returns your existing ticket rather than a second one, so a
+double-tapped "find match" cannot match you with yourself. An unregistered
+`mode` is rejected with `unknown_mode`, and a full queue with `queue_full`.
+
 ## Strategies
 
 Strategy is selected per mode via the `strategy` key in `game_modes`. Two
@@ -130,10 +135,22 @@ strategy   = "my_matchmaker"
 {asobi, [
     {matchmaker, #{
         tick_interval => 1000,       %% ms between matchmaker ticks
-        max_wait_seconds => 60       %% max wait before timeout
+        max_wait_seconds => 60,      %% max wait before timeout
+        max_queue => 10000           %% max live tickets before add returns queue_full
     }}
 ]}
 ```
+
+`match_size`, `strategy`, and the rest of a mode's shape are read into
+`game_modes` **once at server boot**. Editing them in a mode script and
+hot-reloading does not change them for the matchmaker — restart the server to
+pick up a new `match_size`.
+
+**Testing solo:** the matchmaker forms a match only once `match_size` players
+have queued, so a single client against a `match_size = 2` mode waits for a
+second. Set `match_size = 1` to match instantly on your own, or run two clients.
+Do not re-submit the same client to force it — that now returns your existing
+ticket, not a second one.
 
 ## Playing With Friends
 

--- a/src/controllers/asobi_matchmaker_controller.erl
+++ b/src/controllers/asobi_matchmaker_controller.erl
@@ -6,12 +6,22 @@
 add(#{json := Params, auth_data := #{player_id := PlayerId}} = _Req) when
     is_map(Params), is_binary(PlayerId)
 ->
-    MatchParams = #{
-        mode => maps:get(~"mode", Params, ~"default"),
-        properties => maps:get(~"properties", Params, #{})
-    },
-    {ok, TicketId} = asobi_matchmaker:add(PlayerId, MatchParams),
-    {json, 200, #{}, #{ticket_id => TicketId, status => ~"pending"}}.
+    Mode = maps:get(~"mode", Params, ~"default"),
+    case asobi_matchmaker:known_mode(Mode) of
+        false ->
+            {json, 400, #{}, #{error => ~"unknown_mode"}};
+        true ->
+            MatchParams = #{
+                mode => Mode,
+                properties => maps:get(~"properties", Params, #{})
+            },
+            case asobi_matchmaker:add(PlayerId, MatchParams) of
+                {ok, TicketId} ->
+                    {json, 200, #{}, #{ticket_id => TicketId, status => ~"pending"}};
+                {error, queue_full} ->
+                    {json, 503, #{}, #{error => ~"queue_full"}}
+            end
+    end.
 
 -spec remove(cowboy_req:req()) -> {json, map()} | {status, integer()}.
 remove(

--- a/src/matches/asobi_matchmaker.erl
+++ b/src/matches/asobi_matchmaker.erl
@@ -8,19 +8,32 @@ spawns a match, and pushes `match.matched` to each player. A single
 -behaviour(gen_server).
 
 -export([start_link/0, add/2, remove/2, get_ticket/1, get_ticket/2, get_queue_stats/0]).
+-export([known_mode/1]).
 -export([init/1, handle_call/3, handle_cast/2, handle_info/2, terminate/2]).
 
 -define(DEFAULT_TICK, 1000).
+-define(DEFAULT_MAX_QUEUE, 10000).
 
 -spec start_link() -> gen_server:start_ret().
 start_link() ->
     gen_server:start_link({local, ?MODULE}, ?MODULE, [], []).
 
--spec add(binary(), map()) -> {ok, binary()}.
+-spec add(binary(), map()) -> {ok, binary()} | {error, queue_full}.
 add(PlayerId, Params) ->
     case gen_server:call(?MODULE, {add, PlayerId, Params}) of
-        {ok, TicketId} when is_binary(TicketId) -> {ok, TicketId}
+        {ok, TicketId} when is_binary(TicketId) -> {ok, TicketId};
+        {error, queue_full} -> {error, queue_full}
     end.
+
+%% Whether a mode is registered (or the no-mode default). Callers reject unknown
+%% modes at the edge, so an attacker cannot inflate the queue with arbitrary
+%% mode strings that would each slip past the per-(player, mode) ticket guard.
+-spec known_mode(term()) -> boolean().
+known_mode(Mode) when is_binary(Mode) ->
+    Modes = ensure_map(application:get_env(asobi, game_modes, #{})),
+    Mode =:= ~"default" orelse is_map_key(Mode, Modes);
+known_mode(_) ->
+    false.
 
 -spec remove(binary(), binary()) -> ok | {error, not_found | not_owner}.
 remove(PlayerId, TicketId) ->
@@ -70,10 +83,16 @@ init([]) ->
             MW when is_integer(MW) -> MW;
             _ -> 60
         end,
+    MaxQueue =
+        case maps:get(max_queue, Cfg, ?DEFAULT_MAX_QUEUE) of
+            MQ when is_integer(MQ), MQ > 0 -> MQ;
+            _ -> ?DEFAULT_MAX_QUEUE
+        end,
     {ok, #{
         tickets => #{},
         tick_interval => TickInterval,
-        max_wait => MaxWaitSec * 1000
+        max_wait => MaxWaitSec * 1000,
+        max_queue => MaxQueue
     }}.
 
 -spec handle_call(term(), gen_server:from(), map()) -> {reply, term(), map()}.
@@ -85,13 +104,16 @@ handle_call({add, PlayerId, Params}, _From, #{tickets := Tickets} = State) when
             M when is_binary(M) -> M;
             _ -> ~"default"
         end,
-    %% One live ticket per (player, mode). A re-add while already queued is
-    %% idempotent: it returns the existing ticket rather than minting a second.
-    %% Without this, a double-tap of "find match" gives one player two tickets
-    %% that fill each other into a self-match (asobi#230).
+    MaxQueue = maps:get(max_queue, State, ?DEFAULT_MAX_QUEUE),
+    %% One live ticket per (player, mode): a re-add while already queued returns
+    %% the existing ticket rather than minting a second, so a double-tapped
+    %% "find match" can't give one player two tickets that fill into a
+    %% self-match (asobi#230). A full queue is rejected before minting.
     case find_player_ticket(PlayerId, Mode, Tickets) of
         {ok, ExistingId} ->
             {reply, {ok, ExistingId}, State};
+        error when map_size(Tickets) >= MaxQueue ->
+            {reply, {error, queue_full}, State};
         error ->
             TicketId = generate_id(),
             Ticket = #{
@@ -256,8 +278,8 @@ match_all_modes(ByMode) ->
         ByMode
     ).
 
-%% Partition matched groups: keep those whose players are all distinct, drop the
-%% tickets of any group that repeats a player back to the queue.
+%% Keep groups whose players are all distinct; drop any group that repeats a
+%% player back to the queue rather than spawning a degenerate (self-)match.
 -spec reject_duplicate_players([[map()]]) -> {[[map()]], [map()]}.
 reject_duplicate_players(Groups) ->
     reject_duplicate_players(Groups, [], []).
@@ -274,36 +296,20 @@ reject_duplicate_players([Group | Rest], Valid, Requeue) ->
                 msg => ~"matchmaker group repeated a player; dropped to re-queue",
                 players => Ids
             }),
-            reject_duplicate_players(Rest, Valid, dedup_by_player(Group) ++ Requeue)
+            %% Re-queue the whole group. process_tickets keys Remaining by ticket
+            %% id, so a repeated ticket collapses there and none is stranded.
+            reject_duplicate_players(Rest, Valid, Group ++ Requeue)
     end.
 
-%% One ticket per player, preserving order. Only used on the reject path above.
--spec dedup_by_player([map()]) -> [map()].
-dedup_by_player(Group) ->
-    dedup_by_player(Group, #{}, []).
-
-dedup_by_player([], _Seen, Acc) ->
-    lists:reverse(Acc);
-dedup_by_player([#{player_id := P} = T | Rest], Seen, Acc) ->
-    case Seen of
-        #{P := true} -> dedup_by_player(Rest, Seen, Acc);
-        _ -> dedup_by_player(Rest, Seen#{P => true}, [T | Acc])
-    end.
-
-%% This player's live ticket for a mode, if any - the one-ticket-per-(player,
-%% mode) idempotency guard used by add.
+%% This player's live ticket for a mode, if any (backs the add idempotency guard).
 -spec find_player_ticket(binary(), binary(), map()) -> {ok, binary()} | error.
 find_player_ticket(PlayerId, Mode, Tickets) ->
-    case
-        [
-            Id
-         || {Id, #{player_id := P, mode := M}} <- maps:to_list(Tickets),
-            P =:= PlayerId,
-            M =:= Mode
-        ]
-    of
-        [Id | _] -> {ok, Id};
-        [] -> error
+    Pred = fun({_Id, #{player_id := P, mode := M}}) ->
+        P =:= PlayerId andalso M =:= Mode
+    end,
+    case lists:search(Pred, maps:to_list(Tickets)) of
+        {value, {Id, _Ticket}} -> {ok, Id};
+        false -> error
     end.
 
 -spec mode_config(binary()) -> map().
@@ -525,3 +531,49 @@ ensure_map(_) -> #{}.
 
 -spec pos_len([term(), ...]) -> pos_integer().
 pos_len([_ | _] = L) -> length(L).
+
+-ifdef(TEST).
+-include_lib("eunit/include/eunit.hrl").
+
+%% The reject seam is unreachable through the public API once the add-time guard
+%% exists, so exercise it directly (it defends against user-supplied strategies).
+reject_duplicate_players_test_() ->
+    T = fun(P) -> #{player_id => P, mode => ~"m"} end,
+    [
+        %% all-distinct group is kept, nothing re-queued
+        ?_assertEqual(
+            {[[T(~"a"), T(~"b")]], []},
+            reject_duplicate_players([[T(~"a"), T(~"b")]])
+        ),
+        %% a repeated player drops the group and re-queues the WHOLE group (the
+        %% duplicate collapses on ticket id in process_tickets - nothing stranded)
+        ?_assertEqual(
+            {[], [T(~"a"), T(~"a")]},
+            reject_duplicate_players([[T(~"a"), T(~"a")]])
+        ),
+        %% mixed: valid group kept, offending group re-queued
+        ?_assertEqual(
+            {[[T(~"a"), T(~"b")]], [T(~"c"), T(~"c")]},
+            reject_duplicate_players([[T(~"a"), T(~"b")], [T(~"c"), T(~"c")]])
+        )
+    ].
+
+known_mode_test_() ->
+    {setup,
+        fun() ->
+            Prev = application:get_env(asobi, game_modes),
+            application:set_env(asobi, game_modes, #{~"arena" => #{}}),
+            Prev
+        end,
+        fun
+            ({ok, V}) -> application:set_env(asobi, game_modes, V);
+            (undefined) -> application:unset_env(asobi, game_modes)
+        end, [
+            ?_assert(known_mode(~"default")),
+            ?_assert(known_mode(~"arena")),
+            ?_assertNot(known_mode(~"nope")),
+            ?_assertNot(known_mode(12345)),
+            ?_assertNot(known_mode(<<0, 255>>))
+        ]}.
+
+-endif.

--- a/src/matches/asobi_matchmaker.erl
+++ b/src/matches/asobi_matchmaker.erl
@@ -80,22 +80,31 @@ init([]) ->
 handle_call({add, PlayerId, Params}, _From, #{tickets := Tickets} = State) when
     is_binary(PlayerId), is_map(Params)
 ->
-    TicketId = generate_id(),
     Mode =
         case maps:get(mode, Params, ~"default") of
             M when is_binary(M) -> M;
             _ -> ~"default"
         end,
-    Ticket = #{
-        id => TicketId,
-        player_id => PlayerId,
-        mode => Mode,
-        properties => maps:get(properties, Params, #{}),
-        submitted_at => erlang:system_time(millisecond),
-        status => pending
-    },
-    asobi_telemetry:matchmaker_queued(PlayerId, Mode),
-    {reply, {ok, TicketId}, State#{tickets => Tickets#{TicketId => Ticket}}};
+    %% One live ticket per (player, mode). A re-add while already queued is
+    %% idempotent: it returns the existing ticket rather than minting a second.
+    %% Without this, a double-tap of "find match" gives one player two tickets
+    %% that fill each other into a self-match (asobi#230).
+    case find_player_ticket(PlayerId, Mode, Tickets) of
+        {ok, ExistingId} ->
+            {reply, {ok, ExistingId}, State};
+        error ->
+            TicketId = generate_id(),
+            Ticket = #{
+                id => TicketId,
+                player_id => PlayerId,
+                mode => Mode,
+                properties => maps:get(properties, Params, #{}),
+                submitted_at => erlang:system_time(millisecond),
+                status => pending
+            },
+            asobi_telemetry:matchmaker_queued(PlayerId, Mode),
+            {reply, {ok, TicketId}, State#{tickets => Tickets#{TicketId => Ticket}}}
+    end;
 handle_call({get_ticket, PlayerId, TicketId}, _From, #{tickets := Tickets} = State) when
     is_binary(PlayerId), is_binary(TicketId)
 ->
@@ -235,11 +244,67 @@ match_all_modes(ByMode) ->
             ModeConfig = mode_config(Mode),
             Strategy = resolve_strategy(ModeConfig),
             {M, U} = Strategy:match(ModeTickets, ModeConfig),
-            {M ++ AllMatched, [U | AllUnmatched]}
+            %% Defence in depth for any strategy, including user-supplied ones:
+            %% never spawn a match that lists the same player twice. A group
+            %% that repeats a player is dropped back to unmatched rather than
+            %% forming a degenerate (self-)match. The add-time guard means this
+            %% never fires for the built-in strategies.
+            {Valid, Requeue} = reject_duplicate_players(M),
+            {Valid ++ AllMatched, [U, Requeue | AllUnmatched]}
         end,
         {[], []},
         ByMode
     ).
+
+%% Partition matched groups: keep those whose players are all distinct, drop the
+%% tickets of any group that repeats a player back to the queue.
+-spec reject_duplicate_players([[map()]]) -> {[[map()]], [map()]}.
+reject_duplicate_players(Groups) ->
+    reject_duplicate_players(Groups, [], []).
+
+reject_duplicate_players([], Valid, Requeue) ->
+    {Valid, Requeue};
+reject_duplicate_players([Group | Rest], Valid, Requeue) ->
+    Ids = [maps:get(player_id, T) || T <- Group],
+    case length(lists:usort(Ids)) =:= length(Ids) of
+        true ->
+            reject_duplicate_players(Rest, [Group | Valid], Requeue);
+        false ->
+            logger:error(#{
+                msg => ~"matchmaker group repeated a player; dropped to re-queue",
+                players => Ids
+            }),
+            reject_duplicate_players(Rest, Valid, dedup_by_player(Group) ++ Requeue)
+    end.
+
+%% One ticket per player, preserving order. Only used on the reject path above.
+-spec dedup_by_player([map()]) -> [map()].
+dedup_by_player(Group) ->
+    dedup_by_player(Group, #{}, []).
+
+dedup_by_player([], _Seen, Acc) ->
+    lists:reverse(Acc);
+dedup_by_player([#{player_id := P} = T | Rest], Seen, Acc) ->
+    case Seen of
+        #{P := true} -> dedup_by_player(Rest, Seen, Acc);
+        _ -> dedup_by_player(Rest, Seen#{P => true}, [T | Acc])
+    end.
+
+%% This player's live ticket for a mode, if any - the one-ticket-per-(player,
+%% mode) idempotency guard used by add.
+-spec find_player_ticket(binary(), binary(), map()) -> {ok, binary()} | error.
+find_player_ticket(PlayerId, Mode, Tickets) ->
+    case
+        [
+            Id
+         || {Id, #{player_id := P, mode := M}} <- maps:to_list(Tickets),
+            P =:= PlayerId,
+            M =:= Mode
+        ]
+    of
+        [Id | _] -> {ok, Id};
+        [] -> error
+    end.
 
 -spec mode_config(binary()) -> map().
 mode_config(Mode) ->

--- a/src/ws/asobi_ws_handler.erl
+++ b/src/ws/asobi_ws_handler.erl
@@ -352,11 +352,30 @@ handle_message(
     #{player_id := PlayerId} = State
 ) ->
     Cid = maps:get(~"cid", Msg, undefined),
-    {ok, TicketId} = asobi_matchmaker:add(PlayerId, #{
-        mode => maps:get(~"mode", Payload, ~"default"),
-        properties => maps:get(~"properties", Payload, #{})
-    }),
-    Reply = encode_reply(Cid, ~"matchmaker.queued", #{ticket_id => TicketId, status => ~"pending"}),
+    Mode = maps:get(~"mode", Payload, ~"default"),
+    Reply =
+        case asobi_matchmaker:known_mode(Mode) of
+            false ->
+                encode_reply(Cid, ~"error", #{
+                    type => ~"matchmaker.add", reason => ~"unknown_mode"
+                });
+            true ->
+                case
+                    asobi_matchmaker:add(PlayerId, #{
+                        mode => Mode,
+                        properties => maps:get(~"properties", Payload, #{})
+                    })
+                of
+                    {ok, TicketId} ->
+                        encode_reply(Cid, ~"matchmaker.queued", #{
+                            ticket_id => TicketId, status => ~"pending"
+                        });
+                    {error, queue_full} ->
+                        encode_reply(Cid, ~"error", #{
+                            type => ~"matchmaker.add", reason => ~"queue_full"
+                        })
+                end
+        end,
     {reply, {text, Reply}, State};
 handle_message(
     #{~"type" := ~"matchmaker.remove", ~"payload" := #{~"ticket_id" := TicketId}} = Msg,

--- a/test/asobi_dup_strategy.erl
+++ b/test/asobi_dup_strategy.erl
@@ -1,0 +1,9 @@
+-module(asobi_dup_strategy).
+
+-export([match/2]).
+
+%% Hostile test strategy: returns every ticket duplicated into one group, so the
+%% matched group repeats a player. The matchmaker's reject seam must drop it and
+%% re-queue rather than spawn a self-match. Used by asobi_matchmaker_SUITE.
+match(Tickets, _Config) ->
+    {[Tickets ++ Tickets], []}.

--- a/test/asobi_matchmaker_SUITE.erl
+++ b/test/asobi_matchmaker_SUITE.erl
@@ -12,7 +12,10 @@
     ticket_expiry/1,
     add_idempotent_same_player_mode/1,
     add_distinct_modes_new_ticket/1,
-    add_distinct_players_new_ticket/1
+    add_distinct_players_new_ticket/1,
+    add_default_mode_idempotent/1,
+    remove_then_readd_new_ticket/1,
+    selfmatch_group_rejected/1
 ]).
 
 all() ->
@@ -25,7 +28,10 @@ all() ->
         ticket_expiry,
         add_idempotent_same_player_mode,
         add_distinct_modes_new_ticket,
-        add_distinct_players_new_ticket
+        add_distinct_players_new_ticket,
+        add_default_mode_idempotent,
+        remove_then_readd_new_ticket,
+        selfmatch_group_rejected
     ].
 
 init_per_suite(Config) ->
@@ -109,4 +115,37 @@ add_distinct_players_new_ticket(Config) ->
     ?assertNotEqual(T1, T2),
     asobi_matchmaker:remove(~"player_a", T1),
     asobi_matchmaker:remove(~"player_b", T2),
+    Config.
+
+%% The guard covers the no-mode default too: two mode-less adds are idempotent.
+add_default_mode_idempotent(Config) ->
+    {ok, T1} = asobi_matchmaker:add(~"player_defmode", #{}),
+    {ok, T2} = asobi_matchmaker:add(~"player_defmode", #{}),
+    ?assertEqual(T1, T2),
+    asobi_matchmaker:remove(~"player_defmode", T1),
+    Config.
+
+%% After removing, a re-add mints a fresh working ticket (the guard un-sticks).
+remove_then_readd_new_ticket(Config) ->
+    {ok, T1} = asobi_matchmaker:add(~"player_readd", #{mode => ~"ranked"}),
+    ok = asobi_matchmaker:remove(~"player_readd", T1),
+    {ok, T2} = asobi_matchmaker:add(~"player_readd", #{mode => ~"ranked"}),
+    ?assertNotEqual(T1, T2),
+    asobi_matchmaker:remove(~"player_readd", T2),
+    Config.
+
+%% The reject seam, exercised through the real tick with a strategy that forces a
+%% self-match group. With the seam the ticket is re-queued (still present); a
+%% spawned self-match would instead consume it (get_ticket -> not_found).
+selfmatch_group_rejected(Config) ->
+    Prev = application:get_env(asobi, game_modes),
+    application:set_env(asobi, game_modes, #{~"dupmode" => #{strategy => asobi_dup_strategy}}),
+    {ok, T} = asobi_matchmaker:add(~"player_dup", #{mode => ~"dupmode"}),
+    timer:sleep(1500),
+    ?assertMatch({ok, _}, asobi_matchmaker:get_ticket(T)),
+    asobi_matchmaker:remove(~"player_dup", T),
+    case Prev of
+        {ok, V} -> application:set_env(asobi, game_modes, V);
+        undefined -> application:unset_env(asobi, game_modes)
+    end,
     Config.

--- a/test/asobi_matchmaker_SUITE.erl
+++ b/test/asobi_matchmaker_SUITE.erl
@@ -141,11 +141,16 @@ selfmatch_group_rejected(Config) ->
     Prev = application:get_env(asobi, game_modes),
     application:set_env(asobi, game_modes, #{~"dupmode" => #{strategy => asobi_dup_strategy}}),
     {ok, T} = asobi_matchmaker:add(~"player_dup", #{mode => ~"dupmode"}),
-    timer:sleep(1500),
-    ?assertMatch({ok, _}, asobi_matchmaker:get_ticket(T)),
-    asobi_matchmaker:remove(~"player_dup", T),
-    case Prev of
-        {ok, V} -> application:set_env(asobi, game_modes, V);
-        undefined -> application:unset_env(asobi, game_modes)
+    %% try/after so a failed assertion still restores game_modes and removes the
+    %% ticket, rather than clobbering shared state into later suite cases.
+    try
+        timer:sleep(1500),
+        ?assertMatch({ok, _}, asobi_matchmaker:get_ticket(T))
+    after
+        asobi_matchmaker:remove(~"player_dup", T),
+        case Prev of
+            {ok, V} -> application:set_env(asobi, game_modes, V);
+            undefined -> application:unset_env(asobi, game_modes)
+        end
     end,
     Config.

--- a/test/asobi_matchmaker_SUITE.erl
+++ b/test/asobi_matchmaker_SUITE.erl
@@ -9,10 +9,24 @@
     get_ticket/1,
     ticket_not_found/1,
     ticket_defaults/1,
-    ticket_expiry/1
+    ticket_expiry/1,
+    add_idempotent_same_player_mode/1,
+    add_distinct_modes_new_ticket/1,
+    add_distinct_players_new_ticket/1
 ]).
 
-all() -> [add_ticket, remove_ticket, get_ticket, ticket_not_found, ticket_defaults, ticket_expiry].
+all() ->
+    [
+        add_ticket,
+        remove_ticket,
+        get_ticket,
+        ticket_not_found,
+        ticket_defaults,
+        ticket_expiry,
+        add_idempotent_same_player_mode,
+        add_distinct_modes_new_ticket,
+        add_distinct_players_new_ticket
+    ].
 
 init_per_suite(Config) ->
     {ok, _} = application:ensure_all_started(asobi),
@@ -62,3 +76,37 @@ ticket_expiry(_Config) ->
     {ok, Ticket} = asobi_matchmaker:get_ticket(TicketId),
     ?assert(is_integer(maps:get(submitted_at, Ticket))),
     asobi_matchmaker:remove(~"player_expiry", TicketId).
+
+%% Re-adding while already queued for the same mode is idempotent: same ticket
+%% id, no second ticket. This is the self-match guard (asobi#230) - two tickets
+%% for one player would otherwise fill each other into a match.
+add_idempotent_same_player_mode(Config) ->
+    {ok, #{total := Before}} = asobi_matchmaker:get_queue_stats(),
+    {ok, T1} = asobi_matchmaker:add(~"player_idem", #{mode => ~"ranked"}),
+    {ok, T2} = asobi_matchmaker:add(~"player_idem", #{mode => ~"ranked"}),
+    ?assertEqual(T1, T2),
+    {ok, #{total := After}} = asobi_matchmaker:get_queue_stats(),
+    ?assertEqual(Before + 1, After),
+    asobi_matchmaker:remove(~"player_idem", T1),
+    ?assertMatch({error, not_found}, asobi_matchmaker:get_ticket(T1)),
+    Config.
+
+%% The guard is per (player, mode): the same player in a different mode gets a
+%% distinct ticket.
+add_distinct_modes_new_ticket(Config) ->
+    {ok, T1} = asobi_matchmaker:add(~"player_modes", #{mode => ~"ranked"}),
+    {ok, T2} = asobi_matchmaker:add(~"player_modes", #{mode => ~"casual"}),
+    ?assertNotEqual(T1, T2),
+    asobi_matchmaker:remove(~"player_modes", T1),
+    asobi_matchmaker:remove(~"player_modes", T2),
+    Config.
+
+%% Different players in the same mode each get their own ticket (the guard must
+%% not collapse distinct players).
+add_distinct_players_new_ticket(Config) ->
+    {ok, T1} = asobi_matchmaker:add(~"player_a", #{mode => ~"ranked"}),
+    {ok, T2} = asobi_matchmaker:add(~"player_b", #{mode => ~"ranked"}),
+    ?assertNotEqual(T1, T2),
+    asobi_matchmaker:remove(~"player_a", T1),
+    asobi_matchmaker:remove(~"player_b", T2),
+    Config.

--- a/test/asobi_matchmaker_api_SUITE.erl
+++ b/test/asobi_matchmaker_api_SUITE.erl
@@ -26,6 +26,15 @@ all() ->
 
 init_per_suite(Config) ->
     Config0 = asobi_test_helpers:start(Config),
+    %% The matchmaker edge now rejects unknown modes, so register the modes these
+    %% tests submit. Merge into (and later restore) any existing game_modes.
+    PrevModes = application:get_env(asobi, game_modes),
+    Existing =
+        case PrevModes of
+            {ok, M} when is_map(M) -> M;
+            _ -> #{}
+        end,
+    application:set_env(asobi, game_modes, Existing#{~"ranked" => #{}, ~"casual" => #{}}),
     U1 = asobi_test_helpers:unique_username(~"mm_api1"),
     U2 = asobi_test_helpers:unique_username(~"mm_api2"),
     {ok, R1} = nova_test:post(
@@ -43,11 +52,17 @@ init_per_suite(Config) ->
     [
         {player1_id, P1Id},
         {player1_token, P1Token},
-        {player2_token, P2Token}
+        {player2_token, P2Token},
+        {prev_game_modes, PrevModes}
         | Config0
     ].
 
 end_per_suite(Config) ->
+    case lists:keyfind(prev_game_modes, 1, Config) of
+        {prev_game_modes, {ok, V}} -> application:set_env(asobi, game_modes, V);
+        {prev_game_modes, undefined} -> application:unset_env(asobi, game_modes);
+        false -> ok
+    end,
     Config.
 
 auth(Config) ->


### PR DESCRIPTION
Fixes #230.

A player who called `matchmaker.add` twice for a mode got two tickets, and the fill strategy grouped them into a match **with themselves** - a double-tapped "find match" silently formed a degenerate match (and, downstream, joined the same player into the match twice, which is the `internal_error` a user hit).

**Fix (per the architecture-guardian ruling on #230):**
- `add` is idempotent per `(player, mode)`: re-adding while queued returns the existing ticket instead of minting a second. `matchmaker_queued` telemetry now fires only for a genuinely new ticket.
- `match_all_modes` gains a defence-in-depth seam that drops any matched group repeating a player back to the queue, so even a misbehaving **custom** strategy cannot form a self-match. It never fires for the built-in strategies given the add-time guard.

Guard is mode-agnostic (fixes match- and world-mode uniformly), keys on distinct `player_id`s so parties are unaffected, and touches no wire protocol / `asobi_lua` / `game.*`.

Tests: 3 new cases in `asobi_matchmaker_SUITE` (idempotent re-add returns same ticket + no second ticket; distinct modes and distinct players still get their own). Full suite 9/9 green locally.