### PR TITLE
fix: hysteresis, interest-ring diff, and rate limiting for zone crossings

### DIFF
--- a/guides/configuration.md
+++ b/guides/configuration.md
@@ -360,6 +360,28 @@ implement `join/3` in your game module and reject unauthorised joins - see
 A player at the per-player cap gets `429`; once the global cap is reached
 further creates get `503`.
 
+## Zone crossing rate
+
+For `world`-mode games, re-homing a player across a zone boundary is bounded
+per player, not per IP:
+
+```erlang
+{rate_limits, #{
+    rehome => #{algorithm => sliding_window, limit => 5, window => 1000}
+}}
+```
+
+Each crossing updates part of the player's interest ring and resends a full
+zone snapshot to any newly-subscribed zone, so an unbounded rate lets one
+client force that work every tick by parking on (or jittering across) a zone
+boundary. The default (5/sec) bounds the worst case on top of the crossing's
+own hysteresis margin (see [World Server](world-server.md)); it caps sustained
+crossing speed at `limit * zone_size` units/sec, so a fast-moving game (a
+vehicle, flight sim, or racer) on a small `zone_size` may need to raise this.
+Denied crossings are not dropped input - the player's position still updates
+within their current zone, they just don't re-home that tick. Exceeding the
+limit emits `[asobi, rehome, rate_limited]`.
+
 ## Terrain provider allowlist
 
 For Lua large-world games, only allowlisted terrain generators can be named

--- a/guides/world-server.md
+++ b/guides/world-server.md
@@ -349,6 +349,7 @@ Register your world mode in `sys.config`:
 | `zone_size` | 200 | Units per zone side (world size = grid_size * zone_size) |
 | `tick_rate` | 50 | Milliseconds between ticks (50 = 20 Hz) |
 | `view_radius` | 1 | Zones visible in each direction from player's zone |
+| `rehome_margin` | 0.15 | Fraction of `zone_size` a player must clear past their zone's edge before re-homing to the neighbouring zone (see below) |
 | `max_players` | 500 | Maximum concurrent players per world |
 | `zone_idle_timeout` | 30000 | Milliseconds an empty zone lingers before it is released |
 | `empty_grace_ms` | 0 | Milliseconds a world with no players lingers before it finishes (0 = finish immediately) |
@@ -357,6 +358,16 @@ Register your world mode in `sys.config`:
 | `quick_play` | `true` | Whether `world.find_or_create` may place a player into an existing world of this mode |
 
 #> Using a world as a persistent hub is covered in [Lobbies](lobbies.md).
+
+A player must clear their zone's edge by `rehome_margin` (a fraction of
+`zone_size`) before re-homing to the neighbouring zone, so a player parked on
+or jittering across a boundary doesn't re-home every tick. This means a
+player's tracked zone can lag their true position by up to that margin near a
+boundary - if your game reads a zone's own coordinates to bound something
+(a spatial query via `game.zone.query_radius`/`query_rect`, a terrain lookup),
+account for that slack rather than assuming every entity in a zone's entity
+map is strictly within its rectangle. See [Configuration](configuration.md)
+for the matching `rehome` rate limit on how often a player may re-home at all.
 
 ## Visibility
 

--- a/src/asobi_rehome_limiter.erl
+++ b/src/asobi_rehome_limiter.erl
@@ -1,0 +1,63 @@
+-module(asobi_rehome_limiter).
+-moduledoc """
+Backstop on world zone-crossing re-homes (asobi#248): bounds how often a
+single player's `world.input` can force a full interest-ring update, on top
+of the hysteresis margin in asobi_zone's past_zone_margin/4 (private, which
+only filters jitter - an attacker moving with amplitude past the margin
+crosses every tick regardless, so this is the actual adversarial control).
+
+Two `seki` limiters, both registered in `asobi_sup`: `asobi_rehome_limiter`
+(per player_id) bounds one identity's rate, `asobi_rehome_global_limiter`
+(a constant key) bounds the aggregate - every crossing's resubscribe makes a
+blocking call into the single asobi_terrain_store shared by a whole world,
+so N concurrent attackers each keeping their own per-player budget would
+otherwise scale that blocking load linearly with attacker count. The
+per-player check runs first, so an already-denied player never spends any
+of the global budget.
+
+A throttle is a cost control, not a security control, so any failure to
+check either limiter - not registered, seki not started, or a bad `limit`/
+`window` override reaching `seki:check/2`'s arithmetic (e.g. `limit => 0`) -
+fails open rather than crashing the caller. This is checked from inside a
+zone's tick handler, and an uncaught error there crash-loops the zone
+(`asobi_zone_sup` is `simple_one_for_one`) and, once restarts exceed its
+intensity, the whole world instance (`asobi_world_instance` is
+`one_for_all`). See `asobi_script_log_limiter` for the same fail-open
+precedent.
+""".
+
+-export([allow/1]).
+
+-include_lib("kernel/include/logger.hrl").
+
+-doc "Check whether PlayerId may re-home right now.".
+-spec allow(binary()) -> boolean().
+allow(PlayerId) ->
+    try
+        case seki:check(asobi_rehome_limiter, PlayerId) of
+            {deny, _} ->
+                false;
+            {allow, _} ->
+                case seki:check(asobi_rehome_global_limiter, ~"global") of
+                    {allow, _} -> true;
+                    {deny, _} -> false
+                end
+        end
+    catch
+        error:Reason:Stacktrace ->
+            %% Keyed on a constant, not PlayerId: this is "a limiter itself
+            %% is broken", the same failure for every caller, not a per-player
+            %% event - one recurring log line covers it, not one per player.
+            case asobi_script_log_limiter:allow(?MODULE) of
+                {true, Dropped} ->
+                    ?LOG_WARNING(#{
+                        event => rehome_limiter_unavailable,
+                        reason => Reason,
+                        stacktrace => Stacktrace,
+                        suppressed_since_last => Dropped
+                    });
+                false ->
+                    ok
+            end,
+            true
+    end.

