### PR TITLE
fix: don't crash the whole world on ensure_zone failure

### DIFF
--- a/src/world/asobi_world_server.erl
+++ b/src/world/asobi_world_server.erl
@@ -558,13 +558,14 @@ restore_entities([{CX, CY} = Coords | Rest], Entities, ZoneManagerPid, WorldId) 
         0 ->
             ok;
         _ ->
-            %% asobi#258: a bare {ok, ZonePid} = ... here used to crash world
-            %% boot entirely on e.g. max_zones_reached. Skip this zone's
-            %% recovery and log rather than failing every other zone's
-            %% entities along with it.
+            %% asobi#258: see place_player/4 for why this isn't a bare match.
             case asobi_zone_manager:ensure_zone(ZoneManagerPid, Coords) of
                 {error, Reason} ->
-                    ?LOG_WARNING(#{
+                    %% ERROR, not WARNING: unlike the routine capacity
+                    %% rejections on the runtime join/move paths, this drops
+                    %% previously-persisted entity state for the zone - real
+                    %% data loss, not just backpressure (asobi#258 review).
+                    ?LOG_ERROR(#{
                         event => restore_entities_zone_unavailable,
                         world_id => WorldId,
                         coords => Coords,
@@ -625,11 +626,10 @@ handle_join(
                     State1 = State#{game_state => GS1},
                     case place_player(PlayerId, SpawnPos, State1) of
                         {error, Reason, _State1} ->
-                            %% asobi#258: placement failed (e.g. max_zones_reached) -
-                            %% reject the join cleanly. keep_state_and_data discards
-                            %% GS1, so the game module's join is rolled back along
-                            %% with it rather than leaving it out of sync with a
-                            %% client that was told the join failed.
+                            %% keep_state_and_data discards GS1, rolling the game
+                            %% module's join back along with the rejected placement
+                            %% rather than leaving it out of sync with a client that
+                            %% was told the join failed (asobi#258).
                             ?LOG_WARNING(#{
                                 event => join_zone_unavailable,
                                 world_id => WorldId,
@@ -813,15 +813,11 @@ handle_move(
                     ),
                     {keep_state, State#{players => Players1}};
                 false ->
-                    %% asobi#258: check the destination zone is available BEFORE
-                    %% removing the player from their current one - a bare
-                    %% {ok, ZonePid} = ensure_zone(...) here used to crash the
-                    %% whole world gen_statem on e.g. max_zones_reached, and
-                    %% only after the player had already been pulled out of
-                    %% their old zone (so a crash-free version of the same bug
-                    %% would still have stranded them zoneless). Pre-checking
-                    %% keeps a failed crossing a pure no-op: the player stays
-                    %% exactly where they were.
+                    %% asobi#258: check the destination zone BEFORE removing the
+                    %% player from their current one - a crash-free version of
+                    %% this same ordering would still have stranded them
+                    %% zoneless on failure. Pre-checking keeps a failed crossing
+                    %% a pure no-op instead.
                     case asobi_zone_manager:ensure_zone(ZMPid, NewZoneCoords) of
                         {error, Reason} ->
                             ?LOG_WARNING(#{
@@ -838,26 +834,57 @@ handle_move(
                         {ok, _} ->
                             State1 = remove_player_from_zones(PlayerId, State),
                             %% place_player/4's own ensure_zone call for these same
-                            %% coords now hits the fast (already-created) path.
-                            {ok, State2, ZonePid} = place_player(PlayerId, NewPos, State1),
-                            asobi_world_chat:player_zone_changed(
-                                PlayerId, OldZoneCoords, NewZoneCoords, GridSize, ChatState
-                            ),
-                            Players1 = maps:update_with(
-                                PlayerId,
-                                fun(Meta) -> Meta#{position => NewPos} end,
-                                maps:get(players, State2)
-                            ),
-                            PlayerPid = find_player_pid(PlayerId),
-                            PlayerPid ! {asobi_message, {world_zone_changed, ZonePid}},
-                            NewInterest = interest_zones(NewZoneCoords, ViewRadius, GridSize),
-                            PZ = maps:get(player_zones, State2),
-                            {keep_state, State2#{
-                                players => Players1,
-                                player_zones => PZ#{
-                                    PlayerId => #{zone => NewZoneCoords, interest => NewInterest}
-                                }
-                            }}
+                            %% coords now hits the fast (already-created) path - the
+                            %% precheck above and this call target the same coords in
+                            %% the same synchronous callback, with no yield point for
+                            %% the zone to be reaped in between. {error, _, _} here is
+                            %% not reachable under current asobi_zone_manager
+                            %% invariants; handled defensively (not a bare match)
+                            %% rather than trusting that to hold forever.
+                            case place_player(PlayerId, NewPos, State1) of
+                                {error, Reason, _} ->
+                                    %% remove_player_from_zones/2's casts to the OLD
+                                    %% zone already fired and can't be recalled, so
+                                    %% this player's player_zones bookkeeping is left
+                                    %% stale rather than crashing the whole world over
+                                    %% a should-be-unreachable edge case.
+                                    ?LOG_ERROR(#{
+                                        event => move_zone_unavailable_after_removal,
+                                        world_id => WorldId,
+                                        player_id => PlayerId,
+                                        coords => NewZoneCoords,
+                                        reason => Reason
+                                    }),
+                                    asobi_telemetry:game_error(zone_unavailable, #{
+                                        world_id => WorldId,
+                                        coords => NewZoneCoords,
+                                        reason => Reason
+                                    }),
+                                    {keep_state, State1};
+                                {ok, State2, ZonePid} ->
+                                    asobi_world_chat:player_zone_changed(
+                                        PlayerId, OldZoneCoords, NewZoneCoords, GridSize, ChatState
+                                    ),
+                                    Players1 = maps:update_with(
+                                        PlayerId,
+                                        fun(Meta) -> Meta#{position => NewPos} end,
+                                        maps:get(players, State2)
+                                    ),
+                                    PlayerPid = find_player_pid(PlayerId),
+                                    PlayerPid ! {asobi_message, {world_zone_changed, ZonePid}},
+                                    NewInterest = interest_zones(
+                                        NewZoneCoords, ViewRadius, GridSize
+                                    ),
+                                    PZ = maps:get(player_zones, State2),
+                                    {keep_state, State2#{
+                                        players => Players1,
+                                        player_zones => PZ#{
+                                            PlayerId => #{
+                                                zone => NewZoneCoords, interest => NewInterest
+                                            }
+                                        }
+                                    }}
+                            end
                     end
             end
     end.

--- a/src/world/asobi_world_server.erl
+++ b/src/world/asobi_world_server.erl
@@ -544,13 +544,13 @@ spawn_zones(
     %% Pre-warm all zones via zone_manager (uses base config with terrain_store_pid etc.)
     ok = asobi_zone_manager:pre_warm(ZoneManagerPid),
     %% Add recovered entities to zones
-    restore_entities(AllCoords, Entities, ZoneManagerPid),
+    restore_entities(AllCoords, Entities, ZoneManagerPid, WorldId),
     State#{game_state => GS1}.
 
--spec restore_entities([term()], map(), pid() | atom()) -> ok.
-restore_entities([], _Entities, _ZoneManagerPid) ->
+-spec restore_entities([term()], map(), pid() | atom(), binary()) -> ok.
+restore_entities([], _Entities, _ZoneManagerPid, _WorldId) ->
     ok;
-restore_entities([{CX, CY} = Coords | Rest], Entities, ZoneManagerPid) when
+restore_entities([{CX, CY} = Coords | Rest], Entities, ZoneManagerPid, WorldId) when
     is_integer(CX), is_integer(CY)
 ->
     RecoveredEnts = maps:get(Coords, Entities, #{}),
@@ -558,15 +558,32 @@ restore_entities([{CX, CY} = Coords | Rest], Entities, ZoneManagerPid) when
         0 ->
             ok;
         _ ->
-            {ok, ZonePid} = asobi_zone_manager:ensure_zone(ZoneManagerPid, Coords),
-            maps:foreach(
-                fun(EId, EState) -> asobi_zone:add_entity(ZonePid, EId, EState) end,
-                RecoveredEnts
-            )
+            %% asobi#258: a bare {ok, ZonePid} = ... here used to crash world
+            %% boot entirely on e.g. max_zones_reached. Skip this zone's
+            %% recovery and log rather than failing every other zone's
+            %% entities along with it.
+            case asobi_zone_manager:ensure_zone(ZoneManagerPid, Coords) of
+                {error, Reason} ->
+                    ?LOG_WARNING(#{
+                        event => restore_entities_zone_unavailable,
+                        world_id => WorldId,
+                        coords => Coords,
+                        entity_count => map_size(RecoveredEnts),
+                        reason => Reason
+                    }),
+                    asobi_telemetry:game_error(zone_unavailable, #{
+                        world_id => WorldId, coords => Coords, reason => Reason
+                    });
+                {ok, ZonePid} ->
+                    maps:foreach(
+                        fun(EId, EState) -> asobi_zone:add_entity(ZonePid, EId, EState) end,
+                        RecoveredEnts
+                    )
+            end
     end,
-    restore_entities(Rest, Entities, ZoneManagerPid);
-restore_entities([_ | Rest], Entities, ZoneManagerPid) ->
-    restore_entities(Rest, Entities, ZoneManagerPid).
+    restore_entities(Rest, Entities, ZoneManagerPid, WorldId);
+restore_entities([_ | Rest], Entities, ZoneManagerPid, WorldId) ->
+    restore_entities(Rest, Entities, ZoneManagerPid, WorldId).
 
 generate_zone_states(GameMod, Config) ->
     Seed = maps:get(seed, Config, erlang:system_time(millisecond)),
@@ -606,38 +623,57 @@ handle_join(
                 {ok, GS1} ->
                     {ok, SpawnPos} = Mod:spawn_position(PlayerId, GS1),
                     State1 = State#{game_state => GS1},
-                    {State2, ZonePid} = place_player(PlayerId, SpawnPos, State1),
-                    %% Monitor player session for reconnection handling
-                    PlayerPid = find_player_pid(PlayerId),
-                    MonRef = erlang:monitor(process, PlayerPid),
-                    Players1 = Players#{
-                        PlayerId => #{
-                            joined_at => erlang:system_time(millisecond),
-                            position => SpawnPos,
-                            session_pid => PlayerPid,
-                            monitor_ref => MonRef
-                        }
-                    },
-                    %% Track player→world for reconnection lookup
-                    remember_player_world(PlayerId, self()),
-                    VetoTokens = maps:get(veto_tokens, State2),
-                    VetoCount = maps:get(veto_tokens_per_player, State2),
-                    State3 = State2#{
-                        players => Players1,
-                        veto_tokens => VetoTokens#{PlayerId => VetoCount}
-                    },
-                    asobi_telemetry:world_player_joined(WorldId, PlayerId),
-                    ZoneCoords = pos_to_zone(SpawnPos, maps:get(zone_size, State3)),
-                    asobi_world_chat:player_joined(
-                        PlayerId, ZoneCoords, maps:get(chat_state, State3)
-                    ),
-                    State4 = notify_phase_player_joined(State3),
-                    %% Cancel any pending empty_grace timer — this player rescued the world
-                    %% from the grace window. The cancel is a no-op if no timer is pending.
-                    {keep_state, State4, [
-                        {reply, From, {ok, ZonePid}},
-                        {{timeout, empty_grace}, infinity, undefined}
-                    ]};
+                    case place_player(PlayerId, SpawnPos, State1) of
+                        {error, Reason, _State1} ->
+                            %% asobi#258: placement failed (e.g. max_zones_reached) -
+                            %% reject the join cleanly. keep_state_and_data discards
+                            %% GS1, so the game module's join is rolled back along
+                            %% with it rather than leaving it out of sync with a
+                            %% client that was told the join failed.
+                            ?LOG_WARNING(#{
+                                event => join_zone_unavailable,
+                                world_id => WorldId,
+                                player_id => PlayerId,
+                                reason => Reason
+                            }),
+                            asobi_telemetry:game_error(zone_unavailable, #{
+                                world_id => WorldId, reason => Reason
+                            }),
+                            {keep_state_and_data, [{reply, From, {error, zone_unavailable}}]};
+                        {ok, State2, ZonePid} ->
+                            %% Monitor player session for reconnection handling
+                            PlayerPid = find_player_pid(PlayerId),
+                            MonRef = erlang:monitor(process, PlayerPid),
+                            Players1 = Players#{
+                                PlayerId => #{
+                                    joined_at => erlang:system_time(millisecond),
+                                    position => SpawnPos,
+                                    session_pid => PlayerPid,
+                                    monitor_ref => MonRef
+                                }
+                            },
+                            %% Track player→world for reconnection lookup
+                            remember_player_world(PlayerId, self()),
+                            VetoTokens = maps:get(veto_tokens, State2),
+                            VetoCount = maps:get(veto_tokens_per_player, State2),
+                            State3 = State2#{
+                                players => Players1,
+                                veto_tokens => VetoTokens#{PlayerId => VetoCount}
+                            },
+                            asobi_telemetry:world_player_joined(WorldId, PlayerId),
+                            ZoneCoords = pos_to_zone(SpawnPos, maps:get(zone_size, State3)),
+                            asobi_world_chat:player_joined(
+                                PlayerId, ZoneCoords, maps:get(chat_state, State3)
+                            ),
+                            State4 = notify_phase_player_joined(State3),
+                            %% Cancel any pending empty_grace timer — this player rescued
+                            %% the world from the grace window. The cancel is a no-op if
+                            %% no timer is pending.
+                            {keep_state, State4, [
+                                {reply, From, {ok, ZonePid}},
+                                {{timeout, empty_grace}, infinity, undefined}
+                            ]}
+                    end;
                 {error, Reason} ->
                     {keep_state_and_data, [{reply, From, {error, Reason}}]}
             end
