### PR TITLE
fix: handle session DOWN and reconnect calls in waiting/paused states

### DIFF
--- a/src/matches/asobi_match_server.erl
+++ b/src/matches/asobi_match_server.erl
@@ -231,6 +231,22 @@ waiting(cast, {leave, PlayerId}, State) ->
 waiting(cast, {broadcast_event, Event, Payload}, State) ->
     broadcast_match_event(Event, Payload, State),
     keep_state_and_data;
+%% asobi#285: the match hasn't started yet, so no reconnect_state grace
+%% applies pre-match-start - a session dying while still gathering players
+%% is a leave, same as running's no-reconnect-policy branch. Without this
+%% clause the DOWN message hit no clause here and crashed the match server,
+%% taking every player already in the lobby down with it.
+waiting(info, {'DOWN', _MonRef, process, DownPid, _Reason}, State) when is_pid(DownPid) ->
+    case find_player_by_pid(DownPid, State) of
+        {ok, PlayerId} -> handle_leave(PlayerId, State);
+        none -> keep_state_and_data
+    end;
+%% asobi#285: without this clause a reconnect/2 call while still waiting hit
+%% no clause and crashed the match server (waiting/3 has no catch-all) -
+%% handle_reconnect_call/3 already replies {error, no_reconnect_policy} or
+%% {error, not_in_match} correctly for this state, it was just unreachable.
+waiting({call, From}, {reconnect, PlayerId}, State) when is_binary(PlayerId) ->
+    handle_reconnect_call(From, PlayerId, State);
 waiting(cast, cancel, State) ->
     {stop, {shutdown, cancelled}, State}.
 
@@ -427,6 +443,14 @@ paused({call, From}, resume, State) ->
     {next_state, running, State, [{reply, From, ok}]};
 paused({call, From}, pause, _State) ->
     {keep_state_and_data, [{reply, From, {error, already_paused}}]};