--- a/src/asobi_sup.erl
+++ b/src/asobi_sup.erl
@@ -158,7 +158,26 @@ register_limiters() ->
         %% of "same recurring failure" (typically per zone or per callback),
         %% so one broken zone/script doesn't starve another's visibility.
         %% Generous: this is about volume, not adversarial abuse.
-        script_log => #{algorithm => sliding_window, limit => 3, window => 10_000}
+        script_log => #{algorithm => sliding_window, limit => 3, window => 10_000},
+        %% Backstop on world zone-crossing re-homes (asobi#248). Each crossing
+        %% resubscribes part of a player's interest ring, and each new
+        %% subscription makes a blocking asobi_terrain_store call and resends
+        %% a full zone snapshot. asobi_zone's past_zone_margin/4 hysteresis
+        %% only filters jitter (oscillating within the margin); an attacker
+        %% moving with amplitude past it crosses every tick regardless, so
+        %% this limiter is the actual adversarial control, not a backstop
+        %% under it. Keyed on player_id: the cost is per-session. 5/sec is
+        %% generous for real movement (crossing more than a few zones a
+        %% second sustained isn't a realistic player speed) but denies a
+        %% client thrashing a boundary from forcing this every tick.
+        rehome => #{algorithm => sliding_window, limit => 5, window => 1000},
+        %% Per-player alone doesn't bound the aggregate: every subscribe a
+        %% crossing triggers calls into the single asobi_terrain_store shared
+        %% by the whole world, so N concurrent attackers each keeping their
+        %% own 5/sec budget scales that blocking load linearly with attacker
+        %% count. Same reasoning as guest_global. Size from your real
+        %% concurrent-player target; this default is a placeholder.
+        rehome_global => #{algorithm => sliding_window, limit => 200, window => 1000}
     },
     Configured =
         case application:get_env(asobi, rate_limits, #{}) of
@@ -188,7 +207,9 @@ limiter_name(api) -> asobi_api_limiter;
 limiter_name(ws_connect) -> asobi_ws_connect_limiter;
 limiter_name(join) -> asobi_join_limiter;
 limiter_name(guest_global) -> asobi_guest_global_limiter;
-limiter_name(script_log) -> asobi_script_log_limiter.
+limiter_name(script_log) -> asobi_script_log_limiter;
+limiter_name(rehome) -> asobi_rehome_limiter;
+limiter_name(rehome_global) -> asobi_rehome_global_limiter.
 
 cluster_spec() ->
     #{

--- a/src/asobi_telemetry.erl
+++ b/src/asobi_telemetry.erl
@@ -13,6 +13,7 @@
     ws_message_out/1,
     ws_connect_rate_limited/1,
     join_rate_limited/1,
+    rehome_rate_limited/1,
     ws_idle_auth_timeout/0,
     ws_origin_rejected/0
 ]).
@@ -193,6 +194,20 @@ join_rate_limited(PlayerId) ->
 ws_connect_rate_limited(PeerIp) ->
     telemetry:execute(
         [asobi, ws, connect_rate_limited], #{count => 1}, #{peer_ip => PeerIp}
+    ).
+
+-doc """
+asobi#248: a player hit the per-identity or global zone-crossing rate cap.
+Fires per denied crossing - the denied entity is clamped back inside its
+current zone (private, see asobi_zone's clamp_to_zone/3), but under
+sustained input the crossing is still re-detected (and re-denied) every
+tick, so a client thrashing a boundary can drive this at up to the world
+tick rate. Aggregate this; do not use `player_id` as a metric label.
+""".
+-spec rehome_rate_limited(binary()) -> ok.
+rehome_rate_limited(PlayerId) ->
+    telemetry:execute(
+        [asobi, rehome, rate_limited], #{count => 1}, #{player_id => PlayerId}
     ).
 
 -spec ws_idle_auth_timeout() -> ok.

--- a/src/world/asobi_world_server.erl
+++ b/src/world/asobi_world_server.erl
@@ -39,6 +39,12 @@ transient matches use `asobi_match_server` instead.
 -define(DEFAULT_TICK_RATE, 50).
 -define(DEFAULT_MAX_PLAYERS, 500).
 -define(DEFAULT_VIEW_RADIUS, 1).
+%% Fraction of zone_size a position must clear past a zone's own rectangle
+%% before asobi_zone treats it as a real crossing rather than jitter -
+%% widgrensit/asobi#248. A fixed fraction, not absolute units, since it
+%% should scale with whatever zone_size a world picks; games wanting a
+%% tighter or looser boundary can override rehome_margin per world.
+-define(DEFAULT_REHOME_MARGIN, 0.15).
 
 %% --- Public API ---
 
@@ -171,6 +177,7 @@ init(Config) ->
     TickRate = maps:get(tick_rate, Config, ?DEFAULT_TICK_RATE),
     MaxPlayers = maps:get(max_players, Config, ?DEFAULT_MAX_PLAYERS),
     ViewRadius = maps:get(view_radius, Config, ?DEFAULT_VIEW_RADIUS),
+    RehomeMargin = maps:get(rehome_margin, Config, ?DEFAULT_REHOME_MARGIN),
     VetoTokensPerPlayer = maps:get(veto_tokens_per_player, Config, 0),
     FrustrationBonus = maps:get(frustration_bonus, Config, 0.5),
     Persistent = maps:get(persistent, Config, false),
@@ -203,6 +210,7 @@ init(Config) ->
         tick_rate => TickRate,
         max_players => MaxPlayers,
         view_radius => ViewRadius,
+        rehome_margin => RehomeMargin,
         players => #{},
         player_zones => #{},
         instance_sup => InstanceSup,
