### PR TITLE
fix: ws_handler accepts binary match/world event names

### DIFF
--- a/src/ws/asobi_ws_handler.erl
+++ b/src/ws/asobi_ws_handler.erl
@@ -152,8 +152,14 @@ websocket_info({asobi_message, {match_state, MatchState}}, State) ->
     {reply, {text, Reply}, State};
 websocket_info({asobi_message, {match_state_raw, PreEncoded}}, State) when is_binary(PreEncoded) ->
     {reply, {text, PreEncoded}, State};
-websocket_info({asobi_message, {match_event, Event, Payload}}, State) when is_atom(Event) ->
-    Type = iolist_to_binary([~"match.", atom_to_binary(Event)]),
+websocket_info({asobi_message, {match_event, Event, Payload}}, State) when
+    is_atom(Event); is_binary(Event)
+->
+    %% #297: asobi_match_server:broadcast_event/3 accepts a binary event
+    %% name (Lua's game.broadcast never turns client/script-influenced
+    %% names into atoms — atom_to_binary here, never binary_to_atom).
+    Name = event_name_binary(Event),
+    Type = iolist_to_binary([~"match.", Name]),
     Reply = encode_reply(undefined, Type, Payload),
     {reply, {text, Reply}, State};
 websocket_info({asobi_message, {zone_delta_raw, PreEncoded}}, State) when is_binary(PreEncoded) ->
@@ -167,8 +173,17 @@ websocket_info({asobi_message, {terrain_chunk, {CX, CY}, Data}}, State) when is_
         data => base64:encode(Data)
     }),
     {reply, {text, Reply}, State};
-websocket_info({asobi_message, {world_event, Event, Payload}}, State) when is_atom(Event) ->
-    Type = iolist_to_binary([~"world.", atom_to_binary(Event)]),
+websocket_info({asobi_message, {world_event, Event, Payload}}, State) when
+    is_atom(Event); is_binary(Event)
+->
+    %% #297: a Lua world script's game.broadcast(event, payload) sends Event
+    %% as a binary via asobi_lua_api:fun_broadcast/1 ->
+    %% asobi_match_server:broadcast_event/3 -> asobi_world_server -> here.
+    %% The old is_atom-only guard silently dropped every such frame. Convert
+    %% atom->binary here at the socket only; never binary_to_atom on a
+    %% client/Lua-influenced name (atom-table exhaustion risk).
+    Name = event_name_binary(Event),
+    Type = iolist_to_binary([~"world.", Name]),
     Reply = encode_reply(undefined, Type, Payload),
     {reply, {text, Reply}, State};
 websocket_info({chat_message, ChannelId, Msg}, State) when is_map(Msg) ->
@@ -802,6 +817,12 @@ encode_reply(Cid, Type, Payload) ->
     json:encode(Msg).
 
 to_reason_binary(R) when is_atom(R) -> atom_to_binary(R, utf8).
+
+%% #297: normalizes a match/world event name to a binary for the wire
+%% `Type` field. Atom->binary only — never binary_to_atom on a
+%% client/Lua-influenced event name (atom-table exhaustion risk).
+event_name_binary(Event) when is_atom(Event) -> atom_to_binary(Event);
+event_name_binary(Event) when is_binary(Event) -> Event.
 
 %% F-16: chat.join must require a small, namespaced channel id so an
 %% attacker can't spawn unbounded chat channel gen_servers via WS.

--- a/src/ws/asobi_ws_handler.erl
+++ b/src/ws/asobi_ws_handler.erl
@@ -4,6 +4,9 @@
 -export([init/1, websocket_init/1, websocket_handle/2, websocket_info/2, terminate/3]).
 %% Exported for tests (pure allowlist predicate), mirroring deployable/1.
 -export([origin_allowed/1]).
