### PR TITLE
fix: asobi_zone declines reap while it still holds entities

### DIFF
--- a/src/world/asobi_zone.erl
+++ b/src/world/asobi_zone.erl
@@ -327,10 +327,24 @@ handle_call(_Request, _From, State) ->
 
 -spec handle_cast(term(), map()) ->
     {noreply, map()} | {noreply, map(), hibernate} | {stop, normal, map()}.
-handle_cast(reap, State) ->
+handle_cast(reap, #{entities := Entities} = State) when map_size(Entities) =:= 0 ->
     %% Graceful stop so terminate/2 writes a final snapshot. Transient restart
     %% means a normal stop is not respawned.
     {stop, normal, State};
+handle_cast(reap, #{zone_manager_pid := ZMPid, coords := Coords} = State) ->
+    %% asobi#283: the manager decides to reap from its own zone_last_active
+    %% bookkeeping, which can lag real occupancy - release_zone backdates it
+    %% the moment a zone empties, and nothing re-touches it for an occupied
+    %% zone with no live subscribers (this zone's own tick only touches on
+    %% the map_size(Subs) > 0 branch). Trusting the cast here would tear down
+    %% an occupied zone out from under its entities. This zone is the one
+    %% source of truth for its own occupancy at the moment it actually
+    %% receives the cast, so decline and re-touch instead of stopping.
+    case ZMPid of
+        undefined -> ok;
+        _ -> asobi_zone_manager:touch_zone(ZMPid, Coords)
+    end,
+    {noreply, State};
 handle_cast({tick, TickN}, State) ->
     State1 = do_tick(TickN, State),
     State2 = resolve_zone_crossings(State1),

--- a/src/world/asobi_zone_manager.erl
+++ b/src/world/asobi_zone_manager.erl
@@ -37,23 +37,12 @@ is what brought the zone into existence (`created`) or whether it was already
 running (`existing`) - callers that need to backfill subscribers whose
 interest ring already covered these coords (widgrensit/asobi#275) only need
 to act on `created`.
-
-An ETS-fast-path hit touches the zone (asobi#283): `release_zone/2`
-backdates `zone_last_active` as soon as a zone empties out, and nothing else
-un-stales it once that happened, since a zone with no subscribers is never
-`touch_zone`d by its own tick either (asobi_zone only touches on tick when
-`map_size(Subs) > 0`). Without this, a zone that empties and is then
-re-occupied before the next reap sweep keeps its stale timestamp and can be
-reaped out from under its new occupants - an ensure_zone call is itself
-evidence of active use, so it must count as a touch even on the path that
-never talks to the gen_server for the lookup itself.
 """.
 -spec ensure_zone(pid() | atom(), {integer(), integer()}) ->
     {ok, pid(), created | existing} | {error, term()}.
 ensure_zone(Ref, Coords) ->
     case ets_lookup(Ref, Coords) of
         {ok, Pid} ->
-            touch_zone(Ref, Coords),
             {ok, Pid, existing};
         not_loaded ->
             case gen_server:call(Ref, {ensure_zone, Coords}) of

--- a/src/world/asobi_zone_manager.erl
+++ b/src/world/asobi_zone_manager.erl
@@ -37,12 +37,23 @@ is what brought the zone into existence (`created`) or whether it was already
 running (`existing`) - callers that need to backfill subscribers whose
 interest ring already covered these coords (widgrensit/asobi#275) only need
 to act on `created`.
+
+An ETS-fast-path hit touches the zone (asobi#283): `release_zone/2`
+backdates `zone_last_active` as soon as a zone empties out, and nothing else
+un-stales it once that happened, since a zone with no subscribers is never
+`touch_zone`d by its own tick either (asobi_zone only touches on tick when
+`map_size(Subs) > 0`). Without this, a zone that empties and is then
+re-occupied before the next reap sweep keeps its stale timestamp and can be
+reaped out from under its new occupants - an ensure_zone call is itself
+evidence of active use, so it must count as a touch even on the path that
+never talks to the gen_server for the lookup itself.
 """.
 -spec ensure_zone(pid() | atom(), {integer(), integer()}) ->
     {ok, pid(), created | existing} | {error, term()}.
 ensure_zone(Ref, Coords) ->
     case ets_lookup(Ref, Coords) of
         {ok, Pid} ->
+            touch_zone(Ref, Coords),
             {ok, Pid, existing};
         not_loaded ->
             case gen_server:call(Ref, {ensure_zone, Coords}) of

--- a/test/asobi_zone_manager_tests.erl
+++ b/test/asobi_zone_manager_tests.erl
@@ -53,6 +53,8 @@ zone_manager_test_() ->
         {"pre_warm spawns all zones", fun pre_warm_all/0},
         {"touch_zone resets timer", fun touch_zone_resets/0},
         {"release_zone marks stale", fun release_zone_marks_stale/0},
+        {"stale zone is reaped on sweep", fun stale_zone_reaped_on_sweep/0},
+        {"ensure_zone fast path un-stales a released zone", fun reoccupied_zone_survives_reap/0},
         {"per-coord initial zone_state reaches zone init", fun initial_zone_states_threaded/0},
         {"missing per-coord state leaves zone_state default", fun initial_zone_states_default/0}
     ]}.
@@ -150,6 +152,46 @@ release_zone_marks_stale() ->
     timer:sleep(10),
     ?assertMatch({ok, _}, asobi_zone_manager:get_zone(Mgr, {0, 0})),
     stop_manager(Ctx).
+
+%% Sanity check for the forced-sweep technique the next test relies on: a
+%% genuinely-idle (released, never re-touched) zone is torn down once a reap
+%% sweep runs past its idle_timeout. Triggers the sweep directly via the
+%% manager's own reap_ref instead of waiting out ?REAP_INTERVAL.
+stale_zone_reaped_on_sweep() ->
+    Ctx = #{mgr := Mgr} = start_manager(#{idle_timeout => 20}),
+    {ok, ZonePid, created} = asobi_zone_manager:ensure_zone(Mgr, {0, 0}),
+    ok = asobi_zone_manager:release_zone(Mgr, {0, 0}),
+    force_reap_sweep(Mgr),
+    ?assertEqual(not_loaded, asobi_zone_manager:get_zone(Mgr, {0, 0})),
+    ?assert(not is_process_alive(ZonePid)),
+    stop_manager(Ctx).
+
+%% Regression widgrensit/asobi#283, found via the prop_input_never_dropped
+%% nightly flake (asobi#282): release_zone/2 backdates zone_last_active as
+%% soon as a zone empties out, but nothing un-stales it on re-occupation via
+%% ensure_zone/2's ETS fast path (the hot path used by join/reconnect/
+%% crossing lookups once a zone exists) - so a zone that empties and is then
+%% re-occupied before the next reap sweep used to get torn down out from
+%% under its new occupant. ensure_zone must count as a touch even on the
+%% ETS-only path.
+reoccupied_zone_survives_reap() ->
+    Ctx = #{mgr := Mgr} = start_manager(#{idle_timeout => 20}),
+    {ok, ZonePid, created} = asobi_zone_manager:ensure_zone(Mgr, {0, 0}),
+    ok = asobi_zone_manager:release_zone(Mgr, {0, 0}),
+    timer:sleep(5),
+    %% Re-occupy via the ETS fast path, exactly as a rejoining player would.
+    ?assertEqual({ok, ZonePid, existing}, asobi_zone_manager:ensure_zone(Mgr, {0, 0})),
+    force_reap_sweep(Mgr),
+    ?assertEqual({ok, ZonePid}, asobi_zone_manager:get_zone(Mgr, {0, 0})),
+    ?assert(is_process_alive(ZonePid)),
+    stop_manager(Ctx).
+
+%% Sends the manager's own {reap_idle, Ref} message directly instead of
+%% waiting out the real ?REAP_INTERVAL (10s), so the sweep runs immediately.
+force_reap_sweep(Mgr) ->
+    #{reap_ref := ReapRef} = sys:get_state(Mgr),
+    Mgr ! {reap_idle, ReapRef},
+    timer:sleep(20).
 
 %% Regression: per-coord state from generate_world/2 must reach the zone's
 %% init. Before this fix, the world server discarded ZoneStates entirely so

--- a/test/asobi_zone_manager_tests.erl
+++ b/test/asobi_zone_manager_tests.erl
@@ -54,7 +54,8 @@ zone_manager_test_() ->
         {"touch_zone resets timer", fun touch_zone_resets/0},
         {"release_zone marks stale", fun release_zone_marks_stale/0},
         {"stale zone is reaped on sweep", fun stale_zone_reaped_on_sweep/0},
-        {"ensure_zone fast path un-stales a released zone", fun reoccupied_zone_survives_reap/0},
+        {"an occupied zone survives a reap sweep against a stale timestamp",
+            fun occupied_zone_survives_reap/0},
         {"per-coord initial zone_state reaches zone init", fun initial_zone_states_threaded/0},
         {"missing per-coord state leaves zone_state default", fun initial_zone_states_default/0}
     ]}.
