### PR TITLE
fix: re-home players across zone boundaries in world.input

### DIFF
--- a/src/world/asobi_world_chat.erl
+++ b/src/world/asobi_world_chat.erl
@@ -157,13 +157,22 @@ leave_zone_chats(PlayerId, PlayerPid, WorldId, ZoneCoords, ChatConfig) ->
 proximity_zones({ZX, ZY}, Radius, GridSize) when is_integer(ZX), is_integer(ZY) ->
     [
         {X, Y}
-     || X <- lists:seq(clamp_lo(ZX - Radius), min(GridSize - 1, ZX + Radius)),
-        Y <- lists:seq(clamp_lo(ZY - Radius), min(GridSize - 1, ZY + Radius))
+     || X <- safe_seq(clamp_lo(ZX - Radius), min(GridSize - 1, ZX + Radius)),
+        Y <- safe_seq(clamp_lo(ZY - Radius), min(GridSize - 1, ZY + Radius))
     ].
 
 -spec clamp_lo(integer()) -> non_neg_integer().
 clamp_lo(N) when N < 0 -> 0;
 clamp_lo(N) -> N.
+
+%% ZoneCoords here comes from asobi_world_server:pos_to_zone/3, which clamps
+%% to the grid - but this module can't rely on every future caller doing the
+%% same, and lists:seq/2 requires Hi >= Lo - 1. Degrade to an empty ring
+%% rather than crashing the caller (this ran the whole world down before
+%% pos_to_zone/3 existed - widgrensit/asobi#248).
+-spec safe_seq(integer(), integer()) -> [integer()].
+safe_seq(Lo, Hi) when Hi < Lo -> [];
+safe_seq(Lo, Hi) -> lists:seq(Lo, Hi).
 
 find_player_pid(PlayerId) ->
     case pg:get_members(nova_scope, {player, PlayerId}) of

--- a/src/world/asobi_world_server.erl
+++ b/src/world/asobi_world_server.erl
@@ -17,6 +17,7 @@ transient matches use `asobi_match_server` instead.
     join/4,
     leave/2,
     move_player/3,
+    move_player/4,
     post_tick/2,
     get_info/1,
     get_info/2,
@@ -28,6 +29,7 @@ transient matches use `asobi_match_server` instead.
 -export([reconnect/2]).
 -export([start_vote/2, cast_vote/4, use_veto/3]).
 -export([whereis/1]).
+-export([pos_to_zone/3]).
 -export([callback_mode/0, init/1, terminate/3]).
 -export([loading/3, running/3, finished/3]).
 
@@ -79,7 +81,18 @@ leave(Pid, PlayerId) ->
 
 -spec move_player(pid(), binary(), {number(), number()}) -> ok.
 move_player(Pid, PlayerId, NewPos) ->
-    gen_statem:cast(Pid, {move_player, PlayerId, NewPos}).
+    gen_statem:cast(Pid, {move_player, PlayerId, NewPos, undefined}).
+
+-doc """
+As `move_player/3`, but for a caller that already holds the entity's full
+state (asobi_zone's resolve_zone_crossings/1). `Entity` is written into the
+target zone as-is instead of being reconstructed as `#{x, y, type}` only, so
+fields a game script keeps beyond position - health, inventory, whatever -
+survive the zone boundary. See widgrensit/asobi#248.
+""".
+-spec move_player(pid(), binary(), {number(), number()}, map()) -> ok.
+move_player(Pid, PlayerId, NewPos, Entity) when is_map(Entity) ->
+    gen_statem:cast(Pid, {move_player, PlayerId, NewPos, Entity}).
 
 -spec post_tick(pid(), non_neg_integer()) -> ok.
 post_tick(Pid, TickN) ->
@@ -247,6 +260,12 @@ loading({call, _From}, {join, _PlayerId}, _State) ->
     %% Postpone join until we transition to running. Otherwise the call
     %% would crash with function_clause and the caller would time out.
     {keep_state_and_data, [postpone]};
+%% A zone's post-tick crossing check (asobi_zone:resolve_zone_crossings/1)
+%% can fire on a pre-warmed zone recovered from a snapshot before the world
+%% has finished loading. Without this, that cast is a function_clause and
+%% kills the world instead of just running once we reach running.
+loading(cast, {move_player, _PlayerId, _NewPos, _Entity}, _State) ->
+    {keep_state_and_data, [postpone]};
 %% A world script broadcasting during generate_world/init reaches the world
 %% server while it is still loading. Without this clause that is a
 %% function_clause and the world dies before it ever runs.
@@ -276,8 +295,8 @@ running({call, From}, {join, PlayerId, Ctx}, State) ->
     handle_join(From, PlayerId, Ctx, State);
 running(cast, {leave, PlayerId}, State) ->
     handle_leave(PlayerId, State);
-running(cast, {move_player, PlayerId, NewPos}, State) ->
-    handle_move(PlayerId, NewPos, State);
+running(cast, {move_player, PlayerId, NewPos, Entity}, State) ->
+    handle_move(PlayerId, NewPos, Entity, State);
 running(
     cast,
     {post_tick, TickN},
@@ -330,9 +349,14 @@ running({call, From}, {use_veto, PlayerId, VoteId}, State) ->
 running(
     cast,
     {spawn_at, TemplateId, {X, Y} = Pos, Overrides},
-    #{zone_manager_pid := ZMPid, zone_size := ZS, world_id := WorldId} = _State
+    #{
+        zone_manager_pid := ZMPid,
+        zone_size := ZS,
+        grid_size := GridSize,
+        world_id := WorldId
+    } = _State
 ) when is_binary(TemplateId), is_number(X), is_number(Y), is_map(Overrides) ->
-    Coords = pos_to_zone(Pos, ZS),
+    Coords = pos_to_zone(Pos, ZS, GridSize),
     case asobi_zone_manager:ensure_zone(ZMPid, Coords) of
         {ok, ZonePid} ->
             asobi_zone:spawn_entity(ZonePid, TemplateId, Pos, Overrides),
@@ -485,6 +509,8 @@ configure_zone_manager(
         ticker_pid := TickerPid,
         world_id := WorldId,
         game_module := GameMod,
+        zone_size := ZoneSize,
+        grid_size := GridSize,
         config := Config
     } = State
 ) ->
