### PR TITLE
fix: isolate matchmaker join fan-out from match server exits

### DIFF
--- a/src/matches/asobi_matchmaker.erl
+++ b/src/matches/asobi_matchmaker.erl
@@ -11,7 +11,7 @@ spawns a match, and pushes `match.matched` to each player. A single
 -export([known_mode/1]).
 -export([init/1, handle_call/3, handle_cast/2, handle_info/2, terminate/2]).
 -ifdef(TEST).
--export([next_spawn_attempt/1]).
+-export([next_spawn_attempt/1, join_matched_players/3]).
 -endif.
 
 -define(DEFAULT_TICK, 1000).
@@ -407,21 +407,7 @@ spawn_match(Mode, ModeConfig, PlayerIds, Group, Rest, Failed) ->
                         lists:sum([Now - maps:get(submitted_at, T) || T <- Group]) div
                             pos_len(Group),
                     asobi_telemetry:matchmaker_formed(Mode, length(PlayerIds), AvgWait),
-                    MatchInfo = asobi_match_server:get_info(MatchPid),
-                    lists:foreach(
-                        fun(PlayerId) when is_binary(PlayerId) ->
-                            _ = asobi_match_server:join(MatchPid, PlayerId),
-                            asobi_presence:send(PlayerId, {match_joined, MatchPid}),
-                            asobi_presence:send(
-                                PlayerId,
-                                {match_event, matched, #{
-                                    match_id => maps:get(match_id, MatchInfo, undefined),
-                                    players => PlayerIds
-                                }}
-                            )
-                        end,
-                        PlayerIds
-                    ),
+                    spawn(fun() -> join_matched_players(MatchPid, Mode, PlayerIds) end),
                     spawn_matches(Rest, Failed);
                 {error, Reason} ->
                     logger:error(#{
@@ -435,6 +421,41 @@ spawn_match(Mode, ModeConfig, PlayerIds, Group, Rest, Failed) ->
         {error, _} ->
             notify_no_game_module(Mode, PlayerIds),
             spawn_matches(Rest, Failed)
+    end.
+
+%% The join fan-out runs detached and exception-isolated (asobi#291). A match
+%% server that exits mid-loop - e.g. `{shutdown, empty}' when a joining player's
+%% session is already gone - would otherwise propagate its exit through the
+%% gen_statem call into the matchmaker gen_server, restarting it and dropping
+%% every ticket queued in every mode.
+-spec join_matched_players(pid(), binary(), [binary()]) -> ok.
+join_matched_players(MatchPid, Mode, PlayerIds) ->
+    try
+        MatchInfo = asobi_match_server:get_info(MatchPid),
+        MatchId = maps:get(match_id, MatchInfo, undefined),
+        lists:foreach(
+            fun(PlayerId) when is_binary(PlayerId) ->
+                _ = asobi_match_server:join(MatchPid, PlayerId),
+                asobi_presence:send(PlayerId, {match_joined, MatchPid}),
+                asobi_presence:send(
+                    PlayerId,
+                    {match_event, matched, #{match_id => MatchId, players => PlayerIds}}
+                )
+            end,
+            PlayerIds
+        )
+    catch
+        Class:Reason:Stack ->
+            logger:error(#{
+                msg => ~"match join fan-out crashed",
+                mode => Mode,
+                players => PlayerIds,
+                class => Class,
+                error => Reason,
+                stacktrace => Stack
+            }),
+            asobi_telemetry:matchmaker_failed(Mode, length(PlayerIds)),
+            notify_matchmaker_failed(PlayerIds, ~"match_start_failed")
     end.
 
 %% Unlike spawn_match, world spawn is detached (spawn/1) to avoid blocking the

--- a/test/asobi_matchmaker_isolation_tests.erl
+++ b/test/asobi_matchmaker_isolation_tests.erl
@@ -1,0 +1,90 @@
+-module(asobi_matchmaker_isolation_tests).
+-include_lib("eunit/include/eunit.hrl").
+
+setup() ->
+    {ok, _} = application:ensure_all_started(telemetry),
+    meck:new(asobi_presence, [non_strict, no_link]),
+    meck:expect(asobi_presence, send, fun(_PlayerId, _Msg) -> ok end),
+    ok.
+
+cleanup(_) ->
+    meck:unload(asobi_presence),
+    ok.
+
+join_isolation_test_() ->
+    {setup, fun setup/0, fun cleanup/1, [
+        {"a match gone before the fan-out never raises", fun match_gone_before_fanout/0},
+        {"a match that exits mid fan-out never raises", fun match_exits_mid_fanout/0},
+        {"a live match joins and notifies every player", fun live_match_notifies_all/0}
+    ]}.
+
+match_gone_before_fanout() ->
+    meck:reset(asobi_presence),
+    Dead = spawn(fun() -> ok end),
+    wait_gone(Dead, 50),
+    ?assertEqual(
+        ok, asobi_matchmaker:join_matched_players(Dead, ~"m1", [~"p1", ~"p2"])
+    ),
+    ?assert(failed_notified(~"p1")),
+    ?assert(failed_notified(~"p2")).
+
+match_exits_mid_fanout() ->
+    meck:reset(asobi_presence),
+    Match = fake_match(fun
+        (get_info) -> {reply, #{match_id => ~"match-1"}};
+        ({join, ~"p2", _}) -> die;
+        ({join, _, _}) -> {reply, ok}
+    end),
+    ?assertEqual(
+        ok, asobi_matchmaker:join_matched_players(Match, ~"m1", [~"p1", ~"p2", ~"p3"])
+    ),
+    ?assert(meck:called(asobi_presence, send, [~"p1", {match_joined, Match}])),
+    ?assert(failed_notified(~"p1")),
+    ?assert(failed_notified(~"p3")).
+
+live_match_notifies_all() ->
+    meck:reset(asobi_presence),
+    Match = fake_match(fun
+        (get_info) -> {reply, #{match_id => ~"match-2"}};
+        ({join, _, _}) -> {reply, ok}
+    end),
+    ?assertEqual(ok, asobi_matchmaker:join_matched_players(Match, ~"m1", [~"p1", ~"p2"])),
+    ?assert(meck:called(asobi_presence, send, [~"p1", {match_joined, Match}])),
+    ?assert(
+        meck:called(asobi_presence, send, [
+            ~"p2", {match_event, matched, #{match_id => ~"match-2", players => [~"p1", ~"p2"]}}
+        ])
+    ),
+    ?assertNot(failed_notified(~"p1")),
+    exit(Match, kill).
+
+failed_notified(PlayerId) ->
+    meck:called(asobi_presence, send, [
+        PlayerId, {match_event, matchmaker_failed, #{reason => ~"match_start_failed"}}
+    ]).
+
+fake_match(Fun) ->
+    spawn(fun() -> fake_loop(Fun) end).
+
+fake_loop(Fun) ->
+    receive
+        {'$gen_call', From, Req} ->
+            case Fun(Req) of
+                {reply, Reply} ->
+                    gen_statem:reply(From, Reply),
+                    fake_loop(Fun);
+                die ->
+                    exit(shutdown)
+            end
+    end.
+
+wait_gone(_Pid, 0) ->
+    ok;
+wait_gone(Pid, N) ->
+    case is_process_alive(Pid) of
+        false ->
+            ok;
+        true ->
+            timer:sleep(5),
+            wait_gone(Pid, N - 1)
+    end.


### PR DESCRIPTION
## Problem

`asobi_matchmaker:spawn_match/6` ran its player-join fan-out inline in the matchmaker `gen_server`'s tick handling. `asobi_match_server:get_info/1` and `join/2` are `gen_statem` calls, so if the freshly created match server exits mid-loop - e.g. `{shutdown, empty}` when a joining player's session is already dead - the exit propagates into the matchmaker, restarting it and dropping every ticket queued in every mode (`tickets => #{}` on restart).

The sibling `spawn_world/6` already isolates its equivalent fan-out; `spawn_match/6` did not.

## Fix

Extract the fan-out into `join_matched_players/3` and run it detached with a `try/catch`, mirroring `spawn_world/6`. `get_info/1` moves inside the isolated region too - it is the same hazard. On failure the group is told `match_start_failed` and `matchmaker_failed` telemetry is emitted, instead of the players being left silently unnotified.

Match spawn itself stays synchronous, so the existing bounded spawn-retry / re-queue path is unchanged.

## Tests

New `test/asobi_matchmaker_isolation_tests.erl`:
- match gone before the fan-out starts -> no raise, both players get `matchmaker_failed`
- match exits mid fan-out (after player 1 joined) -> no raise, already-joined player got `match_joined`, remaining players get `matchmaker_failed`
- live match -> every player gets `match_joined` and `matched` with the match id, no failure notification

`rebar3 fmt --check`, `xref`, `dialyzer`, `eunit` (530 tests) and `ex_doc` all green. CT not run locally (needs the Postgres container); CI covers it.

Closes #291
