### PR TITLE
fix: read entity x/y/type under binary keys as well as atom keys

### DIFF
--- a/guides/world-server.md
+++ b/guides/world-server.md
@@ -320,6 +320,15 @@ post_tick(_TickN, State) ->
 | `get_state/2` | no | Per-player state view |
 | `vote_resolved/3` | no | Handle vote result (inherited from match voting) |
 
+### Entity keys
+
+Entity maps are yours: asobi stores whatever a callback returns and only
+reads `x`, `y`, `type` and `persistent` from them, for zone crossings,
+spatial queries, hibernation and snapshots. Those four are read under either
+an atom key (`x`) or a binary one (`~"x"`), so a scripting bridge that hands
+entities back binary-keyed works the same as a native Erlang module. Mixing
+shapes within one entity is not supported - keep an entity's keys consistent.
+
 ### Configuration
 
 Register your world mode in `sys.config`:

--- a/src/world/asobi_spatial.erl
+++ b/src/world/asobi_spatial.erl
@@ -38,20 +38,22 @@ query_radius(Entities, {CX, CY}, Radius, Opts) ->
     Exclude = exclude_set(Opts),
     CustomFilter = maps:get(filter, Opts, fun(_, _) -> true end),
     Results = maps:fold(
-        fun
-            (Id, #{x := X, y := Y} = Entity, Acc) ->
-                D2 = (X - CX) * (X - CX) + (Y - CY) * (Y - CY),
-                case
-                    D2 =< R2 andalso
-                        TypeFilter(Entity) andalso
-                        not maps:is_key(Id, Exclude) andalso
-                        CustomFilter(Id, Entity)
-                of
-                    true -> [{Id, Entity, math:sqrt(D2)} | Acc];
-                    false -> Acc
-                end;
-            (_Id, _Entity, Acc) ->
-                Acc
+        fun(Id, Entity, Acc) ->
+            case pos(Entity) of
+                {X, Y} ->
+                    D2 = (X - CX) * (X - CX) + (Y - CY) * (Y - CY),
+                    case
+                        D2 =< R2 andalso
+                            TypeFilter(Entity) andalso
+                            not maps:is_key(Id, Exclude) andalso
+                            CustomFilter(Id, Entity)
+                    of
+                        true -> [{Id, Entity, math:sqrt(D2)} | Acc];
+                        false -> Acc
+                    end;
+                undefined ->
+                    Acc
+            end
         end,
         [],
         Entities
@@ -74,20 +76,22 @@ query_rect(Entities, {MinX, MinY}, {MaxX, MaxY}, Opts) ->
     Exclude = exclude_set(Opts),
     CustomFilter = maps:get(filter, Opts, fun(_, _) -> true end),
     Results = maps:fold(
-        fun
-            (Id, #{x := X, y := Y} = Entity, Acc) ->
-                case
-                    X >= MinX andalso X =< MaxX andalso
-                        Y >= MinY andalso Y =< MaxY andalso
-                        TypeFilter(Entity) andalso
-                        not maps:is_key(Id, Exclude) andalso
-                        CustomFilter(Id, Entity)
-                of
-                    true -> [{Id, Entity} | Acc];
-                    false -> Acc
-                end;
-            (_Id, _Entity, Acc) ->
-                Acc
+        fun(Id, Entity, Acc) ->
+            case pos(Entity) of
+                {X, Y} ->
+                    case
+                        X >= MinX andalso X =< MaxX andalso
+                            Y >= MinY andalso Y =< MaxY andalso
+                            TypeFilter(Entity) andalso
+                            not maps:is_key(Id, Exclude) andalso
+                            CustomFilter(Id, Entity)
+                    of
+                        true -> [{Id, Entity} | Acc];
+                        false -> Acc
+                    end;
+                undefined ->
+                    Acc
+            end
         end,
         [],
         Entities
@@ -134,12 +138,17 @@ take([H | T], N) -> [H | take(T, N - 1)].
 ) -> [{float(), binary(), map()}].
 collect_with_distance([], _, _, _, _, _, Acc) ->
     Acc;
-collect_with_distance([{Id, #{x := X, y := Y} = Entity} | Rest], CX, CY, TF, Excl, CF, Acc) ->
-    case TF(Entity) andalso not maps:is_key(Id, Excl) andalso CF(Id, Entity) of
-        true ->
-            D2 = (X - CX) * (X - CX) + (Y - CY) * (Y - CY),
-            collect_with_distance(Rest, CX, CY, TF, Excl, CF, [{D2, Id, Entity} | Acc]);
-        false ->
+collect_with_distance([{Id, Entity} | Rest], CX, CY, TF, Excl, CF, Acc) when is_map(Entity) ->
+    case pos(Entity) of
+        {X, Y} ->
+            case TF(Entity) andalso not maps:is_key(Id, Excl) andalso CF(Id, Entity) of
+                true ->
+                    D2 = (X - CX) * (X - CX) + (Y - CY) * (Y - CY),
+                    collect_with_distance(Rest, CX, CY, TF, Excl, CF, [{D2, Id, Entity} | Acc]);
+                false ->
+                    collect_with_distance(Rest, CX, CY, TF, Excl, CF, Acc)
+            end;
+        undefined ->
             collect_with_distance(Rest, CX, CY, TF, Excl, CF, Acc)
     end;
 collect_with_distance([_ | Rest], CX, CY, TF, Excl, CF, Acc) ->
@@ -156,14 +165,16 @@ format_nearest([{D2, Id, E} | Rest]) ->
 %% -------------------------------------------------------------------
 
 -spec in_range(map(), map(), number()) -> boolean().
-in_range(#{x := X1, y := Y1}, #{x := X2, y := Y2}, Range) ->
+in_range(A, B, Range) ->
+    {X1, Y1} = pos(A),
+    {X2, Y2} = pos(B),
     DX = X2 - X1,
     DY = Y2 - Y1,
     DX * DX + DY * DY =< Range * Range.
 
 -spec distance(map(), map()) -> float().
-distance(#{x := X1, y := Y1}, #{x := X2, y := Y2}) ->
-    distance_pos({X1, Y1}, {X2, Y2}).
+distance(A, B) ->
+    distance_pos(pos(A), pos(B)).
 
 -spec distance_pos({number(), number()}, {number(), number()}) -> float().
 distance_pos({X1, Y1}, {X2, Y2}) ->
@@ -177,17 +188,25 @@ distance_pos({X1, Y1}, {X2, Y2}) ->
 
 type_filter(#{type := Types}) when is_list(Types) ->
     Set = maps:from_keys(Types, true),
-    fun
-        (#{type := T}) -> maps:is_key(T, Set);
-        (_) -> false
-    end;
+    fun(E) -> maps:is_key(entity_type(E), Set) end;
 type_filter(#{type := Type}) ->
-    fun
-        (#{type := T}) -> T =:= Type;
-        (_) -> false
-    end;
+    fun(E) -> entity_type(E) =:= Type end;
 type_filter(_) ->
     fun(_) -> true end.
+
+%% Entity maps are game-supplied: an Erlang game module hands them over
+%% atom-keyed, the Lua bridge hands them over binary-keyed. Read both, or
+%% every query silently skips every entity a Lua world owns. See
+%% widgrensit/asobi#269.
+-spec pos(term()) -> {number(), number()} | undefined.
+pos(#{x := X, y := Y}) when is_number(X), is_number(Y) -> {X, Y};
+pos(#{~"x" := X, ~"y" := Y}) when is_number(X), is_number(Y) -> {X, Y};
+pos(_Entity) -> undefined.
+
+-spec entity_type(term()) -> term().
+entity_type(#{type := T}) -> T;
+entity_type(#{~"type" := T}) -> T;
+entity_type(_Entity) -> undefined.
 
 exclude_set(#{exclude := Ids}) when is_list(Ids) ->
     maps:from_keys(Ids, true);

--- a/src/world/asobi_zone.erl
+++ b/src/world/asobi_zone.erl
@@ -306,8 +306,9 @@ handle_call(
         case Grid of
             undefined ->
                 [
-                    {Id, {maps:get(x, E), maps:get(y, E)}}
-                 || {Id, E, _Dist} <- asobi_spatial:query_radius(Entities, Center, Radius)
+                    {Id, entity_pos(E)}
+                 || {Id, E, _Dist} <- asobi_spatial:query_radius(Entities, Center, Radius),
+                    entity_pos(E) =/= undefined
                 ];
             _ ->
                 asobi_spatial_grid:query_radius(Center, Radius, Grid)
@@ -322,8 +323,9 @@ handle_call(
         case Grid of
             undefined ->
                 [
-                    {Id, {maps:get(x, E), maps:get(y, E)}}
-                 || {Id, E} <- asobi_spatial:query_rect(Entities, TopLeft, BottomRight)
+                    {Id, entity_pos(E)}
+                 || {Id, E} <- asobi_spatial:query_rect(Entities, TopLeft, BottomRight),
+                    entity_pos(E) =/= undefined
                 ];
             _ ->
                 asobi_spatial_grid:query_rect(TopLeft, BottomRight, Grid)
@@ -861,8 +863,11 @@ reindex_clamped(_DeniedList, undefined) ->
     undefined;
 reindex_clamped([], Grid) ->
     Grid;
-reindex_clamped([{Id, #{x := X, y := Y}} | Rest], Grid) ->
-    reindex_clamped(Rest, asobi_spatial_grid:update(Id, {X, Y}, Grid));
+reindex_clamped([{Id, Entity} | Rest], Grid) when is_map(Entity) ->
+    case entity_pos(Entity) of
+        undefined -> reindex_clamped(Rest, Grid);
+        Pos -> reindex_clamped(Rest, asobi_spatial_grid:update(Id, Pos, Grid))
+    end;
 reindex_clamped([_ | Rest], Grid) ->
     reindex_clamped(Rest, Grid).
 
@@ -891,14 +896,20 @@ rehome_or_clamp(WorldServerPid, Id, Pos, Entity, Coords, ZoneSize) ->
 %% it. Epsilon keeps the clamped point strictly inside (at the exact upper
 %% edge, pos_to_zone/3 would compute the next zone over again).
 -spec clamp_to_zone(map(), {integer(), integer()}, pos_integer()) -> map().
-clamp_to_zone(#{x := X, y := Y} = Entity, {ZX, ZY}, ZoneSize) ->
-    Eps = 1.0e-6,
-    XLo = ZX * ZoneSize * 1.0,
-    YLo = ZY * ZoneSize * 1.0,
-    Entity#{
-        x => min(max(X, XLo), XLo + ZoneSize - Eps),
-        y => min(max(Y, YLo), YLo + ZoneSize - Eps)
-    }.
+clamp_to_zone(Entity, {ZX, ZY}, ZoneSize) ->
+    case entity_pos(Entity) of
+        undefined ->
+            Entity;
+        {X, Y} ->
+            Eps = 1.0e-6,
+            XLo = ZX * ZoneSize * 1.0,
+            YLo = ZY * ZoneSize * 1.0,
+            entity_with_pos(
+                Entity,
+                min(max(X, XLo), XLo + ZoneSize - Eps),
+                min(max(Y, YLo), YLo + ZoneSize - Eps)
+            )
+    end.
 
 %% Explicit -spec so eqwalizer treats ToRehome's element type as ground truth
 %% at the move_player/4 call site above, rather than inferring term() through
@@ -909,31 +920,69 @@ clamp_to_zone(#{x := X, y := Y} = Entity, {ZX, ZY}, ZoneSize) ->
     ]}.
 find_zone_crossings(Entities, Coords, ZoneSize, GridSize, RehomeMargin) ->
     maps:fold(
-        fun
-            (Id, #{type := ~"npc", x := X, y := Y} = Entity, {Rem, Trans, Rehome}) when
-                is_binary(Id), is_number(X), is_number(Y)
-            ->
-                case classify_crossing({X, Y}, Coords, ZoneSize, GridSize, RehomeMargin) of
-                    same ->
-                        {Rem, Trans, Rehome};
-                    {crossed, NewCoords} ->
-                        {[Id | Rem], [{Id, NewCoords, Entity} | Trans], Rehome}
-                end;
-            (Id, #{type := ~"player", x := X, y := Y} = Entity, {Rem, Trans, Rehome}) when
-                is_binary(Id), is_number(X), is_number(Y)
-            ->
-                case classify_crossing({X, Y}, Coords, ZoneSize, GridSize, RehomeMargin) of
-                    same ->
-                        {Rem, Trans, Rehome};
-                    {crossed, _NewCoords} ->
-                        {Rem, Trans, [{Id, {X, Y}, Entity} | Rehome]}
-                end;
-            (_, _, Acc) ->
-                Acc
+        fun(Id, Entity, Acc) ->
+            fold_crossing(Id, Entity, Acc, {Coords, ZoneSize, GridSize, RehomeMargin})
         end,
         {[], [], []},
         Entities
     ).
+
+-spec fold_crossing(
+    term(),
+    term(),
+    Acc,
+    {{integer(), integer()}, pos_integer(), pos_integer(), number()}
+) -> Acc when
+    Acc ::
+        {[binary()], [{binary(), {integer(), integer()}, map()}], [
+            {binary(), {number(), number()}, map()}
+        ]}.
+fold_crossing(Id, Entity, {Rem, Trans, Rehome} = Acc, {Coords, ZoneSize, GridSize, Margin}) when
+    is_binary(Id), is_map(Entity)
+->
+    case {entity_type(Entity, ~"unknown"), entity_pos(Entity)} of
+        {~"npc", {_, _} = Pos} ->
+            case classify_crossing(Pos, Coords, ZoneSize, GridSize, Margin) of
+                same -> Acc;
+                {crossed, NewCoords} -> {[Id | Rem], [{Id, NewCoords, Entity} | Trans], Rehome}
+            end;
+        {~"player", {_, _} = Pos} ->
+            case classify_crossing(Pos, Coords, ZoneSize, GridSize, Margin) of
+                same -> Acc;
+                {crossed, _NewCoords} -> {Rem, Trans, [{Id, Pos, Entity} | Rehome]}
+            end;
+        _ ->
+            Acc
+    end;
+fold_crossing(_Id, _Entity, Acc, _Cfg) ->
+    Acc.
+
+%% Entity maps are game-supplied data. An Erlang game module hands the zone
+%% atom keys, but the Lua bridge decodes Luerl tables straight into
+%% binary-keyed maps, so every entity field the zone reads has to accept
+%% both shapes - otherwise re-homing, NPC transfer, snapshotting and grid
+%% indexing are all silently inert for a Lua world. See widgrensit/asobi#269.
+-spec entity_pos(map()) -> {number(), number()} | undefined.
+entity_pos(#{x := X, y := Y}) when is_number(X), is_number(Y) ->
+    {X, Y};
+entity_pos(#{~"x" := X, ~"y" := Y}) when is_number(X), is_number(Y) ->
+    {X, Y};
+entity_pos(_Entity) ->
+    undefined.
+
+-spec entity_with_pos(map(), number(), number()) -> map().
+entity_with_pos(#{x := _, y := _} = Entity, X, Y) -> Entity#{x => X, y => Y};
+entity_with_pos(Entity, X, Y) -> Entity#{~"x" => X, ~"y" => Y}.
+
+-spec entity_type(map(), binary()) -> binary().
+entity_type(#{type := Type}, _Default) when is_binary(Type) -> Type;
+entity_type(#{~"type" := Type}, _Default) when is_binary(Type) -> Type;
+entity_type(_Entity, Default) -> Default.
+
+-spec entity_persistent(map()) -> boolean().
+entity_persistent(#{persistent := P}) when is_boolean(P) -> P;
+entity_persistent(#{~"persistent" := P}) when is_boolean(P) -> P;
+entity_persistent(_Entity) -> true.
 
 %% Hysteresis: pos_to_zone/3 disagreeing with Coords alone is a hard edge
 %% with zero margin, so an entity jittering across a boundary crosses every
@@ -970,8 +1019,8 @@ past_zone_margin({X, Y}, {ZX, ZY}, ZoneSize, RehomeMargin) ->
 snapshot_entities(Entities) ->
     maps:filter(
         fun(_Id, E) ->
-            maps:get(type, E, ~"unknown") =/= ~"player" andalso
-                maps:get(persistent, E, true)
+            entity_type(E, ~"unknown") =/= ~"player" andalso
+                entity_persistent(E)
         end,
         Entities
     ).
@@ -1039,7 +1088,7 @@ notify_zone_manager_terminated(_) ->
 has_tickable_entities(Entities) ->
     maps:fold(
         fun
-            (_, #{type := ~"npc"}, _) -> true;
+            (_, E, Acc) when is_map(E) -> Acc orelse entity_type(E, ~"unknown") =:= ~"npc";
             (_, _, Acc) -> Acc
         end,
         false,
@@ -1176,8 +1225,11 @@ bound_debug_term(Term) ->
 
 spatial_grid_insert(_EntityId, _EntityState, undefined) ->
     undefined;
-spatial_grid_insert(EntityId, #{x := X, y := Y}, Grid) ->
-    asobi_spatial_grid:insert(EntityId, {X, Y}, Grid);
+spatial_grid_insert(EntityId, EntityState, Grid) when is_map(EntityState) ->
+    case entity_pos(EntityState) of
+        undefined -> Grid;
+        Pos -> asobi_spatial_grid:insert(EntityId, Pos, Grid)
+    end;
 spatial_grid_insert(_EntityId, _EntityState, Grid) ->
     Grid.
 
@@ -1240,10 +1292,20 @@ sync_spatial_grid(OldEntities, NewEntities, Grid) when is_map(Grid) ->
     %% Update/insert entities with changed or new positions
     maps:fold(
         fun
-            (Id, #{x := X, y := Y}, G) ->
-                case maps:find(Id, OldEntities) of
-                    {ok, #{x := X, y := Y}} -> G;
-                    _ -> asobi_spatial_grid:update(Id, {X, Y}, G)
+            (Id, Entity, G) when is_map(Entity) ->
+                case entity_pos(Entity) of
+                    undefined ->
+                        G;
+                    Pos ->
+                        case maps:find(Id, OldEntities) of
+                            {ok, Old} when is_map(Old) ->
+                                case entity_pos(Old) of
+                                    Pos -> G;
+                                    _ -> asobi_spatial_grid:update(Id, Pos, G)
+                                end;
+                            _ ->
+                                asobi_spatial_grid:update(Id, Pos, G)
+                        end
                 end;
             (_Id, _Entity, G) ->
                 G

--- a/test/asobi_lua_shaped_world_game.erl
+++ b/test/asobi_lua_shaped_world_game.erl
@@ -1,0 +1,55 @@
+%% Mirrors what the Lua bridge hands a zone: every entity map that comes back
+%% out of a game callback is binary-keyed, because it round-tripped through
+%% Luerl. See widgrensit/asobi#269.
+-module(asobi_lua_shaped_world_game).
+-behaviour(asobi_world).
+
+-export([init/1, join/2, leave/2, spawn_position/2]).
+-export([zone_tick/2, handle_input/3, post_tick/2]).
+
+-spec init(map()) -> {ok, map()}.
+init(_Config) ->
+    {ok, #{}}.
+
+-spec join(binary(), map()) -> {ok, map()}.
+join(_PlayerId, State) ->
+    {ok, State}.
+
+-spec leave(binary(), map()) -> {ok, map()}.
+leave(_PlayerId, State) ->
+    {ok, State}.
+
+-spec spawn_position(binary(), map()) -> {ok, {number(), number()}}.
+spawn_position(_PlayerId, _State) ->
+    {ok, {100.0, 100.0}}.
+
+-spec zone_tick(map(), term()) -> {map(), term()}.
+zone_tick(Entities, ZoneState) ->
+    {binarise_entities(Entities), ZoneState}.
+
+-spec handle_input(binary(), map(), map()) -> {ok, map()} | {error, term()}.
+handle_input(PlayerId, #{~"action" := ~"move", ~"x" := X, ~"y" := Y}, Entities) ->
+    Entity = maps:get(PlayerId, Entities, #{~"type" => ~"player"}),
+    Entity1 = (binarise(Entity))#{~"x" => X, ~"y" => Y},
+    {ok, (binarise_entities(Entities))#{PlayerId => Entity1}};
+handle_input(_PlayerId, _Input, Entities) ->
+    {ok, binarise_entities(Entities)}.
+
+-spec post_tick(non_neg_integer(), map()) -> {ok, map()}.
+post_tick(_TickN, State) ->
+    {ok, State}.
+
+binarise_entities(Entities) ->
+    maps:map(
+        fun
+            (_Id, E) when is_map(E) -> binarise(E);
+            (_Id, V) -> V
+        end,
+        Entities
+    ).
+
+binarise(Entity) ->
+    maps:from_list([{key(K), V} || {K, V} <- maps:to_list(Entity)]).
+
+key(K) when is_atom(K) -> atom_to_binary(K, utf8);
+key(K) -> K.

--- a/test/asobi_spatial_SUITE.erl
+++ b/test/asobi_spatial_SUITE.erl
@@ -20,7 +20,8 @@
     in_range_false/1,
     distance_entities/1,
     distance_pos/1,
-    entities_without_coords_skipped/1
+    entities_without_coords_skipped/1,
+    binary_keyed_entities_queryable/1
 ]).
 
 all() ->
@@ -41,7 +42,8 @@ all() ->
         in_range_false,
         distance_entities,
         distance_pos,
-        entities_without_coords_skipped
+        entities_without_coords_skipped,
+        binary_keyed_entities_queryable
     ].
 
 %% --- Test data ---
@@ -194,4 +196,27 @@ entities_without_coords_skipped(_Config) ->
     E = #{~"no_pos" => #{name => ~"test"}, ~"with_pos" => #{x => 1.0, y => 1.0, type => ~"npc"}},
     Results = asobi_spatial:query_radius(E, {0.0, 0.0}, 10.0),
     ?assertEqual(1, length(Results)),
+    ok.
+
+%% Regression for widgrensit/asobi#269: entity maps are game-supplied, and
+%% the Lua bridge hands them over binary-keyed. Matching x/y/type by atom key
+%% alone silently skipped every entity a Lua world owns, so every spatial
+%% query answered empty.
+binary_keyed_entities_queryable(_Config) ->
+    E = #{
+        ~"a" => #{~"x" => 0.0, ~"y" => 0.0, ~"type" => ~"npc"},
+        ~"b" => #{~"x" => 3.0, ~"y" => 4.0, ~"type" => ~"player"}
+    },
+    Radius = asobi_spatial:query_radius(E, {0.0, 0.0}, 6.0),
+    ?assertEqual(2, length(Radius)),
+    Typed = asobi_spatial:query_radius(E, {0.0, 0.0}, 6.0, #{type => ~"npc"}),
+    ?assertEqual([~"a"], [Id || {Id, _, _} <- Typed]),
+    Rect = asobi_spatial:query_rect(E, {-1.0, -1.0}, {5.0, 5.0}),
+    ?assertEqual(2, length(Rect)),
+    [{Nearest, _, _}] = asobi_spatial:nearest(E, {3.0, 4.0}, 1),
+    ?assertEqual(~"b", Nearest),
+    A = maps:get(~"a", E),
+    B = maps:get(~"b", E),
+    ?assert(asobi_spatial:in_range(A, B, 5.0)),
+    ?assert(abs(asobi_spatial:distance(A, B) - 5.0) < 0.001),
     ok.

--- a/test/asobi_world_zone_integration_tests.erl
+++ b/test/asobi_world_zone_integration_tests.erl
@@ -64,6 +64,8 @@ world_zone_integration_test_() ->
         {"small grid backward compat", fun small_grid_backward_compat/0},
         {"world.input crossing a zone boundary rehomes the player",
             fun world_input_rehomes_across_boundary/0},
+        {"a binary-keyed (Lua-shaped) player entity rehomes across a boundary",
+            fun binary_keyed_player_rehomes_across_boundary/0},
         {"world.input past the world's far edge does not crash the world server",
             fun world_input_past_far_edge_survives/0},
         {"a script-owned player-typed entity the world server never joined survives crossing",
@@ -712,4 +714,33 @@ small_grid_backward_compat() ->
     Info = asobi_world_server:get_info(Pid),
     ?assertEqual(1, maps:get(player_count, Info)),
     ?assertEqual(running, maps:get(status, Info)),
+    stop_world(Ctx).
+
+%% Regression for widgrensit/asobi#269: the crossing check matched entity
+%% fields by atom key only, but every entity map a Lua world produces comes
+%% back from Luerl binary-keyed - so no player in a Lua world ever crossed a
+%% boundary, and their interest ring stayed frozen at the spawn zone for the
+%% whole session. asobi_lua_shaped_world_game reproduces that key shape
+%% without pulling Lua into this repo.
+binary_keyed_player_rehomes_across_boundary() ->
+    Ctx =
+        #{world_pid := Pid, zone_mgr := Mgr} = start_world(#{
+            lazy_zones => true, game_module => asobi_lua_shaped_world_game
+        }),
+    ?assertEqual(ok, asobi_world_server:join(Pid, ~"p1")),
+    timer:sleep(20),
+    %% Spawns at {100.0, 100.0} => zone {1,1}.
+    {ok, ZonePid1} = asobi_zone_manager:get_zone(Mgr, {1, 1}),
+    ?assert(maps:is_key(~"p1", asobi_zone:get_entities(ZonePid1))),
+
+    asobi_zone:player_input(ZonePid1, ~"p1", #{
+        ~"action" => ~"move", ~"x" => 250.0, ~"y" => 250.0
+    }),
+    timer:sleep(150),
+
+    ?assertMatch({ok, _}, asobi_zone_manager:get_zone(Mgr, {2, 2})),
+    {ok, ZonePid2} = asobi_zone_manager:get_zone(Mgr, {2, 2}),
+    Entity = maps:get(~"p1", asobi_zone:get_entities(ZonePid2)),
+    ?assertEqual(250.0, maps:get(~"x", Entity)),
+    ?assertNot(maps:is_key(~"p1", asobi_zone:get_entities(ZonePid1))),
     stop_world(Ctx).

--- a/test/asobi_zone_tests.erl
+++ b/test/asobi_zone_tests.erl
@@ -72,6 +72,10 @@ zone_test_() ->
             fun npc_transfer_zone_manager_error_keeps_entity/0},
         {"an NPC crossing into an unloaded zone has it created for it",
             fun npc_transfer_creates_unloaded_target_zone/0},
+        {"a binary-keyed NPC past the boundary margin transfers too",
+            fun binary_keyed_npc_past_margin_transfers/0},
+        {"a zone holding only binary-keyed NPCs does not hibernate",
+            fun tick_no_hibernate_with_binary_keyed_npcs/0},
         {"reap stops a zone with no entities", fun reap_stops_empty_zone/0},
         {"reap declines and re-touches a zone that still has entities",
             fun reap_declines_when_occupied/0}
@@ -678,6 +682,40 @@ npc_transfer_creates_unloaded_target_zone() ->
         gen_server:stop(Pid),
         ZMPid ! stop
     end.
+
+%% Regression for widgrensit/asobi#269: the crossing fold matched entity
+%% fields by atom key only, so an entity map shaped the way the Lua bridge
+%% hands one over - every key a binary - never reached classify_crossing/5 at
+%% all and simply stayed in the wrong zone forever.
+binary_keyed_npc_past_margin_transfers() ->
+    WorldId = ~"npc_margin_past_binary",
+    Config = #{
+        world_id => WorldId,
+        zone_size => ?NPC_MARGIN_ZONE_SIZE,
+        rehome_margin => ?NPC_MARGIN_REHOME_MARGIN
+    },
+    Pid = start_zone(Config#{coords => {0, 0}}),
+    TargetPid = start_zone(Config#{coords => {1, 0}}),
+    asobi_zone:add_entity(Pid, ~"npc1", #{~"type" => ~"npc", ~"x" => 245.0, ~"y" => 0.0}),
+    timer:sleep(10),
+    asobi_zone:tick(Pid, 1),
+    timer:sleep(20),
+    ?assertNot(maps:is_key(~"npc1", asobi_zone:get_entities(Pid))),
+    ?assert(maps:is_key(~"npc1", asobi_zone:get_entities(TargetPid))),
+    gen_server:stop(Pid),
+    gen_server:stop(TargetPid).
+
+%% Same root cause as above: has_tickable_entities/1 read the type by atom
+%% key, so a zone full of Lua-owned NPCs looked empty and hibernated.
+tick_no_hibernate_with_binary_keyed_npcs() ->
+    Pid = start_zone(),
+    asobi_zone:add_entity(Pid, ~"npc1", #{~"type" => ~"npc", ~"x" => 0, ~"y" => 0}),
+    timer:sleep(10),
+    asobi_zone:tick(Pid, 1),
+    timer:sleep(50),
+    {current_function, CF} = erlang:process_info(Pid, current_function),
+    ?assertNotEqual({erlang, hibernate, 3}, CF),
+    gen_server:stop(Pid).
 
 reap_stops_empty_zone() ->
     Pid = start_zone(),


### PR DESCRIPTION
`asobi_zone` decided zone crossings by matching entity maps with atom keys
(`#{type := ~"player", x := X, y := Y}`). Every entity map a Lua world
produces comes back from Luerl binary-keyed, so the clause never matched, the
fold fell through to its catch-all, and nothing ever reached `move_player/4`:
a player's owning zone and interest ring stayed frozen at the spawn zone for
the whole session. The same assumption made five other things inert or wrong
for a Lua world - NPC out-of-bounds transfer, `has_tickable_entities/1`
(zones with NPCs hibernated), `snapshot_entities/1` (player entities got
persisted into snapshots), spatial-grid insert/reindex, and the zone-level
`query_radius`/`query_rect` fallback.

## Fix

`asobi_zone` and `asobi_spatial` now read the four fields they care about -
`x`, `y`, `type`, `persistent` - under either an atom or a binary key, via
small private helpers. Nothing is normalised or rewritten: entity maps stay
exactly the shape the game module returned, so the deltas a Lua world
broadcasts are unchanged (normalising in the bridge instead would have made
them mixed-key, since `encode_delta/1` adds binary `~"op"`/`~"id"`).

`asobi_spatial` is included because the zone's own `query_radius`/`query_rect`
delegate to it when no spatial grid is configured - fixing only the zone's
`maps:get(x, E)` would still have returned nothing.

## Tests

- `asobi_lua_shaped_world_game` - a test game module that hands entities back
  binary-keyed, reproducing the Luerl round-trip without pulling Lua into this
  repo.
- End-to-end: a binary-keyed player rehomes across a boundary via
  `world.input` (`asobi_world_zone_integration_tests`).
- Unit: a binary-keyed NPC past the margin transfers, and a zone holding only
  binary-keyed NPCs does not hibernate (`asobi_zone_tests`).
- `asobi_spatial_SUITE`: radius, rect, nearest, type filter, `in_range` and
  `distance` over binary-keyed entities.

`fmt --check`, `xref`, `dialyzer`, `ex_doc` and the full `eunit` run (530
tests) are green; `asobi_spatial_SUITE` passes.

Closes #269