+%% asobi#285: without this clause a reconnect/2 call while paused fell
+%% through to the catch-all below, which never replies - the caller's
+%% gen_statem:call/2 (default timeout infinity) would hang forever. Needed
+%% now that a session DOWN while paused starts real grace (see the 'DOWN'
+%% clauses below): a player in grace during a pause must be able to
+%% reconnect before resume/1 is called.
+paused({call, From}, {reconnect, PlayerId}, State) when is_binary(PlayerId) ->
+    handle_reconnect_call(From, PlayerId, State);
 paused(cast, cancel, State) ->
     {next_state, finished, State#{result => #{status => ~"cancelled"}}};
 paused(cast, {leave, PlayerId}, State) ->
@@ -453,6 +477,30 @@ paused(
 paused(info, {vote_vetoed, VoteId, _Template}, State) ->
     Active = maps:remove(VoteId, maps:get(active_votes, State, #{})),
     {keep_state, State#{active_votes => Active}};
+%% asobi#285: mirrors running's pair of 'DOWN' clauses. Without these, a
+%% session dying while paused fell through to the catch-all below and was
+%% silently swallowed - no grace started, no leave, the player stuck in the
+%% roster forever (and, with no reconnect policy, the match could then never
+%% empty and never shut down).
+paused(
+    info, {'DOWN', _MonRef, process, DownPid, _Reason}, #{reconnect_state := undefined} = State
+) when is_pid(DownPid) ->
+    case find_player_by_pid(DownPid, State) of
+        {ok, PlayerId} -> handle_leave(PlayerId, State);
+        none -> keep_state_and_data
+    end;
+paused(info, {'DOWN', _MonRef, process, DownPid, _Reason}, #{reconnect_state := RS} = State) when
+    is_pid(DownPid)
+->
+    case find_player_by_pid(DownPid, State) of
+        {ok, PlayerId} ->
+            Now = erlang:system_time(millisecond),
+            {Events, RS1} = asobi_reconnect:disconnect(PlayerId, Now, RS),
+            State1 = handle_reconnect_events(Events, State#{reconnect_state => RS1}),
+            {keep_state, State1};
+        none ->
+            keep_state_and_data
+    end;
 paused(_EventType, _Event, _State) ->
     keep_state_and_data.
 

--- a/test/asobi_match_server_tests.erl
+++ b/test/asobi_match_server_tests.erl
@@ -64,7 +64,15 @@ match_server_test_() ->
         {"disconnect with reconnect policy starts grace", fun disconnect_starts_grace/0},
         {"disconnect without policy is immediate leave", fun disconnect_no_policy_leaves/0},
         {"reconnect within grace keeps player", fun reconnect_within_grace_keeps/0},
-        {"reconnect with no policy returns error", fun reconnect_no_policy_errors/0}
+        {"reconnect with no policy returns error", fun reconnect_no_policy_errors/0},
+        {"session down while waiting removes player", fun waiting_down_removes_player/0},
+        {"session down while paused with no policy is immediate leave",
+            fun paused_down_no_policy_leaves/0},
+        {"session down while paused with reconnect policy starts grace",
+            fun paused_down_starts_grace/0},
+        {"reconnect while paused succeeds instead of hanging",
+            fun reconnect_while_paused_succeeds/0},
+        {"reconnect while waiting does not crash", fun reconnect_while_waiting_does_not_crash/0}
     ]}.
 
 %% --- Tests ---
@@ -382,6 +390,144 @@ reconnect_no_policy_errors() ->
     ok = asobi_match_server:join(Pid, ~"p1"),
     timer:sleep(50),
     ?assertMatch({error, no_reconnect_policy}, asobi_match_server:reconnect(Pid, ~"p1")),
+    stop(Pid).
+
+%% Regression for widgrensit/asobi#285: waiting/3 had no clause for a
+%% session dying while the match was still gathering players, so a DOWN
+%% message crashed the match server with function_clause and took every
+%% player already in the lobby down with it. Unique player ids - other
+%% tests in this suite leave dangling fake_session processes registered
+%% under {player, ~"p1"} in the shared nova_scope pg group.
+waiting_down_removes_player() ->
+    Pid = start_match(#{min_players => 3, max_players => 4}),
+    SessionPid1 = fake_session(~"p285_waiting_1"),
+    ok = asobi_match_server:join(Pid, ~"p285_waiting_1"),
+    ok = asobi_match_server:join(Pid, ~"p285_waiting_2"),
+    timer:sleep(50),
+    Info0 = asobi_match_server:get_info(Pid),
+    ?assertEqual(waiting, maps:get(status, Info0)),
+    ?assertEqual(2, maps:get(player_count, Info0)),
+
+    exit(SessionPid1, kill),
+    timer:sleep(100),
+    ?assert(is_process_alive(Pid)),
+    Info1 = asobi_match_server:get_info(Pid),
+    ?assertEqual(waiting, maps:get(status, Info1)),
+    ?assertEqual(1, maps:get(player_count, Info1)),
+    ?assertEqual([~"p285_waiting_2"], maps:get(players, Info1)),
+    stop(Pid).
+
+%% Regression for widgrensit/asobi#285: paused/3 had no clause for a
+%% session DOWN, so it fell through to the catch-all and was silently
+%% swallowed. Without a reconnect policy this must behave like running's
+%% no-policy branch: an immediate leave.
+paused_down_no_policy_leaves() ->
+    Pid = start_match(#{min_players => 1, max_players => 2}),
+    unlink(Pid),
+    Ref = monitor(process, Pid),
+    SessionPid = fake_session(~"p285_paused_nopolicy"),
+    ok = asobi_match_server:join(Pid, ~"p285_paused_nopolicy"),
+    timer:sleep(50),
+    ok = asobi_match_server:pause(Pid),
+    ?assertMatch(#{status := paused}, asobi_match_server:get_info(Pid)),
+
+    exit(SessionPid, kill),
+    %% Single-player match shuts down on last leave, same as running.
+    receive
+        {'DOWN', Ref, process, Pid, {shutdown, empty}} -> ok
+    after 2000 ->
+        ?assert(false)
+    end.
+
+%% Regression for widgrensit/asobi#285: with a reconnect policy active, a
+%% session DOWN while paused must start reconnect grace exactly like
+%% running's with-policy branch - not be swallowed by the catch-all.
+%%
+%% paused/3, unlike running/3, still ends in a catch-all, so "player still
+%% counted right after the kill" is not proof grace actually started - the
+%% catch-all silently dropping the DOWN produces the identical observation.
+%% tick_reconnect/2 only runs from running's tick handler, so grace can't
+%% progress while paused; resume/1 and let the (short) grace period expire
+%% instead - that only happens if asobi_reconnect:disconnect/3 genuinely
+%% populated grace state, which only the fixed with-policy clause does.
+paused_down_starts_grace() ->
+    Pid = start_match(#{
+        min_players => 1,
+        max_players => 2,
+        reconnect => #{
+            grace_period => 100,
+            during_grace => idle,
+            on_reconnect => resume,
+            on_expire => remove,
+            pause_match => false,
+            max_offline_total => infinity
+        }
+    }),
+    SessionPid = fake_session(~"p285_paused_policy"),
+    ok = asobi_match_server:join(Pid, ~"p285_paused_policy"),
+    timer:sleep(50),
+    ok = asobi_match_server:pause(Pid),
+    ?assertMatch(#{status := paused}, asobi_match_server:get_info(Pid)),
+
+    exit(SessionPid, kill),
+    timer:sleep(50),
+    %% Grace active - player still counted, match server alive.
+    ?assert(is_process_alive(Pid)),
+    Info = asobi_match_server:get_info(Pid),
+    ?assertEqual(paused, maps:get(status, Info)),
+    ?assertEqual(1, maps:get(player_count, Info)),
+
+    ok = asobi_match_server:resume(Pid),
+    timer:sleep(500),
+    ?assertEqual(0, maps:get(player_count, asobi_match_server:get_info(Pid))),
+    stop(Pid).
+
+%% Regression for widgrensit/asobi#285: paused/3 had no {call, reconnect}
+%% clause, so calling reconnect/2 while paused fell through to the
+%% catch-all, which never replies - gen_statem:call/2 defaults to timeout
+%% infinity, so the caller would hang forever. Calls gen_statem:call/3
+%% directly with a bounded timeout so a regression fails fast here instead
+%% of hanging the whole test run.
+reconnect_while_paused_succeeds() ->
+    Pid = start_match(#{
+        min_players => 1,
+        max_players => 2,
+        reconnect => #{
+            grace_period => 30_000,
+            during_grace => idle,
+            on_reconnect => resume,
+            on_expire => remove,
+            pause_match => false,
+            max_offline_total => infinity
+        }
+    }),
+    PlayerId = ~"p285_reconnect_paused",
+    SessionPid1 = fake_session(PlayerId),
+    ok = asobi_match_server:join(Pid, PlayerId),
+    timer:sleep(50),
+    ok = asobi_match_server:pause(Pid),
+    exit(SessionPid1, kill),
+    timer:sleep(100),
+    %% Grace active (see paused_down_starts_grace/0) - a real session
+    %% arriving now must be able to reconnect before resume/1 is called.
+    _SessionPid2 = fake_session(PlayerId),
+    ?assertEqual(ok, gen_statem:call(Pid, {reconnect, PlayerId}, 2000)),
+    ?assertMatch(#{status := paused}, asobi_match_server:get_info(Pid)),
+    ?assertEqual(1, maps:get(player_count, asobi_match_server:get_info(Pid))),
+    stop(Pid).
+
+%% Regression for widgrensit/asobi#285: waiting/3 had no {call, reconnect}
+%% clause and no catch-all, so calling reconnect/2 while still gathering
+%% players crashed the match server with function_clause. Bounded timeout
+%% for the same reason as reconnect_while_paused_succeeds/0.
+reconnect_while_waiting_does_not_crash() ->
+    Pid = start_match(#{min_players => 2, max_players => 2}),
+    PlayerId = ~"p285_reconnect_waiting",
+    ok = asobi_match_server:join(Pid, PlayerId),
+    ?assertEqual(
+        {error, no_reconnect_policy}, gen_statem:call(Pid, {reconnect, PlayerId}, 2000)
+    ),
+    ?assert(is_process_alive(Pid)),
     stop(Pid).
 
 %% --- Helpers ---


### PR DESCRIPTION
## Summary
`asobi_match_server` monitors player sessions from `handle_join/4`, which runs both in the `waiting` state (lobby, before `min_players` is reached) and while `running`. But only `running/3` had `'DOWN'` handling:

- **`waiting/3`** had no `'DOWN'` clause and no catch-all - a session dying while the match was still gathering players crashed the match server with `function_clause`, taking every player already in the lobby down with it.
- **`paused/3`** ended in a catch-all - a session dying while paused was silently swallowed: no grace started, no leave, the player stuck in the roster forever (and, with no reconnect policy, the match could then never empty and never shut down).
- Neither state had a `{reconnect, PlayerId}` clause either. `paused` fell through to its catch-all, which never replies - since `gen_statem:call/2` defaults to timeout `infinity`, a `reconnect/2` call while paused would **hang the caller forever**. `waiting` crashed the same way `'DOWN'` did.

## Fix
- `waiting/3`: `'DOWN'` is treated as an unconditional leave. No reconnect grace applies pre-match-start - `tick_reconnect/2` is only reached from `running`'s tick handler, so grace could never advance there anyway, and a ghost holding a slot could block `max_players` or trigger `maybe_start/3` early.
- `paused/3`: `'DOWN'` mirrors `running`'s pair exactly - immediate leave without a policy, starts grace with one.
- Both states: `{reconnect, PlayerId}` now routes to `handle_reconnect_call/3`, same as `running`.

Five new regression tests. Two of them (`reconnect_while_paused_succeeds`, `reconnect_while_waiting_does_not_crash`) call `gen_statem:call/3` directly with a bounded 2000ms timeout rather than the public `reconnect/2` wrapper, so a regression fails fast instead of hanging the test run. `paused_down_starts_grace` uses a short `grace_period` + `resume/1` + sleep-past-expiry to prove grace was genuinely started, rather than asserting on state the old catch-all could produce too - confirmed by manually reverting each new clause and observing the corresponding test fail.

Reviewed twice by asobi-architecture-guardian (the agent that originally filed this issue during review of #284) plus erlang-code-reviewer - final verdict ACCEPT, both empirically re-verified by deleting and restoring each fix.

Closes #285

## Follow-ups filed separately (confirmed out of scope for this PR)
- WS-reachable crash/hang paths for `input`/vote calls in `waiting`/`paused` - the same catch-all-hangs-a-call defect this PR fixes for `reconnect`, still present for `start_vote`/`cast_vote`/`use_veto`.
- `asobi_matchmaker`'s inline join loop isn't exception-isolated, so a mid-loop `{shutdown, empty}` drops all queued tickets in that mode.
- `handle_reconnect_events/2`'s `grace_expired`/`remove` branch removes a player but never checks whether the roster is now empty, so a match that empties via grace expiry never shuts down.

## Test plan
- [x] `rebar3 eunit --module=asobi_match_server_tests` - 33/33 pass, including all five new regression tests
- [x] `rebar3 eunit` (full suite) - 527/527 pass (rebased onto current `main`)
- [x] `rebar3 fmt --check`, `rebar3 xref`, `rebar3 dialyzer` - clean
- [x] `elp eqwalize-all` (OTP 28) - NO ERRORS
- [x] `elp lint` - no new findings
- [x] Manually verified each new source clause is load-bearing: removed each in turn, confirmed the corresponding test fails (crash / hang-timeout / wrong count), restored