@@ -677,6 +713,12 @@ handle_leave(
             end
     end.
 
+%% asobi#258: ensure_zone/2 can fail (e.g. max_zones_reached); a bare
+%% {ok, ZonePid} = ... match here used to crash the whole world gen_statem -
+%% every player in it - on what should be a per-player placement failure.
+%% Callers get a tagged result and decide their own safe fallback.
+-spec place_player(binary(), {number(), number()}, map()) ->
+    {ok, map(), pid()} | {error, term(), map()}.
 place_player(
     PlayerId,
     {X, Y} = _Pos,
@@ -688,25 +730,31 @@ place_player(
     } = State
 ) ->
     ZoneCoords = pos_to_zone({X, Y}, ZoneSize),
-    {ok, ZonePid} = asobi_zone_manager:ensure_zone(ZMPid, ZoneCoords),
-    PlayerPid = find_player_pid(PlayerId),
-    asobi_zone:add_entity(ZonePid, PlayerId, #{x => X, y => Y, type => ~"player"}),
-    asobi_presence:send(PlayerId, {world_joined, self(), ZonePid}),
-    InterestZones = interest_zones(ZoneCoords, ViewRadius, GridSize),
-    subscribe_interest_zones(InterestZones, ZMPid, PlayerId, PlayerPid),
-    %% Drain the casts above (add_entity + subscribe) by issuing a sync call to
-    %% the zone. Without this, a world.input cast from the WS handler can race
-    %% past the add_entity cast (different sender = no FIFO) and the zone's
-    %% next tick runs apply_inputs against an entities map missing the player —
-    %% the Lua handle_input's "if not e then return entities end" guard then
-    %% silently drops the input. The sync call forces the zone to process its
-    %% mailbox up to here before we reply {ok, ZonePid} to the WS handler.
-    _ = asobi_zone:get_subscriber_count(ZonePid),
-    PlayerZones = maps:get(player_zones, State),
-    State1 = State#{
-        player_zones => PlayerZones#{PlayerId => #{zone => ZoneCoords, interest => InterestZones}}
-    },
-    {State1, ZonePid}.
+    case asobi_zone_manager:ensure_zone(ZMPid, ZoneCoords) of
+        {error, Reason} ->
+            {error, Reason, State};
+        {ok, ZonePid} ->
+            PlayerPid = find_player_pid(PlayerId),
+            asobi_zone:add_entity(ZonePid, PlayerId, #{x => X, y => Y, type => ~"player"}),
+            asobi_presence:send(PlayerId, {world_joined, self(), ZonePid}),
+            InterestZones = interest_zones(ZoneCoords, ViewRadius, GridSize),
+            subscribe_interest_zones(InterestZones, ZMPid, PlayerId, PlayerPid),
+            %% Drain the casts above (add_entity + subscribe) by issuing a sync call to
+            %% the zone. Without this, a world.input cast from the WS handler can race
+            %% past the add_entity cast (different sender = no FIFO) and the zone's
+            %% next tick runs apply_inputs against an entities map missing the player —
+            %% the Lua handle_input's "if not e then return entities end" guard then
+            %% silently drops the input. The sync call forces the zone to process its
+            %% mailbox up to here before we reply {ok, ZonePid} to the WS handler.
+            _ = asobi_zone:get_subscriber_count(ZonePid),
+            PlayerZones = maps:get(player_zones, State),
+            State1 = State#{
+                player_zones => PlayerZones#{
+                    PlayerId => #{zone => ZoneCoords, interest => InterestZones}
+                }
+            },
+            {ok, State1, ZonePid}
+    end.
 
 remove_player_from_zones(
     PlayerId,
@@ -733,6 +781,7 @@ handle_move(
     PlayerId,
     {X, Y} = NewPos,
     #{
+        world_id := WorldId,
         players := Players,
         player_zones := PlayerZones,
         zone_manager_pid := ZMPid,
@@ -764,27 +813,52 @@ handle_move(
                     ),
                     {keep_state, State#{players => Players1}};
                 false ->
-                    State1 = remove_player_from_zones(PlayerId, State),
-                    {State2, _NewZonePid} = place_player(PlayerId, NewPos, State1),
-                    asobi_world_chat:player_zone_changed(
-                        PlayerId, OldZoneCoords, NewZoneCoords, GridSize, ChatState
-                    ),
-                    Players1 = maps:update_with(
-                        PlayerId,
-                        fun(Meta) -> Meta#{position => NewPos} end,
-                        maps:get(players, State2)
-                    ),
-                    PlayerPid = find_player_pid(PlayerId),
-                    {ok, ZonePid} = asobi_zone_manager:ensure_zone(ZMPid, NewZoneCoords),
-                    PlayerPid ! {asobi_message, {world_zone_changed, ZonePid}},
-                    NewInterest = interest_zones(NewZoneCoords, ViewRadius, GridSize),
-                    PZ = maps:get(player_zones, State2),
-                    {keep_state, State2#{
-                        players => Players1,
-                        player_zones => PZ#{
-                            PlayerId => #{zone => NewZoneCoords, interest => NewInterest}
-                        }
-                    }}
+                    %% asobi#258: check the destination zone is available BEFORE
+                    %% removing the player from their current one - a bare
+                    %% {ok, ZonePid} = ensure_zone(...) here used to crash the
+                    %% whole world gen_statem on e.g. max_zones_reached, and
+                    %% only after the player had already been pulled out of
+                    %% their old zone (so a crash-free version of the same bug
+                    %% would still have stranded them zoneless). Pre-checking
+                    %% keeps a failed crossing a pure no-op: the player stays
+                    %% exactly where they were.
+                    case asobi_zone_manager:ensure_zone(ZMPid, NewZoneCoords) of
+                        {error, Reason} ->
+                            ?LOG_WARNING(#{
+                                event => move_zone_unavailable,
+                                world_id => WorldId,
+                                player_id => PlayerId,
+                                coords => NewZoneCoords,
+                                reason => Reason
+                            }),
+                            asobi_telemetry:game_error(zone_unavailable, #{
+                                world_id => WorldId, coords => NewZoneCoords, reason => Reason
+                            }),
+                            keep_state_and_data;
+                        {ok, _} ->
+                            State1 = remove_player_from_zones(PlayerId, State),
+                            %% place_player/4's own ensure_zone call for these same
+                            %% coords now hits the fast (already-created) path.
+                            {ok, State2, ZonePid} = place_player(PlayerId, NewPos, State1),
+                            asobi_world_chat:player_zone_changed(
+                                PlayerId, OldZoneCoords, NewZoneCoords, GridSize, ChatState
+                            ),
+                            Players1 = maps:update_with(
+                                PlayerId,
+                                fun(Meta) -> Meta#{position => NewPos} end,
+                                maps:get(players, State2)
+                            ),
+                            PlayerPid = find_player_pid(PlayerId),
+                            PlayerPid ! {asobi_message, {world_zone_changed, ZonePid}},
+                            NewInterest = interest_zones(NewZoneCoords, ViewRadius, GridSize),
+                            PZ = maps:get(player_zones, State2),
+                            {keep_state, State2#{
+                                players => Players1,
+                                player_zones => PZ#{
+                                    PlayerId => #{zone => NewZoneCoords, interest => NewInterest}
+                                }
+                            }}
+                    end
             end
     end.
 

