### PR TITLE
fix: recover a placement whose zone is reaped mid-flight

### DIFF
--- a/guides/large-worlds.md
+++ b/guides/large-worlds.md
@@ -65,6 +65,11 @@ A zone with subscribers resets its idle timer each tick. When subscribers drop
 to zero and the zone has no tickable entities, it enters BEAM hibernation to
 reduce memory, then is snapshotted and reaped once `zone_idle_timeout` expires.
 
+A reap is a proposal, not an order. A zone that still holds entities declines
+it, and a join or crossing that finds its zone reaped between resolving the pid
+and placing the player transparently starts a replacement zone and re-places
+them there.
+
 ## Terrain Data
 
 Terrain is separate from entities. Tile chunks are served as compressed binary

--- a/src/world/asobi_world_server.erl
+++ b/src/world/asobi_world_server.erl
@@ -871,29 +871,93 @@ place_player(
             {error, Reason, State};
         {ok, ZonePid, ZoneStatus} ->
             PlayerPid = find_player_pid(PlayerId),
-            asobi_zone:add_entity(ZonePid, PlayerId, Entity),
-            asobi_presence:send(PlayerId, {world_joined, self(), ZonePid}),
             InterestZones = interest_zones(ZoneCoords, ViewRadius, GridSize),
-            subscribe_interest_zones(InterestZones, ZMPid, PlayerId, PlayerPid),
             PlayerZones = maps:get(player_zones, State),
-            case ZoneStatus of
-                created -> backfill_zone_subscribers(ZoneCoords, ZonePid, PlayerId, PlayerZones);
-                existing -> ok
-            end,
-            %% Drain the casts above (add_entity + subscribe) by issuing a sync call to
-            %% the zone. Without this, a world.input cast from the WS handler can race
-            %% past the add_entity cast (different sender = no FIFO) and the zone's
-            %% next tick runs apply_inputs against an entities map missing the player —
-            %% the Lua handle_input's "if not e then return entities end" guard then
-            %% silently drops the input. The sync call forces the zone to process its
-            %% mailbox up to here before we reply {ok, ZonePid} to the WS handler.
-            _ = asobi_zone:get_subscriber_count(ZonePid),
-            State1 = State#{
-                player_zones => PlayerZones#{
-                    PlayerId => #{zone => ZoneCoords, interest => InterestZones}
-                }
+            Bind = #{
+                world_id => maps:get(world_id, State),
+                zone_manager_pid => ZMPid,
+                coords => ZoneCoords,
+                player_id => PlayerId,
+                entity => Entity,
+                player_pid => PlayerPid,
+                player_zones => PlayerZones,
+                subscribe_zones => InterestZones
             },
