### PR TITLE
fix: start the guest reaper unconditionally and gate sweeps lazily

### DIFF
--- a/src/asobi_guest_reaper.erl
+++ b/src/asobi_guest_reaper.erl
@@ -2,10 +2,11 @@
 -behaviour(gen_server).
 
 %% Opt-in sweeper for stale, unclaimed guest accounts. Retention is operator
-%% policy, never a core default: it does nothing unless `guest_reap_after` (a
-%% number of seconds) is configured. "Permanent guests" = leave it unset. It
-%% only removes guests that were never claimed - no password and no non-device
-%% identity - so an upgraded account is never touched.
+%% policy, never a core default: a sweep does nothing unless guest auth is on
+%% and `guest_reap_after` (a number of seconds) is configured, both read at
+%% sweep time. "Permanent guests" = leave it unset. It only removes guests that
+%% were never claimed - no password and no non-device identity - so an upgraded
+%% account is never touched.
 
 -export([start_link/0, sweep_now/0, cached_unlinked_count/0]).
 -export([init/1, handle_call/3, handle_cast/2, handle_info/2]).
@@ -19,14 +20,15 @@
 -define(COUNT_CACHE, asobi_guest_count_cache).
 -define(DEFAULT_COUNT_TTL_MS, 2000).
 
-%% Only runs when guest auth is enabled - otherwise no process, no timer on
-%% deployments that don't use guest auth.
--spec start_link() -> {ok, pid()} | ignore | {error, term()}.
+%% Always started; `guest_auth` is read when a sweep runs, not here (asobi#327).
+%% Gating the start on the flag made this a permanent child that returned
+%% `ignore`, which a supervisor skips and never retries - and every writer of
+%% guest_auth lives in an application that starts after asobi, so the flag was
+%% always false at that moment and the reaper never ran at all. Reading it
+%% lazily also self-corrects when the flag is set later, e.g. a bundle reload.
+-spec start_link() -> {ok, pid()} | {error, term()}.
 start_link() ->
-    case application:get_env(asobi, guest_auth, false) of
-        true -> gen_server:start_link({local, ?MODULE}, ?MODULE, [], []);
-        _ -> ignore
-    end.
+    gen_server:start_link({local, ?MODULE}, ?MODULE, [], []).
 
 %% For tests/ops: run a sweep synchronously.
 -spec sweep_now() -> {ok, non_neg_integer()}.
@@ -130,8 +132,9 @@ schedule() ->
 
 -spec run_sweep() -> non_neg_integer().
 run_sweep() ->
+    GuestAuth = application:get_env(asobi, guest_auth, false),
     case application:get_env(asobi, guest_reap_after, undefined) of
-        Seconds when is_integer(Seconds), Seconds > 0 ->
+        Seconds when GuestAuth =:= true, is_integer(Seconds), Seconds > 0 ->
             Cutoff = subtract_seconds(erlang:universaltime(), Seconds),
             Reaped = reap_older_than(Cutoff),
             Reaped > 0 andalso

--- a/test/asobi_guest_SUITE.erl
+++ b/test/asobi_guest_SUITE.erl
@@ -47,14 +47,6 @@ secret() ->
 device_id() ->
     base64:encode(crypto:strong_rand_bytes(16)).
 
-%% The reaper only starts at boot when guest_auth is set then; the suite enables
-%% guest_auth for its run, so start it on demand for the reaping test.
-ensure_reaper() ->
-    case whereis(asobi_guest_reaper) of
-        undefined -> {ok, _} = asobi_guest_reaper:start_link();
-        _ -> ok
-    end.
-
 create(DeviceId, Secret, Config) ->
     nova_test:post(
         "/api/v1/auth/guest",
@@ -184,7 +176,9 @@ upgrade_clears_stale_auth_cache_entries(Config) ->
     Config.
 
 reaper_removes_unclaimed_guest_and_children(Config) ->
-    ensure_reaper(),
+    %% asobi#327: supervised unconditionally, so it is up from boot whenever the
+    %% app is - no start-on-demand, and no dependency on when guest_auth is set.
+    ?assert(is_pid(whereis(asobi_guest_reaper))),
     {ok, R1} = create(device_id(), secret(), Config),
     #{~"player_id" := Pid} = nova_test:json(R1),
     %% guest_reap_after is 1s and the cutoff is computed at whole-second

--- a/test/asobi_guest_reaper_tests.erl
+++ b/test/asobi_guest_reaper_tests.erl
@@ -1,0 +1,66 @@
+-module(asobi_guest_reaper_tests).
+-include_lib("eunit/include/eunit.hrl").
+
+%% asobi#327: start_link/0 returned `ignore` when guest_auth was false, and a
+%% supervisor skips - never retries - a child that returns ignore. Every writer
+%% of guest_auth is in an application that starts after asobi, so the flag was
+%% always false at asobi_sup boot and the reaper never ran. The boot ordering
+%% these tests pin (unset at start, true afterwards) is the real deployment.
+
+reaper_test_() ->
+    {foreach, fun setup/0, fun cleanup/1, [
+        {"starts even with guest_auth unset", fun starts_without_guest_auth/0},
+        {"sweep is a no-op while guest auth is off", fun sweep_skipped_when_disabled/0},
+        {"guest_auth set after start: a sweep queries", fun sweep_runs_when_enabled_later/0},
+        {"timer tick picks up a flag set after boot", fun timer_sweep_self_corrects/0}
+    ]}.
+
+setup() ->
+    application:unset_env(asobi, guest_auth),
+    application:set_env(asobi, guest_reap_after, 60),
+    meck:new(asobi_repo, [no_link]),
+    meck:expect(asobi_repo, all, fun(_Q) -> {ok, []} end),
+    ok.
+
+cleanup(_) ->
+    case whereis(asobi_guest_reaper) of
+        undefined -> ok;
+        Pid -> gen_server:stop(Pid)
+    end,
+    meck:unload(asobi_repo),
+    application:unset_env(asobi, guest_auth),
+    application:unset_env(asobi, guest_reap_after),
+    application:unset_env(asobi, guest_reap_interval_ms),
+    ok.
+
+starts_without_guest_auth() ->
+    ?assertMatch({ok, _}, asobi_guest_reaper:start_link()),
+    ?assert(is_pid(whereis(asobi_guest_reaper))).
+
+sweep_skipped_when_disabled() ->
+    {ok, _} = asobi_guest_reaper:start_link(),
+    ?assertEqual({ok, 0}, asobi_guest_reaper:sweep_now()),
+    ?assertEqual(0, meck:num_calls(asobi_repo, all, '_')).
+
+sweep_runs_when_enabled_later() ->
+    {ok, _} = asobi_guest_reaper:start_link(),
+    application:set_env(asobi, guest_auth, true),
+    ?assertEqual({ok, 0}, asobi_guest_reaper:sweep_now()),
+    ?assertEqual(1, meck:num_calls(asobi_repo, all, '_')).
+
+timer_sweep_self_corrects() ->
+    application:set_env(asobi, guest_reap_interval_ms, 25),
+    {ok, _} = asobi_guest_reaper:start_link(),
+    application:set_env(asobi, guest_auth, true),
+    ?assert(wait_for_sweep(200)).
+
+wait_for_sweep(0) ->
+    meck:num_calls(asobi_repo, all, '_') > 0;
+wait_for_sweep(Attempts) ->
+    case meck:num_calls(asobi_repo, all, '_') > 0 of
+        true ->
+            true;
+        false ->
+            timer:sleep(25),
+            wait_for_sweep(Attempts - 1)
+    end.


### PR DESCRIPTION
Closes #327

## What was broken

`src/asobi_guest_reaper.erl:24-29` gated `start_link/0` on `guest_auth`:

    start_link() ->
        case application:get_env(asobi, guest_auth, false) of
            true -> gen_server:start_link({local, ?MODULE}, ?MODULE, [], []);
            _ -> ignore
        end.

It is a `permanent` child of `asobi_sup` (`src/asobi_sup.erl:37`, spec at
`src/asobi_sup.erl:41-48`), and a supervisor **skips** a child that returns
`ignore` - it is never retried. `permanent` governs restart-after-exit, not
retry-after-ignore.

`asobi_sup:start_link/0` runs from `asobi_app:start/2` (`src/asobi_app.erl:16`),
and the only writers of `guest_auth` are in applications that start *after*
asobi because they depend on it (`asobi_lua_config`, `asobi_engine_bundle`). So
the flag was always the `false` default at that moment: the reaper was never
started, and `guest_reap_after` has never run anywhere. Unclaimed guest rows
accumulate without bound, which is also the retention control for anonymous
player records.

Guest *authentication* was unaffected - `asobi_guest_controller.erl:330` reads
the flag per request.

## What changed

Option B from the issue - read lazily instead of ordering the boot:

- `start_link/0` always starts the gen_server; the return type narrows to
  `{ok, pid()} | {error, term()}`.
- `run_sweep/0` reads `guest_auth` alongside `guest_reap_after`, so a sweep is
  a no-op while guest auth is off. The ordering dependency is gone and a flag
  set later (including by a bundle reload) is picked up on the next tick.

Cost on deployments that never enable guest auth: one idle hourly timer.

Side effect worth noting: the reaper owns the `asobi_guest_count_cache` ETS
table read by the guest-create cap check (`asobi_guest_controller.erl:377-389`).
Because the reaper never started, that table never existed and every
unauthenticated guest create fell back to a live full-table `COUNT`. With the
process running, the short-TTL cache does what it was written to do.

## What the tests assert

New `test/asobi_guest_reaper_tests.erl` (eunit, `asobi_repo` mecked so no DB is
needed) pins the exact boot ordering the issue describes - `guest_auth` unset at
start, set to `true` afterwards:

1. `start_link/0` returns `{ok, Pid}` with `guest_auth` unset (this is the
   regression - it returned `ignore` before).
2. With guest auth off, `sweep_now/0` returns `{ok, 0}` and issues **no** repo
   query.
3. With `guest_auth` set to `true` *after* the process started, `sweep_now/0`
   runs the reap query.
4. The timer path self-corrects: with a 25 ms interval and the flag set after
   boot, a scheduled tick sweeps without any external nudge.

Verified these fail 4/4 against the old `start_link/0` and pass 4/4 with the fix.

`test/asobi_guest_SUITE.erl` had an `ensure_reaper/0` helper that started the
reaper on demand, with a comment describing the buggy behaviour. Removed; the
reaping test now asserts the supervised process is alive at boot instead.

## Checks

- `rebar3 fmt` / `rebar3 fmt --check` - clean.
- `rebar3 xref` - clean.
- `rebar3 eunit` - 577 tests, 0 failures.
- `rebar3 ct --suite=test/asobi_guest_SUITE` - all 9 passed (against a local
  Postgres, since this PR touches that suite).

Not verified: no dialyzer or eqwalizer run in this environment; the narrowed
`start_link/0` spec (dropping `ignore`) is still a valid `supervisor:start_link`
child return, and `asobi_sup` does not pattern-match the result.