### PR TITLE
fix: game.send/2 messages never reached the client

### DIFF
--- a/priv/protocol/fixtures/game.message.json
+++ b/priv/protocol/fixtures/game.message.json
@@ -1,0 +1,1 @@
+{"type":"game.message","payload":{"message":"jij bent speler nummer 3"}}

--- a/src/ws/asobi_ws_handler.erl
+++ b/src/ws/asobi_ws_handler.erl
@@ -178,6 +178,15 @@ websocket_info({asobi_message, {dm_message, Msg}}, State) when is_map(Msg) ->
 websocket_info({asobi_message, {notification, Notif}}, State) ->
     Reply = encode_reply(undefined, ~"notification.new", Notif),
     {reply, {text, Reply}, State};
+websocket_info({asobi_message, {game_message, Payload}}, State) ->
+    %% Wrapped, not sent raw: every other wire event's payload is an
+    %% object (enforced by asobi_protocol_coverage_tests), but
+    %% game.send/2 accepts any Lua value (string, number, table) as
+    %% the message, so a bare scalar payload would break that
+    %% convention and couldn't carry more fields later without a
+    %% breaking change.
+    Reply = encode_reply(undefined, ~"game.message", #{~"message" => Payload}),
+    {reply, {text, Reply}, State};
 websocket_info({session_revoked, Reason}, State) ->
     logger:notice(#{msg => ~"session_revoked", reason => Reason}),
     {stop, State#{session => undefined}};


### PR DESCRIPTION
## Summary
- `websocket_info/2` had no clause for `{asobi_message, {game_message, _}}` (the tuple `game.send/2` forwards to), so it fell through the catch-all no-op and the message was silently dropped before ever reaching the client.
- Added the missing clause, wire event `game.message`, payload wrapped as `{"message": ...}` to stay consistent with every other event's object-shaped payload (enforced by `asobi_protocol_coverage_tests`), since `game.send/2` accepts arbitrary Lua values.
- Added `priv/protocol/fixtures/game.message.json` so SDK dispatch tests can cover it (the missing fixture is exactly what let this ship broken in the first place).

Companion fix in `asobi_lua` (a second, independent bug in the same code path: plain string messages were silently dropped by `to_map/1` before even leaving the server) and in `asobi-defold` (SDK event map + dispatch fixture) follow in separate PRs.

## Test plan
- [x] `rebar3 fmt --check`
- [x] `rebar3 xref`
- [x] `rebar3 eunit --module=asobi_protocol_coverage_tests` (was red before the fixture was added, green after)
- [ ] Full CI (dialyzer/eqwalizer/mutate) - not run locally, will run on PR

Found while debugging a real user's report that `game.send` appeared to silently do nothing.