### PR TITLE
fix: unsubscribe sends removal deltas for the zone's entities

### DIFF
--- a/src/world/asobi_zone.erl
+++ b/src/world/asobi_zone.erl
@@ -394,12 +394,15 @@ handle_cast(
     State
 ) when is_binary(PlayerId), is_pid(PlayerPid) ->
     subscribe_new(PlayerId, PlayerPid, State);
-handle_cast({unsubscribe, PlayerId}, #{subscribers := Subs} = State) ->
+handle_cast(
+    {unsubscribe, PlayerId}, #{subscribers := Subs, entities := Entities} = State
+) ->
     case maps:get(PlayerId, Subs, undefined) of
         undefined ->
             {noreply, State};
-        {_Pid, MonRef} ->
+        {Pid, MonRef} ->
             demonitor(MonRef, [flush]),
+            send_leave_removals(Pid, Entities),
             {noreply, State#{subscribers => maps:remove(PlayerId, Subs)}}
     end;
 handle_cast({start_entity_timer, Config}, #{entity_timers := ET} = State) when is_map(Config) ->
@@ -506,6 +509,15 @@ subscribe_new(
                 end
         end,
     {noreply, State#{subscribers => Subs#{PlayerId => {PlayerPid, MonRef}}}}.
+
+%% Mirror of subscribe_new/3's snapshot, in reverse. See widgrensit/asobi#293.
+-spec send_leave_removals(pid(), map()) -> ok.
+send_leave_removals(_Pid, Entities) when map_size(Entities) =:= 0 ->
+    ok;
+send_leave_removals(Pid, Entities) ->
+    Removals = encode_deltas([{removed, Id} || Id <- maps:keys(Entities)]),
+    Pid ! {asobi_message, {zone_delta, 0, Removals}},
+    ok.
 
 do_tick(
     TickN,

--- a/test/asobi_world_zone_integration_tests.erl
+++ b/test/asobi_world_zone_integration_tests.erl
@@ -79,7 +79,9 @@ world_zone_integration_test_() ->
         {"a rate-limited crossing leaves the entity in place instead of destroying it",
             fun rehome_denied_by_rate_limit_survives/0},
         {"the global rehome limit denies a crossing even with per-player budget to spare",
-            fun rehome_denied_by_global_limit/0}
+            fun rehome_denied_by_global_limit/0},
+        {"a crossing that drops a zone from the ring removes its stationary occupants",
+            fun crossing_out_of_ring_removes_stationary_neighbour/0}
     ]}.
 
 %% Default (lazy_zones=false, grid_size=3) pre-spawns all 9 zones
@@ -597,6 +599,69 @@ script_spawn_into_a_lazily_created_zone_backfills_neighbours() ->
         ?assertMatch(#{subscribers := #{Ada := {AdaPid, _}}}, sys:get_state(Z21))
     after
         exit(AdaPid, kill),
+        stop_world(Ctx)
+    end.
+
+%% Blocks until PlayerId's forwarded messages include a zone_delta removal
+%% (op "r") for EntityId, or the timeout elapses.
+received_removal(PlayerId, EntityId) ->
+    receive
+        {PlayerId, {asobi_message, {zone_delta, _Tick, Ops}}} ->
+            HasRemoval = lists:any(
+                fun
+                    (#{~"op" := ~"r", ~"id" := Id}) -> Id =:= EntityId;
+                    (_) -> false
+                end,
+                Ops
+            ),
+            case HasRemoval of
+                true -> true;
+                false -> received_removal(PlayerId, EntityId)
+            end
+    after 500 -> false
+    end.
+
+%% Regression for widgrensit/asobi#293: leaving a zone's interest ring must
+%% mirror joining it - subscribe_new/3 already sends a full "add" snapshot to
+%% a fresh subscriber, but unsubscribing previously sent nothing, so a
+%% stationary occupant of a zone a player has ridden out of the ring stayed
+%% frozen on that departing player's client forever. Ada spawns and stays put
+%% in zone {1,1}; Bob spawns alongside her (so he holds her entity via the
+%% shared zone's snapshot) then crosses far enough east that {1,1} falls
+%% entirely outside his new interest ring - not just a one-zone crossing,
+%% which #248/#275 already covered via the entity's own removal, but the
+%% ring-only drop of a zone whose *other* occupants never moved at all.
+crossing_out_of_ring_removes_stationary_neighbour() ->
+    Ctx =
+        #{world_pid := Pid, zone_mgr := Mgr} = start_world(#{
+            lazy_zones => true, grid_size => 6
+        }),
+    Ada = ~"leave_ring_ada",
+    Bob = ~"leave_ring_bob",
+    AdaPid = fake_session(Ada, self()),
+    BobPid = fake_session(Bob, self()),
+    try
+        %% Both spawn at {100.0, 100.0} => zone {1,1}.
+        ?assertEqual(ok, asobi_world_server:join(Pid, Ada)),
+        ?assertEqual(ok, asobi_world_server:join(Pid, Bob)),
+        timer:sleep(20),
+        {ok, Z11} = asobi_zone_manager:get_zone(Mgr, {1, 1}),
+        ?assert(received_entity(Bob, Ada)),
+
+        %% Bob crosses three zones east - view_radius=1 keeps {0,0}..{2,2}
+        %% around his old zone {1,1}, but his new ring around {4,1} is
+        %% {3,0}..{5,2}, nowhere near it, so {1,1} must be dropped entirely.
+        asobi_zone:player_input(Z11, Bob, #{
+            ~"action" => ~"move", ~"x" => 430.0, ~"y" => 100.0
+        }),
+        timer:sleep(150),
+
+        %% Ada never moved, so she's still subscribed - only Bob left.
+        ?assertEqual(1, asobi_zone:get_subscriber_count(Z11)),
+        ?assert(received_removal(Bob, Ada))
+    after
+        exit(AdaPid, kill),
+        exit(BobPid, kill),
         stop_world(Ctx)
     end.
 

--- a/test/asobi_zone_tests.erl
+++ b/test/asobi_zone_tests.erl
@@ -35,6 +35,10 @@ zone_test_() ->
         {"starts empty", fun starts_empty/0},
         {"add and remove entities", fun add_remove_entities/0},
         {"subscribe and unsubscribe", fun subscribe_unsubscribe/0},
+        {"unsubscribe sends a removal for every entity the zone holds",
+            fun unsubscribe_sends_removals_for_entities/0},
+        {"unsubscribe of an unknown player sends nothing",
+            fun unsubscribe_unknown_player_is_noop/0},
         {"resubscribing the same pid is idempotent", fun resubscribe_same_pid_is_idempotent/0},
         {"resubscribing a new pid replaces and demonitors the old one",
             fun resubscribe_new_pid_replaces_and_demonitors_old/0},
@@ -181,6 +185,50 @@ subscribe_unsubscribe() ->
     asobi_zone:unsubscribe(Pid, <<"p1">>),
     timer:sleep(10),
     ?assertEqual(0, asobi_zone:get_subscriber_count(Pid)),
+    gen_server:stop(Pid).
+
+%% widgrensit/asobi#293: leaving a zone's interest ring must mirror joining
+%% it - subscribe_new/3 sends an `a` for every entity, so unsubscribe must
+%% send an `r` for every entity still held, or the departing client's copy
+%% of this zone freezes at its last known state forever (the zone never
+%% sends it another update once the subscription is gone).
+unsubscribe_sends_removals_for_entities() ->
+    Pid = start_zone(),
+    asobi_zone:add_entity(Pid, ~"e1", #{x => 1, y => 1, type => ~"player"}),
+    asobi_zone:add_entity(Pid, ~"e2", #{x => 2, y => 2, type => ~"npc"}),
+    timer:sleep(10),
+    asobi_zone:subscribe(Pid, {~"p1", self()}),
+    timer:sleep(10),
+    flush_messages(),
+
+    asobi_zone:unsubscribe(Pid, ~"p1"),
+    Removals =
+        receive
+            {asobi_message, {zone_delta, 0, Deltas}} -> Deltas
+        after 200 -> []
+        end,
+    ?assertEqual(
+        lists:sort([~"e1", ~"e2"]),
+        lists:sort([Id || #{~"op" := ~"r", ~"id" := Id} <- Removals])
+    ),
+    timer:sleep(10),
+    ?assertEqual(0, asobi_zone:get_subscriber_count(Pid)),
+    gen_server:stop(Pid).
+
+%% Unsubscribing a player who was never subscribed (or already removed) must
+%% stay a pure no-op - no message to a pid that never subscribed.
+unsubscribe_unknown_player_is_noop() ->
+    Pid = start_zone(),
+    asobi_zone:add_entity(Pid, ~"e1", #{x => 1, y => 1, type => ~"player"}),
+    timer:sleep(10),
+    asobi_zone:unsubscribe(Pid, ~"nobody"),
+    ?assertEqual(
+        timeout,
+        receive
+            {asobi_message, {zone_delta, 0, _}} -> resent
+        after 100 -> timeout
+        end
+    ),
     gen_server:stop(Pid).
 
 %% asobi#275: callers now (re-)subscribe a crossing/backfilled player to a


### PR DESCRIPTION
## Summary
- Fixes #293: `asobi_zone:unsubscribe/2` dropped a subscriber without telling their client to drop the zone's entities. `subscribe_new/3` already sends a full "add" (`op=a`) snapshot when a subscriber joins a zone's interest ring; the reverse never happened, so a player whose ring dropped a zone (or who disconnected) kept every entity that zone had ever shown them, frozen at its last known state for the rest of the session.
- `send_leave_removals/2` mirrors `subscribe_new/3`'s snapshot in reverse: before a departing subscriber is dropped from the `subscribers` map, it sends a removal (`op=r`) for every entity still in the zone, reusing the same wire shape as `encode_delta({removed, Id})`.

## Review
- asobi-architecture-guardian: ACCEPT - correct boundary (symmetric with `subscribe_new/3`), no duplication with crossing/rehome logic. Flagged one pre-existing cross-zone message-ordering race (unrelated to this fix, already possible between any two zones' independent per-tick broadcasts) as a follow-up, not a blocker.
- beam-security-reviewer: no finding above Low - no new data exposure (the removal list is a strict subset of what `subscribe_new/3` already unconditionally sends), no new DoS surface (bounded by the same `asobi_rehome_limiter`/join-rate controls), no new trust boundary (same `subscribers`-map pid).
- erlang-code-reviewer: caught an incorrect assertion in the new integration test (expected 0 subscribers instead of 1, since the stationary neighbour never unsubscribes) and two style nits (dedupe the removal-op literal via `encode_deltas/1`, trim a comment) - all applied.

## Test plan
- [x] `rebar3 fmt` / `rebar3 fmt --check`
- [x] `rebar3 xref`
- [x] `rebar3 dialyzer`
- [x] `elp eqwalize-all` (0 errors)
- [x] `elp lint` (no new warnings vs baseline)
- [x] `rebar3 eunit` (0 failures; two new unit tests in `asobi_zone_tests.erl` covering the direct-removal and no-op-on-unknown-player cases)
- [x] `rebar3 ct` (278/278; new integration test in `asobi_world_zone_integration_tests.erl` reproduces the issue's exact repro shape - a stationary neighbour's entity is actively removed from a departing subscriber's client when a zone drops out of their interest ring)