### PR TITLE
fix: stop the match when reconnect grace empties the roster

### DIFF
--- a/src/matches/asobi_match_server.erl
+++ b/src/matches/asobi_match_server.erl
@@ -289,15 +289,20 @@ running(state_timeout, tick, #{game_module := Mod, game_state := GS, input_queue
                 {ok, GS2} ->
                     State1 = State#{game_state => GS2, input_queue => []},
                     State2 = maybe_start_vote(Mod, State1),
-                    State3 = tick_reconnect(TickRate, tick_phases(TickRate, State2)),
-                    case asobi_phase:is_complete(maps:get(phase_state, State3)) of
+                    {State3, Removed} = tick_reconnect(TickRate, tick_phases(TickRate, State2)),
+                    case roster_emptied(State3, Removed) of
                         true ->
-                            {next_state, finished, State3#{
-                                result => #{status => ~"phases_complete"}
-                            }};
+                            {stop, {shutdown, empty}, State3};
                         false ->
-                            broadcast_state(State3),
-                            {keep_state, State3, [{state_timeout, TickRate, tick}]}
+                            case asobi_phase:is_complete(maps:get(phase_state, State3)) of
+                                true ->
+                                    {next_state, finished, State3#{
+                                        result => #{status => ~"phases_complete"}
+                                    }};
+                                false ->
+                                    broadcast_state(State3),
+                                    {keep_state, State3, [{state_timeout, TickRate, tick}]}
+                            end
                     end;
                 {finished, Result, GS2} ->
                     {next_state, finished, State#{game_state => GS2, result => Result}}
@@ -342,8 +347,11 @@ running(info, {'DOWN', _MonRef, process, DownPid, _Reason}, #{reconnect_state :=
         {ok, PlayerId} ->
             Now = erlang:system_time(millisecond),
             {Events, RS1} = asobi_reconnect:disconnect(PlayerId, Now, RS),
-            State1 = handle_reconnect_events(Events, State#{reconnect_state => RS1}),
-            {keep_state, State1};
+            {State1, Removed} = handle_reconnect_events(Events, State#{reconnect_state => RS1}),
+            case roster_emptied(State1, Removed) of
+                true -> {stop, {shutdown, empty}, State1};
+                false -> {keep_state, State1}
+            end;
         none ->
             keep_state_and_data
     end;
@@ -525,8 +533,11 @@ paused(info, {'DOWN', _MonRef, process, DownPid, _Reason}, #{reconnect_state := 
         {ok, PlayerId} ->
             Now = erlang:system_time(millisecond),
             {Events, RS1} = asobi_reconnect:disconnect(PlayerId, Now, RS),
-            State1 = handle_reconnect_events(Events, State#{reconnect_state => RS1}),
-            {keep_state, State1};
+            {State1, Removed} = handle_reconnect_events(Events, State#{reconnect_state => RS1}),
+            case roster_emptied(State1, Removed) of
+                true -> {stop, {shutdown, empty}, State1};
+                false -> {keep_state, State1}
+            end;
         none ->
             keep_state_and_data
     end;
@@ -1006,11 +1017,10 @@ init_reconnect(Config) ->
     end.
 
 tick_reconnect(_DeltaMs, #{reconnect_state := undefined} = State) ->
-    State;
+    {State, false};
 tick_reconnect(DeltaMs, #{reconnect_state := RS} = State) ->
     {Events, RS1} = asobi_reconnect:tick(DeltaMs, RS),
-    State1 = State#{reconnect_state => RS1},
-    handle_reconnect_events(Events, State1).
+    handle_reconnect_events(Events, State#{reconnect_state => RS1}).
 
 handle_reconnect_call(From, PlayerId, #{players := Players, reconnect_state := RS} = State) when
     RS =/= undefined
@@ -1078,29 +1088,34 @@ find_player_by_pid(Pid, #{players := Players}) ->
         Players
     ).
 
-handle_reconnect_events([], State) ->
-    State;
-handle_reconnect_events([{grace_expired, PlayerId, Action} | Rest], State) ->
-    State1 =
-        case Action of
-            remove ->
-                #{players := Players, game_module := Mod, game_state := GS} = State,
-                case maps:is_key(PlayerId, Players) of
-                    false ->
-                        State;
-                    true ->
-                        {ok, GS1} = Mod:leave(PlayerId, GS),
-                        State#{
-                            players => maps:remove(PlayerId, Players),
-                            game_state => GS1
-                        }
-                end;
-            _ ->
-                State
-        end,
-    handle_reconnect_events(Rest, State1);
-handle_reconnect_events([_ | Rest], State) ->
-    handle_reconnect_events(Rest, State).
+handle_reconnect_events(Events, State) ->
+    handle_reconnect_events(Events, State, false).
+
+handle_reconnect_events([], State, Removed) ->
+    {State, Removed};
+handle_reconnect_events([{grace_expired, PlayerId, remove} | Rest], State, Removed) ->
+    #{players := Players, game_module := Mod, game_state := GS} = State,
+    case maps:is_key(PlayerId, Players) of
+        false ->
+            handle_reconnect_events(Rest, State, Removed);
+        true ->
+            {ok, GS1} = Mod:leave(PlayerId, GS),
+            State1 = State#{
+                players => maps:remove(PlayerId, Players),
+                game_state => GS1
+            },
+            handle_reconnect_events(Rest, State1, true)
+    end;
+handle_reconnect_events([_ | Rest], State, Removed) ->
+    handle_reconnect_events(Rest, State, Removed).
+
+%% asobi#292: grace expiry removes a player without going through
+%% handle_leave/2, so the "last player gone" shutdown has to be applied by
+%% every caller of handle_reconnect_events/2 as well.
+roster_emptied(_State, false) ->
+    false;
+roster_emptied(#{players := Players}, true) ->
+    map_size(Players) =:= 0.
 
 generate_id() ->
     asobi_id:generate().

--- a/test/asobi_match_server_tests.erl
+++ b/test/asobi_match_server_tests.erl
@@ -83,7 +83,13 @@ match_server_test_() ->
             fun vote_calls_while_waiting_error/0},
         {"input while paused is dropped without crashing", fun input_while_paused_is_dropped/0},
         {"vote calls while paused error instead of hanging", fun vote_calls_while_paused_error/0},
-        {"join while paused errors instead of hanging", fun join_while_paused_errors/0}
+        {"join while paused errors instead of hanging", fun join_while_paused_errors/0},
+        {timeout, 15,
+            {"grace expiry of the last player stops the match",
+                fun grace_expiry_of_last_player_stops_match/0}},
+        {timeout, 15,
+            {"grace expiry with players left keeps the match running",
+                fun grace_expiry_with_players_left_keeps_match/0}}
     ]}.
 
 %% --- Tests ---
@@ -557,6 +563,8 @@ paused_down_starts_grace() ->
             max_offline_total => infinity
         }
     }),
+    unlink(Pid),
+    Ref = monitor(process, Pid),
     SessionPid = fake_session(~"p285_paused_policy"),
     ok = asobi_match_server:join(Pid, ~"p285_paused_policy"),
     timer:sleep(50),
@@ -571,9 +579,74 @@ paused_down_starts_grace() ->
     ?assertEqual(paused, maps:get(status, Info)),
     ?assertEqual(1, maps:get(player_count, Info)),
 
+    %% asobi#292: resuming lets the grace expire, which empties the roster
+    %% and must shut the match down (it used to tick on with no players).
     ok = asobi_match_server:resume(Pid),
+    receive
+        {'DOWN', Ref, process, Pid, {shutdown, empty}} -> ok
+    after 2000 ->
+        ?assert(false)
+    end.
+
+%% Regression for widgrensit/asobi#292: when the last player's reconnect
+%% grace expired, handle_reconnect_events/2 removed them from the roster but
+%% (unlike handle_leave/2) never checked for an empty roster, so the match
+%% kept ticking forever with no players.
+grace_expiry_of_last_player_stops_match() ->
+    Pid = start_match(#{
+        min_players => 1,
+        max_players => 2,
+        reconnect => #{
+            grace_period => 100,
+            during_grace => idle,
+            on_reconnect => resume,
+            on_expire => remove,
+            pause_match => false,
+            max_offline_total => infinity
+        }
+    }),
+    unlink(Pid),
+    Ref = monitor(process, Pid),
+    PlayerId = ~"p292_grace_last",
+    SessionPid = fake_session(PlayerId),
+    ok = asobi_match_server:join(Pid, PlayerId),
+    timer:sleep(50),
+    ?assertEqual(1, maps:get(player_count, asobi_match_server:get_info(Pid))),
+
+    exit(SessionPid, kill),
+    receive
+        {'DOWN', Ref, process, Pid, {shutdown, empty}} -> ok
+    after 2000 ->
+        ?assert(false)
+    end.
+
+%% asobi#292: only the *last* player's grace expiry stops the match - the
+%% roster still having someone in it must leave the match running.
+grace_expiry_with_players_left_keeps_match() ->
+    Pid = start_match(#{
+        min_players => 1,
+        max_players => 2,
+        reconnect => #{
+            grace_period => 100,
+            during_grace => idle,
+            on_reconnect => resume,
+            on_expire => remove,
+            pause_match => false,
+            max_offline_total => infinity
+        }
+    }),
+    SessionPid = fake_session(~"p292_grace_gone"),
+    ok = asobi_match_server:join(Pid, ~"p292_grace_gone"),
+    ok = asobi_match_server:join(Pid, ~"p292_grace_stays"),
+    timer:sleep(50),
+    ?assertEqual(2, maps:get(player_count, asobi_match_server:get_info(Pid))),
+
+    exit(SessionPid, kill),
     timer:sleep(500),
