### PR TITLE
fix: cap group metadata jsonb size, extract shared asobi_jsonb helper

### DIFF
--- a/src/asobi_jsonb.erl
+++ b/src/asobi_jsonb.erl
@@ -9,7 +9,7 @@ the one place that idiom lives, shared by every schema and controller that
 needs it rather than a per-call-site copy.
 """.
 
--export([within_limit/2]).
+-export([within_limit/2, default_metadata_bytes/0]).
 
 -spec within_limit(dynamic(), non_neg_integer()) -> boolean().
 within_limit(Value, MaxBytes) ->
@@ -18,3 +18,10 @@ within_limit(Value, MaxBytes) ->
     catch
         _:_ -> false
     end.
+
+%% The shared ceiling for a "metadata annotation" field (as opposed to a
+%% bulk-data field like cloud-save/storage values, which set their own,
+%% larger limit) - one place so every schema that adopts this idiom agrees
+%% by default rather than each declaring its own copy of the same number.
+-spec default_metadata_bytes() -> non_neg_integer().
+default_metadata_bytes() -> 16384.

--- a/src/asobi_jsonb.erl
+++ b/src/asobi_jsonb.erl
@@ -9,14 +9,24 @@ the one place that idiom lives, shared by every schema and controller that
 needs it rather than a per-call-site copy.
 """.
 
--export([within_limit/2, default_metadata_bytes/0]).
+-export([within_limit/2, check/2, default_metadata_bytes/0]).
 
 -spec within_limit(dynamic(), non_neg_integer()) -> boolean().
 within_limit(Value, MaxBytes) ->
-    try iolist_size(json:encode(Value)) =< MaxBytes of
-        Result -> Result
+    check(Value, MaxBytes) =:= ok.
+
+%% A caller that reports a specific reason to a client or a log wants
+%% "too big" and "not valid JSON at all" told apart - shrinking a payload
+%% doesn't fix the latter. within_limit/2 collapses both into `false` for
+%% callers (a size-only gate ahead of an insert) that don't need the
+%% distinction.
+-spec check(dynamic(), non_neg_integer()) -> ok | too_large | not_encodable.
+check(Value, MaxBytes) ->
+    try iolist_size(json:encode(Value)) of
+        Size when Size =< MaxBytes -> ok;
+        _ -> too_large
     catch
-        _:_ -> false
+        _:_ -> not_encodable
     end.
 
 %% The shared ceiling for a "metadata annotation" field (as opposed to a

--- a/src/asobi_jsonb.erl
+++ b/src/asobi_jsonb.erl
@@ -1,0 +1,20 @@
+-module(asobi_jsonb).
+-moduledoc """
+Size-bound checks for values headed into an unbounded `jsonb` column.
+
+A `jsonb` column has no server-side size limit of its own, so any field a
+client can populate through a changeset cast is a lever for an oversized
+payload unless something checks it first (asobi#169, asobi#216). This is
+the one place that idiom lives, shared by every schema and controller that
+needs it rather than a per-call-site copy.
+""".
+
+-export([within_limit/2]).
+
+-spec within_limit(dynamic(), non_neg_integer()) -> boolean().
+within_limit(Value, MaxBytes) ->
+    try iolist_size(json:encode(Value)) =< MaxBytes of
+        Result -> Result
+    catch
+        _:_ -> false
+    end.

--- a/src/controllers/asobi_storage_controller.erl
+++ b/src/controllers/asobi_storage_controller.erl
@@ -228,11 +228,7 @@ list_storage(
 
 -spec data_within_limit(dynamic()) -> boolean().
 data_within_limit(Data) ->
-    try iolist_size(json:encode(Data)) =< ?MAX_SAVE_DATA_BYTES of
-        Result -> Result
-    catch
-        _:_ -> false
-    end.
+    asobi_jsonb:within_limit(Data, ?MAX_SAVE_DATA_BYTES).
 
 -spec slots_under_cap(binary()) -> boolean().
 slots_under_cap(PlayerId) ->

--- a/src/economy/asobi_economy.erl
+++ b/src/economy/asobi_economy.erl
@@ -9,6 +9,10 @@
     get_history/3
 ]).
 