+%% Exported so asobi_protocol_coverage_tests can assert every emitted
+%% match./world. event stays inside the reserved namespace (#303).
+-export([reserved_event_names/0]).
 
 -define(WS_MSG_LIMIT, 60).
 -define(WS_MSG_WINDOW_MS, 1000).
@@ -19,6 +22,34 @@
 %% several seconds; 10s gives margin without leaving idle sockets
 %% holding cowboy acceptors. Override via `asobi.ws_idle_auth_timeout_ms`.
 -define(DEFAULT_IDLE_AUTH_TIMEOUT_MS, 10000).
+
+%% #303: script-controlled `game.broadcast` event names share the wire
+%% namespace with asobi's own `match.*`/`world.*` events, so they must be
+%% bounded and validated before ever reaching event_name_binary/1's caller.
+-define(MAX_EVENT_NAME_BYTES, 64).
+%% Every bare event-name suffix asobi itself ever emits under `match.`/
+%% `world.` (per asobi_protocol_coverage_tests:enumerate_emitted_events/0,
+%% restricted to those two namespaces). A script-supplied name equal to one
+%% of these would forge a byte-identical frame to a genuine library event
+%% (fake entity positions via `world.tick`, a false match-end via
+%% `match.finished`, etc), so these stay off-limits to game.broadcast.
+-define(RESERVED_EVENT_NAMES, [
+    ~"state",
+    ~"tick",
+    ~"terrain",
+    ~"list",
+    ~"left",
+    ~"joined",
+    ~"finished",
+    ~"phase_changed",
+    ~"matched",
+    ~"matchmaker_failed",
+    ~"matchmaker_expired",
+    ~"vote_start",
+    ~"vote_tally",
+    ~"vote_result",
+    ~"vote_vetoed"
+]).
 
 -spec init(map()) -> {ok, map()}.
 init(#{req := Req} = State) ->
@@ -158,10 +189,22 @@ websocket_info({asobi_message, {match_event, Event, Payload}}, State) when
     %% #297: asobi_match_server:broadcast_event/3 accepts a binary event
     %% name (Lua's game.broadcast never turns client/script-influenced
     %% names into atoms — atom_to_binary here, never binary_to_atom).
-    Name = event_name_binary(Event),
-    Type = iolist_to_binary([~"match.", Name]),
-    Reply = encode_reply(undefined, Type, Payload),
-    {reply, {text, Reply}, State};
+    %% #303: a script-controlled binary name must be validated first — an
+    %% invalid/non-ASCII name would crash json:encode/1 for every
+    %% subscriber, and a reserved name would forge a genuine match.* frame.
+    case event_name_binary(Event) of
+        {ok, Name} ->
+            Type = iolist_to_binary([~"match.", Name]),
+            Reply = encode_reply(undefined, Type, Payload),
+            {reply, {text, Reply}, State};
+        {error, Reason} ->
+            logger:warning(#{
+                msg => ~"game_broadcast_rejected",
+                namespace => ~"match",
+                reason => Reason
+            }),
+            {ok, State}
+    end;
 websocket_info({asobi_message, {zone_delta_raw, PreEncoded}}, State) when is_binary(PreEncoded) ->
     {reply, {text, PreEncoded}, State};
 websocket_info({asobi_message, {zone_delta, TickN, Deltas}}, State) ->
@@ -182,10 +225,22 @@ websocket_info({asobi_message, {world_event, Event, Payload}}, State) when
     %% The old is_atom-only guard silently dropped every such frame. Convert
     %% atom->binary here at the socket only; never binary_to_atom on a
     %% client/Lua-influenced name (atom-table exhaustion risk).
-    Name = event_name_binary(Event),
-    Type = iolist_to_binary([~"world.", Name]),
-    Reply = encode_reply(undefined, Type, Payload),
-    {reply, {text, Reply}, State};
+    %% #303: a script-controlled binary name must be validated first — an
+    %% invalid/non-ASCII name would crash json:encode/1 for every
+    %% subscriber, and a reserved name would forge a genuine world.* frame.
+    case event_name_binary(Event) of
+        {ok, Name} ->
+            Type = iolist_to_binary([~"world.", Name]),
+            Reply = encode_reply(undefined, Type, Payload),
+            {reply, {text, Reply}, State};
+        {error, Reason} ->
+            logger:warning(#{
+                msg => ~"game_broadcast_rejected",
+                namespace => ~"world",
+                reason => Reason
+            }),
+            {ok, State}
+    end;
 websocket_info({chat_message, ChannelId, Msg}, State) when is_map(Msg) ->
     Reply = encode_reply(undefined, ~"chat.message", Msg#{channel_id => ChannelId}),
     {reply, {text, Reply}, State};
@@ -818,11 +873,46 @@ encode_reply(Cid, Type, Payload) ->
 
 to_reason_binary(R) when is_atom(R) -> atom_to_binary(R, utf8).
 
-%% #297: normalizes a match/world event name to a binary for the wire
-%% `Type` field. Atom->binary only — never binary_to_atom on a
-%% client/Lua-influenced event name (atom-table exhaustion risk).
-event_name_binary(Event) when is_atom(Event) -> atom_to_binary(Event);
-event_name_binary(Event) when is_binary(Event) -> Event.
+-spec reserved_event_names() -> [binary()].
+reserved_event_names() -> ?RESERVED_EVENT_NAMES.
+
+%% #297/#303: normalizes a match/world event name to a binary for the wire
+%% `Type` field, validating any script-controlled binary name first.
+%% Atoms only ever originate in asobi's own source (never binary_to_atom on
+%% a client/Lua-influenced name — atom-table exhaustion risk), so they are
+%% trusted unconditionally; binaries come straight from Lua's
+%% game.broadcast and must be bounded, ASCII-only, and outside the
+%% library-reserved namespace before they may reach the wire:
+%%  - unbounded/non-ASCII bytes (including invalid UTF-8) would crash
+%%    json:encode/1 inside every subscriber's socket process during the
+%%    zone/match broadcast fan-out, disconnecting the whole world/match;
+%%  - a name equal to a reserved suffix would forge a frame byte-identical
+%%    to a genuine authoritative event (e.g. `world.tick`, `match.state`).
+-spec event_name_binary(atom() | binary()) -> {ok, binary()} | {error, atom()}.
+event_name_binary(Event) when is_atom(Event) ->
+    {ok, atom_to_binary(Event)};
+event_name_binary(Event) when is_binary(Event) ->
+    case lists:member(Event, ?RESERVED_EVENT_NAMES) of
+        true ->
+            {error, reserved_event_name};
+        false ->
+            case
+                byte_size(Event) > 0 andalso
+                    byte_size(Event) =< ?MAX_EVENT_NAME_BYTES andalso
+                    lists:all(fun is_event_name_char/1, binary_to_list(Event))
+            of
+                true -> {ok, Event};
+                false -> {error, invalid_event_name}
+            end
+    end.
+
+%% Deliberately excludes `.` — a script must not be able to mint a deeper
+%% `world.foo.bar` sub-namespace.
+is_event_name_char(C) when C >= $a, C =< $z -> true;
+is_event_name_char(C) when C >= $A, C =< $Z -> true;
+is_event_name_char(C) when C >= $0, C =< $9 -> true;
+is_event_name_char(C) when C =:= $_; C =:= $- -> true;
+is_event_name_char(_) -> false.
 
 %% F-16: chat.join must require a small, namespaced channel id so an
 %% attacker can't spawn unbounded chat channel gen_servers via WS.

