### PR TITLE
fix: bound log-line volume from per-tick script-driven error paths

### DIFF
--- a/src/asobi_script_log_limiter.erl
+++ b/src/asobi_script_log_limiter.erl
@@ -18,7 +18,7 @@ more like this were suppressed" instead of the gap just looking like the
 failure stopped.
 """.
 
--export([allow/1, init_table/0]).
+-export([allow/1, forget/1, init_table/0]).
 
 -define(DROP_TABLE, asobi_script_log_limiter_drops).
 
@@ -63,6 +63,22 @@ allow(Key) ->
     catch
         error:{limiter_not_found, _} -> {true, take_dropped(Key)};
         error:badarg -> {true, take_dropped(Key)}
+    end.
+
+-doc """
+Drop any pending drop-count row for `Key`. Callers whose Key's lifetime is
+bounded (e.g. a zone process, keyed on `{WorldId, Coords}`) should call this
+when that lifetime ends, so a Key that suppressed a log line right before
+terminating doesn't leave a permanent stale row behind.
+""".
+-spec forget(term()) -> ok.
+forget(Key) ->
+    case ets:whereis(?DROP_TABLE) of
+        undefined ->
+            ok;
+        _ ->
+            _ = ets:delete(?DROP_TABLE, Key),
+            ok
     end.
 
 -spec take_dropped(term()) -> non_neg_integer().

--- a/src/asobi_script_log_limiter.erl
+++ b/src/asobi_script_log_limiter.erl
@@ -1,0 +1,89 @@
+-module(asobi_script_log_limiter).
+-moduledoc """
+Bounds the rate of *log lines* emitted from per-tick, script-driven error
+paths - a game script that fails on every tick (a typo'd spawn template, a
+Lua callback that always raises) would otherwise log once per tick forever
+(asobi#252). Telemetry counters are unaffected: `asobi_telemetry:game_error/2`
+is cheap to aggregate at any volume and callers should keep emitting it
+unconditionally so dashboards/alerts see the true failure rate. Only the
+disk/log-aggregator cost of the structured log line itself is bounded here.
+
+Backed by the existing `seki` limiter (`asobi_script_log_limiter`,
+registered in `asobi_sup`), keyed per call site by whatever the caller
+considers "the same recurring failure" - typically `{WorldId, Coords}` for
+a zone or `{Script, Callback}` for a Lua callback. Suppressed calls are not
+silently dropped: `allow/1` returns how many were suppressed since the last
+allowed call, so the next log line that does get through can say "and N
+more like this were suppressed" instead of the gap just looking like the
+failure stopped.
+""".
+
+-export([allow/1, init_table/0]).
+
+-define(DROP_TABLE, asobi_script_log_limiter_drops).
+
+-doc "Create the drop-count table once at boot (asobi_sup); idempotent.".
+-spec init_table() -> ok.
+init_table() ->
+    case ets:whereis(?DROP_TABLE) of
+        undefined ->
+            _ = ets:new(?DROP_TABLE, [
+                named_table, public, set, {write_concurrency, true}
+            ]),
+            ok;
+        _ ->
+            ok
+    end.
+
+-doc """
+Check whether a log line for `Key` is allowed right now.
+
+Returns `{true, PreviouslyDropped}` when the caller should log -
+`PreviouslyDropped` is the count of calls suppressed for this `Key` since
+the last time `allow/1` returned `true` (0 the first time / when nothing
+was suppressed). Returns `false` when the caller should skip logging this
+occurrence (the drop is still counted for the next allowed call to report).
+""".
+-spec allow(term()) -> {true, non_neg_integer()} | false.
+allow(Key) ->
+    %% Fail open (allow, don't crash the caller) if seki isn't available -
+    %% this is an observability feature, not a security control, so a
+    %% misconfigured/test environment should over-log rather than take down
+    %% the caller. asobi_sup:register_limiters/0 registers the limiter (and
+    %% starts seki) in a real boot; lightweight eunit setups (e.g.
+    %% asobi_zone_tests) don't - `{limiter_not_found, _}` covers seki running
+    %% with no matching limiter, `badarg` covers seki's own registry table
+    %% not existing at all (its application/supervisor never started).
+    try seki:check(asobi_script_log_limiter, Key) of
+        {allow, _} ->
+            {true, take_dropped(Key)};
+        {deny, _} ->
+            bump_dropped(Key),
+            false
+    catch
+        error:{limiter_not_found, _} -> {true, take_dropped(Key)};
+        error:badarg -> {true, take_dropped(Key)}
+    end.
+
+-spec take_dropped(term()) -> non_neg_integer().
+take_dropped(Key) ->
+    case ets:whereis(?DROP_TABLE) of
+        %% Table not started (e.g. eunit without asobi_sup) - nothing to take.
+        undefined ->
+            0;
+        _ ->
+            case ets:take(?DROP_TABLE, Key) of
+                [{_, N}] when is_integer(N) -> N;
+                _ -> 0
+            end
+    end.
+
+-spec bump_dropped(term()) -> ok.
+bump_dropped(Key) ->
+    case ets:whereis(?DROP_TABLE) of
+        undefined ->
+            ok;
+        _ ->
+            _ = ets:update_counter(?DROP_TABLE, Key, {2, 1}, {Key, 0}),
+            ok
+    end.

--- a/src/asobi_script_log_limiter.erl
+++ b/src/asobi_script_log_limiter.erl
@@ -53,7 +53,12 @@ allow(Key) ->
     %% starts seki) in a real boot; lightweight eunit setups (e.g.
     %% asobi_zone_tests) don't - `{limiter_not_found, _}` covers seki running
     %% with no matching limiter, `badarg` covers seki's own registry table
-    %% not existing at all (its application/supervisor never started).
+    %% not existing at all (its application/supervisor never started). Both
+    %% catches are scoped to the whole seki:check/2 call, not narrowed to
+    %% exactly those two failure points inside it - a badarg raised for any
+    %% other reason in seki's call chain also fails open here. Acceptable
+    %% for a fail-open, non-security path; not narrowable further without a
+    %% seki API change.
     try seki:check(asobi_script_log_limiter, Key) of
         {allow, _} ->
             {true, take_dropped(Key)};

--- a/src/asobi_sup.erl
+++ b/src/asobi_sup.erl
@@ -151,7 +151,14 @@ register_limiters() ->
         %% Global (not per-IP) bound on guest-create throughput. Guest rows are
         %% minted unauthenticated and cheaply, so a per-IP limit alone lets a
         %% botnet spam rows; this caps the total rate. Keyed on a constant.
-        guest_global => #{algorithm => sliding_window, limit => 100, window => 1000}
+        guest_global => #{algorithm => sliding_window, limit => 100, window => 1000},
+        %% asobi#252: bounds LOG LINES (not the telemetry counter, which stays
+        %% unconditional - see asobi_script_log_limiter's moduledoc) from a
+        %% script that fails on every tick. Keyed per call site's own choice
+        %% of "same recurring failure" (typically per zone or per callback),
+        %% so one broken zone/script doesn't starve another's visibility.
+        %% Generous: this is about volume, not adversarial abuse.
+        script_log => #{algorithm => sliding_window, limit => 3, window => 10_000}
     },
     Configured =
         case application:get_env(asobi, rate_limits, #{}) of
@@ -171,6 +178,7 @@ register_limiters() ->
         end,
         Defaults
     ),
+    asobi_script_log_limiter:init_table(),
     ignore.
 
 limiter_name(auth) -> asobi_auth_limiter;
@@ -179,7 +187,8 @@ limiter_name(iap) -> asobi_iap_limiter;
 limiter_name(api) -> asobi_api_limiter;
 limiter_name(ws_connect) -> asobi_ws_connect_limiter;
 limiter_name(join) -> asobi_join_limiter;
-limiter_name(guest_global) -> asobi_guest_global_limiter.
+limiter_name(guest_global) -> asobi_guest_global_limiter;
+limiter_name(script_log) -> asobi_script_log_limiter.
 
 cluster_spec() ->
     #{

--- a/src/world/asobi_zone.erl
+++ b/src/world/asobi_zone.erl
@@ -764,13 +764,22 @@ log_spawn_failed(TemplateId, Reason, #{world_id := WorldId, coords := Coords}) -
     %% Caller-supplied (a Lua script can pass player input straight through
     %% to game.zone.spawn); game_error/2 requires bounded details.
     Id = bound_template_id(TemplateId),
-    ?LOG_WARNING(#{
-        event => zone_spawn_failed,
-        world_id => WorldId,
-        coords => Coords,
-        template_id => Id,
-        reason => Reason
-    }),
+    %% asobi#252: a tick-loop script with a typo'd template_id logs once per
+    %% tick forever. The telemetry counter stays unconditional so dashboards
+    %% see the true rate; only the log line itself is rate-limited per zone.
+    case asobi_script_log_limiter:allow({WorldId, Coords}) of
+        {true, DroppedSinceLastLog} ->
+            ?LOG_WARNING(#{
+                event => zone_spawn_failed,
+                world_id => WorldId,
+                coords => Coords,
+                template_id => Id,
+                reason => Reason,
+                suppressed_since_last => DroppedSinceLastLog
+            });
+        false ->
+            ok
+    end,
     asobi_telemetry:game_error(unknown_spawn_template, #{
         world_id => WorldId,
         template_id => Id

--- a/src/world/asobi_zone.erl
+++ b/src/world/asobi_zone.erl
@@ -432,12 +432,16 @@ terminate(normal, #{world_id := WorldId, coords := Coords} = State) ->
     maybe_final_snapshot(State),
     clear_zone_backup(WorldId, Coords),
     notify_zone_manager_terminated(State),
+    %% asobi#252 review: a zone that ever suppressed a log line leaves a
+    %% permanent drop-count row otherwise - this Key's lifetime ends here.
+    asobi_script_log_limiter:forget({WorldId, Coords}),
     pg:leave(?PG_SCOPE, {asobi_zone, WorldId, Coords}, self()),
     ok;
 terminate({shutdown, _}, #{world_id := WorldId, coords := Coords} = State) ->
     maybe_final_snapshot(State),
     clear_zone_backup(WorldId, Coords),
     notify_zone_manager_terminated(State),
+    asobi_script_log_limiter:forget({WorldId, Coords}),
     pg:leave(?PG_SCOPE, {asobi_zone, WorldId, Coords}, self()),
     ok;
 terminate(_Reason, #{world_id := WorldId, coords := Coords, entities := Entities} = State) ->
@@ -445,6 +449,7 @@ terminate(_Reason, #{world_id := WorldId, coords := Coords, entities := Entities
     maybe_final_snapshot(State),
     backup_zone_state(WorldId, Coords, Entities),
     notify_zone_manager_terminated(State),
+    asobi_script_log_limiter:forget({WorldId, Coords}),
     pg:leave(?PG_SCOPE, {asobi_zone, WorldId, Coords}, self()),
     ok.
 

--- a/test/asobi_script_log_limiter_tests.erl
+++ b/test/asobi_script_log_limiter_tests.erl
@@ -24,7 +24,9 @@ script_log_limiter_test_() ->
         {"buckets are per key", fun per_key_buckets/0},
         {"a denied call is counted and reported on the next allow",
             fun reports_dropped_count_on_next_allow/0},
-        {"an allowed call with nothing suppressed reports zero", fun reports_zero_when_clean/0}
+        {"an allowed call with nothing suppressed reports zero", fun reports_zero_when_clean/0},
+        {"forget drops a pending count so a later allow reports zero, not stale",
+            fun forget_clears_pending_drop_count/0}
     ]}.
 
 denies_past_limit() ->
@@ -59,6 +61,22 @@ reports_dropped_count_on_next_allow() ->
 reports_zero_when_clean() ->
     Key = unique_key(),
     ?assertEqual({true, 0}, asobi_script_log_limiter:allow(Key)).
+
+%% asobi#252 review (used from asobi_zone:terminate/2): a Key with a bounded
+%% lifetime (a zone's {WorldId, Coords}) must not leave a stale drop-count
+%% row behind forever once that lifetime ends.
+forget_clears_pending_drop_count() ->
+    Key = unique_key(),
+    [asobi_script_log_limiter:allow(Key) || _ <- lists:seq(1, 3)],
+    %% Suppressed once - a pending count is now sitting in the drop table.
+    ?assertEqual(false, asobi_script_log_limiter:allow(Key)),
+    ok = asobi_script_log_limiter:forget(Key),
+    catch seki:reset(?LIMITER, Key),
+    ?assertEqual(
+        {true, 0},
+        asobi_script_log_limiter:allow(Key),
+        "forget/1 must clear the pending count, not just let the next allow report it"
+    ).
 
 unique_key() ->
     {test, erlang:unique_integer([positive])}.

--- a/test/asobi_script_log_limiter_tests.erl
+++ b/test/asobi_script_log_limiter_tests.erl
@@ -1,0 +1,64 @@
+-module(asobi_script_log_limiter_tests).
+-include_lib("eunit/include/eunit.hrl").
+
+%% asobi#252: a tick-loop script that fails on every tick must not flood the
+%% logs forever. These pin that the limiter actually suppresses past its
+%% configured rate, that suppression is scoped per key (one broken zone/script
+%% doesn't silence another's), and that a suppressed run is reported (not
+%% just silently swallowed) the next time a log line is allowed through.
+
+-define(LIMITER, asobi_script_log_limiter).
+
+setup() ->
+    application:ensure_all_started(seki),
+    catch seki:new_limiter(?LIMITER, #{algorithm => sliding_window, limit => 3, window => 60000}),
+    ok = asobi_script_log_limiter:init_table(),
+    ok.
+
+cleanup(_) ->
+    ok.
+
+script_log_limiter_test_() ->
+    {setup, fun setup/0, fun cleanup/1, [
+        {"allows up to the limit then denies", fun denies_past_limit/0},
+        {"buckets are per key", fun per_key_buckets/0},
+        {"a denied call is counted and reported on the next allow",
+            fun reports_dropped_count_on_next_allow/0},
+        {"an allowed call with nothing suppressed reports zero", fun reports_zero_when_clean/0}
+    ]}.
+
+denies_past_limit() ->
+    Key = unique_key(),
+    [?assertMatch({true, _}, asobi_script_log_limiter:allow(Key)) || _ <- lists:seq(1, 3)],
+    ?assertEqual(
+        false,
+        asobi_script_log_limiter:allow(Key),
+        "an unbounded per-tick log rate is exactly what this exists to prevent"
+    ).
+
+per_key_buckets() ->
+    A = unique_key(),
+    B = unique_key(),
+    [?assertMatch({true, _}, asobi_script_log_limiter:allow(A)) || _ <- lists:seq(1, 3)],
+    ?assertEqual(false, asobi_script_log_limiter:allow(A)),
+    ?assertMatch(
+        {true, _},
+        asobi_script_log_limiter:allow(B),
+        "one key's broken script must not silence another key's logs"
+    ).
+
+reports_dropped_count_on_next_allow() ->
+    Key = unique_key(),
+    [asobi_script_log_limiter:allow(Key) || _ <- lists:seq(1, 3)],
+    %% Deny window: 2 suppressed calls before the bucket refills.
+    ?assertEqual(false, asobi_script_log_limiter:allow(Key)),
+    ?assertEqual(false, asobi_script_log_limiter:allow(Key)),
+    catch seki:reset(?LIMITER, Key),
+    ?assertEqual({true, 2}, asobi_script_log_limiter:allow(Key)).
+
+reports_zero_when_clean() ->
+    Key = unique_key(),
+    ?assertEqual({true, 0}, asobi_script_log_limiter:allow(Key)).
+
+unique_key() ->
+    {test, erlang:unique_integer([positive])}.

--- a/test/asobi_zone_lifecycle_tests.erl
+++ b/test/asobi_zone_lifecycle_tests.erl
@@ -41,7 +41,10 @@ zone_lifecycle_test_() ->
     {setup, fun setup/0, fun cleanup/1, [
         {"init_zone_state runs via handle_continue", fun init_zone_state_runs/0},
         {"game module without the callback is unaffected", fun no_callback_unaffected/0},
-        {"dump_zone_state strips the runtime before snapshot", fun dump_zone_state_strips_runtime/0}
+        {"dump_zone_state strips the runtime before snapshot",
+            fun dump_zone_state_strips_runtime/0},
+        {"terminating a zone clears its pending script-log drop count",
+            fun terminate_clears_script_log_drop_row/0}
     ]}.
 
 init_zone_state_runs() ->
@@ -83,3 +86,27 @@ dump_zone_state_strips_runtime() ->
     after
         meck:unload(asobi_zone_snapshotter)
     end.
+
+%% asobi#252 code review: asobi_script_log_limiter:forget/1 is called from
+%% all three terminate/2 clauses, but nothing proved it - deleting the call
+%% left the full suite green. Seed a drop-count row directly (bypassing
+%% seki/rate-limiting entirely) and drive the normal-termination path to
+%% confirm the row is actually gone afterward, not just that forget/1 works
+%% in isolation (already covered by asobi_script_log_limiter_tests). Only
+%% the `normal` reason is exercised here: start_zone/2 links the zone to
+%% this test process (via start_link/1, never unlinked in this file), and
+%% the other two terminate/2 clauses ({shutdown, _} and any other reason)
+%% both propagate as a fatal EXIT signal to a non-trapping linked process -
+%% stopping via either would kill the test process itself, not just the
+%% zone. All three clauses call forget/1 identically (same call, same
+%% position, before pg:leave), so this single case already protects the
+%% wiring a refactor could plausibly break.
+terminate_clears_script_log_drop_row() ->
+    ok = asobi_script_log_limiter:init_table(),
+    WorldId = ~"lc_normal",
+    Coords = {9, 1},
+    Key = {WorldId, Coords},
+    true = ets:insert(asobi_script_log_limiter_drops, {Key, 3}),
+    Pid = start_zone(asobi_test_world_game, #{world_id => WorldId, coords => Coords}),
+    gen_server:stop(Pid),
+    ?assertEqual([], ets:lookup(asobi_script_log_limiter_drops, Key)).


### PR DESCRIPTION
## Summary

Refs #252 (this repo's half - see below; the asobi_lua half needs its own PR, so this doesn't close the tracking issue on merge).

`log_spawn_failed/3` (added in #249) has no rate limit - a tick-loop Lua script with a typo'd spawn template logs once per tick forever. Adds `asobi_script_log_limiter`, a thin wrapper around a new `seki` limiter (3 log lines per key per 10s), matching the existing house pattern (`asobi_sup:register_limiters/0`).

Telemetry stays unconditional - `asobi_telemetry:game_error/2` is cheap to aggregate at any rate and dashboards should see the true failure count - only the structured `?LOG_WARNING` line itself is gated. Suppressed calls aren't silently lost: `allow/1` returns how many were dropped since the last allowed call, so the next line through reports "N similar events suppressed" instead of the gap looking like the failure stopped.

Wired into `asobi_zone:log_spawn_failed/3`, keyed per `{WorldId, Coords}`.

Fails open (never crashes the caller) if `seki` isn't available - covers both "the limiter isn't registered" and "seki's own registry never started at all", the latter being what every eunit test file that doesn't boot the full `asobi_sup` tree hits (including `asobi_zone_tests`, which exercises this exact path). Verified via architecture review: `seki` is a real, always-started OTP application dependency in production (both `nova_resilience` and `shigoto` already declare it in `asobi.app.src`'s dependency chain), so this fail-open path is provably eunit-only, never production-reachable.

Also fixes a drop-table row leak the architecture review found: `asobi_script_log_limiter_drops` never cleaned up a zone's row on termination, so a zone that ever suppressed a log line and then terminated left a permanent stale entry. `asobi_zone:terminate/2` now clears it alongside its other per-zone cleanup - and per code review, this wiring is now covered by a regression test (`asobi_zone_lifecycle_tests:terminate_clears_script_log_drop_row`), verified to actually fail when the `forget/1` call is removed.

**Scope note:** the issue also asks for the same treatment on `asobi_lua`'s `log_lua_error/3` - that's a separate repository. It needs its own PR once it bumps its `asobi` pin to include this change; will follow up there directly.

## Test plan

- [x] `rebar3 fmt` / `xref` / `dialyzer` clean
- [x] `elp eqwalize-all` clean (isolated fresh-clone check, `NO ERRORS`)
- [x] `elp lint` clean except 2 pre-existing warnings outside this diff's changed lines, and 6 `catch`-deprecation diagnostics (3 call sites x 2 diagnostics each) in the new test file matching an already-accepted house pattern (`test/asobi_join_limiter_tests.erl`)
- [x] `rebar3 eunit` — 442/442 passing, including `asobi_script_log_limiter_tests` (rate-limiting, per-key isolation, drop-count reporting, `forget/1` clearing a pending count) and a new `asobi_zone_lifecycle_tests` case proving `terminate/2` actually calls `forget/1` (not just that `forget/1` works in isolation)

## Review

- architecture-guardian: ACCEPT. Confirmed the fail-open path is provably eunit-only, the telemetry/log split is correctly drawn, key granularity is the right tradeoff, and ETS growth is bounded. Found the drop-table cleanup gap, fixed in a follow-up push.
- erlang-code-reviewer: found the `terminate/2` wiring had no regression test (verified by deleting the call - suite stayed green) - fixed in this push, verified the new test actually catches the regression. Also flagged the lint-count and comment-scope items above, both addressed.