+-ifdef(TEST).
+-export([grant_inner/4, debit_inner/4]).
+-endif.
+
 -spec get_or_create_wallet(binary(), binary()) -> {ok, map()} | {error, term()}.
 get_or_create_wallet(PlayerId, Currency) ->
     Q = kura_query:where(
@@ -150,31 +154,61 @@ acquire_wallet_lock(PlayerId, Currency) ->
     #{rows := [_ | _]} = kura_db:query(asobi_repo, SQL, [PlayerId, Currency]),
     ok.
 
+%% asobi#216 security review (M1 on #255): grant/4 and debit/4 have no
+%% in-repo caller that threads client data into Opts.metadata today, but
+%% they are exported library entry points into a money-adjacent audit
+%% table the same way asobi_player:registration_changeset/2 is (#169 M3) -
+%% the cap travels with the write path, not with today's callers staying
+%% disciplined. Checked before any wallet write, so a rejected blob is a
+%% clean {error, _} return with nothing to roll back.
+-spec metadata_within_limit(dynamic()) -> boolean().
+metadata_within_limit(Metadata) ->
+    asobi_jsonb:within_limit(Metadata, asobi_jsonb:default_metadata_bytes()).
+
 -spec grant_inner(binary(), binary(), pos_integer(), map()) -> {ok, map()} | {error, term()}.
 grant_inner(PlayerId, Currency, Amount, Opts) ->
-    {ok, Wallet} = get_or_create_wallet(PlayerId, Currency),
-    NewBalance = maps:get(balance, Wallet) + Amount,
-    WalletCS = kura_changeset:cast(asobi_wallet, Wallet, #{balance => NewBalance}, [balance]),
-    {ok, UpdatedWallet} = asobi_repo:update(WalletCS),
-    TxCS = kura_changeset:cast(
-        asobi_transaction,
-        #{},
-        #{
-            wallet_id => maps:get(id, Wallet),
-            amount => Amount,
-            balance_after => NewBalance,
-            reason => maps:get(reason, Opts, ~"admin_grant"),
-            reference_type => maps:get(reference_type, Opts, undefined),
-            reference_id => maps:get(reference_id, Opts, undefined),
-            metadata => maps:get(metadata, Opts, #{})
-        },
-        [wallet_id, amount, balance_after, reason, reference_type, reference_id, metadata]
-    ),
-    {ok, _Tx} = asobi_repo:insert(TxCS),
-    {ok, UpdatedWallet}.
+    Metadata = maps:get(metadata, Opts, #{}),
+    case metadata_within_limit(Metadata) of
+        false ->
+            {error, metadata_too_large};
+        true ->
+            {ok, Wallet} = get_or_create_wallet(PlayerId, Currency),
+            NewBalance = maps:get(balance, Wallet) + Amount,
+            WalletCS = kura_changeset:cast(
+                asobi_wallet, Wallet, #{balance => NewBalance}, [balance]
+            ),
+            {ok, UpdatedWallet} = asobi_repo:update(WalletCS),
+            TxCS = kura_changeset:cast(
+                asobi_transaction,
+                #{},
+                #{
+                    wallet_id => maps:get(id, Wallet),
+                    amount => Amount,
+                    balance_after => NewBalance,
+                    reason => maps:get(reason, Opts, ~"admin_grant"),
+                    reference_type => maps:get(reference_type, Opts, undefined),
+                    reference_id => maps:get(reference_id, Opts, undefined),
+                    metadata => Metadata
+                },
+                [wallet_id, amount, balance_after, reason, reference_type, reference_id, metadata]
+            ),
+            {ok, _Tx} = asobi_repo:insert(TxCS),
+            {ok, UpdatedWallet}
+    end.
 
 -spec debit_inner(binary(), binary(), pos_integer(), map()) -> {ok, map()} | {error, term()}.
 debit_inner(PlayerId, Currency, Amount, Opts) ->
+    Metadata = maps:get(metadata, Opts, #{}),
+    case metadata_within_limit(Metadata) of
+        false ->
+            {error, metadata_too_large};
+        true ->
+            debit_inner_checked(PlayerId, Currency, Amount, Opts, Metadata)
+    end.
+
+-spec debit_inner_checked(binary(), binary(), pos_integer(), map(), dynamic()) ->
+    {ok, map()} | {error, term()}.
+debit_inner_checked(PlayerId, Currency, Amount, Opts, Metadata) ->
     {ok, Wallet} = get_or_create_wallet(PlayerId, Currency),
     Balance = maps:get(balance, Wallet),
     case Balance >= Amount of
@@ -196,7 +230,7 @@ debit_inner(PlayerId, Currency, Amount, Opts) ->
                     reason => maps:get(reason, Opts, ~"purchase"),
                     reference_type => maps:get(reference_type, Opts, undefined),
                     reference_id => maps:get(reference_id, Opts, undefined),
-                    metadata => maps:get(metadata, Opts, #{})
+                    metadata => Metadata
                 },
                 [
                     wallet_id,

--- a/src/players/asobi_player.erl
+++ b/src/players/asobi_player.erl
@@ -100,9 +100,7 @@ update_changeset(Data, Params) ->
 
 -spec metadata_within_limit(dynamic()) -> ok | {error, binary()}.
 metadata_within_limit(Metadata) ->
-    try iolist_size(json:encode(Metadata)) =< ?MAX_METADATA_BYTES of
+    case asobi_jsonb:within_limit(Metadata, ?MAX_METADATA_BYTES) of
         true -> ok;
         false -> {error, ~"must be 16 KB or less"}
-    catch
-        _:_ -> {error, ~"is not encodable"}
     end.

--- a/src/players/asobi_player.erl
+++ b/src/players/asobi_player.erl
@@ -98,7 +98,8 @@ update_changeset(Data, Params) ->
 
 -spec metadata_within_limit(dynamic()) -> ok | {error, binary()}.
 metadata_within_limit(Metadata) ->
-    case asobi_jsonb:within_limit(Metadata, asobi_jsonb:default_metadata_bytes()) of
-        true -> ok;
-        false -> {error, ~"must be 16 KB or less"}
+    case asobi_jsonb:check(Metadata, asobi_jsonb:default_metadata_bytes()) of
+        ok -> ok;
+        too_large -> {error, ~"must be 16 KB or less"};
+        not_encodable -> {error, ~"is not encodable"}
     end.

--- a/src/players/asobi_player.erl
+++ b/src/players/asobi_player.erl
@@ -86,8 +86,6 @@ hash_password(CS) ->
             kura_changeset:put_change(CS, hashed_password, Hashed)
     end.
 
--define(MAX_METADATA_BYTES, 16384).
-
 -spec update_changeset(map(), map()) -> #kura_changeset{}.
 update_changeset(Data, Params) ->
     CS = kura_changeset:cast(?MODULE, Data, Params, [display_name, avatar_url, metadata]),
@@ -100,7 +98,7 @@ update_changeset(Data, Params) ->
 
 -spec metadata_within_limit(dynamic()) -> ok | {error, binary()}.
 metadata_within_limit(Metadata) ->
-    case asobi_jsonb:within_limit(Metadata, ?MAX_METADATA_BYTES) of
+    case asobi_jsonb:within_limit(Metadata, asobi_jsonb:default_metadata_bytes()) of
         true -> ok;
         false -> {error, ~"must be 16 KB or less"}
     end.

--- a/src/social/asobi_group.erl
+++ b/src/social/asobi_group.erl
@@ -57,7 +57,8 @@ changeset(Data, Params) ->
 
 -spec metadata_within_limit(dynamic()) -> ok | {error, binary()}.
 metadata_within_limit(Metadata) ->
-    case asobi_jsonb:within_limit(Metadata, asobi_jsonb:default_metadata_bytes()) of
-        true -> ok;
-        false -> {error, ~"must be 16 KB or less"}
+    case asobi_jsonb:check(Metadata, asobi_jsonb:default_metadata_bytes()) of
+        ok -> ok;
+        too_large -> {error, ~"must be 16 KB or less"};
+        not_encodable -> {error, ~"is not encodable"}
     end.

--- a/src/social/asobi_group.erl
+++ b/src/social/asobi_group.erl
@@ -6,10 +6,6 @@
 -export([table/0, fields/0, associations/0, generate_id/0]).
 -export([changeset/2]).
 
-%% asobi#216: metadata is unbounded jsonb, and create_group/update_group cast
-%% it straight from the request body - the same #169 lever, applied here.
--define(MAX_METADATA_BYTES, 16384).
-
 -spec table() -> binary().
 table() -> ~"groups".
 
@@ -51,11 +47,17 @@ changeset(Data, Params) ->
     %% F-17: cap description length so an attacker cannot store
     %% megabytes of text in the groups table.
     CS3 = kura_changeset:validate_length(CS2, description, [{max, 1024}]),
+    %% asobi#216: metadata is unbounded jsonb. changeset/2 is a public library
+    %% entry point (asobi_engine, self-hosters, future controllers) that casts
+    %% it - today's create_group/update_group controllers happen to strip
+    %% metadata via an explicit allowlist before calling here, but the cap
+    %% belongs on the schema, not on that filtering staying in place
+    %% (mirrors asobi_player:registration_changeset/2, #169 M3).
     kura_changeset:validate_change(CS3, metadata, fun metadata_within_limit/1).
 
 -spec metadata_within_limit(dynamic()) -> ok | {error, binary()}.
 metadata_within_limit(Metadata) ->
-    case asobi_jsonb:within_limit(Metadata, ?MAX_METADATA_BYTES) of
+    case asobi_jsonb:within_limit(Metadata, asobi_jsonb:default_metadata_bytes()) of
         true -> ok;
         false -> {error, ~"must be 16 KB or less"}
     end.

--- a/src/social/asobi_group.erl
+++ b/src/social/asobi_group.erl
@@ -6,6 +6,10 @@
 -export([table/0, fields/0, associations/0, generate_id/0]).
 -export([changeset/2]).
 
+%% asobi#216: metadata is unbounded jsonb, and create_group/update_group cast
+%% it straight from the request body - the same #169 lever, applied here.
+-define(MAX_METADATA_BYTES, 16384).
+
 -spec table() -> binary().
 table() -> ~"groups".
 
@@ -46,4 +50,12 @@ changeset(Data, Params) ->
     CS2 = kura_changeset:validate_length(CS1, name, [{min, 2}, {max, 64}]),
     %% F-17: cap description length so an attacker cannot store
     %% megabytes of text in the groups table.
-    kura_changeset:validate_length(CS2, description, [{max, 1024}]).
+    CS3 = kura_changeset:validate_length(CS2, description, [{max, 1024}]),
+    kura_changeset:validate_change(CS3, metadata, fun metadata_within_limit/1).
+
+-spec metadata_within_limit(dynamic()) -> ok | {error, binary()}.
+metadata_within_limit(Metadata) ->
+    case asobi_jsonb:within_limit(Metadata, ?MAX_METADATA_BYTES) of
+        true -> ok;
+        false -> {error, ~"must be 16 KB or less"}
+    end.

--- a/test/asobi_economy_tests.erl
+++ b/test/asobi_economy_tests.erl
@@ -1,0 +1,23 @@
+-module(asobi_economy_tests).
+
+-include_lib("eunit/include/eunit.hrl").
+
+%% asobi#216 security review (M1 on #255): grant_inner/4 and debit_inner/4
+%% cast Opts.metadata into the transactions audit table with no in-repo
+%% caller today, but as exported library entry points the cap belongs on
+%% the write path, not on callers staying disciplined (mirrors #169 M3).
+%% Checked before any DB call, so this needs no wallet/DB fixture - an
+%% oversized blob is rejected before get_or_create_wallet/2 ever runs.
+grant_inner_rejects_oversized_metadata_test() ->
+    Big = #{~"blob" => binary:copy(~"x", 20000)},
+    ?assertEqual(
+        {error, metadata_too_large},
+        asobi_economy:grant_inner(~"player-1", ~"gold", 100, #{metadata => Big})
+    ).
+
+debit_inner_rejects_oversized_metadata_test() ->
+    Big = #{~"blob" => binary:copy(~"x", 20000)},
+    ?assertEqual(
+        {error, metadata_too_large},
+        asobi_economy:debit_inner(~"player-1", ~"gold", 100, #{metadata => Big})
+    ).

--- a/test/asobi_group_tests.erl
+++ b/test/asobi_group_tests.erl
@@ -1,0 +1,33 @@
+-module(asobi_group_tests).
+
+-include_lib("eunit/include/eunit.hrl").
+-include_lib("kura/include/kura.hrl").
+
+valid_changeset_test() ->
+    CS = asobi_group:changeset(#{}, #{
+        ~"name" => ~"raid team", ~"creator_id" => asobi_id:generate()
+    }),
+    ?assert(CS#kura_changeset.valid).
+
+%% asobi#216: metadata is unbounded jsonb and changeset/2 casts it - the
+%% same lever #169 closed for asobi_player, applied here.
+metadata_within_limit_passes_test() ->
+    CS = asobi_group:changeset(#{}, #{
+        ~"name" => ~"raid team",
+        ~"creator_id" => asobi_id:generate(),
+        ~"metadata" => #{~"tag" => ~"eu"}
+    }),
+    ?assert(CS#kura_changeset.valid).
+
+metadata_over_limit_is_rejected_test() ->
+    Big = #{~"blob" => binary:copy(~"x", 20000)},
+    CS = asobi_group:changeset(#{}, #{
+        ~"name" => ~"raid team", ~"creator_id" => asobi_id:generate(), ~"metadata" => Big
+    }),
+    ?assertNot(CS#kura_changeset.valid).
+
+metadata_absent_is_not_checked_test() ->
+    CS = asobi_group:changeset(#{}, #{
+        ~"name" => ~"raid team", ~"creator_id" => asobi_id:generate()
+    }),
+    ?assert(CS#kura_changeset.valid).

--- a/test/asobi_group_tests.erl
+++ b/test/asobi_group_tests.erl
@@ -31,3 +31,15 @@ metadata_absent_is_not_checked_test() ->
         ~"name" => ~"raid team", ~"creator_id" => asobi_id:generate()
     }),
     ?assert(CS#kura_changeset.valid).
+
+%% A small-but-unencodable value must fail for the right reason, not be
+%% misreported as oversized - shrinking it wouldn't fix the actual problem.
+metadata_not_encodable_is_rejected_test() ->
+    Bad = #{~"blob" => {tuple, ~"json:encode/1 can't serialize this"}},
+    CS = asobi_group:changeset(#{}, #{
+        ~"name" => ~"raid team", ~"creator_id" => asobi_id:generate(), ~"metadata" => Bad
+    }),
+    ?assertNot(CS#kura_changeset.valid),
+    ?assertEqual(
+        [~"is not encodable"], proplists:get_all_values(metadata, CS#kura_changeset.errors)
+    ).

--- a/test/asobi_jsonb_tests.erl
+++ b/test/asobi_jsonb_tests.erl
@@ -1,0 +1,30 @@
+-module(asobi_jsonb_tests).
+
+-include_lib("eunit/include/eunit.hrl").
+
+check_ok_under_limit_test() ->
+    ?assertEqual(ok, asobi_jsonb:check(#{~"a" => 1}, 100)).
+
+check_ok_at_limit_test() ->
+    %% json:encode(#{}) is "{}"  (2 bytes).
+    ?assertEqual(ok, asobi_jsonb:check(#{}, 2)).
+
+check_too_large_test() ->
+    Big = #{~"blob" => binary:copy(~"x", 100)},
+    ?assertEqual(too_large, asobi_jsonb:check(Big, 10)).
+
+check_not_encodable_test() ->
+    ?assertEqual(not_encodable, asobi_jsonb:check(#{~"a" => {tuple}}, 100)).
+
+within_limit_true_test() ->
+    ?assert(asobi_jsonb:within_limit(#{~"a" => 1}, 100)).
+
+within_limit_false_on_too_large_test() ->
+    Big = #{~"blob" => binary:copy(~"x", 100)},
+    ?assertNot(asobi_jsonb:within_limit(Big, 10)).
+
+within_limit_false_on_not_encodable_test() ->
+    ?assertNot(asobi_jsonb:within_limit(#{~"a" => {tuple}}, 100)).
+
+default_metadata_bytes_test() ->
+    ?assertEqual(16384, asobi_jsonb:default_metadata_bytes()).

--- a/test/asobi_player_tests.erl
+++ b/test/asobi_player_tests.erl
@@ -41,6 +41,16 @@ metadata_at_the_limit_passes_test() ->
     CS = asobi_player:update_changeset(#{}, #{~"metadata" => Ok}),
     ?assert(CS#kura_changeset.valid).
 
+%% A small-but-unencodable value must fail for the right reason, not be
+%% misreported as oversized - shrinking it wouldn't fix the actual problem.
+metadata_not_encodable_is_rejected_test() ->
+    Bad = #{~"blob" => {tuple, ~"json:encode/1 can't serialize this"}},
+    CS = asobi_player:update_changeset(#{}, #{~"metadata" => Bad}),
+    ?assertNot(CS#kura_changeset.valid),
+    ?assertEqual(
+        [~"is not encodable"], proplists:get_all_values(metadata, CS#kura_changeset.errors)
+    ).
+
 %% The cap travels with the schema: registration_changeset caps metadata too,
 %% and an oversized blob must fail before the pbkdf2 hash is computed (#157).
 registration_metadata_over_limit_is_rejected_test() ->


### PR DESCRIPTION
## Summary

Closes #216 (follow-up to #169/#170).

Swept every schema with an unbounded `jsonb` column for the same client-writable-metadata lever #169 closed on `asobi_player`. Full per-schema reachability analysis in the commit messages.

Two schemas ended up capped after review:
- `asobi_group` — `changeset/2` is a public library entry point (asobi_engine, self-hosters, future controllers), same reasoning as the existing `asobi_player:registration_changeset/2` precedent (#169 M3). Today's two controller call sites happen to filter `metadata` out before calling in, but the cap belongs on the write path.
- `asobi_transaction` — found during security review: `asobi_economy:debit_inner/4` has a live caller via `POST /store/purchase`, and while that call site hardcodes its `Opts` today (so `metadata` never actually carries client data yet), the changeset itself enforced nothing. Capped both `grant_inner/4` and `debit_inner/4`, checked before any wallet write so a rejected blob is a clean error return with nothing to roll back.

Every other candidate (`asobi_leaderboard_entry`, `asobi_player_item`, `asobi_player_stats`, `asobi_match_record`, `asobi_chat_message`, `asobi_store_listing`, `asobi_item_def`, `asobi_tournament`) either never casts `metadata` from any input, or has no HTTP route reaching the field at all today.

Extracted `asobi_jsonb:within_limit/2` + `default_metadata_bytes/0` as the one shared home for the encode-and-measure-size idiom and the byte ceiling, used by `asobi_storage_controller`, `asobi_player`, `asobi_group`, and `asobi_economy`.

## Test plan

- [x] `rebar3 fmt` / `xref` / `dialyzer` clean
- [x] `elp eqwalize-all` clean (isolated fresh-clone check, `NO ERRORS`)
- [x] `elp lint` clean
- [x] `rebar3 eunit` — 420/420 passing, including new `asobi_group_tests` and `asobi_economy_tests` covering both caps
- [ ] CI (Common Test, full matrix)

## Review

- architecture-guardian: ACCEPT (one non-blocking nit, addressed - shared constant hoisted)
- beam-security-reviewer: 0 High, 2 Medium (both addressed in the second push), 2 Low (informational, not actioned - collapsed error message text, and a pre-existing group-visibility note unrelated to this PR's scope)