-            {ok, State1, ZonePid}
+            case bind_player_zone(Bind, ZonePid, ZoneStatus) of
+                {error, Reason} ->
+                    {error, Reason, State};
+                {ok, BoundZonePid} ->
+                    State1 = State#{
+                        player_zones => PlayerZones#{
+                            PlayerId => #{zone => ZoneCoords, interest => InterestZones}
+                        }
+                    },
+                    {ok, State1, BoundZonePid}
+            end
+    end.
+
+%% Puts the player's entity in the zone and makes that stick.
+%%
+%% The drain call is asobi#248: without it a world.input cast from the WS
+%% handler can race past the add_entity cast (different sender = no FIFO) and
+%% the zone's next tick runs apply_inputs against an entities map missing the
+%% player - the Lua handle_input's "if not e then return entities end" guard
+%% then silently drops the input. The call forces the zone to process its
+%% mailbox up to here before the caller replies to the WS handler.
+%%
+%% asobi#283: the zone can also be gone by now. ensure_zone/2 hands out a pid
+%% without a lease, so a zone that is genuinely empty when the manager's reap
+%% sweep fires stops even though this placement is already in flight against
+%% it - dropping add_entity on the floor and, before this, exiting the whole
+%% world gen_statem with `normal` on the drain call. Once the entity is in,
+%% the zone declines further reaps itself, so a single retry against a
+%% replacement zone is enough.
+-spec bind_player_zone(map(), pid(), created | existing) -> {ok, pid()} | {error, term()}.
+bind_player_zone(Bind, ZonePid, ZoneStatus) ->
+    bind_player_zone(Bind, ZonePid, ZoneStatus, 1).
+
+-spec bind_player_zone(map(), pid(), created | existing, pos_integer()) ->
+    {ok, pid()} | {error, term()}.
+bind_player_zone(Bind, ZonePid, ZoneStatus, Attempt) ->
+    #{
+        world_id := WorldId,
+        zone_manager_pid := ZMPid,
+        coords := Coords,
+        player_id := PlayerId,
+        entity := Entity,
+        player_pid := PlayerPid,
+        player_zones := PlayerZones,
+        subscribe_zones := SubscribeZones
+    } = Bind,
+    asobi_zone:add_entity(ZonePid, PlayerId, Entity),
+    asobi_presence:send(PlayerId, {world_joined, self(), ZonePid}),
+    subscribe_interest_zones(SubscribeZones, ZMPid, PlayerId, PlayerPid),
+    case PlayerPid of
+        undefined -> ok;
+        _ -> asobi_zone:subscribe(ZonePid, {PlayerId, PlayerPid})
+    end,
+    case ZoneStatus of
+        created -> backfill_zone_subscribers(Coords, ZonePid, PlayerId, PlayerZones);
+        existing -> ok
+    end,
+    case asobi_zone:sync(ZonePid) of
+        ok ->
+            {ok, ZonePid};
+        zone_gone when Attempt >= 2 ->
+            {error, zone_gone};
+        zone_gone ->
+            ?LOG_WARNING(#{
+                event => zone_reaped_during_placement,
+                world_id => WorldId,
+                player_id => PlayerId,
+                coords => Coords
+            }),
+            case asobi_zone_manager:revive_zone(ZMPid, Coords, ZonePid) of
+                {ok, NewZonePid, NewStatus} ->
+                    bind_player_zone(Bind, NewZonePid, NewStatus, Attempt + 1);
+                {error, _} = Err ->
+                    Err
+            end
     end.
 
 %% asobi#275: a zone coming into existence has to pick up every already-known
@@ -1063,79 +1127,103 @@ handle_move(
                             %% backfill_zone_subscribers/4).
                             ToSubscribe = (NewInterest -- OldInterest) -- [NewZoneCoords],
 
-                            case asobi_zone_manager:get_zone(ZMPid, OldZoneCoords) of
-                                {ok, OldZonePid} -> asobi_zone:remove_entity(OldZonePid, PlayerId);
-                                not_loaded -> ok
-                            end,
-                            PlayerPid = find_player_pid(PlayerId),
-                            asobi_zone:add_entity(NewZonePid, PlayerId, Entity),
-                            asobi_presence:send(PlayerId, {world_joined, self(), NewZonePid}),
-
-                            unsubscribe_interest_zones(ToUnsubscribe, ZMPid, PlayerId),
                             %% asobi#277: PlayerPid is undefined if this
                             %% crossing player somehow has no live session -
                             %% nothing to subscribe or notify in that case.
