### PR TITLE
fix: stop eunit's 5s default timeout cancelling whole test groups in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,4 +52,9 @@ jobs:
       # and fails to compile on OTP 29 (deprecated catch). Drop it so it
       # re-resolves.
       pre-test-command: 'rm -rf _build/default/lib/asobi/ebin _build/test/lib/asobi/ebin _build/default/lib/asobi/test _build/test/lib/asobi/test _build/test/lib/meck'
+      # Non-verbose eunit names a cancelled test as `undefined`, so a timeout
+      # (#279) is indistinguishable from a real regression in the log. Verbose
+      # names each test and prints its wall time, which also surfaces tests
+      # creeping towards the scaled timeout before they start cancelling groups.
+      eunit-args: '--verbose'
     secrets: inherit

--- a/rebar.config
+++ b/rebar.config
@@ -57,6 +57,14 @@
             {proper, "~> 1.4"}
         ]},
         {ct_opts, [{sys_config, "./config/dev_sys.config.src"}]},
+        %% EUnit's default per-test timeout is 5s, and a timeout kills the whole
+        %% enclosing group's runner process - the remaining tests in that group
+        %% are never run and the summary reads "N tests, 0 failures, M cancelled"
+        %% with a total that shifts between runs (asobi #279). Several match and
+        %% world tests legitimately sit within a second or two of that limit, so
+        %% a loaded 2-core CI runner tips them over at random. Scale every
+        %% timeout so wall-clock jitter can't be mistaken for a regression.
+        {eunit_opts, [{scale_timeouts, 4}]},
         {extra_src_dirs, [{"test", [{recursive, true}]}]},
         {xref_extra_paths, ["test"]}
     ]}

--- a/test/asobi_eunit_config_tests.erl
+++ b/test/asobi_eunit_config_tests.erl
@@ -1,0 +1,12 @@
+-module(asobi_eunit_config_tests).
+-include_lib("eunit/include/eunit.hrl").
+
+%% asobi #279: without a scale factor, EUnit's 5s default per-test timeout kills
+%% the enclosing group's runner on a slow CI machine, cancelling every test after
+%% it and turning a green suite red at random.
+scale_timeouts_configured_test() ->
+    {ok, Terms} = file:consult("rebar.config"),
+    {profiles, Profiles} = lists:keyfind(profiles, 1, Terms),
+    {test, TestProfile} = lists:keyfind(test, 1, Profiles),
+    {eunit_opts, EunitOpts} = lists:keyfind(eunit_opts, 1, TestProfile),
+    ?assert(proplists:get_value(scale_timeouts, EunitOpts, 1) >= 2).


### PR DESCRIPTION
Closes #279

## Root cause

Not a reporting artefact - EUnit's `?DEFAULT_TEST_TIMEOUT` is **5000 ms**
(`eunit_internal.hrl`), and a timeout does not just cancel the one test. In
`eunit_proc:insulator_wait/4` a `{timeout, Child, Id}` sends
`{cancel, timeout}` for the test, `{cancel, {blame, Id}}` for the enclosing
group, and then `kill_task(Child)` - the group's runner process. Every test
after it in that group is never run and never counted.

That produces exactly the reported symptom: `0 failures`, a handful of
`cancelled`, and a *total test count that moves between runs* because a
different amount of each group survives depending on where the timeout landed.

Reproduced deterministically with a throwaway two-test group whose first test
sleeps 6s:

```
3 tests, 0 failures, 3 cancelled
===> Error running tests
```

The sibling test never ran, and non-verbose eunit named the cancelled test
`undefined`.

The suite has several genuinely slow tests sitting just under the limit
(`empty_grace_lapses` 5.25s, `cancel_match` / `cancel_world` /
`leave_last_finishes` ~5.05s locally). They carry explicit `{timeout, 15, ...}`
wrappers, but anything that drifts towards a few seconds on a loaded two-core
runner tips over without warning.

## Fix

- `{eunit_opts, [{scale_timeouts, 4}]}` in the test profile. Multiplies every
  eunit timeout, default and explicit alike, so the default becomes 20s. Real
  hangs still fail, wall-clock jitter no longer does.
- `eunit-args: '--verbose'` in `ci.yml`. Not the fix - the diagnosis. Verbose
  names each test and prints its wall time, so a future timeout is legible in
  the log and tests creeping towards the budget are visible before they start
  cancelling groups.
- A small guard test so the setting cannot be dropped silently.

## Verification

- Probe group failed with `3 cancelled` before the change, passed after.
- `rebar3 eunit` 528 tests, 0 failures; `rebar3 fmt --check` and `rebar3 xref`
  clean.
