### PR TITLE
fix: find_player_pid/1 no longer falls back to self()

### DIFF
--- a/src/world/asobi_world_chat.erl
+++ b/src/world/asobi_world_chat.erl
@@ -33,29 +33,43 @@ init(WorldId, Config) ->
 
 -spec player_joined(binary(), {integer(), integer()}, map()) -> ok.
 player_joined(PlayerId, ZoneCoords, #{world_id := WorldId, chat_config := ChatConfig}) ->
-    PlayerPid = find_player_pid(PlayerId),
-    case maps:get(world, ChatConfig, false) of
-        true ->
-            ChannelId = channel_id(WorldId, world, undefined),
-            asobi_chat_channel:join(ChannelId, PlayerPid);
-        false ->
+    case find_player_pid(PlayerId) of
+        undefined ->
+            %% asobi#277: no live session for this player - nothing to join
+            %% to a chat channel. Falling back to self() here (as this used
+            %% to) would have joined the world server's own pid instead.
+            ok;
+        PlayerPid ->
+            case maps:get(world, ChatConfig, false) of
+                true ->
+                    ChannelId = channel_id(WorldId, world, undefined),
+                    asobi_chat_channel:join(ChannelId, PlayerPid);
+                false ->
+                    ok
+            end,
+            join_zone_chats(PlayerId, PlayerPid, WorldId, ZoneCoords, ChatConfig),
             ok
-    end,
-    join_zone_chats(PlayerId, PlayerPid, WorldId, ZoneCoords, ChatConfig),
-    ok.
+    end.
 
 -spec player_left(binary(), {integer(), integer()}, map()) -> ok.
 player_left(PlayerId, ZoneCoords, #{world_id := WorldId, chat_config := ChatConfig}) ->
-    PlayerPid = find_player_pid(PlayerId),
-    case maps:get(world, ChatConfig, false) of
-        true ->
-            ChannelId = channel_id(WorldId, world, undefined),
-            asobi_chat_channel:leave(ChannelId, PlayerPid);
-        false ->
+    case find_player_pid(PlayerId) of
+        undefined ->
+            %% asobi#277: routine on a real disconnect - the session is
+            %% already gone from pg by the time leave runs. Nothing to
+            %% remove from a chat channel.
+            ok;
+        PlayerPid ->
+            case maps:get(world, ChatConfig, false) of
+                true ->
+                    ChannelId = channel_id(WorldId, world, undefined),
+                    asobi_chat_channel:leave(ChannelId, PlayerPid);
+                false ->
+                    ok
+            end,
+            leave_zone_chats(PlayerId, PlayerPid, WorldId, ZoneCoords, ChatConfig),
             ok
-    end,
-    leave_zone_chats(PlayerId, PlayerPid, WorldId, ZoneCoords, ChatConfig),
-    ok.
+    end.
 
 -spec player_zone_changed(
     binary(), {integer(), integer()}, {integer(), integer()}, non_neg_integer(), map()
@@ -65,38 +79,48 @@ player_zone_changed(
         world_id := WorldId, chat_config := ChatConfig
     }
 ) ->
-    PlayerPid = find_player_pid(PlayerId),
-    case maps:get(zone, ChatConfig, false) of
-        true ->
-            OldChannelId = channel_id(WorldId, zone, OldZoneCoords),
-            NewChannelId = channel_id(WorldId, zone, NewZoneCoords),
-            asobi_chat_channel:leave(OldChannelId, PlayerPid),
-            asobi_chat_channel:join(NewChannelId, PlayerPid);
-        false ->
-            ok
-    end,
-    case maps:get(proximity, ChatConfig, false) of
-        false ->
+    case find_player_pid(PlayerId) of
+        undefined ->
+            %% asobi#277: no live session - nothing to move between chat
+            %% channels.
             ok;
-        Radius when is_integer(Radius) ->
-            OldProx = proximity_zones(OldZoneCoords, Radius, GridSize),
-            NewProx = proximity_zones(NewZoneCoords, Radius, GridSize),
-            LeaveProx = OldProx -- NewProx,
-            JoinProx = NewProx -- OldProx,
-            lists:foreach(
-                fun(Coords) ->
-                    asobi_chat_channel:leave(channel_id(WorldId, proximity, Coords), PlayerPid)
-                end,
-                LeaveProx
-            ),
-            lists:foreach(
-                fun(Coords) ->
-                    asobi_chat_channel:join(channel_id(WorldId, proximity, Coords), PlayerPid)
-                end,
-                JoinProx
-            )
-    end,
-    ok.
+        PlayerPid ->
+            case maps:get(zone, ChatConfig, false) of
+                true ->
+                    OldChannelId = channel_id(WorldId, zone, OldZoneCoords),
+                    NewChannelId = channel_id(WorldId, zone, NewZoneCoords),
+                    asobi_chat_channel:leave(OldChannelId, PlayerPid),
+                    asobi_chat_channel:join(NewChannelId, PlayerPid);
+                false ->
+                    ok
+            end,
+            case maps:get(proximity, ChatConfig, false) of
+                false ->
+                    ok;
+                Radius when is_integer(Radius) ->
+                    OldProx = proximity_zones(OldZoneCoords, Radius, GridSize),
+                    NewProx = proximity_zones(NewZoneCoords, Radius, GridSize),
+                    LeaveProx = OldProx -- NewProx,
+                    JoinProx = NewProx -- OldProx,
+                    lists:foreach(
+                        fun(Coords) ->
+                            asobi_chat_channel:leave(
+                                channel_id(WorldId, proximity, Coords), PlayerPid
+                            )
+                        end,
+                        LeaveProx
+                    ),
+                    lists:foreach(
+                        fun(Coords) ->
+                            asobi_chat_channel:join(
+                                channel_id(WorldId, proximity, Coords), PlayerPid
+                            )
+                        end,
+                        JoinProx
+                    )
+            end,
+            ok
+    end.
 
 %% --- Channel ID generation ---
 
@@ -159,10 +183,15 @@ leave_zone_chats(PlayerId, PlayerPid, WorldId, ZoneCoords, ChatConfig) ->
 proximity_zones(Coords, Radius, GridSize) ->
     asobi_zone_grid:ring(Coords, Radius, GridSize).
 
+%% asobi#277: used to fall back to self() (the caller's own pid, which is
+%% asobi_world_server since that's who calls player_joined/left/zone_changed)
+%% when a player had no live pg registration. All three call sites now check
+%% for undefined instead.
+-spec find_player_pid(binary()) -> pid() | undefined.
 find_player_pid(PlayerId) ->
     case pg:get_members(nova_scope, {player, PlayerId}) of
         [Pid | _] -> Pid;
-        [] -> self()
+        [] -> undefined
     end.
 
 ignore_result(_) -> ok.

--- a/src/world/asobi_world_server.erl
+++ b/src/world/asobi_world_server.erl
@@ -440,7 +440,8 @@ running({call, From}, {reconnect, PlayerId}, State) when is_binary(PlayerId) ->
     #{
         reconnect_state := RS,
         player_zones := PZ,
-        zone_manager_pid := ZMPid
+        zone_manager_pid := ZMPid,
+        world_id := WorldId
     } = State,
     case {RS, maps:get(PlayerId, PZ, undefined)} of
         {undefined, _} ->
@@ -450,28 +451,45 @@ running({call, From}, {reconnect, PlayerId}, State) when is_binary(PlayerId) ->
         {_, #{zone := {ZX, ZY}, interest := InterestZones}} when
             is_integer(ZX), is_integer(ZY), is_list(InterestZones)
         ->
-            ZoneCoords = {ZX, ZY},
-            {_Events, RS1} = asobi_reconnect:reconnect(PlayerId, RS),
-            PlayerPid = find_player_pid(PlayerId),
-            MonRef = erlang:monitor(process, PlayerPid),
-            %% Re-subscribe to all interest zones
-            subscribe_interest_zones(InterestZones, ZMPid, PlayerId, PlayerPid),
-            %% Notify session of world/zone
-            ZonePid =
-                case asobi_zone_manager:get_zone(ZMPid, ZoneCoords) of
-                    {ok, ZP} -> ZP;
-                    not_loaded -> undefined
-                end,
-            asobi_presence:send(PlayerId, {world_joined, self(), ZonePid}),
-            %% Update player entry with new session
-            Players = maps:get(players, State),
-            PlayerMeta = maps:get(PlayerId, Players, #{}),
-            Players1 = Players#{
-                PlayerId => PlayerMeta#{
-                    session_pid => PlayerPid, monitor_ref => MonRef
-                }
-            },
-            {keep_state, State#{reconnect_state => RS1, players => Players1}, [{reply, From, ok}]}
+            %% asobi#277: checked before touching reconnect_state at all, so
+            %% a missing session leaves this a pure no-op (keep_state_and_data
+            %% below discards whatever asobi_reconnect:reconnect/2 would have
+            %% computed) rather than a monitor(process, undefined) crash -
+            %% the caller invoking reconnect/2 IS the reconnecting session, so
+            %% it not being pg-registered yet means the reconnect is broken.
+            case find_player_pid(PlayerId) of
+                undefined ->
+                    ?LOG_WARNING(#{
+                        event => reconnect_no_live_session,
+                        world_id => WorldId,
+                        player_id => PlayerId
+                    }),
+                    {keep_state_and_data, [{reply, From, {error, no_live_session}}]};
+                PlayerPid ->
+                    ZoneCoords = {ZX, ZY},
+                    {_Events, RS1} = asobi_reconnect:reconnect(PlayerId, RS),
+                    MonRef = erlang:monitor(process, PlayerPid),
+                    %% Re-subscribe to all interest zones
+                    subscribe_interest_zones(InterestZones, ZMPid, PlayerId, PlayerPid),
+                    %% Notify session of world/zone
+                    ZonePid =
+                        case asobi_zone_manager:get_zone(ZMPid, ZoneCoords) of
+                            {ok, ZP} -> ZP;
+                            not_loaded -> undefined
+                        end,
+                    asobi_presence:send(PlayerId, {world_joined, self(), ZonePid}),
+                    %% Update player entry with new session
+                    Players = maps:get(players, State),
+                    PlayerMeta = maps:get(PlayerId, Players, #{}),
+                    Players1 = Players#{
+                        PlayerId => PlayerMeta#{
+                            session_pid => PlayerPid, monitor_ref => MonRef
+                        }
+                    },
+                    {keep_state, State#{reconnect_state => RS1, players => Players1}, [
+                        {reply, From, ok}
+                    ]}
+            end
     end.
 
 %% --- finished state ---
