### PR TITLE
fix: backfill zone subscribers a crossing lazily creates

### DIFF
--- a/src/world/asobi_world_server.erl
+++ b/src/world/asobi_world_server.erl
@@ -361,13 +361,21 @@ running(
         zone_manager_pid := ZMPid,
         zone_size := ZS,
         grid_size := GridSize,
-        world_id := WorldId
+        world_id := WorldId,
+        player_zones := PlayerZones
     } = _State
 ) when is_binary(TemplateId), is_number(X), is_number(Y), is_map(Overrides) ->
     Coords = pos_to_zone(Pos, ZS, GridSize),
     case asobi_zone_manager:ensure_zone(ZMPid, Coords) of
-        {ok, ZonePid} ->
+        {ok, ZonePid, ZoneStatus} ->
             asobi_zone:spawn_entity(ZonePid, TemplateId, Pos, Overrides),
+            %% asobi#275: a script-driven spawn can lazily create a zone just
+            %% as a player crossing can - same backfill is needed, just with
+            %% no acting player of its own to exclude.
+            case ZoneStatus of
+                created -> backfill_zone_subscribers(Coords, ZonePid, undefined, PlayerZones);
+                existing -> ok
+            end,
             keep_state_and_data;
         {error, Reason} ->
             %% asobi#251: same "spawn something, hear nothing" pattern
@@ -637,7 +645,7 @@ restore_entities([{CX, CY} = Coords | Rest], Entities, ZoneManagerPid, WorldId) 
                     asobi_telemetry:game_error(zone_unavailable, #{
                         world_id => WorldId, coords => Coords, reason => Reason
                     });
