### PR TITLE
feat(matchmaker): observable queueing + spawn-failure notification

### DIFF
--- a/guides/matchmaking.md
+++ b/guides/matchmaking.md
@@ -40,9 +40,15 @@ curl -X POST http://localhost:8084/api/v1/matchmaker \
 ```
 **Erlang**
 ```erlang
-{ok, TicketId} = asobi_matchmaker:add(PlayerId, #{mode => <<"arena">>, properties => #{skill => 1200, region => <<"eu-west">>}}).
+{ok, TicketId, Meta} = asobi_matchmaker:add(PlayerId, #{mode => <<"arena">>, properties => #{skill => 1200, region => <<"eu-west">>}}).
 ```
 <!-- /tabs -->
+
+The reply (the `matchmaker.queued` message over WS, the JSON body over REST)
+carries `ticket_id`, `status: "pending"`, and **`players_needed`** — the mode's
+`match_size`, or `null` if the mode declares none. Show it as "waiting for N
+players" so a queued client isn't staring at silence. The `Meta` map in the
+Erlang return holds the same `players_needed`.
 
 A ticket supports `mode` and `properties`. A
 query-language extension (numeric ranges, required keys, automatic skill
@@ -53,6 +59,11 @@ The matchmaker holds **one live ticket per player per mode**: submitting again
 while already queued returns your existing ticket rather than a second one, so a
 double-tapped "find match" cannot match you with yourself. An unregistered
 `mode` is rejected with `unknown_mode`, and a full queue with `queue_full`.
+
+If a match cannot start (for example the game's Lua `init` crashes), the
+matchmaker retries a few times, then sends the queued players a
+`matchmaker_failed` event with `reason: "match_start_failed"` rather than leaving
+them queued forever. Handle `matchmaker_failed` in your client.
 
 ## Strategies
 

--- a/src/asobi_telemetry.erl
+++ b/src/asobi_telemetry.erl
@@ -4,7 +4,7 @@
 -export([match_started/2, match_finished/3, match_player_joined/2, match_player_left/2]).
 -export([world_started/2, world_finished/3, world_player_joined/2, world_player_left/2]).
 -export([world_phase_changed/3]).
--export([matchmaker_queued/2, matchmaker_removed/2, matchmaker_formed/3]).
+-export([matchmaker_queued/2, matchmaker_removed/2, matchmaker_formed/3, matchmaker_failed/2]).
 -export([session_connected/1, session_disconnected/2]).
 -export([
     ws_connected/0,
@@ -143,6 +143,14 @@ matchmaker_formed(Mode, PlayerCount, WaitMs) ->
         #{
             player_count => PlayerCount, wait_ms => WaitMs, count => 1
         },
+        #{mode => Mode}
+    ).
+
+-spec matchmaker_failed(binary(), non_neg_integer()) -> ok.
+matchmaker_failed(Mode, PlayerCount) ->
+    telemetry:execute(
+        [asobi, matchmaker, failed],
+        #{player_count => PlayerCount, count => 1},
         #{mode => Mode}
     ).
 

--- a/src/controllers/asobi_matchmaker_controller.erl
+++ b/src/controllers/asobi_matchmaker_controller.erl
@@ -16,8 +16,8 @@ add(#{json := Params, auth_data := #{player_id := PlayerId}} = _Req) when
                 properties => maps:get(~"properties", Params, #{})
             },
             case asobi_matchmaker:add(PlayerId, MatchParams) of
-                {ok, TicketId} ->
-                    {json, 200, #{}, #{ticket_id => TicketId, status => ~"pending"}};
+                {ok, TicketId, Meta} ->
+                    {json, 200, #{}, Meta#{ticket_id => TicketId, status => ~"pending"}};
                 {error, queue_full} ->
                     {json, 503, #{}, #{error => ~"queue_full"}}
             end

--- a/src/controllers/asobi_matchmaker_controller.erl
+++ b/src/controllers/asobi_matchmaker_controller.erl
@@ -38,7 +38,19 @@ status(
     #{bindings := #{~"ticket_id" := TicketId}, auth_data := #{player_id := PlayerId}} = _Req
 ) when is_binary(PlayerId), is_binary(TicketId) ->
     case asobi_matchmaker:get_ticket(PlayerId, TicketId) of
-        {ok, Ticket} -> {json, Ticket};
-        {error, not_owner} -> {status, 403};
-        {error, not_found} -> {status, 404}
+        {ok, Ticket} ->
+            %% Project an explicit shape rather than dumping the internal ticket
+            %% map, so internal fields (attempts, player_id) never leak to the
+            %% client. Keeps the public fields clients already read (`id`).
+            {json, #{
+                id => maps:get(id, Ticket),
+                mode => maps:get(mode, Ticket),
+                status => maps:get(status, Ticket),
+                properties => maps:get(properties, Ticket, #{}),
+                submitted_at => maps:get(submitted_at, Ticket)
+            }};
+        {error, not_owner} ->
+            {status, 403};
+        {error, not_found} ->
+            {status, 404}
     end.

--- a/src/matches/asobi_matchmaker.erl
+++ b/src/matches/asobi_matchmaker.erl
@@ -10,6 +10,9 @@ spawns a match, and pushes `match.matched` to each player. A single
 -export([start_link/0, add/2, remove/2, get_ticket/1, get_ticket/2, get_queue_stats/0]).
 -export([known_mode/1]).
 -export([init/1, handle_call/3, handle_cast/2, handle_info/2, terminate/2]).
+-ifdef(TEST).
+-export([next_spawn_attempt/1]).
+-endif.
 
 -define(DEFAULT_TICK, 1000).
 -define(DEFAULT_MAX_QUEUE, 10000).
@@ -430,6 +433,11 @@ spawn_match(Mode, ModeConfig, PlayerIds, Group, Rest, Failed) ->
             spawn_matches(Rest, Failed)
     end.
 
+%% Unlike spawn_match, world spawn is detached (spawn/1) to avoid blocking the
+%% matchmaker, so there is no clean handle to re-queue the group on failure.
+%% Worlds therefore fail fast: on the first spawn error/crash the players are
+%% notified match_start_failed once, with no bounded retry. Fail-fast is the safe
+%% direction (players told immediately, never left queued).
 spawn_world(Mode, ModeConfig, PlayerIds, Group, Rest, Failed) ->
     MaxPlayers = maps:get(max_players, ModeConfig, 500),
     case resolve_game_module(Mode) of
@@ -531,15 +539,44 @@ notify_no_game_module(Mode, PlayerIds) ->
 %% rather than leaving them queued forever (asobi#232 audit). The reason is
 %% coarse and stable - never the raw crash - so no game internals leak.
 handle_spawn_failure(Group, Mode, PlayerIds, Rest, Failed) ->
-    Attempts = 1 + lists:max([maps:get(attempts, T, 0) || T <- Group]),
-    case Attempts >= ?MAX_SPAWN_ATTEMPTS of
-        true ->
+    case next_spawn_attempt(Group) of
+        give_up ->
             asobi_telemetry:matchmaker_failed(Mode, length(PlayerIds)),
             notify_matchmaker_failed(PlayerIds, ~"match_start_failed"),
             spawn_matches(Rest, Failed);
-        false ->
-            Group1 = [T#{attempts => Attempts} || T <- Group],
+        {retry, Attempt} ->
+            Group1 = [T#{attempts => Attempt} || T <- Group],
             spawn_matches(Rest, [Group1 | Failed])
+    end.
+
+%% Decide whether a failed group gets another spawn attempt (bumping its count)
+%% or is given up on. Exported for test - the off-by-one at the give-up boundary
+%% is the load-bearing bit.
+-spec next_spawn_attempt([map()]) -> {retry, pos_integer()} | give_up.
+next_spawn_attempt(Group) ->
+    Attempt = 1 + max_attempts(Group, 0),
+    case Attempt >= ?MAX_SPAWN_ATTEMPTS of
+        true -> give_up;
+        false -> {retry, Attempt}
+    end.
+
+-spec max_attempts([map()], non_neg_integer()) -> non_neg_integer().
+max_attempts([], Acc) ->
+    Acc;
+max_attempts([T | Rest], Acc) ->
+    A = ticket_attempts(T),
+    Next =
+        case A > Acc of
+            true -> A;
+            false -> Acc
+        end,
+    max_attempts(Rest, Next).
+
+-spec ticket_attempts(map()) -> non_neg_integer().
+ticket_attempts(T) ->
+    case maps:get(attempts, T, 0) of
+        N when is_integer(N), N >= 0 -> N;
+        _ -> 0
     end.
 
 -spec notify_matchmaker_failed([binary()], binary()) -> ok.

--- a/src/matches/asobi_matchmaker.erl
+++ b/src/matches/asobi_matchmaker.erl
@@ -13,15 +13,16 @@ spawns a match, and pushes `match.matched` to each player. A single
 
 -define(DEFAULT_TICK, 1000).
 -define(DEFAULT_MAX_QUEUE, 10000).
+-define(MAX_SPAWN_ATTEMPTS, 3).
 
 -spec start_link() -> gen_server:start_ret().
 start_link() ->
     gen_server:start_link({local, ?MODULE}, ?MODULE, [], []).
 
--spec add(binary(), map()) -> {ok, binary()} | {error, queue_full}.
+-spec add(binary(), map()) -> {ok, binary(), map()} | {error, queue_full}.
 add(PlayerId, Params) ->
     case gen_server:call(?MODULE, {add, PlayerId, Params}) of
-        {ok, TicketId} when is_binary(TicketId) -> {ok, TicketId};
+        {ok, TicketId, Meta} when is_binary(TicketId), is_map(Meta) -> {ok, TicketId, Meta};
         {error, queue_full} -> {error, queue_full}
     end.
 
@@ -34,6 +35,18 @@ known_mode(Mode) when is_binary(Mode) ->
     Mode =:= ~"default" orelse is_map_key(Mode, Modes);
 known_mode(_) ->
     false.
+
+%% Metadata sent back on a matchmaker.queued reply so the client can show
+%% "waiting for N players" instead of silence. players_needed is the mode's
+%% match_size (null if the mode declares none). players_waiting (a count of
+%% others queued) is deliberately not exposed by default - it is a per-mode
+%% opt-in, tracked in asobi#232's follow-up.
+-spec queue_meta(binary()) -> map().
+queue_meta(Mode) ->
+    case maps:get(match_size, mode_config(Mode), undefined) of
+        N when is_integer(N) -> #{players_needed => N};
+        _ -> #{players_needed => null}
+    end.
 
 -spec remove(binary(), binary()) -> ok | {error, not_found | not_owner}.
 remove(PlayerId, TicketId) ->
@@ -111,7 +124,7 @@ handle_call({add, PlayerId, Params}, _From, #{tickets := Tickets} = State) when
     %% self-match (asobi#230). A full queue is rejected before minting.
     case find_player_ticket(PlayerId, Mode, Tickets) of
         {ok, ExistingId} ->
-            {reply, {ok, ExistingId}, State};
+            {reply, {ok, ExistingId, queue_meta(Mode)}, State};
         error when map_size(Tickets) >= MaxQueue ->
             {reply, {error, queue_full}, State};
         error ->
@@ -122,10 +135,13 @@ handle_call({add, PlayerId, Params}, _From, #{tickets := Tickets} = State) when
                 mode => Mode,
                 properties => maps:get(properties, Params, #{}),
                 submitted_at => erlang:system_time(millisecond),
-                status => pending
+                status => pending,
+                attempts => 0
             },
             asobi_telemetry:matchmaker_queued(PlayerId, Mode),
-            {reply, {ok, TicketId}, State#{tickets => Tickets#{TicketId => Ticket}}}
+            {reply, {ok, TicketId, queue_meta(Mode)}, State#{
+                tickets => Tickets#{TicketId => Ticket}
+            }}
     end;
 handle_call({get_ticket, PlayerId, TicketId}, _From, #{tickets := Tickets} = State) when
     is_binary(PlayerId), is_binary(TicketId)
@@ -402,12 +418,12 @@ spawn_match(Mode, ModeConfig, PlayerIds, Group, Rest, Failed) ->
                     spawn_matches(Rest, Failed);
                 {error, Reason} ->
                     logger:error(#{
-                        msg => ~"match spawn failed, re-queuing players",
+                        msg => ~"match spawn failed",
                         mode => Mode,
                         players => PlayerIds,
                         error => Reason
                     }),
-                    spawn_matches(Rest, [Group | Failed])
+                    handle_spawn_failure(Group, Mode, PlayerIds, Rest, Failed)
             end;
         {error, _} ->
             notify_no_game_module(Mode, PlayerIds),
@@ -482,7 +498,9 @@ spawn_world(Mode, ModeConfig, PlayerIds, Group, Rest, Failed) ->
                                 mode => Mode,
                                 players => SpawnPlayerIds,
                                 error => Reason
-                            })
+                            }),
+                            asobi_telemetry:matchmaker_failed(Mode, length(SpawnPlayerIds)),
+                            notify_matchmaker_failed(SpawnPlayerIds, ~"match_start_failed")
                     end
                 catch
                     Class:Reason2:Stack ->
@@ -493,7 +511,9 @@ spawn_world(Mode, ModeConfig, PlayerIds, Group, Rest, Failed) ->
                             class => Class,
                             error => Reason2,
                             stacktrace => Stack
-                        })
+                        }),
+                        asobi_telemetry:matchmaker_failed(Mode, length(SpawnPlayerIds)),
+                        notify_matchmaker_failed(SpawnPlayerIds, ~"match_start_failed")
                 end
             end),
             spawn_matches(Rest, Failed);
@@ -504,11 +524,31 @@ spawn_world(Mode, ModeConfig, PlayerIds, Group, Rest, Failed) ->
 
 notify_no_game_module(Mode, PlayerIds) ->
     logger:warning(#{msg => ~"no game module for mode", mode => Mode}),
+    notify_matchmaker_failed(PlayerIds, ~"no_game_module").
+
+%% A match failed to spawn (e.g. the game's Lua init crashed). Re-queue the group
+%% for a bounded number of attempts; once exhausted, tell the players it failed
+%% rather than leaving them queued forever (asobi#232 audit). The reason is
+%% coarse and stable - never the raw crash - so no game internals leak.
+handle_spawn_failure(Group, Mode, PlayerIds, Rest, Failed) ->
+    Attempts = 1 + lists:max([maps:get(attempts, T, 0) || T <- Group]),
+    case Attempts >= ?MAX_SPAWN_ATTEMPTS of
+        true ->
+            asobi_telemetry:matchmaker_failed(Mode, length(PlayerIds)),
+            notify_matchmaker_failed(PlayerIds, ~"match_start_failed"),
+            spawn_matches(Rest, Failed);
+        false ->
+            Group1 = [T#{attempts => Attempts} || T <- Group],
+            spawn_matches(Rest, [Group1 | Failed])
+    end.
+
+-spec notify_matchmaker_failed([binary()], binary()) -> ok.
+notify_matchmaker_failed(PlayerIds, Reason) ->
     lists:foreach(
         fun(PlayerId) when is_binary(PlayerId) ->
             asobi_presence:send(
                 PlayerId,
-                {match_event, matchmaker_failed, #{reason => ~"no_game_module"}}
+                {match_event, matchmaker_failed, #{reason => Reason}}
             )
         end,
         PlayerIds

--- a/src/ws/asobi_ws_handler.erl
+++ b/src/ws/asobi_ws_handler.erl
@@ -366,8 +366,8 @@ handle_message(
                         properties => maps:get(~"properties", Payload, #{})
                     })
                 of
-                    {ok, TicketId} ->
-                        encode_reply(Cid, ~"matchmaker.queued", #{
+                    {ok, TicketId, Meta} ->
+                        encode_reply(Cid, ~"matchmaker.queued", Meta#{
                             ticket_id => TicketId, status => ~"pending"
                         });
                     {error, queue_full} ->

--- a/test/asobi_matchmaker_SUITE.erl
+++ b/test/asobi_matchmaker_SUITE.erl
@@ -16,7 +16,8 @@
     add_default_mode_idempotent/1,
     remove_then_readd_new_ticket/1,
     selfmatch_group_rejected/1,
-    add_reply_reports_players_needed/1
+    add_reply_reports_players_needed/1,
+    spawn_retry_bounded_then_gives_up/1
 ]).
 
 all() ->
@@ -33,7 +34,8 @@ all() ->
         add_default_mode_idempotent,
         remove_then_readd_new_ticket,
         selfmatch_group_rejected,
-        add_reply_reports_players_needed
+        add_reply_reports_players_needed,
+        spawn_retry_bounded_then_gives_up
     ].
 
 init_per_suite(Config) ->
@@ -176,4 +178,19 @@ add_reply_reports_players_needed(Config) ->
             undefined -> application:unset_env(asobi, game_modes)
         end
     end,
+    Config.
+
+%% Bounded spawn retry: attempts 0->1->2 re-queue, the 3rd (?MAX_SPAWN_ATTEMPTS)
+%% gives up. The group's max attempt count drives the decision.
+spawn_retry_bounded_then_gives_up(Config) ->
+    ?assertEqual(
+        {retry, 1}, asobi_matchmaker:next_spawn_attempt([#{attempts => 0}, #{attempts => 0}])
+    ),
+    ?assertEqual({retry, 2}, asobi_matchmaker:next_spawn_attempt([#{attempts => 1}])),
+    ?assertEqual(give_up, asobi_matchmaker:next_spawn_attempt([#{attempts => 2}])),
+    ?assertEqual(
+        give_up, asobi_matchmaker:next_spawn_attempt([#{attempts => 0}, #{attempts => 2}])
+    ),
+    %% a missing/garbage attempts field defaults to 0
+    ?assertEqual({retry, 1}, asobi_matchmaker:next_spawn_attempt([#{}])),
     Config.

--- a/test/asobi_matchmaker_SUITE.erl
+++ b/test/asobi_matchmaker_SUITE.erl
@@ -15,7 +15,8 @@
     add_distinct_players_new_ticket/1,
     add_default_mode_idempotent/1,
     remove_then_readd_new_ticket/1,
-    selfmatch_group_rejected/1
+    selfmatch_group_rejected/1,
+    add_reply_reports_players_needed/1
 ]).
 
 all() ->
@@ -31,7 +32,8 @@ all() ->
         add_distinct_players_new_ticket,
         add_default_mode_idempotent,
         remove_then_readd_new_ticket,
-        selfmatch_group_rejected
+        selfmatch_group_rejected,
+        add_reply_reports_players_needed
     ].
 
 init_per_suite(Config) ->
@@ -43,18 +45,18 @@ end_per_suite(Config) ->
     Config.
 
 add_ticket(Config) ->
-    {ok, TicketId} = asobi_matchmaker:add(~"player1", #{mode => ~"ranked"}),
+    {ok, TicketId, _} = asobi_matchmaker:add(~"player1", #{mode => ~"ranked"}),
     ?assert(is_binary(TicketId)),
     Config.
 
 remove_ticket(Config) ->
-    {ok, TicketId} = asobi_matchmaker:add(~"player1", #{mode => ~"casual"}),
+    {ok, TicketId, _} = asobi_matchmaker:add(~"player1", #{mode => ~"casual"}),
     ok = asobi_matchmaker:remove(~"player1", TicketId),
     ?assertMatch({error, not_found}, asobi_matchmaker:get_ticket(TicketId)),
     Config.
 
 get_ticket(Config) ->
-    {ok, TicketId} = asobi_matchmaker:add(~"player1", #{
+    {ok, TicketId, _} = asobi_matchmaker:add(~"player1", #{
         mode => ~"ranked", properties => #{skill => 1200}
     }),
     {ok, Ticket} = asobi_matchmaker:get_ticket(TicketId),
@@ -68,7 +70,7 @@ ticket_not_found(Config) ->
     Config.
 
 ticket_defaults(Config) ->
-    {ok, TicketId} = asobi_matchmaker:add(~"player_defaults", #{}),
+    {ok, TicketId, _} = asobi_matchmaker:add(~"player_defaults", #{}),
     {ok, Ticket} = asobi_matchmaker:get_ticket(TicketId),
     ?assertMatch(#{mode := ~"default", properties := #{}, status := pending}, Ticket),
     asobi_matchmaker:remove(~"player_defaults", TicketId),
@@ -78,7 +80,7 @@ ticket_expiry(_Config) ->
     %% Tickets submitted with max_wait=0 should be expired on next tick
     %% We can't easily test this without modifying the matchmaker config,
     %% but we can verify the ticket has submitted_at set
-    {ok, TicketId} = asobi_matchmaker:add(~"player_expiry", #{mode => ~"casual"}),
+    {ok, TicketId, _} = asobi_matchmaker:add(~"player_expiry", #{mode => ~"casual"}),
     {ok, Ticket} = asobi_matchmaker:get_ticket(TicketId),
     ?assert(is_integer(maps:get(submitted_at, Ticket))),
     asobi_matchmaker:remove(~"player_expiry", TicketId).
@@ -88,8 +90,8 @@ ticket_expiry(_Config) ->
 %% for one player would otherwise fill each other into a match.
 add_idempotent_same_player_mode(Config) ->
     {ok, #{total := Before}} = asobi_matchmaker:get_queue_stats(),
-    {ok, T1} = asobi_matchmaker:add(~"player_idem", #{mode => ~"ranked"}),
-    {ok, T2} = asobi_matchmaker:add(~"player_idem", #{mode => ~"ranked"}),
+    {ok, T1, _} = asobi_matchmaker:add(~"player_idem", #{mode => ~"ranked"}),
+    {ok, T2, _} = asobi_matchmaker:add(~"player_idem", #{mode => ~"ranked"}),
     ?assertEqual(T1, T2),
     {ok, #{total := After}} = asobi_matchmaker:get_queue_stats(),
     ?assertEqual(Before + 1, After),
@@ -100,8 +102,8 @@ add_idempotent_same_player_mode(Config) ->
 %% The guard is per (player, mode): the same player in a different mode gets a
 %% distinct ticket.
 add_distinct_modes_new_ticket(Config) ->
-    {ok, T1} = asobi_matchmaker:add(~"player_modes", #{mode => ~"ranked"}),
-    {ok, T2} = asobi_matchmaker:add(~"player_modes", #{mode => ~"casual"}),
+    {ok, T1, _} = asobi_matchmaker:add(~"player_modes", #{mode => ~"ranked"}),
+    {ok, T2, _} = asobi_matchmaker:add(~"player_modes", #{mode => ~"casual"}),
     ?assertNotEqual(T1, T2),
     asobi_matchmaker:remove(~"player_modes", T1),
     asobi_matchmaker:remove(~"player_modes", T2),
@@ -110,8 +112,8 @@ add_distinct_modes_new_ticket(Config) ->
 %% Different players in the same mode each get their own ticket (the guard must
 %% not collapse distinct players).
 add_distinct_players_new_ticket(Config) ->
-    {ok, T1} = asobi_matchmaker:add(~"player_a", #{mode => ~"ranked"}),
-    {ok, T2} = asobi_matchmaker:add(~"player_b", #{mode => ~"ranked"}),
+    {ok, T1, _} = asobi_matchmaker:add(~"player_a", #{mode => ~"ranked"}),
+    {ok, T2, _} = asobi_matchmaker:add(~"player_b", #{mode => ~"ranked"}),
     ?assertNotEqual(T1, T2),
     asobi_matchmaker:remove(~"player_a", T1),
     asobi_matchmaker:remove(~"player_b", T2),
@@ -119,17 +121,17 @@ add_distinct_players_new_ticket(Config) ->
 
 %% The guard covers the no-mode default too: two mode-less adds are idempotent.
 add_default_mode_idempotent(Config) ->
-    {ok, T1} = asobi_matchmaker:add(~"player_defmode", #{}),
-    {ok, T2} = asobi_matchmaker:add(~"player_defmode", #{}),
+    {ok, T1, _} = asobi_matchmaker:add(~"player_defmode", #{}),
+    {ok, T2, _} = asobi_matchmaker:add(~"player_defmode", #{}),
     ?assertEqual(T1, T2),
     asobi_matchmaker:remove(~"player_defmode", T1),
     Config.
 
 %% After removing, a re-add mints a fresh working ticket (the guard un-sticks).
 remove_then_readd_new_ticket(Config) ->
-    {ok, T1} = asobi_matchmaker:add(~"player_readd", #{mode => ~"ranked"}),
+    {ok, T1, _} = asobi_matchmaker:add(~"player_readd", #{mode => ~"ranked"}),
     ok = asobi_matchmaker:remove(~"player_readd", T1),
-    {ok, T2} = asobi_matchmaker:add(~"player_readd", #{mode => ~"ranked"}),
+    {ok, T2, _} = asobi_matchmaker:add(~"player_readd", #{mode => ~"ranked"}),
     ?assertNotEqual(T1, T2),
     asobi_matchmaker:remove(~"player_readd", T2),
     Config.
@@ -140,7 +142,7 @@ remove_then_readd_new_ticket(Config) ->
 selfmatch_group_rejected(Config) ->
     Prev = application:get_env(asobi, game_modes),
     application:set_env(asobi, game_modes, #{~"dupmode" => #{strategy => asobi_dup_strategy}}),
-    {ok, T} = asobi_matchmaker:add(~"player_dup", #{mode => ~"dupmode"}),
+    {ok, T, _} = asobi_matchmaker:add(~"player_dup", #{mode => ~"dupmode"}),
     %% try/after so a failed assertion still restores game_modes and removes the
     %% ticket, rather than clobbering shared state into later suite cases.
     try
@@ -148,6 +150,27 @@ selfmatch_group_rejected(Config) ->
         ?assertMatch({ok, _}, asobi_matchmaker:get_ticket(T))
     after
         asobi_matchmaker:remove(~"player_dup", T),
+        case Prev of
+            {ok, V} -> application:set_env(asobi, game_modes, V);
+            undefined -> application:unset_env(asobi, game_modes)
+        end
+    end,
+    Config.
+
+%% The queued reply reports players_needed (the mode's match_size), so a client
+%% can show "waiting for N" instead of silence. A mode with no match_size -> null.
+add_reply_reports_players_needed(Config) ->
+    Prev = application:get_env(asobi, game_modes),
+    application:set_env(asobi, game_modes, #{~"needmode" => #{match_size => 3}}),
+    try
+        {ok, T1, Meta1} = asobi_matchmaker:add(~"player_need1", #{mode => ~"needmode"}),
+        ?assertEqual(3, maps:get(players_needed, Meta1)),
+        asobi_matchmaker:remove(~"player_need1", T1),
+
+        {ok, T2, Meta2} = asobi_matchmaker:add(~"player_need2", #{mode => ~"unknownmode"}),
+        ?assertEqual(null, maps:get(players_needed, Meta2)),
+        asobi_matchmaker:remove(~"player_need2", T2)
+    after
         case Prev of
             {ok, V} -> application:set_env(asobi, game_modes, V);
             undefined -> application:unset_env(asobi, game_modes)


### PR DESCRIPTION
Wave 2 of the DX fixes. Matchmaking was silent (a queued solo player couldn't tell 'waiting for 1 more' from a broken backend) and a match that failed to start left players queued forever with only a server log.

- `add/2` -> `{ok, TicketId, Meta}` with `players_needed` (mode `match_size`, `null` if unset), surfaced on the `matchmaker.queued` reply (WS + REST).
- Spawn failure: bounded retry (3), then `matchmaker_failed{reason:"match_start_failed"}` to the players (coarse/stable reason, never the raw Lua crash); same on the world-spawn paths. New `asobi_telemetry:matchmaker_failed/2`.

Architecture-guardian approved the shape; `players_waiting` (per-mode gated) + a live waiting push are a deliberate follow-up. 13 CT pass. Gate: beam-security -> erlang-code -> human, then deploy with #232 in one engine roll.