### PR TITLE
fix: log the two remaining silent spawn-failure drops from #249's review

### DIFF
--- a/src/asobi_telemetry.erl
+++ b/src/asobi_telemetry.erl
@@ -21,7 +21,7 @@
 
 %% Categories of game-code error. A fixed literal set on purpose - never derive
 %% Kind from untrusted input (atom-table exhaustion). Extend as categories arise.
--type game_error_kind() :: lua_error | unknown_spawn_template.
+-type game_error_kind() :: lua_error | unknown_spawn_template | zone_unavailable.
 -export_type([game_error_kind/0]).
 -export([economy_transaction/4, store_purchase/3]).
 -export([chat_message_sent/2]).

--- a/src/world/asobi_world_server.erl
+++ b/src/world/asobi_world_server.erl
@@ -8,6 +8,8 @@ transient matches use `asobi_match_server` instead.
 """.
 -behaviour(gen_statem).
 
+-include_lib("kernel/include/logger.hrl").
+
 -export([
     start_link/1, join/2, join/3, join/4, leave/2, move_player/3, post_tick/2, get_info/1, cancel/1
 ]).
@@ -308,14 +310,28 @@ running({call, From}, {use_veto, PlayerId, VoteId}, State) ->
 running(
     cast,
     {spawn_at, TemplateId, {X, Y} = Pos, Overrides},
-    #{zone_manager_pid := ZMPid, zone_size := ZS} = _State
+    #{zone_manager_pid := ZMPid, zone_size := ZS, world_id := WorldId} = _State
 ) when is_binary(TemplateId), is_number(X), is_number(Y), is_map(Overrides) ->
     Coords = pos_to_zone(Pos, ZS),
     case asobi_zone_manager:ensure_zone(ZMPid, Coords) of
         {ok, ZonePid} ->
             asobi_zone:spawn_entity(ZonePid, TemplateId, Pos, Overrides),
             keep_state_and_data;
-        {error, _} ->
+        {error, Reason} ->
+            %% asobi#251: same "spawn something, hear nothing" pattern
+            %% #247/#249 fixed elsewhere - a game.spawn call whose zone
+            %% couldn't be created (e.g. max_zones_reached) used to drop
+            %% with no signal at all.
+            ?LOG_WARNING(#{
+                event => spawn_at_zone_unavailable,
+                world_id => WorldId,
+                coords => Coords,
+                template_id => TemplateId,
+                reason => Reason
+            }),
+            asobi_telemetry:game_error(zone_unavailable, #{
+                world_id => WorldId, coords => Coords, reason => Reason
+            }),
             keep_state_and_data
     end;
 running(cast, {broadcast_event, Event, Payload}, State) ->

--- a/src/world/asobi_zone.erl
+++ b/src/world/asobi_zone.erl
@@ -488,7 +488,16 @@ do_tick(
     Entities3 = apply_timer_events(TimerEvents, Entities2),
     %% Tick spawner — process respawn queue
     Spawner = maps:get(spawner, State),
-    {Respawns, Spawner1} = asobi_zone_spawner:tick(Now, Spawner),
+    {Respawns, FailedRespawns, Spawner1} = asobi_zone_spawner:tick(Now, Spawner),
+    lists:foreach(
+        fun
+            ({TemplateId, unknown_template = Reason}) when is_binary(TemplateId) ->
+                log_spawn_failed(TemplateId, Reason, State);
+            (_) ->
+                ok
+        end,
+        FailedRespawns
+    ),
     Entities4 = apply_respawns(Respawns, Entities3),
     %% Only broadcast every Nth tick to reduce network traffic
     State1 =

--- a/src/world/asobi_zone_spawner.erl
+++ b/src/world/asobi_zone_spawner.erl
@@ -148,31 +148,42 @@ schedule_respawn(EntityId, TemplateId, Now, #{templates := Templates} = State) -
 %% -------------------------------------------------------------------
 
 -spec tick(pos_integer(), state()) ->
-    {[{binary(), map(), {number(), number()}}], state()}.
+    {[{binary(), map(), {number(), number()}}], [{binary(), unknown_template}], state()}.
 tick(Now, #{respawn_queue := Queue} = State) ->
     {Ready, Remaining} = lists:partition(
         fun(#{respawn_at := At}) -> Now >= At end,
         Queue
     ),
-    process_respawns(Ready, [], State#{respawn_queue => Remaining}).
+    process_respawns(Ready, [], [], State#{respawn_queue => Remaining}).
 
+%% asobi#251: a template renamed/removed between an entity's despawn and its
+%% scheduled respawn used to fail here silently - same "spawn something, hear
+%% nothing" pattern #247/#249 fixed for the other spawn paths. This module is
+%% pure (no telemetry/logging side effects of its own), so failures are
+%% returned to the caller (asobi_zone.erl) to log via log_spawn_failed/3.
 -spec process_respawns(
     [spawn_request()],
     [{binary(), map(), {number(), number()}}],
+    [{binary(), unknown_template}],
     state()
 ) ->
-    {[{binary(), map(), {number(), number()}}], state()}.
-process_respawns([], Acc, State) ->
-    {Acc, State};
+    {[{binary(), map(), {number(), number()}}], [{binary(), unknown_template}], state()}.
+process_respawns([], Acc, FailedAcc, State) ->
+    {Acc, FailedAcc, State};
 process_respawns(
-    [#{template_id := TId, entity_id := EId, position := Pos, overrides := Ov} | Rest], Acc, State
+    [#{template_id := TId, entity_id := EId, position := Pos, overrides := Ov} | Rest],
+    Acc,
+    FailedAcc,
+    State
 ) ->
     case spawn_entity(TId, EId, Pos, Ov, State) of
         {ok, {EId2, Entity}, State1} ->
             {X, Y} = Pos,
-            process_respawns(Rest, [{EId2, Entity#{x => X, y => Y}, Pos} | Acc], State1);
-        {error, _} ->
-            process_respawns(Rest, Acc, State)
+            process_respawns(
+                Rest, [{EId2, Entity#{x => X, y => Y}, Pos} | Acc], FailedAcc, State1
+            );
+        {error, Reason} ->
+            process_respawns(Rest, Acc, [{TId, Reason} | FailedAcc], State)
     end.
 
 %% -------------------------------------------------------------------

--- a/test/asobi_zone_spawner_SUITE.erl
+++ b/test/asobi_zone_spawner_SUITE.erl
@@ -10,6 +10,7 @@
     spawn_with_explicit_id/1,
     entity_removed_schedules_respawn/1,
     tick_respawns_entities/1,
+    tick_reports_respawn_of_removed_template/1,
     respawn_max_limit/1,
     no_respawn_when_undefined/1,
     serialise_deserialise/1,
@@ -24,6 +25,7 @@ all() ->
         spawn_with_explicit_id,
         entity_removed_schedules_respawn,
         tick_respawns_entities,
+        tick_reports_respawn_of_removed_template,
         respawn_max_limit,
         no_respawn_when_undefined,
         serialise_deserialise,
@@ -107,13 +109,27 @@ tick_respawns_entities(_Config) ->
     Now = erlang:system_time(millisecond),
     S2 = asobi_zone_spawner:entity_removed(Id, Now, S1),
     %% Not ready yet
-    {[], S3} = asobi_zone_spawner:tick(Now + 500, S2),
+    {[], [], S3} = asobi_zone_spawner:tick(Now + 500, S2),
     %% Ready after delay
-    {Spawned, S4} = asobi_zone_spawner:tick(Now + 1001, S3),
+    {Spawned, [], S4} = asobi_zone_spawner:tick(Now + 1001, S3),
     ?assertEqual(1, length(Spawned)),
     [{_, Entity, {10.0, 20.0}}] = Spawned,
     ?assertMatch(#{type := ~"npc", health := 100}, Entity),
     ?assertEqual(0, maps:get(pending_respawns, asobi_zone_spawner:info(S4))),
+    ok.
+
+%% asobi#251: a template renamed/removed between an entity's despawn and its
+%% scheduled respawn must surface, not silently drop the respawn.
+tick_reports_respawn_of_removed_template(_Config) ->
+    S0 = asobi_zone_spawner:new(templates()),
+    {ok, {Id, _}, S1} = asobi_zone_spawner:spawn_entity(~"goblin", {10.0, 20.0}, S0),
+    Now = erlang:system_time(millisecond),
+    S2 = asobi_zone_spawner:entity_removed(Id, Now, S1),
+    %% The template disappears before the scheduled respawn fires.
+    S3 = asobi_zone_spawner:set_templates(maps:remove(~"goblin", templates()), S2),
+    {Spawned, Failed, _S4} = asobi_zone_spawner:tick(Now + 1001, S3),
+    ?assertEqual([], Spawned),
+    ?assertEqual([{~"goblin", unknown_template}], Failed),
     ok.
 
 respawn_max_limit(_Config) ->
@@ -123,7 +139,7 @@ respawn_max_limit(_Config) ->
     Now = erlang:system_time(millisecond),
     %% First removal: count=1, should schedule respawn (1 < 2)
     S2 = asobi_zone_spawner:entity_removed(Id, Now, S1),
-    {Spawned1, S3} = asobi_zone_spawner:tick(Now + 501, S2),
+    {Spawned1, [], S3} = asobi_zone_spawner:tick(Now + 501, S2),
     ?assertEqual(1, length(Spawned1)),
     %% Second removal: count=2, should NOT schedule respawn (2 >= 2)
     S4 = asobi_zone_spawner:entity_removed(Id, Now + 600, S3),


### PR DESCRIPTION
## Summary

Closes #251 (architecture-guardian follow-up from #249's review).

Two more instances of the "spawn something, hear nothing" pattern #249 fixed for `asobi_zone`'s direct spawn paths:

1. `asobi_zone_spawner:process_respawns/3` discarded a failed scheduled respawn silently - reachable when a template is renamed/removed between an entity's despawn and its respawn firing. Since `asobi_zone_spawner` is a pure module by design, `tick/2`'s return grows to `{Ready, Failed, State}` and the caller logs failures via the existing `log_spawn_failed/3`.
2. `asobi_world_server`'s `spawn_at` clause dropped a zone-creation failure (e.g. `max_zones_reached`) with no signal - a different failure class than #249's (not an unknown template), so it gets its own log line and a new `zone_unavailable` telemetry kind.

## Test plan

- [x] `rebar3 fmt` / `xref` / `dialyzer` clean
- [x] `elp eqwalize-all` clean (isolated fresh-clone check, `NO ERRORS` - needed a type-narrowing guard on the new `lists:foreach` destructure, matching the existing `to_count/1`-style pattern in this codebase)
- [x] `elp lint` clean (3 pre-existing warnings outside this diff's changed line ranges, verified against the diff hunks)
- [x] `rebar3 eunit` — 418/418 passing, including a new CT regression test proving the respawn-queue path surfaces the failure
- [ ] CI (Common Test, full matrix)