--- a/test/asobi_protocol_coverage_tests.erl
+++ b/test/asobi_protocol_coverage_tests.erl
@@ -200,6 +200,34 @@ listing_fixtures_match_the_projection_test() ->
         "match.list fixture must match asobi_match_server:listing_info/1"
     ).
 
+%% #303: game.broadcast's binary event-name path (asobi_ws_handler's
+%% ?RESERVED_EVENT_NAMES) closes the match./world. wire namespace to
+%% scripts by rejecting any name asobi itself would otherwise emit — a
+%% script-supplied "tick" must never produce a frame indistinguishable
+%% from a genuine `world.tick` broadcast. This asserts that guarantee
+%% stays honest: every match./world. event this module discovers is
+%% emitted must have its bare suffix reserved, so a future library event
+%% that's added can't silently reopen the forgery hole.
+every_emitted_match_or_world_event_is_reserved_test() ->
+    Emitted = enumerate_emitted_events(),
+    Suffixes = lists:usort(lists:filtermap(fun match_or_world_suffix/1, Emitted)),
+    Reserved = asobi_ws_handler:reserved_event_names(),
+    Missing = Suffixes -- Reserved,
+    ?assertEqual(
+        [],
+        Missing,
+        lists:flatten(
+            io_lib:format(
+                "match./world. event suffixes not in asobi_ws_handler:?RESERVED_EVENT_NAMES: ~p",
+                [Missing]
+            )
+        )
+    ).
+
+match_or_world_suffix(<<"match.", Suffix/binary>>) -> {true, Suffix};
+match_or_world_suffix(<<"world.", Suffix/binary>>) -> {true, Suffix};
+match_or_world_suffix(_) -> false.
+
 projection_keys(Fun, Sample) ->
     lists:sort([atom_to_binary(K) || K <- maps:keys(Fun(Sample))]).
 

