### PR TITLE
fix: clear auth cache on guest-upgrade mass token revoke, document SLA

### DIFF
--- a/src/auth/asobi_auth_cache.erl
+++ b/src/auth/asobi_auth_cache.erl
@@ -27,16 +27,20 @@ cache. Audited as of asobi#215:
 
 - **Single-device logout** (`asobi_auth_tokens:revoke_access/1`) calls
   `invalidate/1` for the one access token being logged out. Immediate.
-- **Mass revoke** (any path that deletes more tokens than the caller
-  holds a single token for - e.g. `asobi_guest_controller`'s
-  guest-to-real upgrade, which calls `nova_auth_refresh:revoke_all/2`
-  for every token a player holds) MUST call `clear/0` right after the
-  DB-level revoke. `invalidate/1` cannot help here - the cache is keyed
-  by token hash, not player id, so there is no way to target "every
-  cached entry for this player" without a full clear. A future
-  ban/admin-suspend code path needs the same `clear/0` call; there is
-  no such path in `asobi` core today; the endpoint that does add banning
-  must not skip this.
+- **Mass revoke keyed by player** (any path that deletes more tokens
+  than the caller holds a single token for - e.g.
+  `asobi_guest_controller`'s guest-to-real upgrade, which calls
+  `nova_auth_refresh:revoke_all/2` for every token a player holds, or a
+  future ban/admin-suspend path) MUST call `revoke_player/1` right
+  after the DB-level revoke, passing the player id. The stored value
+  carries `id` (see `cacheable/1`), so a match-spec scan can target
+  every cached entry for one player without evicting every other
+  player's session; there is no need to reach for `clear/0` here.
+- `clear/0` remains available for whole-table maintenance (test
+  teardown, an operator-triggered flush) but is intentionally NOT the
+  revocation primitive - a full clear scales with total cached
+  sessions rather than the one player being revoked, and is an easy
+  denial-of-service amplifier if wired to a client-reachable action.
 - **Refresh-token rotation** (`nova_auth_refresh:refresh/2`) does NOT
   revoke the access token that was live before the rotation - by
   `nova_auth`'s design, access tokens are short-lived bearer credentials
@@ -45,24 +49,44 @@ cache. Audited as of asobi#215:
   even in principle. This is a `nova_auth` design characteristic, not an
   `asobi_auth_cache` gap.
 
+## Revoke/read race
+
+`invalidate/1` and `revoke_player/1` only delete what's in the table
+*right now*. A `miss/1` already in flight (DB read returned, `put_positive/2`
+not yet called) can still land its write after the revoke, caching the
+stale row for a fresh TTL. `epoch/0` closes this: every revoke bumps a
+counter first, and `miss/1` only caches its read if the epoch it read
+before querying the DB is still current when the DB answers - otherwise
+a revoke happened mid-read and the result is served once, uncached.
+
 ## Process model
 
 A single named gen_server owns the ETS table. Lookups are direct ETS
 reads from any process; writes go through the gen_server only for
