### PR TITLE
feat: let a live zone pick up spawn template updates via a per-tick hint

### DIFF
--- a/guides/world-server.md
+++ b/guides/world-server.md
@@ -444,6 +444,11 @@ owns the cost of deciding whether anything actually changed (e.g. only doing
 real work right after its own hot-reload check fires), not this callback
 being a place to unconditionally re-derive templates every tick.
 
+`NewTemplates` **replaces** the zone's whole template set, the same as
+`spawn_templates/1`'s result does at creation - it is not a delta. Include
+every template that should still be spawnable, not only the ones that
+changed, or the rest silently stop being spawnable.
+
 ```erlang
 spawn_templates_hint(ZoneState) ->
     case just_reloaded(ZoneState) of

--- a/guides/world-server.md
+++ b/guides/world-server.md
@@ -430,6 +430,28 @@ spawns: `game.zone.spawn` has no return value to report the failure. The zone
 logs a `zone_spawn_failed` warning with the `world_id` and `coords`, and
 emits `[asobi, error]` with `kind => unknown_spawn_template`.
 
+### Updating templates in an already-running zone
+
+`spawn_templates/1` is only ever called once, at zone creation - a template
+added later (e.g. via a script hot-reload) never reaches a zone that's
+already running; it stays invisible to that zone until the zone is recreated.
+
+The optional `spawn_templates_hint/1` Erlang callback closes this: it runs
+every tick, and returning `{changed, NewTemplates}` pushes an updated
+template set into the live zone immediately. Return `unchanged` in the
+common case - this runs on the hot path, so a game module implementing it
+owns the cost of deciding whether anything actually changed (e.g. only doing
+real work right after its own hot-reload check fires), not this callback
+being a place to unconditionally re-derive templates every tick.
+
+```erlang
+spawn_templates_hint(ZoneState) ->
+    case just_reloaded(ZoneState) of
+        false -> unchanged;
+        true -> {changed, current_templates(ZoneState)}
+    end.
+```
+
 ```lua
 function spawn_templates(config)
     return {

--- a/src/world/asobi_world.erl
+++ b/src/world/asobi_world.erl
@@ -84,6 +84,22 @@ behind the join.
 -callback spawn_templates(Config :: map()) ->
     #{binary() => asobi_zone_spawner:spawn_template()}.
 
+-doc """
+Optional (asobi#253): a per-tick, cheap hint that spawn templates may have
+changed since zone creation - e.g. a script hot-reload adding/renaming a
+template. `spawn_templates/1` is only ever called once, at zone creation;
+without this, a long-running zone never learns about a template added
+later and every spawn attempt against it surfaces as `unknown_spawn_template`
+indefinitely, not just until the next reload.
+
+Called every tick if exported, so implementations MUST be cheap in the
+common case - return `unchanged` immediately unless something already
+indicates a real change happened this tick (e.g. a hot-reload just ran).
+Do not unconditionally rebuild/re-read a template source here.
+""".
+-callback spawn_templates_hint(ZoneState :: term()) ->
+    unchanged | {changed, #{binary() => asobi_zone_spawner:spawn_template()}}.
+
 -doc "Optional: the terrain provider module + args, or `none`.".
 -callback terrain_provider(Config :: map()) ->
     {Module :: module(), ProviderArgs :: map()} | none.
@@ -120,6 +136,7 @@ plain terms. The inverse of `init_zone_state`'s restore path.
     on_phase_ended/2,
     on_world_recovered/2,
     spawn_templates/1,
+    spawn_templates_hint/1,
     terrain_provider/1,
     on_zone_loaded/2,
     on_zone_unloaded/2,

--- a/src/world/asobi_world.erl
+++ b/src/world/asobi_world.erl
@@ -96,6 +96,13 @@ Called every tick if exported, so implementations MUST be cheap in the
 common case - return `unchanged` immediately unless something already
 indicates a real change happened this tick (e.g. a hot-reload just ran).
 Do not unconditionally rebuild/re-read a template source here.
+
+`{changed, NewTemplates}` REPLACES the zone's entire template set, the same
+as `spawn_templates/1`'s result does at creation - it is not a delta. An
+implementation built from a partial reload that reconstructs only the
+templates it knows changed will silently drop every other template; make
+sure `NewTemplates` includes every template that should still be spawnable,
+not only the ones that changed.
 """.
 -callback spawn_templates_hint(ZoneState :: term()) ->
     unchanged | {changed, #{binary() => asobi_zone_spawner:spawn_template()}}.

--- a/src/world/asobi_zone.erl
+++ b/src/world/asobi_zone.erl
@@ -780,7 +780,21 @@ maybe_apply_spawn_templates_hint(GameMod, ZoneState, Spawner, WorldId, Coords) -
                         template_count => map_size(NewTemplates)
                     }),
                     asobi_zone_spawner:set_templates(NewTemplates, Spawner);
-                _ ->
+                unchanged ->
+                    Spawner;
+                Other ->
+                    %% A malformed callback return (anything but `unchanged` or
+                    %% a well-formed `{changed, Map}`) is a bug in the game
+                    %% module's implementation, not a normal "nothing changed"
+                    %% outcome - surface it rather than silently no-op like the
+                    %% expected `unchanged` case does.
+                    ?LOG_WARNING(#{
+                        event => zone_spawn_templates_hint_malformed,
+                        world_id => WorldId,
+                        coords => Coords,
+                        game_module => GameMod,
+                        returned => bound_debug_term(Other)
+                    }),
                     Spawner
             end
     end.
@@ -815,6 +829,20 @@ log_spawn_failed(TemplateId, Reason, #{world_id := WorldId, coords := Coords}) -
 -spec bound_template_id(binary()) -> binary().
 bound_template_id(TemplateId) ->
     Head = binary:part(TemplateId, 0, min(64, byte_size(TemplateId))),
+    case unicode:characters_to_binary(Head) of
+        Valid when is_binary(Valid) -> Valid;
+        {incomplete, Valid, _} -> Valid;
+        {error, Valid, _} -> Valid
+    end.
+
+%% A malformed spawn_templates_hint/1 return can be an arbitrary Erlang term
+%% (the callback is game-module code, not asobi's own); ~p-format it before
+%% logging so nova_jsonlogger's JSON encoder always sees a plain, bounded
+%% binary rather than a raw pid/reference/fun it cannot encode.
+-spec bound_debug_term(term()) -> binary().
+bound_debug_term(Term) ->
+    Formatted = iolist_to_binary(io_lib:format("~0p", [Term])),
+    Head = binary:part(Formatted, 0, min(200, byte_size(Formatted))),
     case unicode:characters_to_binary(Head) of
         Valid when is_binary(Valid) -> Valid;
         {incomplete, Valid, _} -> Valid;

--- a/src/world/asobi_zone.erl
+++ b/src/world/asobi_zone.erl
@@ -486,9 +486,14 @@ do_tick(
     Now = erlang:system_time(millisecond),
     {TimerEvents, ET1} = asobi_entity_timer:tick(Now, ET),
     Entities3 = apply_timer_events(TimerEvents, Entities2),
-    %% Tick spawner — process respawn queue
-    Spawner = maps:get(spawner, State),
-    {Respawns, FailedRespawns, Spawner1} = asobi_zone_spawner:tick(Now, Spawner),
+    %% Tick spawner — process respawn queue. asobi#253: pick up a live
+    %% template update (e.g. a script hot-reload) before ticking, so a
+    %% just-renamed/added template doesn't have to wait for the next respawn
+    %% window to become spawnable.
+    Spawner0 = maybe_apply_spawn_templates_hint(
+        GameMod, ZoneState1, maps:get(spawner, State), WorldId, Coords
+    ),
+    {Respawns, FailedRespawns, Spawner1} = asobi_zone_spawner:tick(Now, Spawner0),
     lists:foreach(
         fun
             ({TemplateId, unknown_template = Reason}) when is_binary(TemplateId) ->
@@ -669,9 +674,7 @@ transfer_out_of_bounds_npcs(
     Entities1 = maps:without(ToRemove, Entities),
     Grid = maps:get(spatial_grid, State, undefined),
     Grid1 = remove_from_grid(ToRemove, Grid),
-    State#{entities => Entities1, spatial_grid => Grid1};
-transfer_out_of_bounds_npcs(State) ->
-    State.
+    State#{entities => Entities1, spatial_grid => Grid1}.
 
 %% --- Snapshot Helpers ---
 
@@ -753,6 +756,34 @@ has_tickable_entities(Entities) ->
         false,
         Entities
     ).
+
+%% asobi#253: spawn_templates/1 is only ever called once, at zone creation -
+%% a long-running zone never learns about a template added/renamed by a
+%% later script hot-reload, so it surfaces as unknown_spawn_template
+%% indefinitely rather than just until the next reload. spawn_templates_hint/1
+%% is optional and runs every tick, so it must be cheap when nothing
+%% changed - the callback owns that cost, not this call site.
+-spec maybe_apply_spawn_templates_hint(
+    module(), term(), asobi_zone_spawner:state(), binary(), {integer(), integer()}
+) -> asobi_zone_spawner:state().
+maybe_apply_spawn_templates_hint(GameMod, ZoneState, Spawner, WorldId, Coords) ->
+    case erlang:function_exported(GameMod, spawn_templates_hint, 1) of
+        false ->
+            Spawner;
+        true ->
+            case GameMod:spawn_templates_hint(ZoneState) of
+                {changed, NewTemplates} when is_map(NewTemplates) ->
+                    ?LOG_NOTICE(#{
+                        event => zone_spawn_templates_updated,
+                        world_id => WorldId,
+                        coords => Coords,
+                        template_count => map_size(NewTemplates)
+                    }),
+                    asobi_zone_spawner:set_templates(NewTemplates, Spawner);
+                _ ->
+                    Spawner
+            end
+    end.
 
 %% asobi_zone_spawner:spawn_entity/4's only error today is unknown_template.
 %% The cast API (game.zone.spawn and world-server spawn_at) can't return this

--- a/test/asobi_zone_tests.erl
+++ b/test/asobi_zone_tests.erl
@@ -52,7 +52,9 @@ zone_test_() ->
         {"spawn_entity keeps a multibyte template_id valid UTF-8 when bounding",
             fun spawn_entity_multibyte_template_id_stays_utf8/0},
         {"spawn_templates_hint updates a live zone's spawnable templates",
-            fun spawn_templates_hint_updates_live_zone/0}
+            fun spawn_templates_hint_updates_live_zone/0},
+        {"spawn_templates_hint returning garbage logs a warning and survives",
+            fun spawn_templates_hint_malformed_return_is_observable/0}
     ]}.
 
 starts_empty() ->
@@ -340,6 +342,31 @@ spawn_templates_hint_updates_live_zone() ->
         ?assertEqual(1, map_size(Entities)),
         [Entity] = maps:values(Entities),
         ?assertEqual(~"npc", maps:get(type, Entity))
+    after
+        meck:unload(?GAME),
+        gen_server:stop(Pid)
+    end.
+
+%% asobi#253 code review: a callback return that's neither `unchanged` nor a
+%% well-formed `{changed, Map}` is a bug in the game module, not a normal
+%% "nothing changed" outcome. It must be observable (logged) and must not
+%% touch the spawner's existing templates - not silently swallowed like the
+%% expected `unchanged` case.
+spawn_templates_hint_malformed_return_is_observable() ->
+    Pid = start_zone(#{
+        spawn_templates => #{~"cube" => #{type => ~"object", base_state => #{}}}
+    }),
+    meck:new(?GAME, [passthrough, non_strict]),
+    meck:expect(?GAME, spawn_templates_hint, fun(_ZoneState) -> not_a_valid_hint_return end),
+    try
+        asobi_zone:tick(Pid, 1),
+        timer:sleep(10),
+        ?assert(is_process_alive(Pid)),
+        %% The existing template survives untouched - the malformed return
+        %% must not have reached asobi_zone_spawner:set_templates/2.
+        asobi_zone:spawn_entity(Pid, ~"cube", {1, 1}),
+        timer:sleep(10),
+        ?assertEqual(1, map_size(asobi_zone:get_entities(Pid)))
     after
         meck:unload(?GAME),
         gen_server:stop(Pid)

--- a/test/asobi_zone_tests.erl
+++ b/test/asobi_zone_tests.erl
@@ -50,7 +50,9 @@ zone_test_() ->
         {"spawn_entity bounds an over-long template_id before it is observable",
             fun spawn_entity_long_template_id_bounded/0},
         {"spawn_entity keeps a multibyte template_id valid UTF-8 when bounding",
-            fun spawn_entity_multibyte_template_id_stays_utf8/0}
+            fun spawn_entity_multibyte_template_id_stays_utf8/0},
+        {"spawn_templates_hint updates a live zone's spawnable templates",
+            fun spawn_templates_hint_updates_live_zone/0}
     ]}.
 
 starts_empty() ->
@@ -306,6 +308,42 @@ tick_no_hibernate_with_npcs() ->
     {current_function, CF} = erlang:process_info(Pid, current_function),
     ?assertNotEqual({erlang, hibernate, 3}, CF),
     gen_server:stop(Pid).
+
+%% asobi#253: spawn_templates/1 is only ever called once, at zone creation -
+%% a template added by a later script hot-reload never reached an
+%% already-running zone. spawn_templates_hint/1 is the fix: an optional,
+%% per-tick, cheap "did templates change" callback. asobi_test_world_game
+%% doesn't export it normally (verified: it's absent from
+%% -export([init/1, join/2, ...])), so injecting it via meck's non_strict
+%% mode - the same technique already used for phases/1 in
+%% asobi_world_server_tests.erl - both proves the callback is genuinely
+%% optional (erlang:function_exported/3 must see it appear) and lets this
+%% test control exactly when a "change" is reported.
+spawn_templates_hint_updates_live_zone() ->
+    Pid = start_zone(#{spawn_templates => #{}}),
+    meck:new(?GAME, [passthrough, non_strict]),
+    meck:expect(?GAME, spawn_templates_hint, fun(_ZoneState) ->
+        {changed, #{~"goblin" => #{type => ~"npc", base_state => #{}}}}
+    end),
+    try
+        %% Before the hint has run: the template is genuinely unknown.
+        asobi_zone:spawn_entity(Pid, ~"goblin", {5, 5}),
+        timer:sleep(10),
+        ?assertEqual(#{}, asobi_zone:get_entities(Pid)),
+        %% A tick applies the hint's {changed, _} result to the live spawner.
+        asobi_zone:tick(Pid, 1),
+        timer:sleep(10),
+        %% The same template_id that failed above now spawns.
+        asobi_zone:spawn_entity(Pid, ~"goblin", {5, 5}),
+        timer:sleep(10),
+        Entities = asobi_zone:get_entities(Pid),
+        ?assertEqual(1, map_size(Entities)),
+        [Entity] = maps:values(Entities),
+        ?assertEqual(~"npc", maps:get(type, Entity))
+    after
+        meck:unload(?GAME),
+        gen_server:stop(Pid)
+    end.
 
 start_mock_zone_manager() ->
     spawn(fun() -> mock_zm_loop([]) end).


### PR DESCRIPTION
## Summary

Refs #253 (this repo's half - see below), filed by architecture-guardian review of #249.

`spawn_templates/1` is only ever called once, at zone creation - a template added later (e.g. via a script hot-reload) never reaches a zone that's already running - only newly-created zones pick it up. #249's new `unknown_spawn_template` telemetry made this newly visible: a template added via hot reload surfaces as warnings in already-running zones indefinitely, reading as "the telemetry is lying" rather than "hot reload has a known limitation."

Adds `spawn_templates_hint/1`, a new **optional** `asobi_world` callback. Unlike `spawn_templates/1` it runs every tick, so it's designed to be near-free in the common case: implementations return `unchanged` unless something already indicates a real change happened this tick, and only return `{changed, NewTemplates}` when there's genuinely something new. `asobi_zone` calls it right before ticking the spawner, so a just-updated template is spawnable the same tick the hint fires. `{changed, NewTemplates}` replaces the zone's entire template set (documented explicitly, per architecture review).

A malformed callback return (anything but `unchanged` or a well-formed `{changed, Map}`) now logs a warning identifying the offending game module and a bounded rendering of what it returned, rather than silently no-op'ing like the expected `unchanged` case - a game module's implementation bug shouldn't look identical to "nothing changed" (per code review).

**Scope note:** this is the `asobi`-side primitive only. The `asobi_lua` half (`spawn_templates_hint/1` backed by the existing per-tick hot-reload mtime check) is a separate repository and needs its own PR once it bumps its `asobi` pin.

Also: fixing this surfaced (via tightened dialyzer success typing) a dead catch-all clause in `transfer_out_of_bounds_npcs/1` that's always been unreachable - verified only one call site exists and it always satisfies the surviving clause's pattern. Removed.

## Test plan

- [x] `rebar3 fmt` / `xref` / `dialyzer` clean
- [x] `elp eqwalize-all` clean (isolated fresh-clone check, `NO ERRORS`)
- [x] `elp lint` / `rebar3 ex_doc` clean
- [x] `rebar3 eunit` — 442/442 passing, including a test driving a zone through the full "unknown template fails, hint reports a change, same template spawns" sequence, and a test for the malformed-return warning path (confirms existing templates survive untouched)

## Review

- architecture-guardian: ACCEPT WITH CHANGES (one required doc clarification on whole-map-replace semantics, addressed).
- erlang-code-reviewer: found the malformed-return silent-swallow gap; independently mutation-tested the fix path to confirm it's genuine, not vacuous. Addressed in the same push the reviewer's findings came back on.
- Both reviews independently verified the dead-clause removal, the eunit test's validity (via mutation testing - temporarily breaking the mechanism and confirming the test catches it), and full toolchain cleanliness.