### PR TITLE
feat(ws): not_in_match hint + dev-mode game.error rendering

### DIFF
--- a/guides/websocket-protocol.md
+++ b/guides/websocket-protocol.md
@@ -152,6 +152,25 @@ Send game input to the match server.
 {"type": "match.input", "payload": {"action": "move", "x": 10, "y": 5}}
 ```
 
+Input sent while not in a match or world is dropped. The first drop (at
+most one per 5 seconds per connection) is answered with an error event so
+the client can tell input is going nowhere:
+
+```json
+{"type": "error", "payload": {"type": "match.input", "reason": "not_in_match"}}
+```
+
+### `game.error` (server push)
+
+A Lua callback error, sent to the player whose input triggered it. Only
+emitted when the runtime runs with dev errors enabled
+(`ASOBI_DEV_ERRORS=true`); production runtimes keep script errors
+server-side.
+
+```json
+{"type": "game.error", "payload": {"callback": "handle_input", "script": "match.lua", "message": "bad arithmetic + on nil, 1"}}
+```
+
 ### `match.state` (server push)
 
 Server broadcasts game state updates to all players in the match.

--- a/priv/protocol/fixtures/game.error.json
+++ b/priv/protocol/fixtures/game.error.json
@@ -1,0 +1,1 @@
+{"type":"game.error","payload":{"callback":"handle_input","script":"match.lua","message":"bad arithmetic + on nil, 1"}}

--- a/src/ws/asobi_ws_handler.erl
+++ b/src/ws/asobi_ws_handler.erl
@@ -192,8 +192,15 @@ websocket_info({asobi_message, {game_message, Payload}}, State) ->
 websocket_info({asobi_message, {script_error, Payload}}, State) when is_map(Payload) ->
     %% Dev-mode Lua callback errors (asobi_lua#98). Only ever emitted when
     %% the runtime has dev errors enabled; production runtimes never send
-    %% this, so script internals stay server-side.
-    Reply = encode_reply(undefined, ~"game.error", Payload),
+    %% this, so script internals stay server-side. Encoded defensively: a
+    %% future producer sending a non-JSON-encodable map must degrade to an
+    %% error frame, not crash the connection process.
+    Reply =
+        try
+            encode_reply(undefined, ~"game.error", Payload)
+        catch
+            _:_ -> encode_reply(undefined, ~"error", #{reason => ~"internal"})
+        end,
     {reply, {text, Reply}, State};
 websocket_info({session_revoked, Reason}, State) ->
     logger:notice(#{msg => ~"session_revoked", reason => Reason}),

--- a/src/ws/asobi_ws_handler.erl
+++ b/src/ws/asobi_ws_handler.erl
@@ -189,6 +189,12 @@ websocket_info({asobi_message, {game_message, Payload}}, State) ->
     %% breaking change.
     Reply = encode_reply(undefined, ~"game.message", #{~"message" => Payload}),
     {reply, {text, Reply}, State};
+websocket_info({asobi_message, {script_error, Payload}}, State) when is_map(Payload) ->
+    %% Dev-mode Lua callback errors (asobi_lua#98). Only ever emitted when
+    %% the runtime has dev errors enabled; production runtimes never send
+    %% this, so script internals stay server-side.
+    Reply = encode_reply(undefined, ~"game.error", Payload),
+    {reply, {text, Reply}, State};
 websocket_info({session_revoked, Reason}, State) ->
     logger:notice(#{msg => ~"session_revoked", reason => Reason}),
     {stop, State#{session => undefined}};

--- a/src/ws/asobi_ws_handler.erl
+++ b/src/ws/asobi_ws_handler.erl
@@ -11,6 +11,8 @@
 %% F-16: per-connection cap on simultaneously joined chat channels.
 -define(MAX_JOINED_CHANNELS_PER_CONN, 32).
 -define(MAX_CHANNEL_ID_BYTES, 256).
+%% #236: at most one `not_in_match` hint per connection per this window.
+-define(NOT_IN_MATCH_HINT_WINDOW_MS, 5000).
 
 %% Default time a freshly-connected WS has to send `session.connect`
 %% before we close it. Mobile TLS handshake on poor networks can be
@@ -263,7 +265,7 @@ handle_message(
                 undefined ->
                     case maps:get(zone_pid, SState, undefined) of
                         undefined ->
-                            {ok, State};
+                            not_in_match_hint(State);
                         ZonePid ->
                             asobi_zone:player_input(ZonePid, PlayerId, InputData),
                             {ok, State}
@@ -748,6 +750,23 @@ authenticate(#{~"token" := Token}) when is_binary(Token) ->
     end;
 authenticate(_) ->
     {error, ~"invalid_token"}.
+
+%% #236: input for a match you are not in is still dropped, but the sender
+%% gets a hint so "my input does nothing" is debuggable client-side. One
+%% hint per window per connection - a client spamming input while unjoined
+%% must not turn this into a reflected message stream.
+not_in_match_hint(State) ->
+    Now = erlang:system_time(millisecond),
+    Last = maps:get(not_in_match_hint_at, State, 0),
+    case Now - Last >= ?NOT_IN_MATCH_HINT_WINDOW_MS of
+        true ->
+            Reply = encode_reply(undefined, ~"error", #{
+                type => ~"match.input", reason => ~"not_in_match"
+            }),
+            {reply, {text, Reply}, State#{not_in_match_hint_at => Now}};
+        false ->
+            {ok, State}
+    end.
 
 check_ws_rate_limit(#{ws_msg_count := Count, ws_msg_window_start := WindowStart} = State) ->
     Now = erlang:system_time(millisecond),

--- a/test/asobi_ws_SUITE.erl
+++ b/test/asobi_ws_SUITE.erl
@@ -7,10 +7,20 @@
     ws_connect_invalid_token/1,
     ws_heartbeat/1,
     ws_unknown_type/1,
-    ws_idle_auth_timeout_closes/1
+    ws_idle_auth_timeout_closes/1,
+    ws_match_input_not_in_match_hint/1,
+    ws_match_input_hint_rate_limited/1
 ]).
 
-all() -> [ws_connect_invalid_token, ws_heartbeat, ws_unknown_type, ws_idle_auth_timeout_closes].
+all() ->
+    [
+        ws_connect_invalid_token,
+        ws_heartbeat,
+        ws_unknown_type,
+        ws_idle_auth_timeout_closes,
+        ws_match_input_not_in_match_hint,
+        ws_match_input_hint_rate_limited
+    ].
 
 init_per_suite(Config) ->
     asobi_test_helpers:start(Config).
@@ -62,6 +72,40 @@ ws_unknown_type(Config) ->
     nova_test_ws:close(Conn),
     Config.
 
+%% #236: match.input with no joined match/zone is dropped, but the sender
+%% must get a `not_in_match` hint so the drop is debuggable client-side.
+ws_match_input_not_in_match_hint(Config) ->
+    {_, Token} = register_player(~"nomatch", Config),
+    Conn = ws_connect_authed(Token, Config),
+    ok = nova_test_ws:send_json(
+        #{~"type" => ~"match.input", ~"payload" => #{~"message" => ~"up"}},
+        Conn
+    ),
+    {ok, Reply} = recv_until(
+        fun(M) -> maps:get(~"type", M, undefined) =:= ~"error" end, Conn
+    ),
+    nova_test_ws:close(Conn),
+    ?assertMatch(
+        #{~"payload" := #{~"reason" := ~"not_in_match", ~"type" := ~"match.input"}}, Reply
+    ),
+    Config.
+
+%% #236: the hint is per-connection rate-limited - a client spamming input
+%% while unjoined gets one hint per window, not a reflected stream.
+ws_match_input_hint_rate_limited(Config) ->
+    {_, Token} = register_player(~"nomatchrl", Config),
+    Conn = ws_connect_authed(Token, Config),
+    Input = #{~"type" => ~"match.input", ~"payload" => #{~"message" => ~"up"}},
+    ok = nova_test_ws:send_json(Input, Conn),
+    {ok, _} = recv_until(
+        fun(M) -> maps:get(~"type", M, undefined) =:= ~"error" end, Conn
+    ),
+    ok = nova_test_ws:send_json(Input, Conn),
+    ok = nova_test_ws:send_json(Input, Conn),
+    ?assertEqual({error, timeout}, nova_test_ws:recv(Conn, 300)),
+    nova_test_ws:close(Conn),
+    Config.
+
 %% A WS that opens and never sends `session.connect` must be closed by
 %% the server with code 1008 once the idle-auth window elapses.
 ws_idle_auth_timeout_closes(Config) ->
@@ -77,3 +121,51 @@ ws_idle_auth_timeout_closes(Config) ->
         end
     end,
     Config.
+
+%% --- helpers (mirrors asobi_chat_ws_SUITE) ---
+
+register_player(Suffix, Config) ->
+    Username = unique_name(Suffix),
+    {ok, Resp} = nova_test:post(
+        "/api/v1/auth/register",
+        #{json => #{~"username" => Username, ~"password" => ~"testpass123"}},
+        Config
+    ),
+    #{~"player_id" := PlayerId, ~"access_token" := Token} = nova_test:json(Resp),
+    {PlayerId, Token}.
+
+unique_name(Suffix) ->
+    N = integer_to_binary(erlang:unique_integer([positive])),
+    <<"wsprobe_", N/binary, "_", Suffix/binary>>.
+
+ws_connect_authed(Token, Config) ->
+    {ok, Conn} = nova_test_ws:connect("/ws", Config),
+    ok = nova_test_ws:send_json(
+        #{
+            ~"type" => ~"session.connect",
+            ~"cid" => ~"sess",
+            ~"payload" => #{~"token" => Token}
+        },
+        Conn
+    ),
+    {ok, _} = recv_until(
+        fun(M) -> maps:get(~"type", M, undefined) =:= ~"session.connected" end,
+        Conn
+    ),
+    Conn.
+
+recv_until(Pred, Conn) ->
+    recv_until(Pred, Conn, 50).
+
+recv_until(_Pred, _Conn, 0) ->
+    {error, predicate_not_matched};
+recv_until(Pred, Conn, N) ->
+    case nova_test_ws:recv_json(Conn) of
+        {ok, Msg} ->
+            case Pred(Msg) of
+                true -> {ok, Msg};
+                false -> recv_until(Pred, Conn, N - 1)
+            end;
+        {error, _} = Err ->
+            Err
+    end.

--- a/test/asobi_ws_SUITE.erl
+++ b/test/asobi_ws_SUITE.erl
@@ -9,7 +9,8 @@
     ws_unknown_type/1,
     ws_idle_auth_timeout_closes/1,
     ws_match_input_not_in_match_hint/1,
-    ws_match_input_hint_rate_limited/1
+    ws_match_input_hint_rate_limited/1,
+    ws_script_error_rendered_as_game_error/1
 ]).
 
 all() ->
@@ -19,7 +20,8 @@ all() ->
         ws_unknown_type,
         ws_idle_auth_timeout_closes,
         ws_match_input_not_in_match_hint,
-        ws_match_input_hint_rate_limited
+        ws_match_input_hint_rate_limited,
+        ws_script_error_rendered_as_game_error
     ].
 
 init_per_suite(Config) ->
@@ -104,6 +106,36 @@ ws_match_input_hint_rate_limited(Config) ->
     ok = nova_test_ws:send_json(Input, Conn),
     ?assertEqual({error, timeout}, nova_test_ws:recv(Conn, 300)),
     nova_test_ws:close(Conn),
+    Config.
+
+%% asobi_lua#98: a {script_error, Payload} presence message (sent by the
+%% Lua runtime in dev-errors mode) must reach the client as a game.error
+%% wire event carrying the payload unchanged.
+ws_script_error_rendered_as_game_error(Config) ->
+    {PlayerId, Token} = register_player(~"scripterr", Config),
+    Conn = ws_connect_authed(Token, Config),
+    asobi_presence:send(
+        PlayerId,
+        {script_error, #{
+            ~"callback" => ~"handle_input",
+            ~"script" => ~"match.lua",
+            ~"message" => ~"bad arithmetic + on nil, 1"
+        }}
+    ),
+    {ok, Reply} = recv_until(
+        fun(M) -> maps:get(~"type", M, undefined) =:= ~"game.error" end, Conn
+    ),
+    nova_test_ws:close(Conn),
+    ?assertMatch(
+        #{
+            ~"payload" := #{
+                ~"callback" := ~"handle_input",
+                ~"script" := ~"match.lua",
+                ~"message" := ~"bad arithmetic + on nil, 1"
+            }
+        },
+        Reply
+    ),
     Config.
 
 %% A WS that opens and never sends `session.connect` must be closed by


### PR DESCRIPTION
Two halves of the "my input does nothing" DX fix.

**not_in_match hint (#236).** `match.input` with no joined match/zone was silently discarded. The drop stays, but the sender now gets an unsolicited `error` event with reason `not_in_match`, at most one per 5s window per connection so an unjoined spammer cannot turn it into a reflected stream.

**game.error rendering (widgrensit/asobi_lua#98 companion).** The Lua runtime (dev errors enabled, off by default) sends `{script_error, Payload}` via `asobi_presence` to the player whose input triggered a failing callback; the WS handler renders it as a `game.error` wire event. Production runtimes never send it, so script internals stay server-side.

Includes the `game.error` protocol fixture and websocket-guide docs for both events. CT: `asobi_ws_SUITE` grown from 4 to 7 cases, all green.

Closes #236