### PR TITLE
refactor: dedup zone-ring helper and apply crossing hysteresis to NPCs

### DIFF
--- a/guides/world-server.md
+++ b/guides/world-server.md
@@ -349,7 +349,7 @@ Register your world mode in `sys.config`:
 | `zone_size` | 200 | Units per zone side (world size = grid_size * zone_size) |
 | `tick_rate` | 50 | Milliseconds between ticks (50 = 20 Hz) |
 | `view_radius` | 1 | Zones visible in each direction from player's zone |
-| `rehome_margin` | 0.15 | Fraction of `zone_size` a player must clear past their zone's edge before re-homing to the neighbouring zone (see below) |
+| `rehome_margin` | 0.15 | Fraction of `zone_size` an entity (player or NPC) must clear past its zone's edge before re-homing to the neighbouring zone (see below) |
 | `max_players` | 500 | Maximum concurrent players per world |
 | `zone_idle_timeout` | 30000 | Milliseconds an empty zone lingers before it is released |
 | `empty_grace_ms` | 0 | Milliseconds a world with no players lingers before it finishes (0 = finish immediately) |
@@ -359,15 +359,38 @@ Register your world mode in `sys.config`:
 
 #> Using a world as a persistent hub is covered in [Lobbies](lobbies.md).
 
-A player must clear their zone's edge by `rehome_margin` (a fraction of
-`zone_size`) before re-homing to the neighbouring zone, so a player parked on
-or jittering across a boundary doesn't re-home every tick. This means a
-player's tracked zone can lag their true position by up to that margin near a
-boundary - if your game reads a zone's own coordinates to bound something
-(a spatial query via `game.zone.query_radius`/`query_rect`, a terrain lookup),
-account for that slack rather than assuming every entity in a zone's entity
-map is strictly within its rectangle. See [Configuration](configuration.md)
-for the matching `rehome` rate limit on how often a player may re-home at all.
+An entity - player or NPC - must clear its zone's edge by `rehome_margin` (a
+fraction of `zone_size`) before re-homing to the neighbouring zone, so an
+entity parked on or jittering across a boundary doesn't re-home every tick.
+This means an entity's tracked zone can lag its true position by up to that
+margin near a boundary - an entity in a zone's entity map is not necessarily
+strictly within its rectangle.
+
+`game.zone.query_radius`/`query_rect` only search the calling zone's own
+entity map, so this lag has a direction that matters: an area geometrically
+inside zone A's rectangle can be occupied by an entity zone B still owns,
+because it hasn't cleared the margin yet. A query issued from zone A over
+that area misses it entirely. For NPCs this is a live gap, not just a
+terrain-lookup rounding concern - query_radius/query_rect are exactly how
+game code typically finds NPCs near a point, and the margin means that gap
+can persist (an NPC parked just past its zone's edge stays invisible to the
+neighbour's queries indefinitely, not just for the tick it takes to cross).
+Account for this if your NPC AI queries by position near zone edges - a
+terrain lookup or other bounding use should account for the same slack.
+
+The margin only bounds this slack for positions inside the world rectangle.
+An entity outside it entirely is clamped into the edge zone by `pos_to_zone`
+and stays owned by that zone at any distance past the edge - validate
+positions in your movement handler if your game trusts the zone rectangle as
+a hard bound. Also note that a band-parked NPC only stays visible to a
+neighbouring zone's *subscribers* (not its `query_radius`/`query_rect`
+callers) while `view_radius >= 1` keeps that neighbour touched every tick -
+at `view_radius = 0` the owning zone can idle out and persist the NPC under
+coordinates a player standing metres away never loads.
+
+See [Configuration](configuration.md) for the matching `rehome` rate limit on
+how often a player may re-home at all - NPCs re-home directly without going
+through that limiter, since asobi_zone owns them outright.
 
 ## Visibility
 

--- a/src/world/asobi_world_chat.erl
+++ b/src/world/asobi_world_chat.erl
@@ -154,25 +154,10 @@ leave_zone_chats(PlayerId, PlayerPid, WorldId, ZoneCoords, ChatConfig) ->
     end,
     ignore_result(PlayerId).
 
