### PR TITLE
fix: retry generated-username collisions instead of 500ing

### DIFF
--- a/guides/authentication.md
+++ b/guides/authentication.md
@@ -237,7 +237,7 @@ First call (new account):
   "player_id": "...",
   "access_token": "...",
   "refresh_token": "...",
-  "username": "guest_019f615cbc4a",
+  "username": "guest_9c41e0b7a2d5f318",
   "created": true,
   "guest": true
 }

--- a/guides/rest-api.md
+++ b/guides/rest-api.md
@@ -75,7 +75,7 @@ curl -X POST /api/v1/auth/guest \
 
 ```json
 {"player_id": "...", "access_token": "...", "refresh_token": "...",
- "username": "guest_019f615cbc4a", "created": true, "guest": true}
+ "username": "guest_9c41e0b7a2d5f318", "created": true, "guest": true}
 ```
 
 ## Players

--- a/src/asobi_auth_error.erl
+++ b/src/asobi_auth_error.erl
@@ -7,7 +7,7 @@
 %% per-field detail for form UIs. (asobi_auth_controller:register/1 should adopt
 %% this once its 409 branch lands - see the register-409 change.)
 
--export([from_changeset_fields/1]).
+-export([from_changeset_fields/1, username_taken/1]).
 
 %% kura's default message for a unique-index violation.
 -define(UNIQUE_MSG, ~"has already been taken").
