### PR TITLE
fix: clear the elp eqwalize-all repo-wide debt (51 errors, 14 files)

### DIFF
--- a/src/asobi_guest_reaper.erl
+++ b/src/asobi_guest_reaper.erl
@@ -21,7 +21,7 @@
 
 %% Only runs when guest auth is enabled - otherwise no process, no timer on
 %% deployments that don't use guest auth.
--spec start_link() -> {ok, pid()} | ignore.
+-spec start_link() -> {ok, pid()} | ignore | {error, term()}.
 start_link() ->
     case application:get_env(asobi, guest_auth, false) of
         true -> gen_server:start_link({local, ?MODULE}, ?MODULE, [], []);
@@ -31,7 +31,9 @@ start_link() ->
 %% For tests/ops: run a sweep synchronously.
 -spec sweep_now() -> {ok, non_neg_integer()}.
 sweep_now() ->
-    gen_server:call(?MODULE, sweep, 30000).
+    case gen_server:call(?MODULE, sweep, 30000) of
+        {ok, N} when is_integer(N), N >= 0 -> {ok, N}
+    end.
 
 -spec init([]) -> {ok, map()}.
 init([]) ->
@@ -74,7 +76,15 @@ cached_unlinked_count() ->
 refresh_count(Now) ->
     case live_unlinked_count() of
         N when is_integer(N) ->
-            Ttl = application:get_env(asobi, guest_unlinked_count_ttl_ms, ?DEFAULT_COUNT_TTL_MS),
+            Ttl =
+                case
+                    application:get_env(
+                        asobi, guest_unlinked_count_ttl_ms, ?DEFAULT_COUNT_TTL_MS
+                    )
+                of
+                    T when is_integer(T) -> T;
+                    _ -> ?DEFAULT_COUNT_TTL_MS
+                end,
             true = ets:insert(?COUNT_CACHE, {count, N, Now + Ttl}),
             N;
         unknown ->
@@ -85,7 +95,7 @@ refresh_count(Now) ->
 live_unlinked_count() ->
     Q = kura_query:where(kura_query:from(asobi_player_identity), {provider, ?PROVIDER}),
     case asobi_repo:aggregate(Q, count) of
-        {ok, N} -> N;
+        {ok, N} when is_integer(N), N >= 0 -> N;
         _ -> unknown
     end.
 
@@ -111,7 +121,11 @@ handle_info(_Info, State) ->
 
 -spec schedule() -> reference().
 schedule() ->
-    Interval = application:get_env(asobi, guest_reap_interval_ms, ?DEFAULT_INTERVAL_MS),
+    Interval =
+        case application:get_env(asobi, guest_reap_interval_ms, ?DEFAULT_INTERVAL_MS) of
+            I when is_integer(I) -> I;
+            _ -> ?DEFAULT_INTERVAL_MS
+        end,
     erlang:send_after(Interval, self(), sweep).
 
 -spec run_sweep() -> non_neg_integer().
@@ -238,8 +252,12 @@ unclaimed_guest(PlayerId) ->
                 kura_query:where(kura_query:from(asobi_player_identity), {player_id, PlayerId})
             )
         of
-            {ok, Ids} -> lists:all(fun(I) -> maps:get(provider, I) =:= ?PROVIDER end, Ids);
-            _ -> false
+            {ok, Ids} ->
+                lists:all(
+                    fun(I) -> is_map(I) andalso maps:get(provider, I) =:= ?PROVIDER end, Ids
+                );
+            _ ->
+                false
         end,
     NoPassword andalso OnlyDevice.
 

--- a/src/asobi_peer.erl
+++ b/src/asobi_peer.erl
@@ -52,10 +52,7 @@ peer_ip(Req) ->
 forwarded_client(Req, Cidrs, Peer) ->
     case cowboy_req:header(~"x-forwarded-for", Req) of
         Xff when is_binary(Xff), Xff =/= <<>> ->
-            %% lists:reverse/1's bounded polymorphic spec doesn't propagate the
-            %% element type through eqwalizer here - re-narrow with a guard.
-            Parts = [trim(P) || P <- binary:split(Xff, ~",", [global])],
-            Hops = [H || H <- lists:reverse(Parts), is_binary(H)],
+            Hops = rev_trim(binary:split(Xff, ~",", [global]), []),
             case first_untrusted(Hops, Cidrs) of
                 {ok, Ip} -> Ip;
                 none -> Peer
@@ -161,5 +158,17 @@ to_int(B) ->
 trim(B) ->
     case string:trim(B) of
         Trimmed when is_binary(Trimmed) -> Trimmed;
