### PR TITLE
fix: scope storage HTTP endpoints by player_id, handle multi-row results

### DIFF
--- a/src/controllers/asobi_storage_controller.erl
+++ b/src/controllers/asobi_storage_controller.erl
@@ -1,5 +1,7 @@
 -module(asobi_storage_controller).
 
+-include_lib("kernel/include/logger.hrl").
+
 -export([list_saves/1, get_save/1, put_save/1]).
 -export([get_storage/1, put_storage/1, delete_storage/1, list_storage/1]).
 
@@ -81,20 +83,46 @@ put_save(
 
 %% --- Generic Storage ---
 
+%% asobi#307: `asobi_storage:indexes/0` maintains two distinct partial-unique
+%% namespaces - a global row (`player_id IS NULL`, written by Lua's
+%% `game.storage.set`) and per-player rows (`player_id IS NOT NULL`). The
+%% HTTP `/storage/:collection/:key` endpoints only ever create and act on
+%% per-player rows (see put_storage_checked/6's insert, and the SUITE
+%% comment on put_storage_per_player_keys_dont_collide/1) - a shared object
+%% owned by whoever wrote it first, gated by the owner/public
+%% read_perm/write_perm ACL. Every query below must exclude the global
+%% namespace explicitly, or a global Lua row and a player's HTTP row can
+%% both match the same collection+key and the result stops being the single
+%% row these ACL-based case clauses assume.
+-define(PLAYER_SCOPE, {player_id, is_not_nil}).
+
 -spec get_storage(cowboy_req:req()) -> {json, map()} | {status, integer()}.
 get_storage(
     #{bindings := #{~"collection" := Col, ~"key" := Key}, auth_data := #{player_id := PlayerId}} =
         _Req
 ) ->
     Q = kura_query:where(
-        kura_query:where(kura_query:from(asobi_storage), {collection, Col}),
-        {key, Key}
+        kura_query:where(
+            kura_query:where(kura_query:from(asobi_storage), {collection, Col}),
+            {key, Key}
+        ),
+        ?PLAYER_SCOPE
     ),
     case asobi_repo:all(Q) of
-        {ok, [#{read_perm := ~"public"} = Obj]} -> {json, Obj};
-        {ok, [#{read_perm := ~"owner", player_id := PlayerId} = Obj]} -> {json, Obj};
-        {ok, [_]} -> {status, 403};
-        {ok, []} -> {status, 404}
+        {ok, [#{read_perm := ~"public"} = Obj]} ->
+            {json, Obj};
+        {ok, [#{read_perm := ~"owner", player_id := PlayerId} = Obj]} ->
+            {json, Obj};
+        {ok, [_]} ->
+            {status, 403};
+        {ok, []} ->
+            {status, 404};
+        {ok, [_, _ | _] = Rows} ->
+            log_storage_invariant_violation(Col, Key, length(Rows)),
+            {status, 500};
+        {error, Reason} ->
+            log_storage_query_failed(Col, Key, Reason),
+            {status, 500}
     end.
 
 -spec put_storage(cowboy_req:req()) ->
@@ -132,8 +160,11 @@ put_storage_checked(Col, Key, PlayerId, Value, ReadPerm, WritePerm) ->
             {json, 400, #{}, #{error => ~"invalid_perm"}};
         true ->
             Q = kura_query:where(
-                kura_query:where(kura_query:from(asobi_storage), {collection, Col}),
-                {key, Key}
+                kura_query:where(
+                    kura_query:where(kura_query:from(asobi_storage), {collection, Col}),
+                    {key, Key}
+                ),
+                ?PLAYER_SCOPE
             ),
             case asobi_repo:all(Q) of
                 {ok, [#{write_perm := ~"owner", player_id := PlayerId, version := V} = Existing]} ->
@@ -177,7 +208,13 @@ put_storage_checked(Col, Key, PlayerId, Value, ReadPerm, WritePerm) ->
                         [collection, key, player_id, value, version, read_perm, write_perm]
                     ),
                     {ok, Created} = asobi_repo:insert(CS),
-                    {json, 200, #{}, Created}
+                    {json, 200, #{}, Created};
+                {ok, [_, _ | _] = Rows} ->
+                    log_storage_invariant_violation(Col, Key, length(Rows)),
+                    {json, 500, #{}, #{error => ~"storage_conflict"}};
+                {error, Reason} ->
+                    log_storage_query_failed(Col, Key, Reason),
+                    {json, 500, #{}, #{error => ~"storage_query_failed"}}
             end
     end.
 
@@ -187,8 +224,11 @@ delete_storage(
         _Req
 ) ->
     Q = kura_query:where(
-        kura_query:where(kura_query:from(asobi_storage), {collection, Col}),
-        {key, Key}
+        kura_query:where(
+            kura_query:where(kura_query:from(asobi_storage), {collection, Col}),
+            {key, Key}
+        ),
+        ?PLAYER_SCOPE
     ),
     case asobi_repo:all(Q) of
         {ok, [#{write_perm := ~"owner", player_id := PlayerId} = Obj]} ->
@@ -200,7 +240,13 @@ delete_storage(
         {ok, [_]} ->
             {status, 403};
         {ok, []} ->
-            {status, 404}
+            {status, 404};
+        {ok, [_, _ | _] = Rows} ->
+            log_storage_invariant_violation(Col, Key, length(Rows)),
+            {status, 500};
+        {error, Reason} ->
+            log_storage_query_failed(Col, Key, Reason),
+            {status, 500}
     end.
 
 -spec list_storage(cowboy_req:req()) -> {json, map()}.
@@ -225,6 +271,28 @@ list_storage(
     {json, #{objects => Objects}}.
 
 %% --- Internal ---
+
+%% Should be unreachable now that every query above carries ?PLAYER_SCOPE
+%% (at most one player-owned row can match a given collection+key), but
+%% must not crash the process if it somehow still happens - log it as the
+%% invariant violation it is instead.
+-spec log_storage_invariant_violation(binary(), binary(), pos_integer()) -> ok.
+log_storage_invariant_violation(Col, Key, RowCount) ->
+    ?LOG_ERROR(#{
+        event => storage_multi_row_invariant_violation,
+        collection => Col,
+        key => Key,
+        row_count => RowCount
+    }).
+
+-spec log_storage_query_failed(binary(), binary(), term()) -> ok.
+log_storage_query_failed(Col, Key, Reason) ->
+    ?LOG_ERROR(#{
+        event => storage_query_failed,
+        collection => Col,
+        key => Key,
+        reason => Reason
+    }).
 
 -spec data_within_limit(dynamic()) -> boolean().
 data_within_limit(Data) ->

--- a/test/asobi_storage_SUITE.erl
+++ b/test/asobi_storage_SUITE.erl
@@ -18,7 +18,8 @@
     list_storage_filters_owner_perm/1,
     delete_storage/1,
     storage_owner_permission/1,
-    put_storage_per_player_keys_dont_collide/1
+    put_storage_per_player_keys_dont_collide/1,
+    global_and_player_row_coexist_at_same_key/1
 ]).
 
 all() -> [{group, cloud_saves}, {group, generic_storage}].
@@ -36,7 +37,8 @@ groups() ->
             list_storage_filters_owner_perm,
             delete_storage,
             storage_owner_permission,
-            put_storage_per_player_keys_dont_collide
+            put_storage_per_player_keys_dont_collide,
+            global_and_player_row_coexist_at_same_key
         ]}
     ].
 
@@ -320,4 +322,84 @@ put_storage_per_player_keys_dont_collide(Config) ->
     end,
     ?assertEqual(#{~"n" => 1}, Read(P1)),
     ?assertEqual(#{~"n" => 2}, Read(P2)),
+    Config.
+
+%% Regression for https://github.com/widgrensit/asobi/issues/307:
+%% get_storage/1, put_storage_checked/6, and delete_storage/1 used to
+%% query `WHERE collection = $1 AND key = $2` with no player_id
+%% predicate at all. Now that widgrensit/asobi_lua#124 correctly scopes
+%% `game.storage.set`'s global writes to `player_id IS NULL`, a global
+%% Lua row and a player's own HTTP row can coexist at the same
+%% (collection, key) - the unscoped query then returned 2 rows, which
+%% none of the case clauses handled (`case_clause` crash, 500, for every
+%% subsequent GET/PUT/DELETE of that key by anyone).
+%%
+%% This seeds a global row directly (mirroring what `asobi_lua_api`'s
+%% storage_insert/4 writes when PlayerId =:= undefined) alongside a
+%% player-created row via the real HTTP path, then exercises GET/PUT/
+%% DELETE through the controller and confirms each operates on
+%% player1's own row without crashing, leaving the global row alone.
+global_and_player_row_coexist_at_same_key(Config) ->
+    Suffix = integer_to_binary(erlang:unique_integer([positive])),
+    Col = <<"coexist_", Suffix/binary>>,
+    Key = <<"flag_", Suffix/binary>>,
+    Path = binary_to_list(<<"/api/v1/storage/", Col/binary, "/", Key/binary>>),
+
+    GlobalParams = #{
+        collection => Col,
+        key => Key,
+        value => #{~"owner" => ~"global"},
+        version => 1,
+        read_perm => ~"public",
+        write_perm => ~"owner",
+        updated_at => calendar:universal_time()
+    },
+    GlobalCS = kura_changeset:cast(asobi_storage, #{}, GlobalParams, maps:keys(GlobalParams)),
+    ?assertMatch({ok, _}, asobi_repo:insert(GlobalCS)),
+
+    {ok, PutResp} = nova_test:put(
+        Path,
+        #{headers => auth(Config, player1), json => #{~"value" => #{~"owner" => ~"player1"}}},
+        Config
+    ),
+    ?assertStatus(200, PutResp),
+    ?assertMatch(#{~"collection" := Col, ~"version" := 1}, nova_test:json(PutResp)),
+
+    {ok, GetResp} = nova_test:get(
+        Path,
+        #{headers => auth(Config, player1)},
+        Config
+    ),
+    ?assertStatus(200, GetResp),
+    ?assertMatch(#{~"value" := #{~"owner" := ~"player1"}}, nova_test:json(GetResp)),
+
+    {ok, PutResp2} = nova_test:put(
+        Path,
+        #{
+            headers => auth(Config, player1),
+            json => #{~"value" => #{~"owner" => ~"player1", ~"n" => 2}}
+        },
+        Config
+    ),
+    ?assertStatus(200, PutResp2),
+    ?assertMatch(#{~"version" := 2}, nova_test:json(PutResp2)),
+
+    {ok, DelResp} = nova_test:delete(
+        Path,
+        #{headers => auth(Config, player1)},
+        Config
+    ),
+    ?assertStatus(200, DelResp),
+    {ok, GetAfterDelete} = nova_test:get(
+        Path,
+        #{headers => auth(Config, player1)},
+        Config
+    ),
+    ?assertStatus(404, GetAfterDelete),
+
+    GlobalQ0 = kura_query:from(asobi_storage),
+    GlobalQ1 = kura_query:where(GlobalQ0, {collection, Col}),
+    GlobalQ2 = kura_query:where(GlobalQ1, {key, Key}),
+    GlobalQ3 = kura_query:where(GlobalQ2, {player_id, is_nil}),
+    ?assertMatch({ok, [#{value := #{~"owner" := ~"global"}}]}, asobi_repo:all(GlobalQ3)),
     Config.


### PR DESCRIPTION
## Bug

`get_storage/1`, `put_storage_checked/6`, and `delete_storage/1` in `src/controllers/asobi_storage_controller.erl` queried `WHERE collection = $1 AND key = $2` with no `player_id` predicate at all, then pattern-matched only on 0/1-row results - no clause for a multi-row result or a query error.

A security re-review of widgrensit/asobi_lua#124 (which correctly scopes `game.storage.set`/`get` by `player_id` - global writes now use `player_id IS NULL`, player writes use `player_id = <id>`) found that fix makes a previously-latent bug here newly reachable and dangerous:

Before asobi_lua#124, a global `game.storage.set` write silently UPDATEd any existing player row at the same collection+key, so a global row and a player-scoped row rarely coexisted at the same `(collection, key)`. Now that #124 correctly scopes global writes to `player_id IS NULL` vs a player's `player_id = <id>`, a global Lua write and a player's own `PUT /storage/:collection/:key` (any authenticated player, arbitrary collection/key - this endpoint takes client input directly) can both succeed and **both rows persist** at the same `(collection, key)`. The next `SELECT ... WHERE collection = $1 AND key = $2` then returns 2 rows, which none of the three functions' case clauses handled - `case_clause` crash, 500, for every subsequent GET/PUT/DELETE of that key by anyone. One authenticated player could permanently break a storage key for the whole game.

## Fix

`asobi_storage:indexes/0` maintains two distinct partial-unique namespaces: a global row (`player_id IS NULL`) and per-player rows (`player_id IS NOT NULL`). Reading the controller, its route definitions, and the existing SUITE (`put_storage_per_player_keys_dont_collide`'s comment: "The HTTP /storage path is single-row-per-(collection, key) by design ... that's the path `asobi_lua_api`'s `game.storage.player_set` follows for per-player rows"), the HTTP `/storage/:collection/:key` endpoints only ever create and act on player-owned rows - a shared object per `(collection, key)`, owned by whoever wrote it first, gated by the existing owner/public `read_perm`/`write_perm` ACL. They never touch the global namespace Lua's `game.storage.set` writes to.

Each of the three queries now carries an explicit `{player_id, is_not_nil}` condition (mirroring asobi_lua#124's `{player_id, is_nil}` for its global case), excluding the global namespace from the HTTP path entirely. This is purely a query-scope change - the existing owner/public ACL logic in the 1-row case is untouched.

All three functions now also handle `{ok, [_, _ | _]}` (logs `storage_multi_row_invariant_violation` and returns a 5xx - should be unreachable now that the scope is correct, but must not crash if it somehow still happens) and `{error, Reason}` (logs `storage_query_failed` with the reason and returns a 5xx instead of crashing the process).

`list_storage/1` was left untouched - it already returns a list rather than pattern-matching a fixed shape, and its ACL filter (`read_perm = public OR (read_perm = owner AND player_id = caller)`) already excludes `player_id IS NULL` rows via SQL NULL semantics.

## Test

Added `global_and_player_row_coexist_at_same_key/1` to `asobi_storage_SUITE`: seeds a global row directly (mirroring what `asobi_lua_api`'s `storage_insert/4` writes for `PlayerId =:= undefined`) alongside a player-created row via the real HTTP path, then exercises GET, PUT (both insert and update branches), and DELETE through the controller, confirming every call operates on the player's own row without crashing and the global row is left untouched throughout.

## Checks

`rebar3 fmt` / `xref` / `dialyzer` / `ex_doc` / `fmt --check` all green. `elp eqwalize-all` (via `mise exec erlang@28.4.1`) - no errors. `elp lint` - no new warnings in touched files. `asobi_storage_SUITE` - all 14 tests pass (including the new regression test). Full `rebar3 ct` - 2 pre-existing unrelated failures confirmed present on unmodified `main` too (`asobi_iap_SUITE`'s `apple_valid_jws_correct_bundle` - stale receipt state in the shared Docker Postgres; `asobi_world_lobby_ws_SUITE`'s `observer_sees_movers_input_via_world_tick` - username collision from repeated local runs), both untouched by this change. Full `rebar3 eunit` shows a pre-existing flaky cross-suite `asobi_match_server` cancellation (0 failures, 7 cancelled) reproduced identically on unmodified `main`.

Closes #307