@@ -168,19 +169,22 @@ stale_zone_reaped_on_sweep() ->
 
 %% Regression widgrensit/asobi#283, found via the prop_input_never_dropped
 %% nightly flake (asobi#282): release_zone/2 backdates zone_last_active as
-%% soon as a zone empties out, but nothing un-stales it on re-occupation via
-%% ensure_zone/2's ETS fast path (the hot path used by join/reconnect/
-%% crossing lookups once a zone exists) - so a zone that empties and is then
-%% re-occupied before the next reap sweep used to get torn down out from
-%% under its new occupant. ensure_zone must count as a touch even on the
-%% ETS-only path.
-reoccupied_zone_survives_reap() ->
+%% soon as a zone empties out, and nothing un-stales it on re-occupation - a
+%% zone's own tick only touches the manager when it has live subscribers
+%% (asobi_zone.erl, map_size(Subs) > 0), which this test's raw add_entity
+%% deliberately has none of, mirroring how prop_input_never_dropped joins
+%% players with no live session. Without asobi_zone declining `reap` while
+%% it still holds entities (the actual fix, in asobi_zone.erl's
+%% handle_cast(reap, ...)), a zone that empties and is then re-occupied
+%% before the next reap sweep gets torn down out from under its occupant.
+%% This is the integration-level proof: a real manager, a real zone, and a
+%% forced sweep that would have reaped it under the old unconditional stop.
+occupied_zone_survives_reap() ->
     Ctx = #{mgr := Mgr} = start_manager(#{idle_timeout => 20}),
     {ok, ZonePid, created} = asobi_zone_manager:ensure_zone(Mgr, {0, 0}),
