### PR TITLE
fix: log + emit telemetry when a zone spawn's template_id is unknown

### DIFF
--- a/guides/world-server.md
+++ b/guides/world-server.md
@@ -425,6 +425,11 @@ At runtime, Lua scripts spawn from a template with
 `game.zone.spawn("goblin", x, y, {overrides})`, where the optional table
 overrides fields from the template's `base_state`.
 
+If `template_id` doesn't match a key returned by `spawn_templates`, nothing
+spawns: `game.zone.spawn` has no return value to report the failure. The zone
+logs a `zone_spawn_failed` warning with the `world_id` and `coords`, and
+emits `[asobi, error]` with `kind => unknown_spawn_template`.
+
 ```lua
 function spawn_templates(config)
     return {

--- a/src/asobi_telemetry.erl
+++ b/src/asobi_telemetry.erl
@@ -21,7 +21,7 @@
 
 %% Categories of game-code error. A fixed literal set on purpose - never derive
 %% Kind from untrusted input (atom-table exhaustion). Extend as categories arise.
--type game_error_kind() :: lua_error.
+-type game_error_kind() :: lua_error | unknown_spawn_template.
 -export_type([game_error_kind/0]).
 -export([economy_transaction/4, store_purchase/3]).
 -export([chat_message_sent/2]).

--- a/src/world/asobi_zone.erl
+++ b/src/world/asobi_zone.erl
@@ -750,14 +750,11 @@ has_tickable_entities(Entities) ->
 %% synchronously to the caller, so this is the only place it becomes
 %% observable - without it, a bad template_id silently spawned nothing with
 %% zero signal (asobi#246/#247).
--spec log_spawn_failed(binary(), term(), map()) -> ok.
+-spec log_spawn_failed(binary(), unknown_template, map()) -> ok.
 log_spawn_failed(TemplateId, Reason, #{world_id := WorldId, coords := Coords}) ->
-    %% TemplateId is caller-supplied (a Lua script can pass player input
-    %% straight through to game.zone.spawn) - bound it before it reaches logs
-    %% or telemetry, per asobi_telemetry:game_error/2's own "no unbounded
-    %% values" contract (mirrors asobi_oauth_controller.erl's inline form;
-    %% asobi core has no shared truncation helper).
-    Id = binary:part(TemplateId, 0, min(64, byte_size(TemplateId))),
+    %% Caller-supplied (a Lua script can pass player input straight through
+    %% to game.zone.spawn); game_error/2 requires bounded details.
+    Id = bound_template_id(TemplateId),
     ?LOG_WARNING(#{
         event => zone_spawn_failed,
         world_id => WorldId,
@@ -769,6 +766,20 @@ log_spawn_failed(TemplateId, Reason, #{world_id := WorldId, coords := Coords}) -
         world_id => WorldId,
         template_id => Id
     }).
+
+%% A byte-length cut alone can land mid-codepoint, and the result is exported
+%% verbatim to a JSON log formatter (nova_jsonlogger) and every telemetry
+%% handler - an invalid-UTF8 template_id must not raise there. Re-validate
+%% after truncating and take whichever prefix unicode:characters_to_binary/1
+%% says is actually well-formed (possibly empty, never invalid).
+-spec bound_template_id(binary()) -> binary().
+bound_template_id(TemplateId) ->
+    Head = binary:part(TemplateId, 0, min(64, byte_size(TemplateId))),
+    case unicode:characters_to_binary(Head) of
+        Valid when is_binary(Valid) -> Valid;
+        {incomplete, Valid, _} -> Valid;
+        {error, Valid, _} -> Valid
+    end.
 
 %% --- Spatial Grid Helpers ---
 

--- a/src/world/asobi_zone.erl
+++ b/src/world/asobi_zone.erl
@@ -398,7 +398,8 @@ handle_cast(
                 spawner => Spawner1,
                 spatial_grid => Grid1
             }};
-        {error, _} ->
+        {error, Reason} ->
+            log_spawn_failed(TemplateId, Reason, State),
             {noreply, State}
     end;
 handle_cast({spawn_entities, Spawns}, State) when is_list(Spawns) ->
@@ -744,6 +745,25 @@ has_tickable_entities(Entities) ->
         Entities
     ).
 
+%% asobi_zone_spawner:spawn_entity/4's only error today is unknown_template.
+%% The cast API (game.zone.spawn and world-server spawn_at) can't return this
+%% synchronously to the caller, so this is the only place it becomes
+%% observable - without it, a bad template_id silently spawned nothing with
+%% zero signal (asobi#246/#247).
+-spec log_spawn_failed(binary(), term(), map()) -> ok.
+log_spawn_failed(TemplateId, Reason, #{world_id := WorldId, coords := Coords}) ->
+    ?LOG_WARNING(#{
+        event => zone_spawn_failed,
+        world_id => WorldId,
+        coords => Coords,
+        template_id => TemplateId,
+        reason => Reason
+    }),
+    asobi_telemetry:game_error(unknown_spawn_template, #{
+        world_id => WorldId,
+        template_id => TemplateId
+    }).
+
 %% --- Spatial Grid Helpers ---
 
 spatial_grid_insert(_EntityId, _EntityState, undefined) ->
@@ -774,7 +794,8 @@ apply_spawns(
                     spawner => Sp1,
                     spatial_grid => Gr1
                 };
-            {error, _} ->
+            {error, Reason} ->
+                log_spawn_failed(TemplateId, Reason, State),
                 State
         end,
     apply_spawns(Rest, State1);

--- a/src/world/asobi_zone.erl
+++ b/src/world/asobi_zone.erl
@@ -752,16 +752,22 @@ has_tickable_entities(Entities) ->
 %% zero signal (asobi#246/#247).
 -spec log_spawn_failed(binary(), term(), map()) -> ok.
 log_spawn_failed(TemplateId, Reason, #{world_id := WorldId, coords := Coords}) ->
+    %% TemplateId is caller-supplied (a Lua script can pass player input
+    %% straight through to game.zone.spawn) - bound it before it reaches logs
+    %% or telemetry, per asobi_telemetry:game_error/2's own "no unbounded
+    %% values" contract (mirrors asobi_oauth_controller.erl's inline form;
+    %% asobi core has no shared truncation helper).
+    Id = binary:part(TemplateId, 0, min(64, byte_size(TemplateId))),
     ?LOG_WARNING(#{
         event => zone_spawn_failed,
         world_id => WorldId,
         coords => Coords,
-        template_id => TemplateId,
+        template_id => Id,
         reason => Reason
     }),
     asobi_telemetry:game_error(unknown_spawn_template, #{
         world_id => WorldId,
-        template_id => TemplateId
+        template_id => Id
     }).
 
 %% --- Spatial Grid Helpers ---

--- a/test/asobi_zone_tests.erl
+++ b/test/asobi_zone_tests.erl
@@ -97,7 +97,7 @@ spawn_entity_unknown_template_observable() ->
         receive
             {ev, #{kind := unknown_spawn_template, details := D}} ->
                 ?assertEqual(~"nonexistent", maps:get(template_id, D))
-        after 1000 -> ?assert(false)
+        after 1000 -> ?assert(false, timeout_waiting_for_unknown_spawn_template_event)
         end
     after
         telemetry:detach(Ref),

--- a/test/asobi_zone_tests.erl
+++ b/test/asobi_zone_tests.erl
@@ -46,7 +46,11 @@ zone_test_() ->
         {"spawn_entity with a known template creates the entity",
             fun spawn_entity_known_template/0},
         {"spawn_entity with an unknown template logs and emits telemetry, spawns nothing",
-            fun spawn_entity_unknown_template_observable/0}
+            fun spawn_entity_unknown_template_observable/0},
+        {"spawn_entity bounds an over-long template_id before it is observable",
+            fun spawn_entity_long_template_id_bounded/0},
+        {"spawn_entity keeps a multibyte template_id valid UTF-8 when bounding",
+            fun spawn_entity_multibyte_template_id_stays_utf8/0}
     ]}.
 
 starts_empty() ->
@@ -98,6 +102,55 @@ spawn_entity_unknown_template_observable() ->
             {ev, #{kind := unknown_spawn_template, details := D}} ->
                 ?assertEqual(~"nonexistent", maps:get(template_id, D))
         after 1000 -> ?assert(false, timeout_waiting_for_unknown_spawn_template_event)
+        end
+    after
+        telemetry:detach(Ref),
+        gen_server:stop(Pid)
+    end.
+
+spawn_entity_long_template_id_bounded() ->
+    Self = self(),
+    Ref = make_ref(),
+    {ok, _} = application:ensure_all_started(telemetry),
+    telemetry:attach(
+        Ref, [asobi, error], fun(_E, _M, Meta, _) -> Self ! {ev, Meta} end, []
+    ),
+    Long = binary:copy(~"a", 200),
+    Pid = start_zone(#{spawn_templates => #{}}),
+    try
+        asobi_zone:spawn_entity(Pid, Long, {10, 20}),
+        receive
+            {ev, #{kind := unknown_spawn_template, details := D}} ->
+                Id = maps:get(template_id, D),
+                ?assertEqual(64, byte_size(Id)),
+                ?assertEqual(binary:part(Long, 0, 64), Id)
+        after 1000 -> ?assert(false, timeout_waiting_for_bounded_template_id)
+        end
+    after
+        telemetry:detach(Ref),
+        gen_server:stop(Pid)
+    end.
+
+%% A 64-byte cut lands mid-codepoint here; the details map is exported verbatim
+%% to handlers that JSON-encode it, so it must stay valid UTF-8.
+spawn_entity_multibyte_template_id_stays_utf8() ->
+    Self = self(),
+    Ref = make_ref(),
+    {ok, _} = application:ensure_all_started(telemetry),
+    telemetry:attach(
+        Ref, [asobi, error], fun(_E, _M, Meta, _) -> Self ! {ev, Meta} end, []
+    ),
+    Split = <<(binary:copy(~"a", 63))/binary, "å"/utf8>>,
+    Pid = start_zone(#{spawn_templates => #{}}),
+    try
+        asobi_zone:spawn_entity(Pid, Split, {10, 20}),
+        receive
+            {ev, #{kind := unknown_spawn_template, details := D}} ->
+                Id = maps:get(template_id, D),
+                ?assert(byte_size(Id) =< 64),
+                ?assert(is_binary(unicode:characters_to_binary(Id))),
+                _ = json:encode(#{~"template_id" => Id})
+        after 1000 -> ?assert(false, timeout_waiting_for_utf8_safe_template_id)
         end
     after
         telemetry:detach(Ref),

--- a/test/asobi_zone_tests.erl
+++ b/test/asobi_zone_tests.erl
@@ -42,7 +42,11 @@ zone_test_() ->
         {"subscriber DOWN cleans up", fun subscriber_down_cleanup/0},
         {"tick touches zone_manager when subscribers present", fun tick_touches_zone_manager/0},
         {"tick hibernates when empty", fun tick_hibernates_when_empty/0},
-        {"tick does not hibernate with NPC entities", fun tick_no_hibernate_with_npcs/0}
+        {"tick does not hibernate with NPC entities", fun tick_no_hibernate_with_npcs/0},
+        {"spawn_entity with a known template creates the entity",
+            fun spawn_entity_known_template/0},
+        {"spawn_entity with an unknown template logs and emits telemetry, spawns nothing",
+            fun spawn_entity_unknown_template_observable/0}
     ]}.
 
 starts_empty() ->
@@ -60,6 +64,45 @@ add_remove_entities() ->
     timer:sleep(10),
     ?assertEqual(#{}, asobi_zone:get_entities(Pid)),
     gen_server:stop(Pid).
+
+spawn_entity_known_template() ->
+    Pid = start_zone(#{
+        spawn_templates => #{
+            ~"cube" => #{type => ~"object", base_state => #{~"solid" => true}}
+        }
+    }),
+    asobi_zone:spawn_entity(Pid, ~"cube", {10, 20}),
+    timer:sleep(10),
+    Entities = asobi_zone:get_entities(Pid),
+    ?assertEqual(1, map_size(Entities)),
+    [Entity] = maps:values(Entities),
+    ?assertEqual(~"object", maps:get(type, Entity)),
+    gen_server:stop(Pid).
+
+%% asobi#247: an unresolvable template_id must be observable (log +
+%% telemetry), not silently dropped - the game.zone.spawn caller has no
+%% synchronous way to learn a cast failed, so this is the only signal.
+spawn_entity_unknown_template_observable() ->
+    Self = self(),
+    Ref = make_ref(),
+    {ok, _} = application:ensure_all_started(telemetry),
+    telemetry:attach(
+        Ref, [asobi, error], fun(_E, _M, Meta, _) -> Self ! {ev, Meta} end, []
+    ),
+    Pid = start_zone(#{spawn_templates => #{}}),
+    try
+        asobi_zone:spawn_entity(Pid, ~"nonexistent", {10, 20}),
+        timer:sleep(10),
+        ?assertEqual(#{}, asobi_zone:get_entities(Pid)),
+        receive
+            {ev, #{kind := unknown_spawn_template, details := D}} ->
+                ?assertEqual(~"nonexistent", maps:get(template_id, D))
+        after 1000 -> ?assert(false)
+        end
+    after
+        telemetry:detach(Ref),
+        gen_server:stop(Pid)
+    end.
 
 subscribe_unsubscribe() ->
     Pid = start_zone(),


### PR DESCRIPTION
Fixes widgrensit/asobi#247 (filed during widgrensit/asobi_lua#107's review, root-causing why #246 "took so long to find").

## Summary
`asobi_zone_spawner:spawn_entity/4`'s `{error, unknown_template}` was dropped silently in both `handle_cast({spawn_entity, ...})` and the batch `apply_spawns/2` path in `asobi_zone.erl`. The cast API (`game.zone.spawn`, world-server `spawn_at`) has no synchronous way to return failure to the caller, so this was the only place an unresolvable `template_id` could ever become observable - and it wasn't. Meanwhile `asobi_lua_api:fun_zone_spawn/1` returns `true` on every successful *call*, not successful *spawn*, so a bad template_id looked identical to a real spawn from the Lua side.

Fix: widen `asobi_telemetry:game_error_kind()` with `unknown_spawn_template`, add `log_spawn_failed/3` (log + telemetry), call it from both silent-drop sites.

## Test plan
- [x] New regression test: `spawn_entity_unknown_template_observable` - asserts no entity is created AND the `[asobi, error]` telemetry event fires with the right `kind`/`template_id`
- [x] New coverage test: `spawn_entity_known_template` - the happy path this file had zero coverage for before this PR
- [x] `rebar3 eunit` (full suite) - 412 tests, 0 failures
- [x] `rebar3 fmt --check`, `rebar3 xref` - clean
- [x] `rebar3 dialyzer` - clean
- [x] `elp eqwalize` on both changed modules - clean (verified via an isolated fresh clone, since this repo's local worktree setup had an unrelated tooling quirk during development - see note below)

## Note
Developed in a `git worktree` isolated from a concurrent session's uncommitted work on #248 (same `world/zone` subsystem). Discovered along the way: `elp eqwalize` run from inside a git worktree can silently analyze stale/contaminated state from the primary checkout when both share `.git` - verified this PR's actual diff is eqwalize-clean via a fully independent clone instead.