### PR TITLE
fix: newline-terminate JSON log events

### DIFF
--- a/config/dev_sys.config.src
+++ b/config/dev_sys.config.src
@@ -5,7 +5,8 @@
             {handler, default, logger_std_h, #{
                 formatter => {nova_jsonlogger, #{
                     map_depth => 3,
-                    term_depth => 50
+                    term_depth => 50,
+                    new_line => true
                 }}
             }},
             {filters, log, [

--- a/config/prod_sys.config.src
+++ b/config/prod_sys.config.src
@@ -5,7 +5,8 @@
             {handler, default, logger_std_h, #{
                 formatter => {nova_jsonlogger, #{
                     map_depth => 3,
-                    term_depth => 50
+                    term_depth => 50,
+                    new_line => true
                 }}
             }}
         ]}


### PR DESCRIPTION
Same defect found in widgrensit/asobi_lua#102: the formatter config never sets `new_line => true`, so JSON events concatenate on one never-flushed stdout line. Both config files fixed.