@@ -20,6 +20,15 @@ from_changeset_fields(#{username := Msgs} = Fields) when is_list(Msgs) ->
     end;
 from_changeset_fields(Fields) ->
     validation_failed(Fields).
+
+%% Whether a raw #kura_changeset.errors list is specifically a username
+%% uniqueness conflict (the generated-username retry paths need to tell that
+%% apart from any other error on the same field, e.g. a future format/length
+%% validation, before consuming a retry). One place to know kura's message
+%% shape, shared by the guest and OAuth create-player retry loops.
+-spec username_taken([{atom(), binary()}]) -> boolean().
+username_taken(Errors) ->
+    lists:keyfind(username, 1, Errors) =:= {username, ?UNIQUE_MSG}.
 
 -spec validation_failed(map()) -> {json, 422, map(), map()}.
 validation_failed(Fields) ->

--- a/src/asobi_id.erl
+++ b/src/asobi_id.erl
@@ -17,7 +17,7 @@ ids (e.g. for tokens, invite codes, etc.) generate them via
 `crypto:strong_rand_bytes/1` rather than this function.
 """.
 
--export([generate/0]).
+-export([generate/0, rand_suffix/1]).
 
 -doc "Generate a UUIDv7 as a lowercase hyphenated binary string.".
 -spec generate() -> binary().
@@ -25,3 +25,15 @@ generate() ->
     case jhn_uuid:gen(v7) of
         UUID when is_list(UUID) -> iolist_to_binary(UUID)
     end.
+
+-doc """
+Generate a random lowercase-hex binary carrying `ByteLen` bytes of real
+entropy (2x`ByteLen` hex characters). For handles that need to be
+non-colliding across concurrent generation - e.g. a generated username
+suffix - where a `generate/0` prefix is the wrong tool: its first
+characters are pure millisecond timestamp (see the moduledoc above), so
+two calls in the same millisecond produce the identical prefix.
+""".
+-spec rand_suffix(pos_integer()) -> binary().
+rand_suffix(ByteLen) ->
+    binary:encode_hex(crypto:strong_rand_bytes(ByteLen), lowercase).

--- a/src/controllers/asobi_guest_controller.erl
+++ b/src/controllers/asobi_guest_controller.erl
@@ -30,6 +30,7 @@
 -define(MAX_SECRET_BYTES, 128).
 -define(MAX_SECRET_B64_BYTES, 1024).
 -define(MAX_DEVICE_ID_BYTES, 255).
+-define(MAX_USERNAME_ATTEMPTS, 3).
 
 -spec authenticate(cowboy_req:req()) -> {json, integer(), map(), map()}.
 authenticate(#{json := #{~"device_id" := DeviceId, ~"device_secret" := Secret}} = _Req) when
@@ -197,6 +198,11 @@ create(DeviceId, SecretBin) ->
 
 -spec insert_player_and_identity(binary(), binary()) -> {json, integer(), map(), map()}.
 insert_player_and_identity(DeviceId, SecretBin) ->
+    insert_player_and_identity(DeviceId, SecretBin, 1).
+
+-spec insert_player_and_identity(binary(), binary(), pos_integer()) ->
+    {json, integer(), map(), map()}.
+insert_player_and_identity(DeviceId, SecretBin, Attempt) ->
     Username = generate_username(),
     PlayerCS = kura_changeset:validate_required(
         kura_changeset:cast(asobi_player, #{}, #{username => Username}, [username]),
@@ -217,6 +223,16 @@ insert_player_and_identity(DeviceId, SecretBin) ->
                     %% orphan row.
                     _ = asobi_repo:delete(asobi_player, Player),
                     {json, 409, #{}, #{error => ~"device_already_registered"}}
+            end;
+        {error, #kura_changeset{errors = Errors}} when Attempt < ?MAX_USERNAME_ATTEMPTS ->
+            case asobi_auth_error:username_taken(Errors) of
+                true ->
+                    ?LOG_WARNING(#{
+                        event => guest_username_collision, attempt => Attempt
+                    }),
+                    insert_player_and_identity(DeviceId, SecretBin, Attempt + 1);
+                false ->
+                    {json, 500, #{}, #{error => ~"guest_create_failed"}}
             end;
         {error, _} ->
             {json, 500, #{}, #{error => ~"guest_create_failed"}}
@@ -368,5 +384,5 @@ decode_secret(_B64) ->
 
 -spec generate_username() -> binary().
 generate_username() ->
-    Suffix = binary:part(asobi_id:generate(), 0, 12),
+    Suffix = asobi_id:rand_suffix(8),
     <<"guest_", Suffix/binary>>.

--- a/src/controllers/asobi_oauth_controller.erl
+++ b/src/controllers/asobi_oauth_controller.erl
@@ -1,6 +1,15 @@
 -module(asobi_oauth_controller).
 
+-include_lib("kernel/include/logger.hrl").
+-include_lib("kura/include/kura.hrl").
+
 -export([authenticate/1, link/1, unlink/1]).
+
+-ifdef(TEST).
+-export([create_player_with_identity/2]).
+-endif.
+
+-define(MAX_USERNAME_ATTEMPTS, 3).
 
 %% POST /api/v1/auth/oauth
 %% Body: {"provider": "google", "token": "<id_token>"}
@@ -145,6 +154,11 @@ login_existing_player(Identity) ->
 
 -spec create_player_with_identity(binary(), map()) -> {json, integer(), map(), map()}.
 create_player_with_identity(Provider, Claims) ->
+    create_player_with_identity(Provider, Claims, 1).
+
+-spec create_player_with_identity(binary(), map(), pos_integer()) ->
+    {json, integer(), map(), map()}.
+create_player_with_identity(Provider, Claims, Attempt) ->
     ProviderUid = maps:get(provider_uid, Claims),
     DisplayName = maps:get(provider_display_name, Claims, undefined),
     Username = generate_username(Provider, ProviderUid),
@@ -160,6 +174,16 @@ create_player_with_identity(Provider, Claims) ->
             _ = init_player_stats(PlayerId),
             _ = insert_identity(PlayerId, Provider, Claims),
             asobi_auth_tokens:issue(Player, 200, #{username => Username, created => true});
+        {error, #kura_changeset{errors = Errors}} when Attempt < ?MAX_USERNAME_ATTEMPTS ->
+            case asobi_auth_error:username_taken(Errors) of
+                true ->
+                    ?LOG_WARNING(#{
+                        event => oauth_username_collision, provider => Provider, attempt => Attempt
+                    }),
+                    create_player_with_identity(Provider, Claims, Attempt + 1);
+                false ->
+                    {json, 500, #{}, #{error => ~"registration_failed"}}
+            end;
         {error, _CS} ->
             {json, 500, #{}, #{error => ~"registration_failed"}}
     end.
@@ -208,8 +232,9 @@ has_other_auth(PlayerId, ExcludeProvider) ->
 
 -spec generate_username(binary(), binary()) -> binary().
 generate_username(Provider, ProviderUid) ->
+    %% NOT rand:uniform/1: non-crypto and only ~13 bits of entropy.
     Short = binary:part(ProviderUid, 0, min(8, byte_size(ProviderUid))),
-    Rand = integer_to_binary(rand:uniform(9999)),
+    Rand = asobi_id:rand_suffix(4),
     <<Provider/binary, "_", Short/binary, "_", Rand/binary>>.
 
 -spec maybe_value(term(), term()) -> term().

--- a/test/asobi_guest_SUITE.erl
+++ b/test/asobi_guest_SUITE.erl
@@ -1,6 +1,7 @@
 -module(asobi_guest_SUITE).
 
 -include_lib("nova_test/include/nova_test.hrl").
+-include_lib("kura/include/kura.hrl").
 
 -export([all/0, init_per_suite/1, end_per_suite/1]).
 -export([
@@ -9,7 +10,9 @@
     weak_secret_rejected/1,
     upgrade_then_already_claimed/1,
     upgrade_rejected_for_non_guest/1,
-    reaper_removes_unclaimed_guest_and_children/1
+    reaper_removes_unclaimed_guest_and_children/1,
+    create_retries_on_username_collision/1,
+    create_no_retry_on_non_unique_username_error/1
 ]).
 
 all() ->
@@ -19,7 +22,9 @@ all() ->
         weak_secret_rejected,
         upgrade_then_already_claimed,
         upgrade_rejected_for_non_guest,
-        reaper_removes_unclaimed_guest_and_children
+        reaper_removes_unclaimed_guest_and_children,
+        create_retries_on_username_collision,
+        create_no_retry_on_non_unique_username_error
     ].
 
 init_per_suite(Config) ->
@@ -142,4 +147,66 @@ reaper_removes_unclaimed_guest_and_children(Config) ->
     timer:sleep(2500),
     {ok, _} = asobi_guest_reaper:sweep_now(),
     ?assertEqual({error, not_found}, asobi_repo:get(asobi_player, Pid)),
+    Config.
+
+%% A generated username colliding with an existing one (previously: any two
+%% guests created in the same millisecond, since the old suffix was a UUIDv7
+%% prefix with zero randomness) must retry with a fresh one instead of
+%% surfacing a 500 on the first collision.
+create_retries_on_username_collision(Config) ->
+    CollisionSuffix = asobi_id:rand_suffix(8),
+    CollisionUsername = <<"guest_", CollisionSuffix/binary>>,
+    ExistingCS = kura_changeset:validate_required(
+        kura_changeset:cast(asobi_player, #{}, #{username => CollisionUsername}, [username]),
+        [username]
+    ),
+    {ok, _} = asobi_repo:insert(ExistingCS),
+
+    %% Mock the shared helper, not crypto:strong_rand_bytes/1 directly - the
+    %% latter is process-wide and shared with unrelated 8-byte callers, which
+    %% would make this test flaky against future code that also asks crypto
+    %% for 8 random bytes.
+    Counter = counters:new(1, []),
+    meck:new(asobi_id, [passthrough]),
+    meck:expect(asobi_id, rand_suffix, fun
+        (8) ->
+            case counters:get(Counter, 1) of
+                0 ->
+                    counters:add(Counter, 1, 1),
+                    CollisionSuffix;
+                _ ->
+                    meck:passthrough([8])
+            end;
+        (N) ->
+            meck:passthrough([N])
+    end),
+    try
+        {ok, R} = create(device_id(), secret(), Config),
+        ?assertStatus(200, R),
+        #{~"player_id" := Pid, ~"username" := Username} = nova_test:json(R),
+        ?assert(is_binary(Pid)),
+        ?assertNotEqual(CollisionUsername, Username)
+    after
+        meck:unload(asobi_id)
+    end,
+    Config.
+
+%% A `username` error that is NOT a uniqueness conflict (e.g. a future
+%% format/length validation) must 500 immediately rather than burn all 3
+%% retry attempts on a failure retrying can never fix.
+create_no_retry_on_non_unique_username_error(Config) ->
+    meck:new(asobi_repo, [passthrough]),
+    meck:expect(asobi_repo, insert, fun
+        (#kura_changeset{schema = asobi_player} = CS) ->
+            {error, kura_changeset:add_error(CS, username, ~"is reserved")};
+        (CS) ->
+            meck:passthrough([CS])
+    end),
+    try
+        {ok, R} = create(device_id(), secret(), Config),
+        ?assertStatus(500, R),
+        ?assertEqual(1, meck:num_calls(asobi_repo, insert, '_'))
+    after
+        meck:unload(asobi_repo)
+    end,
     Config.

--- a/test/asobi_oauth_SUITE.erl
+++ b/test/asobi_oauth_SUITE.erl
@@ -1,6 +1,7 @@
 -module(asobi_oauth_SUITE).
 
 -include_lib("nova_test/include/nova_test.hrl").
+-include_lib("kura/include/kura.hrl").
 
 -export([all/0, groups/0, init_per_suite/1, end_per_suite/1, init_per_group/2, end_per_group/2]).
 -export([
@@ -13,10 +14,13 @@
     unlink_last_auth_method/1,
     unlink_success/1,
     identity_db_roundtrip/1,
-    login_existing_identity/1
+    login_existing_identity/1,
+    create_player_retries_on_username_collision/1,
+    create_player_no_retry_on_non_unique_username_error/1
 ]).
 
-all() -> [{group, oauth_errors}, {group, link_unlink}, {group, identity_db}].
+all() ->
+    [{group, oauth_errors}, {group, link_unlink}, {group, identity_db}, {group, create_player}].
 
 groups() ->
     [
@@ -33,6 +37,10 @@ groups() ->
         ]},
         {identity_db, [sequence], [
             identity_db_roundtrip, login_existing_identity
+        ]},
+        {create_player, [], [
+            create_player_retries_on_username_collision,
+            create_player_no_retry_on_non_unique_username_error
         ]}
     ].
 
@@ -227,4 +235,68 @@ login_existing_identity(Config) ->
     ),
     {ok, [Identity]} = asobi_repo:all(Q),
     ?assertEqual(PlayerId, maps:get(player_id, Identity)),
+    Config.
+
+%% --- Username Collision Retry ---
+
+%% A generated username colliding with an existing one (previously:
+%% rand:uniform(9999) gave only ~13 bits of entropy, so two concurrent
+%% first-sign-ins for the same provider_uid collided often) must retry with
+%% a fresh one instead of surfacing a 500 on the first collision.
+create_player_retries_on_username_collision(Config) ->
+    ProviderUid = iolist_to_binary([
+        ~"collide_uid_", integer_to_binary(erlang:unique_integer([positive]))
+    ]),
+    Short = binary:part(ProviderUid, 0, min(8, byte_size(ProviderUid))),
+    CollisionRand = asobi_id:rand_suffix(4),
+    CollisionUsername = <<"discord_", Short/binary, "_", CollisionRand/binary>>,
+    ExistingCS = kura_changeset:validate_required(
+        kura_changeset:cast(asobi_player, #{}, #{username => CollisionUsername}, [username]),
+        [username]
+    ),
+    {ok, _} = asobi_repo:insert(ExistingCS),
+
+    Counter = counters:new(1, []),
+    meck:new(asobi_id, [passthrough]),
+    meck:expect(asobi_id, rand_suffix, fun
+        (4) ->
+            case counters:get(Counter, 1) of
+                0 ->
+                    counters:add(Counter, 1, 1),
+                    CollisionRand;
+                _ ->
+                    meck:passthrough([4])
+            end;
+        (N) ->
+            meck:passthrough([N])
+    end),
+    try
+        Claims = #{provider_uid => ProviderUid, provider_display_name => undefined},
+        {json, 200, _, #{username := Username, created := true}} =
+            asobi_oauth_controller:create_player_with_identity(~"discord", Claims),
+        ?assertNotEqual(CollisionUsername, Username)
+    after
+        meck:unload(asobi_id)
+    end,
+    Config.
+
+%% A `username` error that is NOT a uniqueness conflict (e.g. a future
+%% format/length validation) must 500 immediately rather than burn all 3
+%% retry attempts on a failure retrying can never fix.
+create_player_no_retry_on_non_unique_username_error(Config) ->
+    meck:new(asobi_repo, [passthrough]),
+    meck:expect(asobi_repo, insert, fun
+        (#kura_changeset{schema = asobi_player} = CS) ->
+            {error, kura_changeset:add_error(CS, username, ~"is reserved")};
+        (CS) ->
+            meck:passthrough([CS])
+    end),
+    try
+        Claims = #{provider_uid => ~"reserved_uid", provider_display_name => undefined},
+        {json, 500, _, #{error := ~"registration_failed"}} =
+            asobi_oauth_controller:create_player_with_identity(~"discord", Claims),
+        ?assertEqual(1, meck:num_calls(asobi_repo, insert, '_'))
+    after
+        meck:unload(asobi_repo)
+    end,
     Config.


### PR DESCRIPTION
## Summary
- Concurrent guest sign-in (`POST /api/v1/auth/guest`) failed with `HTTP 500 guest_create_failed` under real concurrency: the generated-username suffix was the first 12 chars of a UUIDv7, which is pure millisecond-timestamp with zero randomness - two guests created in the same millisecond got an identical username, hit the unique index, and surfaced a 500.
- Same bug class, worse, in `asobi_oauth_controller` (`rand:uniform(9999)`, non-crypto, ~13 bits, no retry at all).
- Added `asobi_id:rand_suffix/1` (shared crypto-backed entropy) and `asobi_auth_error:username_taken/1` (one place that knows kura's unique-constraint error shape). Both create-player paths now retry up to 3 attempts on a genuine username collision, log a warning per retry, and still 500 immediately on any other error.
- Regression tests in both CT suites cover the retry-and-succeed path and the non-collision-still-500s path.
- Filed #241 for an adjacent pre-existing OAuth race found during review (orphan player on a lost identity-insert race) - separate failure mode, not fixed here.

Reviewed by asobi-architecture-guardian (accepted, requested the entropy centralization + oauth fix, applied), beam-security-reviewer (no blocking findings), and erlang-code-reviewer (accepted, requested the shared helper + comment trim + doc fixes + negative-path tests, all applied).

## Test plan
- [x] `rebar3 fmt --check` / `xref` / `dialyzer` / `elp lint` / `elp eqwalize` - all clean (only 3 pre-existing, unrelated eqwalizer errors)
- [x] `rebar3 eunit` - 405 tests, 0 failures
- [ ] CT suites (`asobi_guest_SUITE`, `asobi_oauth_SUITE`) - need Docker/Postgres, not available in this environment; will run in CI