### PR TITLE
fix: ci.yml pre-test-command doesn't force-fresh project ebin

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,13 +28,28 @@ jobs:
       extra-services-compose: 'docker-compose.yml'
       enable-dependency-submission: true
       enable-summary: true
-      # erlang-ci restores _build from cache keyed on rebar.lock, then runs
-      # `rebar3 clean` which only wipes ebin. Stale test artifacts copied in
-      # by previous runs survive and get executed by rebar3 eunit/ct. That's
-      # how asobi_lua_SUITE.beam (removed in #59) keeps reappearing in CT
-      # and crashing on `luerl:init/0` undef. Force-fresh project test tree.
-      # meck is a test-only dep (not in rebar.lock) so the cache key never
-      # reflects its version; a stale OTP-28-era meck gets restored and fails
-      # to compile on OTP 29 (deprecated catch). Drop it so it re-resolves.
-      pre-test-command: 'rm -rf _build/default/lib/asobi/test _build/test/lib/asobi/test _build/test/lib/meck'
+      # erlang-ci restores _build from cache keyed on rebar.lock (with a
+      # restore-keys prefix fallback that can resurrect ANY older cache under
+      # the same prefix, matching rebar.lock or not), then runs `rebar3 clean`
+      # with no `-a` flag - which only wipes the DEFAULT profile's ebin
+      # (_build/default/lib/asobi/ebin), never _build/test/lib/asobi/ebin,
+      # which is what `rebar3 eunit`/`rebar3 ct` actually compile into and run
+      # from. A stale project .beam restored into the test profile survives
+      # that clean step untouched, and rebar3's mtime-based incremental
+      # compile can decide it's already up to date post-extraction (asobi
+      # #287 - two consecutive CI runs crashed on `undefined function
+      # asobi_match_server:finished/3` though that export was present in
+      # source both times; only a manual cache delete + full rebuild fixed
+      # it). Force-fresh both ebin dirs so this can't happen again regardless
+      # of what the cache restores.
+      #
+      # Stale test artifacts copied in by previous runs survive the same
+      # default-profile-only clean and get executed by rebar3 eunit/ct.
+      # That's how asobi_lua_SUITE.beam (removed in #59) kept reappearing in
+      # CT and crashing on `luerl:init/0` undef. Force-fresh project test
+      # tree too. meck is a test-only dep (not in rebar.lock) so the cache
+      # key never reflects its version; a stale OTP-28-era meck gets restored
+      # and fails to compile on OTP 29 (deprecated catch). Drop it so it
+      # re-resolves.
+      pre-test-command: 'rm -rf _build/default/lib/asobi/ebin _build/test/lib/asobi/ebin _build/default/lib/asobi/test _build/test/lib/asobi/test _build/test/lib/meck'
     secrets: inherit


### PR DESCRIPTION
## Summary

- \`erlang-ci\`'s composite action restores \`_build\` from a cache keyed on \`rebar.lock\` (with a \`restore-keys\` prefix fallback that can resurrect any older cache under the same prefix, matching \`rebar.lock\` or not), then runs \`rebar3 clean\` with no \`-a\` flag. Verified directly in this PR: that only wipes \`_build/default/lib/asobi/ebin\` - \`_build/test/lib/asobi/ebin\`, which is what \`rebar3 eunit\`/\`rebar3 ct\` actually compile into and run from, is left completely untouched by that clean step.
- A stale project \`.beam\` restored into the test profile survives, and rebar3's mtime-based incremental compile can decide it's already up to date post-extraction.
- \`pre-test-command\` already force-freshes the project's \`test/\` tree and drops \`meck\` for the same class of reason. This extends the same \`rm -rf\` to both \`ebin\` dirs.

## Evidence

This exact gap caused #286/#287: two consecutive CI runs (one on the PR branch, one on \`main\` after merge - each hitting a different cache scope) crashed on \`undefined function asobi_match_server:finished/3\` even though that export was present in source both times. Only a manual \`gh cache delete\` + full rebuild fixed either one, and the fix didn't carry over between the two cache scopes - confirming this needs a code fix, not another cache purge.

Verified locally in this branch:
\`\`\`
$ rebar3 clean          # mirrors erlang-ci's composite action step exactly
===> Cleaning out asobi...
$ ls _build/test/lib/asobi/ebin/asobi_match_server.beam
_build/test/lib/asobi/ebin/asobi_match_server.beam        # <- survives, untouched
$ ls _build/default/lib/asobi/ebin/asobi_match_server.beam
ls: cannot access ... No such file or directory            # <- wiped
\`\`\`

After the extended \`pre-test-command\` \`rm -rf\`, both are gone and \`rebar3 eunit\` recompiles and passes cleanly (28/28 on \`asobi_match_server_tests\`, full suite unaffected by this change since it only touches CI config).

## Test plan

- [x] YAML syntax validated
- [x] Reproduced the exact staleness mechanism locally (\`rebar3 clean\` leaves test-profile ebin in place)
- [x] Confirmed the new \`pre-test-command\` removes it
- [x] \`rebar3 eunit --module=asobi_match_server_tests\` - 28/28 passing after a clean-slate rebuild via the new command
- This is a CI-config-only change (\`.github/workflows/ci.yml\`), no source touched - the real test is whether this PR's own CI run (which exercises the new \`pre-test-command\` on itself) passes