@@ -501,7 +527,11 @@ configure_zone_manager(
         persistence => Persistence,
         snapshot_interval => maps:get(snapshot_interval, Config, 600),
         zone_manager_pid => ZoneManagerPid,
-        terrain_store_pid => TerrainStorePid
+        terrain_store_pid => TerrainStorePid,
+        %% So a zone can decide crossings with the same clamped math - see
+        %% resolve_zone_crossings/1 in asobi_zone.
+        zone_size => ZoneSize,
+        grid_size => GridSize
     },
     asobi_zone_manager:set_zone_config(ZoneManagerPid, BaseZoneConfig),
     State#{terrain_store_pid => TerrainStorePid}.
@@ -683,7 +713,9 @@ handle_join(
                                 veto_tokens => VetoTokens#{PlayerId => VetoCount}
                             },
                             asobi_telemetry:world_player_joined(WorldId, PlayerId),
-                            ZoneCoords = pos_to_zone(SpawnPos, maps:get(zone_size, State3)),
+                            ZoneCoords = pos_to_zone(
+                                SpawnPos, maps:get(zone_size, State3), maps:get(grid_size, State3)
+                            ),
                             asobi_world_chat:player_joined(
                                 PlayerId, ZoneCoords, maps:get(chat_state, State3)
                             ),
