### PR TITLE
fix: guard against phases/1 returning [] in asobi_match_server

### DIFF
--- a/src/matches/asobi_match_server.erl
+++ b/src/matches/asobi_match_server.erl
@@ -170,8 +170,10 @@ init(Config) ->
             {PhaseInitEvents, PhaseState} =
                 case erlang:function_exported(GameMod, phases, 1) of
                     true ->
-                        Phases = GameMod:phases(GameConfig),
-                        asobi_phase:init(Phases);
+                        case GameMod:phases(GameConfig) of
+                            [] -> {[], undefined};
+                            Phases -> asobi_phase:init(Phases)
+                        end;
                     false ->
                         {[], undefined}
                 end,

--- a/test/asobi_match_server_tests.erl
+++ b/test/asobi_match_server_tests.erl
@@ -463,6 +463,7 @@ empty_phases_does_not_finish_test() ->
     ok = asobi_match_server:join(Pid, ~"p1"),
     timer:sleep(100),
     ?assertEqual(running, maps:get(status, asobi_match_server:get_info(Pid))),
+    gen_statem:stop(Pid),
     meck:unload(asobi_test_game),
     cleanup(ok).
 

--- a/test/asobi_match_server_tests.erl
+++ b/test/asobi_match_server_tests.erl
@@ -451,6 +451,21 @@ broadcast_in_finished_is_not_swallowed_test() ->
     meck:unload(asobi_test_game),
     cleanup(ok).
 
+empty_phases_does_not_finish_test() ->
+    %% Inject phases/1 that returns []. Before the fix, the match would
+    %% transition to `finished` on the first tick because asobi_phase:init([])
+    %% returns a state with status=complete. Mirrors
+    %% asobi_world_server_tests:empty_phases_does_not_finish/0.
+    setup(),
+    meck:new(asobi_test_game, [passthrough, non_strict, no_link]),
+    meck:expect(asobi_test_game, phases, fun(_GameConfig) -> [] end),
+    Pid = start_match(#{min_players => 1, max_players => 2, tick_rate => 10}),
+    ok = asobi_match_server:join(Pid, ~"p1"),
+    timer:sleep(100),
+    ?assertEqual(running, maps:get(status, asobi_match_server:get_info(Pid))),
+    meck:unload(asobi_test_game),
+    cleanup(ok).
+
 wait_for_status(_Pid, _Status, 0) ->
     error(timeout_waiting_for_status);
 wait_for_status(Pid, Status, N) ->


### PR DESCRIPTION
## Summary
- `asobi_match_server:init/1` unconditionally called `asobi_phase:init(GameMod:phases(GameConfig))` when `phases/1` was exported, without checking for an empty list.
- `asobi_phase:init([])` returns a state with `complete => true`, so a match whose game module exports `phases/1` but returns `[]` finished itself on the very first tick.
- `asobi_world_server` already guards this exact case (added in #91); `asobi_match_server` never got the matching guard.
- This was latent until `widgrensit/asobi_lua#109` made every Lua match export `phases/1` (mirroring `asobi_lua_world`), which newly exposed it for every Lua match with no phases defined.

## Fix
Mirror `asobi_world_server`'s existing guard: only call `asobi_phase:init/1` when `phases/1` returns a non-empty list.

## Test plan
- [x] New `empty_phases_does_not_finish_test/0` in `asobi_match_server_tests.erl`, mirroring `asobi_world_server_tests:empty_phases_does_not_finish/0`
- [x] `rebar3 fmt --check`, `xref`, `dialyzer` all clean
- [x] `rebar3 eunit --module=asobi_match_server_tests` — 28/28 passing

Closes widgrensit/asobi#273