-                            case PlayerPid of
-                                undefined -> ok;
-                                _ -> asobi_zone:subscribe(NewZonePid, {PlayerId, PlayerPid})
-                            end,
-                            subscribe_interest_zones(ToSubscribe, ZMPid, PlayerId, PlayerPid),
-                            %% asobi#275: this crossing is what brought the zone
-                            %% into existence - any other already-connected
-                            %% player whose interest ring already covers it (a
+                            %%
+                            %% asobi#275 (inside bind_player_zone/3): this
+                            %% crossing may be what brought the zone into
+                            %% existence - any other already-connected player
+                            %% whose interest ring already covers it (a
                             %% stationary neighbour, most commonly) tried to
                             %% subscribe while it was not_loaded and was
                             %% silently skipped, with nothing to retry it since.
-                            case ZoneStatus of
-                                created ->
-                                    backfill_zone_subscribers(
-                                        NewZoneCoords, NewZonePid, PlayerId, PlayerZones
-                                    );
-                                existing ->
-                                    ok
-                            end,
-                            %% Same race place_player/4's join path guards against: a
-                            %% world.input cast can reach the new zone before add_entity
-                            %% lands, since add_entity and the WS handler's cast are
-                            %% different senders (no FIFO guarantee between them).
-                            _ = asobi_zone:get_subscriber_count(NewZonePid),
+                            %%
+                            %% asobi#283: binding runs before the player is
+                            %% taken out of the old zone, for the same reason
+                            %% asobi#258 pre-checks the destination - a
+                            %% destination that turns out to be unusable leaves
+                            %% the crossing a no-op instead of stranding the
+                            %% player zoneless.
+                            PlayerPid = find_player_pid(PlayerId),
+                            Bind = #{
+                                world_id => WorldId,
+                                zone_manager_pid => ZMPid,
+                                coords => NewZoneCoords,
+                                player_id => PlayerId,
+                                entity => Entity,
+                                player_pid => PlayerPid,
+                                player_zones => PlayerZones,
+                                subscribe_zones => ToSubscribe
+                            },
+                            case bind_player_zone(Bind, NewZonePid, ZoneStatus) of
+                                {error, BindReason} ->
+                                    ?LOG_WARNING(#{
+                                        event => move_zone_unavailable,
+                                        world_id => WorldId,
+                                        player_id => PlayerId,
+                                        coords => NewZoneCoords,
+                                        reason => BindReason
+                                    }),
+                                    asobi_telemetry:game_error(zone_unavailable, #{
+                                        world_id => WorldId,
+                                        coords => NewZoneCoords,
+                                        reason => BindReason
+                                    }),
+                                    keep_state_and_data;
+                                {ok, BoundZonePid} ->
+                                    case asobi_zone_manager:get_zone(ZMPid, OldZoneCoords) of
+                                        {ok, OldZonePid} ->
+                                            asobi_zone:remove_entity(OldZonePid, PlayerId);
+                                        not_loaded ->
+                                            ok
+                                    end,
+                                    unsubscribe_interest_zones(ToUnsubscribe, ZMPid, PlayerId),
 
-                            asobi_world_chat:player_zone_changed(
-                                PlayerId, OldZoneCoords, NewZoneCoords, GridSize, ChatState
-                            ),
+                                    asobi_world_chat:player_zone_changed(
+                                        PlayerId, OldZoneCoords, NewZoneCoords, GridSize, ChatState
+                                    ),
 
-                            PlayerZones1 = maps:remove(PlayerId, PlayerZones),
-                            %% The old zone is often still in the player's own
-                            %% new ring (see ToUnsubscribe above) -
-                            %% zone_still_occupied/3 only knows about other
-                            %% players, so check that first.
-                            case
-                                lists:member(OldZoneCoords, NewInterest) orelse
-                                    zone_still_occupied(OldZoneCoords, PlayerId, PlayerZones1)
-                            of
-                                true -> ok;
-                                false -> asobi_zone_manager:release_zone(ZMPid, OldZoneCoords)
-                            end,
+                                    PlayerZones1 = maps:remove(PlayerId, PlayerZones),
+                                    %% The old zone is often still in the player's own
+                                    %% new ring (see ToUnsubscribe above) -
+                                    %% zone_still_occupied/3 only knows about other
+                                    %% players, so check that first.
+                                    case
+                                        lists:member(OldZoneCoords, NewInterest) orelse
+                                            zone_still_occupied(
+                                                OldZoneCoords, PlayerId, PlayerZones1
+                                            )
+                                    of
+                                        true ->
+                                            ok;
+                                        false ->
+                                            asobi_zone_manager:release_zone(ZMPid, OldZoneCoords)
+                                    end,
 
-                            _ =
-                                case PlayerPid of
-                                    undefined ->
-                                        ok;
-                                    _ ->
-                                        PlayerPid !
-                                            {asobi_message, {world_zone_changed, NewZonePid}}
-                                end,
-                            Players1 = maps:update_with(
-                                PlayerId,
-                                fun(Meta) -> Meta#{position => NewPos} end,
-                                Players
-                            ),
-                            {keep_state, State#{
-                                players => Players1,
-                                player_zones => PlayerZones1#{
-                                    PlayerId => #{zone => NewZoneCoords, interest => NewInterest}
-                                }
-                            }}
+                                    _ =
+                                        case PlayerPid of
+                                            undefined ->
+                                                ok;
+                                            _ ->
+                                                PlayerPid !
+                                                    {asobi_message,
+                                                        {world_zone_changed, BoundZonePid}}
+                                        end,
+                                    Players1 = maps:update_with(
+                                        PlayerId,
+                                        fun(Meta) -> Meta#{position => NewPos} end,
+                                        Players
+                                    ),
+                                    {keep_state, State#{
+                                        players => Players1,
+                                        player_zones => PlayerZones1#{
+                                            PlayerId => #{
+                                                zone => NewZoneCoords, interest => NewInterest
+                                            }
+                                        }
+                                    }}
+                            end
                     end
             end
     end.