-        Trimmed -> iolist_to_binary(Trimmed)
+        Trimmed ->
+            case unicode:characters_to_binary(Trimmed) of
+                Bin when is_binary(Bin) -> Bin
+            end
     end.
+
+%% Trims and reverses in one typed pass - avoids lists:reverse/1's bounded
+%% polymorphic spec, which doesn't propagate the element type through
+%% eqwalizer in this position (see forwarded_client/3).
+-spec rev_trim([binary()], [binary()]) -> [binary()].
+rev_trim([], Acc) ->
+    Acc;
+rev_trim([P | Rest], Acc) ->
+    rev_trim(Rest, [trim(P) | Acc]).

--- a/src/asobi_peer.erl
+++ b/src/asobi_peer.erl
@@ -52,7 +52,10 @@ peer_ip(Req) ->
 forwarded_client(Req, Cidrs, Peer) ->
     case cowboy_req:header(~"x-forwarded-for", Req) of
         Xff when is_binary(Xff), Xff =/= <<>> ->
-            Hops = lists:reverse([trim(P) || P <- binary:split(Xff, ~",", [global])]),
+            %% lists:reverse/1's bounded polymorphic spec doesn't propagate the
+            %% element type through eqwalizer here - re-narrow with a guard.
+            Parts = [trim(P) || P <- binary:split(Xff, ~",", [global])],
+            Hops = [H || H <- lists:reverse(Parts), is_binary(H)],
             case first_untrusted(Hops, Cidrs) of
                 {ok, Ip} -> Ip;
                 none -> Peer
@@ -95,9 +98,15 @@ parse_cidr(C0) ->
 -spec ip_in_any(binary(), [cidr()]) -> boolean().
 ip_in_any(IpBin, Cidrs) ->
     case inet:parse_address(binary_to_list(IpBin)) of
-        {ok, IP} -> lists:any(fun(C) -> ip_in_cidr(IP, C) end, Cidrs);
+        {ok, IP} -> ip_in_any_(IP, Cidrs);
         _ -> false
     end.
+
+-spec ip_in_any_(inet:ip_address(), [cidr()]) -> boolean().
+ip_in_any_(_IP, []) ->
+    false;
+ip_in_any_(IP, [Cidr | Rest]) ->
+    ip_in_cidr(IP, Cidr) orelse ip_in_any_(IP, Rest).
 
 -spec ip_in_cidr(inet:ip_address(), cidr()) -> boolean().
 ip_in_cidr(IP, {Net, Bits}) when tuple_size(IP) =:= tuple_size(Net) ->
@@ -110,7 +119,13 @@ ip_in_cidr(_IP, _Cidr) ->
 -spec ip_to_int(inet:ip_address()) -> non_neg_integer().
 ip_to_int(IP) ->
     ElemBits = elem_bits(IP),
-    lists:foldl(fun(E, Acc) -> (Acc bsl ElemBits) bor E end, 0, tuple_to_list(IP)).
+    ip_to_int_(tuple_to_list(IP), ElemBits, 0).
+
+-spec ip_to_int_([term()], 8 | 16, non_neg_integer()) -> non_neg_integer().
+ip_to_int_([], _ElemBits, Acc) ->
+    Acc;
+ip_to_int_([E | Rest], ElemBits, Acc) when is_integer(E) ->
+    ip_to_int_(Rest, ElemBits, (Acc bsl ElemBits) bor E).
 
 -spec width(inet:ip_address()) -> 32 | 128.
 width(IP) -> tuple_size(IP) * elem_bits(IP).
@@ -143,4 +158,8 @@ to_int(B) ->
     end.
 
 -spec trim(binary()) -> binary().
-trim(B) -> string:trim(B).
+trim(B) ->
+    case string:trim(B) of
+        Trimmed when is_binary(Trimmed) -> Trimmed;
+        Trimmed -> iolist_to_binary(Trimmed)
+    end.

