### PR TITLE
fix: strip room: prefix before group ACL lookup

### DIFF
--- a/guides/lobbies.md
+++ b/guides/lobbies.md
@@ -88,9 +88,9 @@ There is no `match:` chat channel scheme. `world:<WorldId>` exists and is
 gated on world membership; matches have no equivalent. Use `game.broadcast`
 with your own message shape.
 
-The `room:` scheme is documented as open-join but is not - it resolves to a
-group membership check. See
-[asobi#209](https://github.com/widgrensit/asobi/issues/209).
+The `room:` scheme is not open-join - it resolves to a group membership check.
+`room:<group_id>` now correctly authorises the members of `<group_id>`
+([asobi#209](https://github.com/widgrensit/asobi/issues/209), resolved).
 
 ### The 60-second timeout
 

--- a/guides/websocket-protocol.md
+++ b/guides/websocket-protocol.md
@@ -382,12 +382,13 @@ membership without a per-frame registry lookup.
 | `world:` | World-wide chat                           | Players currently joined to the world. |
 | `zone:`  | A specific zone within a world            | Players currently joined to the world. |
 | `prox:`  | Proximity chat (radius around a position) | Players currently joined to the world. |
-| `room:`  | App-defined group chat                    | Members of the group whose id equals the channel id. Not open-join. |
+| `room:`  | App-defined group chat                    | Members of the group whose id is the part of the channel id after `room:`. Not open-join. |
 
 There is no open-join room policy and no `match:` scheme. `room:` is authorised
-as a group membership check: the runtime treats the full channel id as the group
-id, so a player must already belong to a group with that exact id. For pre-game
-lobby chat, gate on world membership with `world:<world_id>`, or use
+as a group membership check: the runtime strips the `room:` prefix and looks up
+the remainder as a group id, so `room:<group_id>` authorises exactly the members
+of `<group_id>`, not members of a group literally named `"room:<group_id>"`. For
+pre-game lobby chat, gate on world membership with `world:<world_id>`, or use
 `game.broadcast`; see the [Lobbies](lobbies.md) guide.
 
 The worked examples below use a `world:` channel, which authorises on world

--- a/src/controllers/asobi_chat_controller.erl
+++ b/src/controllers/asobi_chat_controller.erl
@@ -15,7 +15,10 @@ history(
 ) when
     is_binary(ChannelId), is_binary(Qs), is_binary(PlayerId)
 ->
-    case asobi_chat_acl:authorized(ChannelId, PlayerId) of
+    case
+        asobi_chat_acl:validate_channel_id(ChannelId) andalso
+            asobi_chat_acl:authorized(ChannelId, PlayerId)
+    of
         true ->
             Params = cow_qs:parse_qs(Qs),
             Limit = asobi_qs:integer(

--- a/src/social/asobi_chat_acl.erl
+++ b/src/social/asobi_chat_acl.erl
@@ -7,26 +7,37 @@ Channel ID schemes:
   world:<WorldId>            - must currently be joined to the world
   zone:<WorldId>:<X>,<Y>     - must currently be joined to the world
   prox:<WorldId>:<X>,<Y>     - must currently be joined to the world
-  room:<GroupId>             - the `room:` prefix is stripped; must be a
-                                member of the group named by GroupId
+  room:<GroupId>             - the `room:` prefix is stripped; GroupId must
+                                be a canonical lowercase-hyphenated uuid (the
+                                shape `asobi_id:generate/0` always emits) and
+                                the caller must be a member of that group
   <anything else>            - treated as a group_id; must be a group member
 
-A `room:` channel naming a group id that does not exist (or is malformed,
-e.g. not a UUID) is closed, not an open public lobby: the membership lookup
-yields no match (a non-uuid group id fails the query outright rather than
-returning an empty result), and `authorized/2` returns `false`, matching the
-closed-by-default posture of every other channel scheme here.
+A `room:` channel is closed by default: a group id that isn't a canonical
+uuid is denied outright (rather than falling through to a membership lookup
+that merely happens to miss), and a group id that doesn't exist or that the
+caller isn't a member of yields `false`. Requiring the canonical uuid shape
+also prevents one group from acquiring unbounded alias channel ids (dashes
+stripped, different case, padded/garbage-prefixed hex) that a lossy uuid
+decode downstream would otherwise all resolve to the same group - each alias
+would otherwise be a distinct, unmoderated channel process.
 
 Shared by `asobi_chat_controller` (HTTP history) and `asobi_ws_handler`
 (WebSocket `chat.join` / `chat.send`). Keeping a single source of truth
 prevents the WS path from drifting and silently allowing DM eavesdropping.
 """.
 
--export([authorized/2]).
+-include_lib("kernel/include/logger.hrl").
+
+-export([authorized/2, validate_channel_id/1]).
+
+-define(MAX_CHANNEL_ID_BYTES, 256).
 
 -spec authorized(binary(), binary()) -> boolean().
 authorized(ChannelId, PlayerId) when is_binary(ChannelId), is_binary(PlayerId) ->
     case classify(ChannelId) of
+        deny ->
+            false;
         {dm, A, B} ->
             PlayerId =:= A orelse PlayerId =:= B;
         {world, WorldId} ->
@@ -35,7 +46,28 @@ authorized(ChannelId, PlayerId) when is_binary(ChannelId), is_binary(PlayerId) -
             is_group_member(PlayerId, GroupId)
     end.
 
--spec classify(binary()) -> {dm, binary(), binary()} | {world, binary()} | {group, binary()}.
+-doc """
+Validate a channel id shape before it is used at all: bounded length and
+one of the known channel-id prefixes. Shared by the WS `chat.join`/`chat.send`
+path and the HTTP chat-history path so neither can be tricked into treating
+an unprefixed bare id (which `classify/1`'s catch-all clause would otherwise
+happily route to a group lookup) as a valid channel id.
+""".
+-spec validate_channel_id(binary()) -> boolean().
+validate_channel_id(ChannelId) when is_binary(ChannelId) ->
+    byte_size(ChannelId) > 0 andalso
+        byte_size(ChannelId) =< ?MAX_CHANNEL_ID_BYTES andalso
+        valid_channel_prefix(ChannelId).
+
+valid_channel_prefix(<<"dm:", _/binary>>) -> true;
+valid_channel_prefix(<<"world:", _/binary>>) -> true;
+valid_channel_prefix(<<"zone:", _/binary>>) -> true;
+valid_channel_prefix(<<"prox:", _/binary>>) -> true;
+valid_channel_prefix(<<"room:", _/binary>>) -> true;
+valid_channel_prefix(_) -> false.
+
+-spec classify(binary()) ->
+    {dm, binary(), binary()} | {world, binary()} | {group, binary()} | deny.
 classify(<<"dm:", Rest/binary>>) ->
     case binary:split(Rest, ~":", [global]) of
         [A, B] when byte_size(A) > 0, byte_size(B) > 0 -> {dm, A, B};
@@ -47,10 +79,23 @@ classify(<<"zone:", Rest/binary>>) ->
     {world, take_until_colon(Rest)};
 classify(<<"prox:", Rest/binary>>) ->
     {world, take_until_colon(Rest)};
-classify(<<"room:", GroupId/binary>>) when byte_size(GroupId) > 0 ->
-    {group, GroupId};
+classify(<<"room:", GroupId/binary>>) ->
+    case is_uuid(GroupId) of
+        true -> {group, GroupId};
+        false -> deny
+    end;
 classify(ChannelId) ->
     {group, ChannelId}.
+
+-spec is_uuid(binary()) -> boolean().
+is_uuid(<<A:8/binary, $-, B:4/binary, $-, C:4/binary, $-, D:4/binary, $-, E:12/binary>>) ->
+    lists:all(fun is_hex/1, binary_to_list(<<A/binary, B/binary, C/binary, D/binary, E/binary>>));
+is_uuid(_) ->
+    false.
+
+is_hex(C) when C >= $0, C =< $9 -> true;
+is_hex(C) when C >= $a, C =< $f -> true;
+is_hex(_) -> false.
 
 -spec take_until_colon(binary()) -> binary().
 take_until_colon(Bin) ->
@@ -85,6 +130,11 @@ is_group_member(PlayerId, GroupId) ->
         {player_id, PlayerId}
     ),
     case asobi_repo:all(Q) of
-        {ok, [_ | _]} -> true;
-        _ -> false
+        {ok, [_ | _]} ->
+            true;
+        {ok, []} ->
+            false;
+        {error, Reason} ->
+            ?LOG_WARNING(#{event => group_member_lookup_failed, reason => Reason}),
+            false
     end.

--- a/src/social/asobi_chat_acl.erl
+++ b/src/social/asobi_chat_acl.erl
@@ -11,10 +11,11 @@ Channel ID schemes:
                                 member of the group named by GroupId
   <anything else>            - treated as a group_id; must be a group member
 
-A `room:` channel naming a group id that does not exist is closed, not an
-open public lobby: `is_group_member/2` finds no rows and `authorized/2`
-returns `false`, matching the closed-by-default posture of every other
-channel scheme here.
+A `room:` channel naming a group id that does not exist (or is malformed,
+e.g. not a UUID) is closed, not an open public lobby: the membership lookup
+yields no match (a non-uuid group id fails the query outright rather than
+returning an empty result), and `authorized/2` returns `false`, matching the
+closed-by-default posture of every other channel scheme here.
 
 Shared by `asobi_chat_controller` (HTTP history) and `asobi_ws_handler`
 (WebSocket `chat.join` / `chat.send`). Keeping a single source of truth

--- a/src/social/asobi_chat_acl.erl
+++ b/src/social/asobi_chat_acl.erl
@@ -7,7 +7,14 @@ Channel ID schemes:
   world:<WorldId>            - must currently be joined to the world
   zone:<WorldId>:<X>,<Y>     - must currently be joined to the world
   prox:<WorldId>:<X>,<Y>     - must currently be joined to the world
+  room:<GroupId>             - the `room:` prefix is stripped; must be a
+                                member of the group named by GroupId
   <anything else>            - treated as a group_id; must be a group member
+
+A `room:` channel naming a group id that does not exist is closed, not an
+open public lobby: `is_group_member/2` finds no rows and `authorized/2`
+returns `false`, matching the closed-by-default posture of every other
+channel scheme here.
 
 Shared by `asobi_chat_controller` (HTTP history) and `asobi_ws_handler`
 (WebSocket `chat.join` / `chat.send`). Keeping a single source of truth
@@ -39,6 +46,8 @@ classify(<<"zone:", Rest/binary>>) ->
     {world, take_until_colon(Rest)};
 classify(<<"prox:", Rest/binary>>) ->
     {world, take_until_colon(Rest)};
+classify(<<"room:", GroupId/binary>>) when byte_size(GroupId) > 0 ->
+    {group, GroupId};
 classify(ChannelId) ->
     {group, ChannelId}.
 

--- a/src/ws/asobi_ws_handler.erl
+++ b/src/ws/asobi_ws_handler.erl
@@ -10,7 +10,6 @@
 -define(WS_MAX_PAYLOAD_BYTES, 65536).
 %% F-16: per-connection cap on simultaneously joined chat channels.
 -define(MAX_JOINED_CHANNELS_PER_CONN, 32).
--define(MAX_CHANNEL_ID_BYTES, 256).
 %% #236: at most one `not_in_match` hint per connection per this window.
 -define(NOT_IN_MATCH_HINT_WINDOW_MS, 5000).
 
@@ -805,20 +804,9 @@ to_reason_binary(R) when is_atom(R) -> atom_to_binary(R, utf8).
 
 %% F-16: chat.join must require a small, namespaced channel id so an
 %% attacker can't spawn unbounded chat channel gen_servers via WS.
-%% Allowed prefixes mirror the channel id schemes documented in
-%% asobi_chat_controller's classify/1 (`dm:`, `world:`, `zone:`,
-%% `prox:`, plus a `room:` namespace for app-defined group chats).
-validate_channel_id(ChannelId) when is_binary(ChannelId) ->
-    byte_size(ChannelId) > 0 andalso
-        byte_size(ChannelId) =< ?MAX_CHANNEL_ID_BYTES andalso
-        valid_channel_prefix(ChannelId).
-
-valid_channel_prefix(<<"dm:", _/binary>>) -> true;
-valid_channel_prefix(<<"world:", _/binary>>) -> true;
-valid_channel_prefix(<<"zone:", _/binary>>) -> true;
-valid_channel_prefix(<<"prox:", _/binary>>) -> true;
-valid_channel_prefix(<<"room:", _/binary>>) -> true;
-valid_channel_prefix(_) -> false.
+%% Delegates to asobi_chat_acl, the single source of truth for channel id
+%% shape shared with the HTTP chat-history path.
+validate_channel_id(ChannelId) -> asobi_chat_acl:validate_channel_id(ChannelId).
 
 %% F-29: world.list/match.list filter values must be the right type or we
 %% reject the request rather than silently returning unfiltered results.

--- a/test/asobi_social_api_SUITE.erl
+++ b/test/asobi_social_api_SUITE.erl
@@ -12,7 +12,9 @@
     chat_history_with_messages/1,
     chat_history_non_member_forbidden/1,
     chat_history_dm_non_participant_forbidden/1,
-    chat_history_dm_participant_allowed/1
+    chat_history_dm_participant_allowed/1,
+    room_channel_member_authorized/1,
+    room_channel_non_member_rejected/1
 ]).
 
 all() -> [{group, groups_api}, {group, chat_api}].
@@ -27,7 +29,9 @@ groups() ->
             chat_history_with_messages,
             chat_history_non_member_forbidden,
             chat_history_dm_non_participant_forbidden,
-            chat_history_dm_participant_allowed
+            chat_history_dm_participant_allowed,
+            room_channel_member_authorized,
+            room_channel_non_member_rejected
         ]}
     ].
 
@@ -234,4 +238,29 @@ chat_history_dm_participant_allowed(Config) ->
         Config
     ),
     ?assertStatus(200, Resp),
+    Config.
+
+%% Regression for #295: `room:<GroupId>` is the channel id shape
+%% `asobi_ws_handler:validate_channel_id/1` accepts for group chat, but
+%% `asobi_chat_acl:classify/1` was matching the literal "room:<uuid>" as
+%% the group id against `group_members.group_id` (a uuid column), so it
+%% never matched and every member was rejected. A member must authorize.
+%%
+%% Use player1 (the group creator): player2 already left the group in
+%% the earlier `leave_group` test case, and both groups share init_per_suite
+%% fixtures, so player1 is the only membership guaranteed still live here.
+room_channel_member_authorized(Config) ->
+    {group_id, GroupId} = lists:keyfind(group_id, 1, Config),
+    {player1_id, P1Id} = lists:keyfind(player1_id, 1, Config),
+    RoomChannel = <<"room:", GroupId/binary>>,
+    ?assert(asobi_chat_acl:authorized(RoomChannel, P1Id)),
+    Config.
+
+%% Regression for #295: a non-member must still be rejected once the
+%% `room:` prefix is stripped correctly (closed by default).
+room_channel_non_member_rejected(Config) ->
+    {group_id, GroupId} = lists:keyfind(group_id, 1, Config),
+    {player3_id, P3Id} = lists:keyfind(player3_id, 1, Config),
+    RoomChannel = <<"room:", GroupId/binary>>,
+    ?assertNot(asobi_chat_acl:authorized(RoomChannel, P3Id)),
     Config.

--- a/test/asobi_social_api_SUITE.erl
+++ b/test/asobi_social_api_SUITE.erl
@@ -14,7 +14,9 @@
     chat_history_dm_non_participant_forbidden/1,
     chat_history_dm_participant_allowed/1,
     room_channel_member_authorized/1,
-    room_channel_non_member_rejected/1
+    room_channel_non_member_rejected/1,
+    room_channel_nonexistent_group_denied/1,
+    room_channel_malformed_group_id_denied/1
 ]).
 
 all() -> [{group, groups_api}, {group, chat_api}].
@@ -31,7 +33,9 @@ groups() ->
             chat_history_dm_non_participant_forbidden,
             chat_history_dm_participant_allowed,
             room_channel_member_authorized,
-            room_channel_non_member_rejected
+            room_channel_non_member_rejected,
+            room_channel_nonexistent_group_denied,
+            room_channel_malformed_group_id_denied
         ]}
     ].
 
@@ -84,10 +88,12 @@ init_per_suite(Config) ->
         #{headers => auth(P2Token), json => #{}},
         Config0
     ),
-    %% F-10: chat history is now membership-gated. Use the actual GroupId
-    %% as the channel_id so P1 (creator) is authorized via asobi_group_member;
-    %% P3 will be a non-member who must be denied.
-    ChannelId = GroupId,
+    %% F-10: chat history is now membership-gated. Use the canonical
+    %% `room:<GroupId>` channel id so P1 (creator) is authorized via
+    %% asobi_group_member; P3 will be a non-member who must be denied.
+    %% #295/#301: a bare, unprefixed group id is no longer a valid channel
+    %% id on the HTTP path (validate_channel_id/1 now applies there too).
+    ChannelId = <<"room:", GroupId/binary>>,
     asobi_chat_channel:join(ChannelId, self()),
     asobi_chat_channel:send_message(ChannelId, P1Id, ~"Hello from p1"),
     asobi_chat_channel:send_message(ChannelId, P2Id, ~"Hello from p2"),
@@ -241,7 +247,7 @@ chat_history_dm_participant_allowed(Config) ->
     Config.
 
 %% Regression for #295: `room:<GroupId>` is the channel id shape
-%% `asobi_ws_handler:validate_channel_id/1` accepts for group chat, but
+%% `asobi_chat_acl:validate_channel_id/1` accepts for group chat, but
 %% `asobi_chat_acl:classify/1` was matching the literal "room:<uuid>" as
 %% the group id against `group_members.group_id` (a uuid column), so it
 %% never matched and every member was rejected. A member must authorize.
@@ -263,4 +269,24 @@ room_channel_non_member_rejected(Config) ->
     {player3_id, P3Id} = lists:keyfind(player3_id, 1, Config),
     RoomChannel = <<"room:", GroupId/binary>>,
     ?assertNot(asobi_chat_acl:authorized(RoomChannel, P3Id)),
+    Config.
+
+%% Security-review follow-up (#301): a syntactically-valid uuid that names
+%% no group must be denied, not merely fall through to an empty membership
+%% lookup by coincidence.
+room_channel_nonexistent_group_denied(Config) ->
+    {player1_id, P1Id} = lists:keyfind(player1_id, 1, Config),
+    Ghost = asobi_id:generate(),
+    ?assertNot(asobi_chat_acl:authorized(<<"room:", Ghost/binary>>, P1Id)),
+    Config.
+
+%% Security-review follow-up (#301): non-canonical group ids (too short,
+%% empty, or carrying injection-shaped garbage) must be denied outright by
+%% classify/1's uuid-shape check rather than reaching the DB query.
+room_channel_malformed_group_id_denied(Config) ->
+    {player1_id, P1Id} = lists:keyfind(player1_id, 1, Config),
+    [
+        ?assertNot(asobi_chat_acl:authorized(C, P1Id))
+     || C <- [~"room:abc", ~"room:", ~"room:' OR 1=1 --"]
+    ],
     Config.


### PR DESCRIPTION
## Bug

`asobi_ws_handler:validate_channel_id/1` allows a `room:` channel prefix for app-defined group chat, but `asobi_chat_acl:classify/1` treated anything that wasn't `dm:`/`world:`/`zone:`/`prox:` as a group id **without** stripping the `room:` prefix. It matched the literal `"room:<uuid>"` string against `group_members.group_id` (a `uuid` column) via `kura_query`, which never matches. `is_group_member/2` was therefore always `false`, and `authorized/2` rejected every player, including a group's own members. There was no channel id that satisfied both `validate_channel_id/1`'s prefix requirement and `classify/1`'s group lookup.

## Fix

Add a `classify/1` clause that strips the `room:` prefix before treating the remainder as a group id, placed before the catch-all group clause:

```erlang
classify(<<"room:", GroupId/binary>>) when byte_size(GroupId) > 0 ->
    {group, GroupId};
```

`validate_channel_id/1` in `asobi_ws_handler` was already correct (it accepts `room:` already) and needed no change.

## Design decision: nonexistent group behind `room:`

A `room:` channel naming a group id that doesn't exist stays **closed**, not an open public lobby. `is_group_member/2` finds no matching rows for a nonexistent group id, so `authorized/2` returns `false` — the same closed-by-default posture as every other channel scheme (`dm:`, `world:`, `zone:`, `prox:`). This required no code change beyond the fix above; it falls out of the existing membership-lookup semantics. Went with closed since it matches the existing shape and there's no established convention in the codebase for an intentionally-open public channel.

## Tests

Added two regression cases to `test/asobi_social_api_SUITE.erl` (`chat_api` group), reusing the existing group/player fixtures from `init_per_suite`:
- `room_channel_member_authorized` — the group's creator (still a member) authorizes `room:<group_id>`.
- `room_channel_non_member_rejected` — a non-member is rejected for the same `room:<group_id>` channel.

Closes #295

## Pre-push checks

- `rebar3 fmt` / `rebar3 fmt --check` — clean
- `rebar3 xref` — clean
- `rebar3 dialyzer` — clean
- `elp eqwalize-all` (via `mise exec erlang@28.4.1`) — `NO ERRORS`
- `elp lint` — no findings in touched files (pre-existing parse-panic errors and `catch`-deprecation warnings exist elsewhere in the repo, unrelated to this change)
- `rebar3 eunit` (`asobi_chat_acl_tests`) — 3/3 pass; full-suite run shows a pre-existing `0 failures, 7 cancelled` flake reproduced identically on `main` before this change (unrelated match-server/gate timeout tests)
- `rebar3 ct` — `asobi_social_api_SUITE` 11/11 pass (both new cases included); full `rebar3 ct` run has one pre-existing, unrelated failure in `asobi_iap_SUITE` (Apple JWS test)