### PR TITLE
fix: create the target zone for a crossing NPC instead of deleting it

### DIFF
--- a/src/world/asobi_world_server.erl
+++ b/src/world/asobi_world_server.erl
@@ -26,6 +26,7 @@ transient matches use `asobi_match_server` instead.
 -export([listing_info/1]).
 -export_type([listing/0]).
 -export([spawn_at/3, spawn_at/4]).
+-export([zone_created/3]).
 -export([reconnect/2]).
 -export([start_vote/2, cast_vote/4, use_veto/3]).
 -export([whereis/1]).
@@ -89,6 +90,17 @@ join(Pid, PlayerId, SessionPid, Ctx) when is_pid(SessionPid), is_map(Ctx) ->
 -spec leave(pid(), binary()) -> ok.
 leave(Pid, PlayerId) ->
     gen_statem:cast(Pid, {leave, PlayerId}).
+
+-doc """
+Tell the world server a zone was just created by something other than a
+player join or crossing - `asobi_zone` creating a neighbour to receive a
+crossing NPC (widgrensit/asobi#271). The world server owns `player_zones`,
+so only it can subscribe the already-connected players whose interest ring
+already covered those coords (widgrensit/asobi#275).
+""".
+-spec zone_created(pid(), {integer(), integer()}, pid()) -> ok.
+zone_created(Pid, Coords, ZonePid) when is_pid(ZonePid) ->
+    gen_statem:cast(Pid, {zone_created, Coords, ZonePid}).
 
 -spec move_player(pid(), binary(), {number(), number()}) -> ok.
 move_player(Pid, PlayerId, NewPos) ->
@@ -279,6 +291,8 @@ loading({call, _From}, {join, _PlayerId}, _State) ->
 %% kills the world instead of just running once we reach running.
 loading(cast, {move_player, _PlayerId, _NewPos, _Entity}, _State) ->
     {keep_state_and_data, [postpone]};
+loading(cast, {zone_created, _Coords, _ZonePid}, _State) ->
+    {keep_state_and_data, [postpone]};
 %% A world script broadcasting during generate_world/init reaches the world
 %% server while it is still loading. Without this clause that is a
 %% function_clause and the world dies before it ever runs.
@@ -310,6 +324,9 @@ running(cast, {leave, PlayerId}, State) ->
     handle_leave(PlayerId, State);
 running(cast, {move_player, PlayerId, NewPos, Entity}, State) ->
     handle_move(PlayerId, NewPos, Entity, State);
