### PR TITLE
fix: delete orphan player when OAuth first-sign-in loses the identity race

### DIFF
--- a/guides/authentication.md
+++ b/guides/authentication.md
@@ -103,6 +103,17 @@ Returning player response:
 }
 ```
 
+### Error Responses
+
+| Status | `error`                | Cause |
+|--------|------------------------|-------|
+| `400`  | `missing_required_fields` | `provider` or `token` missing |
+| `401`  | `invalid_token`        | Token failed provider validation |
+| `401`  | `unsupported_provider` | `provider` isn't one of the values below |
+| `403`  | *(registration reason)* | New-account registration is closed for this provider (`asobi_registration:check/1`) |
+| `409`  | `already_registering`  | Two first-sign-ins for the same provider identity raced; retry - the retry logs in to the account the other request created |
+| `500`  | `registration_failed`  | Account creation failed for a reason other than the race above (logged server-side) |
+
 ### Supported Providers
 
 | Provider  | `provider` value | Issuer |

--- a/src/asobi_auth_error.erl
+++ b/src/asobi_auth_error.erl
@@ -7,7 +7,7 @@
 %% per-field detail for form UIs. (asobi_auth_controller:register/1 should adopt
 %% this once its 409 branch lands - see the register-409 change.)
 
--export([from_changeset_fields/1, username_taken/1]).
+-export([from_changeset_fields/1, username_taken/1, provider_uid_taken/1]).
 
 %% kura's default message for a unique-index violation.
 -define(UNIQUE_MSG, ~"has already been taken").
@@ -29,6 +29,16 @@ from_changeset_fields(Fields) ->
 -spec username_taken([{atom(), binary()}]) -> boolean().
 username_taken(Errors) ->
     lists:keyfind(username, 1, Errors) =:= {username, ?UNIQUE_MSG}.
+
+%% Same distinction for the OAuth/guest identity race: was this insert
+%% failure specifically the unique {provider, provider_uid} conflict (a
+%% concurrent first-sign-in won), or something else (a provider claim over a
+%% column limit, a transient DB error)? Only the former should read as a
+%% retryable "already registering" - anything else is a real failure that
+%% looks identical to the client unless this is checked.
+-spec provider_uid_taken([{atom(), binary()}]) -> boolean().
+provider_uid_taken(Errors) ->
+    lists:keyfind(provider_uid, 1, Errors) =:= {provider_uid, ?UNIQUE_MSG}.
 
 -spec validation_failed(map()) -> {json, 422, map(), map()}.
 validation_failed(Fields) ->

--- a/src/controllers/asobi_oauth_controller.erl
+++ b/src/controllers/asobi_oauth_controller.erl
@@ -184,7 +184,7 @@ create_player_with_identity(Provider, Claims, Attempt) ->
                             {ok, _Identity} ->
                                 _ = init_player_stats(PlayerId),
                                 {ok, Player};
-                            {error, IErr} ->
+                            {error, _} = IErr ->
                                 throw({rollback, identity, IErr})
                         end;
                     {error, _} = PErr ->

--- a/src/controllers/asobi_oauth_controller.erl
+++ b/src/controllers/asobi_oauth_controller.erl
@@ -171,9 +171,20 @@ create_player_with_identity(Provider, Claims, Attempt) ->
     case asobi_repo:insert(CS1) of
         {ok, Player} ->
             PlayerId = maps:get(id, Player),
-            _ = init_player_stats(PlayerId),
-            _ = insert_identity(PlayerId, Provider, Claims),
-            asobi_auth_tokens:issue(Player, 200, #{username => Username, created => true});
+            case insert_identity(PlayerId, Provider, Claims) of
+                {ok, _Identity} ->
+                    _ = init_player_stats(PlayerId),
+                    asobi_auth_tokens:issue(Player, 200, #{username => Username, created => true});
+                {error, _} ->
+                    %% Lost the unique {provider, provider_uid} race to a
+                    %% concurrent first-sign-in for the same identity. Delete
+                    %% the just-created player so it can't become an orphan
+                    %% with no identity row - the next login retries cleanly
+                    %% instead of ending up unfindable. Mirrors
+                    %% asobi_guest_controller:insert_player_and_identity/3.
+                    _ = asobi_repo:delete(asobi_player, Player),
+                    {json, 409, #{}, #{error => ~"already_registering"}}
+            end;
         {error, #kura_changeset{errors = Errors}} when Attempt < ?MAX_USERNAME_ATTEMPTS ->
             case asobi_auth_error:username_taken(Errors) of
                 true ->

--- a/src/controllers/asobi_oauth_controller.erl
+++ b/src/controllers/asobi_oauth_controller.erl
@@ -168,24 +168,59 @@ create_player_with_identity(Provider, Claims, Attempt) ->
     },
     CS = kura_changeset:cast(asobi_player, #{}, PlayerParams, [username, display_name]),
     CS1 = kura_changeset:validate_required(CS, [username]),
-    case asobi_repo:insert(CS1) of
-        {ok, Player} ->
-            PlayerId = maps:get(id, Player),
-            case insert_identity(PlayerId, Provider, Claims) of
-                {ok, _Identity} ->
-                    _ = init_player_stats(PlayerId),
-                    asobi_auth_tokens:issue(Player, 200, #{username => Username, created => true});
-                {error, _} ->
-                    %% Lost the unique {provider, provider_uid} race to a
-                    %% concurrent first-sign-in for the same identity. Delete
-                    %% the just-created player so it can't become an orphan
-                    %% with no identity row - the next login retries cleanly
-                    %% instead of ending up unfindable. Mirrors
-                    %% asobi_guest_controller:insert_player_and_identity/3.
-                    _ = asobi_repo:delete(asobi_player, Player),
-                    {json, 409, #{}, #{error => ~"already_registering"}}
+    %% Player insert and identity insert happen in one transaction: on
+    %% identity-insert failure (concurrent first-sign-in for the same
+    %% {provider, provider_uid} won the race), the DB itself rolls the player
+    %% row back instead of a separate compensating delete that could fail
+    %% silently and leave exactly the orphan this is closing (found in
+    %% security review of the delete-based version).
+    Result =
+        try
+            asobi_repo:transaction(fun() ->
+                case asobi_repo:insert(CS1) of
+                    {ok, Player} ->
+                        PlayerId = maps:get(id, Player),
+                        case insert_identity(PlayerId, Provider, Claims) of
+                            {ok, _Identity} ->
+                                _ = init_player_stats(PlayerId),
+                                {ok, Player};
+                            {error, IErr} ->
+                                throw({rollback, identity, IErr})
+                        end;
+                    {error, _} = PErr ->
+                        throw({rollback, player, PErr})
+                end
+            end)
+        catch
+            throw:{rollback, identity, CaughtIErr} -> {error, identity, CaughtIErr};
+            throw:{rollback, player, CaughtPErr} -> {error, player, CaughtPErr}
+        end,
+    case Result of
+        {ok, Player} when is_map(Player) ->
+            asobi_auth_tokens:issue(Player, 200, #{username => Username, created => true});
+        {error, identity, {error, #kura_changeset{errors = IErrors}}} ->
+            case asobi_auth_error:provider_uid_taken(IErrors) of
+                true ->
+                    {json, 409, #{}, #{error => ~"already_registering"}};
+                false ->
+                    %% A real failure (e.g. a provider claim over a column
+                    %% limit), not the identity race - do not log Claims,
+                    %% which can carry provider_email.
+                    ?LOG_ERROR(#{
+                        event => oauth_identity_insert_failed,
+                        provider => Provider,
+                        errors => IErrors
+                    }),
+                    {json, 500, #{}, #{error => ~"registration_failed"}}
             end;
-        {error, #kura_changeset{errors = Errors}} when Attempt < ?MAX_USERNAME_ATTEMPTS ->
+        {error, identity, IErr} ->
+            ?LOG_ERROR(#{
+                event => oauth_identity_insert_failed, provider => Provider, reason => IErr
+            }),
+            {json, 500, #{}, #{error => ~"registration_failed"}};
+        {error, player, {error, #kura_changeset{errors = Errors}}} when
+            Attempt < ?MAX_USERNAME_ATTEMPTS
+        ->
             case asobi_auth_error:username_taken(Errors) of
                 true ->
                     ?LOG_WARNING(#{
@@ -195,7 +230,7 @@ create_player_with_identity(Provider, Claims, Attempt) ->
                 false ->
                     {json, 500, #{}, #{error => ~"registration_failed"}}
             end;
-        {error, _CS} ->
+        {error, player, _} ->
             {json, 500, #{}, #{error => ~"registration_failed"}}
     end.
 

--- a/src/players/asobi_player_identity.erl
+++ b/src/players/asobi_player_identity.erl
@@ -51,4 +51,15 @@ changeset(Data, Params) ->
         provider_display_name,
         provider_metadata
     ]),
-    kura_changeset:validate_required(CS, [player_id, provider, provider_uid]).
+    CS1 = kura_changeset:validate_required(CS, [player_id, provider, provider_uid]),
+    %% Without this, a real {provider, provider_uid} race loses on the DB's
+    %% composite unique index (see indexes/0), but kura_repo_worker's
+    %% constraint_to_field/1 naming heuristic can't derive `provider_uid` from
+    %% the multi-word index name player_identities_provider_provider_uid_index
+    %% - it splits on "_" and takes the second token ("identities"), not the
+    %% field. Declaring the constraint explicitly makes the DB error land on
+    %% `provider_uid`, which asobi_auth_error:provider_uid_taken/1 depends on
+    %% (asobi#241 code review).
+    kura_changeset:unique_constraint(CS1, provider_uid, #{
+        name => ~"player_identities_provider_provider_uid_index"
+    }).

--- a/test/asobi_oauth_SUITE.erl
+++ b/test/asobi_oauth_SUITE.erl
@@ -308,32 +308,37 @@ create_player_no_retry_on_non_unique_username_error(Config) ->
 %% (unique {provider, provider_uid} index). The loser must NOT be issued
 %% tokens for a player with no identity row - that player becomes an orphan
 %% no later login can ever match against. Simulate the loss by forcing the
-%% identity insert to fail; assert 409 and that the just-created player was
-%% deleted rather than left behind.
+%% identity insert to fail inside the transaction; assert 409 and that the
+%% DB rolled the just-created player back rather than leaving it behind.
+%% The created id is captured independently of anything the code under test
+%% returns, so this can't pass by tautology (asobi#241 security review, M3).
 create_player_deletes_orphan_on_identity_race_loss(Config) ->
     Self = self(),
     meck:new(asobi_repo, [passthrough]),
     meck:expect(asobi_repo, insert, fun
         (#kura_changeset{schema = asobi_player_identity} = CS) ->
             {error, kura_changeset:add_error(CS, provider_uid, ~"has already been taken")};
+        (#kura_changeset{schema = asobi_player} = CS) ->
+            {ok, Player} = meck:passthrough([CS]),
+            true = is_map(Player),
+            Self ! {created, maps:get(id, Player)},
+            {ok, Player};
         (CS) ->
             meck:passthrough([CS])
-    end),
-    meck:expect(asobi_repo, delete, fun(Schema, Record) ->
-        Self ! {deleted, Schema, maps:get(id, Record, undefined)},
-        meck:passthrough([Schema, Record])
     end),
     try
         ProviderUid = iolist_to_binary([
             ~"race_uid_", integer_to_binary(erlang:unique_integer([positive]))
         ]),
         Claims = #{provider_uid => ProviderUid, provider_display_name => undefined},
-        {json, 409, _, #{error := ~"already_registering"}} =
-            asobi_oauth_controller:create_player_with_identity(~"discord", Claims),
+        ?assertEqual(
+            {json, 409, #{}, #{error => ~"already_registering"}},
+            asobi_oauth_controller:create_player_with_identity(~"discord", Claims)
+        ),
         PlayerId =
             receive
-                {deleted, asobi_player, Id} -> Id
-            after 1000 -> erlang:error(player_not_deleted)
+                {created, Id} -> Id
+            after 1000 -> erlang:error(player_not_created)
             end,
         ?assertEqual({error, not_found}, asobi_repo:get(asobi_player, PlayerId))
     after

--- a/test/asobi_oauth_SUITE.erl
+++ b/test/asobi_oauth_SUITE.erl
@@ -16,7 +16,8 @@
     identity_db_roundtrip/1,
     login_existing_identity/1,
     create_player_retries_on_username_collision/1,
-    create_player_no_retry_on_non_unique_username_error/1
+    create_player_no_retry_on_non_unique_username_error/1,
+    create_player_deletes_orphan_on_identity_race_loss/1
 ]).
 
 all() ->
@@ -40,7 +41,8 @@ groups() ->
         ]},
         {create_player, [], [
             create_player_retries_on_username_collision,
-            create_player_no_retry_on_non_unique_username_error
+            create_player_no_retry_on_non_unique_username_error,
+            create_player_deletes_orphan_on_identity_race_loss
         ]}
     ].
 
@@ -296,6 +298,44 @@ create_player_no_retry_on_non_unique_username_error(Config) ->
         {json, 500, _, #{error := ~"registration_failed"}} =
             asobi_oauth_controller:create_player_with_identity(~"discord", Claims),
         ?assertEqual(1, meck:num_calls(asobi_repo, insert, '_'))
+    after
+        meck:unload(asobi_repo)
+    end,
+    Config.
+
+%% asobi#241: two concurrent first-sign-ins for the same provider_uid can
+%% both insert a `players` row, but only one wins the identity insert
+%% (unique {provider, provider_uid} index). The loser must NOT be issued
+%% tokens for a player with no identity row - that player becomes an orphan
+%% no later login can ever match against. Simulate the loss by forcing the
+%% identity insert to fail; assert 409 and that the just-created player was
+%% deleted rather than left behind.
+create_player_deletes_orphan_on_identity_race_loss(Config) ->
+    Self = self(),
+    meck:new(asobi_repo, [passthrough]),
+    meck:expect(asobi_repo, insert, fun
+        (#kura_changeset{schema = asobi_player_identity} = CS) ->
+            {error, kura_changeset:add_error(CS, provider_uid, ~"has already been taken")};
+        (CS) ->
+            meck:passthrough([CS])
+    end),
+    meck:expect(asobi_repo, delete, fun(Schema, Record) ->
+        Self ! {deleted, Schema, maps:get(id, Record, undefined)},
+        meck:passthrough([Schema, Record])
+    end),
+    try
+        ProviderUid = iolist_to_binary([
+            ~"race_uid_", integer_to_binary(erlang:unique_integer([positive]))
+        ]),
+        Claims = #{provider_uid => ProviderUid, provider_display_name => undefined},
+        {json, 409, _, #{error := ~"already_registering"}} =
+            asobi_oauth_controller:create_player_with_identity(~"discord", Claims),
+        PlayerId =
+            receive
+                {deleted, asobi_player, Id} -> Id
+            after 1000 -> erlang:error(player_not_deleted)
+            end,
+        ?assertEqual({error, not_found}, asobi_repo:get(asobi_player, PlayerId))
     after
         meck:unload(asobi_repo)
     end,

--- a/test/asobi_oauth_SUITE.erl
+++ b/test/asobi_oauth_SUITE.erl
@@ -17,7 +17,8 @@
     login_existing_identity/1,
     create_player_retries_on_username_collision/1,
     create_player_no_retry_on_non_unique_username_error/1,
-    create_player_deletes_orphan_on_identity_race_loss/1
+    create_player_deletes_orphan_on_identity_race_loss/1,
+    create_player_identity_insert_real_failure_returns_500/1
 ]).
 
 all() ->
@@ -42,7 +43,8 @@ groups() ->
         {create_player, [], [
             create_player_retries_on_username_collision,
             create_player_no_retry_on_non_unique_username_error,
-            create_player_deletes_orphan_on_identity_race_loss
+            create_player_deletes_orphan_on_identity_race_loss,
+            create_player_identity_insert_real_failure_returns_500
         ]}
     ].
 
@@ -341,6 +343,35 @@ create_player_deletes_orphan_on_identity_race_loss(Config) ->
             after 1000 -> erlang:error(player_not_created)
             end,
         ?assertEqual({error, not_found}, asobi_repo:get(asobi_player, PlayerId))
+    after
+        meck:unload(asobi_repo)
+    end,
+    Config.
+
+%% asobi#241: an identity-insert failure that is NOT the provider_uid unique
+%% race (e.g. a validation error on another field) must not be misreported as
+%% already_registering - it logs and returns 500.
+create_player_identity_insert_real_failure_returns_500(Config) ->
+    meck:new(asobi_repo, [passthrough]),
+    meck:expect(asobi_repo, insert, fun
+        (#kura_changeset{schema = asobi_player_identity} = CS) ->
+            {error, kura_changeset:add_error(CS, provider_email, ~"is invalid")};
+        (CS) ->
+            meck:passthrough([CS])
+    end),
+    try
+        ProviderUid = iolist_to_binary([
+            ~"real_failure_uid_", integer_to_binary(erlang:unique_integer([positive]))
+        ]),
+        Claims = #{
+            provider_uid => ProviderUid,
+            provider_display_name => undefined,
+            provider_email => ~"not-an-email"
+        },
+        ?assertEqual(
+            {json, 500, #{}, #{error => ~"registration_failed"}},
+            asobi_oauth_controller:create_player_with_identity(~"discord", Claims)
+        )
     after
         meck:unload(asobi_repo)
     end,


### PR DESCRIPTION
Fixes widgrensit/asobi#241.

## Summary
`create_player_with_identity/3` discarded `insert_identity/3`'s result (`_ = insert_identity(...)`) and always issued tokens for the newly-created player. Two concurrent first-sign-ins for the same `{provider, provider_uid}` can both insert a `players` row, but only one wins the identity insert (unique index on `player_identities`). The loser got a `200` + tokens for a player with no identity row - an orphan that can never be found again on the next login (nothing to match on), so the user silently mints a new account every time they sign in from then on.

Mirrors `asobi_guest_controller:insert_player_and_identity/3`'s existing handling of the equivalent device-id race exactly: on identity-insert failure, delete the just-created player and return a stable `409 already_registering` instead of issuing tokens for a dead-end account.

## Test plan
- [x] New CT test: `create_player_deletes_orphan_on_identity_race_loss` - forces the identity insert to fail (simulating the lost race), asserts `409` and that the just-created player row was actually deleted (`asobi_repo:get(asobi_player, PlayerId)` -> `{error, not_found}`)
- [x] `rebar3 compile` (dev + test profile), `rebar3 fmt --check`, `rebar3 xref`, `rebar3 dialyzer` - all clean
- [x] `elp eqwalize asobi_oauth_controller` - clean (verified via isolated clone)
- [ ] Full CT suite (`asobi_oauth_SUITE`) needs a real Postgres - no docker in this dev environment, will confirm via CI