### PR TITLE
docs: correct company name to Widgrens IT AB in the exit guide

### DIFF
--- a/guides/exit.md
+++ b/guides/exit.md
@@ -1,6 +1,6 @@
 # If asobi disappears tomorrow
 
-This is a one-page runbook for keeping your game alive if Widgrensit AB
+This is a one-page runbook for keeping your game alive if Widgrens IT AB
 (the company behind asobi) vanishes, pivots to AI, gets acquired, or
 otherwise ceases to exist. **We wrote it because you shouldn't have to
 trust us.**


### PR DESCRIPTION
`guides/exit.md` names "Widgrensit AB", which is not a registered entity. The Bolagsverket registration is **Widgrens IT AB**, org.nr 559241-2752.

Source-of-truth companion to widgrensit/asobi_site#134, which corrects the same name across every hand-written legal page on asobi.dev. The /docs/exit page is generated from this guide (ADR 0003), so it cannot be fixed in asobi_site - the drift guard rejects hand-edits to generated views. Once this merges, asobi_site needs a `scripts/gen-docs.sh` regeneration PR to pick it up.

Docs-only, no code change.