-                {ok, ZonePid} ->
+                {ok, ZonePid, _Status} ->
                     maps:foreach(
                         fun(EId, EState) -> asobi_zone:add_entity(ZonePid, EId, EState) end,
                         RecoveredEnts
@@ -805,12 +813,17 @@ place_player(
     case asobi_zone_manager:ensure_zone(ZMPid, ZoneCoords) of
         {error, Reason} ->
             {error, Reason, State};
-        {ok, ZonePid} ->
+        {ok, ZonePid, ZoneStatus} ->
             PlayerPid = find_player_pid(PlayerId),
             asobi_zone:add_entity(ZonePid, PlayerId, Entity),
             asobi_presence:send(PlayerId, {world_joined, self(), ZonePid}),
             InterestZones = interest_zones(ZoneCoords, ViewRadius, GridSize),
             subscribe_interest_zones(InterestZones, ZMPid, PlayerId, PlayerPid),
+            PlayerZones = maps:get(player_zones, State),
+            case ZoneStatus of
+                created -> backfill_zone_subscribers(ZoneCoords, ZonePid, PlayerId, PlayerZones);
+                existing -> ok
+            end,
             %% Drain the casts above (add_entity + subscribe) by issuing a sync call to
             %% the zone. Without this, a world.input cast from the WS handler can race
             %% past the add_entity cast (different sender = no FIFO) and the zone's
@@ -819,7 +832,6 @@ place_player(
             %% silently drops the input. The sync call forces the zone to process its
             %% mailbox up to here before we reply {ok, ZonePid} to the WS handler.
             _ = asobi_zone:get_subscriber_count(ZonePid),
-            PlayerZones = maps:get(player_zones, State),
             State1 = State#{
                 player_zones => PlayerZones#{
                     PlayerId => #{zone => ZoneCoords, interest => InterestZones}
@@ -827,6 +839,40 @@ place_player(
             },
             {ok, State1, ZonePid}
     end.
+
+%% asobi#275: a zone coming into existence has to pick up every already-known
+%% player whose interest ring already covers it - the ring-diff subscribe path
+%% only fires for zones newly entering a player's ring, never for one that was
+%% already there but unloaded at the time. ExcludePlayerId is whichever player
+%% caused this creation - they are subscribed separately by the caller (with
+%% the full context of their own crossing/join), so skip them here.
+%%
+%% Deliberately does not reuse find_player_pid/1 - its self()-fallback exists
+%% for "the player currently acting" (always a live caller), but a
+%% player_zones entry outlives disconnection (kept around for reconnect, see
+%% the {reconnect_state := RS} clause above), so a player here can legitimately
+%% have no live session. Falling back to self() would subscribe the world
+%% server's own pid as that player's "session" - a silent wrong subscriber
+%% that stalls out the zone_delta stream until they actually reconnect.
+-spec backfill_zone_subscribers({integer(), integer()}, pid(), binary() | undefined, map()) -> ok.
+backfill_zone_subscribers(ZoneCoords, ZonePid, ExcludePlayerId, PlayerZones) ->
+    maps:foreach(
+        fun
+            (PlayerId, _) when PlayerId =:= ExcludePlayerId ->
+                ok;
+            (PlayerId, #{interest := Interest}) ->
+                case lists:member(ZoneCoords, Interest) of
+                    true ->
+                        case pg:get_members(?PG_SCOPE, {player, PlayerId}) of
+                            [PlayerPid | _] -> asobi_zone:subscribe(ZonePid, {PlayerId, PlayerPid});
+                            [] -> ok
+                        end;
+                    false ->
+                        ok
+                end
+        end,
+        PlayerZones
+    ).
 
 remove_player_from_zones(
     PlayerId,
@@ -939,7 +985,7 @@ handle_move(
                                 world_id => WorldId, coords => NewZoneCoords, reason => Reason
                             }),
                             keep_state_and_data;
-                        {ok, NewZonePid} ->
+                        {ok, NewZonePid, ZoneStatus} ->
                             %% A single-step crossing keeps most of the ring in
                             %% common (radius 1 keeps 6 of 9 zones on an
                             %% orthogonal move) - touching only the zones that
@@ -949,7 +995,17 @@ handle_move(
                             %% change. See widgrensit/asobi#248.
                             NewInterest = interest_zones(NewZoneCoords, ViewRadius, GridSize),
                             ToUnsubscribe = OldInterest -- NewInterest,
-                            ToSubscribe = NewInterest -- OldInterest,
+                            %% NewZoneCoords is itself always part of NewInterest
+                            %% (the ring includes its own centre), so a one-step
+                            %% crossing where it was already a ring neighbour
+                            %% never appears in this diff. asobi#275: subscribe
+                            %% is idempotent for an already-subscribed pid, so
+                            %% NewZoneCoords is dropped here and subscribed
+                            %% unconditionally below instead of relying on the
+                            %% diff to have subscribed it correctly the first
+                            %% time it entered the ring (it may not have - see
+                            %% backfill_zone_subscribers/4).
+                            ToSubscribe = (NewInterest -- OldInterest) -- [NewZoneCoords],
 
                             case asobi_zone_manager:get_zone(ZMPid, OldZoneCoords) of
                                 {ok, OldZonePid} -> asobi_zone:remove_entity(OldZonePid, PlayerId);
@@ -960,7 +1016,22 @@ handle_move(
                             asobi_presence:send(PlayerId, {world_joined, self(), NewZonePid}),
 
                             unsubscribe_interest_zones(ToUnsubscribe, ZMPid, PlayerId),
+                            asobi_zone:subscribe(NewZonePid, {PlayerId, PlayerPid}),
                             subscribe_interest_zones(ToSubscribe, ZMPid, PlayerId, PlayerPid),
+                            %% asobi#275: this crossing is what brought the zone
+                            %% into existence - any other already-connected
+                            %% player whose interest ring already covers it (a
+                            %% stationary neighbour, most commonly) tried to
+                            %% subscribe while it was not_loaded and was
+                            %% silently skipped, with nothing to retry it since.
+                            case ZoneStatus of
+                                created ->
+                                    backfill_zone_subscribers(
+                                        NewZoneCoords, NewZonePid, PlayerId, PlayerZones
+                                    );
+                                existing ->
+                                    ok
+                            end,
                             %% Same race place_player/4's join path guards against: a
                             %% world.input cast can reach the new zone before add_entity
                             %% lands, since add_entity and the WS handler's cast are

--- a/src/world/asobi_zone.erl
+++ b/src/world/asobi_zone.erl
@@ -360,31 +360,26 @@ handle_cast({remove_entity, EntityId}, #{entities := Entities, spatial_grid := G
     {noreply, State#{entities => maps:remove(EntityId, Entities), spatial_grid => Grid1}};
 handle_cast(
     {subscribe, PlayerId, PlayerPid},
-    #{subscribers := Subs, entities := Entities, coords := Coords} = State
+    #{subscribers := Subs} = State
+) when is_binary(PlayerId), is_pid(PlayerPid), is_map_key(PlayerId, Subs) ->
+    %% Re-affirming a subscription that already holds for this pid is a no-op:
+    %% callers now subscribe a crossing player to their destination zone
+    %% unconditionally (widgrensit/asobi#275), so this is the common case on
+    %% every crossing, not just a rare double-call. Re-monitoring here would
+    %% leak the old MonRef (never demonitored) and resending the snapshot is
+    %% wasted - the next tick already delivers deltas to a live subscriber.
+    case maps:get(PlayerId, Subs) of
+        {PlayerPid, _MonRef} ->
+            {noreply, State};
+        {_OldPid, OldMonRef} ->
+            demonitor(OldMonRef, [flush]),
+            subscribe_new(PlayerId, PlayerPid, State)
+    end;
+handle_cast(
+    {subscribe, PlayerId, PlayerPid},
+    State
 ) when is_binary(PlayerId), is_pid(PlayerPid) ->
-    MonRef = monitor(process, PlayerPid),
-    %% Send immediate snapshot so new subscribers see all current entities
-    _ =
-        case map_size(Entities) of
-            0 ->
-                ok;
-            _ ->
-                Snapshot = [E#{~"op" => ~"a", ~"id" => Id} || {Id, E} <- maps:to_list(Entities)],
-                PlayerPid ! {asobi_message, {zone_delta, 0, Snapshot}}
-        end,
-    _ =
-        case maps:get(terrain_store_pid, State, undefined) of
-            undefined ->
-                ok;
-            StorePid ->
-                case asobi_terrain_store:get_chunk(StorePid, Coords) of
-                    {ok, Data} ->
-                        PlayerPid ! {asobi_message, {terrain_chunk, Coords, Data}};
-                    _ ->
-                        ok
-                end
-        end,
-    {noreply, State#{subscribers => Subs#{PlayerId => {PlayerPid, MonRef}}}};
+    subscribe_new(PlayerId, PlayerPid, State);
 handle_cast({unsubscribe, PlayerId}, #{subscribers := Subs} = State) ->
     case maps:get(PlayerId, Subs, undefined) of
         undefined ->
@@ -467,6 +462,36 @@ terminate(_Reason, #{world_id := WorldId, coords := Coords, entities := Entities
     ok.
 
 %% --- Internal ---
+
+-spec subscribe_new(binary(), pid(), map()) -> {noreply, map()}.
+subscribe_new(
+    PlayerId,
+    PlayerPid,
+    #{subscribers := Subs, entities := Entities, coords := Coords} = State
+) ->
+    MonRef = monitor(process, PlayerPid),
+    %% Send immediate snapshot so new subscribers see all current entities
+    _ =
+        case map_size(Entities) of
+            0 ->
+                ok;
+            _ ->
+                Snapshot = [E#{~"op" => ~"a", ~"id" => Id} || {Id, E} <- maps:to_list(Entities)],
+                PlayerPid ! {asobi_message, {zone_delta, 0, Snapshot}}
+        end,
+    _ =
+        case maps:get(terrain_store_pid, State, undefined) of
+            undefined ->
+                ok;
+            StorePid ->
+                case asobi_terrain_store:get_chunk(StorePid, Coords) of
+                    {ok, Data} ->
+                        PlayerPid ! {asobi_message, {terrain_chunk, Coords, Data}};
+                    _ ->
+                        ok
+                end
+        end,
+    {noreply, State#{subscribers => Subs#{PlayerId => {PlayerPid, MonRef}}}}.
 
 do_tick(
     TickN,

--- a/src/world/asobi_zone_manager.erl
+++ b/src/world/asobi_zone_manager.erl
@@ -29,15 +29,25 @@ Hot-path lookups go through ETS directly, bypassing the gen_server.
 start_link(Opts) ->
     gen_server:start_link(?MODULE, Opts, []).
 
--doc "Return existing zone or start a new one. ETS fast path first.".
--spec ensure_zone(pid() | atom(), {integer(), integer()}) -> {ok, pid()} | {error, term()}.
+-doc """
+Return existing zone or start a new one. ETS fast path first.
+
+The third element of a successful result tells the caller whether this call
+is what brought the zone into existence (`created`) or whether it was already
+running (`existing`) - callers that need to backfill subscribers whose
+interest ring already covered these coords (widgrensit/asobi#275) only need
+to act on `created`.
+""".
+-spec ensure_zone(pid() | atom(), {integer(), integer()}) ->
+    {ok, pid(), created | existing} | {error, term()}.
 ensure_zone(Ref, Coords) ->
     case ets_lookup(Ref, Coords) of
         {ok, Pid} ->
-            {ok, Pid};
+            {ok, Pid, existing};
         not_loaded ->
             case gen_server:call(Ref, {ensure_zone, Coords}) of
-                {ok, P} when is_pid(P) -> {ok, P};
+                {ok, P, created} when is_pid(P) -> {ok, P, created};
+                {ok, P, existing} when is_pid(P) -> {ok, P, existing};
                 {error, _} = Err -> Err
             end
     end.
@@ -142,11 +152,11 @@ init(Opts) ->
 handle_call({ensure_zone, Coords}, _From, #{ets_tab := Tab} = State) ->
     case ets:lookup(Tab, Coords) of
         [{Coords, Pid}] ->
-            {reply, {ok, Pid}, touch(Coords, State)};
+            {reply, {ok, Pid, existing}, touch(Coords, State)};
         [] ->
             case start_zone(Coords, State) of
                 {ok, Pid, State1} ->
-                    {reply, {ok, Pid}, State1};
+                    {reply, {ok, Pid, created}, State1};
                 {error, Reason} ->
                     {reply, {error, Reason}, State}
             end

--- a/test/asobi_terrain_integration_tests.erl
+++ b/test/asobi_terrain_integration_tests.erl
@@ -63,7 +63,7 @@ terrain_chunk_on_subscribe() ->
     unlink(InstancePid),
     timer:sleep(100),
     ZMPid = asobi_world_instance:get_child(InstancePid, asobi_zone_manager),
-    {ok, ZonePid} = asobi_zone_manager:ensure_zone(ZMPid, {0, 0}),
+    {ok, ZonePid, _Status} = asobi_zone_manager:ensure_zone(ZMPid, {0, 0}),
     asobi_zone:subscribe(ZonePid, {~"test_player", self()}),
     Received = collect_messages(500),
     HasTerrain = lists:any(
@@ -82,7 +82,7 @@ terrain_data_correct() ->
     unlink(InstancePid),
     timer:sleep(100),
     ZMPid = asobi_world_instance:get_child(InstancePid, asobi_zone_manager),
-    {ok, ZonePid} = asobi_zone_manager:ensure_zone(ZMPid, {1, 2}),
+    {ok, ZonePid, _Status} = asobi_zone_manager:ensure_zone(ZMPid, {1, 2}),
     asobi_zone:subscribe(ZonePid, {~"test_player2", self()}),
     Received = collect_messages(500),
     [{asobi_message, {terrain_chunk, {1, 2}, ChunkData}}] =

--- a/test/asobi_world_zone_integration_tests.erl
+++ b/test/asobi_world_zone_integration_tests.erl
@@ -70,6 +70,10 @@ world_zone_integration_test_() ->
             fun script_owned_player_entity_survives_crossing/0},
         {"a crossing only touches the interest-ring zones that actually changed",
             fun world_input_crossing_touches_only_ring_delta/0},
+        {"a crossing into a lazily-created zone backfills a stationary neighbour",
+            fun crossing_into_a_lazily_created_zone_backfills_stationary_neighbours/0},
+        {"a script-driven spawn into a lazily-created zone backfills neighbours",
+            fun script_spawn_into_a_lazily_created_zone_backfills_neighbours/0},
         {"a position within the boundary margin does not rehome the player",
             fun world_input_within_margin_does_not_rehome/0},
         {"a rate-limited crossing leaves the entity in place instead of destroying it",
@@ -129,7 +133,7 @@ shared_zone_process() ->
     timer:sleep(20),
     %% Both spawn at {100.0, 100.0} => zone {1,1}
     {ok, ZonePid1} = asobi_zone_manager:get_zone(Mgr, {1, 1}),
-    {ok, ZonePid2} = asobi_zone_manager:ensure_zone(Mgr, {1, 1}),
+    {ok, ZonePid2, existing} = asobi_zone_manager:ensure_zone(Mgr, {1, 1}),
     ?assertEqual(ZonePid1, ZonePid2),
     ?assert(is_process_alive(ZonePid1)),
     stop_world(Ctx).
@@ -369,7 +373,7 @@ rehome_denied_by_global_limit() ->
 %% attempted a hand-off nothing claimed - it must stay exactly where it was.
 script_owned_player_entity_survives_crossing() ->
     Ctx = #{world_pid := Pid, zone_mgr := Mgr} = start_world(#{lazy_zones => true}),
-    {ok, ZonePid1} = asobi_zone_manager:ensure_zone(Mgr, {1, 1}),
+    {ok, ZonePid1, created} = asobi_zone_manager:ensure_zone(Mgr, {1, 1}),
     asobi_zone:add_entity(ZonePid1, ~"bot1", #{
         x => 100.0, y => 100.0, type => ~"player", hp => 7
     }),
@@ -422,7 +426,10 @@ world_input_crossing_touches_only_ring_delta() ->
     %% Reaching the same end state doesn't prove the ring diff ran instead of
     %% a full unsubscribe-everything/resubscribe-everything pass - both reach
     %% identical final counts. Count the actual subscribe/unsubscribe calls:
-    %% only 3 zones left the ring and 3 entered it, not all 9.
+    %% only 3 zones left the ring and 3 entered it (not all 9), plus one more
+    %% unconditional subscribe to the destination zone itself (asobi#275: the
+    %% crossing player is always (re-)subscribed to the zone they land in,
+    %% even though it stayed in the ring and so is never in the ring diff).
     Self = self(),
     meck:new(asobi_zone, [passthrough]),
     try
@@ -445,14 +452,17 @@ world_input_crossing_touches_only_ring_delta() ->
         SubscribeCalls = count_messages(subscribed),
         UnsubscribeCalls = count_messages(unsubscribed),
 
-        ?assertEqual(3, SubscribeCalls),
+        ?assertEqual(4, SubscribeCalls),
         ?assertEqual(3, UnsubscribeCalls),
         %% {1,1} is in both rings - never unsubscribed, so it's never re-touched.
         ?assertEqual(1, asobi_zone:get_subscriber_count(Z11)),
         %% {0,0} left the ring (x=0 column no longer in range) - unsubscribed.
         ?assertEqual(0, asobi_zone:get_subscriber_count(Z00)),
         %% {3,0} entered the ring (x=3 column, new only) - freshly subscribed.
-        ?assertEqual(1, asobi_zone:get_subscriber_count(Z30))
+        ?assertEqual(1, asobi_zone:get_subscriber_count(Z30)),
+        %% {2,1} is the destination zone itself - subscribed unconditionally.
+        {ok, Z21} = asobi_zone_manager:get_zone(Mgr, {2, 1}),
+        ?assertEqual(1, asobi_zone:get_subscriber_count(Z21))
     after
         meck:unload(asobi_zone),
         stop_world(Ctx)
@@ -462,6 +472,132 @@ count_messages(Tag) ->
     receive
         Tag -> 1 + count_messages(Tag)
     after 0 -> 0
+    end.
+
+%% A live, pg-registered session for a player, so find_player_pid/1 and
+%% backfill_zone_subscribers/4 (both pg-based) resolve to a real process
+%% instead of silently falling through to not_loaded/self()-fallback
+%% behaviour. Forwards every asobi_message to Owner so a test can assert on
+%% actual delivery, not just zone subscriber-map bookkeeping.
+fake_session(PlayerId, Owner) ->
+    Pid = spawn(fun Loop() ->
+        receive
+            stop ->
+                ok;
+            Msg ->
+                Owner ! {PlayerId, Msg},
+                Loop()
+        end
+    end),
+    ok = pg:join(nova_scope, {player, PlayerId}, Pid),
+    Pid.
+
+%% Blocks until PlayerId's forwarded messages include a zone_delta mentioning
+%% EntityId, or the timeout elapses.
+received_entity(PlayerId, EntityId) ->
+    receive
+        {PlayerId, {asobi_message, {zone_delta, _Tick, Ops}}} ->
+            HasEntity = lists:any(
+                fun
+                    (#{~"id" := Id}) -> Id =:= EntityId;
+                    (_) -> false
+                end,
+                Ops
+            ),
+            case HasEntity of
+                true -> true;
+                false -> received_entity(PlayerId, EntityId)
+            end
+    after 500 -> false
+    end.
+
+%% Regression for widgrensit/asobi#275: a zone that a crossing brings into
+%% existence for the first time must pick up every already-connected player
+%% whose interest ring already covered it, not just the crossing player.
+%% Before the fix, a stationary neighbour's earlier subscribe attempt (made
+%% back when the zone was still not_loaded) was silently skipped, and the
+%% ring-diff on the crossing player's own move never re-touched a zone that
+%% stayed in their ring - so nothing ever subscribed the neighbour to it.
+%%
+%% Player ids are namespaced (bf275_*) and each has a real pg-registered
+%% session killed at the end - a stale {player, <<"p1">>} registration
+%% leaking from an unrelated suite must not be able to satisfy this test the
+%% way a bare ~"p1"/~"p2" id previously could.
+crossing_into_a_lazily_created_zone_backfills_stationary_neighbours() ->
+    Ctx =
+        #{world_pid := Pid, zone_mgr := Mgr} = start_world(#{
+            lazy_zones => true, grid_size => 5
+        }),
+    Ada = ~"bf275_ada",
+    Bob = ~"bf275_bob",
+    AdaPid = fake_session(Ada, self()),
+    BobPid = fake_session(Bob, self()),
+    try
+        %% Ada joins and stays put. Spawns at {100.0,100.0} => zone {1,1};
+        %% with view_radius=1 that ring already covers {2,1} - but {2,1} is
+        %% not_loaded at join, so the ring-subscribe attempt to it silently
+        %% no-ops (subscribe_interest_zones/4 uses get_zone, never
+        %% ensure_zone).
+        ?assertEqual(ok, asobi_world_server:join(Pid, Ada)),
+        timer:sleep(20),
+        ?assertEqual(not_loaded, asobi_zone_manager:get_zone(Mgr, {2, 1})),
+
+        %% Bob joins (also spawns in {1,1}) and then crosses one zone east
+        %% into {2,1} - the same crossing that lazily creates the zone for
+        %% the first time.
+        ?assertEqual(ok, asobi_world_server:join(Pid, Bob)),
+        timer:sleep(20),
+        {ok, Z11} = asobi_zone_manager:get_zone(Mgr, {1, 1}),
+        %% x=225 clears zone {1,1}'s margin (edge at 200 + 15% of 100),
+        %% landing in zone {2,1}.
+        asobi_zone:player_input(Z11, Bob, #{
+            ~"action" => ~"move", ~"x" => 225.0, ~"y" => 100.0
+        }),
+        timer:sleep(150),
+
+        {ok, Z21} = asobi_zone_manager:get_zone(Mgr, {2, 1}),
+        %% The right pids, not just the right keys.
+        ?assertMatch(
+            #{subscribers := #{Ada := {AdaPid, _}, Bob := {BobPid, _}}}, sys:get_state(Z21)
+        ),
+        %% And the thing #275 actually reports: the stationary neighbour
+        %% receives the crossing player's entity.
+        ?assert(received_entity(Ada, Bob))
+    after
+        exit(AdaPid, kill),
+        exit(BobPid, kill),
+        stop_world(Ctx)
+    end.
+
+%% Regression for widgrensit/asobi#275, spawn_at variant: a script-driven
+%% game.spawn call can lazily create a zone just as a player crossing can -
+%% same backfill applies, just with no acting player of its own to exclude
+%% (ExcludePlayerId = undefined at that call site). The template_id is
+%% deliberately unresolvable - spawn_at's backfill runs off ensure_zone's
+%% created/existing status, not off whether the spawn itself succeeds, so
+%% this doesn't need a real template registered in the test game module.
+script_spawn_into_a_lazily_created_zone_backfills_neighbours() ->
+    Ctx =
+        #{world_pid := Pid, zone_mgr := Mgr} = start_world(#{
+            lazy_zones => true, grid_size => 5
+        }),
+    Ada = ~"bf275_spawn_ada",
+    AdaPid = fake_session(Ada, self()),
+    try
+        ?assertEqual(ok, asobi_world_server:join(Pid, Ada)),
+        timer:sleep(20),
+        ?assertEqual(not_loaded, asobi_zone_manager:get_zone(Mgr, {2, 1})),
+
+        %% {225.0, 100.0} is zone {2,1} - already in Ada's interest ring
+        %% (view_radius=1 from {1,1}), but not yet loaded.
+        ok = asobi_world_server:spawn_at(Pid, ~"unresolvable_template", {225.0, 100.0}),
+        timer:sleep(150),
+
+        {ok, Z21} = asobi_zone_manager:get_zone(Mgr, {2, 1}),
+        ?assertMatch(#{subscribers := #{Ada := {AdaPid, _}}}, sys:get_state(Z21))
+    after
+        exit(AdaPid, kill),
+        stop_world(Ctx)
     end.
 
 %% Small grid (grid_size=3) without explicit lazy_zones works like before

--- a/test/asobi_zone_manager_tests.erl
+++ b/test/asobi_zone_manager_tests.erl
@@ -64,15 +64,15 @@ starts_ok() ->
 
 ensure_zone_creates() ->
     Ctx = #{mgr := Mgr} = start_manager(),
-    {ok, ZonePid} = asobi_zone_manager:ensure_zone(Mgr, {0, 0}),
+    {ok, ZonePid, created} = asobi_zone_manager:ensure_zone(Mgr, {0, 0}),
     ?assert(is_pid(ZonePid)),
     ?assert(is_process_alive(ZonePid)),
     stop_manager(Ctx).
 
 ensure_zone_existing() ->
     Ctx = #{mgr := Mgr} = start_manager(),
-    {ok, Pid1} = asobi_zone_manager:ensure_zone(Mgr, {1, 1}),
-    {ok, Pid2} = asobi_zone_manager:ensure_zone(Mgr, {1, 1}),
+    {ok, Pid1, created} = asobi_zone_manager:ensure_zone(Mgr, {1, 1}),
+    {ok, Pid2, existing} = asobi_zone_manager:ensure_zone(Mgr, {1, 1}),
     ?assertEqual(Pid1, Pid2),
     stop_manager(Ctx).
 
@@ -83,14 +83,14 @@ get_zone_not_loaded() ->
 
 get_zone_loaded() ->
     Ctx = #{mgr := Mgr} = start_manager(),
-    {ok, ZonePid} = asobi_zone_manager:ensure_zone(Mgr, {0, 1}),
+    {ok, ZonePid, created} = asobi_zone_manager:ensure_zone(Mgr, {0, 1}),
     ?assertEqual({ok, ZonePid}, asobi_zone_manager:get_zone(Mgr, {0, 1})),
     stop_manager(Ctx).
 
 get_active_zones() ->
     Ctx = #{mgr := Mgr} = start_manager(),
-    {ok, P1} = asobi_zone_manager:ensure_zone(Mgr, {0, 0}),
-    {ok, P2} = asobi_zone_manager:ensure_zone(Mgr, {1, 0}),
+    {ok, P1, created} = asobi_zone_manager:ensure_zone(Mgr, {0, 0}),
+    {ok, P2, created} = asobi_zone_manager:ensure_zone(Mgr, {1, 0}),
     Active = asobi_zone_manager:get_active_zones(Mgr),
     ?assertEqual(2, length(Active)),
     ?assert(lists:member(P1, Active)),
@@ -99,7 +99,7 @@ get_active_zones() ->
 
 zone_terminated_cleanup() ->
     Ctx = #{mgr := Mgr} = start_manager(),
-    {ok, ZonePid} = asobi_zone_manager:ensure_zone(Mgr, {0, 0}),
+    {ok, ZonePid, created} = asobi_zone_manager:ensure_zone(Mgr, {0, 0}),
     exit(ZonePid, kill),
     timer:sleep(50),
     ?assertEqual(not_loaded, asobi_zone_manager:get_zone(Mgr, {0, 0})),
@@ -107,20 +107,20 @@ zone_terminated_cleanup() ->
 
 down_monitor_cleanup() ->
     Ctx = #{mgr := Mgr} = start_manager(),
-    {ok, ZonePid} = asobi_zone_manager:ensure_zone(Mgr, {2, 1}),
+    {ok, ZonePid, created} = asobi_zone_manager:ensure_zone(Mgr, {2, 1}),
     exit(ZonePid, kill),
     timer:sleep(50),
     ?assertEqual(not_loaded, asobi_zone_manager:get_zone(Mgr, {2, 1})),
     %% Can recreate after cleanup
-    {ok, NewPid} = asobi_zone_manager:ensure_zone(Mgr, {2, 1}),
+    {ok, NewPid, created} = asobi_zone_manager:ensure_zone(Mgr, {2, 1}),
     ?assert(is_pid(NewPid)),
     ?assertNotEqual(ZonePid, NewPid),
     stop_manager(Ctx).
 
 max_zones_enforced() ->
     Ctx = #{mgr := Mgr} = start_manager(#{max_active_zones => 2}),
-    {ok, _} = asobi_zone_manager:ensure_zone(Mgr, {0, 0}),
-    {ok, _} = asobi_zone_manager:ensure_zone(Mgr, {1, 0}),
+    {ok, _, created} = asobi_zone_manager:ensure_zone(Mgr, {0, 0}),
+    {ok, _, created} = asobi_zone_manager:ensure_zone(Mgr, {1, 0}),
     ?assertEqual({error, max_zones_reached}, asobi_zone_manager:ensure_zone(Mgr, {2, 0})),
     stop_manager(Ctx).
 
@@ -137,7 +137,7 @@ pre_warm_all() ->
 
 touch_zone_resets() ->
     Ctx = #{mgr := Mgr} = start_manager(),
-    {ok, _} = asobi_zone_manager:ensure_zone(Mgr, {0, 0}),
+    {ok, _, created} = asobi_zone_manager:ensure_zone(Mgr, {0, 0}),
     ok = asobi_zone_manager:touch_zone(Mgr, {0, 0}),
     timer:sleep(10),
     ?assertMatch({ok, _}, asobi_zone_manager:get_zone(Mgr, {0, 0})),
@@ -145,7 +145,7 @@ touch_zone_resets() ->
 
 release_zone_marks_stale() ->
     Ctx = #{mgr := Mgr} = start_manager(),
-    {ok, _} = asobi_zone_manager:ensure_zone(Mgr, {0, 0}),
+    {ok, _, created} = asobi_zone_manager:ensure_zone(Mgr, {0, 0}),
     ok = asobi_zone_manager:release_zone(Mgr, {0, 0}),
     timer:sleep(10),
     ?assertMatch({ok, _}, asobi_zone_manager:get_zone(Mgr, {0, 0})),
@@ -162,8 +162,8 @@ initial_zone_states_threaded() ->
         {1, 1} => #{marker => one_one, lua_state => fake_lua_one}
     },
     ok = asobi_zone_manager:set_initial_zone_states(Mgr, States),
-    {ok, P00} = asobi_zone_manager:ensure_zone(Mgr, {0, 0}),
-    {ok, P11} = asobi_zone_manager:ensure_zone(Mgr, {1, 1}),
+    {ok, P00, created} = asobi_zone_manager:ensure_zone(Mgr, {0, 0}),
+    {ok, P11, created} = asobi_zone_manager:ensure_zone(Mgr, {1, 1}),
     #{zone_state := ZS00} = sys:get_state(P00),
     #{zone_state := ZS11} = sys:get_state(P11),
     ?assertMatch(#{marker := zero_zero, lua_state := fake_lua_zero}, ZS00),
@@ -174,7 +174,7 @@ initial_zone_states_default() ->
     Ctx = #{mgr := Mgr} = start_manager(),
     %% No set_initial_zone_states call — zone should still start with the
     %% default empty zone_state, not crash.
-    {ok, P} = asobi_zone_manager:ensure_zone(Mgr, {0, 0}),
+    {ok, P, created} = asobi_zone_manager:ensure_zone(Mgr, {0, 0}),
     #{zone_state := ZS} = sys:get_state(P),
     ?assertEqual(#{}, ZS),
     stop_manager(Ctx).

--- a/test/asobi_zone_tests.erl
+++ b/test/asobi_zone_tests.erl
@@ -35,6 +35,9 @@ zone_test_() ->
         {"starts empty", fun starts_empty/0},
         {"add and remove entities", fun add_remove_entities/0},
         {"subscribe and unsubscribe", fun subscribe_unsubscribe/0},
+        {"resubscribing the same pid is idempotent", fun resubscribe_same_pid_is_idempotent/0},
+        {"resubscribing a new pid replaces and demonitors the old one",
+            fun resubscribe_new_pid_replaces_and_demonitors_old/0},
         {"tick processes inputs and broadcasts deltas", fun tick_broadcasts/0},
         {"tick with no changes sends no deltas", fun tick_no_changes/0},
         {"tick acks to ticker", fun tick_acks/0},
@@ -175,6 +178,75 @@ subscribe_unsubscribe() ->
     asobi_zone:unsubscribe(Pid, <<"p1">>),
     timer:sleep(10),
     ?assertEqual(0, asobi_zone:get_subscriber_count(Pid)),
+    gen_server:stop(Pid).
+
+%% asobi#275: callers now (re-)subscribe a crossing/backfilled player to a
+%% zone unconditionally, even when they may already be subscribed - a
+%% same-pid re-subscribe must be a true no-op, not a second monitor/2 (which
+%% would leak the first MonRef, since only the latest one is ever kept in
+%% subscribers) or a wasted second snapshot send.
+resubscribe_same_pid_is_idempotent() ->
+    Pid = start_zone(),
+    asobi_zone:add_entity(Pid, ~"e1", #{x => 1, y => 1, type => ~"player"}),
+    timer:sleep(10),
+    asobi_zone:subscribe(Pid, {~"p1", self()}),
+    timer:sleep(10),
+    #{subscribers := #{~"p1" := {_, Ref0}}} = sys:get_state(Pid),
+    {monitored_by, Before} = process_info(self(), monitored_by),
+    flush_messages(),
+
+    asobi_zone:subscribe(Pid, {~"p1", self()}),
+    timer:sleep(10),
+    #{subscribers := #{~"p1" := {SamePid, Ref1}}} = sys:get_state(Pid),
+    ?assertEqual(self(), SamePid),
+    %% The original monitor ref is retained - a fresh monitor/2 call would
+    %% have replaced it with a new one and left the old one dangling.
+    ?assertEqual(Ref0, Ref1),
+    {monitored_by, After} = process_info(self(), monitored_by),
+    ?assertEqual(length(Before), length(After)),
+    ?assertEqual(1, asobi_zone:get_subscriber_count(Pid)),
+    ?assertEqual(
+        timeout,
+        receive
+            {asobi_message, {zone_delta, 0, _}} -> resent
+        after 100 -> timeout
+        end
+    ),
+    gen_server:stop(Pid).
+
+%% A reconnect legitimately re-subscribes the same PlayerId under a new
+%% session pid - that must replace the old subscription (fresh monitor, fresh
+%% snapshot) and demonitor the stale one so its later DOWN can't evict the
+%% live subscription (asobi_zone's DOWN handler filters by pid, not by ref).
+resubscribe_new_pid_replaces_and_demonitors_old() ->
+    Pid = start_zone(),
+    asobi_zone:add_entity(Pid, ~"e1", #{x => 1, y => 1, type => ~"player"}),
+    timer:sleep(10),
+    Old = spawn(fun() ->
+        receive
+            stop -> ok
+        end
+    end),
+    asobi_zone:subscribe(Pid, {~"p1", Old}),
+    timer:sleep(10),
+    #{subscribers := #{~"p1" := {Old, OldRef}}} = sys:get_state(Pid),
+
+    asobi_zone:subscribe(Pid, {~"p1", self()}),
+    timer:sleep(10),
+    #{subscribers := #{~"p1" := {NewPid, NewRef}}} = sys:get_state(Pid),
+    ?assertEqual(self(), NewPid),
+    ?assertNotEqual(OldRef, NewRef),
+    ?assertMatch(
+        [_ | _],
+        receive
+            {asobi_message, {zone_delta, 0, Snapshot}} -> Snapshot
+        after 200 -> []
+        end
+    ),
+
+    exit(Old, kill),
+    timer:sleep(50),
+    ?assertEqual(1, asobi_zone:get_subscriber_count(Pid)),
     gen_server:stop(Pid).
 
 tick_broadcasts() ->

--- a/test/prop_input_never_dropped.erl
+++ b/test/prop_input_never_dropped.erl
@@ -185,7 +185,7 @@ zone_at(#{world_pid := WorldPid}, Coords) ->
         {_StateName, StateData} when is_map(StateData) ->
             case maps:get(zone_manager_pid, StateData) of
                 ZMPid when is_pid(ZMPid) ->
-                    {ok, ZP} = asobi_zone_manager:ensure_zone(ZMPid, Coords),
+                    {ok, ZP, _Status} = asobi_zone_manager:ensure_zone(ZMPid, Coords),
                     ZP
             end
     end.


### PR DESCRIPTION
## Summary

Fixes #275: crossing a single zone boundary made the destination zone deliver nothing to anyone - the crossing player (including their own entity), a stationary neighbour whose interest ring already covered the zone, and a later entrant.

**Root cause:** `subscribe_interest_zones/4` only subscribes ring zones that are already loaded (`get_zone`, never `ensure_zone`), so the first subscribe attempt to a not-yet-created ring neighbour silently no-ops. The crossing path's ring-diff subscribe (`ToSubscribe = NewInterest -- OldInterest`) then never re-touches that zone once it exists, because for a one-step crossing the destination zone was already part of both the old and new ring - so it's never in the diff, and nothing else ever retries.

**Fix:**
- `ensure_zone/2` now returns `{ok, Pid, created | existing}` so callers can tell whether their call brought the zone into existence.
- A crossing player is now unconditionally (re-)subscribed to their destination zone, rather than relying solely on the ring diff.
- New `backfill_zone_subscribers/4`: when a zone is freshly created, walk connected players and subscribe any whose interest ring already covers it. Wired into the join path, the crossing path, and the script-driven `spawn_at` path - all three can lazily create a zone. Resolves pids via `pg` directly rather than `find_player_pid/1`, whose `self()`-fallback is meant for "the currently acting player" and would otherwise subscribe the world server itself as a disconnected player's "session" (a `player_zones` entry outlives disconnection, kept around for reconnect).
- `asobi_zone`'s subscribe cast is now idempotent for a repeat `{PlayerId, PlayerPid}` pair, so the unconditional resubscribe above doesn't leak the previous monitor ref or resend an unneeded snapshot. A genuine pid change (reconnect) still replaces the subscription and demonitors the stale one.

Filed #277 as a follow-up: `find_player_pid/1`'s `self()`-fallback is still used by the pre-existing acting-player call sites and should be tightened the same way - out of scope for this fix.

Reviewed by asobi-architecture-guardian and erlang-code-reviewer; both rounds of findings (a real bug in the first backfill draft subscribing the world server as a disconnected player, and a regression test that passed for the wrong reason due to cross-suite pg registration leakage) are addressed in this diff.

## Test plan
- [x] `rebar3 fmt --check`
- [x] `rebar3 xref`
- [x] `rebar3 dialyzer`
- [x] `mise exec erlang@28.4.1 -- elp eqwalize-all` (NO ERRORS)
- [x] `elp lint` (only a pre-existing, unrelated warning)
- [x] `rebar3 eunit` - 494 tests, 0 failures, including:
  - a rewritten regression test proving the stationary-neighbour backfill, using real pg-registered sessions and asserting actual entity delivery (not just subscriber-map membership) so it can't pass for the wrong reason
  - a `spawn_at`-path backfill regression test
  - two new zone-level tests locking in the idempotent-subscribe behaviour (no leaked monitor on same-pid resubscribe; correct replace+demonitor on a pid change)