### PR TITLE
feat: game-wide `global:` chat channels above the world tier

### DIFF
--- a/guides/websocket-protocol.md
+++ b/guides/websocket-protocol.md
@@ -379,10 +379,20 @@ membership without a per-frame registry lookup.
 | Prefix   | Used for                                  | Membership rule |
 |----------|-------------------------------------------|-----------------|
 | `dm:`    | Direct messages                           | The two named participants only. |
+| `global:`| Game-wide chat, spans every world         | Any signed-in player, for a name the operator declared. |
 | `world:` | World-wide chat                           | Players currently joined to the world. |
 | `zone:`  | A specific zone within a world            | Players currently joined to the world. |
 | `prox:`  | Proximity chat (radius around a position) | Players currently joined to the world. |
 | `room:`  | App-defined group chat                    | Members of the group whose id is the part of the channel id after `room:`. Not open-join. |
+
+`global:<name>` is the only scheme that outlives a single world, so it is the
+one to use for "everyone in the game". A client cannot mint one: the name must
+appear in the `chat => #{global => [...]}` of a configured game mode, otherwise
+the join is rejected like any other unauthorised channel. Names are up to 64
+bytes of `a-z A-Z 0-9 _ - .`. Players in a world whose mode declares a global
+channel are joined to it automatically on `world.join` and left on
+`world.leave`, exactly as with `world:` - see the
+[World Server](world-server.md#chat-channels) guide.
 
 There is no open-join room policy and no `match:` scheme. `room:` is authorised
 as a group membership check: the runtime strips the `room:` prefix and looks up

--- a/guides/world-server.md
+++ b/guides/world-server.md
@@ -569,7 +569,8 @@ game mode:
             type => world,
             module => my_game,
             chat => #{
-                world => true,       %% global channel for everyone in the world
+                global => [~"general", ~"trade"], %% game-wide, spans every world
+                world => true,       %% one channel for everyone in this world
                 zone => true,        %% auto-join/leave as players move between zones
                 proximity => 2       %% chat with players within N zones of you
             }
@@ -591,6 +592,7 @@ chat_proximity = 2
 
 | Type | Scope | Lifecycle |
 |------|-------|-----------|
+| **Global** | Every player in the game, across all worlds | Join on world join, leave on world leave |
 | **World** | All players in the world instance | Join on world join, leave on world leave |
 | **Zone** | Players in the same zone cell | Auto-swap when crossing zone boundaries |
 | **Proximity** | Players within N zones | Follows your interest radius, updates on zone change |
@@ -611,9 +613,17 @@ No extra client code needed. Chat messages arrive via the same WebSocket
 as `chat.message` events. Clients just need to know the channel IDs,
 which follow a predictable format:
 
+- Global: `global:{name}`
 - World: `world:{world_id}`
 - Zone: `zone:{world_id}:{x},{y}`
 - Proximity: `prox:{world_id}:{x},{y}`
+
+A global channel carries no world id on purpose: every world of every mode
+that declares the same name resolves the same channel process, so one message
+is one broadcast and one row of history, not one per world. Only names
+declared in a mode's `chat.global` are authorised, so a client cannot mint
+new ones; names are up to 64 bytes of `a-z A-Z 0-9 _ - .` and anything else
+is dropped with a warning at join time.
 
 ### No Chat Config
 

--- a/src/asobi_game_modes.erl
+++ b/src/asobi_game_modes.erl
@@ -1,6 +1,6 @@
 -module(asobi_game_modes).
 
--export([mode_config/1, resolve_game_module/1, world_config/1]).
+-export([mode_config/1, resolve_game_module/1, world_config/1, global_chat_channels/0]).
 
 -spec mode_config(binary()) -> map().
 mode_config(Mode) ->
@@ -45,10 +45,28 @@ world_config(Mode) ->
                 listed => maps:get(listed, ModeConfig, true),
                 quick_play => maps:get(quick_play, ModeConfig, true)
             },
-            {ok, forward_optional(ModeConfig, [empty_grace_ms, player_ttl_ms], Base)};
+            {ok, forward_optional(ModeConfig, [empty_grace_ms, player_ttl_ms, chat], Base)};
         {error, _} = Err ->
             Err
     end.
