### PR TITLE
Cap broadcast payload size, tighten dm: channel minting, document open-group history

### DIFF
--- a/guides/websocket-protocol.md
+++ b/guides/websocket-protocol.md
@@ -391,6 +391,14 @@ of `<group_id>`, not members of a group literally named `"room:<group_id>"`. For
 pre-game lobby chat, gate on world membership with `world:<world_id>`, or use
 `game.broadcast`; see the [Lobbies](lobbies.md) guide.
 
+For a group created with `open=true`, anyone can join without an invite
+(`POST /api/v1/groups/:id/join` never rejects with `group_closed`). Membership
+is still required to read `room:<group_id>` - joining is what's unrestricted,
+not reading. Once joined, a member sees the group's full retained history (up
+to the last 200 messages, per the `history` limit below), including messages
+sent before they joined. This is intentional and matches how public channels
+work in Slack/Discord: it is not a bug or a cutoff to add later.
+
 The worked examples below use a `world:` channel, which authorises on world
 membership you already hold after `world.join`.
 

--- a/src/matches/asobi_match_server.erl
+++ b/src/matches/asobi_match_server.erl
@@ -45,6 +45,11 @@ the place to put callback hardening.
 -define(DEFAULT_MAX_PLAYERS, 10).
 -define(WAITING_TIMEOUT, 60000).
 -define(STATE_TABLE, asobi_match_state).
+%% #304: mirrors asobi_ws_handler's ?WS_MAX_PAYLOAD_BYTES. game.broadcast's
+%% payload is fanned out to every player in the match, so an unbounded
+%% payload multiplies egress bandwidth and per-socket buffer memory by
+%% player count; bound it the same way the inbound frame is bounded.
+-define(MAX_BROADCAST_PAYLOAD_BYTES, 65536).
 
 %% --- Public API ---
 
@@ -584,13 +589,36 @@ apply_inputs(Mod, [{PlayerId, Input} | Rest], GS) ->
             apply_inputs(Mod, Rest, GS)
     end.
 