@@ -511,6 +519,7 @@ configure_zone_manager(
         game_module := GameMod,
         zone_size := ZoneSize,
         grid_size := GridSize,
+        rehome_margin := RehomeMargin,
         config := Config
     } = State
 ) ->
@@ -531,7 +540,8 @@ configure_zone_manager(
         %% So a zone can decide crossings with the same clamped math - see
         %% resolve_zone_crossings/1 in asobi_zone.
         zone_size => ZoneSize,
-        grid_size => GridSize
+        grid_size => GridSize,
+        rehome_margin => RehomeMargin
     },
     asobi_zone_manager:set_zone_config(ZoneManagerPid, BaseZoneConfig),
     State#{terrain_store_pid => TerrainStorePid}.

--- a/src/world/asobi_zone.erl
+++ b/src/world/asobi_zone.erl
@@ -15,6 +15,9 @@ via `asobi_spatial`. Zones are created and reaped lazily as players move.
 -export([start_entity_timer/2, cancel_entity_timer/3]).
 -export([query_radius/3, query_rect/3]).
 -export([init/1, handle_call/3, handle_cast/2, handle_continue/2, handle_info/2, terminate/2]).
+-ifdef(TEST).
+-export([past_zone_margin/4]).
+-endif.
 
 -include_lib("kernel/include/logger.hrl").
 
@@ -22,6 +25,7 @@ via `asobi_spatial`. Zones are created and reaped lazily as players move.
 %% Must match asobi_world_server's own defaults of the same name.
 -define(DEFAULT_ZONE_SIZE, 200).
 -define(DEFAULT_GRID_SIZE, 10).
+-define(DEFAULT_REHOME_MARGIN, 0.15).
 
 %% --- Public API ---
 
@@ -129,6 +133,7 @@ init(Config) ->
     TerrainStorePid = maps:get(terrain_store_pid, Config, undefined),
     ZoneSize = maps:get(zone_size, Config, ?DEFAULT_ZONE_SIZE),
     GridSize = maps:get(grid_size, Config, ?DEFAULT_GRID_SIZE),
+    RehomeMargin = maps:get(rehome_margin, Config, ?DEFAULT_REHOME_MARGIN),
     pg:join(?PG_SCOPE, {asobi_zone, WorldId, Coords}, self()),
     %% Recover entity state from ETS backup if available (zone crash recovery)
     RecoveredEntities = recover_zone_state(WorldId, Coords),
@@ -163,6 +168,7 @@ init(Config) ->
             terrain_store_pid => TerrainStorePid,
             zone_size => ZoneSize,
             grid_size => GridSize,
+            rehome_margin => RehomeMargin,
             entities => RecoveredEntities,
             prev_entities => #{},
             broadcast_entities => #{},
@@ -657,10 +663,13 @@ resolve_zone_crossings(
         coords := Coords,
         zone_size := ZoneSize,
         grid_size := GridSize,
+        rehome_margin := RehomeMargin,
         world_server_pid := WorldServerPid
     } = State
 ) ->
