### PR TITLE
docs: document game-defined match./world. events, drop closed-namespace claim

### DIFF
--- a/guides/lobbies.md
+++ b/guides/lobbies.md
@@ -80,7 +80,10 @@ what a lobby shows differs per game - a bare count, a full roster, nothing
 until it fills.
 
 `game.broadcast` from your join callback is the whole of it, as above. It
-reaches every player currently in the match.
+reaches every player currently in the match, and the example above arrives
+client-side as `{"type": "match.lobby_update", "payload": {"players": ...}}`.
+Naming rules and the SDK-side handler for these are in
+[Custom events](websocket-protocol.md#custom-events).
 
 ### Chat in a lobby
 

--- a/guides/phases.md
+++ b/guides/phases.md
@@ -89,7 +89,10 @@ end
 ```
 
 `game.broadcast` is how the phase reaches your own clients with your own
-shape. See the callback reference for the full callback list.
+shape. The two calls above arrive as `{"type": "match.round_start"}` and
+`{"type": "match.round_over"}` (`world.*` from a world script); see
+[Custom events](websocket-protocol.md#custom-events) for the naming rules.
+See the callback reference for the full callback list.
 
 ### What the client sees on the wire
 

--- a/guides/websocket-protocol.md
+++ b/guides/websocket-protocol.md
@@ -35,6 +35,59 @@ are JSON with a common envelope format.
 The `cid` field is optional. When provided, the server echoes it back in
 the response so the client can correlate request/response pairs.
 
+## Custom events
+
+The events listed on this page are the ones asobi itself emits. They are not
+the whole `type` space: a game script owns the leaf name under `match.` and
+`world.`, so a client must never switch exhaustively on the list below.
+
+`game.broadcast` from a match script:
+
+```lua
+game.broadcast("round_start", { phase = "combat" })
+```
+
+reaches every player in that match as:
+
+```json
+{"type": "match.round_start", "payload": {"phase": "combat"}}
+```
+
+The same call from a world script produces `world.round_start` and reaches
+every player in the world. There is no `cid` - these are pushes, never
+replies.
+
+The runtime validates the leaf name before it goes on the wire:
+
+- 1 to 64 bytes.
+- `A-Z`, `a-z`, `0-9`, `_` and `-` only. `.` is excluded, so a script cannot
+  mint a deeper `world.foo.bar` sub-namespace.
+- Not one of asobi's own leaf names, otherwise a script could forge a frame
+  byte-identical to an authoritative event such as `world.tick` or
+  `match.finished`. The reserved set is
+  `asobi_ws_handler:reserved_event_names/0`:
+
+<!-- BEGIN reserved-event-names (verified against asobi_ws_handler:reserved_event_names/0 by asobi_protocol_coverage_tests) -->
+```
+finished            joined              left                list
+matched             matchmaker_expired  matchmaker_failed   phase_changed
+state               terrain             tick                vote_result
+vote_start          vote_tally          vote_vetoed
+```
+<!-- END reserved-event-names -->
+
+The payload is also capped at 64 KiB encoded, the same bound as an inbound
+frame, because it fans out to every player. A payload that cannot be encoded
+as JSON at all is rejected on the same path.
+
+A broadcast that fails any of these is dropped and logged server-side. The
+client is told nothing, so do not wait for an error frame that will not come.
+
+Client SDKs handle this open namespace with a generic fallback: any
+`match.*`/`world.*` type with no dedicated callback has its prefix stripped
+and is handed to a catch-all match/world event handler. Every official SDK
+has one; a client written from scratch needs one too.
+
 ## Connection
 
 ### `session.connect`

--- a/priv/protocol/README.md
+++ b/priv/protocol/README.md
@@ -1,6 +1,11 @@
 # Asobi WebSocket Protocol Fixtures
 
-Canonical examples of every server-to-client message asobi emits over its WebSocket.
+Canonical examples of every server-to-client message the asobi library itself emits over its WebSocket.
+
+The `match.` and `world.` namespaces are open: a game can push its own events
+through them, and those are not (and cannot be) in this corpus. See
+[Game-defined events](#game-defined-events-are-not-in-the-corpus) before
+writing an SDK dispatcher that switches exhaustively on `type`.
 
 ## What this is for
 
@@ -11,6 +16,16 @@ The corpus only covers **envelope routing** — `type` plus a representative `pa
 ## Coverage contract
 
 `asobi_protocol_coverage_tests.erl` is the keeper. It scans the asobi source for every emit site (`encode_reply/3` calls plus `{match_event, _, _}` and `{world_event, _, _}` send sites) and asserts that each event has exactly one fixture file. Adding an emit site without a fixture fails CI. Adding a stale fixture for a removed event fails CI.
+
+The scan only recognises literal lowercase atoms, so an emit site whose event name is a variable is invisible to it. That is deliberate: the only such sites are the `game.broadcast` relays described below, whose names are game-owned and unenumerable.
+
+## Game-defined events are not in the corpus
+
+A game script's `game.broadcast("round_start", ...)` reaches clients as `{"type": "match.round_start"}` from a match, or `{"type": "world.round_start"}` from a world. asobi owns the prefix and validates the leaf name (1-64 bytes, `[A-Za-z0-9_-]`, and never one of asobi's own leaf names - see `asobi_ws_handler:reserved_event_names/0`); the leaf itself belongs entirely to the game.
+
+That class of message is open-ended by design and can never be enumerated here. **Do not read this corpus as a closed set of wire types.** Every official SDK already has a generic fallback for exactly this reason - Unity's `AsobiDispatcher.HandleMessage` has a `default:` branch that strips the `match.`/`world.` prefix and fires `OnMatchEvent`/`OnWorldEvent`, and Godot and the JS SDK have the same path. A new SDK needs that fallback too; without it, every game-defined event is silently dropped.
+
+The wire-level detail, including what happens to a rejected name, is in [guides/websocket-protocol.md](../../guides/websocket-protocol.md#custom-events).
 
 ## Layout
 
@@ -56,5 +71,5 @@ The pattern is identical across every SDK.
 
 - Client→server messages (the SDK *sends* these — different test category).
 - Payload field-rename drift inside an event (e.g. `match.state` payload schema). Game modes own their payload shape, not the asobi library.
-- Lua-side `world.broadcast_event/3` and `match.broadcast_event/3` — those are user code; their event names are mode-specific.
+- Game-defined `match.<name>`/`world.<name>` events from `game.broadcast` - the leaf name is game-owned, so there is no finite set to fixture. Dispatch-test those in the game's own SDK tests, against the generic `match.*`/`world.*` fallback.
 - Authoring docs or types from these fixtures — that's a separate codegen step, not built today.

--- a/test/asobi_protocol_coverage_tests.erl
+++ b/test/asobi_protocol_coverage_tests.erl
@@ -4,6 +4,7 @@
 
 -define(FIXTURE_DIR, "priv/protocol/fixtures").
 -define(WS_HANDLER, "src/ws/asobi_ws_handler.erl").
+-define(WS_GUIDE, "guides/websocket-protocol.md").
 -define(MATCH_SERVER, "src/matches/asobi_match_server.erl").
 -define(WORLD_SERVER, "src/world/asobi_world_server.erl").
 -define(DYNAMIC_EMIT_SOURCES, [
@@ -223,6 +224,27 @@ every_emitted_match_or_world_event_is_reserved_test() ->
             )
         )
     ).