-    ?assertEqual(0, maps:get(player_count, asobi_match_server:get_info(Pid))),
+    ?assert(is_process_alive(Pid)),
+    Info = asobi_match_server:get_info(Pid),
+    ?assertEqual(1, maps:get(player_count, Info)),
+    ?assertEqual([~"p292_grace_stays"], maps:get(players, Info)),
     stop(Pid).
 
 %% Regression for widgrensit/asobi#285: paused/3 had no {call, reconnect}


### PR DESCRIPTION
`handle_reconnect_events/2`'s `grace_expired`/`remove` branch removed the
expired player from `players` and called `Mod:leave/2`, but - unlike
`handle_leave/2` - never checked whether the roster had emptied. A match with
a reconnect policy whose last player's grace expired (rather than them calling
`leave/2`) never stopped: it kept ticking with an empty `players` map forever.

## Fix

- `handle_reconnect_events/2` now returns `{State, Removed}` where `Removed`
  says whether any player was actually taken off the roster; `tick_reconnect/2`
  threads it through.
- All three callers (running's tick handler, running's and paused's
  with-policy `'DOWN'` clauses) stop with `{shutdown, empty}` when the removal
  emptied the roster, matching `handle_leave/2`.

Scoped to the empty-check only. The demonitor asymmetry noted in the issue is
benign (the monitor ref was already consumed by the `'DOWN'` that started
grace) and is left alone.

## Tests

- `grace_expiry_of_last_player_stops_match/0` - new regression: single-player
  match, session killed, expects a `{shutdown, empty}` exit.
- `grace_expiry_with_players_left_keeps_match/0` - new guard: with another
  player still in the roster the match stays alive with the right roster.
- `paused_down_starts_grace/0` updated - it previously observed the
  empty-but-alive state; it now asserts the shutdown after resume.

Both new tests fail on `main` (verified) and pass with the fix. `rebar3 fmt
--check`, `xref`, `dialyzer`, `ex_doc` and the full `rebar3 eunit` (529 tests)
are green.

Closes #292
