### PR TITLE
refactor: resolve game modes through a provider registry

### DIFF
--- a/guides/configuration.md
+++ b/guides/configuration.md
@@ -93,6 +93,13 @@ Lua scripts work too:
 }}
 ```
 
+`{lua, ...}` needs a scripting runtime in the release. asobi itself has no Lua
+dependency: [asobi_lua](https://github.com/widgrensit/asobi_lua) registers the
+modules that run scripted modes (`asobi_game_modes:register_game_mode/2`) when it
+starts. Consume asobi directly without it and every `{lua, _}` mode fails with
+`{error, lua_runtime_unavailable}` — matchmaking rejects the mode as unknown and
+world creation refuses it. Erlang-module modes are unaffected.
+
 Shorthand (Erlang module only):
 
 ```erlang

--- a/src/asobi_game_modes.erl
+++ b/src/asobi_game_modes.erl
@@ -1,6 +1,59 @@
 -module(asobi_game_modes).
+-moduledoc """
+Game-mode configuration, and the registry that maps a mode kind to the module
+that provides it.
 
--export([mode_config/1, resolve_game_module/1, world_config/1, global_chat_channels/0]).
+A mode declaring `module => {lua, "game/match.lua"}` needs a scripting runtime
+to run it. That runtime lives outside this library (`asobi_lua`), so the
+provider module is registered here at boot rather than named in core - core
+depends on no bridge module.
+""".
+
+-export([
+    register_game_mode/2,
+    unregister_game_mode/1,
+    mode_config/1,
+    resolve_game_module/1,
+    world_config/1,
+    global_chat_channels/0
+]).
+
+-export_type([game_mode_kind/0]).
+
+-type game_mode_kind() :: lua_world | lua_match | lua_match_shared.
+
+%% persistent_term, not an ETS table owned by a supervised process: the table is
+%% written once per provider at application start and read on every mode
+%% resolution (each matchmaker add, each match/world spawn). persistent_term
+%% reads are lock-free and copy-free, and - decisively - the table cannot be lost
+%% by a restart. An owner process that dies takes its registrations with it, and
+%% nothing would re-register them: the writer is a *different* application that
+%% only registers when it starts, so every lua mode would fail permanently after
+%% one unrelated crash. The usual persistent_term caveat (a write triggers a
+%% global scan) does not bite here because writes only happen at boot.
+-define(PROVIDER(Kind), {?MODULE, provider, Kind}).
+-define(IS_KIND(K),
+    (K =:= lua_world orelse K =:= lua_match orelse K =:= lua_match_shared)
+).
+
+-doc """
+Register `Module` as the provider for a game-mode kind.
+
+Call this once, at application start - a `persistent_term` write is not a
+hot-path operation. `asobi_lua` registers its bridge modules this way; a release
+built without a scripting runtime simply leaves the table empty, and every
+`{lua, _}` mode then fails with `{error, lua_runtime_unavailable}` rather than
+calling a module that is not in the release.
+""".
+-spec register_game_mode(game_mode_kind(), module()) -> ok.
+register_game_mode(Kind, Module) when ?IS_KIND(Kind), is_atom(Module) ->
+    persistent_term:put(?PROVIDER(Kind), Module).
+
+-doc "Drop a registration. Mainly for tests; releases register once and keep it.".
+-spec unregister_game_mode(game_mode_kind()) -> ok.
+unregister_game_mode(Kind) when ?IS_KIND(Kind) ->
+    _ = persistent_term:erase(?PROVIDER(Kind)),
+    ok.
 
 -spec mode_config(binary()) -> map().
 mode_config(Mode) ->
@@ -11,23 +64,43 @@ mode_config(Mode) ->
         _ -> #{}
     end.
 