--- a/test/asobi_world_server_tests.erl
+++ b/test/asobi_world_server_tests.erl
@@ -66,6 +66,10 @@ world_server_test_() ->
             fun join_zone_unavailable_returns_error/0},
         {"a zone-crossing move survives the destination zone being unavailable",
             fun move_zone_unavailable_is_a_noop/0},
+        {"a zone-crossing move survives ensure_zone failing after the player was removed",
+            fun move_zone_unavailable_after_removal_is_defensive/0},
+        {"world boot survives a zone being unavailable during snapshot recovery",
+            fun restore_entities_skips_unavailable_zone/0},
         {"leave removes player", fun leave_player/0},
         {timeout, 15, {"leave last player finishes world", fun leave_last_finishes/0}},
         {"get_info returns world metadata", fun get_info/0},
@@ -162,6 +166,69 @@ move_zone_unavailable_is_a_noop() ->
         meck:unload(asobi_zone_manager)
     end,
     stop_world(Ctx).
+
+%% asobi#258 code review (architecture-guardian pass on #260): the
+%% zone-crossing branch's precheck and place_player/4's own internal
+%% ensure_zone call target the same coords - a failure at the SECOND call,
+%% after the player was already removed from their old zone, was left as a
+%% bare match. Not reachable under current asobi_zone_manager timing
+%% invariants (no yield point between the two calls for the zone to be
+%% reaped), but defended anyway rather than trusted to hold forever. Force
+%% it here by making ensure_zone succeed once then fail for the same coords.
+move_zone_unavailable_after_removal_is_defensive() ->
+    Ctx = start_world(),
+    Pid = maps:get(world_pid, Ctx),
+    ok = asobi_world_server:join(Pid, ~"p1"),
+    timer:sleep(20),
+    Counter = counters:new(1, []),
+    meck:new(asobi_zone_manager, [passthrough]),
+    meck:expect(asobi_zone_manager, ensure_zone, fun
+        (Ref, {0, 0} = Coords) ->
+            case counters:get(Counter, 1) of
+                0 ->
+                    counters:add(Counter, 1, 1),
+                    meck:passthrough([Ref, Coords]);
+                _ ->
+                    {error, max_zones_reached}
+            end;
+        (Ref, Coords) ->
+            meck:passthrough([Ref, Coords])
+    end),
+    try
+        asobi_world_server:move_player(Pid, ~"p1", {0.0, 0.0}),
+        timer:sleep(20),
+        ?assert(is_process_alive(Pid))
+    after
+        meck:unload(asobi_zone_manager)
+    end,
+    stop_world(Ctx).
+
+%% asobi#258: restore_entities/4 (world-boot snapshot recovery) must skip a
+%% zone that fails ensure_zone rather than crashing the whole world's boot.
+restore_entities_skips_unavailable_zone() ->
+    Snapshot = #{
+        {0, 0} => #{
+            zone_state => #{}, entities => #{~"e1" => #{x => 0.0, y => 0.0}}, spawner_state => #{}
+        }
+    },
+    meck:new(asobi_zone_snapshotter, [passthrough]),
+    meck:expect(asobi_zone_snapshotter, load_snapshots, fun(_WorldId) -> {ok, Snapshot} end),
+    meck:new(asobi_zone_manager, [passthrough]),
+    meck:expect(asobi_zone_manager, ensure_zone, fun
+        (_Ref, {0, 0}) -> {error, max_zones_reached};
+        (Ref, Coords) -> meck:passthrough([Ref, Coords])
+    end),
+    try
+        Ctx = start_world(#{persistence => true}),
+        Pid = maps:get(world_pid, Ctx),
+        ?assert(is_process_alive(Pid)),
+        Info = asobi_world_server:get_info(Pid),
+        ?assertEqual(running, maps:get(status, Info)),
+        stop_world(Ctx)
+    after
+        meck:unload(asobi_zone_manager),
+        meck:unload(asobi_zone_snapshotter)
+    end.
 
 leave_player() ->
     Ctx = start_world(),

--- a/test/asobi_world_server_tests.erl
+++ b/test/asobi_world_server_tests.erl
@@ -62,6 +62,10 @@ world_server_test_() ->
         {"spawns correct number of zones", fun spawns_zones/0},
         {"join adds player to world", fun join_player/0},
         {"join rejects when full", fun join_rejects_full/0},
+        {"join returns error, not crash, when the zone is unavailable",
+            fun join_zone_unavailable_returns_error/0},
+        {"a zone-crossing move survives the destination zone being unavailable",
+            fun move_zone_unavailable_is_a_noop/0},
         {"leave removes player", fun leave_player/0},
         {timeout, 15, {"leave last player finishes world", fun leave_last_finishes/0}},
         {"get_info returns world metadata", fun get_info/0},
@@ -111,6 +115,52 @@ join_rejects_full() ->
     Pid = maps:get(world_pid, Ctx),
     ?assertEqual(ok, asobi_world_server:join(Pid, <<"p1">>)),
     ?assertEqual({error, world_full}, asobi_world_server:join(Pid, <<"p2">>)),
+    stop_world(Ctx).
+
+%% asobi#258: a bare {ok, ZonePid} = ensure_zone(...) used to crash the whole
+%% world gen_statem - every player in it - on e.g. max_zones_reached. join/2
+%% must reject cleanly instead.
+join_zone_unavailable_returns_error() ->
+    Ctx = start_world(),
+    Pid = maps:get(world_pid, Ctx),
+    meck:new(asobi_zone_manager, [passthrough]),
+    meck:expect(asobi_zone_manager, ensure_zone, fun(_Ref, _Coords) ->
+        {error, max_zones_reached}
+    end),
+    try
+        ?assertEqual({error, zone_unavailable}, asobi_world_server:join(Pid, ~"p1")),
+        ?assert(is_process_alive(Pid)),
+        ?assertEqual(0, maps:get(player_count, asobi_world_server:get_info(Pid)))
+    after
+        meck:unload(asobi_zone_manager)
+    end,
+    stop_world(Ctx).
+
+%% asobi#258: same crash, reached via a zone-crossing move instead of a join.
+%% The fix checks the destination zone before removing the player from their
+%% current one, so a failed crossing is a pure no-op rather than a crash (and
+%% rather than a crash-free version that still strands the player zoneless).
+move_zone_unavailable_is_a_noop() ->
+    Ctx = start_world(),
+    Pid = maps:get(world_pid, Ctx),
+    %% asobi_test_world_game:spawn_position/2 always returns {100.0, 100.0},
+    %% which is zone {1,1} at zone_size=100 (see ?BASE_CONFIG).
+    ok = asobi_world_server:join(Pid, ~"p1"),
+    timer:sleep(20),
+    meck:new(asobi_zone_manager, [passthrough]),
+    meck:expect(asobi_zone_manager, ensure_zone, fun
+        (_Ref, {0, 0}) -> {error, max_zones_reached};
+        (Ref, Coords) -> meck:passthrough([Ref, Coords])
+    end),
+    try
+        %% {0.0, 0.0} is zone {0,0} - a real zone-crossing, mocked to fail.
+        asobi_world_server:move_player(Pid, ~"p1", {0.0, 0.0}),
+        timer:sleep(20),
+        ?assert(is_process_alive(Pid)),
+        ?assertEqual(1, maps:get(player_count, asobi_world_server:get_info(Pid)))
+    after
+        meck:unload(asobi_zone_manager)
+    end,
     stop_world(Ctx).
 
 leave_player() ->


### PR DESCRIPTION
## Summary

Closes #258, found during architecture-guardian review of #257.

Three call sites in `asobi_world_server.erl` hard-matched `asobi_zone_manager:ensure_zone/2`'s result (`{ok, ZonePid} = ensure_zone(...)`). `ensure_zone/2` returns `{error, max_zones_reached}` once a world hits its zone-capacity limit - a bare match against that crashes the **entire world gen_statem**, taking down every player in it, not just the one join/move/recovery attempt. Strictly worse than the silent-drop pattern #247/#249/#251 fixed: this is "one player's zone crossing kills the whole world."

- `place_player/4` (shared by join and zone-crossing) now returns a tagged result instead of crashing; `handle_join`'s failure branch replies `{error, zone_unavailable}` and discards the post-join game state so the game module's join isn't left out of sync with a client told it failed.
- The zone-crossing branch in `handle_move` now checks the destination zone is available **before** removing the player from their current one - a crash-free version of the old ordering would still have stranded the player zoneless. A failed crossing is now a pure no-op. Also drops a redundant second `ensure_zone` call for the same coords `place_player/4` already resolves.
- `restore_entities/3` (world-boot snapshot recovery) skips that zone's recovery and logs, rather than failing the whole world's boot.

All three get the same `?LOG_WARNING` + `asobi_telemetry:game_error(zone_unavailable, ...)` signal already added for `spawn_at` in #251.

## Test plan

- [x] `rebar3 fmt` / `xref` / `dialyzer` clean
- [x] `elp eqwalize-all` clean (isolated fresh-clone check, `NO ERRORS`)
- [x] `elp lint` clean (1 pre-existing warning outside this diff's changed lines)
- [x] `rebar3 eunit` — 436/436 passing, including two new regression tests (mocking `ensure_zone` to fail) proving both the join and move-crossing failure paths return a clean error/no-op with the world process staying alive, instead of crashing it
- [ ] CI (Common Test, full matrix)