### PR TITLE
fix: harden asobi_match_server find_player_pid against no live session

### DIFF
--- a/src/matches/asobi_match_server.erl
+++ b/src/matches/asobi_match_server.erl
@@ -39,6 +39,8 @@ the place to put callback hardening.
 -export([callback_mode/0, init/1, terminate/3]).
 -export([waiting/3, running/3, paused/3, finished/3]).
 
+-include_lib("kernel/include/logger.hrl").
+
 %% 10 ticks/sec
 -define(DEFAULT_TICK_RATE, 100).
 -define(DEFAULT_MIN_PLAYERS, 2).
@@ -513,8 +515,22 @@ handle_join(
                     %% Monitor the player session so we can run reconnect grace
                     %% (or immediate cleanup) when the WS process dies. Mirrors
                     %% asobi_world_server's handle_join monitor setup.
+                    %% asobi#280: no live session degrades gracefully (no
+                    %% monitor) rather than crashing on
+                    %% monitor(process, undefined).
                     SessionPid = find_player_pid(PlayerId),
-                    MonRef = erlang:monitor(process, SessionPid),
+                    MonRef =
+                        case SessionPid of
+                            undefined ->
+                                ?LOG_WARNING(#{
+                                    event => match_join_no_live_session,
+                                    match_id => maps:get(match_id, State),
+                                    player_id => PlayerId
+                                }),
+                                undefined;
+                            _ ->
+                                erlang:monitor(process, SessionPid)
+                        end,
                     Players1 = Players#{
                         PlayerId => #{
                             joined_at => erlang:system_time(millisecond),
@@ -576,7 +592,7 @@ apply_inputs(Mod, [{PlayerId, Input} | Rest], GS) ->
         {ok, GS1} ->
             apply_inputs(Mod, Rest, GS1);
         {error, Reason} ->
-            logger:warning(#{
+            ?LOG_WARNING(#{
                 msg => ~"game input rejected",
                 player_id => PlayerId,
                 reason => Reason
@@ -876,33 +892,50 @@ handle_reconnect_call(From, PlayerId, #{players := Players, reconnect_state := R
         false ->
             {keep_state_and_data, [{reply, From, {error, not_in_match}}]};
         true ->
-            {_Events, RS1} = asobi_reconnect:reconnect(PlayerId, RS),
-            %% Re-monitor: the new session pid is whoever is currently
-            %% registered as the WS owner for this player_id.
-            PlayerMeta0 = maps:get(PlayerId, Players),
-            case maps:get(monitor_ref, PlayerMeta0, undefined) of
-                undefined -> ok;
-                OldRef -> erlang:demonitor(OldRef, [flush])
-            end,
-            NewSessionPid = find_player_pid(PlayerId),
-            NewMonRef = erlang:monitor(process, NewSessionPid),
-            PlayerMeta1 = PlayerMeta0#{
-                session_pid => NewSessionPid,
-                monitor_ref => NewMonRef
-            },
-            Players1 = Players#{PlayerId => PlayerMeta1},
-            {keep_state, State#{reconnect_state => RS1, players => Players1}, [
-                {reply, From, ok}
-            ]}
+            %% asobi#280: checked before touching reconnect_state or the old
+            %% monitor at all, so a missing session leaves this a pure no-op
+            %% rather than a monitor(process, undefined) crash - mirrors the
+            %% asobi_world_server handle_reconnect_call fix from asobi#277.
+            case find_player_pid(PlayerId) of
+                undefined ->
+                    ?LOG_WARNING(#{
+                        event => match_reconnect_no_live_session,
+                        match_id => maps:get(match_id, State),
+                        player_id => PlayerId
+                    }),
+                    {keep_state_and_data, [{reply, From, {error, no_live_session}}]};
+                NewSessionPid ->
+                    {_Events, RS1} = asobi_reconnect:reconnect(PlayerId, RS),
+                    %% Re-monitor: the new session pid is whoever is currently
+                    %% registered as the WS owner for this player_id.
+                    PlayerMeta0 = maps:get(PlayerId, Players),
+                    case maps:get(monitor_ref, PlayerMeta0, undefined) of
+                        undefined -> ok;
+                        OldRef -> erlang:demonitor(OldRef, [flush])
+                    end,
+                    NewMonRef = erlang:monitor(process, NewSessionPid),
+                    PlayerMeta1 = PlayerMeta0#{
+                        session_pid => NewSessionPid,
+                        monitor_ref => NewMonRef
+                    },
+                    Players1 = Players#{PlayerId => PlayerMeta1},
+                    {keep_state, State#{reconnect_state => RS1, players => Players1}, [
+                        {reply, From, ok}
+                    ]}
+            end
     end;
 handle_reconnect_call(From, _PlayerId, _State) ->
     {keep_state_and_data, [{reply, From, {error, no_reconnect_policy}}]}.
 