--- a/src/asobi_repo.erl
+++ b/src/asobi_repo.erl
@@ -30,7 +30,7 @@ otp_app() -> asobi.
 all(Q) -> kura_repo_worker:all(?MODULE, Q).
 
 -spec aggregate(#kura_query{}, count | {count | sum | avg | min | max, atom()}) ->
-    {ok, number()} | {error, term()}.
+    {ok, term()} | {error, term()}.
 aggregate(Q, Agg) -> kura_repo_worker:aggregate(?MODULE, Q, Agg).
 
 -spec get(module(), term()) -> {ok, map()} | {error, term()}.

--- a/src/controllers/asobi_guest_controller.erl
+++ b/src/controllers/asobi_guest_controller.erl
@@ -344,7 +344,7 @@ pepper(KeyId) ->
     case application:get_env(asobi, guest_verifier_pepper, undefined) of
         Peppers when is_map(Peppers) ->
             case maps:get(KeyId, Peppers, undefined) of
-                Bin when is_binary(Bin) -> Bin;
+                Bin when is_binary(Bin), byte_size(Bin) >= 32 -> Bin;
                 _ -> undefined
             end;
         Bin when is_binary(Bin), byte_size(Bin) >= 32 -> Bin;

--- a/src/controllers/asobi_guest_controller.erl
+++ b/src/controllers/asobi_guest_controller.erl
@@ -263,7 +263,12 @@ issue_for_player(PlayerId) ->
 make_verifier(SecretBin) ->
     Salt = crypto:strong_rand_bytes(16),
     KeyId = current_key_id(),
-    Mac = crypto:mac(hmac, sha256, pepper(KeyId), <<Salt/binary, SecretBin/binary>>),
+    Pepper =
+        case pepper(KeyId) of
+            Key when is_binary(Key) -> Key;
+            undefined -> error(guest_verifier_pepper_missing)
+        end,
+    Mac = crypto:mac(hmac, sha256, Pepper, <<Salt/binary, SecretBin/binary>>),
     #{
         ~"salt" => base64:encode(Salt),
         ~"key_id" => KeyId,
@@ -329,14 +334,22 @@ guest_enabled() ->
 
 -spec current_key_id() -> binary().
 current_key_id() ->
-    application:get_env(asobi, guest_verifier_key_id, ~"v1").
+    case application:get_env(asobi, guest_verifier_key_id, ~"v1") of
+        KeyId when is_binary(KeyId) -> KeyId;
+        _ -> ~"v1"
+    end.
 
 -spec pepper(binary()) -> binary() | undefined.
 pepper(KeyId) ->
     case application:get_env(asobi, guest_verifier_pepper, undefined) of
-        Peppers when is_map(Peppers) -> maps:get(KeyId, Peppers, undefined);
+        Peppers when is_map(Peppers) ->
+            case maps:get(KeyId, Peppers, undefined) of
+                Bin when is_binary(Bin) -> Bin;
+                _ -> undefined
+            end;
         Bin when is_binary(Bin), byte_size(Bin) >= 32 -> Bin;
-        _ -> undefined
+        _ ->
+            undefined
     end.
 
 -spec global_create_allowed() -> boolean().

--- a/src/plugins/asobi_rate_limit_plugin.erl
+++ b/src/plugins/asobi_rate_limit_plugin.erl
@@ -85,19 +85,44 @@ select_limiter(Req) ->
 -ifdef(TEST).
 -include_lib("eunit/include/eunit.hrl").
 
+%% select_limiter/1 only reads `path` via cowboy_req:path/1, so a bare map is
+%% fine at runtime - this just tells eqwalizer to trust it as a
+%% cowboy_req:req() for the duration of the test (mirrors asobi_body_cap_plugin_tests).
+-spec fake_req(map()) -> dynamic().
+fake_req(M) -> M.
+
 select_limiter_test_() ->
     [
-        ?_assertEqual(asobi_register_limiter, select_limiter(#{path => ~"/api/v1/auth/register"})),
-        ?_assertEqual(asobi_auth_limiter, select_limiter(#{path => ~"/api/v1/auth/login"})),
-        ?_assertEqual(asobi_auth_limiter, select_limiter(#{path => ~"/api/v1/auth/refresh"})),
-        ?_assertEqual(asobi_iap_limiter, select_limiter(#{path => ~"/api/v1/iap/purchase"})),
-        ?_assertEqual(asobi_api_limiter, select_limiter(#{path => ~"/api/v1/friends"})),
+        ?_assertEqual(
+            asobi_register_limiter, select_limiter(fake_req(#{path => ~"/api/v1/auth/register"}))
+        ),
+        ?_assertEqual(
+            asobi_auth_limiter, select_limiter(fake_req(#{path => ~"/api/v1/auth/login"}))
+        ),
+        ?_assertEqual(
+            asobi_auth_limiter, select_limiter(fake_req(#{path => ~"/api/v1/auth/refresh"}))
+        ),
+        ?_assertEqual(
+            asobi_iap_limiter, select_limiter(fake_req(#{path => ~"/api/v1/iap/purchase"}))
+        ),
+        ?_assertEqual(asobi_api_limiter, select_limiter(fake_req(#{path => ~"/api/v1/friends"}))),
         %% asobi#157 regression: slash-normalisation variants that the
         %% router folds onto /auth/register must not escape the register
         %% bucket onto the looser auth (5/s) or api (300/s) limiter.
-        ?_assertEqual(asobi_register_limiter, select_limiter(#{path => ~"/api/v1/auth//register"})),
-        ?_assertEqual(asobi_register_limiter, select_limiter(#{path => ~"/api/v1/auth/register/"})),
-        ?_assertEqual(asobi_register_limiter, select_limiter(#{path => ~"/api/v1//auth/register"})),
-        ?_assertEqual(asobi_register_limiter, select_limiter(#{path => ~"//api/v1/auth/register"}))
+        ?_assertEqual(
+            asobi_register_limiter,
+            select_limiter(fake_req(#{path => ~"/api/v1/auth//register"}))
+        ),
+        ?_assertEqual(
+            asobi_register_limiter,
+            select_limiter(fake_req(#{path => ~"/api/v1/auth/register/"}))
+        ),
+        ?_assertEqual(
+            asobi_register_limiter,
+            select_limiter(fake_req(#{path => ~"/api/v1//auth/register"}))
+        ),
+        ?_assertEqual(
+            asobi_register_limiter, select_limiter(fake_req(#{path => ~"//api/v1/auth/register"}))
+        )
     ].
 -endif.

--- a/test/asobi_client_gate_plugin_tests.erl
+++ b/test/asobi_client_gate_plugin_tests.erl
@@ -2,7 +2,13 @@
 
 -include_lib("eunit/include/eunit.hrl").
 
--define(REGISTER, #{path => ~"/api/v1/auth/register"}).
+%% decision/1 and context/1 only read `path`/`headers`/`json`, so a bare map
+%% is fine at runtime - this just tells eqwalizer to trust it as a
+%% cowboy_req:req() for the duration of the test (mirrors asobi_body_cap_plugin_tests).
+-spec fake_req(map()) -> dynamic().
+fake_req(M) -> M.
+
+-define(REGISTER, fake_req(#{path => ~"/api/v1/auth/register"})).
 
 gate_test_() ->
     {foreach, fun setup/0, fun cleanup/1, [
@@ -42,7 +48,7 @@ unset_gate_is_noop() ->
 
 non_auth_path_is_noop() ->
     set_gate(fun(_) -> {deny, ~"nope"} end),
-    ?assertEqual(pass, asobi_client_gate_plugin:decision(#{path => ~"/api/v1/friends"})).
+    ?assertEqual(pass, asobi_client_gate_plugin:decision(fake_req(#{path => ~"/api/v1/friends"}))).
 
 deny_propagates() ->
     set_gate(fun(_) -> {deny, ~"captcha_failed"} end),
@@ -80,15 +86,19 @@ false_disables_gate() ->
 
 applies_to_oauth_and_guest() ->
     set_gate(fun(_) -> {deny, ~"x"} end),
-    ?assertEqual({deny, ~"x"}, asobi_client_gate_plugin:decision(#{path => ~"/api/v1/auth/oauth"})),
-    ?assertEqual({deny, ~"x"}, asobi_client_gate_plugin:decision(#{path => ~"/api/v1/auth/guest"})).
+    ?assertEqual(
+        {deny, ~"x"}, asobi_client_gate_plugin:decision(fake_req(#{path => ~"/api/v1/auth/oauth"}))
+    ),
+    ?assertEqual(
+        {deny, ~"x"}, asobi_client_gate_plugin:decision(fake_req(#{path => ~"/api/v1/auth/guest"}))
+    ).
 
 %% Slash-fold variants the router collapses onto a gated path must still gate,
 %% mirroring the asobi#157 regression cases on select_limiter/1.
 folds_slash_variants() ->
     set_gate(fun(_) -> {deny, ~"x"} end),
     [
-        ?assertEqual({deny, ~"x"}, asobi_client_gate_plugin:decision(#{path => P}))
+        ?assertEqual({deny, ~"x"}, asobi_client_gate_plugin:decision(fake_req(#{path => P})))
      || P <- [
             ~"/api/v1/auth//register",
             ~"/api/v1/auth/register/",
@@ -100,7 +110,7 @@ folds_slash_variants() ->
 %% The central security claim: the context handed to a gate carries the
 %% challenge token but NOT the registration plaintext password.
 context_omits_password_and_extracts_token() ->
-    Req = #{
+    Req = fake_req(#{
         path => ~"/api/v1/auth/register",
         headers => #{~"cf-turnstile-response" => ~"tok"},
         json => #{
@@ -108,7 +118,7 @@ context_omits_password_and_extracts_token() ->
             ~"password" => ~"secret",
             ~"client_gate_token" => ~"tok"
         }
-    },
+    }),
     Ctx = asobi_client_gate_plugin:context(Req),
     ?assertEqual([headers, ip, path, token], lists:sort(maps:keys(Ctx))),
     ?assertEqual(~"tok", maps:get(token, Ctx)),

--- a/test/asobi_client_gate_plugin_tests.erl
+++ b/test/asobi_client_gate_plugin_tests.erl
@@ -2,9 +2,11 @@
 
 -include_lib("eunit/include/eunit.hrl").
 
-%% decision/1 and context/1 only read `path`/`headers`/`json`, so a bare map
-%% is fine at runtime - this just tells eqwalizer to trust it as a
-%% cowboy_req:req() for the duration of the test (mirrors asobi_body_cap_plugin_tests).
+%% decision/1 and context/1 only read `path`/`headers`/`json` (context/1 also
+%% derives `ip` via asobi_peer:client_ip/1, safe here since trusted_proxies
+%% defaults to [] and the header lookup is try-wrapped), so a bare map is fine
+%% at runtime - this just tells eqwalizer to trust it as a cowboy_req:req()
+%% for the duration of the test (mirrors asobi_body_cap_plugin_tests).
 -spec fake_req(map()) -> dynamic().
 fake_req(M) -> M.
 

--- a/test/asobi_entity_timer_tests.erl
+++ b/test/asobi_entity_timer_tests.erl
@@ -208,6 +208,6 @@ deserialise_malformed_entry_is_skipped_test() ->
     ?assertEqual(~"good", maps:get(timer_id, Timer)).
 
 round_trip(State) ->
-    asobi_entity_timer:deserialise(
-        json:decode(iolist_to_binary(json:encode(asobi_entity_timer:serialise(State))))
-    ).
+    case json:decode(iolist_to_binary(json:encode(asobi_entity_timer:serialise(State)))) of
+        Decoded when is_map(Decoded) -> asobi_entity_timer:deserialise(Decoded)
+    end.

--- a/test/asobi_guest_controller_tests.erl
+++ b/test/asobi_guest_controller_tests.erl
@@ -20,7 +20,8 @@ verifier_test_() ->
         {"correct secret verifies", fun correct_secret_verifies/0},
         {"wrong secret is rejected", fun wrong_secret_rejected/0},
         {"tampered verifier is rejected", fun tampered_verifier_rejected/0},
-        {"verify fails closed without a pepper", fun no_pepper_fails_closed/0}
+        {"verify fails closed without a pepper", fun no_pepper_fails_closed/0},
+        {"make_verifier fails loud without a pepper", fun make_verifier_no_pepper_errors/0}
     ]}.
 
 correct_secret_verifies() ->
@@ -43,6 +44,14 @@ no_pepper_fails_closed() ->
     Meta = asobi_guest_controller:make_verifier(Secret),
     application:unset_env(asobi, guest_verifier_pepper),
     ?assertNot(asobi_guest_controller:verify(Secret, Meta)),
+    application:set_env(asobi, guest_verifier_pepper, crypto:strong_rand_bytes(32)).
+
+make_verifier_no_pepper_errors() ->
+    application:unset_env(asobi, guest_verifier_pepper),
+    ?assertError(
+        guest_verifier_pepper_missing,
+        asobi_guest_controller:make_verifier(crypto:strong_rand_bytes(32))
+    ),
     application:set_env(asobi, guest_verifier_pepper, crypto:strong_rand_bytes(32)).
 
 decode_secret_test() ->

--- a/test/asobi_guest_controller_tests.erl
+++ b/test/asobi_guest_controller_tests.erl
@@ -2,6 +2,12 @@
 
 -include_lib("eunit/include/eunit.hrl").
 
+%% authenticate/1 only pattern-matches the `json` key here, so a bare map is
+%% fine at runtime - this just tells eqwalizer to trust it as a
+%% cowboy_req:req() for the duration of the test (mirrors asobi_body_cap_plugin_tests).
+-spec fake_req(map()) -> dynamic().
+fake_req(M) -> M.
+
 setup() ->
     application:set_env(asobi, guest_verifier_pepper, crypto:strong_rand_bytes(32)),
     ok.
@@ -61,12 +67,12 @@ decode_secret_upper_bound_test() ->
 
 authenticate_disabled_returns_403_test() ->
     application:unset_env(asobi, guest_auth),
-    Req = #{
+    Req = fake_req(#{
         json => #{
             ~"device_id" => ~"dev-abc",
             ~"device_secret" => base64:encode(crypto:strong_rand_bytes(32))
         }
-    },
+    }),
     ?assertMatch(
         {json, 403, _, #{error := ~"guest_auth_disabled", message := _}},
         asobi_guest_controller:authenticate(Req)

--- a/test/asobi_iap_controller_tests.erl
+++ b/test/asobi_iap_controller_tests.erl
@@ -1,6 +1,12 @@
 -module(asobi_iap_controller_tests).
 -include_lib("eunit/include/eunit.hrl").
 
+%% verify_apple/1 and verify_google/1 only read json/auth_data, so a bare map
+%% is fine at runtime - this just tells eqwalizer to trust it as a
+%% cowboy_req:req() for the duration of the test (mirrors asobi_body_cap_plugin_tests).
+-spec fake_req(map()) -> dynamic().
+fake_req(M) -> M.
+
 iap_test_() ->
     {foreach, fun setup/0, fun cleanup/1, [
         fun first_purchase_recorded/0,
@@ -45,7 +51,7 @@ cross_account_replay_rejected() ->
     ).
 
 unauthenticated_rejected() ->
-    Req = #{json => #{~"signed_transaction" => ~"jws"}},
+    Req = fake_req(#{json => #{~"signed_transaction" => ~"jws"}}),
     ?assertMatch({json, 400, _, _}, asobi_iap_controller:verify_apple(Req)).
 
 verify_failure_surfaced() ->
@@ -61,10 +67,10 @@ google_uses_order_id() ->
     end),
     no_existing(),
     meck:expect(asobi_repo, insert, fun(_CS) -> {ok, #{}} end),
-    Req = #{
+    Req = fake_req(#{
         json => #{~"product_id" => ~"coins", ~"purchase_token" => ~"tok"},
         auth_data => #{player_id => ~"p1"}
-    },
+    }),
     {json, 200, _, Body} = asobi_iap_controller:verify_google(Req),
     ?assertEqual(false, maps:get(duplicate, Body)).
 

--- a/test/asobi_peer_tests.erl
+++ b/test/asobi_peer_tests.erl
@@ -7,6 +7,7 @@ peer_test_() ->
         fun untrusted_peer_ignores_xff/0,
         fun trusted_peer_uses_xff/0,
         fun strips_trusted_hops/0,
+        fun rightmost_untrusted_hop_wins/0,
         fun trusted_peer_no_xff_returns_peer/0,
         fun ipv6_trusted_proxy/0
     ]}.
@@ -46,6 +47,19 @@ strips_trusted_hops() ->
     ?assertEqual(
         ~"203.0.113.9",
         asobi_peer:client_ip(req({{10, 0, 0, 1}, 1234}, ~"203.0.113.9, 10.0.0.5"))
+    ).
+
+%% Two untrusted hops: the client controls the left-hand entries, so only the
+%% right-most non-proxy hop (the one our own proxy appended) may be trusted.
+%% An implementation that fails to reverse (or drops a hop) returns the
+%% attacker-controlled 203.0.113.9 instead.
+rightmost_untrusted_hop_wins() ->
+    application:set_env(asobi, trusted_proxies, [~"10.0.0.0/8"]),
+    ?assertEqual(
+        ~"198.51.100.7",
+        asobi_peer:client_ip(
+            req({{10, 0, 0, 1}, 1234}, ~"203.0.113.9, 198.51.100.7, 10.0.0.5")
+        )
     ).
 
 trusted_peer_no_xff_returns_peer() ->

--- a/test/asobi_registration_tests.erl
+++ b/test/asobi_registration_tests.erl
@@ -2,6 +2,12 @@
 
 -include_lib("eunit/include/eunit.hrl").
 
+%% register/1 only reads `json`, so a bare map is fine at runtime - this just
+%% tells eqwalizer to trust it as a cowboy_req:req() for the duration of the
+%% test (mirrors asobi_body_cap_plugin_tests).
+-spec fake_req(map()) -> dynamic().
+fake_req(M) -> M.
+
 registration_test_() ->
     {foreach, fun setup/0, fun cleanup/1, [
         fun defaults_to_open/0,
@@ -51,7 +57,7 @@ oauth_only_denies_password_only() ->
 %% before any account/DB work - the check is the first thing register/1 does.
 register_controller_denies_before_db() ->
     application:set_env(asobi, registration, closed),
-    Req = #{json => #{~"username" => ~"validname", ~"password" => ~"longenough1"}},
+    Req = fake_req(#{json => #{~"username" => ~"validname", ~"password" => ~"longenough1"}}),
     ?assertEqual(
         {json, 403, #{}, #{error => ~"registration_closed"}},
         asobi_auth_controller:register(Req)

--- a/test/asobi_tls_client_tests.erl
+++ b/test/asobi_tls_client_tests.erl
@@ -8,10 +8,7 @@ verifies_peer_test() ->
 
 uses_system_trust_store_test() ->
     Ssl = asobi_tls_client:ssl_options(),
-    case proplists:get_value(cacerts, Ssl) of
-        CaCerts when is_list(CaCerts) -> ?assert(length(CaCerts) > 0);
-        _ -> ?assert(false)
-    end.
+    ?assertMatch([_ | _], proplists:get_value(cacerts, Ssl)).
 
 checks_hostname_test() ->
     Ssl = asobi_tls_client:ssl_options(),

--- a/test/asobi_tls_client_tests.erl
+++ b/test/asobi_tls_client_tests.erl
@@ -8,9 +8,10 @@ verifies_peer_test() ->
 
 uses_system_trust_store_test() ->
     Ssl = asobi_tls_client:ssl_options(),
-    CaCerts = proplists:get_value(cacerts, Ssl),
-    ?assert(is_list(CaCerts)),
-    ?assert(length(CaCerts) > 0).
+    case proplists:get_value(cacerts, Ssl) of
+        CaCerts when is_list(CaCerts) -> ?assert(length(CaCerts) > 0);
+        _ -> ?assert(false)
+    end.
 
 checks_hostname_test() ->
     Ssl = asobi_tls_client:ssl_options(),

--- a/test/asobi_world_lobby_cache_tests.erl
+++ b/test/asobi_world_lobby_cache_tests.erl
@@ -67,7 +67,7 @@ distinct_modes_do_not_grow_table() ->
     A = #{world_id => ~"a", mode => ~"barrow"},
     ets:insert(?TAB, {?KEY(false), [A], Now + ?TTL_MS}),
     lists:foreach(
-        fun(N) ->
+        fun(N) when is_integer(N) ->
             Mode = integer_to_binary(N),
             _ = asobi_world_lobby:list_worlds_cached(#{mode => Mode})
         end,

--- a/test/asobi_zone_lifecycle_tests.erl
+++ b/test/asobi_zone_lifecycle_tests.erl
@@ -29,6 +29,14 @@ start_zone(GameMod, Overrides) ->
     {ok, Pid} = asobi_zone:start_link(Config),
     Pid.
 
+%% sys:get_state/1 returns term() generically - narrow it to the map shape
+%% asobi_zone's gen_server state actually is.
+-spec gen_server_state(pid()) -> map().
+gen_server_state(Pid) ->
+    case sys:get_state(Pid) of
+        State when is_map(State) -> State
+    end.
+
 zone_lifecycle_test_() ->
     {setup, fun setup/0, fun cleanup/1, [
         {"init_zone_state runs via handle_continue", fun init_zone_state_runs/0},
@@ -38,7 +46,7 @@ zone_lifecycle_test_() ->
 
 init_zone_state_runs() ->
     Pid = start_zone(asobi_zone_ctx_test_game, #{}),
-    ZoneState = maps:get(zone_state, sys:get_state(Pid)),
+    ZoneState = maps:get(zone_state, gen_server_state(Pid)),
     ?assertEqual(init_zone_state, maps:get(built_by, ZoneState)),
     ?assertEqual({2, 3}, maps:get(coords, ZoneState)),
     ?assert(is_reference(maps:get(runtime, ZoneState))),
@@ -47,7 +55,7 @@ init_zone_state_runs() ->
 no_callback_unaffected() ->
     %% asobi_test_world_game exports no init_zone_state; zone_state stays as given.
     Pid = start_zone(asobi_test_world_game, #{zone_state => #{seeded => true}}),
-    ?assertEqual(#{seeded => true}, maps:get(zone_state, sys:get_state(Pid))),
+    ?assertEqual(#{seeded => true}, maps:get(zone_state, gen_server_state(Pid))),
     gen_server:stop(Pid).
 
 dump_zone_state_strips_runtime() ->

--- a/test/asobi_zone_snapshot_recovery_tests.erl
+++ b/test/asobi_zone_snapshot_recovery_tests.erl
@@ -30,6 +30,14 @@ start_zone(Overrides) ->
     {ok, Pid} = asobi_zone:start_link(Config),
     Pid.
 
+%% sys:get_state/1 returns term() generically - narrow it to the map shape
+%% asobi_zone's gen_server state actually is.
+-spec gen_server_state(pid()) -> map().
+gen_server_state(Pid) ->
+    case sys:get_state(Pid) of
+        State when is_map(State) -> State
+    end.
+
 recovery_test_() ->
     {setup, fun setup/0, fun cleanup/1, [
         {"reap snapshots full state and stops the zone", fun reap_snapshots_full_state/0},
@@ -88,7 +96,7 @@ cold_start_restores() ->
     meck:expect(asobi_zone_snapshotter, load_snapshot, fun(_, _) -> {ok, Snapshot} end),
     try
         Pid = start_zone(#{persistence => true, spawn_templates => Templates}),
-        State = sys:get_state(Pid),
+        State = gen_server_state(Pid),
         ZoneState = maps:get(zone_state, State),
         %% Restored from the snapshot...
         ?assertEqual(true, maps:get(~"saved", ZoneState)),
@@ -115,7 +123,7 @@ cold_start_load_error_suppresses_persistence() ->
         Pid = start_zone(#{persistence => true}),
         %% Load failed: the zone starts (no crash) but with persistence
         %% suppressed, so it never overwrites the unreadable-but-present row.
-        ?assertEqual(false, maps:get(persistence, sys:get_state(Pid))),
+        ?assertEqual(false, maps:get(persistence, gen_server_state(Pid))),
         Ref = monitor(process, Pid),
         asobi_zone:reap(Pid),
         receive


### PR DESCRIPTION
## Summary

Clears all 51 pre-existing `elp eqwalize-all` errors flagged during PR #244's code review (`erlang-code-reviewer`), across 14 files. Every fix is a real type correction or narrowing - no `eqwalizer:fixme`, no suppressions.

**Production code** (`src/`, 24 errors across 5 files):
- `asobi_repo:aggregate/2` - widened its spec to `{ok, term()}` to match what `kura_repo_worker:aggregate/3` actually returns (was over-promising `number()`)
- `asobi_guest_reaper` - guarded `application:get_env`/`gen_server:call` results (same pattern as `asobi_matchmaker:init/1`), widened `start_link/0`'s spec to include `{error, term()}`
- `asobi_peer` - replaced two `lists:any`/`lists:foldl` closures with direct recursion (eqwalizer wasn't threading the element type through), fixed `trim/1` to actually guarantee `binary()` (`string:trim/1` returns `unicode:chardata()`), and worked around a `lists:reverse/1` bounded-polymorphism quirk with a re-narrowing guard
- `asobi_guest_controller` - `make_verifier/1` now fails loudly (`error/1`) on a missing pepper instead of crashing inside `crypto:mac` - matches the module's own stated "fail closed and loud" philosophy
- `asobi_rate_limit_plugin` - embedded eunit tests passed a bare `#{path => ...}` map where `cowboy_req:req()` structurally requires ~16 unrelated fields

**Tests** (`test/`, 27 errors across 9 files):
- Most were the same `cowboy_req:req()` shape mismatch (a controller/plugin only reads 1-2 keys, but its declared param type is the full opaque req shape). Added a `fake_req/1` helper per file, following the existing convention already in `asobi_body_cap_plugin_tests.erl` (`-spec fake_req(map()) -> dynamic().` - a real, sanctioned gradual-typing escape, not `eqwalizer:fixme`)
- `asobi_zone_lifecycle_tests`/`asobi_zone_snapshot_recovery_tests` - `sys:get_state/1` returns `term()` generically; added a `gen_server_state/1` helper narrowing it to the map the gen_server actually holds
- `asobi_tls_client_tests`, `asobi_world_lobby_cache_tests`, `asobi_entity_timer_tests` - guarded `proplists:get_value/2`, a `lists:foreach` closure parameter, and a `json:decode/1` union result respectively

## Test plan
- [x] `elp eqwalize-all` (via `mise exec erlang@28.4.1`) - **0 errors** (was 51)
- [x] `rebar3 fmt --check`, `rebar3 xref`, `rebar3 dialyzer` - all clean
- [x] `rebar3 eunit` (full suite) - **405 tests, 0 failures**
- [ ] CT - needs CI (no docker in dev environment); this branch touches no CT suites directly, only eunit-tested modules and `_tests.erl` files