@@ -739,11 +771,19 @@ handle_leave(
 %% {ok, ZonePid} = ... match here used to crash the whole world gen_statem -
 %% every player in it - on what should be a per-player placement failure.
 %% Callers get a tagged result and decide their own safe fallback.
+%%
+%% Called at join, where there is no prior entity to preserve.
 -spec place_player(binary(), {number(), number()}, map()) ->
+    {ok, map(), pid()} | {error, term(), map()}.
+place_player(PlayerId, {X, Y} = Pos, State) ->
+    place_player(PlayerId, Pos, #{x => X, y => Y, type => ~"player"}, State).
+
+-spec place_player(binary(), {number(), number()}, map(), map()) ->
     {ok, map(), pid()} | {error, term(), map()}.
 place_player(
     PlayerId,
     {X, Y} = _Pos,
+    Entity,
     #{
         zone_manager_pid := ZMPid,
         view_radius := ViewRadius,
@@ -751,13 +791,13 @@ place_player(
         grid_size := GridSize
     } = State
 ) ->
-    ZoneCoords = pos_to_zone({X, Y}, ZoneSize),
+    ZoneCoords = pos_to_zone({X, Y}, ZoneSize, GridSize),
     case asobi_zone_manager:ensure_zone(ZMPid, ZoneCoords) of
         {error, Reason} ->
             {error, Reason, State};
         {ok, ZonePid} ->
             PlayerPid = find_player_pid(PlayerId),
-            asobi_zone:add_entity(ZonePid, PlayerId, #{x => X, y => Y, type => ~"player"}),
+            asobi_zone:add_entity(ZonePid, PlayerId, Entity),
             asobi_presence:send(PlayerId, {world_joined, self(), ZonePid}),
             InterestZones = interest_zones(ZoneCoords, ViewRadius, GridSize),
             subscribe_interest_zones(InterestZones, ZMPid, PlayerId, PlayerPid),
@@ -794,14 +834,43 @@ remove_player_from_zones(
                 not_loaded -> ok
             end,
             unsubscribe_interest_zones(InterestZones, ZMPid, PlayerId),
-            %% Release primary zone if no other players need it
-            asobi_zone_manager:release_zone(ZMPid, ZoneCoords),
+            %% release_zone unconditionally backdates the zone past its idle
+            %% timeout (asobi_zone_manager.erl) - it does not itself check for
+            %% other occupants despite what its name suggests. Do that check
+            %% here instead, from player_zones already in hand: releasing a
+            %% zone another player is still standing in risks the reaper
+            %% killing it inside the backdate-to-reap-sweep race window,
+            %% dropping every subscriber with nothing to re-subscribe them.
+            %% See widgrensit/asobi#248.
+            case zone_still_occupied(ZoneCoords, PlayerId, PlayerZones) of
+                true -> ok;
+                false -> asobi_zone_manager:release_zone(ZMPid, ZoneCoords)
+            end,
             State#{player_zones => maps:remove(PlayerId, PlayerZones)}
     end.
+
+%% "Occupied" covers both a player standing in the zone (its `zone`) and one
+%% merely watching it from a neighbouring cell (in its `interest` ring) -
+%% releasing a zone the latter is still subscribed to risks the same reaper
+%% race, just for a subscriber the zone never itself notices leaving.
+-spec zone_still_occupied({integer(), integer()}, binary(), map()) -> boolean().
+zone_still_occupied(ZoneCoords, LeavingPlayerId, PlayerZones) ->
+    lists:any(
+        fun
+            (#{zone := Zone}) when Zone =:= ZoneCoords ->
+                true;
+            (#{interest := Interest}) when is_list(Interest) ->
+                lists:member(ZoneCoords, Interest);
+            (_) ->
+                false
+        end,
+        maps:values(maps:remove(LeavingPlayerId, PlayerZones))
+    ).
 
 handle_move(
     PlayerId,
     {X, Y} = NewPos,
+    MaybeEntity,
     #{
         world_id := WorldId,
         players := Players,
@@ -816,15 +885,22 @@ handle_move(
     case maps:get(PlayerId, PlayerZones, undefined) of
         undefined ->
             keep_state_and_data;
-        #{zone := OldZoneCoords} ->
-            NewZoneCoords = pos_to_zone(NewPos, ZoneSize),
+        #{zone := OldZoneCoords, interest := OldInterest} ->
+            NewZoneCoords = pos_to_zone(NewPos, ZoneSize, GridSize),
+            %% move_player/3 (existing test/external callers) passes no
+            %% entity; move_player/4 (asobi_zone:resolve_zone_crossings/1)
+            %% passes the entity's current full state so fields beyond x/y/type
+            %% survive the crossing. See widgrensit/asobi#248.
+            Entity =
+                case MaybeEntity of
+                    undefined -> #{x => X, y => Y, type => ~"player"};
+                    Map when is_map(Map) -> Map
+                end,
             case OldZoneCoords =:= NewZoneCoords of
                 true ->
                     case asobi_zone_manager:get_zone(ZMPid, OldZoneCoords) of
                         {ok, ZonePid} ->
-                            asobi_zone:add_entity(ZonePid, PlayerId, #{
-                                x => X, y => Y, type => ~"player"
-                            });
+                            asobi_zone:add_entity(ZonePid, PlayerId, Entity);
                         not_loaded ->
                             ok
                     end,
@@ -853,60 +929,63 @@ handle_move(
                                 world_id => WorldId, coords => NewZoneCoords, reason => Reason
                             }),
                             keep_state_and_data;
-                        {ok, _} ->
-                            State1 = remove_player_from_zones(PlayerId, State),
-                            %% place_player/4's own ensure_zone call for these same
-                            %% coords now hits the fast (already-created) path - the
-                            %% precheck above and this call target the same coords in
-                            %% the same synchronous callback, with no yield point for
-                            %% the zone to be reaped in between. {error, _, _} here is
-                            %% not reachable under current asobi_zone_manager
-                            %% invariants; handled defensively (not a bare match)
-                            %% rather than trusting that to hold forever.
-                            case place_player(PlayerId, NewPos, State1) of
-                                {error, Reason, _} ->
-                                    %% remove_player_from_zones/2's casts to the OLD
-                                    %% zone already fired and can't be recalled, so
-                                    %% this player's player_zones bookkeeping is left
-                                    %% stale rather than crashing the whole world over
-                                    %% a should-be-unreachable edge case.
-                                    ?LOG_ERROR(#{
-                                        event => move_zone_unavailable_after_removal,
-                                        world_id => WorldId,
-                                        player_id => PlayerId,
-                                        coords => NewZoneCoords,
-                                        reason => Reason
-                                    }),
-                                    asobi_telemetry:game_error(zone_unavailable, #{
-                                        world_id => WorldId,
-                                        coords => NewZoneCoords,
-                                        reason => Reason
-                                    }),
-                                    {keep_state, State1};
-                                {ok, State2, ZonePid} ->
-                                    asobi_world_chat:player_zone_changed(
-                                        PlayerId, OldZoneCoords, NewZoneCoords, GridSize, ChatState
-                                    ),
-                                    Players1 = maps:update_with(
-                                        PlayerId,
-                                        fun(Meta) -> Meta#{position => NewPos} end,
-                                        maps:get(players, State2)
-                                    ),
-                                    PlayerPid = find_player_pid(PlayerId),
-                                    PlayerPid ! {asobi_message, {world_zone_changed, ZonePid}},
-                                    NewInterest = interest_zones(
-                                        NewZoneCoords, ViewRadius, GridSize
-                                    ),
-                                    PZ = maps:get(player_zones, State2),
-                                    {keep_state, State2#{
-                                        players => Players1,
-                                        player_zones => PZ#{
-                                            PlayerId => #{
-                                                zone => NewZoneCoords, interest => NewInterest
-                                            }
-                                        }
-                                    }}
-                            end
+                        {ok, NewZonePid} ->
+                            %% A single-step crossing keeps most of the ring in
+                            %% common (radius 1 keeps 6 of 9 zones on an
+                            %% orthogonal move) - touching only the zones that
+                            %% actually entered or left avoids an unsubscribe/
+                            %% resubscribe (and the full zone snapshot resend
+                            %% subscribing triggers) for every zone that didn't
+                            %% change. See widgrensit/asobi#248.
+                            NewInterest = interest_zones(NewZoneCoords, ViewRadius, GridSize),
+                            ToUnsubscribe = OldInterest -- NewInterest,
+                            ToSubscribe = NewInterest -- OldInterest,
+
+                            case asobi_zone_manager:get_zone(ZMPid, OldZoneCoords) of
+                                {ok, OldZonePid} -> asobi_zone:remove_entity(OldZonePid, PlayerId);
+                                not_loaded -> ok
+                            end,
+                            PlayerPid = find_player_pid(PlayerId),
+                            asobi_zone:add_entity(NewZonePid, PlayerId, Entity),
+                            asobi_presence:send(PlayerId, {world_joined, self(), NewZonePid}),
+
+                            unsubscribe_interest_zones(ToUnsubscribe, ZMPid, PlayerId),
+                            subscribe_interest_zones(ToSubscribe, ZMPid, PlayerId, PlayerPid),
+                            %% Same race place_player/4's join path guards against: a
+                            %% world.input cast can reach the new zone before add_entity
+                            %% lands, since add_entity and the WS handler's cast are
+                            %% different senders (no FIFO guarantee between them).
+                            _ = asobi_zone:get_subscriber_count(NewZonePid),
+
+                            asobi_world_chat:player_zone_changed(
+                                PlayerId, OldZoneCoords, NewZoneCoords, GridSize, ChatState
+                            ),
+
+                            PlayerZones1 = maps:remove(PlayerId, PlayerZones),
+                            %% The old zone is often still in the player's own
+                            %% new ring (see ToUnsubscribe above) -
+                            %% zone_still_occupied/3 only knows about other
+                            %% players, so check that first.
+                            case
+                                lists:member(OldZoneCoords, NewInterest) orelse
+                                    zone_still_occupied(OldZoneCoords, PlayerId, PlayerZones1)
+                            of
+                                true -> ok;
+                                false -> asobi_zone_manager:release_zone(ZMPid, OldZoneCoords)
+                            end,
+
+                            PlayerPid ! {asobi_message, {world_zone_changed, NewZonePid}},
+                            Players1 = maps:update_with(
+                                PlayerId,
+                                fun(Meta) -> Meta#{position => NewPos} end,
+                                Players
+                            ),
+                            {keep_state, State#{
+                                players => Players1,
+                                player_zones => PlayerZones1#{
+                                    PlayerId => #{zone => NewZoneCoords, interest => NewInterest}
+                                }
+                            }}
                     end
             end
     end.