--spec resolve_game_module(binary()) -> {ok, module(), map()} | {error, not_found}.
+-doc """
+Resolve a mode to the module that runs it, plus the extra game config it needs.
+
+`{error, not_found}` means the mode declares no usable module.
+`{error, lua_runtime_unavailable}` means it declares a Lua script but no
+runtime registered a provider for that kind - a release built without
+`asobi_lua`. That case used to be an unenforced convention that failed later
+and obscurely; it is now a named error at the point of resolution.
+""".
+-spec resolve_game_module(binary()) ->
+    {ok, module(), map()} | {error, not_found | lua_runtime_unavailable}.
 resolve_game_module(Mode) ->
     case mode_config(Mode) of
         #{type := world, module := {lua, Script}} ->
-            {ok, asobi_lua_world, #{lua_script => Script}};
+            lua_provider(lua_world, Script);
         #{module := {lua, Script}, state_strategy := shared} ->
-            {ok, asobi_lua_match_shared, #{lua_script => Script}};
+            lua_provider(lua_match_shared, Script);
         #{module := {lua, Script}} ->
-            {ok, asobi_lua_match, #{lua_script => Script}};
+            lua_provider(lua_match, Script);
         #{module := Mod} when is_atom(Mod) ->
             {ok, Mod, #{}};
         _ ->
             {error, not_found}
     end.
 
+-spec lua_provider(game_mode_kind(), term()) ->
+    {ok, module(), map()} | {error, lua_runtime_unavailable}.
+lua_provider(Kind, Script) ->
+    case persistent_term:get(?PROVIDER(Kind), undefined) of
+        Module when is_atom(Module), Module =/= undefined ->
+            {ok, Module, #{lua_script => Script}};
+        _ ->
+            {error, lua_runtime_unavailable}
+    end.
+
 -doc "Build a world server config map from a mode's game_modes config.".
--spec world_config(binary()) -> {ok, map()} | {error, not_found}.
+-spec world_config(binary()) -> {ok, map()} | {error, not_found | lua_runtime_unavailable}.
 world_config(Mode) ->
     ModeConfig = mode_config(Mode),
     case resolve_game_module(Mode) of

--- a/src/matches/asobi_matchmaker.erl
+++ b/src/matches/asobi_matchmaker.erl
@@ -37,9 +37,14 @@ add(PlayerId, Params) ->
 %% that each slip past the per-(player, mode) ticket guard, and turns a
 %% typo'd/omitted/half-configured mode into an immediate 400 instead of a
 %% silent queue that only ever ends in `matchmaker_expired' after `max_wait'.
+%% `lua_runtime_unavailable' (a Lua mode in a release with no scripting runtime)
+%% is rejected here for the same reason: it can never spawn either.
 -spec known_mode(term()) -> boolean().
 known_mode(Mode) when is_binary(Mode), byte_size(Mode) =< 64 ->
-    resolve_game_module(Mode) =/= {error, not_found};
+    case asobi_game_modes:resolve_game_module(Mode) of
+        {ok, _Module, _GameConfig} -> true;
+        {error, _} -> false
+    end;
 known_mode(_) ->
     false.
 
@@ -50,7 +55,7 @@ known_mode(_) ->
 %% opt-in, tracked in asobi#232's follow-up.
 -spec queue_meta(binary()) -> map().
 queue_meta(Mode) ->
-    case maps:get(match_size, mode_config(Mode), undefined) of
+    case maps:get(match_size, asobi_game_modes:mode_config(Mode), undefined) of
         N when is_integer(N) -> #{players_needed => N};
         _ -> #{players_needed => null}
     end.
@@ -286,7 +291,7 @@ ensure_typed_map(Map) ->
 match_all_modes(ByMode) ->
     maps:fold(
         fun(Mode, ModeTickets, {AllMatched, AllUnmatched}) ->
-            ModeConfig = mode_config(Mode),
+            ModeConfig = asobi_game_modes:mode_config(Mode),
             Strategy = resolve_strategy(ModeConfig),
             {M, U} = Strategy:match(ModeTickets, ModeConfig),
             %% Defence in depth for any strategy, including user-supplied ones:
@@ -335,15 +340,6 @@ find_player_ticket(PlayerId, Mode, Tickets) ->
         false -> error
     end.
 
--spec mode_config(binary()) -> map().
-mode_config(Mode) ->
-    Modes = ensure_map(application:get_env(asobi, game_modes, #{})),
-    case Modes of
-        #{Mode := Config} when is_map(Config) -> Config;
-        #{Mode := Mod} when is_atom(Mod) -> #{module => Mod};
-        _ -> #{}
-    end.
-
 -spec resolve_strategy(map()) -> module().
 resolve_strategy(#{strategy := Strategy}) when is_atom(Strategy) ->
     case Strategy of
@@ -353,21 +349,6 @@ resolve_strategy(#{strategy := Strategy}) when is_atom(Strategy) ->
     end;
 resolve_strategy(_) ->
     asobi_matchmaker_fill.
-
--spec resolve_game_module(binary()) -> {ok, module(), map()} | {error, not_found}.
-resolve_game_module(Mode) ->
-    case mode_config(Mode) of
-        #{type := world, module := {lua, Script}} ->
-            {ok, asobi_lua_world, #{lua_script => Script}};
-        #{module := {lua, Script}, state_strategy := shared} ->
-            {ok, asobi_lua_match_shared, #{lua_script => Script}};
-        #{module := {lua, Script}} ->
-            {ok, asobi_lua_match, #{lua_script => Script}};
-        #{module := Mod} when is_atom(Mod) ->
-            {ok, Mod, #{}};
-        _ ->
-            {error, not_found}
-    end.
 
 -spec spawn_matches([[map()]]) -> [[map()]].
 spawn_matches(Groups) ->
@@ -379,7 +360,7 @@ spawn_matches([Group | Rest], Failed) ->
     PlayerIds = [maps:get(player_id, T) || T <- Group],
     [First | _] = Group,
     Mode = maps:get(mode, First),
-    ModeConfig = mode_config(Mode),
+    ModeConfig = asobi_game_modes:mode_config(Mode),
     case maps:get(type, ModeConfig, match) of
         world ->
             spawn_world(Mode, ModeConfig, PlayerIds, Group, Rest, Failed);
@@ -390,7 +371,7 @@ spawn_matches([Group | Rest], Failed) ->
 spawn_match(Mode, ModeConfig, PlayerIds, Group, Rest, Failed) ->
     MatchSize = maps:get(match_size, ModeConfig, length(PlayerIds)),
     MaxPlayers = maps:get(max_players, ModeConfig, MatchSize),
-    case resolve_game_module(Mode) of
+    case asobi_game_modes:resolve_game_module(Mode) of
         {ok, GameMod, ExtraConfig} ->
             Config = #{
                 mode => Mode,
@@ -418,8 +399,8 @@ spawn_match(Mode, ModeConfig, PlayerIds, Group, Rest, Failed) ->
                     }),
                     handle_spawn_failure(Group, Mode, PlayerIds, Rest, Failed)
             end;
-        {error, _} ->
-            notify_no_game_module(Mode, PlayerIds),
+        {error, Reason} ->
+            notify_no_game_module(Mode, Reason, PlayerIds),
             spawn_matches(Rest, Failed)
     end.
 
@@ -465,7 +446,7 @@ join_matched_players(MatchPid, Mode, PlayerIds) ->
 %% direction (players told immediately, never left queued).
 spawn_world(Mode, ModeConfig, PlayerIds, Group, Rest, Failed) ->
     MaxPlayers = maps:get(max_players, ModeConfig, 500),
-    case resolve_game_module(Mode) of
+    case asobi_game_modes:resolve_game_module(Mode) of
         {ok, GameMod, ExtraConfig} ->
             Config = #{
                 mode => Mode,
@@ -550,13 +531,16 @@ spawn_world(Mode, ModeConfig, PlayerIds, Group, Rest, Failed) ->
                 end
             end),
             spawn_matches(Rest, Failed);
-        {error, _} ->
-            notify_no_game_module(Mode, PlayerIds),
+        {error, Reason} ->
+            notify_no_game_module(Mode, Reason, PlayerIds),
             spawn_matches(Rest, Failed)
     end.
 
-notify_no_game_module(Mode, PlayerIds) ->
-    logger:warning(#{msg => ~"no game module for mode", mode => Mode}),
+%% The player-facing reason stays coarse and stable; the resolver's own reason
+%% (`not_found' vs `lua_runtime_unavailable', i.e. a Lua mode with no scripting
+%% runtime in the release) only goes to the log, where the operator needs it.
+notify_no_game_module(Mode, Reason, PlayerIds) ->
+    logger:warning(#{msg => ~"no game module for mode", mode => Mode, reason => Reason}),
     notify_matchmaker_failed(PlayerIds, ~"no_game_module").
 
 %% A match failed to spawn (e.g. the game's Lua init crashed). Re-queue the group
@@ -708,6 +692,35 @@ known_mode_single_mode_default_test_() ->
             (undefined) -> application:unset_env(asobi, game_modes)
         end, [
             ?_assert(known_mode(~"default"))
+        ]}.
+
+%% A mode declaring a Lua script in a release with no scripting runtime resolves
+%% to {error, lua_runtime_unavailable}: it can never spawn, so the edge rejects
+%% it exactly like a half-configured mode. Once a provider is registered the
+%% same mode is accepted.
+known_mode_lua_runtime_test_() ->
+    {setup,
+        fun() ->
+            Prev = application:get_env(asobi, game_modes),
+            application:set_env(asobi, game_modes, #{
+                ~"scripted" => #{module => {lua, "game/match.lua"}}
+            }),
+            ok = asobi_game_modes:unregister_game_mode(lua_match),
+            Prev
+        end,
+        fun(Prev) ->
+            ok = asobi_game_modes:unregister_game_mode(lua_match),
+            case Prev of
+                {ok, V} -> application:set_env(asobi, game_modes, V);
+                undefined -> application:unset_env(asobi, game_modes)
+            end
+        end,
+        [
+            ?_assertNot(known_mode(~"scripted")),
+            ?_test(begin
+                ok = asobi_game_modes:register_game_mode(lua_match, fake_lua_match),
+                ?assert(known_mode(~"scripted"))
+            end)
         ]}.
 
 -endif.

--- a/test/asobi_game_modes_tests.erl
+++ b/test/asobi_game_modes_tests.erl
@@ -40,3 +40,76 @@ chat_absent() ->
 
 global_union() ->
     ?assertEqual([~"general", ~"trade"], asobi_game_modes:global_chat_channels()).
+
+%% The provider registry: core used to name asobi_lua_world / asobi_lua_match /
+%% asobi_lua_match_shared by atom, an inverted dependency (asobi_lua depends on
+%% asobi, not the reverse) that also failed obscurely when the runtime wasn't in
+%% the release. Resolution now goes through whatever registered a provider, and
+%% names the failure when nothing did.
+provider_registry_test_() ->
+    {setup, fun setup_lua/0, fun cleanup_lua/1, [
+        {"a lua mode with no registered provider names the missing runtime",
+            fun lua_without_provider/0},
+        {"a registered provider resolves the mode", fun lua_with_provider/0},
+        {"each kind resolves through its own registration", fun lua_kinds_are_independent/0},
+        {"an erlang-module mode resolves with an empty registry", fun erlang_module_unaffected/0},
+        {"world_config propagates the named failure", fun world_config_without_provider/0}
+    ]}.
+
+setup_lua() ->
+    Prev = application:get_env(asobi, game_modes),
+    application:set_env(asobi, game_modes, #{
+        ~"arena" => #{module => {lua, "game/match.lua"}},
+        ~"raid" => #{module => {lua, "game/raid.lua"}, state_strategy => shared},
+        ~"galaxy" => #{type => world, module => {lua, "game/world.lua"}},
+        ~"native" => #{module => some_game}
+    }),
+    Prev.
+
+cleanup_lua(Prev) ->
+    lists:foreach(
+        fun(Kind) -> ok = asobi_game_modes:unregister_game_mode(Kind) end,
+        [lua_world, lua_match, lua_match_shared]
+    ),
+    cleanup(Prev).
+
+lua_without_provider() ->
+    ?assertEqual(
+        {error, lua_runtime_unavailable}, asobi_game_modes:resolve_game_module(~"arena")
+    ).
+
+lua_with_provider() ->
+    ok = asobi_game_modes:register_game_mode(lua_match, fake_lua_match),
+    ?assertEqual(
+        {ok, fake_lua_match, #{lua_script => "game/match.lua"}},
+        asobi_game_modes:resolve_game_module(~"arena")
+    ),
+    ok = asobi_game_modes:unregister_game_mode(lua_match),
+    ?assertEqual(
+        {error, lua_runtime_unavailable}, asobi_game_modes:resolve_game_module(~"arena")
+    ).
+
+lua_kinds_are_independent() ->
+    ok = asobi_game_modes:register_game_mode(lua_world, fake_lua_world),
+    ok = asobi_game_modes:register_game_mode(lua_match_shared, fake_lua_shared),
+    ?assertEqual(
+        {ok, fake_lua_world, #{lua_script => "game/world.lua"}},
+        asobi_game_modes:resolve_game_module(~"galaxy")
+    ),
+    ?assertEqual(
+        {ok, fake_lua_shared, #{lua_script => "game/raid.lua"}},
+        asobi_game_modes:resolve_game_module(~"raid")
+    ),
+    %% A world/shared registration says nothing about plain matches.
+    ?assertEqual(
+        {error, lua_runtime_unavailable}, asobi_game_modes:resolve_game_module(~"arena")
+    ),
+    ok = asobi_game_modes:unregister_game_mode(lua_world),
+    ok = asobi_game_modes:unregister_game_mode(lua_match_shared).
+
+erlang_module_unaffected() ->
+    ?assertEqual({ok, some_game, #{}}, asobi_game_modes:resolve_game_module(~"native")),
+    ?assertEqual({error, not_found}, asobi_game_modes:resolve_game_module(~"nope")).
+
+world_config_without_provider() ->
+    ?assertEqual({error, lua_runtime_unavailable}, asobi_game_modes:world_config(~"galaxy")).


### PR DESCRIPTION
## What was broken

`src/asobi_game_modes.erl:14-27` and `src/matches/asobi_matchmaker.erl:357-370` were
byte-identical copies of `resolve_game_module/1`, each hardcoding `asobi_lua_world`,
`asobi_lua_match_shared` and `asobi_lua_match` by atom (six references). `mode_config/1`
was duplicated the same way (`asobi_game_modes.erl:5-12` / `asobi_matchmaker.erl:338-345`).

Two problems:

1. **Inverted dependency.** `asobi_lua` depends on `asobi`, not the reverse, yet core
   named its bridge modules. Any change to the bridge's module names was a silent
   cross-repo break, and the duplication meant a fix to one resolver missed the other.
2. **Unenforced convention.** Consuming `asobi` without a scripting runtime and still
   declaring `module => {lua, "game/match.lua"}` resolved happily to `asobi_lua_match`,
   then failed later and obscurely (an `undef` deep in a match/world spawn, or a ticket
   that just expired). Nothing named the actual mistake.

## What changed

- **`asobi_game_modes:register_game_mode/2`** - a core-owned dispatch table from mode
  kind (`lua_world | lua_match | lua_match_shared`) to provider module, plus
  `unregister_game_mode/1`. `resolve_game_module/1` now looks the provider up instead
  of naming it. All six atom references are gone.
- **`asobi_matchmaker`** calls `asobi_game_modes:mode_config/1` and
  `asobi_game_modes:resolve_game_module/1`; its own copies of both are deleted.
- **S2:** a `{lua, Script}` mode whose kind has no registered provider returns
  `{error, lua_runtime_unavailable}`. `world_config/1` propagates it;
  `known_mode/1` rejects it (a mode that can never spawn must not be queueable, the
  same reasoning that already rejected a half-configured mode), so the client gets an
  immediate 400 rather than a ticket that expires. `notify_no_game_module/3` now logs
  the resolver's reason so the operator sees *which* failure it was; the player-facing
  reason stays the coarse, stable `no_game_module`.

### persistent_term, not an ETS table owned by a supervised process

The table is written once per provider at application start and read on every mode
resolution (each matchmaker add, each match/world spawn). `persistent_term` reads are
lock-free and copy-free, and - decisively - the table cannot be lost by a restart. An
ETS owner that dies takes its registrations with it and *nothing would re-register
them*: the writer is a different application that only registers when it starts, so one
unrelated crash would permanently break every Lua mode. The usual `persistent_term`
caveat (a write triggers a global scan) does not bite: writes only happen at boot.
Rationale is captured in the module source.

### Empty table tolerance

`asobi_lua` is deliberately **not** touched here, so on this commit the registry is
empty in every deployment. Nothing depends on the table existing: there is no process
to start, no table to create, and `persistent_term:get/2` is called with a default.
Erlang-module modes (`module => my_game`, and the shorthand form) resolve exactly as
before - that is the entire existing test corpus and every non-scripted game.

**Cross-repo note, stated plainly:** while the registry is empty, `{lua, _}` modes
resolve to `{error, lua_runtime_unavailable}` instead of the old bridge atoms. That is
S2's intended behaviour, but it means this must land together with (or before) the
`asobi_lua` PR that calls `register_game_mode/2` at boot - an `asobi_lua` image built
against this asobi without that registration would fail every scripted mode. Nothing in
this repo can verify that half.

## What the tests assert

`test/asobi_game_modes_tests.erl` (new `provider_registry_test_/0`, 5 cases):

- a `{lua, _}` mode with an empty registry returns `{error, lua_runtime_unavailable}`;
- after `register_game_mode(lua_match, fake_lua_match)` the same mode resolves to
  `{ok, fake_lua_match, #{lua_script => "game/match.lua"}}`, and returns to the named
  error once unregistered;
- kinds are independent - registering `lua_world` and `lua_match_shared` resolves
  `type => world` and `state_strategy => shared` modes to their own providers while a
  plain match mode is still unavailable;
- an Erlang-module mode resolves unchanged with an empty registry, and an unconfigured
  mode still returns `{error, not_found}` (the empty-table tolerance claim above);
- `world_config/1` propagates the named failure.

`src/matches/asobi_matchmaker.erl` (new inline `known_mode_lua_runtime_test_/0`): a Lua
mode is not a known mode with no provider registered, and is once one is.

## Checks

- `rebar3 fmt` - clean (`fmt --check`: all matched files use erlfmt code style)
- `rebar3 xref` - clean
- `rebar3 eunit` - **580 tests, 0 failures**
- `rebar3 dialyzer` - clean (also run, since the `resolve_game_module/1` and
  `world_config/1` specs widened)
- `elp eqwalize-all` - 27 errors, all pre-existing. One is in `asobi_game_modes`
  (`global_chat_channels/0`'s comprehension, untouched by this PR); verified identical
  on `origin/main` by stashing the change and re-running. No new errors introduced.

## Not verified / follow-ups

- The `asobi_lua` side (actually registering the three providers) is out of scope here
  and untested from this repo - see the cross-repo note above.
- An ADR for the registry would be reasonable; not added to avoid colliding with
  concurrent ADR numbering.
- `ensure_map/1` stays in `asobi_matchmaker`: after removing `mode_config/1` it is
  still used by `init/1` (matchmaker config) and `process_tickets/3`. Deduplicating it
  across `asobi_matchmaker`, `asobi_cluster` and `asobi_vote_server` needs a shared
  helper module and is a separate change.