--- a/src/world/asobi_zone.erl
+++ b/src/world/asobi_zone.erl
@@ -11,7 +11,7 @@ via `asobi_spatial`. Zones are created and reaped lazily as players move.
 -export([tick/2, player_input/3, add_entity/3, remove_entity/2]).
 -export([spawn_entity/3, spawn_entity/4, spawn_entities/2, despawn_entity/2]).
 -export([subscribe/2, unsubscribe/2]).
--export([get_entities/1, get_subscriber_count/1]).
+-export([get_entities/1, get_subscriber_count/1, sync/1]).
 -export([start_entity_timer/2, cancel_entity_timer/3]).
 -export([query_radius/3, query_rect/3]).
 -export([init/1, handle_call/3, handle_cast/2, handle_continue/2, handle_info/2, terminate/2]).
@@ -82,6 +82,32 @@ get_entities(Pid) ->
 get_subscriber_count(Pid) ->
     case gen_server:call(Pid, get_subscriber_count) of
         N when is_integer(N), N >= 0 -> N
+    end.
+
+-doc """
+Drain everything this caller has already cast to the zone, reporting whether
+the zone is still alive rather than exiting the caller if it is not.
+
+Callers that cast to a zone and then need the cast to have landed (the join
+and crossing paths in `asobi_world_server`) must not use a raw
+`get_subscriber_count/1` for that: a zone reaped between the caller resolving
+its pid and the drain exits the caller with `{normal, {gen_server, call, _}}`,
+taking the whole world down over one player's placement
+(widgrensit/asobi#283). `ok` means every earlier cast from this process was
+processed; `zone_gone` means the zone died and those casts were dropped.
+""".
+-spec sync(pid()) -> ok | zone_gone.
+sync(Pid) ->
+    try
+        _ = gen_server:call(Pid, get_subscriber_count),
+        ok
+    catch
+        exit:{Reason, {gen_server, call, _}} when
+            Reason =:= noproc; Reason =:= normal; Reason =:= shutdown; Reason =:= killed
+        ->
+            zone_gone;
+        exit:{{shutdown, _}, {gen_server, call, _}} ->
+            zone_gone
     end.
 
 -spec start_entity_timer(pid(), map()) -> ok.