@@ -921,6 +1000,8 @@ leave_chat(PlayerId, #{player_zones := PlayerZones, chat_state := ChatState}) ->
 
 %% --- Internal: Spatial ---
 
+%% Only clamps the low end - not safe for a position past the world's far
+%% edge. pos_to_zone/3 below is what every other module should call.
 -spec pos_to_zone({number(), number()}, non_neg_integer()) ->
     {non_neg_integer(), non_neg_integer()}.
 pos_to_zone({X, Y}, ZoneSize) when is_number(X), is_number(Y), ZoneSize > 0 ->
@@ -938,22 +1019,36 @@ pos_to_zone({X, Y}, ZoneSize) when is_number(X), is_number(Y), ZoneSize > 0 ->
         end,
     {ZX, ZY}.
 
+-doc """
+As `pos_to_zone/2`, additionally clamped to `0 .. GridSize - 1` on both axes.
+Use this wherever a player's current zone is derived from position. See
+widgrensit/asobi#248.
+""".
+-spec pos_to_zone({number(), number()}, non_neg_integer(), pos_integer()) ->
+    {non_neg_integer(), non_neg_integer()}.
+pos_to_zone(Pos, ZoneSize, GridSize) when is_integer(GridSize), GridSize > 0 ->
+    {ZX, ZY} = pos_to_zone(Pos, ZoneSize),
+    {min(ZX, GridSize - 1), min(ZY, GridSize - 1)}.
+
 -spec interest_zones({integer(), integer()}, non_neg_integer(), non_neg_integer()) ->
     [{integer(), integer()}].
 interest_zones({ZX, ZY}, Radius, GridSize) ->
-    XLo = clamp_lo(ZX - Radius),
-    XHi = min(GridSize - 1, ZX + Radius),
-    YLo = clamp_lo(ZY - Radius),
-    YHi = min(GridSize - 1, ZY + Radius),
     [
         {X, Y}
-     || X <- lists:seq(XLo, XHi),
-        Y <- lists:seq(YLo, YHi)
+     || X <- safe_seq(clamp_lo(ZX - Radius), min(GridSize - 1, ZX + Radius)),
+        Y <- safe_seq(clamp_lo(ZY - Radius), min(GridSize - 1, ZY + Radius))
     ].
 
 -spec clamp_lo(integer()) -> non_neg_integer().
 clamp_lo(N) when N < 0 -> 0;
 clamp_lo(N) -> N.
+
+%% lists:seq/2 requires Hi >= Lo - 1; a coordinate outside the grid (only
+%% possible if a caller skips pos_to_zone/3's clamp) would otherwise crash
+%% this function_clause deep instead of degrading to an empty ring.
+-spec safe_seq(integer(), integer()) -> [integer()].
+safe_seq(Lo, Hi) when Hi < Lo -> [];
+safe_seq(Lo, Hi) -> lists:seq(Lo, Hi).
 
 find_player_pid(PlayerId) ->
     case pg:get_members(?PG_SCOPE, {player, PlayerId}) of

--- a/src/world/asobi_zone.erl
+++ b/src/world/asobi_zone.erl
@@ -19,6 +19,9 @@ via `asobi_spatial`. Zones are created and reaped lazily as players move.
 -include_lib("kernel/include/logger.hrl").
 
 -define(PG_SCOPE, nova_scope).
+%% Must match asobi_world_server's own defaults of the same name.
+-define(DEFAULT_ZONE_SIZE, 200).
+-define(DEFAULT_GRID_SIZE, 10).
 
 %% --- Public API ---
 
@@ -124,6 +127,8 @@ init(Config) ->
     ZoneState = maps:get(zone_state, Config, #{}),
     ZoneManagerPid = maps:get(zone_manager_pid, Config, undefined),
     TerrainStorePid = maps:get(terrain_store_pid, Config, undefined),
+    ZoneSize = maps:get(zone_size, Config, ?DEFAULT_ZONE_SIZE),
+    GridSize = maps:get(grid_size, Config, ?DEFAULT_GRID_SIZE),
     pg:join(?PG_SCOPE, {asobi_zone, WorldId, Coords}, self()),
     %% Recover entity state from ETS backup if available (zone crash recovery)
     RecoveredEntities = recover_zone_state(WorldId, Coords),
@@ -156,6 +161,8 @@ init(Config) ->
             spawn_templates => Templates,
             zone_manager_pid => ZoneManagerPid,
             terrain_store_pid => TerrainStorePid,
+            zone_size => ZoneSize,
+            grid_size => GridSize,
             entities => RecoveredEntities,
             prev_entities => #{},
             broadcast_entities => #{},
@@ -320,7 +327,7 @@ handle_cast(reap, State) ->
     {stop, normal, State};
 handle_cast({tick, TickN}, State) ->
     State1 = do_tick(TickN, State),
-    State2 = transfer_out_of_bounds_npcs(State1),
+    State2 = resolve_zone_crossings(State1),
     #{subscribers := Subs, entities := Ents, zone_manager_pid := ZMPid, coords := Coords} = State2,
     case map_size(Subs) of
         0 ->
@@ -636,32 +643,24 @@ encode_delta({added, Id, FullState}) ->
 encode_delta({removed, Id}) ->
     #{~"op" => ~"r", ~"id" => Id}.
 
-%% --- NPC Zone Crossing ---
+%% --- Zone Crossing ---
 
-transfer_out_of_bounds_npcs(
+%% Called after every tick, once entity positions for this tick are final.
+%% NPCs are transferred directly (asobi_zone owns them outright). Players
+%% can't be: only asobi_world_server can move a session's subscriptions and
+%% zone_pid, so those are handed off via move_player/4 instead. See
+%% widgrensit/asobi#248.
+resolve_zone_crossings(
     #{
         entities := Entities,
-        zone_state := ZS,
         world_id := WorldId,
-        coords := {ZX, ZY}
+        coords := Coords,
+        zone_size := ZoneSize,
+        grid_size := GridSize,
+        world_server_pid := WorldServerPid
     } = State
 ) ->
-    Zs = maps:get(zone_size, ZS, 1200) * 1.0,
-    {ToRemove, ToTransfer} = maps:fold(
-        fun
-            (Id, #{type := ~"npc", x := X, y := Y} = Entity, {Rem, Trans}) ->
-                NewZX = trunc(X / Zs),
-                NewZY = trunc(Y / Zs),
-                case {NewZX, NewZY} =/= {ZX, ZY} of
-                    true -> {[Id | Rem], [{Id, {NewZX, NewZY}, Entity} | Trans]};
-                    false -> {Rem, Trans}
-                end;
-            (_, _, Acc) ->
-                Acc
-        end,
-        {[], []},
-        Entities
-    ),
+    {ToRemove, ToTransfer, ToRehome} = find_zone_crossings(Entities, Coords, ZoneSize, GridSize),
     %% Transfer each NPC to the target zone
     lists:foreach(
         fun({Id, TargetCoords, Entity}) ->
@@ -675,11 +674,73 @@ transfer_out_of_bounds_npcs(
         end,
         ToTransfer
     ),
-    %% Remove transferred NPCs from this zone
+    %% Hand each player off to move_player/4 rather than writing them into the
+    %% target zone directly - handle_move/4 (via remove_player_from_zones/2)
+    %% is what actually removes them from this zone, re-subscribes their
+    %% interest ring and re-points their session's zone_pid. move_player/4 is
+    %% a cast: it always returns ok whether or not the world server has a
+    %% player_zones entry for this id, so that can't be used to decide
+    %% whether to delete the entity here. Deleting it unconditionally instead
+    %% destroyed any non-NPC entity a game script keeps as type "player"
+    %% (bots, decoys, ...) that the world server has never joined - it now
+    %% simply stays here, exactly as it did before this fix, until something
+    %% actually claims it. See widgrensit/asobi#248.
+    case WorldServerPid of
+        undefined ->
+            ok;
+        _ ->
+            lists:foreach(
+                fun
+                    ({Id, {X, Y} = Pos, Entity}) when
+                        is_binary(Id), is_number(X), is_number(Y), is_map(Entity)
+                    ->
+                        asobi_world_server:move_player(WorldServerPid, Id, Pos, Entity);
+                    (_) ->
+                        ok
+                end,
+                ToRehome
+            )
+    end,
+    %% Remove transferred NPCs from this zone. Rehomed players are removed by
+    %% asobi_world_server:remove_player_from_zones/2 once move_player/4's cast
+    %% is processed, not here.
     Entities1 = maps:without(ToRemove, Entities),
     Grid = maps:get(spatial_grid, State, undefined),
     Grid1 = remove_from_grid(ToRemove, Grid),
     State#{entities => Entities1, spatial_grid => Grid1}.
+
+%% Explicit -spec so eqwalizer treats ToRehome's element type as ground truth
+%% at the move_player/4 call site above, rather than inferring term() through
+%% the fold's multi-branch accumulator.
+-spec find_zone_crossings(map(), {integer(), integer()}, pos_integer(), pos_integer()) ->
+    {[binary()], [{binary(), {integer(), integer()}, map()}], [
+        {binary(), {number(), number()}, map()}
+    ]}.
+find_zone_crossings(Entities, Coords, ZoneSize, GridSize) ->
+    maps:fold(
+        fun
+            (Id, #{type := ~"npc", x := X, y := Y} = Entity, {Rem, Trans, Rehome}) when
+                is_binary(Id), is_number(X), is_number(Y)
+            ->
+                case asobi_world_server:pos_to_zone({X, Y}, ZoneSize, GridSize) of
+                    Coords ->
+                        {Rem, Trans, Rehome};
+                    NewCoords ->
+                        {[Id | Rem], [{Id, NewCoords, Entity} | Trans], Rehome}
+                end;
+            (Id, #{type := ~"player", x := X, y := Y} = Entity, {Rem, Trans, Rehome}) when
+                is_binary(Id), is_number(X), is_number(Y)
+            ->
+                case asobi_world_server:pos_to_zone({X, Y}, ZoneSize, GridSize) of
+                    Coords -> {Rem, Trans, Rehome};
+                    _NewCoords -> {Rem, Trans, [{Id, {X, Y}, Entity} | Rehome]}
+                end;
+            (_, _, Acc) ->
+                Acc
+        end,
+        {[], [], []},
+        Entities
+    ).
 
 %% --- Snapshot Helpers ---
 

--- a/test/asobi_world_server_tests.erl
+++ b/test/asobi_world_server_tests.erl
@@ -514,3 +514,14 @@ broadcast_in_running_does_not_kill_the_world_test() ->
     ?assert(is_process_alive(Pid)),
     ?assertEqual(running, maps:get(status, asobi_world_server:get_info(Pid))),
     stop_world(Ctx).
+
+%% pos_to_zone/2 only clamps the low end; a position past the world's far
+%% edge fed an out-of-grid coordinate to interest_zones/3 and
+%% asobi_world_chat:proximity_zones/3, both of which crashed on it
+%% (widgrensit/asobi#248). pos_to_zone/3 is what closes that.
+pos_to_zone_clamps_both_ends_test() ->
+    ?assertEqual({0, 0}, asobi_world_server:pos_to_zone({-500.0, -1.0}, 100, 3)),
+    ?assertEqual({1, 1}, asobi_world_server:pos_to_zone({150.0, 150.0}, 100, 3)),
+    ?assertEqual({2, 2}, asobi_world_server:pos_to_zone({299.0, 299.0}, 100, 3)),
+    ?assertEqual({2, 2}, asobi_world_server:pos_to_zone({1.0e9, 1.0e9}, 100, 3)),
+    ?assertEqual({0, 0}, asobi_world_server:pos_to_zone({999.0, 999.0}, 100, 1)).

--- a/test/asobi_world_zone_integration_tests.erl
+++ b/test/asobi_world_zone_integration_tests.erl
@@ -53,7 +53,13 @@ world_zone_integration_test_() ->
         {"player move across boundary creates new zone", fun lazy_move_creates_zone/0},
         {"multiple players share same zone process", fun shared_zone_process/0},
         {"get_active_zones correct after lazy joins", fun active_zones_after_joins/0},
-        {"small grid backward compat", fun small_grid_backward_compat/0}
+        {"small grid backward compat", fun small_grid_backward_compat/0},
+        {"world.input crossing a zone boundary rehomes the player",
+            fun world_input_rehomes_across_boundary/0},
+        {"world.input past the world's far edge does not crash the world server",
+            fun world_input_past_far_edge_survives/0},
+        {"a script-owned player-typed entity the world server never joined survives crossing",
+            fun script_owned_player_entity_survives_crossing/0}
     ]}.
 
 %% Default (lazy_zones=false, grid_size=3) pre-spawns all 9 zones
@@ -125,6 +131,97 @@ active_zones_after_joins() ->
     timer:sleep(20),
     Count2 = length(asobi_zone_manager:get_active_zones(Mgr)),
     ?assert(Count2 > Count1),
+    stop_world(Ctx).
+
+%% Regression for widgrensit/asobi#248: a real world.input (asobi_zone:player_input,
+%% what asobi_ws_handler actually calls - NOT asobi_world_server:move_player/3
+%% directly, which lazy_move_creates_zone above already covered) has to rehome a
+%% player across a zone boundary on its own, via resolve_zone_crossings/1.
+world_input_rehomes_across_boundary() ->
+    Ctx = #{world_pid := Pid, zone_mgr := Mgr} = start_world(#{lazy_zones => true}),
+    ?assertEqual(ok, asobi_world_server:join(Pid, ~"p1")),
+    timer:sleep(20),
+    %% Spawns at {100.0, 100.0} => zone {1,1}
+    {ok, ZonePid1} = asobi_zone_manager:get_zone(Mgr, {1, 1}),
+    Entities0 = asobi_zone:get_entities(ZonePid1),
+    ?assert(maps:is_key(~"p1", Entities0)),
+    %% Simulate a game script that keeps state on the entity beyond x/y/type
+    %% (hp, inventory, whatever) - regression for the move_player/3 path
+    %% reconstructing a bare #{x, y, type} and silently dropping everything
+    %% else on every crossing.
+    asobi_zone:add_entity(ZonePid1, ~"p1", (maps:get(~"p1", Entities0))#{hp => 42}),
+
+    %% The WS handler routes world.input straight to the zone the player
+    %% joined - never to asobi_world_server - so drive the same entry point.
+    asobi_zone:player_input(ZonePid1, ~"p1", #{
+        ~"action" => ~"move", ~"x" => 250.0, ~"y" => 250.0
+    }),
+    timer:sleep(150),
+
+    ?assertMatch({ok, _}, asobi_zone_manager:get_zone(Mgr, {2, 2})),
+    {ok, ZonePid2} = asobi_zone_manager:get_zone(Mgr, {2, 2}),
+    Entities2 = asobi_zone:get_entities(ZonePid2),
+    ?assert(maps:is_key(~"p1", Entities2)),
+    ?assertEqual(42, maps:get(hp, maps:get(~"p1", Entities2))),
+    ?assertNot(maps:is_key(~"p1", asobi_zone:get_entities(ZonePid1))),
+    stop_world(Ctx).
+
+%% Regression for widgrensit/asobi#248 (security review of the fix): a
+%% position past the world's far edge crossed pos_to_zone/2's missing upper
+%% clamp into interest_zones/3 and asobi_world_chat:proximity_zones/3, both
+%% of which called lists:seq(Lo, Hi) with Hi &lt; Lo and crashed - and via
+%% asobi_world_instance's one_for_all supervisor, took the whole world down
+%% with it. pos_to_zone/3 clamps to the grid before either is reached.
+world_input_past_far_edge_survives() ->
+    Ctx = #{world_pid := Pid, zone_mgr := Mgr} = start_world(#{lazy_zones => true}),
+    ?assertEqual(ok, asobi_world_server:join(Pid, ~"p1")),
+    timer:sleep(20),
+    %% Spawns at {100.0, 100.0} => zone {1,1}
+    {ok, ZonePid1} = asobi_zone_manager:get_zone(Mgr, {1, 1}),
+
+    %% grid_size=3, zone_size=100: x=500 is zone column 5 unclamped, two past
+    %% the last valid column (2) plus view_radius (1).
+    asobi_zone:player_input(ZonePid1, ~"p1", #{
+        ~"action" => ~"move", ~"x" => 500.0, ~"y" => 100.0
+    }),
+    timer:sleep(150),
+
+    ?assert(is_process_alive(Pid)),
+    Info = asobi_world_server:get_info(Pid),
+    ?assertEqual(running, maps:get(status, Info)),
+    %% Clamped to the grid's last column (2), not stuck in {1,1} nor crashed.
+    ?assertMatch({ok, _}, asobi_zone_manager:get_zone(Mgr, {2, 1})),
+    stop_world(Ctx).
+
+%% Regression for widgrensit/asobi#248 (security review): a game script can
+%% type a non-session entity "player" (a bot, a decoy) without it ever
+%% joining, so the world server holds no player_zones entry for it.
+%% resolve_zone_crossings/1 must not delete such an entity just because it
+%% attempted a hand-off nothing claimed - it must stay exactly where it was.
+script_owned_player_entity_survives_crossing() ->
+    Ctx = #{world_pid := Pid, zone_mgr := Mgr} = start_world(#{lazy_zones => true}),
+    {ok, ZonePid1} = asobi_zone_manager:ensure_zone(Mgr, {1, 1}),
+    asobi_zone:add_entity(ZonePid1, ~"bot1", #{
+        x => 100.0, y => 100.0, type => ~"player", hp => 7
+    }),
+    %% Give the zone a tick so it starts receiving ticks from the ticker.
+    timer:sleep(20),
+    ?assert(maps:is_key(~"bot1", asobi_zone:get_entities(ZonePid1))),
+
+    %% Move it across a boundary the same way handle_input would.
+    asobi_zone:player_input(ZonePid1, ~"bot1", #{
+        ~"action" => ~"move", ~"x" => 250.0, ~"y" => 250.0
+    }),
+    timer:sleep(150),
+
+    ?assert(is_process_alive(Pid)),
+    Survived =
+        maps:is_key(~"bot1", asobi_zone:get_entities(ZonePid1)) orelse
+            case asobi_zone_manager:get_zone(Mgr, {2, 2}) of
+                {ok, ZonePid2} -> maps:is_key(~"bot1", asobi_zone:get_entities(ZonePid2));
+                not_loaded -> false
+            end,
+    ?assert(Survived),
     stop_world(Ctx).
 
 %% Small grid (grid_size=3) without explicit lazy_zones works like before


### PR DESCRIPTION
## Summary

Fixes #248. `world.input` routed straight to `asobi_zone:player_input` using the `zone_pid` cached at join, so a player's interest-zone subscription and zone-owning process never updated as they moved — `view_radius` had no effect in production. `move_player/3`/`handle_move/3` already implemented the correct re-home but had no caller outside the test suite. `asobi_zone` now detects a boundary crossing after each tick and calls `move_player/4`.

Three review passes (architecture-guardian, beam-security-reviewer, erlang-code-reviewer) found real defects in the previously-dead `move_player`/`handle_move` path, all fixed here:

- **CRITICAL** (reproduced live): `pos_to_zone/2` only clamped the low end, so a player walking far enough past the world's edge fed an out-of-grid zone coordinate into `interest_zones/3` / `asobi_world_chat:proximity_zones/3`, both of which crashed on `lists:seq(Lo, Hi)` with `Hi < Lo` — taking the whole world instance down via its `one_for_all` supervisor. Fixed with a grid-clamping `pos_to_zone/3` used everywhere, plus `safe_seq/2` as defence in depth.
- **HIGH**: crossing a boundary reconstructed a bare `#{x, y, type}`, discarding every other entity field a game script keeps (health, inventory, ...). Fixed by carrying the full entity through `move_player/4`.
- **HIGH**: releasing a zone on player-leave never checked for other occupants, racing the periodic reaper into killing a zone other players were still in or watching. Fixed with `zone_still_occupied/3`.
- **MEDIUM** (caught on the third review pass — a first attempt at this looked right but didn't work): a script-owned `"player"`-typed entity (bot/decoy) the world server never joined was still silently destroyed on its first crossing, because `move_player/4` is a cast that always returns `ok` regardless of whether anything claimed the entity. Fixed by never deleting a player locally — only the world server's own accounting removes it once a re-home actually completes.
- Added a `loading`-state postpone clause for `move_player`, mirroring the existing `join` postpone.

**Deferred to a follow-up ticket** (not fixed here, both predate this change but only become reachable now that re-homing runs): no ring set-difference on resubscribe (security review measured 9 redundant full-zone snapshot resends for one crossing, ~1.7 MB/s outbound from an oscillating client), and no hysteresis on the boundary check.

## Test plan

- [x] `rebar3 fmt --check`, `rebar3 xref`, `rebar3 dialyzer` — clean
- [x] `elp eqwalize-all` (OTP 28.4.1) — clean
- [x] `rebar3 eunit` — 422 tests, 0 failures
- [x] New regression tests: player re-homing preserves custom entity fields across a crossing; a position past the world's far edge no longer crashes the world server; a script-owned non-joined `"player"`-typed entity survives a crossing; `pos_to_zone/3` clamps both ends
- [x] Rebased cleanly onto current `origin/main` (post #249/#250/#254)