### PR TITLE
fix: reach live/1 for GET /api/v1/matches/live

### DIFF
--- a/src/asobi_router.erl
+++ b/src/asobi_router.erl
@@ -64,9 +64,15 @@ api_routes() ->
             {~"/worlds", fun asobi_world_controller:create/1, #{methods => [post, options]}},
 
             %% Matches
+            %% Declaration order matters here. routing_tree prepends on insert and
+            %% lookup returns on the first sibling that matches, and a binding
+            %% matches any segment - so `/matches/live` must be declared AFTER every
+            %% `/matches/:id...` route or `:id` sits ahead of it and swallows "live"
+            %% (asobi #326). Keep the vote route in this group for the same reason.
             {~"/matches", fun asobi_match_controller:index/1, #{methods => [get, options]}},
-            {~"/matches/live", fun asobi_match_controller:live/1, #{methods => [get, options]}},
             {~"/matches/:id", fun asobi_match_controller:show/1, #{methods => [get, options]}},
+            {~"/matches/:id/votes", fun asobi_vote_controller:index/1, #{methods => [get, options]}},
+            {~"/matches/live", fun asobi_match_controller:live/1, #{methods => [get, options]}},
 
             %% Matchmaker
             {~"/matchmaker", fun asobi_matchmaker_controller:add/1, #{methods => [post, options]}},
@@ -149,8 +155,7 @@ api_routes() ->
                 methods => [get, options]
             }},
 
-            %% Votes
-            {~"/matches/:id/votes", fun asobi_vote_controller:index/1, #{methods => [get, options]}},
+            %% Votes (`/matches/:id/votes` lives in the Matches group above)
             {~"/votes/:id", fun asobi_vote_controller:show/1, #{methods => [get, options]}},
 
             %% Tournaments

--- a/test/asobi_router_tests.erl
+++ b/test/asobi_router_tests.erl
@@ -1,0 +1,39 @@
+-module(asobi_router_tests).
+
+-include_lib("eunit/include/eunit.hrl").
+-include_lib("nova/include/nova_router.hrl").
+
+dispatch() ->
+    nova_router:compile([asobi]).
+
+resolve(Dispatch, Path) ->
+    case routing_tree:lookup('_', Path, ~"GET", Dispatch) of
+        {ok, Bindings, #nova_handler_value{callback = Callback}} -> {ok, Bindings, Callback};
+        Other -> Other
+    end.
+
+matches_live_test() ->
+    ?assertEqual(
+        {ok, #{}, fun asobi_match_controller:live/1},
+        resolve(dispatch(), ~"/api/v1/matches/live")
+    ).
+
+matches_show_test() ->
+    ?assertEqual(
+        {ok, #{~"id" => ~"0198c0de-0000-7000-8000-000000000001"},
+            fun asobi_match_controller:show/1},
+        resolve(dispatch(), ~"/api/v1/matches/0198c0de-0000-7000-8000-000000000001")
+    ).
+
+matches_index_test() ->
+    ?assertEqual(
+        {ok, #{}, fun asobi_match_controller:index/1},
+        resolve(dispatch(), ~"/api/v1/matches")
+    ).
+
+match_votes_test() ->
+    ?assertEqual(
+        {ok, #{~"id" => ~"0198c0de-0000-7000-8000-000000000002"},
+            fun asobi_vote_controller:index/1},
+        resolve(dispatch(), ~"/api/v1/matches/0198c0de-0000-7000-8000-000000000002/votes")
+    ).


### PR DESCRIPTION
Closes #326

## What was broken

`GET /api/v1/matches/live` dispatched to `asobi_match_controller:show/1` with `id = "live"`. `live/1` (`src/controllers/asobi_match_controller.erl:24`, `:38`) was unreachable dead code, while `guides/rest-api.md:115` documents the endpoint and four SDKs call it.

`routing_tree` prepends on insert (`routing_tree.erl:210,213,216` - `[#node{...} | Siblings]`), so siblings are stored in reverse declaration order. `lookup_segment/4` walks that list and returns on the first match, and a binding node matches any segment:

```erlang
lookup_segment(Ident, Bindings, [#node{segment = Segment, is_binding = true} = N|_Tl], _WCNode) ->
    {ok, Bindings#{Segment => Ident}, N};
```

`src/asobi_router.erl:67-69` declared `/matches`, then `/matches/live`, then `/matches/:id`, so `:id` sat at the head of the `matches` children and swallowed `"live"`.

## What changed

`src/asobi_router.erl` - `/matches/live` is now declared last in the Matches group, after `/matches/:id`.

**The swap suggested in the issue is not sufficient on its own.** `/matches/:id/votes` was declared much later, in the Votes section (`src/asobi_router.erl:153` before this change). Its insert takes the `Node` branch of `routing_tree:insert/4`:

```erlang
[Node#node{children = insert(Tl, CompNode, Node#node.children, Options), ...} | lists:delete(Node, Siblings)]
```

which re-prepends the `:id` node and puts it back ahead of `live`. I verified this: with only lines 68/69 swapped and `/matches/:id/votes` left in the Votes section, `matches_live_test` still fails with `{ok, #{<<"id">> => <<"live">>}, fun asobi_match_controller:show/1}`.

So the fix moves `/matches/:id/votes` up into the Matches group as well, and `/matches/live` is declared after every `/matches/:id...` route. The Votes section keeps `/votes/:id` and carries a one-line pointer. The ordering constraint is stated in a comment above the group, since the counter-intuitive semantics are exactly why this shipped.

No behaviour change for `/matches/:id/votes` itself - only its declaration position moved.

## What the test asserts

New `test/asobi_router_tests.erl` compiles the real dispatch with `nova_router:compile([asobi])` and resolves paths through `routing_tree:lookup/4`, asserting on the callback in `#nova_handler_value{}`:

- `/api/v1/matches/live` -> `fun asobi_match_controller:live/1`, empty bindings (the regression; fails on `main` with `{ok, #{<<"id">> => <<"live">>}, fun asobi_match_controller:show/1}`)
- `/api/v1/matches/<uuid>` -> `show/1` with `#{~"id" => <uuid>}`
- `/api/v1/matches` -> `index/1`
- `/api/v1/matches/<uuid>/votes` -> `asobi_vote_controller:index/1` with the id binding

Confirmed the test fails against the pre-fix router and against the naive-swap variant, and passes with this change.

## Checks

- `rebar3 fmt` / `rebar3 fmt --check` - clean
- `rebar3 xref` - clean
- `rebar3 eunit` - 577 tests, 0 failures

## Not verified

- Only eunit was run, per the task brief. No CT suites, dialyzer, eqwalizer or `elp lint` in this pass.
- No end-to-end HTTP request against a running node; the assertion is at the dispatch-table level.
- The four SDKs that call this endpoint (godot / unity / defold / dart) are untouched and unretested here - they should start getting real data once this ships, but that is a separate verification.
- The issue's "worth considering alongside" note about enabling `use_strict_routing` is deliberately out of scope. Turning it on would have caught this at boot, but it needs a full router audit first; worth its own ticket.