--- a/test/asobi_ws_handler_tests.erl
+++ b/test/asobi_ws_handler_tests.erl
@@ -2,6 +2,10 @@
 
 -include_lib("eunit/include/eunit.hrl").
 
+%% logger_handler callback used by the #303 rejection tests below to prove
+%% a rejected event name is logged, not silently dropped.
+-export([log/2]).
+
 %% #297: game.broadcast(event, payload) from a Lua world/match script sends
 %% Event as a binary. Before the fix, websocket_info/2's world_event and
 %% match_event clauses were guarded `when is_atom(Event)` only, so a binary
@@ -43,3 +47,72 @@ match_event_atom_name_still_works_test() ->
 world_event_other_type_is_ignored_test() ->
     Msg = {asobi_message, {world_event, 123, #{}}},
     ?assertEqual({ok, #{}}, asobi_ws_handler:websocket_info(Msg, #{})).
+
+%% #303: a script-supplied binary name still reaches the wire when it's
+%% valid ASCII, unreserved, and within the size cap — the happy path the
+%% hardening must not regress.
+world_event_valid_binary_name_still_works_test() ->
+    Msg = {asobi_message, {world_event, ~"pong", #{}}},
+    {reply, {text, Frame}, _State1} = asobi_ws_handler:websocket_info(Msg, #{}),
+    ?assertMatch(#{~"type" := ~"world.pong"}, json:decode(iolist_to_binary(Frame))).
+
+%% #303 finding 1: a non-ASCII (here, invalid-UTF-8) event name must not
+%% crash json:encode/1 inside the caller's process — it is dropped with a
+%% logged warning instead of producing a frame or a crash.
+world_event_non_ascii_name_is_rejected_and_logged_test() ->
+    ok = install_log_capture(),
+    BadName = <<"evt", 255>>,
+    Msg = {asobi_message, {world_event, BadName, #{}}},
+    ?assertEqual({ok, #{}}, asobi_ws_handler:websocket_info(Msg, #{})),
+    ?assertEqual(#{namespace => ~"world", reason => invalid_event_name}, await_rejection()),
+    ok = remove_log_capture().
+
+%% #303: an oversized name is dropped rather than silently truncated or
+%% forwarded — same log-not-crash contract as the non-ASCII case.
+world_event_oversized_name_is_rejected_and_logged_test() ->
+    ok = install_log_capture(),
+    TooLong = list_to_binary(lists:duplicate(65, $a)),
+    Msg = {asobi_message, {world_event, TooLong, #{}}},
+    ?assertEqual({ok, #{}}, asobi_ws_handler:websocket_info(Msg, #{})),
+    ?assertEqual(#{namespace => ~"world", reason => invalid_event_name}, await_rejection()),
+    ok = remove_log_capture().
+
+%% #303 finding 2: a name equal to a reserved library event name must be
+%% dropped, not forwarded as a byte-identical forged frame.
+world_event_reserved_name_is_rejected_and_logged_test() ->
+    ok = install_log_capture(),
+    Msg = {asobi_message, {world_event, ~"tick", #{}}},
+    ?assertEqual({ok, #{}}, asobi_ws_handler:websocket_info(Msg, #{})),
+    ?assertEqual(#{namespace => ~"world", reason => reserved_event_name}, await_rejection()),
+    ok = remove_log_capture().
+
+match_event_reserved_name_is_rejected_and_logged_test() ->
+    ok = install_log_capture(),
+    Msg = {asobi_message, {match_event, ~"state", #{}}},
+    ?assertEqual({ok, #{}}, asobi_ws_handler:websocket_info(Msg, #{})),
+    ?assertEqual(#{namespace => ~"match", reason => reserved_event_name}, await_rejection()),
+    ok = remove_log_capture().
+
+%% --- log capture helpers ---
+
+install_log_capture() ->
+    logger:add_handler(?MODULE, ?MODULE, #{level => warning, config => #{pid => self()}}).
+
+remove_log_capture() ->
+    logger:remove_handler(?MODULE).
+
+%% logger_handler callback: forwards only the rejection report this test
+%% suite cares about to the installing test process, filtering out any
+%% unrelated warning-level log traffic from the rest of the system.
+log(#{msg := {report, #{msg := ~"game_broadcast_rejected"} = Report}}, #{config := #{pid := Pid}}) ->
+    Pid ! {game_broadcast_rejected, maps:with([namespace, reason], Report)},
+    ok;
+log(_Event, _Config) ->
+    ok.
+
+await_rejection() ->
+    receive
+        {game_broadcast_rejected, Report} -> Report
+    after 1000 ->
+        error(timeout_waiting_for_rejection_log)
+    end.

--- a/test/asobi_ws_handler_tests.erl
+++ b/test/asobi_ws_handler_tests.erl
@@ -1,0 +1,45 @@
+-module(asobi_ws_handler_tests).
+
+-include_lib("eunit/include/eunit.hrl").
+
+%% #297: game.broadcast(event, payload) from a Lua world/match script sends
+%% Event as a binary. Before the fix, websocket_info/2's world_event and
+%% match_event clauses were guarded `when is_atom(Event)` only, so a binary
+%% event name fell through to the catch-all clause and was silently
+%% dropped — no frame, no error, no log. These tests call websocket_info/2
+%% directly (a pure function given a plain State map) to prove a binary
+%% event name now produces a text frame with the expected wire envelope.
+
+world_event_binary_name_reaches_socket_test() ->
+    Msg = {asobi_message, {world_event, ~"door_opened", #{~"room" => 1}}},
+    {reply, {text, Frame}, _State1} = asobi_ws_handler:websocket_info(Msg, #{}),
+    ?assertMatch(
+        #{~"type" := ~"world.door_opened", ~"payload" := #{~"room" := 1}},
+        json:decode(iolist_to_binary(Frame))
+    ).
+
+world_event_atom_name_still_works_test() ->
+    Msg = {asobi_message, {world_event, finished, #{}}},
+    {reply, {text, Frame}, _State1} = asobi_ws_handler:websocket_info(Msg, #{}),
+    ?assertMatch(#{~"type" := ~"world.finished"}, json:decode(iolist_to_binary(Frame))).
+
+match_event_binary_name_reaches_socket_test() ->
+    Msg = {asobi_message, {match_event, ~"round_started", #{~"round" => 2}}},
+    {reply, {text, Frame}, _State1} = asobi_ws_handler:websocket_info(Msg, #{}),
+    ?assertMatch(
+        #{~"type" := ~"match.round_started", ~"payload" := #{~"round" := 2}},
+        json:decode(iolist_to_binary(Frame))
+    ).
+
+match_event_atom_name_still_works_test() ->
+    Msg = {asobi_message, {match_event, finished, #{}}},
+    {reply, {text, Frame}, _State1} = asobi_ws_handler:websocket_info(Msg, #{}),
+    ?assertMatch(#{~"type" := ~"match.finished"}, json:decode(iolist_to_binary(Frame))).
+
+%% A non-atom, non-binary Event (a shape that should never occur, but the
+%% guard is now `is_atom(Event); is_binary(Event)` rather than a catch-all)
+%% must still fall through harmlessly rather than crash the connection
+%% process.
+world_event_other_type_is_ignored_test() ->
+    Msg = {asobi_message, {world_event, 123, #{}}},
+    ?assertEqual({ok, #{}}, asobi_ws_handler:websocket_info(Msg, #{})).


### PR DESCRIPTION
## Summary

`game.broadcast(event, payload)` called from a Lua world script never reached any client. The Lua bridge (`asobi_lua_api.erl:fun_broadcast/1`, in the separate `asobi_lua` repo) sends the event name as a **binary** via `asobi_match_server:broadcast_event/3`. `asobi_world_server:broadcast_world_event/3` fans it out unchanged via `asobi_presence:send(PlayerId, {world_event, Event, Payload})`.

The only `websocket_info/2` clause in `src/ws/asobi_ws_handler.erl` that turns a `{world_event, Event, Payload}` message into a frame was guarded `when is_atom(Event)` — built for asobi's own internal callers (`finished`, `phase_changed`, both atoms). A binary event name fell through to the catch-all clause and was silently dropped: no error, no log, no frame.

## Fix

Widened the guard on both `{match_event, ...}` and `{world_event, ...}` clauses to `is_atom(Event); is_binary(Event)`, and added a small `event_name_binary/1` helper that converts atom -> binary at the socket. The conversion only ever goes atom->binary here; no `binary_to_atom/1` is introduced anywhere on a client- or Lua-influenced event name, to avoid an atom-table exhaustion / atom-leak risk (`asobi_lua` deliberately never turns event names into atoms).

## Match mode

The issue's "worth checking" note was right: match mode had the **identical hole**. `asobi_match_server:broadcast_event/3` is typed `atom() | binary()` and both `broadcast_match_event/3` and `notify_players/2` fan out via `asobi_presence:send(PlayerId, {match_event, Event, Payload})`, landing on the same `websocket_info/2` in `asobi_ws_handler.erl`, which had the same `is_atom(Event)`-only guard. Fixed identically.

## Tests

Added `test/asobi_ws_handler_tests.erl` — direct unit tests on `websocket_info/2` (a pure function given a plain `State` map) proving:
- a binary `world_event`/`match_event` name now produces a text frame with the correct `world.<name>` / `match.<name>` type and payload
- the existing atom-name path still works (regression coverage)
- a non-atom/non-binary event value still falls through harmlessly rather than crashing the connection process

## Checks

`rebar3 fmt`, `xref`, `dialyzer`, `elp eqwalize-all` (via `mise exec erlang@28.4.1`), `elp lint`, `rebar3 eunit`, `rebar3 ct`, `rebar3 fmt --check`, and `rebar3 ex_doc` all pass. `rebar3_mutate` isn't configured in this repo so mutation testing was skipped. `elp lint` reports a pre-existing set of warnings/errors across unrelated files (confirmed identical count on a clean baseline via `git stash`); none touch the files changed in this PR.

Closes #297

## Security hardening (post-review)

A security review of the binary-event-name widening above found two HIGH severity issues, both fixed in a follow-up commit:

1. **Non-UTF-8 event name crashes every connected socket in the world/match.** Luerl strings are raw byte binaries with no UTF-8 validation. `game.broadcast("evt" .. string.char(255), {})` sent an invalid-UTF-8 binary straight through `event_name_binary/1` to `json:encode/1`, which raised inside *every* subscriber's own websocket process during the broadcast fan-out — cowboy_websocket caught it and closed every connection in the world/match. Fixes #303.
2. **Script-controlled names could forge byte-identical library-reserved frames.** Before this PR the `world.`/`match.` wire namespace was closed to scripts. The widened guard opened it: `game.broadcast("tick", {...})` produced a frame indistinguishable from a genuine `world.tick` zone-delta broadcast (same for `state`, `matched`, `finished`, `phase_changed`, the matchmaker/vote events, `list`, `left`, `joined`) — a direct bypass of server-authoritative state.

`event_name_binary/1` now returns `{ok, Binary} | {error, Reason}`. Atoms (asobi's own source) are trusted unconditionally; binaries (Lua's `game.broadcast`) must be non-empty, <=64 bytes, ASCII alnum/underscore/hyphen only (no `.`, so a script can't mint a deeper sub-namespace), and outside a `?RESERVED_EVENT_NAMES` list covering every bare suffix asobi itself emits under `match.`/`world.`. A rejected name is dropped with a logged warning — never a crash, never a silent no-op.

`asobi_protocol_coverage_tests` gained an assertion that every `match.`/`world.` event `enumerate_emitted_events/0` discovers has its suffix in `?RESERVED_EVENT_NAMES`, so a future library event can't silently reopen the forgery hole. `asobi_ws_handler_tests` gained coverage for the non-ASCII, oversized, reserved-name, and still-valid-name paths.

Closes #303
