### PR TITLE
fix: skip roster projection in world/match listing enumeration

### DIFF
--- a/src/asobi_discovery.erl
+++ b/src/asobi_discovery.erl
@@ -3,9 +3,10 @@
 Shared enumeration for the discovery surfaces.
 
 Worlds and matches both register as `{ServerMod, Id}` in the `nova_scope`
-pg scope and both expose `get_info/1` plus `listing_info/1`, so browsing
-either is the same walk: enumerate the live processes, apply the caller's
-filter to the full info, and return the listing projection.
+pg scope and both expose `get_info/2` (the `listing` variant, asobi#194)
+plus `listing_info/1`, so browsing either is the same walk: enumerate the
+live processes, apply the caller's filter to the listing info, and return
+the listing projection.
 
 Enumeration is a pull, not a push. Worlds churn on *attributes* — the set
 of worlds is near-static while occupancy changes constantly — so a delta
@@ -23,9 +24,17 @@ refreshes per second regardless of load. See `asobi_world_lobby`.
 List live `ServerMod` processes whose info satisfies `FilterFun`, each as
 its `ServerMod:listing_info/1` projection.
 
-`ServerMod` is both the pg group tag and the module supplying `get_info/1`
+`ServerMod` is both the pg group tag and the module supplying `get_info/2`
 and `listing_info/1`. A process that dies mid-enumeration, or whose
-`get_info/1` fails, is skipped rather than failing the whole listing.
+`get_info/2` fails, is skipped rather than failing the whole listing.
+
+asobi#194: uses `get_info(Pid, listing)`, not `get_info/1` - the roster
+(`players`) is not read by any consumer here (`FilterFun` only reads
+scalar fields like `player_count`; `listing_info/1` never projects
+`players` into its output either), so fanning it out to every process just
+to discard it was copying up to `max_players` binaries per process, per
+call, for nothing. At up to 1000 worlds of up to 500 players that is up to
+500k discarded binaries per enumeration.
 """.
 -spec enumerate(module(), map(), fun((map(), map()) -> boolean())) -> [map()].
 enumerate(ServerMod, Filters, FilterFun) ->
@@ -37,7 +46,7 @@ enumerate(ServerMod, Filters, FilterFun) ->
     ],
     lists:filtermap(
         fun(Pid) ->
-            try ServerMod:get_info(Pid) of
+            try ServerMod:get_info(Pid, listing) of
                 Info when is_map(Info) ->
                     case FilterFun(Info, Filters) of
                         true -> {true, ServerMod:listing_info(Info)};

--- a/src/matches/asobi_match_server.erl
+++ b/src/matches/asobi_match_server.erl
@@ -19,7 +19,16 @@ the place to put callback hardening.
 -behaviour(gen_statem).
 
 -export([
-    start_link/1, join/2, join/3, leave/2, handle_input/3, get_info/1, pause/1, resume/1, cancel/1
+    start_link/1,
+    join/2,
+    join/3,
+    leave/2,
+    handle_input/3,
+    get_info/1,
+    get_info/2,
+    pause/1,
+    resume/1,
+    cancel/1
 ]).
 -export([reconnect/2]).
 -export([listing_info/1]).
@@ -69,6 +78,17 @@ handle_input(Pid, PlayerId, Input) ->
 -spec get_info(pid()) -> map().
 get_info(Pid) ->
     case gen_statem:call(Pid, get_info) of
+        Info when is_map(Info) -> Info;
+        _ -> #{}
+    end.
+
+%% asobi#194: mirrors asobi_world_server:get_info/2 - the discovery-listing
+%% consumers (asobi_discovery:enumerate/3, via list_matches/1) never read
+%% `players`, only player_count. Skips computing maps:keys(Players) at all
+%% rather than fanning it out to every live match just to discard it.
+-spec get_info(pid(), listing) -> map().
+get_info(Pid, listing) ->
+    case gen_statem:call(Pid, {get_info, listing}) of
         Info when is_map(Info) -> Info;
         _ -> #{}
     end.
@@ -194,6 +214,8 @@ waiting({call, From}, {join, PlayerId, Ctx}, State) ->
     handle_join(From, PlayerId, Ctx, State);
 waiting({call, From}, get_info, State) ->
     {keep_state_and_data, [{reply, From, match_info(waiting, State)}]};
+waiting({call, From}, {get_info, listing}, State) ->
+    {keep_state_and_data, [{reply, From, match_info(waiting, State, false)}]};
 waiting(state_timeout, waiting_timeout, State) ->
     {stop, {shutdown, timeout}, State};
 waiting(cast, {leave, PlayerId}, State) ->
@@ -291,6 +313,8 @@ running({call, From}, resume, _State) ->
     {keep_state_and_data, [{reply, From, {error, not_paused}}]};
 running({call, From}, get_info, State) ->
     {keep_state_and_data, [{reply, From, match_info(running, State)}]};
+running({call, From}, {get_info, listing}, State) ->
+    {keep_state_and_data, [{reply, From, match_info(running, State, false)}]};
 running({call, From}, {join, PlayerId, Ctx}, State) ->
     handle_join(From, PlayerId, Ctx, State);
 running(
@@ -405,6 +429,8 @@ paused(cast, {leave, PlayerId}, State) ->
     handle_leave(PlayerId, State);
 paused({call, From}, get_info, State) ->
     {keep_state_and_data, [{reply, From, match_info(paused, State)}]};
+paused({call, From}, {get_info, listing}, State) ->
+    {keep_state_and_data, [{reply, From, match_info(paused, State, false)}]};
 paused(cast, {broadcast_event, Event, Payload}, State) ->
     broadcast_match_event(Event, Payload, State),
     keep_state_and_data;
@@ -444,6 +470,8 @@ finished(state_timeout, cleanup, State) ->
     {stop, normal, State};
 finished({call, From}, get_info, State) ->
     {keep_state_and_data, [{reply, From, match_info(finished, State)}]};
+finished({call, From}, {get_info, listing}, State) ->
+    {keep_state_and_data, [{reply, From, match_info(finished, State, false)}]};
 %% A game ending its match from `tick` and broadcasting the result in the
 %% same callback lands here. Without this clause the catch-all below
 %% swallows it silently, which reads as a client bug. Players are still in
@@ -623,16 +651,27 @@ persist_result(#{match_id := MatchId, players := Players} = State) ->
     _ = asobi_repo:insert(CS),
     ok.
 
-match_info(Status, #{match_id := MatchId, players := Players} = State) ->
-    Base = #{
+match_info(Status, State) ->
+    match_info(Status, State, true).
+
+%% IncludeRoster = false skips maps:keys(Players) entirely rather than
+%% computing then discarding it - see get_info/2's moduledoc note (#194).
+%% Every other field is a cheap scalar already required by
+%% asobi_match_lobby:matches_filters/2 and listing_info/1.
+match_info(Status, #{match_id := MatchId, players := Players} = State, IncludeRoster) ->
+    Base0 = #{
         match_id => MatchId,
         status => Status,
         player_count => map_size(Players),
-        players => maps:keys(Players),
         mode => maps:get(mode, State, undefined),
         max_players => maps:get(max_players, State, ?DEFAULT_MAX_PLAYERS),
         listed => maps:get(listed, State, false)
     },
+    Base =
+        case IncludeRoster of
+            true -> Base0#{players => maps:keys(Players)};
+            false -> Base0
+        end,
     case maps:get(phase_state, State, undefined) of
         undefined -> Base;
         PS -> Base#{phase => asobi_phase:info(PS)}

--- a/src/matches/asobi_match_server.erl
+++ b/src/matches/asobi_match_server.erl
@@ -82,10 +82,7 @@ get_info(Pid) ->
         _ -> #{}
     end.
 
-%% asobi#194: mirrors asobi_world_server:get_info/2 - the discovery-listing
-%% consumers (asobi_discovery:enumerate/3, via list_matches/1) never read
-%% `players`, only player_count. Skips computing maps:keys(Players) at all
-%% rather than fanning it out to every live match just to discard it.
+%% asobi#194: mirrors asobi_world_server:get_info/2; see asobi_discovery's doc.
 -spec get_info(pid(), listing) -> map().
 get_info(Pid, listing) ->
     case gen_statem:call(Pid, {get_info, listing}) of
@@ -654,10 +651,6 @@ persist_result(#{match_id := MatchId, players := Players} = State) ->
 match_info(Status, State) ->
     match_info(Status, State, true).
 
-%% IncludeRoster = false skips maps:keys(Players) entirely rather than
-%% computing then discarding it - see get_info/2's moduledoc note (#194).
-%% Every other field is a cheap scalar already required by
-%% asobi_match_lobby:matches_filters/2 and listing_info/1.
 match_info(Status, #{match_id := MatchId, players := Players} = State, IncludeRoster) ->
     Base0 = #{
         match_id => MatchId,

--- a/src/world/asobi_world_server.erl
+++ b/src/world/asobi_world_server.erl
@@ -89,12 +89,7 @@ get_info(Pid) ->
         M when is_map(M) -> M
     end.
 
-%% asobi#194: the discovery-listing consumers (asobi_discovery:enumerate/3,
-%% via list_worlds/1) never read `players` - matches_filters/2 only reads
-%% player_count, and listing_info/1 doesn't project it either. Fanning that
-%% out to every running world just to throw it away is copying up to 500
-%% player-id binaries per world, across a process boundary, per world, on
-%% every uncached enumeration. This variant skips computing it at all.
+%% asobi#194: skips the roster; see asobi_discovery:enumerate/3's doc.
 -spec get_info(pid(), listing) -> map().
 get_info(Pid, listing) ->
     case gen_statem:call(Pid, {get_info, listing}) of
@@ -1099,10 +1094,6 @@ notify_players(Event, #{players := Players, world_id := WorldId} = State) ->
 world_info(Status, State) ->
     world_info(Status, State, true).
 
-%% IncludeRoster = false skips `maps:keys(Players)` entirely rather than
-%% computing then discarding it - see get_info/2's moduledoc note (#194).
-%% Every other field is a cheap scalar already required by
-%% asobi_world_lobby:matches_filters/2 and listing_info/1.
 world_info(Status, #{world_id := WorldId, players := Players} = State, IncludeRoster) ->
     Base0 = #{
         world_id => WorldId,

--- a/src/world/asobi_world_server.erl
+++ b/src/world/asobi_world_server.erl
@@ -9,7 +9,16 @@ transient matches use `asobi_match_server` instead.
 -behaviour(gen_statem).
 
 -export([
-    start_link/1, join/2, join/3, join/4, leave/2, move_player/3, post_tick/2, get_info/1, cancel/1
+    start_link/1,
+    join/2,
+    join/3,
+    join/4,
+    leave/2,
+    move_player/3,
+    post_tick/2,
+    get_info/1,
+    get_info/2,
+    cancel/1
 ]).
 -export([listing_info/1]).
 -export_type([listing/0]).
@@ -77,6 +86,18 @@ post_tick(Pid, TickN) ->
 -spec get_info(pid()) -> map().
 get_info(Pid) ->
     case gen_statem:call(Pid, get_info) of
+        M when is_map(M) -> M
+    end.
+
+%% asobi#194: the discovery-listing consumers (asobi_discovery:enumerate/3,
+%% via list_worlds/1) never read `players` - matches_filters/2 only reads
+%% player_count, and listing_info/1 doesn't project it either. Fanning that
+%% out to every running world just to throw it away is copying up to 500
+%% player-id binaries per world, across a process boundary, per world, on
+%% every uncached enumeration. This variant skips computing it at all.
+-spec get_info(pid(), listing) -> map().
+get_info(Pid, listing) ->
+    case gen_statem:call(Pid, {get_info, listing}) of
         M when is_map(M) -> M
     end.
 
@@ -223,6 +244,8 @@ loading(state_timeout, zones_ready, State) ->
     {next_state, running, State#{started_at => erlang:system_time(millisecond)}};
 loading({call, From}, get_info, State) ->
     {keep_state_and_data, [{reply, From, world_info(loading, State)}]};
+loading({call, From}, {get_info, listing}, State) ->
+    {keep_state_and_data, [{reply, From, world_info(loading, State, false)}]};
 loading({call, _From}, {join, _PlayerId}, _State) ->
     %% Postpone join until we transition to running. Otherwise the call
     %% would crash with function_clause and the caller would time out.
@@ -299,6 +322,8 @@ running({timeout, empty_grace}, _Content, #{players := Players} = State) ->
     end;
 running({call, From}, get_info, State) ->
     {keep_state_and_data, [{reply, From, world_info(running, State)}]};
+running({call, From}, {get_info, listing}, State) ->
+    {keep_state_and_data, [{reply, From, world_info(running, State, false)}]};
 running({call, From}, {start_vote, VoteConfig}, State) ->
     handle_start_vote(From, VoteConfig, State);
 running({call, From}, {cast_vote, PlayerId, VoteId, OptionId}, State) ->
@@ -427,6 +452,8 @@ finished(cast, {broadcast_event, Event, Payload}, State) ->
     keep_state_and_data;
 finished({call, From}, get_info, State) ->
     {keep_state_and_data, [{reply, From, world_info(finished, State)}]};
+finished({call, From}, {get_info, listing}, State) ->
+    {keep_state_and_data, [{reply, From, world_info(finished, State, false)}]};
 finished(_EventType, _Event, _State) ->
     keep_state_and_data.
 
@@ -1069,19 +1096,30 @@ notify_players(Event, #{players := Players, world_id := WorldId} = State) ->
         Players
     ).
 
-world_info(Status, #{world_id := WorldId, players := Players} = State) ->
-    Base = #{
+world_info(Status, State) ->
+    world_info(Status, State, true).
+
+%% IncludeRoster = false skips `maps:keys(Players)` entirely rather than
+%% computing then discarding it - see get_info/2's moduledoc note (#194).
+%% Every other field is a cheap scalar already required by
+%% asobi_world_lobby:matches_filters/2 and listing_info/1.
+world_info(Status, #{world_id := WorldId, players := Players} = State, IncludeRoster) ->
+    Base0 = #{
         world_id => WorldId,
         status => Status,
         player_count => map_size(Players),
         max_players => maps:get(max_players, State, 500),
-        players => maps:keys(Players),
         mode => maps:get(mode, State, undefined),
         grid_size => maps:get(grid_size, State),
         started_at => maps:get(started_at, State, undefined),
         listed => maps:get(listed, State, true),
         quick_play => maps:get(quick_play, State, true)
     },
+    Base =
+        case IncludeRoster of
+            true -> Base0#{players => maps:keys(Players)};
+            false -> Base0
+        end,
     case maps:get(phase_state, State, undefined) of
         undefined -> Base;
         PS -> Base#{phase => asobi_phase:info(PS)}

--- a/test/asobi_match_server_tests.erl
+++ b/test/asobi_match_server_tests.erl
@@ -41,6 +41,8 @@ match_server_test_() ->
     {setup, fun setup/0, fun cleanup/1, [
         {"starts in waiting state", fun starts_waiting/0},
         {"get_info returns match metadata", fun get_info_waiting/0},
+        {"get_info(Pid, listing) omits the roster but keeps filter/listing fields",
+            fun get_info_listing/0},
         {"join adds player", fun join_adds_player/0},
         {"join rejects when full", fun join_rejects_full/0},
         {"duplicate join is idempotent", fun duplicate_join/0},
@@ -78,6 +80,22 @@ get_info_waiting() ->
     Pid = start_match(),
     Info = asobi_match_server:get_info(Pid),
     ?assertMatch(#{match_id := _, status := waiting, player_count := 0, players := []}, Info),
+    stop(Pid).
+
+%% asobi#194: mirrors asobi_world_server_tests:get_info_listing/0.
+get_info_listing() ->
+    Pid = start_match(),
+    ok = asobi_match_server:join(Pid, ~"p1"),
+    Full = asobi_match_server:get_info(Pid),
+    Listing = asobi_match_server:get_info(Pid, listing),
+    ?assertNot(maps:is_key(players, Listing)),
+    [
+        ?assertEqual(maps:get(K, Full), maps:get(K, Listing))
+     || K <- [match_id, status, player_count, max_players, mode, listed]
+    ],
+    ?assertEqual(
+        asobi_match_server:listing_info(Full), asobi_match_server:listing_info(Listing)
+    ),
     stop(Pid).
 
 join_adds_player() ->

--- a/test/asobi_world_server_tests.erl
+++ b/test/asobi_world_server_tests.erl
@@ -65,6 +65,8 @@ world_server_test_() ->
         {"leave removes player", fun leave_player/0},
         {timeout, 15, {"leave last player finishes world", fun leave_last_finishes/0}},
         {"get_info returns world metadata", fun get_info/0},
+        {"get_info(Pid, listing) omits the roster but keeps filter/listing fields",
+            fun get_info_listing/0},
         {timeout, 15, {"cancel finishes world", fun cancel_world/0}},
         {"whereis finds world by id", fun whereis_world/0},
         {"join records player in ETS, leave clears it", fun ets_tracks_player_world/0},
@@ -144,6 +146,28 @@ get_info() ->
     ?assert(maps:is_key(status, Info)),
     ?assert(maps:is_key(player_count, Info)),
     ?assert(maps:is_key(grid_size, Info)),
+    ?assert(maps:is_key(players, Info)),
+    stop_world(Ctx).
+
+%% asobi#194: the listing variant must not carry the roster at all - not
+%% just omit it from the eventual listing_info/1 projection, since the
+%% whole point is to never copy it across the process boundary - but must
+%% keep every field asobi_world_lobby:matches_filters/2 and listing_info/1
+%% read (player_count, max_players, mode, status, listed, quick_play).
+get_info_listing() ->
+    Ctx = start_world(),
+    Pid = maps:get(world_pid, Ctx),
+    ok = asobi_world_server:join(Pid, ~"p1"),
+    Full = asobi_world_server:get_info(Pid),
+    Listing = asobi_world_server:get_info(Pid, listing),
+    ?assertNot(maps:is_key(players, Listing)),
+    [
+        ?assertEqual(maps:get(K, Full), maps:get(K, Listing))
+     || K <- [world_id, status, player_count, max_players, mode, grid_size, listed, quick_play]
+    ],
+    ?assertEqual(
+        asobi_world_server:listing_info(Full), asobi_world_server:listing_info(Listing)
+    ),
     stop_world(Ctx).
 
 cancel_world() ->


### PR DESCRIPTION
## Summary

Closes #194.

`asobi_discovery:enumerate/3` (the shared enumerator behind `list_worlds/1` and `list_matches/1`) called `get_info/1` per live process, which always built `players => maps:keys(Players)` - the full roster - even though neither the filter function nor `listing_info/1`'s output ever reads it. At up to 1000 worlds of up to 500 players, that's up to 500k discarded binary copies per uncached listing call.

Added `get_info(Pid, listing)` to both `asobi_world_server` and `asobi_match_server`: same state-machine call clauses, but the info-builder takes an `IncludeRoster` flag that skips `maps:keys(Players)` entirely rather than computing then discarding it. `get_info/1` is unchanged and still used everywhere else (single-process lookups: `show/1`, `do_create_world/2`, WS/vote/matchmaker/chat-ACL call sites) - only the fan-out enumeration path switches.

## Test plan

- [x] `rebar3 fmt` / `xref` / `dialyzer` clean
- [x] `elp eqwalize-all` clean (isolated fresh-clone check, `NO ERRORS`)
- [x] `elp lint` clean (two pre-existing, unrelated `catch` warnings in touched test files, not introduced by this diff)
- [x] `rebar3 eunit` — 420/420 passing, including new tests confirming the listing variant omits `players` while agreeing with `get_info/1` on every field the filter/listing functions read
- [ ] CI (Common Test, full matrix)