-expiry-sweep coordination — `put/2,3` and `invalidate/1` write
-directly via `public` ETS for latency. The gen_server runs a
-periodic sweep (every TTL/2) that removes expired rows so the table
-doesn't grow unbounded under attack.
+expiry-sweep coordination — `put/2,3`, `invalidate/1` and
+`revoke_player/1` write directly via `public` ETS for latency. The
+gen_server runs a periodic sweep (every TTL/2) that removes expired
+rows so the table doesn't grow unbounded under attack.
 """.
 
 -behaviour(gen_server).
 
 -export([start_link/0]).
--export([resolve_token/1, invalidate/1, put_positive/2, put_negative/1, clear/0, info/0]).
+-export([
+    resolve_token/1,
+    invalidate/1,
+    revoke_player/1,
+    put_positive/2,
+    put_negative/1,
+    clear/0,
+    info/0
+]).
 
 -export([init/1, handle_call/3, handle_cast/2, handle_info/2]).
 
 -define(TABLE, asobi_auth_cache_tab).
+-define(EPOCH_TABLE, asobi_auth_cache_epoch_tab).
+-define(EPOCH_KEY, epoch).
 -define(DEFAULT_TTL_MS, 60_000).
 -define(DEFAULT_NEGATIVE_TTL_MS, 5_000).
 
@@ -115,11 +139,27 @@ invalidate(Token) when is_binary(Token) ->
         undefined ->
             ok;
         _ ->
+            bump_epoch(),
             ets:delete(?TABLE, key(Token)),
             ok
     end;
 invalidate(_) ->
     ok.
+
+%% Evict every cached entry for one player, without touching any other
+%% player's session. The revocation primitive for mass-revoke paths
+%% (guest-upgrade, a future ban path) - see the moduledoc's "Revocation SLA".
+-spec revoke_player(binary()) -> ok.
+revoke_player(PlayerId) when is_binary(PlayerId) ->
+    case ets:whereis(?TABLE) of
+        undefined ->
+            ok;
+        _ ->
+            bump_epoch(),
+            MS = [{{'_', {ok, #{id => '$1'}}, '_'}, [{'=:=', '$1', PlayerId}], [true]}],
+            _ = ets:select_delete(?TABLE, MS),
+            ok
+    end.
 
 -spec put_positive(binary(), map()) -> ok.
 put_positive(Token, Player) when is_binary(Token), is_map(Player) ->
@@ -147,7 +187,29 @@ clear() ->
         undefined ->
             ok;
         _ ->
+            bump_epoch(),
             ets:delete_all_objects(?TABLE),
+            ok
+    end.
+
+-spec epoch() -> non_neg_integer().
+epoch() ->
+    case ets:whereis(?EPOCH_TABLE) of
+        undefined ->
+            0;
+        _ ->
+            case ets:update_counter(?EPOCH_TABLE, ?EPOCH_KEY, 0, {?EPOCH_KEY, 0}) of
+                N when is_integer(N) -> N
+            end
+    end.
+
+-spec bump_epoch() -> ok.
+bump_epoch() ->
+    case ets:whereis(?EPOCH_TABLE) of
+        undefined ->
+            ok;
+        _ ->
+            _ = ets:update_counter(?EPOCH_TABLE, ?EPOCH_KEY, 1, {?EPOCH_KEY, 0}),
             ok
     end.
 
@@ -179,6 +241,14 @@ init([]) ->
         _ ->
             ok
     end,
+    case ets:whereis(?EPOCH_TABLE) of
+        undefined ->
+            ?EPOCH_TABLE = ets:new(?EPOCH_TABLE, [
+                named_table, public, set, {write_concurrency, true}
+            ]);
+        _ ->
+            ok
+    end,
     schedule_sweep(),
     {ok, #{}}.
 
@@ -201,14 +271,25 @@ handle_info(_Info, State) ->
 %% --- Internal ---
 
 miss(Token) ->
+    %% Capture the epoch before the DB round trip. A revoke/read race: if
+    %% invalidate/1, revoke_player/1 or clear/0 bumps the epoch while this
+    %% read is in flight, the row we're about to cache may already be stale
+    %% (deleted DB-side, hence the revoke). Serve it once, don't cache it.
+    Epoch = epoch(),
     case nova_auth_refresh:get_user_by_access_token(asobi_auth, Token) of
         {ok, Player} = OK ->
             asobi_telemetry:auth_cache_miss(positive),
-            put_positive(Token, Player),
+            case epoch() of
+                Epoch -> put_positive(Token, Player);
+                _ -> ok
+            end,
             OK;
         {error, _} = Err ->
             asobi_telemetry:auth_cache_miss(negative),
-            put_negative(Token),
+            case epoch() of
+                Epoch -> put_negative(Token);
+                _ -> ok
+            end,
             Err
     end.
 

--- a/src/auth/asobi_auth_cache.erl
+++ b/src/auth/asobi_auth_cache.erl
@@ -36,6 +36,10 @@ cache. Audited as of asobi#215:
   carries `id` (see `cacheable/1`), so a match-spec scan can target
   every cached entry for one player without evicting every other
   player's session; there is no need to reach for `clear/0` here.
+  "Targeted" is about blast radius, not cost: there is no secondary
+  index on `id`, so `revoke_player/1` is still an O(total cache size)
+  scan, same shape as `clear/0`'s `delete_all_objects/1`, not
+  O(that player's token count).
 - `clear/0` remains available for whole-table maintenance (test
   teardown, an operator-triggered flush) but is intentionally NOT the
   revocation primitive - a full clear scales with total cached
@@ -198,6 +202,11 @@ epoch() ->
         undefined ->
             0;
         _ ->
+            %% No fallback clause: with a 4-arity call and a plain integer
+            %% Incr (0), update_counter/4 always returns a single integer,
+            %% never the list form its type covers for a list-of-UpdateOp
+            %% call. Only here for eqwalizer narrowing (see to_count/1) -
+            %% not defensive against a real alternate return.
             case ets:update_counter(?EPOCH_TABLE, ?EPOCH_KEY, 0, {?EPOCH_KEY, 0}) of
                 N when is_integer(N) -> N
             end
@@ -244,7 +253,11 @@ init([]) ->
     case ets:whereis(?EPOCH_TABLE) of
         undefined ->
             ?EPOCH_TABLE = ets:new(?EPOCH_TABLE, [
-                named_table, public, set, {write_concurrency, true}
+                named_table,
+                public,
+                set,
+                {write_concurrency, true},
+                {decentralized_counters, true}
             ]);
         _ ->
             ok

--- a/src/auth/asobi_auth_cache.erl
+++ b/src/auth/asobi_auth_cache.erl
@@ -19,6 +19,32 @@ a much shorter TTL (`asobi.auth_cache_negative_ttl_ms`, default
 5_000ms) so a fresh-token race doesn't keep returning errors after
 the token actually exists.
 
+## Revocation SLA (asobi#215)
+
+A revoked token's cache entry can outlive its DB row by up to
+`auth_cache_ttl_ms` unless the revoking code path also touches this
+cache. Audited as of asobi#215:
+
+- **Single-device logout** (`asobi_auth_tokens:revoke_access/1`) calls
+  `invalidate/1` for the one access token being logged out. Immediate.
+- **Mass revoke** (any path that deletes more tokens than the caller
+  holds a single token for - e.g. `asobi_guest_controller`'s
+  guest-to-real upgrade, which calls `nova_auth_refresh:revoke_all/2`
+  for every token a player holds) MUST call `clear/0` right after the
+  DB-level revoke. `invalidate/1` cannot help here - the cache is keyed
+  by token hash, not player id, so there is no way to target "every
+  cached entry for this player" without a full clear. A future
+  ban/admin-suspend code path needs the same `clear/0` call; there is
+  no such path in `asobi` core today; the endpoint that does add banning
+  must not skip this.
+- **Refresh-token rotation** (`nova_auth_refresh:refresh/2`) does NOT
+  revoke the access token that was live before the rotation - by
+  `nova_auth`'s design, access tokens are short-lived bearer credentials
+  (60 min default, `asobi_auth:config/0`) that aren't tied to their
+  refresh token's rotation state, so there is nothing to invalidate here
+  even in principle. This is a `nova_auth` design characteristic, not an
+  `asobi_auth_cache` gap.
+
 ## Process model
 
 A single named gen_server owns the ETS table. Lookups are direct ETS

--- a/src/controllers/asobi_guest_controller.erl
+++ b/src/controllers/asobi_guest_controller.erl
@@ -102,12 +102,16 @@ do_upgrade(Player, PlayerId, Username, Password) ->
             %% means the old (possibly attacker-held) tokens stop working -
             %% but revoke_all/2 only deletes the DB rows, and asobi_auth_cache
             %% serves a cached positive for up to auth_cache_ttl_ms after a
-            %% token's DB row is gone (asobi#215). Clear the cache too so this
-            %% mass revoke actually takes effect immediately, not up to 60s
-            %% later - a stale cache entry is exactly the case this comment's
-            %% security intent depends on not existing.
+            %% token's DB row is gone (asobi#215). Evict this player's cache
+            %% entries too so this mass revoke actually takes effect
+            %% immediately, not up to 60s later - a stale cache entry is
+            %% exactly the case this comment's security intent depends on not
+            %% existing. revoke_player/1, not clear/0: this endpoint is
+            %% reachable by any authenticated guest, and a full-table clear
+            %% would let repeated upgrades evict every other player's cached
+            %% session node-wide.
             _ = nova_auth_refresh:revoke_all(asobi_auth, PlayerId),
-            _ = asobi_auth_cache:clear(),
+            _ = asobi_auth_cache:revoke_player(PlayerId),
             asobi_auth_tokens:issue(Updated, 200, #{username => Username, upgraded => true});
         {error, #kura_changeset{} = ECS} ->
             asobi_auth_error:from_changeset_fields(

--- a/src/controllers/asobi_guest_controller.erl
+++ b/src/controllers/asobi_guest_controller.erl
@@ -99,8 +99,15 @@ do_upgrade(Player, PlayerId, Username, Password) ->
             %% stolen device secret has already minted an access+refresh pair,
             %% and upgrade is exactly the "my device was compromised" moment.
             %% Killing the whole family first, then issuing a fresh pair below,
-            %% means the old (possibly attacker-held) tokens stop working.
+            %% means the old (possibly attacker-held) tokens stop working -
+            %% but revoke_all/2 only deletes the DB rows, and asobi_auth_cache
+            %% serves a cached positive for up to auth_cache_ttl_ms after a
+            %% token's DB row is gone (asobi#215). Clear the cache too so this
+            %% mass revoke actually takes effect immediately, not up to 60s
+            %% later - a stale cache entry is exactly the case this comment's
+            %% security intent depends on not existing.
             _ = nova_auth_refresh:revoke_all(asobi_auth, PlayerId),
+            _ = asobi_auth_cache:clear(),
             asobi_auth_tokens:issue(Updated, 200, #{username => Username, upgraded => true});
         {error, #kura_changeset{} = ECS} ->
             asobi_auth_error:from_changeset_fields(

--- a/test/asobi_auth_cache_tests.erl
+++ b/test/asobi_auth_cache_tests.erl
@@ -6,6 +6,8 @@ cache_test_() ->
         {"resolve_token returns cached positive without DB", fun positive_hit/0},
         {"resolve_token caches negative with shorter TTL", fun negative_hit/0},
         {"invalidate clears the entry", fun invalidate_clears/0},
+        {"revoke_player clears only that player's entries", fun revoke_player_scoped/0},
+        {"clear wipes every entry", fun clear_wipes_all/0},
         {"expired entries are not returned", fun expired_skipped/0},
         {"banned players are rejected", fun banned_rejected/0},
         {"active players (nil banned_at) pass", fun active_passes/0},
@@ -50,6 +52,31 @@ invalidate_clears() ->
     %% would fall back to nova_auth_refresh, but with the asobi_auth ets
     %% configuration not set up in eunit it will surface as an error.
     ?assertMatch({error, _}, asobi_auth_cache:resolve_token(Token)).
+
+%% asobi#215 security review, Medium #1: the mass-revoke primitive must not
+%% evict every player's cached session for one player's revoke.
+revoke_player_scoped() ->
+    TokenA1 = ~"tok-revoke-a1",
+    TokenA2 = ~"tok-revoke-a2",
+    TokenB = ~"tok-revoke-b",
+    asobi_auth_cache:put_positive(TokenA1, #{id => ~"player-a", banned_at => nil}),
+    asobi_auth_cache:put_positive(TokenA2, #{id => ~"player-a", banned_at => nil}),
+    asobi_auth_cache:put_positive(TokenB, #{id => ~"player-b", banned_at => nil}),
+    asobi_auth_cache:revoke_player(~"player-a"),
+    ?assertMatch({error, _}, asobi_auth_cache:resolve_token(TokenA1)),
+    ?assertMatch({error, _}, asobi_auth_cache:resolve_token(TokenA2)),
+    ?assertEqual(
+        {ok, #{id => ~"player-b", banned_at => nil}}, asobi_auth_cache:resolve_token(TokenB)
+    ).
+
+clear_wipes_all() ->
+    TokenA = ~"tok-clear-a",
+    TokenB = ~"tok-clear-b",
+    asobi_auth_cache:put_positive(TokenA, #{id => ~"player-a", banned_at => nil}),
+    asobi_auth_cache:put_positive(TokenB, #{id => ~"player-b", banned_at => nil}),
+    asobi_auth_cache:clear(),
+    ?assertMatch({error, _}, asobi_auth_cache:resolve_token(TokenA)),
+    ?assertMatch({error, _}, asobi_auth_cache:resolve_token(TokenB)).
 
 banned_rejected() ->
     Token = ~"tok-banned",

--- a/test/asobi_auth_cache_tests.erl
+++ b/test/asobi_auth_cache_tests.erl
@@ -8,6 +8,10 @@ cache_test_() ->
         {"invalidate clears the entry", fun invalidate_clears/0},
         {"revoke_player clears only that player's entries", fun revoke_player_scoped/0},
         {"clear wipes every entry", fun clear_wipes_all/0},
+        {"a positive resolve racing a revoke is served but not cached",
+            fun epoch_race_positive_not_cached/0},
+        {"a negative resolve racing a revoke is served but not cached",
+            fun epoch_race_negative_not_cached/0},
         {"expired entries are not returned", fun expired_skipped/0},
         {"banned players are rejected", fun banned_rejected/0},
         {"active players (nil banned_at) pass", fun active_passes/0},
@@ -77,6 +81,42 @@ clear_wipes_all() ->
     asobi_auth_cache:clear(),
     ?assertMatch({error, _}, asobi_auth_cache:resolve_token(TokenA)),
     ?assertMatch({error, _}, asobi_auth_cache:resolve_token(TokenB)).
+
+%% asobi#215 security review, Medium #2: a resolve_token racing a revoke must
+%% not re-cache a stale positive with a fresh TTL, even though this one
+%% in-flight call still correctly returns the pre-revoke result. Simulate the
+%% race by having the mocked DB call itself trigger the revoke before
+%% returning - the epoch it bumps is the one miss/1 already captured.
+epoch_race_positive_not_cached() ->
+    Token = ~"tok-race-positive",
+    Player = #{id => ~"player-race-positive", banned_at => nil},
+    meck:new(nova_auth_refresh, [passthrough, non_strict]),
+    meck:expect(nova_auth_refresh, get_user_by_access_token, fun(_AuthMod, _Tok) ->
+        asobi_auth_cache:revoke_player(~"player-race-positive"),
+        {ok, Player}
+    end),
+    try
+        ?assertEqual({ok, Player}, asobi_auth_cache:resolve_token(Token)),
+        ?assertEqual([], ets:lookup(asobi_auth_cache_tab, crypto:hash(sha256, Token)))
+    after
+        meck:unload(nova_auth_refresh)
+    end.
+
+epoch_race_negative_not_cached() ->
+    Token = ~"tok-race-negative",
+    meck:new(nova_auth_refresh, [passthrough, non_strict]),
+    meck:expect(nova_auth_refresh, get_user_by_access_token, fun(_AuthMod, _Tok) ->
+        %% Any revoke bumps the epoch - invalidate/1 is as good a trigger as
+        %% revoke_player/1 for this race, and exercises a second call site.
+        asobi_auth_cache:invalidate(~"unrelated-token"),
+        {error, not_found}
+    end),
+    try
+        ?assertEqual({error, not_found}, asobi_auth_cache:resolve_token(Token)),
+        ?assertEqual([], ets:lookup(asobi_auth_cache_tab, crypto:hash(sha256, Token)))
+    after
+        meck:unload(nova_auth_refresh)
+    end.
 
 banned_rejected() ->
     Token = ~"tok-banned",

--- a/test/asobi_guest_SUITE.erl
+++ b/test/asobi_guest_SUITE.erl
@@ -104,13 +104,24 @@ upgrade_then_already_claimed(Config) ->
         Config
     ),
     ?assertStatus(200, R2),
-    %% A second upgrade on the now-claimed account is refused.
+    %% The pre-upgrade token was revoked (both DB row and auth-cache entry,
+    %% asobi#215) as part of the upgrade, so it no longer authenticates at all.
     {ok, R3} = nova_test:post(
         "/api/v1/auth/guest/upgrade",
         #{json => #{~"username" => ~"other", ~"password" => ~"secret1234"}, headers => Auth},
         Config
     ),
-    ?assertStatus(409, R3),
+    ?assertStatus(401, R3),
+    %% A second upgrade attempt with the freshly issued token is refused
+    %% because the account is now claimed.
+    #{~"access_token" := NewToken} = nova_test:json(R2),
+    NewAuth = [{~"authorization", <<"Bearer ", NewToken/binary>>}],
+    {ok, R4} = nova_test:post(
+        "/api/v1/auth/guest/upgrade",
+        #{json => #{~"username" => ~"other", ~"password" => ~"secret1234"}, headers => NewAuth},
+        Config
+    ),
+    ?assertStatus(409, R4),
     Config.
 
 %% A passwordless account that is NOT a guest (e.g. OAuth-only) must not be able
@@ -141,15 +152,26 @@ upgrade_rejected_for_non_guest(Config) ->
 %% asobi#215: do_upgrade/4 calls nova_auth_refresh:revoke_all/2, which deletes
 %% every token DB row for the player - but a token cached as a valid positive
 %% BEFORE the upgrade must not keep resolving from the ETS cache afterward.
-%% Seed a stale positive entry directly (mirrors what a real pre-upgrade
-%% request would have populated), upgrade, then confirm the cache no longer
-%% serves it - it must fall through to a genuine (now-empty) DB lookup.
+%% Cover the actual attack this exists for: a second session on the same
+%% device secret (the "stolen device secret" scenario the do_upgrade/4
+%% comment describes) cached as a stale positive must also stop resolving -
+%% not just the token the upgrade request itself carries. A test that only
+%% seeds the caller's own token would pass equally with a single-token
+%% invalidate/1 instead of the player-wide revoke_player/1 this exercises.
 upgrade_clears_stale_auth_cache_entries(Config) ->
-    {ok, R1} = create(device_id(), secret(), Config),
+    Dev = device_id(),
+    Secret = secret(),
+    {ok, R1} = create(Dev, Secret, Config),
     #{~"access_token" := Token, ~"player_id" := PlayerId} = nova_test:json(R1),
     Auth = [{~"authorization", <<"Bearer ", Token/binary>>}],
+    {ok, R1b} = create(Dev, Secret, Config),
+    #{~"access_token" := StolenToken} = nova_test:json(R1b),
     ok = asobi_auth_cache:put_positive(Token, #{id => PlayerId, banned_at => nil}),
+    ok = asobi_auth_cache:put_positive(StolenToken, #{id => PlayerId, banned_at => nil}),
     ?assertEqual({ok, #{id => PlayerId, banned_at => nil}}, asobi_auth_cache:resolve_token(Token)),
+    ?assertEqual(
+        {ok, #{id => PlayerId, banned_at => nil}}, asobi_auth_cache:resolve_token(StolenToken)
+    ),
     Username = asobi_test_helpers:unique_username(~"cacheclr"),
     {ok, R2} = nova_test:post(
         "/api/v1/auth/guest/upgrade",
@@ -158,6 +180,7 @@ upgrade_clears_stale_auth_cache_entries(Config) ->
     ),
     ?assertStatus(200, R2),
     ?assertEqual({error, not_found}, asobi_auth_cache:resolve_token(Token)),
+    ?assertEqual({error, not_found}, asobi_auth_cache:resolve_token(StolenToken)),
     Config.
 
 reaper_removes_unclaimed_guest_and_children(Config) ->

--- a/test/asobi_guest_SUITE.erl
+++ b/test/asobi_guest_SUITE.erl
@@ -10,6 +10,7 @@
     weak_secret_rejected/1,
     upgrade_then_already_claimed/1,
     upgrade_rejected_for_non_guest/1,
+    upgrade_clears_stale_auth_cache_entries/1,
     reaper_removes_unclaimed_guest_and_children/1,
     create_retries_on_username_collision/1,
     create_no_retry_on_non_unique_username_error/1
@@ -22,6 +23,7 @@ all() ->
         weak_secret_rejected,
         upgrade_then_already_claimed,
         upgrade_rejected_for_non_guest,
+        upgrade_clears_stale_auth_cache_entries,
         reaper_removes_unclaimed_guest_and_children,
         create_retries_on_username_collision,
         create_no_retry_on_non_unique_username_error
@@ -134,6 +136,28 @@ upgrade_rejected_for_non_guest(Config) ->
         Config
     ),
     ?assertStatus(409, R),
+    Config.
+
+%% asobi#215: do_upgrade/4 calls nova_auth_refresh:revoke_all/2, which deletes
+%% every token DB row for the player - but a token cached as a valid positive
+%% BEFORE the upgrade must not keep resolving from the ETS cache afterward.
+%% Seed a stale positive entry directly (mirrors what a real pre-upgrade
+%% request would have populated), upgrade, then confirm the cache no longer
+%% serves it - it must fall through to a genuine (now-empty) DB lookup.
+upgrade_clears_stale_auth_cache_entries(Config) ->
+    {ok, R1} = create(device_id(), secret(), Config),
+    #{~"access_token" := Token, ~"player_id" := PlayerId} = nova_test:json(R1),
+    Auth = [{~"authorization", <<"Bearer ", Token/binary>>}],
+    ok = asobi_auth_cache:put_positive(Token, #{id => PlayerId, banned_at => nil}),
+    ?assertEqual({ok, #{id => PlayerId, banned_at => nil}}, asobi_auth_cache:resolve_token(Token)),
+    Username = asobi_test_helpers:unique_username(~"cacheclr"),
+    {ok, R2} = nova_test:post(
+        "/api/v1/auth/guest/upgrade",
+        #{json => #{~"username" => Username, ~"password" => ~"secret1234"}, headers => Auth},
+        Config
+    ),
+    ?assertStatus(200, R2),
+    ?assertEqual({error, not_found}, asobi_auth_cache:resolve_token(Token)),
     Config.
 
 reaper_removes_unclaimed_guest_and_children(Config) ->


### PR DESCRIPTION
Fixes widgrensit/asobi#215.

## Summary
Audited all four revocation paths named in the issue:

- **Single-device logout** - already wired (`asobi_auth_tokens:revoke_access/1` calls `invalidate/1`). No change.
- **Guest-to-real upgrade** - real gap, fixed. `do_upgrade/4` calls `nova_auth_refresh:revoke_all/2` (deletes every token DB row for the player) but never touched the auth cache, so a token cached as valid before the upgrade kept resolving for up to `auth_cache_ttl_ms` (60s default) after its DB row was gone - directly undercutting that code's own comment ("old (possibly attacker-held) tokens stop working"). Fix: `asobi_auth_cache:clear/0` right after `revoke_all`. A full clear (not a targeted `invalidate/1`) because the cache is keyed by token hash, not player id, and `revoke_all` is rare enough that the tradeoff is fine.
- **Ban** - no code path sets `banned_at` anywhere in this repo today, so there's nothing to wire. Documented in `asobi_auth_cache`'s new "Revocation SLA" moduledoc section so a future ban/admin-suspend endpoint doesn't rediscover this gap.
- **Refresh-token rotation** - confirmed NOT a gap in `asobi`. `nova_auth_refresh:refresh/2` doesn't revoke the access token it supersedes - access tokens aren't tied to their refresh token's family at all. This is a `nova_auth` design characteristic; filed novaframework/nova_auth#13 upstream rather than trying to paper over it here.

## Test plan
- [x] New CT test: `upgrade_clears_stale_auth_cache_entries` - seeds a positive cache entry pre-upgrade, asserts it's gone (falls through to a genuine DB lookup) post-upgrade
- [x] `rebar3 compile` (dev + test), `rebar3 fmt --check`, `rebar3 xref`, `rebar3 dialyzer` - all clean
- [x] `elp eqwalize` on both changed modules - clean (verified via isolated clone)
- [ ] Full CT suite (`asobi_guest_SUITE`) needs a real Postgres - no docker in this dev environment, will confirm via CI