-proximity_zones({ZX, ZY}, Radius, GridSize) when is_integer(ZX), is_integer(ZY) ->
-    [
-        {X, Y}
-     || X <- safe_seq(clamp_lo(ZX - Radius), min(GridSize - 1, ZX + Radius)),
-        Y <- safe_seq(clamp_lo(ZY - Radius), min(GridSize - 1, ZY + Radius))
-    ].
-
--spec clamp_lo(integer()) -> non_neg_integer().
-clamp_lo(N) when N < 0 -> 0;
-clamp_lo(N) -> N.
-
-%% ZoneCoords here comes from asobi_world_server:pos_to_zone/3, which clamps
-%% to the grid - but this module can't rely on every future caller doing the
-%% same, and lists:seq/2 requires Hi >= Lo - 1. Degrade to an empty ring
-%% rather than crashing the caller (this ran the whole world down before
-%% pos_to_zone/3 existed - widgrensit/asobi#248).
--spec safe_seq(integer(), integer()) -> [integer()].
-safe_seq(Lo, Hi) when Hi < Lo -> [];
-safe_seq(Lo, Hi) -> lists:seq(Lo, Hi).
+%% Callers feed a pos_to_zone/3 result; ring/3 owns the malformed-centre
+%% degrade (widgrensit/asobi#248).
+proximity_zones(Coords, Radius, GridSize) ->
+    asobi_zone_grid:ring(Coords, Radius, GridSize).
 
 find_player_pid(PlayerId) ->
     case pg:get_members(nova_scope, {player, PlayerId}) of

--- a/src/world/asobi_world_server.erl
+++ b/src/world/asobi_world_server.erl
@@ -1042,23 +1042,8 @@ pos_to_zone(Pos, ZoneSize, GridSize) when is_integer(GridSize), GridSize > 0 ->
 
 -spec interest_zones({integer(), integer()}, non_neg_integer(), non_neg_integer()) ->
     [{integer(), integer()}].
-interest_zones({ZX, ZY}, Radius, GridSize) ->
-    [
-        {X, Y}
-     || X <- safe_seq(clamp_lo(ZX - Radius), min(GridSize - 1, ZX + Radius)),
-        Y <- safe_seq(clamp_lo(ZY - Radius), min(GridSize - 1, ZY + Radius))
-    ].
-
--spec clamp_lo(integer()) -> non_neg_integer().
-clamp_lo(N) when N < 0 -> 0;
-clamp_lo(N) -> N.
-
-%% lists:seq/2 requires Hi >= Lo - 1; a coordinate outside the grid (only
-%% possible if a caller skips pos_to_zone/3's clamp) would otherwise crash
-%% this function_clause deep instead of degrading to an empty ring.
--spec safe_seq(integer(), integer()) -> [integer()].
-safe_seq(Lo, Hi) when Hi < Lo -> [];
-safe_seq(Lo, Hi) -> lists:seq(Lo, Hi).
+interest_zones(Coords, Radius, GridSize) ->
+    asobi_zone_grid:ring(Coords, Radius, GridSize).
 
 find_player_pid(PlayerId) ->
     case pg:get_members(?PG_SCOPE, {player, PlayerId}) of

--- a/src/world/asobi_zone.erl
+++ b/src/world/asobi_zone.erl
@@ -16,7 +16,7 @@ via `asobi_spatial`. Zones are created and reaped lazily as players move.
 -export([query_radius/3, query_rect/3]).
 -export([init/1, handle_call/3, handle_cast/2, handle_continue/2, handle_info/2, terminate/2]).
 -ifdef(TEST).
--export([past_zone_margin/4]).
+-export([past_zone_margin/4, classify_crossing/5]).
 -endif.
 
 -include_lib("kernel/include/logger.hrl").
@@ -672,13 +672,14 @@ resolve_zone_crossings(
     ),
     %% Transfer each NPC to the target zone
     lists:foreach(
-        fun({Id, TargetCoords, Entity}) ->
+        fun({Id, {TX, TY} = TargetCoords, Entity}) when
+            is_binary(Id), is_integer(TX), is_integer(TY)
+        ->
             case pg:get_members(?PG_SCOPE, {asobi_zone, WorldId, TargetCoords}) of
                 [TargetPid | _] ->
                     gen_server:cast(TargetPid, {add_entity, Id, Entity});
                 [] ->
-                    %% Target zone doesn't exist, NPC disappears
-                    ok
+                    log_npc_transfer_unavailable(WorldId, Id, TargetCoords)
             end
         end,
         ToTransfer
@@ -794,30 +795,20 @@ find_zone_crossings(Entities, Coords, ZoneSize, GridSize, RehomeMargin) ->
             (Id, #{type := ~"npc", x := X, y := Y} = Entity, {Rem, Trans, Rehome}) when
                 is_binary(Id), is_number(X), is_number(Y)
             ->
-                case asobi_world_server:pos_to_zone({X, Y}, ZoneSize, GridSize) of
-                    Coords ->
+                case classify_crossing({X, Y}, Coords, ZoneSize, GridSize, RehomeMargin) of
+                    same ->
                         {Rem, Trans, Rehome};
-                    NewCoords ->
+                    {crossed, NewCoords} ->
                         {[Id | Rem], [{Id, NewCoords, Entity} | Trans], Rehome}
                 end;
             (Id, #{type := ~"player", x := X, y := Y} = Entity, {Rem, Trans, Rehome}) when
                 is_binary(Id), is_number(X), is_number(Y)
             ->
-                %% Hysteresis: pos_to_zone/3 disagreeing with Coords alone is
-                %% a hard edge with zero margin, so a player camped on (or
-                %% jittering across) a boundary would re-home every tick -
-                %% full interest-ring diff, zone snapshot resend, session
-                %% zone_pid flip, each time. Require the position to be
-                %% ZoneSize * RehomeMargin past this zone's own bounds before
-                %% treating it as a real crossing. See widgrensit/asobi#248.
-                case asobi_world_server:pos_to_zone({X, Y}, ZoneSize, GridSize) of
-                    Coords ->
+                case classify_crossing({X, Y}, Coords, ZoneSize, GridSize, RehomeMargin) of
+                    same ->
                         {Rem, Trans, Rehome};
-                    _NewCoords ->
-                        case past_zone_margin({X, Y}, Coords, ZoneSize, RehomeMargin) of
-                            true -> {Rem, Trans, [{Id, {X, Y}, Entity} | Rehome]};
-                            false -> {Rem, Trans, Rehome}
-                        end
+                    {crossed, _NewCoords} ->
+                        {Rem, Trans, [{Id, {X, Y}, Entity} | Rehome]}
                 end;
             (_, _, Acc) ->
                 Acc
@@ -825,6 +816,27 @@ find_zone_crossings(Entities, Coords, ZoneSize, GridSize, RehomeMargin) ->
         {[], [], []},
         Entities
     ).
+
+%% Hysteresis: pos_to_zone/3 disagreeing with Coords alone is a hard edge
+%% with zero margin, so an entity jittering across a boundary crosses every
+%% tick it does - for a player a full ring diff, snapshot resend and
+%% zone_pid flip. Require ZoneSize * RehomeMargin of clearance first, for
+%% both entity types. This is a jitter filter, not a rate limit - see
+%% asobi_rehome_limiter for that. widgrensit/asobi#248.
+-spec classify_crossing(
+    {number(), number()}, {integer(), integer()}, pos_integer(), pos_integer(), number()
+) ->
+    same | {crossed, {integer(), integer()}}.
+classify_crossing({X, Y}, Coords, ZoneSize, GridSize, RehomeMargin) ->
+    case asobi_world_server:pos_to_zone({X, Y}, ZoneSize, GridSize) of
+        Coords ->
+            same;
+        NewCoords ->
+            case past_zone_margin({X, Y}, Coords, ZoneSize, RehomeMargin) of
+                true -> {crossed, NewCoords};
+                false -> same
+            end
+    end.
 
 -spec past_zone_margin({number(), number()}, {integer(), integer()}, pos_integer(), number()) ->
     boolean().
@@ -987,6 +999,31 @@ log_spawn_failed(TemplateId, Reason, #{world_id := WorldId, coords := Coords}) -
     asobi_telemetry:game_error(unknown_spawn_template, #{
         world_id => WorldId,
         template_id => Id
+    }).
+
+%% An NPC crossing into an unloaded target zone is dropped (widgrensit/
+%% asobi#251 gave the analogous spawn failure a signal; this closes the same
+%% gap here - the drop itself, not just its silence, is tracked separately
+%% as widgrensit/asobi#271). This runs from the per-tick crossing check, so
+%% a spawner parked near an unloaded neighbour would otherwise log once per
+%% tick forever (asobi#252) - only the log line is rate-limited, the
+%% telemetry counter stays unconditional.
+-spec log_npc_transfer_unavailable(binary(), binary(), {integer(), integer()}) -> ok.
+log_npc_transfer_unavailable(WorldId, Id, TargetCoords) ->
+    case asobi_script_log_limiter:allow({WorldId, TargetCoords}) of
+        {true, DroppedSinceLastLog} ->
+            ?LOG_WARNING(#{
+                event => npc_transfer_zone_unavailable,
+                world_id => WorldId,
+                entity_id => Id,
+                coords => TargetCoords,
+                suppressed_since_last => DroppedSinceLastLog
+            });
+        false ->
+            ok
+    end,
+    asobi_telemetry:game_error(zone_unavailable, #{
+        world_id => WorldId, coords => TargetCoords, entity_id => Id
     }).
 
 %% A byte-length cut alone can land mid-codepoint, and the result is exported

--- a/src/world/asobi_zone_grid.erl
+++ b/src/world/asobi_zone_grid.erl
@@ -1,0 +1,53 @@
+-module(asobi_zone_grid).
+-moduledoc """
+Shared square-ring helper for `asobi_world_server`'s interest zones and
+`asobi_world_chat`'s proximity zones - both computed the exact same bounded
+neighbourhood of grid coordinates around a centre, previously duplicated
+verbatim in both modules. See widgrensit/asobi#248.
+""".
+
+-export([ring/3]).
+
+-include_lib("kernel/include/logger.hrl").
+
+-doc """
+All grid coordinates within `Radius` of `{ZX, ZY}` on both axes, clamped to
+`0 .. GridSize - 1`.
+
+`{ZX, ZY}` is expected to already be a `pos_to_zone/3` result (always
+integers by construction) - a non-integer centre, or a `GridSize` of 0,
+degrades to an empty ring rather than crashing the caller. An oversized
+`Radius` does not degrade - it simply clamps to the whole grid.
+""".
+-spec ring({integer(), integer()}, non_neg_integer(), non_neg_integer()) ->
+    [{integer(), integer()}].
+ring({ZX, ZY}, Radius, GridSize) when is_integer(ZX), is_integer(ZY) ->
+    [
+        {X, Y}
+     || X <- safe_seq(clamp_lo(ZX - Radius), min(GridSize - 1, ZX + Radius)),
+        Y <- safe_seq(clamp_lo(ZY - Radius), min(GridSize - 1, ZY + Radius))
+    ];
+ring(Coords, Radius, GridSize) ->
+    %% Only reachable via a caller contract violation (every current caller
+    %% feeds a pos_to_zone/3 result), but silently returning [] here reads
+    %% upstream as "no zones in range" - a player would subscribe to nothing
+    %% with no error anywhere. Rate is bounded by joins/zone-changes, not
+    %% ticks, so an unconditional log is safe.
+    ?LOG_WARNING(#{
+        event => zone_ring_malformed_centre,
+        coords => Coords,
+        radius => Radius,
+        grid_size => GridSize
+    }),
+    [].
+
+-spec clamp_lo(integer()) -> non_neg_integer().
+clamp_lo(N) when N < 0 -> 0;
+clamp_lo(N) -> N.
+
+%% lists:seq/2 requires Hi >= Lo - 1; a coordinate outside the grid (only
+%% possible if a caller skips pos_to_zone/3's clamp) would otherwise crash
+%% this function_clause deep instead of degrading to an empty ring.
+-spec safe_seq(integer(), integer()) -> [integer()].
+safe_seq(Lo, Hi) when Hi < Lo -> [];
+safe_seq(Lo, Hi) -> lists:seq(Lo, Hi).

--- a/test/asobi_zone_grid_tests.erl
+++ b/test/asobi_zone_grid_tests.erl
@@ -1,0 +1,49 @@
+-module(asobi_zone_grid_tests).
+-include_lib("eunit/include/eunit.hrl").
+
+ring_centred_within_bounds_test() ->
+    ?assertEqual(
+        [{0, 0}, {0, 1}, {0, 2}, {1, 0}, {1, 1}, {1, 2}, {2, 0}, {2, 1}, {2, 2}],
+        asobi_zone_grid:ring({1, 1}, 1, 10)
+    ).
+
+ring_clamps_low_edge_test() ->
+    ?assertEqual(
+        [{0, 0}, {0, 1}, {1, 0}, {1, 1}],
+        asobi_zone_grid:ring({0, 0}, 1, 10)
+    ).
+
+%% pos_to_zone/3 clamps its callers to 0 .. GridSize - 1, but a coordinate
+%% right at that upper edge still needs a ring that doesn't run off the grid.
+ring_clamps_high_edge_test() ->
+    ?assertEqual(
+        [{1, 1}, {1, 2}, {2, 1}, {2, 2}],
+        asobi_zone_grid:ring({2, 2}, 1, 3)
+    ).
+
+%% Guards the degrade-to-empty path a caller can only hit by skipping
+%% pos_to_zone/3's clamp and passing an already out-of-grid centre.
+ring_out_of_grid_centre_is_empty_test() ->
+    ?assertEqual([], asobi_zone_grid:ring({5, 5}, 1, 3)).
+
+ring_radius_zero_is_just_the_centre_test() ->
+    ?assertEqual([{4, 4}], asobi_zone_grid:ring({4, 4}, 0, 10)).
+
+%% A non-integer centre is a caller contract violation (Coords should always
+%% come from pos_to_zone/3), but both interest_zones/3 and proximity_zones/3
+%% delegate here unconditionally, so this degrades rather than crashing
+%% either caller differently.
+ring_non_integer_centre_is_empty_test() ->
+    ?assertEqual([], asobi_zone_grid:ring({1.0, 1}, 1, 10)),
+    ?assertEqual([], asobi_zone_grid:ring({1, 1.0}, 1, 10)).
+
+%% Radius wider than the grid clamps to the whole grid rather than
+%% degrading - min/2 is the mutation-sensitive edge here.
+ring_radius_exceeding_grid_clamps_to_whole_grid_test() ->
+    ?assertEqual(
+        [{X, Y} || X <- lists:seq(0, 2), Y <- lists:seq(0, 2)],
+        asobi_zone_grid:ring({1, 1}, 50, 3)
+    ).
+
+ring_zero_grid_is_empty_test() ->
+    ?assertEqual([], asobi_zone_grid:ring({0, 0}, 1, 0)).

--- a/test/asobi_zone_tests.erl
+++ b/test/asobi_zone_tests.erl
@@ -54,7 +54,13 @@ zone_test_() ->
         {"spawn_templates_hint updates a live zone's spawnable templates",
             fun spawn_templates_hint_updates_live_zone/0},
         {"spawn_templates_hint returning garbage logs a warning and survives",
-            fun spawn_templates_hint_malformed_return_is_observable/0}
+            fun spawn_templates_hint_malformed_return_is_observable/0},
+        {"an NPC within the boundary margin does not transfer zones",
+            fun npc_within_margin_does_not_transfer/0},
+        {"an NPC past the boundary margin transfers to the neighbouring zone",
+            fun npc_past_margin_transfers/0},
+        {"an NPC transfer to an unloaded target zone is observable, not silent",
+            fun npc_transfer_unavailable_zone_is_observable/0}
     ]}.
 
 starts_empty() ->
@@ -397,6 +403,93 @@ past_zone_margin_test() ->
     %% argument is live and not shadowed by a leftover constant.
     ?assertNot(asobi_zone:past_zone_margin({210.0, 150.0}, Coords, ZoneSize, 0.5)),
     ?assert(asobi_zone:past_zone_margin({210.0, 150.0}, Coords, ZoneSize, 0.05)).
+
+%% zone_size=200, grid_size=10, rehome_margin=0.15 => 30-unit margin.
+classify_crossing_boundary_test() ->
+    C = {0, 0},
+    ?assertEqual(same, asobi_zone:classify_crossing({199.0, 0.0}, C, 200, 10, 0.15)),
+    ?assertEqual(same, asobi_zone:classify_crossing({229.9, 0.0}, C, 200, 10, 0.15)),
+    ?assertEqual({crossed, {1, 0}}, asobi_zone:classify_crossing({230.0, 0.0}, C, 200, 10, 0.15)),
+    %% One axis clear, the other still inside its margin: still a crossing,
+    %% and the target is the zone that actually contains the point.
+    ?assertEqual(
+        {crossed, {1, 1}}, asobi_zone:classify_crossing({245.0, 215.0}, C, 200, 10, 0.15)
+    ),
+    %% Out-of-world clamps back onto Coords before the margin is consulted.
+    ?assertEqual(same, asobi_zone:classify_crossing({-9000.0, 0.0}, C, 200, 10, 0.15)).
+
+%% zone_size=200, rehome_margin=0.15 => zone {0,0} covers x in [0, 200),
+%% margin is 30 units. Passed explicitly so a change to either default
+%% doesn't silently retune what these tests exercise.
+-define(NPC_MARGIN_ZONE_SIZE, 200).
+-define(NPC_MARGIN_REHOME_MARGIN, 0.15).
+
+npc_within_margin_does_not_transfer() ->
+    Pid = start_zone(#{
+        world_id => ~"npc_margin_within",
+        zone_size => ?NPC_MARGIN_ZONE_SIZE,
+        rehome_margin => ?NPC_MARGIN_REHOME_MARGIN
+    }),
+    %% x=215 is past the raw edge (200) but within the 30-unit margin (230).
+    asobi_zone:add_entity(Pid, ~"npc1", #{type => ~"npc", x => 215.0, y => 0.0}),
+    timer:sleep(10),
+    asobi_zone:tick(Pid, 1),
+    timer:sleep(20),
+    ?assert(maps:is_key(~"npc1", asobi_zone:get_entities(Pid))),
+    gen_server:stop(Pid).
+
+npc_past_margin_transfers() ->
+    WorldId = ~"npc_margin_past",
+    Config = #{
+        world_id => WorldId,
+        zone_size => ?NPC_MARGIN_ZONE_SIZE,
+        rehome_margin => ?NPC_MARGIN_REHOME_MARGIN
+    },
+    Pid = start_zone(Config#{coords => {0, 0}}),
+    TargetPid = start_zone(Config#{coords => {1, 0}}),
+    %% x=245 clears the 30-unit margin past the raw edge (200 + 30 = 230).
+    asobi_zone:add_entity(Pid, ~"npc1", #{type => ~"npc", x => 245.0, y => 0.0}),
+    timer:sleep(10),
+    asobi_zone:tick(Pid, 1),
+    timer:sleep(20),
+    ?assertNot(maps:is_key(~"npc1", asobi_zone:get_entities(Pid))),
+    ?assert(maps:is_key(~"npc1", asobi_zone:get_entities(TargetPid))),
+    gen_server:stop(Pid),
+    gen_server:stop(TargetPid).
+
+%% An NPC crossing into a zone that isn't loaded is dropped (asobi_zone_sup
+%% doesn't eagerly spawn every grid cell) - that loss must be observable the
+%% same way #251 made spawn_at_zone_unavailable observable, not silent.
+npc_transfer_unavailable_zone_is_observable() ->
+    Self = self(),
+    Ref = make_ref(),
+    {ok, _} = application:ensure_all_started(telemetry),
+    telemetry:attach(
+        Ref, [asobi, error], fun(_E, _M, Meta, _) -> Self ! {ev, Meta} end, []
+    ),
+    Pid = start_zone(#{
+        world_id => ~"npc_transfer_no_target",
+        coords => {0, 0},
+        zone_size => ?NPC_MARGIN_ZONE_SIZE,
+        rehome_margin => ?NPC_MARGIN_REHOME_MARGIN
+    }),
+    try
+        %% x=245 clears the margin; no zone is loaded at {1,0} in this world.
+        asobi_zone:add_entity(Pid, ~"npc1", #{type => ~"npc", x => 245.0, y => 0.0}),
+        timer:sleep(10),
+        asobi_zone:tick(Pid, 1),
+        timer:sleep(20),
+        ?assertNot(maps:is_key(~"npc1", asobi_zone:get_entities(Pid))),
+        receive
+            {ev, #{kind := zone_unavailable, details := D}} ->
+                ?assertEqual({1, 0}, maps:get(coords, D)),
+                ?assertEqual(~"npc1", maps:get(entity_id, D))
+        after 1000 -> ?assert(false, timeout_waiting_for_zone_unavailable_event)
+        end
+    after
+        telemetry:detach(Ref),
+        gen_server:stop(Pid)
+    end.
 
 start_mock_zone_manager() ->
     spawn(fun() -> mock_zm_loop([]) end).


### PR DESCRIPTION
## Summary

Deferred follow-ups from #248/#266, now that world-mode interest management is live in production:

- **Dedup**: `asobi_world_server:interest_zones/3` and `asobi_world_chat:proximity_zones/3` computed the exact same bounded square-ring (`clamp_lo` + `safe_seq`), duplicated verbatim. Extracted into `asobi_zone_grid:ring/3`, shared by both. The `is_integer` centre guard moves there too, so a malformed centre now degrades to `[]` identically for both callers (previously each crashed differently) - and logs a warning rather than failing silently.
- **NPC hysteresis**: `find_zone_crossings/5` only applied the crossing margin (`past_zone_margin/4`) to players; NPCs crossed a boundary on the hard edge with zero margin. Extracted the shared decision into `classify_crossing/5`, now used by both fold clauses, so NPCs get the same jitter filter players already had.
- **Adjacent fix**: an NPC crossing into an unloaded target zone was silently dropped. Now logs (rate-limited per target zone via `asobi_script_log_limiter`, matching the existing `log_spawn_failed/3` precedent) and emits `asobi_telemetry:game_error(zone_unavailable, ...)`. The deeper asymmetry - a player crossing into an unloaded zone gets `ensure_zone/2`, an NPC gets deleted - is tracked separately as #271, not fixed here (needs its own design pass for a synchronous call from a hot tick path).
- **Docs**: `guides/world-server.md`'s containment-slack note now covers the widened `query_radius`/`query_rect` visibility gap, the out-of-world-rectangle case, and `view_radius=0` idle-out.

Went through the full BEAM-lib review gate (architecture-guardian → security-reviewer → code-reviewer) with all findings from all three passes addressed in the pushed commit.

## Test plan
- [x] `rebar3 fmt --check`, `xref`, `dialyzer`, `elp eqwalize-all`, `elp lint` all clean
- [x] `rebar3 eunit` - 488/488, including new `asobi_zone_grid_tests` and NPC hysteresis/observability tests in `asobi_zone_tests`
- [x] `rebar3 ex_doc` clean
- [ ] CI (Docker Postgres `ct` suite - unavailable locally, no touched module reaches the DB layer)