### PR TITLE
fix: log unrecognised websocket_info messages instead of dropping them silently

### DIFF
--- a/src/ws/asobi_ws_handler.erl
+++ b/src/ws/asobi_ws_handler.erl
@@ -8,6 +8,8 @@
 %% match./world. event stays inside the reserved namespace (#303).
 -export([reserved_event_names/0]).
 
+-include_lib("kernel/include/logger.hrl").
+
 -define(WS_MSG_LIMIT, 60).
 -define(WS_MSG_WINDOW_MS, 1000).
 -define(WS_MAX_PAYLOAD_BYTES, 65536).
@@ -284,8 +286,43 @@ websocket_info(idle_auth_timeout, State) ->
     %% Race: the timer fired but session.connect already succeeded.
     %% Ignore.
     {ok, State};
-websocket_info(_Info, State) ->
+websocket_info(Info, State) ->
+    %% #308: dropping an unrecognised message with no signal is the exact
+    %% failure class #297 was - a producer's frame vanishing between the
+    %% game server and the socket, invisible to the game developer. The
+    %% drop itself stays (an unknown shape has no wire encoding), but it is
+    %% now observable. Rate-limited per tag because a per-tick producer
+    %% would otherwise log once per tick per connection.
+    log_unhandled_info(Info),
     {ok, State}.
+
+-spec log_unhandled_info(term()) -> ok.
+log_unhandled_info(Info) ->
+    Tag = unhandled_tag(Info),
+    case asobi_script_log_limiter:allow({?MODULE, Tag}) of
+        {true, DroppedSinceLastLog} ->
+            ?LOG_WARNING(#{
+                event => ws_unhandled_info,
+                tag => Tag,
+                suppressed_since_last => DroppedSinceLastLog
+            });
+        false ->
+            ok
+    end.
+
+%% Tag only, never the payload: an unhandled message may carry player data
+%% of unbounded size. Non-atom tags collapse to `unknown` so neither the log
+%% field nor the limiter's key space can be grown by a message sender.
+-spec unhandled_tag(term()) -> atom() | {asobi_message, atom()}.
+unhandled_tag({asobi_message, Inner}) -> {asobi_message, plain_tag(Inner)};
+unhandled_tag(Info) -> plain_tag(Info).
+
+-spec plain_tag(term()) -> atom().
+plain_tag(Tag) when is_atom(Tag) -> Tag;
+plain_tag(Tuple) when is_tuple(Tuple), tuple_size(Tuple) > 0, is_atom(element(1, Tuple)) ->
+    element(1, Tuple);
+plain_tag(_) ->
+    unknown.
 
 -spec terminate(term(), term(), map()) -> ok.
 terminate(_Reason, _Req, #{session := undefined}) ->

--- a/test/asobi_ws_handler_tests.erl
+++ b/test/asobi_ws_handler_tests.erl
@@ -93,6 +93,40 @@ match_event_reserved_name_is_rejected_and_logged_test() ->
     ?assertEqual(#{namespace => ~"match", reason => reserved_event_name}, await_rejection()),
     ok = remove_log_capture().
 
+%% #308: the catch-all clause still drops what it cannot encode, but the
+%% drop must leave a signal - the tag of the unrecognised message - so the
+%% next producer that invents an {asobi_message, _} shape shows up in the
+%% logs instead of needing another bug-hunt.
+unknown_asobi_message_is_logged_test() ->
+    ok = install_log_capture(),
+    Msg = {asobi_message, {brand_new_shape, #{~"a" => 1}}},
+    ?assertEqual({ok, #{}}, asobi_ws_handler:websocket_info(Msg, #{})),
+    ?assertEqual({asobi_message, brand_new_shape}, await_unhandled()),
+    ok = remove_log_capture().
+
+unknown_bare_message_is_logged_test() ->
+    ok = install_log_capture(),
+    ?assertEqual({ok, #{}}, asobi_ws_handler:websocket_info(some_stray_message, #{})),
+    ?assertEqual(some_stray_message, await_unhandled()),
+    ok = remove_log_capture().
+
+%% A sender-controlled tag must not widen the log field or the rate
+%% limiter's key space.
+non_atom_tag_collapses_to_unknown_test() ->
+    ok = install_log_capture(),
+    Msg = {asobi_message, {~"from_the_wire", 1}},
+    ?assertEqual({ok, #{}}, asobi_ws_handler:websocket_info(Msg, #{})),
+    ?assertEqual({asobi_message, unknown}, await_unhandled()),
+    ok = remove_log_capture().
+
+%% Handled shapes must not start logging as unhandled.
+handled_message_is_not_logged_as_unhandled_test() ->
+    ok = install_log_capture(),
+    Msg = {asobi_message, {world_event, ~"pong", #{}}},
+    ?assertMatch({reply, {text, _}, _}, asobi_ws_handler:websocket_info(Msg, #{})),
+    ?assertEqual(no_log, await_no_unhandled()),
+    ok = remove_log_capture().
+
 %% --- log capture helpers ---
 
 install_log_capture() ->
@@ -107,6 +141,9 @@ remove_log_capture() ->
 log(#{msg := {report, #{msg := ~"game_broadcast_rejected"} = Report}}, #{config := #{pid := Pid}}) ->
     Pid ! {game_broadcast_rejected, maps:with([namespace, reason], Report)},
     ok;
+log(#{msg := {report, #{event := ws_unhandled_info, tag := Tag}}}, #{config := #{pid := Pid}}) ->
+    Pid ! {ws_unhandled_info, Tag},
+    ok;
 log(_Event, _Config) ->
     ok.
 
@@ -115,4 +152,18 @@ await_rejection() ->
         {game_broadcast_rejected, Report} -> Report
     after 1000 ->
         error(timeout_waiting_for_rejection_log)
+    end.
+
+await_unhandled() ->
+    receive
+        {ws_unhandled_info, Tag} -> Tag
+    after 1000 ->
+        error(timeout_waiting_for_unhandled_log)
+    end.
+
+await_no_unhandled() ->
+    receive
+        {ws_unhandled_info, Tag} -> {unexpected, Tag}
+    after 200 ->
+        no_log
     end.


### PR DESCRIPTION
`asobi_ws_handler`'s catch-all `websocket_info/2` clause returned `{ok, State}` for any message it did not recognise, with no log line. That is the mechanism that hid #297 for weeks: a producer emits a new `{asobi_message, _}` shape, the frame never reaches the client, and nothing anywhere says so. #300 widened the two specific guards that mattered; this closes the drop-with-no-signal mechanism itself.

## Change

- The catch-all still drops (an unknown shape has no wire encoding) but now emits `?LOG_WARNING(#{event => ws_unhandled_info, tag => Tag, suppressed_since_last => N})`.
- Rate limited per tag through the existing `asobi_script_log_limiter`, so a per-tick producer cannot log once per tick per connection. Suppressed occurrences are reported on the next allowed line rather than vanishing.
- Only the tag is logged, never the payload (an unhandled message may carry unbounded player data). `{asobi_message, Inner}` reports `{asobi_message, InnerTag}`; non-atom tags collapse to `unknown` so a sender cannot grow either the log field or the limiter's key space.

## Tests

`test/asobi_ws_handler_tests.erl`: unknown `{asobi_message, _}` shape logged with its inner tag, bare unknown message logged, non-atom tag collapses to `unknown`, and a handled shape does not log as unhandled.

`rebar3 compile`, `xref`, `dialyzer`, `eunit` (531 tests, 0 failures), `ex_doc`, `fmt --check` all green.

Closes #308