### PR TITLE
fix: stop match gen_statem before meck:unload in finished-state test

### DIFF
--- a/test/asobi_match_server_tests.erl
+++ b/test/asobi_match_server_tests.erl
@@ -448,6 +448,11 @@ broadcast_in_finished_is_not_swallowed_test() ->
     asobi_match_server:broadcast_event(Pid, game_over, #{winner => ~"p1"}),
     timer:sleep(20),
     ?assert(is_process_alive(Pid)),
+    %% Still in `finished`, with its 5s state_timeout `cleanup` pending -
+    %% stop the process before tearing down mecks, or the timer fires after
+    %% unload and crashes the runner (undef in finished/3), aborting the
+    %% rest of the eunit suite (asobi#300/#301 review).
+    gen_statem:stop(Pid),
     meck:unload(asobi_test_game),
     cleanup(ok).
 


### PR DESCRIPTION
## Summary

Fixes a pre-existing flake in the eunit suite discovered while reviewing #300 and #301: `rebar3 eunit --verbose` sometimes aborts the whole run partway through with `Passed: 305` / `One or more tests were cancelled`, exit 1 - before ever reaching later modules like `asobi_ws_handler_tests` or `asobi_world_server_tests`. CI's `EUnit (OTP 29.0.2)` job has been observed red with this exact signature on multiple recent PR branches, and `main` itself reproduces it locally.

## Root cause

`broadcast_in_finished_is_not_swallowed_test/0` in `test/asobi_match_server_tests.erl` drives a match `gen_statem` to the `finished` state. Entering `finished` arms a 5000ms `state_timeout, cleanup` (see `asobi_match_server:finished/3`). The test then calls `meck:unload(asobi_test_game)` and `cleanup(ok)` (which unloads `asobi_presence`/`asobi_repo`) without ever stopping the process - it stays alive with the pending timer. When the timer later fires with the mocks gone, the process crashes (undef, showing up as `{'$meck_call', undefined}` in the process dictionary), and that crash aborts the eunit runner's remaining test discovery/execution for the rest of the suite - silently skipping any modules that hadn't run yet.

The sibling test `empty_phases_does_not_finish_test/0` in the same file already does this correctly (`gen_statem:stop(Pid)` before `meck:unload`), which is the pattern this fix mirrors.

## Fix

Added `gen_statem:stop(Pid)` before `meck:unload(asobi_test_game)` in `broadcast_in_finished_is_not_swallowed_test/0`. `gen_statem:stop/1` is synchronous and cancels all pending timers as part of termination, so this eliminates the pending `state_timeout` entirely rather than just narrowing the race window.

## Verification

- `rebar3 eunit --verbose` (full suite): 10 consecutive runs, all "All 506 tests passed", exit 0, zero cancellations.
- `rebar3 ct`: 278/278 passed.
- Pre-push checklist: fmt / xref / dialyzer / `elp eqwalize-all` / `elp lint` / fmt --check all clean, with `elp lint`'s baseline "Errors found" confirmed pre-existing and identical on `main` (unrelated to this change).

## Test plan

- [x] Repeated `rebar3 eunit --verbose` (10x) confirming no cancellations
- [x] `rebar3 ct` full suite green
- [x] Pre-push checklist clean