-broadcast_match_event(Event, Payload, #{players := Players}) ->
-    maps:foreach(
-        fun(PlayerId, _Meta) ->
-            asobi_presence:send(PlayerId, {match_event, Event, Payload})
-        end,
-        Players
-    ).
+broadcast_match_event(Event, Payload, #{players := Players, match_id := MatchId}) ->
+    case payload_within_limit(Payload) of
+        true ->
+            maps:foreach(
+                fun(PlayerId, _Meta) ->
+                    asobi_presence:send(PlayerId, {match_event, Event, Payload})
+                end,
+                Players
+            );
+        false ->
+            logger:warning(#{
+                msg => ~"game_broadcast_rejected",
+                namespace => ~"match",
+                reason => ~"payload_too_large",
+                match_id => MatchId
+            })
+    end.
+
+%% #304: measured on the encoded wire form (same unit ?WS_MAX_PAYLOAD_BYTES
+%% bounds inbound), not the raw Erlang term — a small term can still encode
+%% to an oversized JSON payload. An unencodable payload is rejected too,
+%% same as an oversized one, rather than crashing every subscriber's
+%% json:encode/1 downstream in asobi_ws_handler.
+-spec payload_within_limit(map()) -> boolean().
+payload_within_limit(Payload) ->
+    try iolist_size(json:encode(Payload)) of
+        Size -> Size =< ?MAX_BROADCAST_PAYLOAD_BYTES
+    catch
+        _:_ -> false
+    end.
 
 broadcast_state(#{players := Players, game_module := Mod, game_state := GS}) ->
     case erlang:function_exported(Mod, get_state, 1) of

--- a/src/social/asobi_chat_acl.erl
+++ b/src/social/asobi_chat_acl.erl
@@ -3,7 +3,9 @@
 Authorisation policy for chat channels.
 
 Channel ID schemes:
-  dm:<A>:<B>                 - A and B are the only allowed readers
+  dm:<A>:<B>                 - A and B are the only allowed readers, and B
+                                (the participant that isn't the caller) must
+                                resolve to a real player id (see #305 below)
   world:<WorldId>            - must currently be joined to the world
   zone:<WorldId>:<X>,<Y>     - must currently be joined to the world
   prox:<WorldId>:<X>,<Y>     - must currently be joined to the world
@@ -22,6 +24,25 @@ stripped, different case, padded/garbage-prefixed hex) that a lossy uuid
 decode downstream would otherwise all resolve to the same group - each alias
 would otherwise be a distinct, unmoderated channel process.
 
+#306: for a group with `open=true`, membership (checked here) is easy to
+get - anyone can join without an invite - but membership is still what
+gates reading. Once joined, a member sees the group's full retained
+history, including messages sent before they joined; this is intentional
+(see `guides/websocket-protocol.md`), not a gap to close here.
+
+#305: `dm:<A>:<B>` had the same unbounded-minting shape as the pre-fix
+`room:` scheme — `classify/1` authorised `dm:<self>:<anything>` for any
+value of `<anything>`, and `chat.send`/`send_message/3` start a channel
+process on demand with no prior `chat.join`, so `MAX_JOINED_CHANNELS_PER_CONN`
+never bounded it. The other participant must now resolve to a real,
+currently-known player id (checked against the `players` table via
+`asobi_repo:get/2`, the same lookup `asobi_social_controller` already uses
+to verify a friend id is real). This bounds minting to O(known players)
+instead of unbounded arbitrary strings. Checking "is a real player" rather
+than "is currently online" is deliberate: the other participant is very
+often offline (that's when you send someone a DM), so an online-only check
+would break ordinary DMing, not just close the abuse case.
+
 Shared by `asobi_chat_controller` (HTTP history) and `asobi_ws_handler`
 (WebSocket `chat.join` / `chat.send`). Keeping a single source of truth
 prevents the WS path from drifting and silently allowing DM eavesdropping.
@@ -39,11 +60,29 @@ authorized(ChannelId, PlayerId) when is_binary(ChannelId), is_binary(PlayerId) -
         deny ->
             false;
         {dm, A, B} ->
-            PlayerId =:= A orelse PlayerId =:= B;
+            dm_authorized(PlayerId, A, B);
         {world, WorldId} ->
             player_in_world(PlayerId, WorldId);
         {group, GroupId} ->
             is_group_member(PlayerId, GroupId)
+    end.
+
+%% #305: PlayerId must be one of the two named participants, and the OTHER
+%% participant must resolve to a real, currently-known player - otherwise
+%% PlayerId could mint `dm:<self>:<anything>` for any value of `<anything>`.
+-spec dm_authorized(binary(), binary(), binary()) -> boolean().
+dm_authorized(PlayerId, PlayerId, Other) ->
+    is_known_player(Other);
+dm_authorized(PlayerId, Other, PlayerId) ->
+    is_known_player(Other);
+dm_authorized(_PlayerId, _A, _B) ->
+    false.
+
+-spec is_known_player(binary()) -> boolean().
+is_known_player(PlayerId) ->
+    case asobi_repo:get(asobi_player, PlayerId) of
+        {ok, _} -> true;
+        {error, _} -> false
     end.
 
 -doc """

--- a/src/world/asobi_world_server.erl
+++ b/src/world/asobi_world_server.erl
@@ -45,6 +45,11 @@ transient matches use `asobi_match_server` instead.
 %% should scale with whatever zone_size a world picks; games wanting a
 %% tighter or looser boundary can override rehome_margin per world.
 -define(DEFAULT_REHOME_MARGIN, 0.15).
+%% #304: mirrors asobi_ws_handler's ?WS_MAX_PAYLOAD_BYTES. game.broadcast's
+%% payload is fanned out to every player in the world, so an unbounded
+%% payload multiplies egress bandwidth and per-socket buffer memory by
+%% player count; bound it the same way the inbound frame is bounded.
+-define(MAX_BROADCAST_PAYLOAD_BYTES, 65536).
 
 %% --- Public API ---
 
@@ -1402,13 +1407,36 @@ the general path a Lua `game.broadcast` reaches. asobi_lua binds the world
 server pid as `match_pid` in world and zone contexts, so `game.broadcast`
 from a world script casts `{broadcast_event, ...}` here.
 """.
-broadcast_world_event(Event, Payload, #{players := Players}) ->
-    maps:foreach(
-        fun(PlayerId, _Meta) ->
-            asobi_presence:send(PlayerId, {world_event, Event, Payload})
-        end,
-        Players
-    ).
+broadcast_world_event(Event, Payload, #{players := Players, world_id := WorldId}) ->
+    case payload_within_limit(Payload) of
+        true ->
+            maps:foreach(
+                fun(PlayerId, _Meta) ->
+                    asobi_presence:send(PlayerId, {world_event, Event, Payload})
+                end,
+                Players
+            );
+        false ->
+            ?LOG_WARNING(#{
+                msg => ~"game_broadcast_rejected",
+                namespace => ~"world",
+                reason => ~"payload_too_large",
+                world_id => WorldId
+            })
+    end.
+
+%% #304: measured on the encoded wire form (same unit ?WS_MAX_PAYLOAD_BYTES
+%% bounds inbound), not the raw Erlang term — a small term can still encode
+%% to an oversized JSON payload. An unencodable payload is rejected too,
+%% same as an oversized one, rather than crashing every subscriber's
+%% json:encode/1 downstream in asobi_ws_handler.
+-spec payload_within_limit(map()) -> boolean().
+payload_within_limit(Payload) ->
+    try iolist_size(json:encode(Payload)) of
+        Size -> Size =< ?MAX_BROADCAST_PAYLOAD_BYTES
+    catch
+        _:_ -> false
+    end.
 
 notify_players(Event, #{players := Players, world_id := WorldId} = State) ->
     Payload =

--- a/test/asobi_chat_acl_tests.erl
+++ b/test/asobi_chat_acl_tests.erl
@@ -3,17 +3,53 @@
 
 %% H1 (2026-05-19): chat ACL must reject third parties on DMs. World and
 %% group channels require live processes / DB and are exercised via
-%% asobi_chat_SUITE; here we cover the deterministic dm path that the WS
-%% handler now gates `chat.join` and `chat.send` through.
+%% asobi_chat_SUITE; here we cover the dm path that the WS handler gates
+%% `chat.join` and `chat.send` through. #305 made the dm path DB-backed
+%% (the non-caller participant must resolve to a real player), so these
+%% now mock asobi_repo:get/2 the same way asobi_social_controller's
+%% "friend id must exist" check is exercised elsewhere in this suite.
 
-dm_member_authorized_test() ->
+setup() ->
+    meck:new(asobi_repo, [no_link]),
+    ok.
+
+cleanup(_) ->
+    meck:unload(asobi_repo),
+    ok.
+
+dm_acl_test_() ->
+    {setup, fun setup/0, fun cleanup/1, [
+        {"both named participants are authorized when the other is a real player",
+            fun dm_member_authorized/0},
+        {"a third party is rejected regardless of player-registry state",
+            fun dm_third_party_rejected/0},
+        {"a channel id that merely contains PlayerId as a substring is rejected",
+            fun dm_substring_does_not_grant_access/0},
+        {"#305: an unknown/arbitrary other-participant segment is rejected",
+            fun dm_unknown_participant_rejected/0}
+    ]}.
+
+dm_member_authorized() ->
+    meck:expect(asobi_repo, get, fun(asobi_player, _Id) -> {ok, #{}} end),
     ?assert(asobi_chat_acl:authorized(~"dm:alice:bob", ~"alice")),
     ?assert(asobi_chat_acl:authorized(~"dm:alice:bob", ~"bob")).
 
-dm_third_party_rejected_test() ->
+dm_third_party_rejected() ->
+    %% Neither "eve" nor "" is a named participant, so dm_authorized/3 must
+    %% short-circuit to `false` without ever consulting the player registry.
+    meck:expect(asobi_repo, get, fun(asobi_player, _Id) -> error(should_not_be_called) end),
     ?assertNot(asobi_chat_acl:authorized(~"dm:alice:bob", ~"eve")),
     ?assertNot(asobi_chat_acl:authorized(~"dm:alice:bob", ~"")).
 
-dm_substring_does_not_grant_access_test() ->
+dm_substring_does_not_grant_access() ->
+    meck:expect(asobi_repo, get, fun(asobi_player, _Id) -> error(should_not_be_called) end),
     ?assertNot(asobi_chat_acl:authorized(~"dm:alice:bob", ~"ali")),
     ?assertNot(asobi_chat_acl:authorized(~"dm:alice:bob", ~"alicee")).
+
+%% #305: without this, `PlayerId =:= A orelse PlayerId =:= B` let any
+%% authenticated player mint an unbounded number of `dm:<self>:<anything>`
+%% channel ids by varying the second segment - none of them a real player.
+dm_unknown_participant_rejected() ->
+    meck:expect(asobi_repo, get, fun(asobi_player, _Id) -> {error, not_found} end),
+    ?assertNot(asobi_chat_acl:authorized(~"dm:alice:not_a_real_player", ~"alice")),
+    ?assertNot(asobi_chat_acl:authorized(~"dm:not_a_real_player:alice", ~"alice")).

--- a/test/asobi_match_broadcast_tests.erl
+++ b/test/asobi_match_broadcast_tests.erl
@@ -39,7 +39,11 @@ cleanup(_) ->
 broadcast_test_() ->
     {setup, fun setup/0, fun cleanup/1, [
         {"per-player path delivers match_state per player", fun per_player_path/0},
-        {"shared path delivers match_state_raw with same binary", fun shared_path/0}
+        {"shared path delivers match_state_raw with same binary", fun shared_path/0},
+        {"#304: oversized game.broadcast payload is not fanned out to players",
+            fun oversized_broadcast_rejected/0},
+        {"#304: normal-size game.broadcast payload is still delivered",
+            fun normal_broadcast_delivered/0}
     ]}.
 
 per_player_path() ->
@@ -77,6 +81,36 @@ shared_path() ->
         _ ->
             ?assert(false)
     end,
+    stop(Pid).
+
+%% #304: ?WS_MAX_PAYLOAD_BYTES caps inbound frames but nothing capped what
+%% game.broadcast fanned out to every player in the match - a large payload
+%% multiplied egress bandwidth and per-socket buffer memory by player count.
+%% broadcast_match_event/3 must reject an oversized payload instead of
+%% fanning it out.
+oversized_broadcast_rejected() ->
+    ets:delete_all_objects(?SENT_TAB),
+    Pid = start_match(asobi_test_game),
+    ok = asobi_match_server:join(Pid, ~"p1"),
+    ets:delete_all_objects(?SENT_TAB),
+    HugePayload = #{data => binary:copy(~"a", 70000)},
+    asobi_match_server:broadcast_event(Pid, ~"huge", HugePayload),
+    timer:sleep(50),
+    Sent = ets:tab2list(?SENT_TAB),
+    MatchEvents = [X || X = {_, {match_event, ~"huge", _}} <- Sent],
+    ?assertEqual([], MatchEvents),
+    stop(Pid).
+
+normal_broadcast_delivered() ->
+    ets:delete_all_objects(?SENT_TAB),
+    Pid = start_match(asobi_test_game),
+    ok = asobi_match_server:join(Pid, ~"p1"),
+    ets:delete_all_objects(?SENT_TAB),
+    asobi_match_server:broadcast_event(Pid, ~"small", #{msg => ~"hi"}),
+    timer:sleep(50),
+    Sent = ets:tab2list(?SENT_TAB),
+    MatchEvents = [X || X = {_, {match_event, ~"small", _}} <- Sent],
+    ?assert(length(MatchEvents) >= 1),
     stop(Pid).
 
 %% --- Helpers ---

--- a/test/asobi_world_server_tests.erl
+++ b/test/asobi_world_server_tests.erl
@@ -97,7 +97,11 @@ world_server_test_() ->
         {"reconnect with no live session returns an error, not a crash",
             fun reconnect_with_no_live_session_returns_error/0},
         {"a failed reconnect leaves the disconnected grace entry intact",
-            fun failed_reconnect_leaves_grace_intact/0}
+            fun failed_reconnect_leaves_grace_intact/0},
+        {"#304: oversized game.broadcast payload is not fanned out to players",
+            fun broadcast_oversized_payload_is_rejected/0},
+        {"#304: normal-size game.broadcast payload is still delivered",
+            fun broadcast_normal_payload_is_delivered/0}
     ]}.
 
 starts_running() ->
@@ -593,3 +597,45 @@ pos_to_zone_clamps_both_ends_test() ->
     ?assertEqual({2, 2}, asobi_world_server:pos_to_zone({299.0, 299.0}, 100, 3)),
     ?assertEqual({2, 2}, asobi_world_server:pos_to_zone({1.0e9, 1.0e9}, 100, 3)),
     ?assertEqual({0, 0}, asobi_world_server:pos_to_zone({999.0, 999.0}, 100, 1)).
+
+%% #304: ?WS_MAX_PAYLOAD_BYTES caps inbound frames but nothing capped what
+%% game.broadcast fanned out to every player in the world - a large payload
+%% multiplied egress bandwidth and per-socket buffer memory by player count.
+%% broadcast_world_event/3 must reject an oversized payload instead of
+%% fanning it out.
+broadcast_oversized_payload_is_rejected() ->
+    Ctx = #{world_pid := Pid} = start_world(),
+    ok = asobi_world_server:join(Pid, ~"p1"),
+    Self = self(),
+    meck:expect(asobi_presence, send, fun(PlayerId, Msg) ->
+        Self ! {sent, PlayerId, Msg},
+        ok
+    end),
+    HugePayload = #{data => binary:copy(~"a", 70000)},
+    gen_statem:cast(Pid, {broadcast_event, ~"huge", HugePayload}),
+    timer:sleep(50),
+    Received = flush_sent(),
+    ?assertEqual([], [M || {sent, _, {world_event, ~"huge", _}} = M <- Received]),
+    meck:expect(asobi_presence, send, fun(_PlayerId, _Msg) -> ok end),
+    stop_world(Ctx).
+
+broadcast_normal_payload_is_delivered() ->
+    Ctx = #{world_pid := Pid} = start_world(),
+    ok = asobi_world_server:join(Pid, ~"p1"),
+    Self = self(),
+    meck:expect(asobi_presence, send, fun(PlayerId, Msg) ->
+        Self ! {sent, PlayerId, Msg},
+        ok
+    end),
+    gen_statem:cast(Pid, {broadcast_event, ~"small", #{msg => ~"hi"}}),
+    timer:sleep(50),
+    Received = flush_sent(),
+    ?assert(length([M || {sent, _, {world_event, ~"small", _}} = M <- Received]) >= 1),
+    meck:expect(asobi_presence, send, fun(_PlayerId, _Msg) -> ok end),
+    stop_world(Ctx).
+
+flush_sent() ->
+    receive
+        {sent, _, _} = M -> [M | flush_sent()]
+    after 0 -> []
+    end.


### PR DESCRIPTION
## Summary

Three related chat/broadcast issues, fixed together.

### #304 - game.broadcast payload size is unbounded outbound

`?WS_MAX_PAYLOAD_BYTES` capped inbound WS frames but nothing capped what
`game.broadcast`'s payload produced outbound. A large payload was fanned
out unbounded to every player in the world/match via
`broadcast_world_event/3` / `broadcast_match_event/3`, multiplying egress
bandwidth and per-socket buffer memory by player count.

Both functions now measure the payload's JSON-encoded size against a new
`?MAX_BROADCAST_PAYLOAD_BYTES` (65536, mirroring `?WS_MAX_PAYLOAD_BYTES`)
and reject + log (`game_broadcast_rejected` / `payload_too_large`, same
shape as the existing #303 reserved-event-name rejection) instead of
fanning out. An unencodable payload is rejected the same way, rather than
crashing every subscriber's `json:encode/1` downstream in
`asobi_ws_handler`.

### #305 - dm: channel scheme allowed unbounded authorized channel-id minting

`asobi_chat_acl:classify(<<"dm:", Rest/binary>>)` authorized
`dm:<self>:<anything>` for any value of `<anything>`, and `chat.send`
doesn't require a prior `chat.join` (`send_message/3` starts a channel
process on demand), so `MAX_JOINED_CHANNELS_PER_CONN` never bounded this.
Any authenticated player could mint an unbounded number of distinct,
self-authorized channel ids.

**Approach taken**: the participant that isn't the caller must resolve to
a real, currently-known player id, checked via `asobi_repo:get(asobi_player,
_)` - the same lookup `asobi_social_controller` already uses to verify a
friend id is real (F-23). This bounds channel-id minting to O(known
players) instead of unbounded arbitrary strings, matching the shape
validation already applied to `room:` in #301.

I deliberately checked "is a real player" rather than "is currently
online" (e.g. via `asobi_presence:get_status/1`). DMs are routinely sent
to offline players - that's often the whole point - so an online-only
check would break ordinary DMing, not just close the abuse case. The
rate/count-limiting fallback mentioned in the issue wasn't needed since
the registry lookup is a clean fit with the codebase's existing pattern
(same DB round-trip cost as the existing `room:` group-membership check).

### #306 - open groups: room: chat history is join-to-read with no cutoff

Per the decision already made on the issue, this is intended behavior
(matches Slack/Discord public-channel norms) - no query logic changed.
Added a doc note to `guides/websocket-protocol.md` and
`asobi_chat_acl`'s moduledoc stating explicitly that an open group's
full retained history becomes visible once joined, including messages
sent before joining, so this isn't rediscovered as a surprise later.

## Test plan

- [x] `rebar3 fmt` / `rebar3 fmt --check` - clean
- [x] `rebar3 xref` - clean
- [x] `rebar3 dialyzer` - clean
- [x] `elp eqwalize-all` (via `mise exec erlang@28.4.1`) - NO ERRORS
- [x] `elp lint` - no new warnings (diffed against a stashed baseline; the
      184 pre-existing warnings are unchanged)
- [x] `rebar3 eunit` - 522 tests, 0 failures, including new coverage:
  - `asobi_match_broadcast_tests`: oversized `game.broadcast` payload is
    rejected / not fanned out; normal payload still delivered
  - `asobi_world_server_tests`: same, for the world-broadcast path
  - `asobi_chat_acl_tests`: unknown/arbitrary `dm:` other-participant is
    rejected; real participants (mocked as known) are still authorized;
    third-party/substring rejection still holds without touching the
    registry
- [x] `rebar3 ct` - targeted suites (`asobi_chat_SUITE`, `asobi_chat_ws_SUITE`,
      `asobi_social_SUITE`, `asobi_social_api_SUITE`) all pass; full CT run
      passed 282/283 (the one failure, an IAP idempotency 409, is a
      pre-existing artifact of re-running against a non-reset shared test
      DB, unrelated to this change - no file in this PR touches IAP)
- [x] `rebar3 ex_doc` - no warnings