### PR TITLE
fix: handle input and vote calls in waiting/paused match states

### DIFF
--- a/src/matches/asobi_match_server.erl
+++ b/src/matches/asobi_match_server.erl
@@ -18,6 +18,8 @@ the place to put callback hardening.
 """.
 -behaviour(gen_statem).
 
+-include_lib("kernel/include/logger.hrl").
+
 -export([
     start_link/1,
     join/2,
@@ -247,6 +249,24 @@ waiting(info, {'DOWN', _MonRef, process, DownPid, _Reason}, State) when is_pid(D
 %% {error, not_in_match} correctly for this state, it was just unreachable.
 waiting({call, From}, {reconnect, PlayerId}, State) when is_binary(PlayerId) ->
     handle_reconnect_call(From, PlayerId, State);
+%% asobi#290: asobi_ws_handler casts input as soon as the client holds a
+%% match_pid, which can be before the last player has joined - waiting/3 had
+%% no clause and no catch-all, so early input crashed the whole match. The
+%% input is dropped rather than queued: there is no tick before `running` to
+%% apply it, so queuing would both replay stale pre-match input on the first
+%% tick and grow without bound for the whole waiting window.
+waiting(cast, {input, PlayerId, _Input}, #{match_id := MatchId}) ->
+    log_dropped_input(MatchId, PlayerId, match_not_started),
+    keep_state_and_data;
+%% asobi#290: no votes before the match starts - explicit replies, because
+%% waiting/3 deliberately has no catch-all and these would otherwise crash
+%% the match with function_clause.
+waiting({call, From}, {start_vote, _VoteConfig}, _State) ->
+    {keep_state_and_data, [{reply, From, {error, match_not_started}}]};
+waiting({call, From}, {cast_vote, _PlayerId, _VoteId, _OptionId}, _State) ->
+    {keep_state_and_data, [{reply, From, {error, match_not_started}}]};
+waiting({call, From}, {use_veto, _PlayerId, _VoteId}, _State) ->
+    {keep_state_and_data, [{reply, From, {error, match_not_started}}]};
 waiting(cast, cancel, State) ->
     {stop, {shutdown, cancelled}, State}.
 
@@ -462,6 +482,13 @@ paused({call, From}, {get_info, listing}, State) ->
 paused(cast, {broadcast_event, Event, Payload}, State) ->
     broadcast_match_event(Event, Payload, State),
     keep_state_and_data;
+%% asobi#290: a paused match has no tick to apply input against, so input is
+%% dropped, not queued (a long pause would otherwise grow the queue without
+%% bound and replay stale input on resume). Explicit clause so the drop is
+%% observable instead of being silently swallowed by the catch-all below.
+paused(cast, {input, PlayerId, _Input}, #{match_id := MatchId}) ->
+    log_dropped_input(MatchId, PlayerId, match_paused),
+    keep_state_and_data;
 paused(
     info, {vote_resolved, VoteId, Template, Result}, #{game_module := Mod, game_state := GS} = State
 ) ->
@@ -501,6 +528,13 @@ paused(info, {'DOWN', _MonRef, process, DownPid, _Reason}, #{reconnect_state := 
         none ->
             keep_state_and_data
     end;
+%% asobi#290: every call with no clause above (start_vote, cast_vote,
+%% use_veto, join) used to fall through to the catch-all, which never
+%% replies - gen_statem:call/2 defaults to timeout infinity, so the caller
+%% hung forever. Replying an error keeps that defect closed for calls added
+%% later too; only non-call events reach the catch-all now.
+paused({call, From}, _Event, _State) ->
+    {keep_state_and_data, [{reply, From, {error, match_paused}}]};
 paused(_EventType, _Event, _State) ->
     keep_state_and_data.
 
@@ -550,6 +584,23 @@ terminate(_Reason, StateName, #{match_id := MatchId} = State) ->
     ok.
 
 %% --- Internal ---
+
+%% Rate-limited: input arrives per client per tick, so an unbounded log here
+%% would be a flood channel a client controls.
+-spec log_dropped_input(binary(), binary(), atom()) -> ok.
+log_dropped_input(MatchId, PlayerId, Reason) ->
+    case asobi_script_log_limiter:allow({?MODULE, input_dropped, MatchId}) of
+        {true, Dropped} ->
+            ?LOG_INFO(#{
+                event => match_input_dropped,
+                match_id => MatchId,
+                player_id => PlayerId,
+                reason => Reason,
+                suppressed_since_last => Dropped
+            });
+        false ->
+            ok
+    end.
 
 handle_join(
     From,

--- a/test/asobi_match_server_tests.erl
+++ b/test/asobi_match_server_tests.erl
@@ -72,7 +72,13 @@ match_server_test_() ->
             fun paused_down_starts_grace/0},
         {"reconnect while paused succeeds instead of hanging",
             fun reconnect_while_paused_succeeds/0},
-        {"reconnect while waiting does not crash", fun reconnect_while_waiting_does_not_crash/0}
+        {"reconnect while waiting does not crash", fun reconnect_while_waiting_does_not_crash/0},
+        {"input while waiting is dropped without crashing", fun input_while_waiting_is_dropped/0},
+        {"vote calls while waiting error instead of crashing",
+            fun vote_calls_while_waiting_error/0},
+        {"input while paused is dropped without crashing", fun input_while_paused_is_dropped/0},
+        {"vote calls while paused error instead of hanging", fun vote_calls_while_paused_error/0},
+        {"join while paused errors instead of hanging", fun join_while_paused_errors/0}
     ]}.
 
 %% --- Tests ---
@@ -528,6 +534,85 @@ reconnect_while_waiting_does_not_crash() ->
         {error, no_reconnect_policy}, gen_statem:call(Pid, {reconnect, PlayerId}, 2000)
     ),
     ?assert(is_process_alive(Pid)),
+    stop(Pid).
+
+%% Regression for widgrensit/asobi#290: waiting/3 had no {input, _, _} clause
+%% and no catch-all, so a client casting input before the last player joined
+%% crashed the match with function_clause.
+input_while_waiting_is_dropped() ->
+    Pid = start_match(#{min_players => 2, max_players => 2}),
+    ok = asobi_match_server:join(Pid, ~"p290_waiting_input"),
+    asobi_match_server:handle_input(Pid, ~"p290_waiting_input", #{~"action" => ~"move"}),
+    timer:sleep(50),
+    ?assert(is_process_alive(Pid)),
+    ?assertMatch(#{status := waiting}, asobi_match_server:get_info(Pid)),
+    stop(Pid).
+
+%% Regression for widgrensit/asobi#290: the vote trio had no clause in
+%% waiting/3 either - same function_clause crash. Bounded timeout so a
+%% regression fails fast instead of hanging the run.
+vote_calls_while_waiting_error() ->
+    Pid = start_match(#{min_players => 2, max_players => 2}),
+    ok = asobi_match_server:join(Pid, ~"p290_waiting_vote"),
+    ?assertEqual(
+        {error, match_not_started}, gen_statem:call(Pid, {start_vote, #{}}, 2000)
+    ),
+    ?assertEqual(
+        {error, match_not_started},
+        gen_statem:call(Pid, {cast_vote, ~"p290_waiting_vote", ~"v1", ~"o1"}, 2000)
+    ),
+    ?assertEqual(
+        {error, match_not_started},
+        gen_statem:call(Pid, {use_veto, ~"p290_waiting_vote", ~"v1"}, 2000)
+    ),
+    ?assert(is_process_alive(Pid)),
+    stop(Pid).
+
+%% Regression for widgrensit/asobi#290: input while paused was swallowed by
+%% paused/3's catch-all; it now hits an explicit clause that logs the drop.
+%% The observable contract is the same from the client's side - the match
+%% survives and stays paused - so this guards the crash/regression case.
+input_while_paused_is_dropped() ->
+    Pid = start_match(#{min_players => 1, max_players => 2}),
+    ok = asobi_match_server:join(Pid, ~"p290_paused_input"),
+    timer:sleep(50),
+    ok = asobi_match_server:pause(Pid),
+    asobi_match_server:handle_input(Pid, ~"p290_paused_input", #{~"action" => ~"move"}),
+    timer:sleep(50),
+    ?assert(is_process_alive(Pid)),
+    ?assertMatch(#{status := paused}, asobi_match_server:get_info(Pid)),
+    stop(Pid).
+
+%% Regression for widgrensit/asobi#290: the vote trio fell through to
+%% paused/3's catch-all, which never replies - gen_statem:call/2 defaults to
+%% timeout infinity, so the caller hung forever.
+vote_calls_while_paused_error() ->
+    Pid = start_match(#{min_players => 1, max_players => 2}),
+    ok = asobi_match_server:join(Pid, ~"p290_paused_vote"),
+    timer:sleep(50),
+    ok = asobi_match_server:pause(Pid),
+    ?assertEqual({error, match_paused}, gen_statem:call(Pid, {start_vote, #{}}, 2000)),
+    ?assertEqual(
+        {error, match_paused},
+        gen_statem:call(Pid, {cast_vote, ~"p290_paused_vote", ~"v1", ~"o1"}, 2000)
+    ),
+    ?assertEqual(
+        {error, match_paused}, gen_statem:call(Pid, {use_veto, ~"p290_paused_vote", ~"v1"}, 2000)
+    ),
+    ?assert(is_process_alive(Pid)),
+    stop(Pid).
+
+%% Regression for widgrensit/asobi#290: join is the fourth call with no
+%% paused/3 clause, and hung the caller the same way.
+join_while_paused_errors() ->
+    Pid = start_match(#{min_players => 1, max_players => 4}),
+    ok = asobi_match_server:join(Pid, ~"p290_paused_join1"),
+    timer:sleep(50),
+    ok = asobi_match_server:pause(Pid),
+    ?assertEqual(
+        {error, match_paused}, gen_statem:call(Pid, {join, ~"p290_paused_join2", #{}}, 2000)
+    ),
+    ?assertEqual(1, maps:get(player_count, asobi_match_server:get_info(Pid))),
     stop(Pid).
 
 %% --- Helpers ---


### PR DESCRIPTION
## Summary

Follow-up to #289 (fix for #285) - the same defect class was still open for other event types reachable from `waiting`/`paused`.

- `waiting/3` had no clause for `cast {input, _, _}` and no catch-all, so input arriving before the last player joined crashed the match with `function_clause`. `asobi_ws_handler` casts input as soon as a client holds a `match_pid`, and the matchmaker's inline join fan-out means an earlier-joined player can be sending input while later players are still joining.
- `waiting/3` had no clause for `{start_vote, _}` / `{cast_vote, ...}` / `{use_veto, ...}` either - same crash.
- `paused/3`'s catch-all never replies, so those three calls (and `{join, ...}`, the fourth call with no `paused` clause) hung the caller forever - `gen_statem:call/2` defaults to timeout `infinity`. Identical to the `{reconnect, _}` hang #289 fixed.

## Changes

- `waiting/3`: explicit `{input, _, _}` clause that **drops** the input (there is no tick before `running` to apply it, and queuing would replay stale pre-match input and grow unbounded for the whole waiting window) with a rate-limited log line via the existing `asobi_script_log_limiter`; explicit vote clauses replying `{error, match_not_started}`.
- `paused/3`: explicit `{input, _, _}` clause dropping with the same observable log instead of the silent catch-all; a `{call, From}` fallback replying `{error, match_paused}` placed before the catch-all, so no call - including ones added later - can fall into a never-replying clause again.

Input drops are logged through the shared limiter because input is client-driven and per-tick; an unbounded log there would be a flood channel a client controls.

Closes #290

## Test plan

- [x] 5 new regression tests in `asobi_match_server_tests` (input + vote trio in `waiting`, input + vote trio + join in `paused`, all vote/join calls asserted with a bounded `gen_statem:call/3` timeout so a regression fails fast instead of hanging the run)
- [x] `rebar3 eunit --module=asobi_match_server_tests` - 38/38 pass
- [x] `rebar3 eunit` (full suite) - 532/532 pass
- [x] `rebar3 fmt --check`, `rebar3 xref`, `rebar3 dialyzer`, `rebar3 ex_doc` - clean
- [ ] `rebar3 ct` - skipped, no Postgres container claimed for this session