--- a/src/world/asobi_zone_manager.erl
+++ b/src/world/asobi_zone_manager.erl
@@ -13,7 +13,7 @@ Hot-path lookups go through ETS directly, bypassing the gen_server.
 """.
 
 -export([start_link/1]).
--export([ensure_zone/2, ensure_zone/3, get_zone/2, touch_zone/2, release_zone/2]).
+-export([ensure_zone/2, ensure_zone/3, get_zone/2, touch_zone/2, release_zone/2, revive_zone/3]).
 -export([get_active_zones/1, zone_terminated/3, pre_warm/1]).
 -export([register_zone/3, set_zone_config/2, set_initial_zone_states/2]).
 -export([init/1, handle_call/3, handle_cast/2, handle_info/2, terminate/2]).
@@ -68,6 +68,29 @@ ensure_zone(Ref, Coords, Timeout) ->
 -spec get_zone(pid() | atom(), {integer(), integer()}) -> {ok, pid()} | not_loaded.
 get_zone(Ref, Coords) ->
     ets_lookup(Ref, Coords).
+
+-doc """
+Replace a zone that died under a caller holding its pid.
+
+`ensure_zone/2` hands out a pid without a lease on it, so a genuinely-idle
+zone can still be reaped in the gap between the lookup and the caller proving
+it occupied (widgrensit/asobi#283). The caller that notices this cannot just
+retry `ensure_zone/2`: the ETS slot still points at the dead pid until the
+manager has processed its `DOWN`, so the retry would hand back the same
+corpse. This waits for that `DOWN` (the zone's `terminate/2` snapshot has
+already run by then, so the replacement loads current state) and starts a
+fresh zone.
+
+Returns the already-live zone when someone else got there first.
+""".
+-spec revive_zone(pid() | atom(), {integer(), integer()}, pid()) ->
+    {ok, pid(), created | existing} | {error, term()}.
+revive_zone(Ref, Coords, DeadPid) when is_pid(DeadPid) ->
+    case gen_server:call(Ref, {revive_zone, Coords, DeadPid}) of
+        {ok, P, created} when is_pid(P) -> {ok, P, created};
+        {ok, P, existing} when is_pid(P) -> {ok, P, existing};
+        {error, _} = Err -> Err
+    end.
 
 -doc "Reset idle timer for a zone. Fire-and-forget.".
 -spec touch_zone(pid() | atom(), {integer(), integer()}) -> ok.
@@ -171,6 +194,26 @@ handle_call({ensure_zone, Coords}, _From, #{ets_tab := Tab} = State) ->
                     {reply, {ok, Pid, created}, State1};
                 {error, Reason} ->
                     {reply, {error, Reason}, State}
+            end
+    end;
+handle_call({revive_zone, Coords, DeadPid}, _From, #{ets_tab := Tab} = State) ->
+    case ets:lookup(Tab, Coords) of
+        [{Coords, DeadPid}] ->
+            case await_zone_down(Coords, DeadPid, State) of
+                {ok, State1} ->
+                    case start_zone(Coords, State1) of
+                        {ok, Pid, State2} -> {reply, {ok, Pid, created}, State2};
+                        {error, Reason} -> {reply, {error, Reason}, State1}
+                    end;
+                timeout ->
+                    {reply, {error, zone_stopping}, State}
+            end;
+        [{Coords, Pid}] ->
+            {reply, {ok, Pid, existing}, touch(Coords, State)};
+        [] ->
+            case start_zone(Coords, State) of
+                {ok, Pid, State1} -> {reply, {ok, Pid, created}, State1};
+                {error, Reason} -> {reply, {error, Reason}, State}
             end
     end;
 handle_call(pre_warm, _From, #{grid_size := GridSize} = State) ->
@@ -322,6 +365,27 @@ cleanup_zone(
         zone_last_active => maps:remove(Coords, Active),
         zone_monitors => Monitors1
     }.
+
+%% The manager owns a monitor on every zone it has in ETS, so the DOWN for a
+%% zone a caller has just seen die is either already in this mailbox or on its
+%% way. Consuming it here (instead of returning and letting the normal
+%% handle_info clean up later) is what makes revive_zone/3 a single atomic
+%% step from the caller's point of view. The bound is a backstop for a zone
+%% that turns out not to be dying at all - reply an error rather than start a
+%% second zone over a live one.
+-spec await_zone_down({integer(), integer()}, pid(), map()) -> {ok, map()} | timeout.
+await_zone_down(Coords, ZonePid, #{zone_monitors := Monitors} = State) ->
+    case maps:get(Coords, Monitors, undefined) of
+        undefined ->
+            {ok, cleanup_zone(Coords, State)};
+        MonRef ->
+            receive
+                {'DOWN', MonRef, process, ZonePid, _Reason} ->
+                    {ok, cleanup_zone(Coords, State)}
+            after 1_000 ->
+                timeout
+            end
+    end.
 
 reap_idle_zones(
     #{

--- a/test/asobi_world_zone_integration_tests.erl
+++ b/test/asobi_world_zone_integration_tests.erl
@@ -85,7 +85,11 @@ world_zone_integration_test_() ->
         {"the global rehome limit denies a crossing even with per-player budget to spare",
             fun rehome_denied_by_global_limit/0},
         {"a crossing that drops a zone from the ring removes its stationary occupants",
-            fun crossing_out_of_ring_removes_stationary_neighbour/0}
+            fun crossing_out_of_ring_removes_stationary_neighbour/0},
+        {"a join whose zone is reaped right after the lookup still lands the player",
+            fun join_survives_zone_reaped_after_lookup/0},
+        {"a crossing whose destination is reaped right after the lookup still lands the player",
+            fun crossing_survives_zone_reaped_after_lookup/0}
     ]}.
 
 %% Default (lazy_zones=false, grid_size=3) pre-spawns all 9 zones
@@ -744,3 +748,68 @@ binary_keyed_player_rehomes_across_boundary() ->
     ?assertEqual(250.0, maps:get(~"x", Entity)),
     ?assertNot(maps:is_key(~"p1", asobi_zone:get_entities(ZonePid1))),
     stop_world(Ctx).
+
+%% Regression widgrensit/asobi#283 (join half): ensure_zone/2 hands out a pid
+%% without a lease on it, so a zone that is genuinely empty when the manager's
+%% reap sweep fires stops while a placement is already in flight against it.
+%% The add_entity cast was dropped on the floor and the drain call that
+%% followed exited the whole world gen_statem with `normal` - every player in
+%% the world lost, over one join. Stopping the zone from inside ensure_zone/2
+%% reproduces exactly that ordering, deterministically.
+join_survives_zone_reaped_after_lookup() ->
+    Ctr = counters:new(1, []),
+    meck:new(asobi_zone_manager, [passthrough, no_link]),
+    meck:expect(asobi_zone_manager, ensure_zone, fun(Ref, Coords) ->
+        Result = meck:passthrough([Ref, Coords]),
+        reap_first_zone_at({1, 1}, Coords, Result, Ctr)
+    end),
+    Ctx = #{world_pid := Pid, zone_mgr := Mgr} = start_world(#{lazy_zones => true}),
+    try
+        ?assertEqual(ok, asobi_world_server:join(Pid, ~"p1")),
+        ?assert(is_process_alive(Pid)),
+        {ok, ZonePid} = asobi_zone_manager:get_zone(Mgr, {1, 1}),
+        ?assert(is_process_alive(ZonePid)),
+        ?assert(maps:is_key(~"p1", asobi_zone:get_entities(ZonePid)))
+    after
+        stop_world(Ctx),
+        meck:unload(asobi_zone_manager)
+    end.
+
+%% Same race on the crossing half: the destination zone a crossing just
+%% resolved can be reaped before the entity reaches it.
+crossing_survives_zone_reaped_after_lookup() ->
+    Ctr = counters:new(1, []),
+    Ctx = #{world_pid := Pid, zone_mgr := Mgr} = start_world(#{lazy_zones => true}),
+    try
+        ?assertEqual(ok, asobi_world_server:join(Pid, ~"p1")),
+        timer:sleep(20),
+        meck:new(asobi_zone_manager, [passthrough, no_link]),
+        meck:expect(asobi_zone_manager, ensure_zone, fun(Ref, Coords) ->
+            Result = meck:passthrough([Ref, Coords]),
+            reap_first_zone_at({2, 2}, Coords, Result, Ctr)
+        end),
+        %% Player starts at {100.0, 100.0} => zone {1,1}; move into {2,2}.
+        asobi_world_server:move_player(Pid, ~"p1", {250.0, 250.0}),
+        timer:sleep(50),
+        ?assert(is_process_alive(Pid)),
+        {ok, ZonePid} = asobi_zone_manager:get_zone(Mgr, {2, 2}),
+        ?assert(is_process_alive(ZonePid)),
+        ?assert(maps:is_key(~"p1", asobi_zone:get_entities(ZonePid)))
+    after
+        stop_world(Ctx),
+        meck:unload(asobi_zone_manager)
+    end.
+
+%% Stops the zone the caller just resolved, once, mimicking a reap sweep
+%% landing in the gap between the lookup and the caller using the pid.
+reap_first_zone_at(Target, Coords, {ok, ZonePid, _Status} = Result, Ctr) when Coords =:= Target ->
+    case counters:get(Ctr, 1) of
+        0 ->
+            counters:add(Ctr, 1, 1),
+            ok = gen_server:stop(ZonePid, normal, 1000),
+            Result;
+        _ ->
+            Result
+    end;
+reap_first_zone_at(_Target, _Coords, Result, _Ctr) ->
+    Result.

--- a/test/asobi_zone_manager_tests.erl
+++ b/test/asobi_zone_manager_tests.erl
@@ -56,6 +56,12 @@ zone_manager_test_() ->
         {"stale zone is reaped on sweep", fun stale_zone_reaped_on_sweep/0},
         {"an occupied zone survives a reap sweep against a stale timestamp",
             fun occupied_zone_survives_reap/0},
+        {"revive_zone replaces a zone reaped under a caller holding its pid",
+            fun revive_zone_replaces_reaped_zone/0},
+        {"revive_zone returns the live zone when the coords were already recreated",
+            fun revive_zone_returns_already_recreated_zone/0},
+        {"revive_zone declines while the named zone is still running",
+            fun revive_zone_declines_live_zone/0},
         {"per-coord initial zone_state reaches zone init", fun initial_zone_states_threaded/0},
         {"missing per-coord state leaves zone_state default", fun initial_zone_states_default/0}
     ]}.
@@ -188,6 +194,57 @@ occupied_zone_survives_reap() ->
     force_reap_sweep(Mgr),
     ?assertEqual({ok, ZonePid}, asobi_zone_manager:get_zone(Mgr, {0, 0})),
     ?assert(is_process_alive(ZonePid)),
+    stop_manager(Ctx).
+
+%% Regression widgrensit/asobi#283 (follow-up to the zone-side fix above):
+%% ensure_zone/2 hands out a pid without a lease on it, so a zone that is
+%% genuinely empty when the sweep fires still stops while a join is already in
+%% flight against it. The joiner cannot recover by calling ensure_zone/2 again
+%% - the ETS slot still points at the corpse until the manager has processed
+%% the DOWN. Suspending the manager here queues the revive_zone call ahead of
+%% that DOWN, which is exactly the ordering the race produces.
+revive_zone_replaces_reaped_zone() ->
+    Ctx = #{mgr := Mgr} = start_manager(),
+    {ok, ZonePid, created} = asobi_zone_manager:ensure_zone(Mgr, {0, 0}),
+    Self = self(),
+    ok = sys:suspend(Mgr),
+    _ = spawn(fun() -> Self ! {revived, asobi_zone_manager:revive_zone(Mgr, {0, 0}, ZonePid)} end),
+    timer:sleep(20),
+    exit(ZonePid, kill),
+    timer:sleep(20),
+    ok = sys:resume(Mgr),
+    receive
+        {revived, Result} ->
+            ?assertMatch({ok, P, created} when is_pid(P), Result),
+            {ok, NewPid, created} = Result,
+            ?assertNotEqual(ZonePid, NewPid),
+            ?assert(is_process_alive(NewPid)),
+            ?assertEqual({ok, NewPid}, asobi_zone_manager:get_zone(Mgr, {0, 0}))
+    after 2000 ->
+        ?assert(false, timeout_waiting_for_revive)
+    end,
+    stop_manager(Ctx).
+
+revive_zone_returns_already_recreated_zone() ->
+    Ctx = #{mgr := Mgr} = start_manager(),
+    {ok, ZonePid, created} = asobi_zone_manager:ensure_zone(Mgr, {1, 0}),
+    exit(ZonePid, kill),
+    timer:sleep(50),
+    {ok, NewPid, created} = asobi_zone_manager:ensure_zone(Mgr, {1, 0}),
+    ?assertEqual(
+        {ok, NewPid, existing}, asobi_zone_manager:revive_zone(Mgr, {1, 0}, ZonePid)
+    ),
+    stop_manager(Ctx).
+
+%% Backstop: a caller that reports a zone dead while it is demonstrably still
+%% running must not get a second zone started over the live one.
+revive_zone_declines_live_zone() ->
+    Ctx = #{mgr := Mgr} = start_manager(),
+    {ok, ZonePid, created} = asobi_zone_manager:ensure_zone(Mgr, {2, 2}),
+    ?assertEqual(
+        {error, zone_stopping}, asobi_zone_manager:revive_zone(Mgr, {2, 2}, ZonePid)
+    ),
+    ?assertEqual({ok, ZonePid}, asobi_zone_manager:get_zone(Mgr, {2, 2})),
     stop_manager(Ctx).
 
 %% Sends the manager's own {reap_idle, Ref} message directly instead of

--- a/test/asobi_zone_tests.erl
+++ b/test/asobi_zone_tests.erl
@@ -78,7 +78,10 @@ zone_test_() ->
             fun tick_no_hibernate_with_binary_keyed_npcs/0},
         {"reap stops a zone with no entities", fun reap_stops_empty_zone/0},
         {"reap declines and re-touches a zone that still has entities",
-            fun reap_declines_when_occupied/0}
+            fun reap_declines_when_occupied/0},
+        {"sync drains earlier casts to a live zone", fun sync_drains_live_zone/0},
+        {"sync reports a stopped zone instead of exiting the caller",
+            fun sync_reports_stopped_zone/0}
     ]}.
 
 starts_empty() ->
@@ -757,6 +760,22 @@ reap_declines_when_occupied() ->
     end,
     gen_server:stop(Pid),
     ZMPid ! stop.
+
+sync_drains_live_zone() ->
+    Pid = start_zone(),
+    asobi_zone:add_entity(Pid, <<"p1">>, #{type => ~"player", x => 0, y => 0}),
+    ?assertEqual(ok, asobi_zone:sync(Pid)),
+    ?assert(maps:is_key(<<"p1">>, asobi_zone:get_entities(Pid))),
+    gen_server:stop(Pid).
+
+%% asobi#283: a zone reaped between a caller resolving its pid and draining
+%% its casts used to exit that caller with {normal, {gen_server, call, _}} -
+%% for asobi_world_server that meant the whole world gen_statem going down
+%% over one player's placement.
+sync_reports_stopped_zone() ->
+    Pid = start_zone(),
+    gen_server:stop(Pid),
+    ?assertEqual(zone_gone, asobi_zone:sync(Pid)).
 
 start_mock_zone_manager() ->
     start_mock_zone_manager(#{}).


### PR DESCRIPTION
Closes #283

## The remaining race

#286 closed the wide window (a zone declines `reap` while it still holds entities). What is left is the narrow TOCTOU the issue's follow-up comment describes: a zone that is *genuinely* empty when the sweep fires correctly stops, even though a join or crossing has already resolved its pid and is about to put an entity in it.

`ensure_zone/2` hands out a pid without a lease on it, so:

- the `add_entity` cast goes to a dead process and is silently dropped, and
- the drain call right after it (`get_subscriber_count/1`, the asobi#248 guard) exits the caller with `{normal, {gen_server, call, ...}}` - taking the whole world `gen_statem` down, every player in it, over one player's placement.

## The fix

- `asobi_zone:sync/1` replaces the raw `get_subscriber_count/1` drain: same drain semantics, but reports `zone_gone` rather than exiting the caller.
- `asobi_zone_manager:revive_zone/3` swaps the corpse for a fresh zone. A caller cannot recover with another `ensure_zone/2` - the ETS slot still points at the dead pid until the manager has processed its `DOWN` - so the manager consumes that `DOWN` itself and starts the replacement inside the same call. It returns the live zone if someone else got there first, and declines (`{error, zone_stopping}`) rather than starting a second zone over one that turns out not to be dying.
- `asobi_world_server` binds the player's entity through one retryable step (`bind_player_zone/3`) shared by the join and crossing paths: add entity, presence, subscribe, backfill, drain - and re-runs it once against the replacement zone if the drain proves the old one gone. Once the entity is in, the zone declines further reaps itself (#286), so one retry is enough.
- The crossing now binds the destination *before* removing the player from the old zone, for the same reason asobi#258 pre-checks the destination: an unusable destination leaves the crossing a no-op instead of stranding the player zoneless.
- A recovered placement logs `zone_reaped_during_placement`; a placement that still cannot be bound degrades to the existing `zone_unavailable` path.

## Verification

- With `?REAP_INTERVAL`/`idle_timeout` temporarily shrunk to 200ms/50ms (the settings the issue reproduced under), `prop_input_never_dropped` fails after 39 iterations on `main` with exactly the reported `exception exit: {normal, {gen_server,call,[...,get_subscriber_count]}}`, and passes 250/250 with this change.
- New tests: `asobi_zone:sync/1` on a live and a stopped zone; `revive_zone/3` against a reaped zone (manager suspended so the call is queued ahead of the `DOWN`, reproducing the real ordering), an already-recreated coords, and a live zone; and two `asobi_world_zone_integration_tests` cases that stop the zone from inside `ensure_zone/2` and assert the join/crossing still lands the player in a live zone with the world server alive.
- `rebar3 fmt --check`, `xref`, `dialyzer`, `ex_doc`, full `rebar3 eunit` (534 tests, 0 failures) green. `rebar3 ct` not run here (shared Docker Postgres); CI covers it.

Per AGENTS.md this adds public API surface to two world modules, so it wants an `asobi-architecture-guardian` pass before merge.