+
+%% #302: the reserved set is a contract game authors design event names
+%% against, so the guide spells it out rather than sending them to the
+%% source. A library event added later moves ?RESERVED_EVENT_NAMES (the
+%% test above sees to that) and would leave the guide quietly wrong.
+guide_documents_the_reserved_event_names_test() ->
+    Documented = lists:usort(scan_documented_reserved_names(read_file(?WS_GUIDE))),
+    Reserved = lists:usort(asobi_ws_handler:reserved_event_names()),
+    ?assertEqual(
+        Reserved,
+        Documented,
+        "reserved-event-names block in guides/websocket-protocol.md is out of sync "
+        "with asobi_ws_handler:reserved_event_names/0"
+    ).
+
+scan_documented_reserved_names(Bin) ->
+    Re = "BEGIN reserved-event-names.*?```\\s*(.*?)```",
+    case re:run(Bin, Re, [dotall, {capture, all_but_first, binary}]) of
+        {match, [Block]} -> binary:split(Block, [~" ", ~"\n"], [global, trim_all]);
+        nomatch -> []
+    end.
 
 match_or_world_suffix(<<"match.", Suffix/binary>>) -> {true, Suffix};
 match_or_world_suffix(<<"world.", Suffix/binary>>) -> {true, Suffix};


### PR DESCRIPTION
`priv/protocol/README.md` claimed the fixture corpus held "every server-to-client message asobi emits". That stopped being true when #300 unblocked `game.broadcast`'s binary event names: game-defined `match.<name>`/`world.<name>` frames are now a real class of server-to-client message, and one that is open-ended by design (core owns the prefix, the game owns the leaf), so it can never be enumerated in a fixture corpus. The regex-based coverage gate cannot see it either, since it only recognises literal atoms. An SDK author reading the corpus as a closed set would ship a dispatcher that silently drops every game event.

- `priv/protocol/README.md`: scope the claim to asobi's own fixed events, add a "Game-defined events are not in the corpus" section, and point SDK authors at the generic `match.*`/`world.*` fallback every official SDK already has (Unity's `AsobiDispatcher.HandleMessage` `default:` branch, and the equivalents in Godot and the JS SDK).
- `guides/websocket-protocol.md`: new **Custom events** section covering what `game.broadcast("round_start", ...)` looks like on the wire, the naming rules the runtime enforces (1-64 bytes, `[A-Za-z0-9_-]`, no reserved leaf name), the reserved set itself, the 64 KiB payload cap, and the fact that a rejected broadcast is dropped silently with no client-visible error.
- `guides/lobbies.md` and `guides/phases.md`: their `game.broadcast` examples now name the resulting client-side type and link to the new section.
- `asobi_protocol_coverage_tests`: new gate asserting the guide's reserved-name block matches `asobi_ws_handler:reserved_event_names/0`, so a library event added later cannot leave the guide quietly wrong.

Docs and test only, no behaviour change. `rebar3 compile`, `rebar3 eunit --module=asobi_protocol_coverage_tests` (6 tests, 0 failures), `rebar3 xref`, `rebar3 ex_doc` and `rebar3 fmt --check` all green.

Closes #302