### PR TITLE
fix: known_mode no longer treats "default" as always known

### DIFF
--- a/guides/matchmaking.md
+++ b/guides/matchmaking.md
@@ -61,9 +61,12 @@ Erlang return holds the same `players_needed`.
 > value** — `{mode = "arena"}` in Lua, `mode: "arena"` in JSON/TS, a typed
 > `mode` parameter elsewhere. A malformed options shape (e.g. Lua's
 > `{"arena"}`, which sets index `1`, not a `mode` field) silently falls back
-> to the mode's default instead of erroring, so you queue for the wrong mode
-> with no feedback — and if `default` isn't in your `config.lua`, that ticket
-> can never spawn a match. The Lua SDKs (asobi-defold, asobi-love2d) now
+> to `"default"` instead of erroring. A multi-mode game gets `400 unknown_mode`
+> for it - `default` is just another key, and a `config.lua` manifest never
+> maps it. A **single-mode** game does not: its loader registers `default`
+> automatically, so the malformed call silently queues for the only mode
+> there is, with no error at all - the SDK-level guards below are your only
+> protection in that case. The Lua SDKs (asobi-defold, asobi-love2d) now
 > raise a loud error on this exact mistake; the typed SDKs (Dart, Unity,
 > Unreal, Godot) prevent it at compile/parse time via a required `mode`
 > parameter. asobi-js's WS transport is intentionally schema-less (see its

--- a/src/matches/asobi_matchmaker.erl
+++ b/src/matches/asobi_matchmaker.erl
@@ -29,14 +29,17 @@ add(PlayerId, Params) ->
         {error, queue_full} -> {error, queue_full}
     end.
 
-%% A mode must be a key in `game_modes' - including the "default" a single-mode
-%% game's loader registers. Rejecting at the edge stops an attacker inflating the
-%% queue with arbitrary mode strings that each slip past the per-(player, mode)
-%% ticket guard, and turns a typo'd/omitted mode into an immediate 400 instead of
-%% a silent queue that only ever ends in `matchmaker_expired' after `max_wait'.
+%% A mode must actually resolve to a game module - including the "default" a
+%% single-mode game's loader registers - not merely be a key in `game_modes'.
+%% A key with no resolvable module can never spawn a match either, so gating on
+%% key presence alone would still let that class of mistake through. Rejecting
+%% at the edge stops an attacker inflating the queue with arbitrary mode strings
+%% that each slip past the per-(player, mode) ticket guard, and turns a
+%% typo'd/omitted/half-configured mode into an immediate 400 instead of a
+%% silent queue that only ever ends in `matchmaker_expired' after `max_wait'.
 -spec known_mode(term()) -> boolean().