--spec find_player_pid(binary()) -> pid().
+%% widgrensit/asobi#280: fall back to undefined rather than self() when a
+%% player has no live pg-registered session, mirroring the asobi#277 fix in
+%% asobi_world_server - self() would silently monitor/track this match
+%% server's own pid as that player's session instead of failing visibly.
+-spec find_player_pid(binary()) -> pid() | undefined.
 find_player_pid(PlayerId) ->
     case pg:get_members(?PG_SCOPE, {player, PlayerId}) of
         [Pid | _] -> Pid;
-        [] -> self()
+        [] -> undefined
     end.
 
 -spec find_player_by_pid(pid(), map()) -> {ok, binary()} | none.

--- a/test/asobi_match_server_tests.erl
+++ b/test/asobi_match_server_tests.erl
@@ -64,7 +64,12 @@ match_server_test_() ->
         {"disconnect with reconnect policy starts grace", fun disconnect_starts_grace/0},
         {"disconnect without policy is immediate leave", fun disconnect_no_policy_leaves/0},
         {"reconnect within grace keeps player", fun reconnect_within_grace_keeps/0},
-        {"reconnect with no policy returns error", fun reconnect_no_policy_errors/0}
+        {"reconnect with no policy returns error", fun reconnect_no_policy_errors/0},
+        {"join with no live session does not crash",
+            fun join_with_no_live_session_does_not_crash/0},
+        {"reconnect with no live session returns error",
+            fun reconnect_with_no_live_session_returns_error/0},
+        {"failed reconnect leaves grace intact", fun failed_reconnect_leaves_grace_intact/0}
     ]}.
 
 %% --- Tests ---
@@ -382,6 +387,89 @@ reconnect_no_policy_errors() ->
     ok = asobi_match_server:join(Pid, ~"p1"),
     timer:sleep(50),
     ?assertMatch({error, no_reconnect_policy}, asobi_match_server:reconnect(Pid, ~"p1")),