@@ -711,9 +729,25 @@ handle_join(
                             }),
                             {keep_state_and_data, [{reply, From, {error, zone_unavailable}}]};
                         {ok, State2, ZonePid} ->
-                            %% Monitor player session for reconnection handling
+                            %% Monitor player session for reconnection handling.
+                            %% asobi#277: place_player/4 already degrades
+                            %% gracefully if this player has no live session
+                            %% (its subscribe becomes a no-op); do the same
+                            %% here rather than crashing on
+                            %% monitor(process, undefined).
                             PlayerPid = find_player_pid(PlayerId),
-                            MonRef = erlang:monitor(process, PlayerPid),
+                            MonRef =
+                                case PlayerPid of
+                                    undefined ->
+                                        ?LOG_WARNING(#{
+                                            event => join_no_live_session,
+                                            world_id => WorldId,
+                                            player_id => PlayerId
+                                        }),
+                                        undefined;
+                                    _ ->
+                                        erlang:monitor(process, PlayerPid)
+                                end,
                             Players1 = Players#{
                                 PlayerId => #{
                                     joined_at => erlang:system_time(millisecond),
@@ -847,13 +881,13 @@ place_player(
 %% caused this creation - they are subscribed separately by the caller (with
 %% the full context of their own crossing/join), so skip them here.
 %%
-%% Deliberately does not reuse find_player_pid/1 - its self()-fallback exists
-%% for "the player currently acting" (always a live caller), but a
-%% player_zones entry outlives disconnection (kept around for reconnect, see
-%% the {reconnect_state := RS} clause above), so a player here can legitimately
-%% have no live session. Falling back to self() would subscribe the world
-%% server's own pid as that player's "session" - a silent wrong subscriber
-%% that stalls out the zone_delta stream until they actually reconnect.
+%% Resolves other players' pids via find_player_pid/1 - safe since asobi#277
+%% made it return undefined instead of falling back to self() for a player
+%% with no live pg registration. A player_zones entry outlives disconnection
+%% (kept around for reconnect, see the {reconnect_state := RS} clause above),
+%% so a player here can legitimately have no live session; undefined lets
+%% this skip them instead of subscribing the world server's own pid as their
+%% "session".
 -spec backfill_zone_subscribers({integer(), integer()}, pid(), binary() | undefined, map()) -> ok.
 backfill_zone_subscribers(ZoneCoords, ZonePid, ExcludePlayerId, PlayerZones) ->
     maps:foreach(
@@ -863,9 +897,9 @@ backfill_zone_subscribers(ZoneCoords, ZonePid, ExcludePlayerId, PlayerZones) ->
             (PlayerId, #{interest := Interest}) ->
                 case lists:member(ZoneCoords, Interest) of
                     true ->
-                        case pg:get_members(?PG_SCOPE, {player, PlayerId}) of
-                            [PlayerPid | _] -> asobi_zone:subscribe(ZonePid, {PlayerId, PlayerPid});
-                            [] -> ok
+                        case find_player_pid(PlayerId) of
+                            undefined -> ok;
+                            PlayerPid -> asobi_zone:subscribe(ZonePid, {PlayerId, PlayerPid})
                         end;
                     false ->
                         ok
@@ -1016,7 +1050,13 @@ handle_move(
                             asobi_presence:send(PlayerId, {world_joined, self(), NewZonePid}),
 
                             unsubscribe_interest_zones(ToUnsubscribe, ZMPid, PlayerId),
-                            asobi_zone:subscribe(NewZonePid, {PlayerId, PlayerPid}),
+                            %% asobi#277: PlayerPid is undefined if this
+                            %% crossing player somehow has no live session -
+                            %% nothing to subscribe or notify in that case.
+                            case PlayerPid of
+                                undefined -> ok;
+                                _ -> asobi_zone:subscribe(NewZonePid, {PlayerId, PlayerPid})
+                            end,
                             subscribe_interest_zones(ToSubscribe, ZMPid, PlayerId, PlayerPid),
                             %% asobi#275: this crossing is what brought the zone
                             %% into existence - any other already-connected
@@ -1055,7 +1095,14 @@ handle_move(
                                 false -> asobi_zone_manager:release_zone(ZMPid, OldZoneCoords)
                             end,
 
-                            PlayerPid ! {asobi_message, {world_zone_changed, NewZonePid}},
+                            _ =
+                                case PlayerPid of
+                                    undefined ->
+                                        ok;
+                                    _ ->
+                                        PlayerPid !
+                                            {asobi_message, {world_zone_changed, NewZonePid}}
+                                end,
                             Players1 = maps:update_with(
                                 PlayerId,
                                 fun(Meta) -> Meta#{position => NewPos} end,
@@ -1116,10 +1163,19 @@ pos_to_zone(Pos, ZoneSize, GridSize) when is_integer(GridSize), GridSize > 0 ->
 interest_zones(Coords, Radius, GridSize) ->
     asobi_zone_grid:ring(Coords, Radius, GridSize).
 
+%% asobi#277: used to fall back to self() when a player had no live pg
+%% registration - meant for "the player currently acting" call sites, where
+%% the caller's own session is always registered before it ever reaches
+%% here. But a player_zones entry outlives disconnection (kept around for
+%% reconnect), so that invariant isn't structural - a future caller reaching
+%% this with a disconnected player would have silently subscribed/monitored
+%% the world server itself as that player's "session". undefined makes the
+%% no-live-session case something every caller has to handle explicitly.
+-spec find_player_pid(binary()) -> pid() | undefined.
 find_player_pid(PlayerId) ->
     case pg:get_members(?PG_SCOPE, {player, PlayerId}) of
         [Pid | _] -> Pid;
-        [] -> self()
+        [] -> undefined
     end.
 
 -spec remember_player_world(binary(), pid()) -> ok.
@@ -1142,7 +1198,10 @@ forget_player_world(PlayerId) ->
             ok
     end.
 
--spec subscribe_interest_zones([term()], pid() | atom(), binary(), pid()) -> ok.
+-spec subscribe_interest_zones([term()], pid() | atom(), binary(), pid() | undefined) -> ok.
+subscribe_interest_zones(_Zones, _ZMPid, _PlayerId, undefined) ->
+    %% asobi#277: no live session to subscribe - nothing to do.
+    ok;
 subscribe_interest_zones([], _ZMPid, _PlayerId, _PlayerPid) ->
     ok;
 subscribe_interest_zones([{CX, CY} | Rest], ZMPid, PlayerId, PlayerPid) when

--- a/test/asobi_world_chat_tests.erl
+++ b/test/asobi_world_chat_tests.erl
@@ -46,7 +46,9 @@ integration_test_() ->
         {"player leave cleans up channels", fun leave_cleans_up/0},
         {"zone change swaps zone chat", fun zone_change_swaps_chat/0},
         {"proximity chat subscribes to nearby zones", fun proximity_chat/0},
-        {"no chat config means no channels", fun no_chat_config/0}
+        {"no chat config means no channels", fun no_chat_config/0},
+        {"a player with no live session never joins as the calling process",
+            fun no_live_session_does_not_join_as_caller/0}
     ]}.
 
 setup() ->
@@ -137,3 +139,23 @@ no_chat_config() ->
     ?assertNot(lists:member(self(), pg:get_members(nova_scope, {chat, WorldChannel}))),
     ?assertNot(lists:member(self(), pg:get_members(nova_scope, {chat, ZoneChannel}))),
     unregister_player().
+
+%% Regression for widgrensit/asobi#277: find_player_pid/1 in this module used
+%% to fall back to self() (the caller's own pid - asobi_world_server in
+%% production) when a player had no live pg registration. Deliberately not
+%% calling register_player/0 here - a player with no session must not join,
+%% leave, or move any channel using the calling process's own pid.
+no_live_session_does_not_join_as_caller() ->
+    ChatState = asobi_world_chat:init(~"wc7", #{
+        chat => #{world => true, zone => true, proximity => 1, grid_size => 5}
+    }),
+    ok = asobi_world_chat:player_joined(~"ghost", {2, 2}, ChatState),
+    WorldChannel = asobi_world_chat:channel_id(~"wc7", world, undefined),
+    ZoneChannel = asobi_world_chat:channel_id(~"wc7", zone, {2, 2}),
+    ProxChannel = asobi_world_chat:channel_id(~"wc7", proximity, {2, 2}),
+    ?assertNot(lists:member(self(), pg:get_members(nova_scope, {chat, WorldChannel}))),
+    ?assertNot(lists:member(self(), pg:get_members(nova_scope, {chat, ZoneChannel}))),
+    ?assertNot(lists:member(self(), pg:get_members(nova_scope, {chat, ProxChannel}))),
+    %% zone_changed and left must also degrade cleanly, not crash.
+    ok = asobi_world_chat:player_zone_changed(~"ghost", {2, 2}, {3, 3}, 5, ChatState),
+    ok = asobi_world_chat:player_left(~"ghost", {3, 3}, ChatState).

--- a/test/asobi_world_server_tests.erl
+++ b/test/asobi_world_server_tests.erl
@@ -91,7 +91,13 @@ world_server_test_() ->
         {timeout, 15,
             {"player_ttl_ms>0: DOWN starts grace, fires reconnect events",
                 fun player_ttl_grace_starts_grace/0}},
-        {"join/3 sets zone_pid in player_session synchronously", fun join_three_sets_zone_pid/0}
+        {"join/3 sets zone_pid in player_session synchronously", fun join_three_sets_zone_pid/0},
+        {"join with no live session does not crash",
+            fun join_with_no_live_session_does_not_crash/0},
+        {"reconnect with no live session returns an error, not a crash",
+            fun reconnect_with_no_live_session_returns_error/0},
+        {"a failed reconnect leaves the disconnected grace entry intact",
+            fun failed_reconnect_leaves_grace_intact/0}
     ]}.
 
 starts_running() ->
@@ -440,6 +446,68 @@ join_three_sets_zone_pid() ->
     ?assert(is_pid(maps:get(zone_pid, State1))),
     ?assertEqual(Pid, maps:get(world_pid, State1)),
     asobi_player_session:stop(SessionPid),
+    stop_world(Ctx).
+
+%% Regression for widgrensit/asobi#277: find_player_pid/1 used to fall back
+%% to self() when a player had no live pg registration, which would have
+%% recorded the world server's own pid as that player's session and
+%% subscribed it to the player's zone - not a crash, but silently wrong.
+%% join/2 (test-only, no session registered) is exactly that case.
+join_with_no_live_session_does_not_crash() ->
+    Ctx = #{world_pid := Pid, instance_pid := InstancePid} = start_world(),
+    PlayerId = ~"no_session",
+    ?assertEqual(ok, asobi_world_server:join(Pid, PlayerId)),
+    ?assert(is_process_alive(Pid)),
+    ?assertEqual(1, maps:get(player_count, asobi_world_server:get_info(Pid))),
+    %% The actual defect: under the old self() fallback, this player's
+    %% session_pid/monitor_ref would be the world server itself, and the
+    %% world server would show up as a subscriber of the player's own zone.
+    {_StateName, #{
+        players := #{PlayerId := #{session_pid := SessionPid, monitor_ref := MonRef}}
+    }} = sys:get_state(Pid),
+    ?assertEqual(undefined, SessionPid),
+    ?assertEqual(undefined, MonRef),
+    ZMPid = asobi_world_instance:get_child(InstancePid, asobi_zone_manager),
+    %% asobi_test_world_game:spawn_position/2 always returns {100.0, 100.0},
+    %% zone {1,1} at zone_size=100 (?BASE_CONFIG).
+    {ok, ZonePid} = asobi_zone_manager:get_zone(ZMPid, {1, 1}),
+    ?assertEqual(0, asobi_zone:get_subscriber_count(ZonePid)),
+    stop_world(Ctx).
+
+%% Regression for widgrensit/asobi#277: a reconnect attempt with no live
+%% pg-registered session for the player must fail cleanly (the caller
+%% invoking reconnect/2 IS supposed to be that live session) rather than
+%% crash on monitor(process, undefined) or silently monitor the world
+%% server's own pid.
+reconnect_with_no_live_session_returns_error() ->
+    Ctx = #{world_pid := Pid} = start_world(#{player_ttl_ms => 5_000}),
+    PlayerId = ~"reconnect_no_session",
+    SessionPid = fake_session(PlayerId),
+    ?assertEqual(ok, asobi_world_server:join(Pid, PlayerId)),
+    ?assertEqual(1, maps:get(player_count, asobi_world_server:get_info(Pid))),
+    exit(SessionPid, kill),
+    timer:sleep(100),
+    %% No new session registered before reconnecting.
+    ?assertEqual({error, no_live_session}, asobi_world_server:reconnect(Pid, PlayerId)),
+    ?assert(is_process_alive(Pid)),
+    stop_world(Ctx).
+
+%% Regression for widgrensit/asobi#277: the no-live-session check runs before
+%% asobi_reconnect:reconnect/2, so a rejected reconnect must not consume the
+%% player's disconnected/grace entry - a real session arriving afterwards
+%% still gets to reconnect normally.
+failed_reconnect_leaves_grace_intact() ->
+    Ctx = #{world_pid := Pid} = start_world(#{player_ttl_ms => 5_000}),
+    PlayerId = ~"retry_after_no_session",
+    S1 = fake_session(PlayerId),
+    ?assertEqual(ok, asobi_world_server:join(Pid, PlayerId)),
+    exit(S1, kill),
+    timer:sleep(100),
+    ?assertEqual({error, no_live_session}, asobi_world_server:reconnect(Pid, PlayerId)),
+    {_StateName, #{reconnect_state := #{disconnected := #{PlayerId := _}}}} = sys:get_state(Pid),
+    _S2 = fake_session(PlayerId),
+    ?assertEqual(ok, asobi_world_server:reconnect(Pid, PlayerId)),
+    ?assertEqual(1, maps:get(player_count, asobi_world_server:get_info(Pid))),
     stop_world(Ctx).
 
 %% --- listing_info/1 (pure projection, no world needed) ---


### PR DESCRIPTION
## Summary

Closes #277: `find_player_pid/1` used to fall back to `self()` (the calling process's own pid) when a player had no live pg registration for `{player, PlayerId}`. That fallback was meant for "the player currently acting" call sites (join, move, reconnect), where in practice the caller's session is always registered via `asobi_presence:track/2` before reaching here. But the invariant isn't structural - a `player_zones` entry outlives disconnection (kept for reconnect) - so a caller that reached this without a live session would have silently subscribed/monitored/messaged the world server itself as that player's "session".

**Fix:**
- `find_player_pid/1` now returns `pid() | undefined`.
- `subscribe_interest_zones/4` gained a leading clause that no-ops on `undefined`.
- The crossing path's direct subscribe call and its `world_zone_changed` message send are now guarded.
- `handle_join` logs a warning and stores `monitor_ref => undefined` instead of crashing on `monitor(process, undefined)` - the join still succeeds since `place_player/4` already placed the entity.
- The reconnect call handler checks for `undefined` before touching `reconnect_state` at all, so a missing session is a pure no-op returning `{error, no_live_session}` instead of crashing.
- `backfill_zone_subscribers/4` (from #275) now reuses `find_player_pid/1` instead of its own inline pg lookup, since the function it was deliberately avoiding is now safe to call directly.

**Found in review:** `asobi_world_chat.erl` had its own private copy of the same helper with the same `self()` fallback, reachable from the join path via `player_joined/3` (and from leave/zone-change via `player_left/3` and `player_zone_changed/5`). Fixed the same way.

Filed #280 as a follow-up: `asobi_match_server.erl` has an independent copy of the same pattern in a different subsystem - out of scope here.

Reviewed by asobi-architecture-guardian and erlang-code-reviewer. Both rounds of findings are addressed: the architecture guardian caught the stale `backfill_zone_subscribers` comment/duplication and the `asobi_world_chat.erl` copy of the bug; the code reviewer caught that my first regression test would have passed against the pre-fix code too (rewrote it to assert on the actual internal state that used to be wrong, not just "no crash"), and pointed out a real value in adding a test locking in that a rejected reconnect doesn't consume the player's grace window.

## Test plan
- [x] `rebar3 fmt --check`
- [x] `rebar3 xref`
- [x] `rebar3 dialyzer`
- [x] `mise exec erlang@28.4.1 -- elp eqwalize-all` (NO ERRORS)
- [x] `elp lint` (only pre-existing, unrelated warnings)
- [x] `rebar3 eunit` - 499 tests, 0 failures, including:
  - `join_with_no_live_session_does_not_crash` - asserts `session_pid`/`monitor_ref` stay `undefined` and the player's own zone has 0 subscribers (the actual old defect, not just "doesn't crash")
  - `reconnect_with_no_live_session_returns_error`
  - `failed_reconnect_leaves_grace_intact` - a rejected reconnect doesn't consume the disconnected/grace entry
  - `no_live_session_does_not_join_as_caller` (asobi_world_chat) - asserts the calling process never ends up a member of any chat channel