+
+-doc """
+Every game-wide chat channel name declared by any configured game mode.
+
+#299: `global:<Name>` is the one channel scheme that outlives a single world,
+so the set of legal names cannot come from the joining client. It is the union
+of the `chat => #{global => [...]}` declarations across `game_modes`, which is
+what `asobi_chat_acl` authorises against.
+""".
+-spec global_chat_channels() -> [binary()].
+global_chat_channels() ->
+    Modes = ensure_map(application:get_env(asobi, game_modes, #{})),
+    lists:usort([
+        Name
+     || Config <- maps:values(Modes),
+        is_map(Config),
+        Name <- asobi_world_chat:global_channels(maps:get(chat, Config, #{}))
+    ]).
 
 -spec forward_optional(map(), [atom()], map()) -> map().
 forward_optional(_Src, [], Acc) ->

--- a/src/social/asobi_chat_acl.erl
+++ b/src/social/asobi_chat_acl.erl
@@ -3,6 +3,10 @@
 Authorisation policy for chat channels.
 
 Channel ID schemes:
+  global:<Name>              - game-wide channel; any signed-in player may
+                                join, but only for a `<Name>` declared in the
+                                `chat => #{global => [...]}` of some configured
+                                game mode (see #299)
   dm:<A>:<B>                 - A and B are the only allowed readers, and B
                                 (the participant that isn't the caller) must
                                 resolve to a real player id (see #305 below)
@@ -14,6 +18,13 @@ Channel ID schemes:
                                 shape `asobi_id:generate/0` always emits) and
                                 the caller must be a member of that group
   <anything else>            - treated as a group_id; must be a group member
+
+#299: every other scheme stops at one world or one pair of players, so a
+game whose locations are separate worlds had no id its whole player base
+could share. `global:<Name>` is that tier. It is operator-declared rather
+than client-minted: the name must appear in a game mode's
+`chat => #{global => [...]}`, so `chat.join` still cannot spawn unbounded
+channel processes, and the per-connection channel cap still applies.
 
 A `room:` channel is closed by default: a group id that isn't a canonical
 uuid is denied outright (rather than falling through to a membership lookup
@@ -63,6 +74,8 @@ authorized(ChannelId, PlayerId) when is_binary(ChannelId), is_binary(PlayerId) -
             dm_authorized(PlayerId, A, B);
         {world, WorldId} ->
             player_in_world(PlayerId, WorldId);
+        {global, Name} ->
+            lists:member(Name, asobi_game_modes:global_chat_channels());
         {group, GroupId} ->
             is_group_member(PlayerId, GroupId)
     end.
@@ -98,6 +111,7 @@ validate_channel_id(ChannelId) when is_binary(ChannelId) ->
         byte_size(ChannelId) =< ?MAX_CHANNEL_ID_BYTES andalso
         valid_channel_prefix(ChannelId).
 
+valid_channel_prefix(<<"global:", _/binary>>) -> true;
 valid_channel_prefix(<<"dm:", _/binary>>) -> true;
 valid_channel_prefix(<<"world:", _/binary>>) -> true;
 valid_channel_prefix(<<"zone:", _/binary>>) -> true;
@@ -106,7 +120,15 @@ valid_channel_prefix(<<"room:", _/binary>>) -> true;
 valid_channel_prefix(_) -> false.
 
 -spec classify(binary()) ->
-    {dm, binary(), binary()} | {world, binary()} | {group, binary()} | deny.
+    {dm, binary(), binary()}
+    | {world, binary()}
+    | {global, binary()}
+    | {group, binary()}
+    | deny.
+classify(<<"global:", Name/binary>>) when byte_size(Name) > 0 ->
+    {global, Name};
+classify(<<"global:">>) ->
+    deny;
 classify(<<"dm:", Rest/binary>>) ->
     case binary:split(Rest, ~":", [global]) of
         [A, B] when byte_size(A) > 0, byte_size(B) > 0 -> {dm, A, B};

--- a/src/world/asobi_world_chat.erl
+++ b/src/world/asobi_world_chat.erl
@@ -9,9 +9,10 @@
 %%     ~"galaxy" => #{
 %%         type => world,
 %%         chat => #{
-%%             world => true,       %% global channel for all players in the world
-%%             zone => true,        %% auto-join/leave as players move between zones
-%%             proximity => 2       %% chat with players within N zones (uses interest radius)
+%%             global => [~"general"], %% game-wide, spans every world (#299)
+%%             world => true,          %% one channel for all players in the world
+%%             zone => true,           %% auto-join/leave as players move between zones
+%%             proximity => 2          %% chat with players within N zones (uses interest radius)
 %%         }
 %%     }
 %% }}
@@ -19,9 +20,13 @@
 %%
 %% Federation chat is handled separately by the social system.
 
+-include_lib("kernel/include/logger.hrl").
+
 -export([init/2]).
 -export([player_joined/3, player_left/3, player_zone_changed/5]).
--export([channel_id/3]).
+-export([channel_id/3, global_channel_id/1, global_channels/1]).
+
+-define(MAX_GLOBAL_NAME_BYTES, 64).
 
 -spec init(binary(), map()) -> map().
 init(WorldId, Config) ->
@@ -47,6 +52,10 @@ player_joined(PlayerId, ZoneCoords, #{world_id := WorldId, chat_config := ChatCo
                 false ->
                     ok
             end,
+            lists:foreach(
+                fun(Name) -> asobi_chat_channel:join(global_channel_id(Name), PlayerPid) end,
+                global_channels(ChatConfig)
+            ),
             join_zone_chats(PlayerId, PlayerPid, WorldId, ZoneCoords, ChatConfig),
             ok
     end.
@@ -67,6 +76,10 @@ player_left(PlayerId, ZoneCoords, #{world_id := WorldId, chat_config := ChatConf
                 false ->
                     ok
             end,
+            lists:foreach(
+                fun(Name) -> asobi_chat_channel:leave(global_channel_id(Name), PlayerPid) end,
+                global_channels(ChatConfig)
+            ),
             leave_zone_chats(PlayerId, PlayerPid, WorldId, ZoneCoords, ChatConfig),
             ok
     end.
@@ -131,6 +144,48 @@ channel_id(WorldId, zone, {X, Y}) when is_integer(X), is_integer(Y) ->
     iolist_to_binary([~"zone:", WorldId, ~":", integer_to_binary(X), ~",", integer_to_binary(Y)]);
 channel_id(WorldId, proximity, {X, Y}) when is_integer(X), is_integer(Y) ->
     iolist_to_binary([~"prox:", WorldId, ~":", integer_to_binary(X), ~",", integer_to_binary(Y)]).
+
+-doc "Channel id of a game-wide chat channel. Deliberately carries no world id.".
+-spec global_channel_id(binary()) -> binary().
+global_channel_id(Name) when is_binary(Name) ->
+    <<"global:", Name/binary>>.
+
+-doc """
+The game-wide channel names a chat config declares, deduplicated.
+
+Shared with `asobi_game_modes:global_chat_channels/0`, which the chat ACL
+consults, so a name is auto-joined here exactly when it is authorised there.
+Malformed names are dropped loudly rather than silently minting a channel
+nothing can join.
+""".
+-spec global_channels(term()) -> [binary()].
+global_channels(#{global := Names}) when is_list(Names) ->
+    lists:usort([Name || Name <- Names, valid_global_name(Name)]);
+global_channels(#{global := Other}) ->
+    ?LOG_WARNING(#{event => invalid_global_chat_config, value => Other}),
+    [];
+global_channels(_) ->
+    [].
+
+-spec valid_global_name(term()) -> boolean().
+valid_global_name(Name) when is_binary(Name), byte_size(Name) > 0 ->
+    case byte_size(Name) =< ?MAX_GLOBAL_NAME_BYTES andalso is_name_chars(Name) of
+        true ->
+            true;
+        false ->
+            ?LOG_WARNING(#{event => invalid_global_chat_channel_name, name => Name}),
+            false
+    end;
+valid_global_name(Name) ->
+    ?LOG_WARNING(#{event => invalid_global_chat_channel_name, name => Name}),
+    false.
+
+is_name_chars(<<>>) -> true;
+is_name_chars(<<C, Rest/binary>>) when C >= $a, C =< $z -> is_name_chars(Rest);
+is_name_chars(<<C, Rest/binary>>) when C >= $A, C =< $Z -> is_name_chars(Rest);
+is_name_chars(<<C, Rest/binary>>) when C >= $0, C =< $9 -> is_name_chars(Rest);
+is_name_chars(<<C, Rest/binary>>) when C =:= $_; C =:= $-; C =:= $. -> is_name_chars(Rest);
+is_name_chars(_) -> false.
 
 %% --- Internal ---
 

--- a/test/asobi_chat_acl_tests.erl
+++ b/test/asobi_chat_acl_tests.erl
@@ -53,3 +53,48 @@ dm_unknown_participant_rejected() ->
     meck:expect(asobi_repo, get, fun(asobi_player, _Id) -> {error, not_found} end),
     ?assertNot(asobi_chat_acl:authorized(~"dm:alice:not_a_real_player", ~"alice")),
     ?assertNot(asobi_chat_acl:authorized(~"dm:not_a_real_player:alice", ~"alice")).
+
+%% #299: the one scheme that spans worlds. Any signed-in player may join a
+%% declared name; an undeclared one must not authorise, or `chat.join` would
+%% mint unbounded channel processes.
+global_acl_test_() ->
+    {setup, fun global_setup/0, fun global_cleanup/1, [
+        {"a declared global channel authorises any player", fun global_declared_authorized/0},
+        {"an undeclared global channel authorises nobody", fun global_undeclared_rejected/0},
+        {"names are collected across every configured mode", fun global_union_across_modes/0},
+        {"a bare `global:` prefix is denied", fun global_empty_name_rejected/0},
+        {"the `global:` prefix passes channel-id validation", fun global_prefix_validates/0}
+    ]}.
+
+global_setup() ->
+    Prev = application:get_env(asobi, game_modes),
+    application:set_env(asobi, game_modes, #{
+        ~"galaxy" => #{type => world, chat => #{global => [~"general"], world => true}},
+        ~"arena" => #{chat => #{global => [~"trade", ~"general"]}},
+        ~"quiet" => #{chat => #{world => true}}
+    }),
+    Prev.
+
+global_cleanup({ok, Prev}) ->
+    application:set_env(asobi, game_modes, Prev);
+global_cleanup(undefined) ->
+    application:unset_env(asobi, game_modes).
+
+global_declared_authorized() ->
+    ?assert(asobi_chat_acl:authorized(~"global:general", ~"alice")),
+    ?assert(asobi_chat_acl:authorized(~"global:general", ~"bob")).
+
+global_undeclared_rejected() ->
+    ?assertNot(asobi_chat_acl:authorized(~"global:not-declared", ~"alice")),
+    ?assertNot(asobi_chat_acl:authorized(~"global:general:extra", ~"alice")).
+
+global_union_across_modes() ->
+    ?assert(asobi_chat_acl:authorized(~"global:trade", ~"alice")),
+    ?assertEqual([~"general", ~"trade"], asobi_game_modes:global_chat_channels()).
+
+global_empty_name_rejected() ->
+    ?assertNot(asobi_chat_acl:authorized(~"global:", ~"alice")),
+    ?assertNot(asobi_chat_acl:validate_channel_id(~"global")).
+
+global_prefix_validates() ->
+    ?assert(asobi_chat_acl:validate_channel_id(~"global:general")).

--- a/test/asobi_game_modes_tests.erl
+++ b/test/asobi_game_modes_tests.erl
@@ -1,0 +1,42 @@
+-module(asobi_game_modes_tests).
+-include_lib("eunit/include/eunit.hrl").
+
+%% #299: `chat` was never forwarded into the world server config, so a mode
+%% that declared chat channels got none of them - the world server always
+%% read `maps:get(chat, Config, #{})` from a map the lobby had stripped it
+%% from.
+world_config_test_() ->
+    {setup, fun setup/0, fun cleanup/1, [
+        {"chat config reaches the world server config", fun chat_forwarded/0},
+        {"a mode without chat config forwards no chat key", fun chat_absent/0},
+        {"declared global channel names are the union across modes", fun global_union/0}
+    ]}.
+
+setup() ->
+    Prev = application:get_env(asobi, game_modes),
+    application:set_env(asobi, game_modes, #{
+        ~"galaxy" => #{
+            type => world,
+            module => some_game,
+            chat => #{global => [~"general"], world => true}
+        },
+        ~"arena" => #{type => world, module => some_game, chat => #{global => [~"trade"]}},
+        ~"quiet" => #{type => world, module => some_game}
+    }),
+    Prev.
+
+cleanup({ok, Prev}) ->
+    application:set_env(asobi, game_modes, Prev);
+cleanup(undefined) ->
+    application:unset_env(asobi, game_modes).
+
+chat_forwarded() ->
+    {ok, Config} = asobi_game_modes:world_config(~"galaxy"),
+    ?assertEqual(#{global => [~"general"], world => true}, maps:get(chat, Config)).
+
+chat_absent() ->
+    {ok, Config} = asobi_game_modes:world_config(~"quiet"),
+    ?assertNot(maps:is_key(chat, Config)).
+
+global_union() ->
+    ?assertEqual([~"general", ~"trade"], asobi_game_modes:global_chat_channels()).

--- a/test/asobi_world_chat_tests.erl
+++ b/test/asobi_world_chat_tests.erl
@@ -47,6 +47,8 @@ integration_test_() ->
         {"zone change swaps zone chat", fun zone_change_swaps_chat/0},
         {"proximity chat subscribes to nearby zones", fun proximity_chat/0},
         {"no chat config means no channels", fun no_chat_config/0},
+        {"a declared global channel is joined on world join and left on world leave",
+            fun global_chat_joined_and_left/0},
         {"a player with no live session never joins as the calling process",
             fun no_live_session_does_not_join_as_caller/0}
     ]}.
@@ -139,6 +141,50 @@ no_chat_config() ->
     ?assertNot(lists:member(self(), pg:get_members(nova_scope, {chat, WorldChannel}))),
     ?assertNot(lists:member(self(), pg:get_members(nova_scope, {chat, ZoneChannel}))),
     unregister_player().
+
+%% #299: the global tier carries no world id, so two worlds of the same game
+%% resolve the same channel process.
+global_chat_joined_and_left() ->
+    register_player(),
+    ChatState = asobi_world_chat:init(~"wc8", #{chat => #{global => [~"general"]}}),
+    ChatState2 = asobi_world_chat:init(~"wc9", #{chat => #{global => [~"general"]}}),
+    ChannelId = asobi_world_chat:global_channel_id(~"general"),
+    ?assertEqual(~"global:general", ChannelId),
+    asobi_world_chat:player_joined(~"p1", {0, 0}, ChatState),
+    ?assert(lists:member(self(), pg:get_members(nova_scope, {chat, ChannelId}))),
+    asobi_world_chat:player_joined(~"p1", {0, 0}, ChatState2),
+    asobi_world_chat:player_left(~"p1", {0, 0}, ChatState2),
+    asobi_world_chat:player_left(~"p1", {0, 0}, ChatState),
+    ?assertNot(lists:member(self(), pg:get_members(nova_scope, {chat, ChannelId}))),
+    unregister_player().
+
+global_channels_test_() ->
+    [
+        {"names are deduplicated", fun() ->
+            ?assertEqual(
+                [~"general", ~"trade"],
+                asobi_world_chat:global_channels(#{global => [~"trade", ~"general", ~"trade"]})
+            )
+        end},
+        {"malformed names are dropped", fun() ->
+            ?assertEqual(
+                [~"general"],
+                asobi_world_chat:global_channels(#{
+                    global => [~"general", ~"has:colon", ~"", "not-a-binary", 42]
+                })
+            )
+        end},
+        {"an over-long name is dropped", fun() ->
+            Long = binary:copy(~"a", 65),
+            ?assertEqual([], asobi_world_chat:global_channels(#{global => [Long]}))
+        end},
+        {"a non-list global is dropped", fun() ->
+            ?assertEqual([], asobi_world_chat:global_channels(#{global => true}))
+        end},
+        {"no global key means no channels", fun() ->
+            ?assertEqual([], asobi_world_chat:global_channels(#{world => true}))
+        end}
+    ].
 
 %% Regression for widgrensit/asobi#277: find_player_pid/1 in this module used
 %% to fall back to self() (the caller's own pid - asobi_world_server in


### PR DESCRIPTION
Adds the chat tier above the world, as proposed in #299.

## What changed

- **`global:<name>` channel scheme** (`asobi_chat_acl`): validated as a channel-id prefix and classified as its own tier. Authorised for any signed-in player, but only for a name the operator declared - an undeclared name authorises nobody, so `chat.join` still cannot mint unbounded channel processes and the 32-channels-per-connection cap still applies.
- **Declared in the mode config**, next to the tiers already there: `chat => #{global => [~"general", ~"trade"], world => true, zone => true}`. `asobi_game_modes:global_chat_channels/0` is the union across every configured mode and is what the ACL checks against. Names are bounded (64 bytes, `a-z A-Z 0-9 _ - .`); anything else is dropped with a warning rather than silently minting a channel nothing can join.
- **Auto-join/leave** (`asobi_world_chat`): players join declared global channels on world join and leave them on world leave, exactly as with the world tier - no client protocol change, and `/api/v1/chat/:channel_id/history` comes along free since it shares the ACL.
- **`chat` config is now forwarded** by `asobi_game_modes:world_config/1`. It was silently dropped, so no lobby-created world ever got any chat tier at all - world/zone/proximity included.

The channel id deliberately carries no world id, so every world of every mode that declares the same name resolves the same channel process: one broadcast, one row of history, instead of one per world.

The Lua half (reading a `chat` table in `asobi_lua_config`) belongs in asobi_lua and is not in this PR.

## Tests

New eunit coverage for the ACL (declared vs undeclared name, union across modes, bare `global:` denied, prefix validation), for auto-join/leave across two worlds sharing one channel, for name validation, and for the `chat` forwarding gap. Full `rebar3 eunit` green (541 tests), plus fmt/xref/dialyzer.

Closes #299