+    stop(Pid).
+
+%% Regression for widgrensit/asobi#280: find_player_pid/1 used to fall back
+%% to self() when a player had no live pg registration, which would have
+%% recorded this match server's own pid as that player's session_pid and
+%% monitor_ref - not a crash, but silently wrong. join/2 with no fake_session
+%% registered first is exactly that case.
+join_with_no_live_session_does_not_crash() ->
+    Pid = start_match(#{min_players => 2, max_players => 2}),
+    ok = asobi_match_server:join(Pid, ~"no_session"),
+    ?assert(is_process_alive(Pid)),
+    ?assertEqual(1, maps:get(player_count, asobi_match_server:get_info(Pid))),
+    {_StateName, #{
+        players := #{~"no_session" := #{session_pid := SessionPid, monitor_ref := MonRef}}
+    }} = sys:get_state(Pid),
+    ?assertEqual(undefined, SessionPid),
+    ?assertEqual(undefined, MonRef),
+    stop(Pid).
+
+%% Regression for widgrensit/asobi#280: a reconnect attempt with no live
+%% pg-registered session for the player must fail cleanly (the caller
+%% invoking reconnect/2 IS supposed to be that live session) rather than
+%% crash on monitor(process, undefined) or silently monitor this match
+%% server's own pid.
+reconnect_with_no_live_session_returns_error() ->
+    Pid = start_match(#{
+        min_players => 1,
+        max_players => 2,
+        reconnect => #{
+            grace_period => 30_000,
+            during_grace => idle,
+            on_reconnect => resume,
+            on_expire => remove,
+            pause_match => false,
+            max_offline_total => infinity
+        }
+    }),
+    %% Unique player id - other tests in this suite leave dangling
+    %% fake_session processes registered under {player, ~"p1"} in the shared
+    %% nova_scope pg group, which would make find_player_pid/1 see a stray
+    %% live pid instead of the empty-group case this test needs.
+    PlayerId = ~"reconnect_no_session_280",
+    SessionPid = fake_session(PlayerId),
+    ok = asobi_match_server:join(Pid, PlayerId),
+    timer:sleep(50),
+    exit(SessionPid, kill),
+    timer:sleep(100),
+    %% No new session registered before reconnecting.
+    ?assertEqual({error, no_live_session}, asobi_match_server:reconnect(Pid, PlayerId)),
+    ?assert(is_process_alive(Pid)),
+    stop(Pid).
+
+%% Regression for widgrensit/asobi#280: the no-live-session check runs before
+%% asobi_reconnect:reconnect/2, so a rejected reconnect must not consume the
+%% player's disconnected/grace entry - a real session arriving afterwards
+%% still gets to reconnect normally.
+failed_reconnect_leaves_grace_intact() ->
+    Pid = start_match(#{
+        min_players => 1,
+        max_players => 2,
+        reconnect => #{
+            grace_period => 30_000,
+            during_grace => idle,
+            on_reconnect => resume,
+            on_expire => remove,
+            pause_match => false,
+            max_offline_total => infinity
+        }
+    }),
+    %% Unique player id - see reconnect_with_no_live_session_returns_error/0.
+    PlayerId = ~"retry_after_no_session_280",
+    SessionPid1 = fake_session(PlayerId),
+    ok = asobi_match_server:join(Pid, PlayerId),
+    timer:sleep(50),
+    exit(SessionPid1, kill),
+    timer:sleep(100),
+    ?assertEqual({error, no_live_session}, asobi_match_server:reconnect(Pid, PlayerId)),
+    {_StateName, #{reconnect_state := #{disconnected := #{PlayerId := _}}}} = sys:get_state(Pid),
+    catch pg:leave(nova_scope, {player, PlayerId}, SessionPid1),
+    _SessionPid2 = fake_session(PlayerId),
+    ?assertEqual(ok, asobi_match_server:reconnect(Pid, PlayerId)),
+    timer:sleep(30),
+    ?assertEqual(1, maps:get(player_count, asobi_match_server:get_info(Pid))),
     stop(Pid).
 
 %% --- Helpers ---


### PR DESCRIPTION
## Summary
- `find_player_pid/1` in `asobi_match_server.erl` fell back to `self()` when a player had no live pg-registered session - the same landmine fixed in `asobi_world_server.erl` (and `asobi_world_chat.erl`) for #277, but this is an independent copy in the matches subsystem, out of scope for that PR.
- `find_player_pid/1` now returns `undefined` instead of `self()`.
- Join path (`handle_join/4`): on `undefined`, logs a warning and stores `session_pid`/`monitor_ref => undefined` instead of crashing on `monitor(process, undefined)`.
- Reconnect path (`handle_reconnect_call/3`): on `undefined`, logs a warning and rejects with `{error, no_live_session}` before touching `reconnect_state` or the old monitor - mirrors the `asobi_world_server` fix exactly.
- Three new regression tests mirroring `asobi_world_server_tests.erl`'s #277 tests.

Reviewed by asobi-architecture-guardian and erlang-code-reviewer - no blockers. The architecture guardian also flagged a separate pre-existing bug (`waiting/3` has no `'DOWN'` clause, so a session dying while a match is still in the lobby crashes the match server) - filing that as a follow-up issue, out of scope here.

Closes #280

## Test plan
- [x] `rebar3 eunit --module=asobi_match_server_tests` - 31/31 pass, including the three new regression tests
- [x] `rebar3 eunit` (full suite) - 502/502 pass
- [x] `rebar3 fmt --check`, `rebar3 xref`, `rebar3 dialyzer` - clean
- [x] `elp eqwalize-all` (OTP 28) - NO ERRORS
- [x] `elp lint` - no new findings on either changed file
- [ ] `rebar3 ct` - skipped, port 5432 held by another active session's container