-    {ToRemove, ToTransfer, ToRehome} = find_zone_crossings(Entities, Coords, ZoneSize, GridSize),
+    {ToRemove, ToTransfer, ToRehome} = find_zone_crossings(
+        Entities, Coords, ZoneSize, GridSize, RehomeMargin
+    ),
     %% Transfer each NPC to the target zone
     lists:foreach(
         fun({Id, TargetCoords, Entity}) ->
@@ -685,38 +694,101 @@ resolve_zone_crossings(
     %% (bots, decoys, ...) that the world server has never joined - it now
     %% simply stays here, exactly as it did before this fix, until something
     %% actually claims it. See widgrensit/asobi#248.
-    case WorldServerPid of
-        undefined ->
-            ok;
-        _ ->
-            lists:foreach(
-                fun
-                    ({Id, {X, Y} = Pos, Entity}) when
-                        is_binary(Id), is_number(X), is_number(Y), is_map(Entity)
-                    ->
-                        asobi_world_server:move_player(WorldServerPid, Id, Pos, Entity);
-                    (_) ->
-                        ok
-                end,
-                ToRehome
-            )
-    end,
-    %% Remove transferred NPCs from this zone. Rehomed players are removed by
-    %% asobi_world_server:remove_player_from_zones/2 once move_player/4's cast
-    %% is processed, not here.
-    Entities1 = maps:without(ToRemove, Entities),
+    %%
+    %% A rate-limited crossing is denied here (WorldServerPid never learns
+    %% about it), but denying the hand-off alone would leave the entity's raw
+    %% x/y outside this zone's own rectangle while this zone keeps owning it -
+    %% security review measured that divergence running over a second at a
+    %% time under sustained denial, with the entity invisible to
+    %% query_radius/3 and query_rect/3 callers at its true position and this
+    %% zone re-detecting the same crossing (and re-denying it) every tick.
+    %% Clamping the denied entity back inside Coords closes the divergence:
+    %% once input stops, the position is self-consistent with Coords again.
+    %% Under sustained input the crossing is still re-detected (and
+    %% re-denied) every tick - clamping does not stop that - but each denied
+    %% tick now costs no hand-off, no ring diff and no terrain-store call,
+    %% only this cheap re-clamp.
+    DeniedEntities =
+        case WorldServerPid of
+            undefined ->
+                #{};
+            _ ->
+                Results = [
+                    rehome_or_clamp(WorldServerPid, Id, Pos, Entity, Coords, ZoneSize)
+                 || {Id, {X, Y} = Pos, Entity} <- ToRehome,
+                    is_binary(Id),
+                    is_number(X),
+                    is_number(Y),
+                    is_map(Entity)
+                ],
+                maps:from_list([R || R <- Results, R =/= moved])
+        end,
+    %% Remove transferred NPCs and rehomed players from this zone; a denied
+    %% player is kept, clamped back inside these bounds.
+    Entities1 = maps:merge(maps:without(ToRemove, Entities), DeniedEntities),
     Grid = maps:get(spatial_grid, State, undefined),
     Grid1 = remove_from_grid(ToRemove, Grid),
-    State#{entities => Entities1, spatial_grid => Grid1}.
+    %% query_radius/3 and query_rect/3 read positions from this grid, not
+    %% Entities1, when spatial_grid_cell_size is configured - without
+    %% re-indexing here, a denied entity's clamp is invisible to both and
+    %% they keep answering with its out-of-zone position: exactly the
+    %% divergence clamping exists to close. See widgrensit/asobi#248.
+    Grid2 = reindex_clamped(maps:to_list(DeniedEntities), Grid1),
+    State#{entities => Entities1, spatial_grid => Grid2}.
+
+-spec reindex_clamped([{binary(), map()}], asobi_spatial_grid:grid() | undefined) ->
+    asobi_spatial_grid:grid() | undefined.
+reindex_clamped(_DeniedList, undefined) ->
+    undefined;
+reindex_clamped([], Grid) ->
+    Grid;
+reindex_clamped([{Id, #{x := X, y := Y}} | Rest], Grid) ->
+    reindex_clamped(Rest, asobi_spatial_grid:update(Id, {X, Y}, Grid));
+reindex_clamped([_ | Rest], Grid) ->
+    reindex_clamped(Rest, Grid).
+
+%% Attempts the hand-off; returns `moved` (caller does nothing further) or
+%% `{Id, ClampedEntity}` for a denied crossing (caller keeps the entity here).
+-spec rehome_or_clamp(
+    pid(), binary(), {number(), number()}, map(), {integer(), integer()}, pos_integer()
+) ->
+    moved | {binary(), map()}.
+rehome_or_clamp(WorldServerPid, Id, Pos, Entity, Coords, ZoneSize) ->
+    %% Backstop under the crossing hysteresis: a client that still manages to
+    %% force repeated re-homes (a modified client skipping the margin, or
+    %% plain jitter at the wrong instant) gets denied rather than paying for
+    %% a fresh interest-ring diff and zone snapshot resend every tick.
+    case asobi_rehome_limiter:allow(Id) of
+        true ->
+            asobi_world_server:move_player(WorldServerPid, Id, Pos, Entity),
+            moved;
+        false ->
+            asobi_telemetry:rehome_rate_limited(Id),
+            {Id, clamp_to_zone(Entity, Coords, ZoneSize)}
+    end.
+
+%% Pulls a denied entity's x/y back inside the zone rectangle Coords owns, so
+%% the position this zone broadcasts never disagrees with the zone that owns
+%% it. Epsilon keeps the clamped point strictly inside (at the exact upper
+%% edge, pos_to_zone/3 would compute the next zone over again).
+-spec clamp_to_zone(map(), {integer(), integer()}, pos_integer()) -> map().
+clamp_to_zone(#{x := X, y := Y} = Entity, {ZX, ZY}, ZoneSize) ->
+    Eps = 1.0e-6,
+    XLo = ZX * ZoneSize * 1.0,
+    YLo = ZY * ZoneSize * 1.0,
+    Entity#{
+        x => min(max(X, XLo), XLo + ZoneSize - Eps),
+        y => min(max(Y, YLo), YLo + ZoneSize - Eps)
+    }.
 
 %% Explicit -spec so eqwalizer treats ToRehome's element type as ground truth
 %% at the move_player/4 call site above, rather than inferring term() through
 %% the fold's multi-branch accumulator.
--spec find_zone_crossings(map(), {integer(), integer()}, pos_integer(), pos_integer()) ->
+-spec find_zone_crossings(map(), {integer(), integer()}, pos_integer(), pos_integer(), number()) ->
     {[binary()], [{binary(), {integer(), integer()}, map()}], [
         {binary(), {number(), number()}, map()}
     ]}.
-find_zone_crossings(Entities, Coords, ZoneSize, GridSize) ->
+find_zone_crossings(Entities, Coords, ZoneSize, GridSize, RehomeMargin) ->
     maps:fold(
         fun
             (Id, #{type := ~"npc", x := X, y := Y} = Entity, {Rem, Trans, Rehome}) when
@@ -731,9 +803,21 @@ find_zone_crossings(Entities, Coords, ZoneSize, GridSize) ->
             (Id, #{type := ~"player", x := X, y := Y} = Entity, {Rem, Trans, Rehome}) when
                 is_binary(Id), is_number(X), is_number(Y)
             ->
+                %% Hysteresis: pos_to_zone/3 disagreeing with Coords alone is
+                %% a hard edge with zero margin, so a player camped on (or
+                %% jittering across) a boundary would re-home every tick -
+                %% full interest-ring diff, zone snapshot resend, session
+                %% zone_pid flip, each time. Require the position to be
+                %% ZoneSize * RehomeMargin past this zone's own bounds before
+                %% treating it as a real crossing. See widgrensit/asobi#248.
                 case asobi_world_server:pos_to_zone({X, Y}, ZoneSize, GridSize) of
-                    Coords -> {Rem, Trans, Rehome};
-                    _NewCoords -> {Rem, Trans, [{Id, {X, Y}, Entity} | Rehome]}
+                    Coords ->
+                        {Rem, Trans, Rehome};
+                    _NewCoords ->
+                        case past_zone_margin({X, Y}, Coords, ZoneSize, RehomeMargin) of
+                            true -> {Rem, Trans, [{Id, {X, Y}, Entity} | Rehome]};
+                            false -> {Rem, Trans, Rehome}
+                        end
                 end;
             (_, _, Acc) ->
                 Acc
@@ -741,6 +825,15 @@ find_zone_crossings(Entities, Coords, ZoneSize, GridSize) ->
         {[], [], []},
         Entities
     ).
+
+-spec past_zone_margin({number(), number()}, {integer(), integer()}, pos_integer(), number()) ->
+    boolean().
+past_zone_margin({X, Y}, {ZX, ZY}, ZoneSize, RehomeMargin) ->
+    Margin = ZoneSize * RehomeMargin,
+    XLo = ZX * ZoneSize,
+    YLo = ZY * ZoneSize,
+    X < XLo - Margin orelse X >= XLo + ZoneSize + Margin orelse
+        Y < YLo - Margin orelse Y >= YLo + ZoneSize + Margin.
 
 %% --- Snapshot Helpers ---
 

--- a/test/asobi_rehome_limiter_tests.erl
+++ b/test/asobi_rehome_limiter_tests.erl
@@ -1,0 +1,30 @@
+-module(asobi_rehome_limiter_tests).
+-include_lib("eunit/include/eunit.hrl").
+
+%% asobi#248: asobi_rehome_limiter:allow/1 runs inside a zone's tick handler,
+%% so any failure checking the underlying seki limiters must fail open
+%% (allow) rather than crash the zone - a crash there cascades through
+%% asobi_zone_sup's restart intensity to the whole world instance
+%% (one_for_all). These pin the two failure modes found in review.
+
+unregistered_limiter_fails_open_test() ->
+    catch seki:delete_limiter(asobi_rehome_limiter),
+    ?assert(asobi_rehome_limiter:allow(~"p1")).
+
+%% `limit => 0` is a natural way to try to express "never allow" in
+%% rate_limits config. It registers cleanly but seki:check/2 then raises
+%% badarith on the first check (division by Limit). The ?assertError pins
+%% *why* the wide catch is needed - if this ever narrows back to a specific
+%% error pattern, this fails loudly instead of quietly passing.
+zero_limit_fails_open_test() ->
+    {ok, _} = application:ensure_all_started(seki),
+    %% Delete first: seki:new_limiter/2 returns {error, already_registered}
+    %% rather than raising if another test in this run already registered
+    %% this name with different options - catch alone would not surface
+    %% that, and this test's limit => 0 would silently not take effect.
+    catch seki:delete_limiter(asobi_rehome_limiter),
+    ok = seki:new_limiter(asobi_rehome_limiter, #{
+        algorithm => sliding_window, limit => 0, window => 1000
+    }),
+    ?assertError(badarith, seki:check(asobi_rehome_limiter, ~"p1")),
+    ?assert(asobi_rehome_limiter:allow(~"p1")).

--- a/test/asobi_world_zone_integration_tests.erl
+++ b/test/asobi_world_zone_integration_tests.erl
@@ -16,6 +16,14 @@ setup() ->
         undefined -> pg:start_link(nova_scope);
         _ -> ok
     end,
+    application:ensure_all_started(seki),
+    %% Deliberately not registering asobi_rehome_limiter here: every crossing
+    %% test below exercises asobi_rehome_limiter:allow/1 with the limiter
+    %% unregistered (this harness never starts asobi_sup), which is exactly
+    %% the fail-open path that matters - a bare seki:check/2 here used to
+    %% crash the zone, and via asobi_zone_sup/asobi_world_instance's
+    %% supervision, the whole world. rehome_denied_by_rate_limit_survives/0
+    %% registers its own tight limiter locally to exercise the deny path.
     meck:new(asobi_repo, [no_link]),
     meck:expect(asobi_repo, insert, fun(_CS) -> {ok, #{}} end),
     meck:expect(asobi_repo, insert, fun(_CS, _Opts) -> {ok, #{}} end),
@@ -59,7 +67,15 @@ world_zone_integration_test_() ->
         {"world.input past the world's far edge does not crash the world server",
             fun world_input_past_far_edge_survives/0},
         {"a script-owned player-typed entity the world server never joined survives crossing",
-            fun script_owned_player_entity_survives_crossing/0}
+            fun script_owned_player_entity_survives_crossing/0},
+        {"a crossing only touches the interest-ring zones that actually changed",
+            fun world_input_crossing_touches_only_ring_delta/0},
+        {"a position within the boundary margin does not rehome the player",
+            fun world_input_within_margin_does_not_rehome/0},
+        {"a rate-limited crossing leaves the entity in place instead of destroying it",
+            fun rehome_denied_by_rate_limit_survives/0},
+        {"the global rehome limit denies a crossing even with per-player budget to spare",
+            fun rehome_denied_by_global_limit/0}
     ]}.
 
 %% Default (lazy_zones=false, grid_size=3) pre-spawns all 9 zones
@@ -193,6 +209,159 @@ world_input_past_far_edge_survives() ->
     ?assertMatch({ok, _}, asobi_zone_manager:get_zone(Mgr, {2, 1})),
     stop_world(Ctx).
 
+%% Regression for widgrensit/asobi#248 (security review): without a margin,
+%% pos_to_zone/3 disagreeing with the zone's own Coords by even a fraction of
+%% a unit is treated as a crossing - a player parked on (or jittering across)
+%% a boundary re-homes every tick. asobi_zone's past_zone_margin/4 requires
+%% clearing the zone's own rectangle by rehome_margin (default 15% of
+%% zone_size) first; this proves
+%% that suppression end to end, not just the margin math in isolation
+%% (past_zone_margin_test/0 in asobi_zone_tests.erl covers that).
+world_input_within_margin_does_not_rehome() ->
+    Ctx = #{world_pid := Pid, zone_mgr := Mgr} = start_world(#{lazy_zones => true}),
+    ?assertEqual(ok, asobi_world_server:join(Pid, ~"p1")),
+    timer:sleep(20),
+    %% Spawns at {100.0, 100.0} => zone {1,1}, bounds x/y in [100, 200).
+    {ok, ZonePid1} = asobi_zone_manager:get_zone(Mgr, {1, 1}),
+
+    %% x=205 is past the raw edge (200) but within the 15-unit margin
+    %% (200 + 100*0.15 = 215) - pos_to_zone/3 alone would call this zone {2,1}.
+    asobi_zone:player_input(ZonePid1, ~"p1", #{
+        ~"action" => ~"move", ~"x" => 205.0, ~"y" => 100.0
+    }),
+    timer:sleep(150),
+
+    ?assertEqual(not_loaded, asobi_zone_manager:get_zone(Mgr, {2, 1})),
+    ?assert(maps:is_key(~"p1", asobi_zone:get_entities(ZonePid1))),
+    stop_world(Ctx).
+
+%% Regression for widgrensit/asobi#248 (security review): move_player/4 is a
+%% cast, so a rate-limited crossing must be decided BEFORE that cast - once
+%% resolve_zone_crossings/1 fires it, there is no undoing the hand-off. This
+%% exercises asobi_rehome_limiter denying a crossing outright and asserts the
+%% entity survives exactly where it was, the same guarantee
+%% script_owned_player_entity_survives_crossing/0 proves for an unclaimed
+%% hand-off - a rate-limited one must not destroy the entity either.
+%%
+%% It also asserts the denied entity's position was clamped back inside its
+%% owning zone: denying the hand-off without correcting x/y left the entity's
+%% true position outside the zone that still claims to own it - invisible to
+%% query_radius/3 and query_rect/3 at its real location, and re-detected (and
+%% re-denied) as a fresh crossing on every subsequent tick.
+rehome_denied_by_rate_limit_survives() ->
+    %% Not registered in setup/0 (see its comment) - one allowed crossing,
+    %% then every other crossing in the 60s window is denied.
+    %% seki:new_limiter/2 returns {error, already_registered} rather than
+    %% raising if the name is already registered (e.g. by another test in
+    %% this run with different options) - catch alone does not guard against
+    %% that, since it is a return value, not an exception. Delete first so
+    %% this test's own limit actually takes effect regardless of what ran
+    %% before it.
+    catch seki:delete_limiter(asobi_rehome_limiter),
+    ok = seki:new_limiter(asobi_rehome_limiter, #{
+        algorithm => sliding_window, limit => 1, window => 60000
+    }),
+    Self = self(),
+    Ref = make_ref(),
+    {ok, _} = application:ensure_all_started(telemetry),
+    telemetry:attach(
+        Ref, [asobi, rehome, rate_limited], fun(_E, _M, Meta, _) -> Self ! {denied, Meta} end, []
+    ),
+    Ctx = #{world_pid := Pid, zone_mgr := Mgr} = start_world(#{lazy_zones => true}),
+    try
+        ?assertEqual(ok, asobi_world_server:join(Pid, ~"p1")),
+        timer:sleep(20),
+        %% Spawns at {100.0, 100.0} => zone {1,1}.
+        {ok, ZonePid1} = asobi_zone_manager:get_zone(Mgr, {1, 1}),
+
+        %% First crossing: clears the margin, consumes the one allowed token.
+        asobi_zone:player_input(ZonePid1, ~"p1", #{
+            ~"action" => ~"move", ~"x" => 220.0, ~"y" => 100.0
+        }),
+        timer:sleep(150),
+        ?assertMatch({ok, _}, asobi_zone_manager:get_zone(Mgr, {2, 1})),
+        {ok, ZonePid2} = asobi_zone_manager:get_zone(Mgr, {2, 1}),
+        ?assert(maps:is_key(~"p1", asobi_zone:get_entities(ZonePid2))),
+
+        %% Second crossing: also clears its zone's margin, but the limiter is
+        %% now exhausted - must be denied, not applied.
+        asobi_zone:player_input(ZonePid2, ~"p1", #{
+            ~"action" => ~"move", ~"x" => 220.0, ~"y" => 220.0
+        }),
+        timer:sleep(150),
+
+        ?assertEqual(not_loaded, asobi_zone_manager:get_zone(Mgr, {2, 2})),
+        Entities = asobi_zone:get_entities(ZonePid2),
+        ?assert(maps:is_key(~"p1", Entities)),
+        %% Zone {2,1} spans x in [200,300), y in [100,200): the attempted
+        %% y=220 is clamped back just inside the top edge, x=220 is untouched
+        %% (already inside the zone on that axis).
+        #{x := DeniedX, y := DeniedY} = maps:get(~"p1", Entities),
+        ?assertEqual(220.0, DeniedX),
+        ?assert(DeniedY < 200.0),
+        ?assert(DeniedY > 199.0),
+        receive
+            {denied, #{player_id := ~"p1"}} -> ok
+        after 1000 -> ?assert(false, timeout_waiting_for_rehome_rate_limited_event)
+        end
+    after
+        telemetry:detach(Ref),
+        catch seki:reset(asobi_rehome_limiter, ~"p1"),
+        stop_world(Ctx)
+    end.
+
+%% Regression for widgrensit/asobi#248 (security review): per-player limiting
+%% alone doesn't bound the aggregate - every crossing's resubscribe makes a
+%% blocking asobi_terrain_store call into the one store a whole world shares,
+%% so N attackers each within their own per-player budget scale that load
+%% linearly with attacker count. asobi_rehome_global_limiter is the ceiling.
+%% Registered generously per-player and tightly globally, so only the global
+%% limiter can be what denies this crossing.
+rehome_denied_by_global_limit() ->
+    %% Delete before create: see rehome_denied_by_rate_limit_survives/0's
+    %% comment on why catch alone does not guarantee this test's own limits
+    %% take effect over whatever another test in this run already registered.
+    catch seki:delete_limiter(asobi_rehome_limiter),
+    ok = seki:new_limiter(asobi_rehome_limiter, #{
+        algorithm => sliding_window, limit => 1000, window => 60000
+    }),
+    catch seki:delete_limiter(asobi_rehome_global_limiter),
+    ok = seki:new_limiter(asobi_rehome_global_limiter, #{
+        algorithm => sliding_window, limit => 1, window => 60000
+    }),
+    %% Pre-spend the one global token so the very first crossing below is
+    %% denied by it, not by coincidentally being the window's first check.
+    seki:check(asobi_rehome_global_limiter, ~"global"),
+    Self = self(),
+    Ref = make_ref(),
+    {ok, _} = application:ensure_all_started(telemetry),
+    telemetry:attach(
+        Ref, [asobi, rehome, rate_limited], fun(_E, _M, Meta, _) -> Self ! {denied, Meta} end, []
+    ),
+    Ctx = #{world_pid := Pid, zone_mgr := Mgr} = start_world(#{lazy_zones => true}),
+    try
+        ?assertEqual(ok, asobi_world_server:join(Pid, ~"p1")),
+        timer:sleep(20),
+        {ok, ZonePid1} = asobi_zone_manager:get_zone(Mgr, {1, 1}),
+        asobi_zone:player_input(ZonePid1, ~"p1", #{
+            ~"action" => ~"move", ~"x" => 220.0, ~"y" => 100.0
+        }),
+        timer:sleep(150),
+        %% The player's own budget (1000) is untouched - only the global cap
+        %% can have denied this, so the hand-off must not have happened.
+        ?assertEqual(not_loaded, asobi_zone_manager:get_zone(Mgr, {2, 1})),
+        ?assert(maps:is_key(~"p1", asobi_zone:get_entities(ZonePid1))),
+        receive
+            {denied, #{player_id := ~"p1"}} -> ok
+        after 1000 -> ?assert(false, timeout_waiting_for_global_rehome_denial)
+        end
+    after
+        telemetry:detach(Ref),
+        catch seki:reset(asobi_rehome_limiter, ~"p1"),
+        catch seki:reset(asobi_rehome_global_limiter, ~"global"),
+        stop_world(Ctx)
+    end.
+
 %% Regression for widgrensit/asobi#248 (security review): a game script can
 %% type a non-session entity "player" (a bot, a decoy) without it ever
 %% joining, so the world server holds no player_zones entry for it.
@@ -223,6 +392,77 @@ script_owned_player_entity_survives_crossing() ->
             end,
     ?assert(Survived),
     stop_world(Ctx).
+
+%% Regression for widgrensit/asobi#248 (security review): a crossing used to
+%% unsubscribe the whole old ring and resubscribe the whole new ring, even
+%% though most zones are common to both - each resubscribe resends a full
+%% zone snapshot. On a grid_size=5, view_radius=1 world, moving from zone
+%% {1,1} to {2,1} keeps {1,0}..{2,2} in the ring the whole time: only the
+%% x=0 column should be dropped and only the x=3 column newly picked up.
+%%
+%% Retroactive coverage: the ring diff itself shipped in #259, not in the
+%% commit this test was added by. It lives here because that is where it
+%% was originally (mis-)attributed.
+world_input_crossing_touches_only_ring_delta() ->
+    %% subscribe_interest_zones/4 only subscribes zones that already exist
+    %% (it uses get_zone, not ensure_zone, so it never spins up an empty zone
+    %% just because it's in view) - lazy_zones=false pre-spawns the whole
+    %% grid so every ring zone is subscribable at join time.
+    Ctx = #{world_pid := Pid, zone_mgr := Mgr} = start_world(#{grid_size => 5}),
+    ?assertEqual(ok, asobi_world_server:join(Pid, ~"p1")),
+    timer:sleep(20),
+    %% Spawns at {100.0, 100.0} => zone {1,1}.
+    {ok, Z11} = asobi_zone_manager:get_zone(Mgr, {1, 1}),
+    ?assertEqual(1, asobi_zone:get_subscriber_count(Z11)),
+    {ok, Z00} = asobi_zone_manager:get_zone(Mgr, {0, 0}),
+    ?assertEqual(1, asobi_zone:get_subscriber_count(Z00)),
+    {ok, Z30} = asobi_zone_manager:get_zone(Mgr, {3, 0}),
+    ?assertEqual(0, asobi_zone:get_subscriber_count(Z30)),
+
+    %% Reaching the same end state doesn't prove the ring diff ran instead of
+    %% a full unsubscribe-everything/resubscribe-everything pass - both reach
+    %% identical final counts. Count the actual subscribe/unsubscribe calls:
+    %% only 3 zones left the ring and 3 entered it, not all 9.
+    Self = self(),
+    meck:new(asobi_zone, [passthrough]),
+    try
+        meck:expect(asobi_zone, subscribe, fun(ZPid, Sub) ->
+            Self ! subscribed,
+            meck:passthrough([ZPid, Sub])
+        end),
+        meck:expect(asobi_zone, unsubscribe, fun(ZPid, PId) ->
+            Self ! unsubscribed,
+            meck:passthrough([ZPid, PId])
+        end),
+
+        %% x=225 clears zone {1,1}'s margin (edge at 200 + 15% of 100), landing
+        %% in zone {2,1}.
+        asobi_zone:player_input(Z11, ~"p1", #{
+            ~"action" => ~"move", ~"x" => 225.0, ~"y" => 100.0
+        }),
+        timer:sleep(150),
+
+        SubscribeCalls = count_messages(subscribed),
+        UnsubscribeCalls = count_messages(unsubscribed),
+
+        ?assertEqual(3, SubscribeCalls),
+        ?assertEqual(3, UnsubscribeCalls),
+        %% {1,1} is in both rings - never unsubscribed, so it's never re-touched.
+        ?assertEqual(1, asobi_zone:get_subscriber_count(Z11)),
+        %% {0,0} left the ring (x=0 column no longer in range) - unsubscribed.
+        ?assertEqual(0, asobi_zone:get_subscriber_count(Z00)),
+        %% {3,0} entered the ring (x=3 column, new only) - freshly subscribed.
+        ?assertEqual(1, asobi_zone:get_subscriber_count(Z30))
+    after
+        meck:unload(asobi_zone),
+        stop_world(Ctx)
+    end.
+
+count_messages(Tag) ->
+    receive
+        Tag -> 1 + count_messages(Tag)
+    after 0 -> 0
+    end.
 
 %% Small grid (grid_size=3) without explicit lazy_zones works like before
 small_grid_backward_compat() ->

--- a/test/asobi_zone_tests.erl
+++ b/test/asobi_zone_tests.erl
@@ -372,6 +372,32 @@ spawn_templates_hint_malformed_return_is_observable() ->
         gen_server:stop(Pid)
     end.
 
+%% Regression for widgrensit/asobi#248 (security review): the crossing check
+%% needs a margin, not a hard edge, or a player camped on a boundary re-homes
+%% every tick - full interest-ring diff and zone snapshot resend each time.
+past_zone_margin_test() ->
+    ZoneSize = 100,
+    Coords = {1, 1},
+    Fraction = 0.15,
+    %% Just inside the zone: never past the margin.
+    ?assertNot(asobi_zone:past_zone_margin({150.0, 150.0}, Coords, ZoneSize, Fraction)),
+    %% Just past the edge (100..200), but within the 15-unit margin.
+    ?assertNot(asobi_zone:past_zone_margin({205.0, 150.0}, Coords, ZoneSize, Fraction)),
+    ?assertNot(asobi_zone:past_zone_margin({95.0, 150.0}, Coords, ZoneSize, Fraction)),
+    %% Exactly at the margin boundary (200 + 100*0.15 = 215 / 100 - 15 = 85):
+    %% the low side's `<` excludes 85, the high side's `>=` includes 215.
+    ?assertNot(asobi_zone:past_zone_margin({85.0, 150.0}, Coords, ZoneSize, Fraction)),
+    ?assert(asobi_zone:past_zone_margin({215.0, 150.0}, Coords, ZoneSize, Fraction)),
+    %% Clearly past the margin on every side.
+    ?assert(asobi_zone:past_zone_margin({220.0, 150.0}, Coords, ZoneSize, Fraction)),
+    ?assert(asobi_zone:past_zone_margin({80.0, 150.0}, Coords, ZoneSize, Fraction)),
+    ?assert(asobi_zone:past_zone_margin({150.0, 220.0}, Coords, ZoneSize, Fraction)),
+    ?assert(asobi_zone:past_zone_margin({150.0, 80.0}, Coords, ZoneSize, Fraction)),
+    %% A different fraction actually changes the threshold, proving the
+    %% argument is live and not shadowed by a leftover constant.
+    ?assertNot(asobi_zone:past_zone_margin({210.0, 150.0}, Coords, ZoneSize, 0.5)),
+    ?assert(asobi_zone:past_zone_margin({210.0, 150.0}, Coords, ZoneSize, 0.05)).
+
 start_mock_zone_manager() ->
     spawn(fun() -> mock_zm_loop([]) end).
 


### PR DESCRIPTION
## Summary

Follow-up to #248/#259, which wired `world.input` into real zone-boundary re-homing. Once re-homing actually ran, security review measured a client oscillating across a single zone edge at 15Hz for 2.3s producing 270 full-zone snapshots (~3.86MB, ~3800x amplification over 30 movement frames sent), plus a blocking `asobi_terrain_store` call per subscription serialising tick processing for every zone in the world. #259 already shipped the interest-ring set-difference. This PR adds the rest, after three review passes (architecture-guardian, beam-security-reviewer x2, erlang-code-reviewer) on iterations of this change:

- **Hysteresis** (`asobi_zone:find_zone_crossings/5`, new `past_zone_margin/4`): a crossing requires clearing the zone's own rectangle by a margin (`rehome_margin`, default 15% of `zone_size`, per-world configurable like `view_radius`/`zone_size`). This is a **jitter filter, not an adversarial control** — measured, an attacker oscillating with amplitude greater than the margin crosses every tick exactly as before, byte-identical to no margin at all. It fully eliminates the accidental case (boundary camping, jitter), which is the common one.
- **Rate limiting** (new `asobi_rehome_limiter` module): the actual adversarial control. Per-player (5/sec) and global (200/sec, since every crossing's resubscribe hits the single `asobi_terrain_store` shared by a world) `seki` limiters, checked before each `move_player/4` call. Fails open on any limiter-check error — `limit => 0` registers cleanly but raises `badarith` on first check, confirmed — since this runs inside a zone's tick handler and an uncaught error there cascades through supervision to kill the whole world instance.
- **Clamp on deny** (`asobi_zone:clamp_to_zone/3` + `reindex_clamped/2`): denying a crossing without correcting position left the entity outside the zone that still owns it — measured over a second of divergence under sustained denial, invisible to `query_radius/3`/`query_rect/3` at its true position (both the entities map and, once caught in review, the spatial grid backing those queries). A denied entity is now clamped back inside its zone's rectangle in both places.

## Test plan

- [x] `rebar3 fmt --check`, `rebar3 xref`, `rebar3 dialyzer`, `rebar3 ex_doc` — all clean
- [x] `elp eqwalize-all` (OTP 28.4.1) — clean
- [x] `rebar3 eunit` — 459 tests, 0 failures
- [x] New tests: margin math (`past_zone_margin_test/0`, including exact boundary + fraction sensitivity), hysteresis suppression end-to-end, per-player and global rate-limit denial (asserting the denied entity's clamped position, not just survival), the limiter's own fail-open paths (unregistered, `limit => 0`)
- [x] Rebased cleanly onto current `origin/main` (post #259)