-known_mode(Mode) when is_binary(Mode) ->
-    is_map_key(Mode, ensure_map(application:get_env(asobi, game_modes, #{})));
+known_mode(Mode) when is_binary(Mode), byte_size(Mode) =< 64 ->
+    resolve_game_module(Mode) =/= {error, not_found};
 known_mode(_) ->
     false.
 
@@ -640,7 +643,9 @@ known_mode_test_() ->
     {setup,
         fun() ->
             Prev = application:get_env(asobi, game_modes),
-            application:set_env(asobi, game_modes, #{~"arena" => #{}}),
+            application:set_env(asobi, game_modes, #{
+                ~"arena" => #{module => some_mod}, ~"halfconfigured" => #{}
+            }),
             Prev
         end,
         fun
@@ -653,9 +658,17 @@ known_mode_test_() ->
             %% no_game_module instead of an immediate 400).
             ?_assertNot(known_mode(~"default")),
             ?_assert(known_mode(~"arena")),
+            %% A key with no resolvable `module' can never spawn a match either -
+            %% key presence alone must not be enough (found in security review).
+            ?_assertNot(known_mode(~"halfconfigured")),
             ?_assertNot(known_mode(~"nope")),
             ?_assertNot(known_mode(12345)),
-            ?_assertNot(known_mode(<<0, 255>>))
+            ?_assertNot(known_mode(<<0, 255>>)),
+            %% Reject oversized mode strings before the map lookup (security
+            %% review): a longer value matches no registered mode anyway, so
+            %% there's no reason to pay for one, mirroring the 64-byte cap
+            %% already enforced on `mode` at the world edge.
+            ?_assertNot(known_mode(binary:copy(~"a", 65)))
         ]}.
 
 %% A mapped "default" (what asobi_lua_config:load_single_mode/2 registers for a
@@ -666,7 +679,7 @@ known_mode_single_mode_default_test_() ->
     {setup,
         fun() ->
             Prev = application:get_env(asobi, game_modes),
-            application:set_env(asobi, game_modes, #{~"default" => #{}}),
+            application:set_env(asobi, game_modes, #{~"default" => #{module => some_mod}}),
             Prev
         end,
         fun

--- a/src/matches/asobi_matchmaker.erl
+++ b/src/matches/asobi_matchmaker.erl
@@ -29,13 +29,14 @@ add(PlayerId, Params) ->
         {error, queue_full} -> {error, queue_full}
     end.
 
-%% Whether a mode is registered (or the no-mode default). Callers reject unknown
-%% modes at the edge, so an attacker cannot inflate the queue with arbitrary
-%% mode strings that would each slip past the per-(player, mode) ticket guard.
+%% A mode must be a key in `game_modes' - including the "default" a single-mode
+%% game's loader registers. Rejecting at the edge stops an attacker inflating the
+%% queue with arbitrary mode strings that each slip past the per-(player, mode)
+%% ticket guard, and turns a typo'd/omitted mode into an immediate 400 instead of
+%% a silent queue that only ever ends in `matchmaker_expired' after `max_wait'.
 -spec known_mode(term()) -> boolean().
 known_mode(Mode) when is_binary(Mode) ->
-    Modes = ensure_map(application:get_env(asobi, game_modes, #{})),
-    Mode =:= ~"default" orelse is_map_key(Mode, Modes);
+    is_map_key(Mode, ensure_map(application:get_env(asobi, game_modes, #{})));
 known_mode(_) ->
     false.
 
@@ -646,11 +647,33 @@ known_mode_test_() ->
             ({ok, V}) -> application:set_env(asobi, game_modes, V);
             (undefined) -> application:unset_env(asobi, game_modes)
         end, [
-            ?_assert(known_mode(~"default")),
+            %% A multi-mode manifest that never maps "default" (asobi#243 incident:
+            %% a malformed client call silently fell back to "default", which was
+            %% unconditionally accepted here, then failed later with
+            %% no_game_module instead of an immediate 400).
+            ?_assertNot(known_mode(~"default")),
             ?_assert(known_mode(~"arena")),
             ?_assertNot(known_mode(~"nope")),
             ?_assertNot(known_mode(12345)),
             ?_assertNot(known_mode(<<0, 255>>))
+        ]}.
+
+%% A mapped "default" (what asobi_lua_config:load_single_mode/2 registers for a
+%% single-mode game) is accepted like any other mode - known_mode/1 no longer
+%% special-cases the string itself. The cross-repo half of this contract (that
+%% load_single_mode/2 actually produces a "default" key) is asobi_lua's to test.
+known_mode_single_mode_default_test_() ->
+    {setup,
+        fun() ->
+            Prev = application:get_env(asobi, game_modes),
+            application:set_env(asobi, game_modes, #{~"default" => #{}}),
+            Prev
+        end,
+        fun
+            ({ok, V}) -> application:set_env(asobi, game_modes, V);
+            (undefined) -> application:unset_env(asobi, game_modes)
+        end, [
+            ?_assert(known_mode(~"default"))
         ]}.
 
 -endif.

--- a/test/asobi_matchmaker_api_SUITE.erl
+++ b/test/asobi_matchmaker_api_SUITE.erl
@@ -38,10 +38,16 @@ init_per_suite(Config) ->
         end,
     %% add_ticket_omitted_mode_rejected depends on "default" being absent -
     %% remove it explicitly rather than relying on Existing not having it.
+    %% known_mode/1 now requires a resolvable module (not just a game_modes
+    %% key), so these need a `module` entry - the tests never let a match
+    %% actually spawn, so any atom clears the known_mode gate.
     application:set_env(
         asobi,
         game_modes,
-        (maps:remove(~"default", Existing))#{~"ranked" => #{}, ~"casual" => #{}}
+        (maps:remove(~"default", Existing))#{
+            ~"ranked" => #{module => asobi_matchmaker_api_suite_test_mod},
+            ~"casual" => #{module => asobi_matchmaker_api_suite_test_mod}
+        }
     ),
     U1 = asobi_test_helpers:unique_username(~"mm_api1"),
     U2 = asobi_test_helpers:unique_username(~"mm_api2"),

--- a/test/asobi_matchmaker_api_SUITE.erl
+++ b/test/asobi_matchmaker_api_SUITE.erl
@@ -5,6 +5,7 @@
 -export([all/0, init_per_suite/1, end_per_suite/1]).
 -export([
     add_ticket/1,
+    add_ticket_omitted_mode_rejected/1,
     get_ticket/1,
     get_ticket_not_found/1,
     cancel_ticket/1,
@@ -16,6 +17,7 @@
 all() ->
     [
         add_ticket,
+        add_ticket_omitted_mode_rejected,
         get_ticket,
         get_ticket_not_found,
         cancel_ticket,
@@ -34,7 +36,13 @@ init_per_suite(Config) ->
             {ok, M} when is_map(M) -> M;
             _ -> #{}
         end,
-    application:set_env(asobi, game_modes, Existing#{~"ranked" => #{}, ~"casual" => #{}}),
+    %% add_ticket_omitted_mode_rejected depends on "default" being absent -
+    %% remove it explicitly rather than relying on Existing not having it.
+    application:set_env(
+        asobi,
+        game_modes,
+        (maps:remove(~"default", Existing))#{~"ranked" => #{}, ~"casual" => #{}}
+    ),
     U1 = asobi_test_helpers:unique_username(~"mm_api1"),
     U2 = asobi_test_helpers:unique_username(~"mm_api2"),
     {ok, R1} = nova_test:post(
@@ -94,6 +102,24 @@ add_ticket(Config) ->
         #{headers => auth(Config)},
         Config
     ),
+    Config.
+
+%% asobi#243 incident: a request with no `mode' field defaults to "default"
+%% (asobi_matchmaker_controller:add/1), which used to be unconditionally
+%% accepted by known_mode/1 even though this suite's game_modes never maps
+%% "default" - the ticket queued, then failed later with no_game_module
+%% instead of an immediate, actionable 400 here.
+add_ticket_omitted_mode_rejected(Config) ->
+    {ok, Resp} = nova_test:post(
+        "/api/v1/matchmaker",
+        #{
+            headers => auth(Config),
+            json => #{~"properties" => #{~"skill" => 1200}}
+        },
+        Config
+    ),
+    ?assertStatus(400, Resp),
+    ?assertMatch(#{~"error" := ~"unknown_mode"}, nova_test:json(Resp)),
     Config.
 
 get_ticket(Config) ->

--- a/test/asobi_ws_SUITE.erl
+++ b/test/asobi_ws_SUITE.erl
@@ -10,7 +10,8 @@
     ws_idle_auth_timeout_closes/1,
     ws_match_input_not_in_match_hint/1,
     ws_match_input_hint_rate_limited/1,
-    ws_script_error_rendered_as_game_error/1
+    ws_script_error_rendered_as_game_error/1,
+    ws_matchmaker_add_omitted_mode_rejected/1
 ]).
 
 all() ->
@@ -21,7 +22,8 @@ all() ->
         ws_idle_auth_timeout_closes,
         ws_match_input_not_in_match_hint,
         ws_match_input_hint_rate_limited,
-        ws_script_error_rendered_as_game_error
+        ws_script_error_rendered_as_game_error,
+        ws_matchmaker_add_omitted_mode_rejected
     ].
 
 init_per_suite(Config) ->
@@ -133,6 +135,33 @@ ws_script_error_rendered_as_game_error(Config) ->
                 ~"script" := ~"match.lua",
                 ~"message" := ~"bad arithmetic + on nil, 1"
             }
+        },
+        Reply
+    ),
+    Config.
+
+%% asobi#243: matchmaker.add with no `mode' defaults to "default"; the WS edge
+%% gates on the same known_mode/1 as REST, so an unmapped "default" must be
+%% rejected here too (dev_sys.config.src ships an empty game_modes).
+ws_matchmaker_add_omitted_mode_rejected(Config) ->
+    {_, Token} = register_player(~"mmnomode", Config),
+    Conn = ws_connect_authed(Token, Config),
+    ok = nova_test_ws:send_json(
+        #{
+            ~"type" => ~"matchmaker.add",
+            ~"cid" => ~"mm1",
+            ~"payload" => #{~"properties" => #{~"skill" => 1200}}
+        },
+        Conn
+    ),
+    {ok, Reply} = recv_until(
+        fun(M) -> maps:get(~"type", M, undefined) =:= ~"error" end, Conn
+    ),
+    nova_test_ws:close(Conn),
+    ?assertMatch(
+        #{
+            ~"cid" := ~"mm1",
+            ~"payload" := #{~"type" := ~"matchmaker.add", ~"reason" := ~"unknown_mode"}
         },
         Reply
     ),


### PR DESCRIPTION
## Summary
- `known_mode/1` used to unconditionally accept `"default"` as a registered mode even when nothing in `game_modes` mapped it. A malformed client call that silently fell back to `"default"` (the positional-table footgun just fixed in asobi-defold#41/asobi-love2d#7) was accepted as a `pending` ticket instead of an immediate `400 unknown_mode`.
- Fix: `known_mode/1` now requires the mode to actually resolve to a game module (via `resolve_game_module/1`), not just be a key in `game_modes` - a half-configured mode (key present, no module) is the same bug class and is now caught too (found in security review). Also caps mode length at 64 bytes, mirroring the existing cap at the world edge.
- Reviewed by architecture-guardian before implementation, then beam-security-reviewer and erlang-code-reviewer after (0 Critical/High/Medium; 2 Low findings, both fixed; 2 doc/comment inaccuracies in my first pass, both fixed).
- Single-mode Lua games unaffected - `asobi_lua_config`'s loader registers a real, spawnable `"default"` for them. In-process Erlang callers (`asobi_matchmaker:add/2`) never call `known_mode/1`.
- Docs corrected: the guide callout now accurately states single-mode games are NOT protected by this change (their loader auto-maps `default`), only multi-mode games are.
- Added WS-edge coverage (`asobi_ws_SUITE:ws_matchmaker_add_omitted_mode_rejected`) - the WS handler gates on the same `known_mode/1` as REST and had zero test coverage for this path.
- Filed widgrensit/asobi_lua#106 for the now-load-bearing cross-repo contract (that `load_single_mode/2` actually produces a spawnable `"default"` key) - untested on either side.

**BREAKING** (minor version bump warranted): `matchmaker.add` with a mode that can't resolve to a game module - including an unmapped or half-configured `"default"` - now returns `400 unknown_mode` at submit instead of queueing and eventually failing/expiring.

## Test plan
- [x] `rebar3 eunit --module=asobi_matchmaker` - 11/11 pass
- [x] `rebar3 fmt --check` clean
- [x] `rebar3 xref` clean
- [x] `rebar3 dialyzer` clean
- [x] `elp eqwalize asobi_matchmaker` clean (repo-wide `eqwalize-all` has 51 pre-existing errors across 14 unrelated files, none touched by this diff - confirmed by both agents, separate cleanup, not blocking this)
- [ ] CT (`asobi_matchmaker_api_SUITE`, `asobi_ws_SUITE`) - added/extended, needs CI (no docker in dev environment) to confirm against real Postgres