+running(cast, {zone_created, Coords, ZonePid}, #{player_zones := PlayerZones}) ->
+    backfill_zone_subscribers(Coords, ZonePid, undefined, PlayerZones),
+    keep_state_and_data;
 running(
     cast,
     {post_tick, TickN},

--- a/src/world/asobi_zone.erl
+++ b/src/world/asobi_zone.erl
@@ -26,6 +26,13 @@ via `asobi_spatial`. Zones are created and reaped lazily as players move.
 -define(DEFAULT_ZONE_SIZE, 200).
 -define(DEFAULT_GRID_SIZE, 10).
 -define(DEFAULT_REHOME_MARGIN, 0.15).
+%% Bound on the per-tick zone-manager call an NPC crossing into an unloaded
+%% neighbour makes (widgrensit/asobi#271). The manager's own work there is
+%% an ETS lookup plus a supervisor:start_child (the new zone's snapshot load
+%% happens in its handle_continue, off the manager), so exceeding this means
+%% the manager is saturated - in which case the NPC waits in this zone for a
+%% later tick rather than the zone stalling behind a 5s gen_server default.
+-define(ENSURE_ZONE_TIMEOUT, 1_000).
 
 %% --- Public API ---
 
@@ -710,7 +717,6 @@ encode_delta({removed, Id}) ->
 resolve_zone_crossings(
     #{
         entities := Entities,
-        world_id := WorldId,
         coords := Coords,
         zone_size := ZoneSize,
         grid_size := GridSize,
@@ -721,20 +727,9 @@ resolve_zone_crossings(
     {ToRemove, ToTransfer, ToRehome} = find_zone_crossings(
         Entities, Coords, ZoneSize, GridSize, RehomeMargin
     ),
-    %% Transfer each NPC to the target zone
-    lists:foreach(
-        fun({Id, {TX, TY} = TargetCoords, Entity}) when
-            is_binary(Id), is_integer(TX), is_integer(TY)
-        ->
-            case pg:get_members(?PG_SCOPE, {asobi_zone, WorldId, TargetCoords}) of
-                [TargetPid | _] ->
-                    gen_server:cast(TargetPid, {add_entity, Id, Entity});
-                [] ->
-                    log_npc_transfer_unavailable(WorldId, Id, TargetCoords)
-            end
-        end,
-        ToTransfer
-    ),
+    %% Transfer each NPC to the target zone. An NPC whose target zone can't be
+    %% reached is kept here (clamped), never deleted - see transfer_npcs/2.
+    KeptNpcs = transfer_npcs(ToTransfer, State),
     %% Hand each player off to move_player/4 rather than writing them into the
     %% target zone directly - handle_move/4 (via remove_player_from_zones/2)
     %% is what actually removes them from this zone, re-subscribes their
@@ -776,8 +771,10 @@ resolve_zone_crossings(
                 maps:from_list([R || R <- Results, R =/= moved])
         end,
     %% Remove transferred NPCs and rehomed players from this zone; a denied
-    %% player is kept, clamped back inside these bounds.
-    Entities1 = maps:merge(maps:without(ToRemove, Entities), DeniedEntities),
+    %% player and an NPC whose target zone was unreachable are kept, clamped
+    %% back inside these bounds.
+    Kept = maps:merge(DeniedEntities, KeptNpcs),
+    Entities1 = maps:merge(maps:without(ToRemove, Entities), Kept),
     Grid = maps:get(spatial_grid, State, undefined),
     Grid1 = remove_from_grid(ToRemove, Grid),
     %% query_radius/3 and query_rect/3 read positions from this grid, not
@@ -785,8 +782,78 @@ resolve_zone_crossings(
     %% re-indexing here, a denied entity's clamp is invisible to both and
     %% they keep answering with its out-of-zone position: exactly the
     %% divergence clamping exists to close. See widgrensit/asobi#248.
-    Grid2 = reindex_clamped(maps:to_list(DeniedEntities), Grid1),
+    Grid2 = reindex_clamped(maps:to_list(Kept), Grid1),
     State#{entities => Entities1, spatial_grid => Grid2}.
+
+%% A player crossing into an unloaded zone gets it created for them
+%% (asobi_world_server:handle_move/4 calls ensure_zone/2 before it moves
+%% anyone), so under lazy_zones - where an unloaded neighbour is the normal
+%% state - an NPC crossing the same boundary must not simply cease to exist.
+%% Same ordering as asobi#258: resolve the target first, and if it can't be
+%% resolved the crossing is a no-op, with the NPC clamped back inside this
+%% zone exactly as a rate-limited player is. Returns the NPCs to keep here.
+%%
+%% pg is tried first so the common case (target already loaded) stays a
+%% local ETS read; only a real miss pays a call to the zone manager, and
+%% that call is bounded so a busy manager costs this tick's crossing rather
+%% than stalling the whole zone's tick loop.
+-spec transfer_npcs([{binary(), {integer(), integer()}, map()}], map()) -> #{binary() => map()}.
+transfer_npcs(ToTransfer, State) ->
+    Results = [
+        transfer_npc(Id, TargetCoords, Entity, State)
+     || {Id, {TX, TY} = TargetCoords, Entity} <- ToTransfer,
+        is_binary(Id),
+        is_integer(TX),
+        is_integer(TY)
+    ],
+    maps:from_list([R || R <- Results, R =/= transferred]).
+
+-spec transfer_npc(binary(), {integer(), integer()}, map(), map()) ->
+    transferred | {binary(), map()}.
+transfer_npc(Id, TargetCoords, Entity, State) ->
+    #{world_id := WorldId, coords := Coords, zone_size := ZoneSize} = State,
+    case target_zone_pid(TargetCoords, State) of
+        {ok, TargetPid} ->
+            gen_server:cast(TargetPid, {add_entity, Id, Entity}),
+            transferred;
+        {error, Reason} ->
+            log_npc_transfer_unavailable(WorldId, Id, TargetCoords, Reason),
+            {Id, clamp_to_zone(Entity, Coords, ZoneSize)}
+    end.
+
+-spec target_zone_pid({integer(), integer()}, map()) -> {ok, pid()} | {error, term()}.
+target_zone_pid(TargetCoords, #{world_id := WorldId} = State) ->
+    case pg:get_members(?PG_SCOPE, {asobi_zone, WorldId, TargetCoords}) of
+        [TargetPid | _] ->
+            {ok, TargetPid};
+        [] ->
+            ensure_target_zone(TargetCoords, State)
+    end.
+
+-spec ensure_target_zone({integer(), integer()}, map()) -> {ok, pid()} | {error, term()}.
+ensure_target_zone(_TargetCoords, #{zone_manager_pid := undefined}) ->
+    {error, no_zone_manager};
+ensure_target_zone(TargetCoords, #{zone_manager_pid := ZMPid, world_server_pid := WSPid}) ->
+    try asobi_zone_manager:ensure_zone(ZMPid, TargetCoords, ?ENSURE_ZONE_TIMEOUT) of
+        {ok, TargetPid, created} ->
+            notify_zone_created(WSPid, TargetCoords, TargetPid),
+            {ok, TargetPid};
+        {ok, TargetPid, existing} ->
+            {ok, TargetPid};
+        {error, _} = Err ->
+            Err
+    catch
+        %% A manager that is overloaded, restarting or gone must not take the
+        %% zone down with it - the NPC stays here instead.
+        Class:Reason ->
+            {error, {Class, Reason}}
+    end.
+
+-spec notify_zone_created(pid() | undefined, {integer(), integer()}, pid()) -> ok.
+notify_zone_created(undefined, _Coords, _ZonePid) ->
+    ok;
+notify_zone_created(WSPid, Coords, ZonePid) ->
+    asobi_world_server:zone_created(WSPid, Coords, ZonePid).
 
 -spec reindex_clamped([{binary(), map()}], asobi_spatial_grid:grid() | undefined) ->
     asobi_spatial_grid:grid() | undefined.
@@ -1052,15 +1119,14 @@ log_spawn_failed(TemplateId, Reason, #{world_id := WorldId, coords := Coords}) -
         template_id => Id
     }).
 
-%% An NPC crossing into an unloaded target zone is dropped (widgrensit/
-%% asobi#251 gave the analogous spawn failure a signal; this closes the same
-%% gap here - the drop itself, not just its silence, is tracked separately
-%% as widgrensit/asobi#271). This runs from the per-tick crossing check, so
-%% a spawner parked near an unloaded neighbour would otherwise log once per
-%% tick forever (asobi#252) - only the log line is rate-limited, the
-%% telemetry counter stays unconditional.
--spec log_npc_transfer_unavailable(binary(), binary(), {integer(), integer()}) -> ok.
-log_npc_transfer_unavailable(WorldId, Id, TargetCoords) ->
+%% An NPC whose target zone could not be reached or created stays in this
+%% zone (widgrensit/asobi#271); the denied crossing is still reported the way
+%% asobi#251 reports a failed spawn. This runs from the per-tick crossing
+%% check, so an NPC parked against an unreachable neighbour would otherwise
+%% log once per tick forever (asobi#252) - only the log line is rate-limited,
+%% the telemetry counter stays unconditional.
+-spec log_npc_transfer_unavailable(binary(), binary(), {integer(), integer()}, term()) -> ok.
+log_npc_transfer_unavailable(WorldId, Id, TargetCoords, Reason) ->
     case asobi_script_log_limiter:allow({WorldId, TargetCoords}) of
         {true, DroppedSinceLastLog} ->
             ?LOG_WARNING(#{
@@ -1068,13 +1134,14 @@ log_npc_transfer_unavailable(WorldId, Id, TargetCoords) ->
                 world_id => WorldId,
                 entity_id => Id,
                 coords => TargetCoords,
+                reason => Reason,
                 suppressed_since_last => DroppedSinceLastLog
             });
         false ->
             ok
     end,
     asobi_telemetry:game_error(zone_unavailable, #{
-        world_id => WorldId, coords => TargetCoords, entity_id => Id
+        world_id => WorldId, coords => TargetCoords, entity_id => Id, reason => Reason
     }).
 
 %% A byte-length cut alone can land mid-codepoint, and the result is exported

--- a/src/world/asobi_zone_manager.erl
+++ b/src/world/asobi_zone_manager.erl
@@ -13,7 +13,7 @@ Hot-path lookups go through ETS directly, bypassing the gen_server.
 """.
 
 -export([start_link/1]).
--export([ensure_zone/2, get_zone/2, touch_zone/2, release_zone/2]).
+-export([ensure_zone/2, ensure_zone/3, get_zone/2, touch_zone/2, release_zone/2]).
 -export([get_active_zones/1, zone_terminated/3, pre_warm/1]).
 -export([register_zone/3, set_zone_config/2, set_initial_zone_states/2]).
 -export([init/1, handle_call/3, handle_cast/2, handle_info/2, terminate/2]).
@@ -21,6 +21,7 @@ Hot-path lookups go through ETS directly, bypassing the gen_server.
 -define(REAP_INTERVAL, 10_000).
 -define(DEFAULT_IDLE_TIMEOUT, 30_000).
 -define(DEFAULT_MAX_ACTIVE, 10_000).
+-define(DEFAULT_CALL_TIMEOUT, 5_000).
 
 %% --- Public API ---
 
@@ -41,11 +42,22 @@ to act on `created`.
 -spec ensure_zone(pid() | atom(), {integer(), integer()}) ->
     {ok, pid(), created | existing} | {error, term()}.
 ensure_zone(Ref, Coords) ->
-    case ets_lookup(Ref, Coords) of
+    ensure_zone(Ref, Coords, ?DEFAULT_CALL_TIMEOUT).
+
+-doc """
+As `ensure_zone/2`, with an explicit call timeout. Callers on a hot path
+that must not stall on a busy manager (`asobi_zone`'s per-tick crossing
+check, widgrensit/asobi#271) pass a tighter bound than the gen_server
+default and treat a timeout as "not available this tick".
+""".
+-spec ensure_zone(pid() | atom(), {integer(), integer()}, timeout()) ->
+    {ok, pid(), created | existing} | {error, term()}.
+ensure_zone(Ref, Coords, Timeout) ->
+    case ets_lookup(Ref, Coords, Timeout) of
         {ok, Pid} ->
             {ok, Pid, existing};
         not_loaded ->
-            case gen_server:call(Ref, {ensure_zone, Coords}) of
+            case gen_server:call(Ref, {ensure_zone, Coords}, Timeout) of
                 {ok, P, created} when is_pid(P) -> {ok, P, created};
                 {ok, P, existing} when is_pid(P) -> {ok, P, existing};
                 {error, _} = Err -> Err
@@ -357,13 +369,16 @@ schedule_reap() ->
     erlang:send_after(?REAP_INTERVAL, self(), {reap_idle, Ref}),
     Ref.
 
-ets_lookup(Ref, Coords) when is_atom(Ref) ->
+ets_lookup(Ref, Coords) ->
+    ets_lookup(Ref, Coords, ?DEFAULT_CALL_TIMEOUT).
+
+ets_lookup(Ref, Coords, _Timeout) when is_atom(Ref) ->
     case ets:lookup(Ref, Coords) of
         [{Coords, Pid}] -> {ok, Pid};
         [] -> not_loaded
     end;
-ets_lookup(Ref, Coords) when is_pid(Ref) ->
-    case gen_server:call(Ref, {lookup_zone, Coords}) of
+ets_lookup(Ref, Coords, Timeout) when is_pid(Ref) ->
+    case gen_server:call(Ref, {lookup_zone, Coords}, Timeout) of
         {ok, P} when is_pid(P) -> {ok, P};
         not_loaded -> not_loaded
     end.

--- a/test/asobi_world_zone_integration_tests.erl
+++ b/test/asobi_world_zone_integration_tests.erl
@@ -74,6 +74,8 @@ world_zone_integration_test_() ->
             fun crossing_into_a_lazily_created_zone_backfills_stationary_neighbours/0},
         {"a script-driven spawn into a lazily-created zone backfills neighbours",
             fun script_spawn_into_a_lazily_created_zone_backfills_neighbours/0},
+        {"an NPC crossing into an unloaded zone creates it and backfills neighbours",
+            fun npc_crossing_into_an_unloaded_zone_creates_it_and_backfills/0},
         {"a position within the boundary margin does not rehome the player",
             fun world_input_within_margin_does_not_rehome/0},
         {"a rate-limited crossing leaves the entity in place instead of destroying it",
@@ -568,6 +570,41 @@ crossing_into_a_lazily_created_zone_backfills_stationary_neighbours() ->
     after
         exit(AdaPid, kill),
         exit(BobPid, kill),
+        stop_world(Ctx)
+    end.
+
+%% Regression for widgrensit/asobi#271: under lazy_zones an unloaded
+%% neighbour is the normal state, and an NPC crossing into one used to be
+%% deleted outright while a player crossing the same boundary got the zone
+%% created for them. The NPC must arrive in a zone created for it, and the
+%% stationary neighbour whose ring already covered those coords must be
+%% backfilled onto it exactly as #275 requires for a player-created zone.
+npc_crossing_into_an_unloaded_zone_creates_it_and_backfills() ->
+    Ctx =
+        #{world_pid := Pid, zone_mgr := Mgr} = start_world(#{
+            lazy_zones => true, grid_size => 5
+        }),
+    Ada = ~"npc271_ada",
+    AdaPid = fake_session(Ada, self()),
+    try
+        %% Ada joins at {100.0,100.0} => zone {1,1}; {2,1} is in her ring but
+        %% not loaded, so her ring-subscribe to it no-ops.
+        ?assertEqual(ok, asobi_world_server:join(Pid, Ada)),
+        timer:sleep(20),
+        ?assertEqual(not_loaded, asobi_zone_manager:get_zone(Mgr, {2, 1})),
+
+        {ok, Z11} = asobi_zone_manager:get_zone(Mgr, {1, 1}),
+        %% x=225 clears zone {1,1}'s margin (edge at 200 + 15% of 100).
+        asobi_zone:add_entity(Z11, ~"npc271", #{type => ~"npc", x => 225.0, y => 100.0}),
+        timer:sleep(150),
+
+        {ok, Z21} = asobi_zone_manager:get_zone(Mgr, {2, 1}),
+        ?assertNot(maps:is_key(~"npc271", asobi_zone:get_entities(Z11))),
+        ?assert(maps:is_key(~"npc271", asobi_zone:get_entities(Z21))),
+        ?assertMatch(#{subscribers := #{Ada := {AdaPid, _}}}, sys:get_state(Z21)),
+        ?assert(received_entity(Ada, ~"npc271"))
+    after
+        exit(AdaPid, kill),
         stop_world(Ctx)
     end.
 

--- a/test/asobi_zone_tests.erl
+++ b/test/asobi_zone_tests.erl
@@ -66,8 +66,12 @@ zone_test_() ->
             fun npc_within_margin_does_not_transfer/0},
         {"an NPC past the boundary margin transfers to the neighbouring zone",
             fun npc_past_margin_transfers/0},
-        {"an NPC transfer to an unloaded target zone is observable, not silent",
-            fun npc_transfer_unavailable_zone_is_observable/0},
+        {"an NPC whose target zone cannot be resolved stays here, clamped",
+            fun npc_transfer_unavailable_zone_keeps_entity/0},
+        {"an NPC stays here when the zone manager refuses to create the target",
+            fun npc_transfer_zone_manager_error_keeps_entity/0},
+        {"an NPC crossing into an unloaded zone has it created for it",
+            fun npc_transfer_creates_unloaded_target_zone/0},
         {"reap stops a zone with no entities", fun reap_stops_empty_zone/0},
         {"reap declines and re-touches a zone that still has entities",
             fun reap_declines_when_occupied/0}
@@ -580,10 +584,11 @@ npc_past_margin_transfers() ->
     gen_server:stop(Pid),
     gen_server:stop(TargetPid).
 
-%% An NPC crossing into a zone that isn't loaded is dropped (asobi_zone_sup
-%% doesn't eagerly spawn every grid cell) - that loss must be observable the
-%% same way #251 made spawn_at_zone_unavailable observable, not silent.
-npc_transfer_unavailable_zone_is_observable() ->
+%% asobi#271: an NPC whose target zone can't be resolved must stay in this
+%% zone (clamped back inside its bounds, as a rate-limited player is), not be
+%% destroyed - and the denied crossing stays observable the same way #251
+%% made spawn_at_zone_unavailable observable.
+npc_transfer_unavailable_zone_keeps_entity() ->
     Self = self(),
     Ref = make_ref(),
     {ok, _} = application:ensure_all_started(telemetry),
@@ -597,21 +602,81 @@ npc_transfer_unavailable_zone_is_observable() ->
         rehome_margin => ?NPC_MARGIN_REHOME_MARGIN
     }),
     try
-        %% x=245 clears the margin; no zone is loaded at {1,0} in this world.
+        %% x=245 clears the margin; no zone is loaded at {1,0} in this world
+        %% and this zone has no zone manager to create one.
         asobi_zone:add_entity(Pid, ~"npc1", #{type => ~"npc", x => 245.0, y => 0.0}),
         timer:sleep(10),
         asobi_zone:tick(Pid, 1),
         timer:sleep(20),
-        ?assertNot(maps:is_key(~"npc1", asobi_zone:get_entities(Pid))),
+        Npc = maps:get(~"npc1", asobi_zone:get_entities(Pid)),
+        ?assert(maps:get(x, Npc) < ?NPC_MARGIN_ZONE_SIZE),
         receive
             {ev, #{kind := zone_unavailable, details := D}} ->
                 ?assertEqual({1, 0}, maps:get(coords, D)),
-                ?assertEqual(~"npc1", maps:get(entity_id, D))
+                ?assertEqual(~"npc1", maps:get(entity_id, D)),
+                ?assertEqual(no_zone_manager, maps:get(reason, D))
         after 1000 -> ?assert(false, timeout_waiting_for_zone_unavailable_event)
         end
     after
         telemetry:detach(Ref),
         gen_server:stop(Pid)
+    end.
+
+%% Same, for a zone manager that refuses to create the target (the world hit
+%% max_active_zones): the crossing is denied, the NPC survives.
+npc_transfer_zone_manager_error_keeps_entity() ->
+    ZMPid = start_mock_zone_manager(#{ensure_zone => {error, max_zones_reached}}),
+    Pid = start_zone(#{
+        world_id => ~"npc_transfer_zm_error",
+        coords => {0, 0},
+        zone_size => ?NPC_MARGIN_ZONE_SIZE,
+        rehome_margin => ?NPC_MARGIN_REHOME_MARGIN,
+        zone_manager_pid => ZMPid
+    }),
+    try
+        asobi_zone:add_entity(Pid, ~"npc1", #{type => ~"npc", x => 245.0, y => 0.0}),
+        timer:sleep(10),
+        asobi_zone:tick(Pid, 1),
+        timer:sleep(20),
+        Npc = maps:get(~"npc1", asobi_zone:get_entities(Pid)),
+        ?assert(maps:get(x, Npc) < ?NPC_MARGIN_ZONE_SIZE)
+    after
+        gen_server:stop(Pid),
+        ZMPid ! stop
+    end.
+
+%% asobi#271: an unloaded neighbour is the normal state under lazy_zones, so
+%% the NPC crossing path asks the zone manager to create it - exactly as
+%% asobi_world_server:handle_move/4 does for a crossing player - and tells
+%% the world server about the creation so it can backfill subscribers (#275).
+npc_transfer_creates_unloaded_target_zone() ->
+    WorldId = ~"npc_transfer_creates_target",
+    Config = #{
+        world_id => WorldId,
+        zone_size => ?NPC_MARGIN_ZONE_SIZE,
+        rehome_margin => ?NPC_MARGIN_REHOME_MARGIN
+    },
+    ZMPid = start_mock_zone_manager(#{spawn_zone_config => Config}),
+    Pid = start_zone(Config#{
+        coords => {0, 0}, zone_manager_pid => ZMPid, world_server_pid => self()
+    }),
+    flush_messages(),
+    try
+        asobi_zone:add_entity(Pid, ~"npc1", #{type => ~"npc", x => 245.0, y => 0.0}),
+        timer:sleep(10),
+        asobi_zone:tick(Pid, 1),
+        timer:sleep(50),
+        ?assertNot(maps:is_key(~"npc1", asobi_zone:get_entities(Pid))),
+        receive
+            {'$gen_cast', {zone_created, Coords, TargetPid}} ->
+                ?assertEqual({1, 0}, Coords),
+                ?assert(maps:is_key(~"npc1", asobi_zone:get_entities(TargetPid))),
+                gen_server:stop(TargetPid)
+        after 1000 -> ?assert(false, timeout_waiting_for_zone_created)
+        end
+    after
+        gen_server:stop(Pid),
+        ZMPid ! stop
     end.
 
 reap_stops_empty_zone() ->
@@ -656,17 +721,35 @@ reap_declines_when_occupied() ->
     ZMPid ! stop.
 
 start_mock_zone_manager() ->
-    spawn(fun() -> mock_zm_loop([]) end).
+    start_mock_zone_manager(#{}).
 
-mock_zm_loop(Touches) ->
+start_mock_zone_manager(Opts) ->
+    spawn(fun() -> mock_zm_loop([], Opts) end).
+
+mock_zm_loop(Touches, Opts) ->
     receive
         {'$gen_cast', {touch_zone, Coords}} ->
-            mock_zm_loop([Coords | Touches]);
+            mock_zm_loop([Coords | Touches], Opts);
         {get_touches, From} ->
             From ! {touches, Touches},
-            mock_zm_loop(Touches);
+            mock_zm_loop(Touches, Opts);
+        {'$gen_call', From, {lookup_zone, _Coords}} ->
+            gen_server:reply(From, not_loaded),
+            mock_zm_loop(Touches, Opts);
+        {'$gen_call', From, {ensure_zone, Coords}} ->
+            gen_server:reply(From, mock_zm_ensure(Coords, Opts)),
+            mock_zm_loop(Touches, Opts);
         stop ->
             ok
+    end.
+
+mock_zm_ensure(Coords, Opts) ->
+    case maps:get(ensure_zone, Opts, undefined) of
+        undefined ->
+            Config = maps:get(spawn_zone_config, Opts, #{}),
+            {ok, start_zone(Config#{coords => Coords}), created};
+        Reply ->
+            Reply
     end.
 
 flush_messages() ->


### PR DESCRIPTION
Closes #271

## Problem

A player crossing into an unloaded zone gets it created for them - `asobi_world_server:handle_move/4` calls `asobi_zone_manager:ensure_zone/2` before it moves anyone (#258). An NPC crossing the same boundary did a bare `pg:get_members` in `asobi_zone:resolve_zone_crossings/1` and was deleted outright on a miss. With `lazy_zones` an unloaded neighbour is the normal state, so NPCs ceased to exist at any boundary a player had not happened to cross first.

## Fix

- `asobi_zone` resolves an NPC's target zone the same way the player path does: pg first (unchanged hot path, no manager involved when the target is loaded), then `asobi_zone_manager:ensure_zone/3` on a miss.
- If the target still cannot be resolved - no zone manager, `max_zones_reached`, an overloaded/restarting manager - the crossing is a no-op: the NPC stays in this zone, clamped back inside its bounds exactly as a rate-limited player is, instead of being destroyed. Still logged and telemetried (`npc_transfer_zone_unavailable` / `zone_unavailable`), now carrying the reason.
- The manager call is bounded rather than the 5s gen_server default (`ensure_zone/3`, 1s here). The manager's own work on that path is an ETS lookup plus `supervisor:start_child` - the new zone's snapshot load happens in its own `handle_continue` - so blowing the bound means the manager is saturated, and the NPC waiting a tick beats stalling the zone's tick loop.
- A zone this path creates notifies the world server via the new `asobi_world_server:zone_created/3` cast, so already-connected players whose interest ring already covered those coords get subscribed - the same backfill #275 needs for player- and script-created zones. Without it the NPC would arrive in a zone nobody is watching.

Zone creation stays capped by `max_active_zones`; hitting the cap denies the crossing and keeps the NPC.

## Tests

- `asobi_zone_tests`: target unresolvable (no manager) keeps + clamps the NPC and stays observable; manager returning `{error, max_zones_reached}` keeps + clamps; a crossing into an unloaded zone creates it, delivers the NPC there and notifies the world server.
- `asobi_world_zone_integration_tests`: end-to-end on a lazy world - an NPC crossing east into a not-loaded `{2,1}` creates that zone, arrives in it, and a stationary neighbour whose ring already covered it receives the entity.

`rebar3 fmt` / `xref` / `dialyzer` / `eunit` (530 tests, 0 failures) / `ex_doc` / `fmt --check` all green.