-    ok = asobi_zone_manager:release_zone(Mgr, {0, 0}),
+    ok = asobi_zone:add_entity(ZonePid, <<"p1">>, #{type => ~"player", x => 0, y => 0}),
     timer:sleep(5),
-    %% Re-occupy via the ETS fast path, exactly as a rejoining player would.
-    ?assertEqual({ok, ZonePid, existing}, asobi_zone_manager:ensure_zone(Mgr, {0, 0})),
+    ok = asobi_zone_manager:release_zone(Mgr, {0, 0}),
     force_reap_sweep(Mgr),
     ?assertEqual({ok, ZonePid}, asobi_zone_manager:get_zone(Mgr, {0, 0})),
     ?assert(is_process_alive(ZonePid)),

--- a/test/asobi_zone_tests.erl
+++ b/test/asobi_zone_tests.erl
@@ -63,7 +63,10 @@ zone_test_() ->
         {"an NPC past the boundary margin transfers to the neighbouring zone",
             fun npc_past_margin_transfers/0},
         {"an NPC transfer to an unloaded target zone is observable, not silent",
-            fun npc_transfer_unavailable_zone_is_observable/0}
+            fun npc_transfer_unavailable_zone_is_observable/0},
+        {"reap stops a zone with no entities", fun reap_stops_empty_zone/0},
+        {"reap declines and re-touches a zone that still has entities",
+            fun reap_declines_when_occupied/0}
     ]}.
 
 starts_empty() ->
@@ -562,6 +565,47 @@ npc_transfer_unavailable_zone_is_observable() ->
         telemetry:detach(Ref),
         gen_server:stop(Pid)
     end.
