### PR TITLE
feat: dispatch asobi_lua pin bump on release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,3 +18,28 @@ jobs:
     uses: Taure/erlang-ci/.github/workflows/release.yml@v2.1.4
     permissions:
       contents: write
+
+  # Downstream asobi_lua pins asobi by git ref and only refreshes that pin on
+  # its nightly schedule, so a fix released here can sit unpublished for a day
+  # (asobi_lua#103). Push the news instead of waiting for the poll.
+  #
+  # A separate job, not a step: the release itself is a reusable workflow this
+  # repo cannot add steps to. It also reports success when git-cliff decided no
+  # bump was due, so `needs.release.result` alone would dispatch on every merge
+  # to main - the script gates on a tag actually pointing at HEAD.
+  notify-asobi-lua:
+    needs: release
+    if: needs.release.result == 'success'
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+      - name: Trigger asobi_lua's pin bump
+        env:
+          # Cross-repo dispatch; the default GITHUB_TOKEN cannot do it.
+          GH_TOKEN: ${{ secrets.ASOBI_LUA_DISPATCH_TOKEN }}
+        run: scripts/dispatch-asobi-lua-pin-bump.sh

--- a/.github/workflows/scripts.yml
+++ b/.github/workflows/scripts.yml
@@ -1,0 +1,37 @@
+name: Scripts
+
+# ci.yml delegates wholesale to the erlang-ci reusable workflow, which only
+# knows about rebar3. The shell scripts under scripts/ run in release and
+# release-adjacent paths, so their tests need a home of their own.
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'scripts/**'
+      - '.github/workflows/scripts.yml'
+  pull_request:
+    branches: [main]
+    paths:
+      - 'scripts/**'
+      - '.github/workflows/scripts.yml'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  shell-tests:
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+      - name: Run script tests
+        run: |
+          status=0
+          for t in scripts/test/*-test.sh; do
+            echo "== $t"
+            bash "$t" || status=1
+          done
+          exit "$status"

--- a/scripts/dispatch-asobi-lua-pin-bump.sh
+++ b/scripts/dispatch-asobi-lua-pin-bump.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+# Tells widgrensit/asobi_lua a release just happened here, so its pin-bump
+# workflow runs immediately instead of waiting up to a day for its next
+# nightly schedule (asobi #276, asobi_lua #103).
+#
+# The release job only tags when git-cliff decides a bump is due, and the
+# reusable erlang-ci workflow exports no output saying whether it did. A tag
+# pointing at HEAD is the signal: present means this run released, absent
+# means it skipped and there is nothing for asobi_lua to pick up.
+#
+# Usage: scripts/dispatch-asobi-lua-pin-bump.sh
+# Env:   GH_TOKEN - PAT or app token with write access to widgrensit/asobi_lua.
+#        The default GITHUB_TOKEN cannot dispatch across repositories.
+set -uo pipefail
+
+tag="$(git tag --points-at HEAD --list 'v*' | sort -V | tail -1)"
+
+if [ -z "$tag" ]; then
+  echo "No release tag on HEAD; nothing to dispatch."
+  exit 0
+fi
+
+if [ -z "${GH_TOKEN:-}" ]; then
+  echo "::warning::No dispatch token configured; asobi_lua will not see $tag until its nightly pin bump."
+  exit 0
+fi
+
+if ! gh api repos/widgrensit/asobi_lua/dispatches \
+  -f event_type=asobi-released \
+  -f "client_payload[tag]=$tag"; then
+  echo "::error::Failed to dispatch asobi-released ($tag) to widgrensit/asobi_lua."
+  exit 1
+fi
+
+echo "Dispatched asobi-released ($tag) to widgrensit/asobi_lua."

--- a/scripts/test/dispatch-asobi-lua-pin-bump-test.sh
+++ b/scripts/test/dispatch-asobi-lua-pin-bump-test.sh
@@ -1,0 +1,99 @@
+#!/usr/bin/env bash
+# Tests for scripts/dispatch-asobi-lua-pin-bump.sh. Runs the script against a
+# throwaway git repo with `gh` stubbed on PATH, so the release-detection and
+# token-handling branches are exercised without touching GitHub.
+set -uo pipefail
+
+script_dir="$(cd "$(dirname "$0")/.." && pwd)"
+script="$script_dir/dispatch-asobi-lua-pin-bump.sh"
+fail=0
+
+setup() {
+  work="$(mktemp -d)"
+  stub_bin="$work/bin"
+  mkdir -p "$stub_bin"
+  cat >"$stub_bin/gh" <<'STUB'
+#!/usr/bin/env bash
+printf '%s\n' "$*" >>"$GH_CALLS"
+exit "${GH_EXIT:-0}"
+STUB
+  chmod +x "$stub_bin/gh"
+  export GH_CALLS="$work/gh-calls"
+  : >"$GH_CALLS"
+
+  git init --quiet "$work/repo"
+  git -C "$work/repo" config user.email test@example.com
+  git -C "$work/repo" config user.name test
+  git -C "$work/repo" commit --quiet --allow-empty -m "chore: initial"
+}
+
+teardown() {
+  rm -rf "$work"
+  unset GH_CALLS GH_EXIT
+}
+
+run_script() {
+  (cd "$work/repo" && PATH="$stub_bin:$PATH" "$script" 2>&1)
+}
+
+check() {
+  local name="$1" expected="$2" actual="$3"
+  if [ "$expected" = "$actual" ]; then
+    echo "ok - $name"
+  else
+    echo "FAIL - $name: expected '$expected', got '$actual'"
+    fail=1
+  fi
+}
+
+# Untagged HEAD: the release job skipped, so nothing is dispatched.
+setup
+export GH_TOKEN=t
+out="$(run_script)"; rc=$?
+check "untagged HEAD exits 0" 0 "$rc"
+check "untagged HEAD dispatches nothing" "" "$(cat "$GH_CALLS")"
+case "$out" in *"nothing to dispatch"*) echo "ok - untagged HEAD says why";; *) echo "FAIL - untagged HEAD message: $out"; fail=1;; esac
+teardown
+
+# Tagged HEAD without a token: warn loudly, never fail the release.
+setup
+git -C "$work/repo" tag v1.2.3
+unset GH_TOKEN
+out="$(run_script)"; rc=$?
+check "missing token exits 0" 0 "$rc"
+check "missing token dispatches nothing" "" "$(cat "$GH_CALLS")"
+case "$out" in *"::warning::"*) echo "ok - missing token warns";; *) echo "FAIL - missing token warning: $out"; fail=1;; esac
+teardown
+
+# Tagged HEAD with a token: dispatch carries the tag that was just released.
+setup
+git -C "$work/repo" tag v1.2.3
+export GH_TOKEN=t
+out="$(run_script)"; rc=$?
+check "release exits 0" 0 "$rc"
+check "release dispatches once" \
+  "api repos/widgrensit/asobi_lua/dispatches -f event_type=asobi-released -f client_payload[tag]=v1.2.3" \
+  "$(cat "$GH_CALLS")"
+teardown
+
+# Several tags on one commit: the highest version wins, not the first sorted.
+setup
+git -C "$work/repo" tag v1.9.0
+git -C "$work/repo" tag v1.10.0
+export GH_TOKEN=t
+run_script >/dev/null
+check "highest version dispatched" \
+  "api repos/widgrensit/asobi_lua/dispatches -f event_type=asobi-released -f client_payload[tag]=v1.10.0" \
+  "$(cat "$GH_CALLS")"
+teardown
+
+# A refused dispatch is a red job, not a silent no-op.
+setup
+git -C "$work/repo" tag v1.2.3
+export GH_TOKEN=t GH_EXIT=1
+out="$(run_script)"; rc=$?
+check "failed dispatch exits 1" 1 "$rc"
+case "$out" in *"::error::"*) echo "ok - failed dispatch errors";; *) echo "FAIL - failed dispatch message: $out"; fail=1;; esac
+teardown
+
+exit "$fail"


### PR DESCRIPTION
Downstream `asobi_lua` pins `asobi` by git ref and only refreshes that pin on its nightly schedule, so a fix released here can sit unpublished for up to a day (widgrensit/asobi_lua#103, mitigations 2 and 3 shipped in asobi_lua#115). This is the missing option 1: push the news instead of making asobi_lua poll for it.

## What changed

- `scripts/dispatch-asobi-lua-pin-bump.sh` fires `repository_dispatch` (`event_type=asobi-released`, `client_payload[tag]`) at `widgrensit/asobi_lua`.
- `release.yml` runs it as a follow-on job after the release job.
- `scripts/test/dispatch-asobi-lua-pin-bump-test.sh` covers the branches with `gh` stubbed on PATH; `scripts.yml` runs the script tests in CI (ci.yml delegates wholesale to erlang-ci, which only knows rebar3).

## Why a job and not a step

The release is a reusable workflow (`Taure/erlang-ci`), so no step can be inserted into it, and it exports no output saying whether it actually tagged - it reports success on every merge to main, including the ones git-cliff decides need no bump. The script therefore gates on a release tag actually pointing at HEAD, so ordinary merges dispatch nothing.

## Follow-ups outside this repo

- A repo secret `ASOBI_LUA_DISPATCH_TOKEN` (PAT or app token with write access to `widgrensit/asobi_lua`) has to be added; the default `GITHUB_TOKEN` cannot dispatch across repositories. Until it exists the job logs a `::warning::` and passes, so releases never go red on a missing secret.
- `asobi_lua`'s `bump-asobi-pin.yml` needs `repository_dispatch: types: [asobi-released]` alongside its `schedule` and `workflow_dispatch` triggers. Until then the dispatch is accepted and ignored, and the nightly remains the only path.

Closes #276