+
+reap_stops_empty_zone() ->
+    Pid = start_zone(),
+    Ref = monitor(process, Pid),
+    asobi_zone:reap(Pid),
+    receive
+        {'DOWN', Ref, process, Pid, normal} -> ok
+    after 1000 -> ?assert(false, timeout_waiting_for_reap_stop)
+    end.
+
+%% asobi#283, found via the nightly prop_input_never_dropped flake (#282):
+%% asobi_zone_manager:release_zone/2 backdates a zone's zone_last_active the
+%% moment it empties out, so it becomes reap-eligible on the next sweep. But
+%% nothing un-stales that timestamp on re-occupation for a zone with no live
+%% subscribers - this zone's own tick only touches the manager on the
+%% map_size(Subs) > 0 branch, and neither does asobi_zone_manager:ensure_zone
+%% for an existing zone. A zone could empty, get re-occupied (players joined
+%% with no live session, exactly as prop_input_never_dropped's harness does),
+%% and still get torn down by a sweep the manager scheduled while it was
+%% briefly empty. The zone is the one source of truth for its own occupancy
+%% at the moment it actually receives the cast, so it must decline instead
+%% of trusting the manager's bookkeeping - and re-touch so the manager's
+%% timestamp catches up instead of retrying every sweep.
+reap_declines_when_occupied() ->
+    ZMPid = start_mock_zone_manager(),
+    Pid = start_zone(#{zone_manager_pid => ZMPid}),
+    asobi_zone:add_entity(Pid, <<"p1">>, #{type => ~"player", x => 0, y => 0}),
+    timer:sleep(10),
+    asobi_zone:reap(Pid),
+    timer:sleep(20),
+    ?assert(is_process_alive(Pid)),
+    ZMPid ! {get_touches, self()},
+    receive
+        {touches, Touches} ->
+            ?assert(length(Touches) > 0),
+            ?assertEqual({0, 0}, hd(Touches))
+    after 1000 ->
+        ?assert(false, timeout_waiting_for_touch)
+    end,
+    gen_server:stop(Pid),
+    ZMPid ! stop.
 
 start_mock_zone_manager() ->
     spawn(fun() -> mock_zm_loop([]) end).


### PR DESCRIPTION
## Summary

- `asobi_zone_manager:release_zone/2` backdates a zone's `zone_last_active` the moment it empties out, marking it reap-eligible on the next sweep. Nothing un-stales that timestamp for a zone re-occupied with no live subscribers (its own tick only touches the manager on the `map_size(Subs) > 0` branch - exactly the case when players join with no live session, as `prop_input_never_dropped`'s harness does). A zone could empty, get re-occupied, and still get torn down by a sweep the manager scheduled while it was briefly empty - the occupants' entities silently vanish.
- **Fix:** `asobi_zone`'s `handle_cast(reap, ...)` now declines and re-touches the manager instead of unconditionally stopping when it still has entities. The zone is the one process that knows its real occupancy at the moment it receives the cast - fresher and more reliable than the manager's bookkeeping.

### Revision history on this PR

An earlier version of this fix touched `zone_last_active` on `ensure_zone/2`'s ETS fast path instead. An independent `erlang-code-reviewer` pass on this PR found that approach doesn't actually close the race and adds overhead doing it (`asobi_world_instance` never starts the manager with a `name`, so that "fast path" was already a `gen_server:call` for every real caller). Deterministic probing in that review showed a reap already queued ahead of an `ensure_zone` call still hands back a pid that dies moments later. The fix now lives in `asobi_zone` itself instead - see the second commit for the full writeup.

### What this does and doesn't close

Verified at realistic production settings (`?REAP_INTERVAL=10s`, `idle_timeout=30s`): `prop_input_never_dropped` passes 800/800 iterations cleanly (previously failed within ~200-980). This closes the race that caused #282.

It does not close every race in this area. Stress-testing at an aggressive `?REAP_INTERVAL=200ms`/`idle_timeout=50ms` surfaced a distinct, narrower failure: a zone that's genuinely empty when a reap sweep fires stops correctly, but if a concurrent join's `place_player/4` casts `add_entity` and then synchronously drains via `asobi_zone:get_subscriber_count/1` in that same narrow window, the drain call can hit a zone that already exited, crashing the calling `asobi_world_server` with `exit:{normal, {gen_server, call, ...}}`. That's a sub-millisecond window at real settings rather than the up-to-10-second one this fix closes, but it's real. Documented as a follow-up on #283 (left open, not closed by this PR) rather than attempted here - closing it needs either making `place_player`'s entity-add+drain atomic against a concurrent reap, or a synchronous confirm step before a zone actually stops, and deserves its own design pass.

## Test plan

- [x] `rebar3 fmt` / `rebar3 fmt --check` clean
- [x] `rebar3 xref` clean
- [x] `rebar3 dialyzer` clean
- [x] `elp eqwalize-all` (OTP 28.4.1) - NO ERRORS
- [x] `elp lint` - no new findings in changed files
- [x] `rebar3 eunit` - 503 tests, 0 failures
- [x] `rebar3 ct` - 278 tests passed
- [x] `rebar3 ex_doc` - no warnings
- [x] Three regression tests (`asobi_zone_tests:reap_stops_empty_zone`, `asobi_zone_tests:reap_declines_when_occupied`, `asobi_zone_manager_tests:occupied_zone_survives_reap`) verified to fail against the pre-fix code and pass after
- [x] `prop_input_never_dropped` at PROPER_NUMTESTS=800, realistic reap-interval settings: 800/800 passed clean after the fix

Closes #282