### PR TITLE
feat: add asobi_ops read plane with clamped paging and sort allowlist

### DIFF
--- a/guides/rest-api.md
+++ b/guides/rest-api.md
@@ -230,6 +230,77 @@ PUT    /api/v1/storage/:collection/:key        Write object
 DELETE /api/v1/storage/:collection/:key        Delete object
 ```
 
+## Ops
+
+```
+GET /api/v1/ops/players     Paginated player list
+GET /api/v1/ops/matches     Paginated match-record list
+GET /api/v1/ops/features    Installed feature set
+```
+
+The game-operations read plane, for a console rather than a game client. The
+lists differ from the ones above in three ways: they report a total, they
+accept a sort, and they page by offset.
+
+Every list returns the same envelope:
+
+```json
+{
+  "data": [ ... ],
+  "page": { "limit": 50, "offset": 0, "total": 137 }
+}
+```
+
+Parameters shared by `ops/players` and `ops/matches`:
+
+| Parameter | Meaning |
+| --- | --- |
+| `limit` | Rows per page. Default 50, clamped to 1-200. |
+| `page` | 1-based page number. Wins over `offset` when both are given. |
+| `offset` | Rows to skip. Clamped to 0-100000 and snapped down to a multiple of `limit`, so the `offset` in the response is the one the query ran with. |
+| `sort` | Field to sort by. Must be one of the fields listed below - anything else is **400**, never a silent fallback. |
+| `order` | `asc` (default) or `desc`. Anything else is **400**. |
+| `q` | Case-insensitive substring search. `%` and `_` are matched literally. |
+
+A malformed number is never an error: `?limit=abc` uses the default. A
+malformed *sort* always is, because ordering the wrong rows silently is worse
+than a 400.
+
+Sorts always end on `id`, so paging by offset cannot repeat or skip a row when
+the sort key has duplicates.
+
+`ops/players` sorts on `id`, `username`, `display_name`, `inserted_at`,
+`updated_at`, and searches username and display name. `ops/matches` sorts on
+`id`, `mode`, `status`, `started_at`, `finished_at`, `inserted_at`, filters on
+`mode` and `status`, and searches mode. Both return the same fields as their
+public counterparts - no roster, no credentials.
+
+`GET /api/v1/ops/features` reports what this deployment has installed:
+
+```json
+{
+  "data": {
+    "core": {
+      "name": "asobi",
+      "version": "0.46.0",
+      "capabilities": [{ "name": "guest_auth", "enabled": true }]
+    },
+    "extensions": []
+  }
+}
+```
+
+Capabilities report what is *configured*, not what is compiled in, and carry a
+boolean only - never the configured value. `extensions` is empty until an
+extension registry exists; entries will have the same shape as `core`.
+
+> #### Ops routes use player auth today {: .warning}
+>
+> These routes sit behind the same bearer check as the rest of `/api/v1`, so
+> any authenticated player can read them, and their fields are held to exactly
+> what the public endpoints already expose. An operator capability model is
+> the follow-up.
+
 ## Next steps
 
 - [WebSocket protocol](websocket-protocol.md) - the push side of the API.

--- a/rebar.config
+++ b/rebar.config
@@ -205,6 +205,14 @@
             asobi_storage_controller,
             asobi_vote_controller
         ]},
+        {<<"Ops">>, [
+            asobi_ops_controller,
+            asobi_ops_params,
+            asobi_ops_page,
+            asobi_ops_players,
+            asobi_ops_matches,
+            asobi_ops_features
+        ]},
         {<<"Real-Time">>, [
             asobi_ws_handler,
             asobi_match_server,

--- a/src/asobi_router.erl
+++ b/src/asobi_router.erl
@@ -178,6 +178,12 @@ api_routes() ->
             {~"/saves/:slot", fun asobi_storage_controller:get_save/1, #{methods => [get, options]}},
             {~"/saves/:slot", fun asobi_storage_controller:put_save/1, #{methods => [put, options]}},
 
+            %% Ops - read plane. Mounted on the existing player-scoped auth
+            %% plugin; the operator capability model is ADR 0007 (follow-up).
+            {~"/ops/players", fun asobi_ops_controller:players/1, #{methods => [get, options]}},
+            {~"/ops/matches", fun asobi_ops_controller:matches/1, #{methods => [get, options]}},
+            {~"/ops/features", fun asobi_ops_controller:features/1, #{methods => [get, options]}},
+
             %% Storage - Generic
             {~"/storage/:collection", fun asobi_storage_controller:list_storage/1, #{
                 methods => [get, options]

--- a/src/ops/asobi_ops_controller.erl
+++ b/src/ops/asobi_ops_controller.erl
@@ -1,0 +1,66 @@
+-module(asobi_ops_controller).
+-moduledoc """
+HTTP surface of the ops read plane.
+
+Every list endpoint here returns the same envelope, clamps its own paging, and
+rejects a sort field it does not recognise with 400 rather than ordering by
+something the caller did not ask for.
+
+These routes are mounted behind `asobi_auth_plugin:verify/1`, the same
+player-scoped bearer check the rest of `/api/v1` uses. That is a placeholder,
+not the destination: ops calls want an operator capability, which is ADR 0007
+and a follow-up PR. Until then every projection here is held to exactly what
+the equivalent public endpoint already exposes.
+""".
+
+-include_lib("kernel/include/logger.hrl").
+-include_lib("kura/include/kura.hrl").
+
+-export([players/1, matches/1, features/1]).
+
+-type response() :: {json, map()} | {json, integer(), map(), map()}.
+
+-spec players(cowboy_req:req()) -> response().
+players(Req) ->
+    list(Req, fun asobi_ops_players:query/1, fun asobi_ops_players:project/1).
+
+-spec matches(cowboy_req:req()) -> response().
+matches(Req) ->
+    list(Req, fun asobi_ops_matches:query/1, fun asobi_ops_matches:project/1).
+
+-spec features(cowboy_req:req()) -> response().
+features(_Req) ->
+    {json, asobi_ops_features:features()}.
+
+-spec list(
+    cowboy_req:req(),
+    fun((asobi_ops_params:params()) -> {ok, #kura_query{}} | {error, term()}),
+    fun((map()) -> map())
+) -> response().
+list(Req, BuildQuery, Project) ->
+    Params = params(Req),
+    case BuildQuery(Params) of
+        {ok, Query} ->
+            page(Query, asobi_ops_params:page(Params), Project);
+        {error, Reason} ->
+            {json, 400, #{}, error_body(Reason)}
+    end.
+
+-spec page(#kura_query{}, asobi_ops_params:page_spec(), fun((map()) -> map())) -> response().
+page(Query, PageSpec, Project) ->
+    case asobi_ops_page:list(Query, PageSpec, Project) of
+        {ok, Envelope} ->
+            {json, Envelope};
+        {error, Reason} ->
+            ?LOG_ERROR(#{msg => ~"ops list query failed", reason => Reason}),
+            {json, 500, #{}, #{error => ~"query_failed"}}
+    end.
+
+-spec params(cowboy_req:req()) -> asobi_ops_params:params().
+params(#{parsed_qs := Params}) when is_map(Params) -> Params;
+params(_Req) -> #{}.
+
+-spec error_body(term()) -> map().
+error_body({unknown_sort, Field}) -> #{error => ~"unknown_sort_field", field => Field};
+error_body({unknown_order, Order}) -> #{error => ~"unknown_sort_order", order => Order};
+error_body(_) -> #{error => ~"bad_request"}.

--- a/src/ops/asobi_ops_features.erl
+++ b/src/ops/asobi_ops_features.erl
@@ -1,0 +1,98 @@
+-module(asobi_ops_features).
+-moduledoc """
+The installed feature set, as the ops read plane reports it.
+
+There is no extension registry yet, so everything here comes from core and
+`extensions/0` is empty. Core and an extension are reported in the same shape
+- `#{name, version, capabilities}` - so a registry can fill `extensions/0`
+later without the endpoint, its envelope, or its consumers changing.
+
+Capabilities report what is *configured*, not what is compiled in: a console
+needs to know whether Steam auth will work on this deployment, and "the module
+exists" does not answer that. Each entry is a name and a boolean only - never
+the configured value, which is usually a secret.
+""".
+
+-export([features/0, extensions/0, capabilities/0]).
+
+-spec features() -> map().
+features() ->
+    #{
+        data => #{
+            core => #{
+                name => ~"asobi",
+                version => version(),
+                capabilities => capabilities()
+            },
+            extensions => extensions()
+        }
+    }.
+
+-doc """
+Installed extensions, in the same shape as the `core` entry.
+
+Always `[]` today. When an extension registry lands this reads from it and
+nothing above this function changes.
+""".
+-spec extensions() -> [map()].
+extensions() -> [].
+
+-doc "Core capabilities, sorted by name so the response is stable.".
+-spec capabilities() -> [#{name := binary(), enabled := boolean()}].
+capabilities() ->
+    [
+        #{name => Name, enabled => Enabled}
+     || {Name, Enabled} <- lists:sort([
+            {~"clustering", configured(cluster)},
+            {~"guest_auth", configured(guest_auth)},
+            {~"iap_apple", configured(apple_bundle_id)},
+            {~"iap_google", configured(google_package_name)},
+            {~"lua", module_available(asobi_lua_match)},
+            {~"matches", any_mode(fun is_match_mode/1)},
+            {~"oidc", configured_collection(oidc_providers)},
+            {~"steam", configured(steam_api_key)},
+            {~"worlds", any_mode(fun is_world_mode/1)}
+        ])
+    ].
+
+-spec version() -> binary().
+version() ->
+    case application:get_key(asobi, vsn) of
+        {ok, Vsn} when is_list(Vsn) -> list_to_binary(Vsn);
+        _ -> ~"unknown"
+    end.
+
+-spec configured(atom()) -> boolean().
+configured(Key) ->
+    case application:get_env(asobi, Key) of
+        {ok, undefined} -> false;
+        {ok, ~""} -> false;
+        {ok, _} -> true;
+        undefined -> false
+    end.
+
+-spec configured_collection(atom()) -> boolean().
+configured_collection(Key) ->
+    case application:get_env(asobi, Key) of
+        {ok, Map} when is_map(Map) -> map_size(Map) > 0;
+        {ok, List} when is_list(List) -> List =/= [];
+        _ -> false
+    end.
+
+-spec module_available(module()) -> boolean().
+module_available(Module) ->
+    code:which(Module) =/= non_existing.
+
+-spec any_mode(fun((term()) -> boolean())) -> boolean().
+any_mode(Pred) ->
+    case application:get_env(asobi, game_modes) of
+        {ok, Modes} when is_map(Modes) -> lists:any(Pred, maps:values(Modes));
+        _ -> false
+    end.
+
+-spec is_world_mode(term()) -> boolean().
+is_world_mode(#{type := world}) -> true;
+is_world_mode(_) -> false.
+
+-spec is_match_mode(term()) -> boolean().
+is_match_mode(Config) -> not is_world_mode(Config).

--- a/src/ops/asobi_ops_matches.erl
+++ b/src/ops/asobi_ops_matches.erl
@@ -1,0 +1,67 @@
+-module(asobi_ops_matches).
+-moduledoc """
+Match-record list for the ops read plane: filter, search, sort, paginate.
+
+`asobi_match_controller:index/1` reads the same table but returns a bare list
+with no total and a fixed order. This returns the standard envelope, so a
+console can page through match history and know how much of it there is.
+""".
+
+-include_lib("kura/include/kura.hrl").
+
+-export([query/1, project/1, sortable/0]).
+
+-define(SORTABLE, [
+    {~"id", id},
+    {~"mode", mode},
+    {~"status", status},
+    {~"started_at", started_at},
+    {~"finished_at", finished_at},
+    {~"inserted_at", inserted_at}
+]).
+
+-define(MAX_FILTER_BYTES, 64).
+
+-doc "Wire-name to column mapping this endpoint accepts in `?sort=`.".
+-spec sortable() -> asobi_ops_params:sort_allowlist().
+sortable() -> ?SORTABLE.
+
+-spec query(asobi_ops_params:params()) ->
+    {ok, #kura_query{}} | {error, {unknown_sort, binary()} | {unknown_order, binary()}}.
+query(Params) ->
+    case asobi_ops_params:sort(Params, ?SORTABLE, [{inserted_at, desc}]) of
+        {ok, Orders} ->
+            Query0 = kura_query:from(asobi_match_record),
+            Query1 = equals(Query0, Params, ~"mode", mode),
+            Query2 = equals(Query1, Params, ~"status", status),
+            {ok, kura_query:order_by(search(Query2, Params), Orders)};
+        {error, _} = Error ->
+            Error
+    end.
+
+-spec equals(#kura_query{}, asobi_ops_params:params(), binary(), atom()) -> #kura_query{}.
+equals(Query, Params, Key, Column) ->
+    case maps:get(Key, Params, undefined) of
+        Value when is_binary(Value), Value =/= ~"", byte_size(Value) =< ?MAX_FILTER_BYTES ->
+            kura_query:where(Query, {Column, Value});
+        _ ->
+            Query
+    end.
+
+-spec search(#kura_query{}, asobi_ops_params:params()) -> #kura_query{}.
+search(Query, Params) ->
+    case asobi_ops_params:like_pattern(Params, ~"q") of
+        none -> Query;
+        {ok, Pattern} -> kura_query:where(Query, {mode, ilike, Pattern})
+    end.
+
+-doc """
+Positive allowlist of the fields a match row may carry off this endpoint.
+
+Identical to `asobi_match_controller`'s public projection, and for the same
+reason: `players` holds the full roster of a match the caller may not have
+been in, so it never leaves. `result` is game-authored and stays.
+""".
+-spec project(map()) -> map().
+project(Record) ->
+    maps:with([id, mode, status, result, started_at, finished_at, inserted_at], Record).

--- a/src/ops/asobi_ops_page.erl
+++ b/src/ops/asobi_ops_page.erl
@@ -1,0 +1,43 @@
+-module(asobi_ops_page).
+-moduledoc """
+The one list envelope every ops read endpoint returns.
+
+```erlang
+#{data => [...], page => #{limit => 50, offset => 0, total => 137}}
+```
+
+`total` is the point of the envelope: a console that cannot say how many rows
+exist cannot render a pager, and every list endpoint that predates this module
+made the caller guess. `kura_paginator:paginate/3` runs the count and the page
+as one unit, so the two can never describe different filters.
+
+`Project` is applied to every row on the way out. It is the endpoint's field
+allowlist, not a formatter - see the projections in `asobi_ops_players` and
+`asobi_ops_matches`.
+""".
+
+-include_lib("kura/include/kura.hrl").
+
+-export([list/3]).
+
+-doc """
+Run `Query` as one page and wrap it in the envelope.
+
+`Query` must already carry a deterministic order; `asobi_ops_params:sort/3`
+guarantees one. Without it the offset window is not stable between requests.
+""".
+-spec list(#kura_query{}, asobi_ops_params:page_spec(), fun((map()) -> map())) ->
+    {ok, map()} | {error, term()}.
+list(Query, #{limit := Limit, offset := Offset}, Project) when
+    is_integer(Limit), Limit > 0, is_integer(Offset), Offset >= 0
+->
+    PageNumber = Offset div Limit + 1,
+    case kura_paginator:paginate(asobi_repo, Query, #{page => PageNumber, page_size => Limit}) of
+        {ok, #{entries := Entries, total_entries := Total}} ->
+            {ok, #{
+                data => [Project(Entry) || Entry <- Entries],
+                page => #{limit => Limit, offset => Offset, total => Total}
+            }};
+        {error, _} = Error ->
+            Error
+    end.

--- a/src/ops/asobi_ops_params.erl
+++ b/src/ops/asobi_ops_params.erl
@@ -1,0 +1,170 @@
+-module(asobi_ops_params).
+-moduledoc """
+Query-string parsing for the ops read plane.
+
+Three rules, each of them load-bearing:
+
+* Numbers are parsed safely and clamped. `?limit=abc` must never reach
+  `binary_to_integer/1` (a `badarg` is a 500 and a free log-flood), and
+  `?limit=10000000` must never reach the database. Parsing goes through
+  `asobi_qs:integer/5`, which already fails soft to a default.
+* `order_by` is built from a per-endpoint allowlist of atoms and nothing else.
+  A user-supplied string reaching `order_by` is SQL injection, so an unknown
+  sort field is *rejected* rather than ignored - silently falling back to a
+  default would hide the mistake from the caller.
+* Every sort ends on a unique column. Offset pagination over a non-unique key
+  can return one row twice and skip another between pages, so `sort/3` appends
+  the primary key as a tie-breaker.
+
+`?page=N` and `?offset=N` both select a window. `page` wins when both are
+given. The offset returned is the one the query actually used - see `page/1`.
+""".
+
+-export([page/1, sort/3, like_pattern/2, cursor/1, encode_cursor/1]).
+
+-export_type([params/0, page_spec/0, sort_spec/0, sort_allowlist/0]).
+
+-type params() :: #{binary() => binary() | true}.
+-type page_spec() :: #{limit := pos_integer(), offset := non_neg_integer()}.
+-type sort_spec() :: [{atom(), asc | desc}].
+-type sort_allowlist() :: [{binary(), atom()}].
+
+-define(DEFAULT_LIMIT, 50).
+-define(MIN_LIMIT, 1).
+-define(MAX_LIMIT, 200).
+-define(MAX_OFFSET, 100000).
+-define(MAX_PAGE, 10000).
+-define(MAX_SEARCH_BYTES, 64).
+-define(MAX_CURSOR_BYTES, 128).
+
+-doc """
+Window for a list endpoint: a clamped limit and a clamped offset.
+
+`limit` defaults to 50 and is clamped to `[1, 200]`. `offset` is clamped to
+`[0, 100000]` - a deeper offset is a sequential scan, not a page.
+
+The offset is then snapped down to a whole multiple of the limit, because
+`kura_paginator:paginate/3` is page-based and can only express offsets that
+land on a page boundary. Snapping keeps the offset reported in the envelope
+equal to the offset the query ran with, rather than echoing one the caller
+asked for and did not get.
+""".
+-spec page(params()) -> page_spec().
+page(Params) ->
+    Props = maps:to_list(Params),
+    Limit = asobi_qs:integer(~"limit", Props, ?DEFAULT_LIMIT, ?MIN_LIMIT, ?MAX_LIMIT),
+    #{limit => Limit, offset => offset(Params, Props, Limit)}.
+
+-spec offset(params(), [{binary(), binary() | true}], pos_integer()) -> non_neg_integer().
+offset(Params, Props, Limit) ->
+    Requested =
+        case maps:is_key(~"page", Params) of
+            true -> (asobi_qs:integer(~"page", Props, 1, 1, ?MAX_PAGE) - 1) * Limit;
+            false -> asobi_qs:integer(~"offset", Props, 0, 0, ?MAX_OFFSET)
+        end,
+    min(Requested, ?MAX_OFFSET) div Limit * Limit.
+
+-doc """
+Resolve `?sort=` and `?order=` against a per-endpoint allowlist.
+
+`Allowed` maps the wire name to the column atom; only atoms already in that
+list can reach the query. An unknown field or direction is an error, so the
+caller answers 400 instead of quietly returning differently-ordered rows.
+
+`Default` is used when no sort is requested. Either way the result is
+completed with `{id, desc}` so the ordering is total.
+""".
+-spec sort(params(), sort_allowlist(), sort_spec()) ->
+    {ok, sort_spec()} | {error, {unknown_sort, binary()} | {unknown_order, binary()}}.
+sort(Params, Allowed, Default) ->
+    case maps:get(~"sort", Params, undefined) of
+        Field when is_binary(Field), Field =/= ~"" ->
+            case lists:keyfind(Field, 1, Allowed) of
+                {_, Column} -> sorted_by(Column, Params);
+                false -> {error, {unknown_sort, Field}}
+            end;
+        _ ->
+            {ok, deterministic(Default)}
+    end.
+
+-spec sorted_by(atom(), params()) -> {ok, sort_spec()} | {error, {unknown_order, binary()}}.
+sorted_by(Column, Params) ->
+    case order(Params) of
+        {ok, Direction} -> {ok, deterministic([{Column, Direction}])};
+        {error, _} = Error -> Error
+    end.
+
+-spec order(params()) -> {ok, asc | desc} | {error, {unknown_order, binary()}}.
+order(Params) ->
+    case maps:get(~"order", Params, undefined) of
+        Raw when is_binary(Raw), Raw =/= ~"" ->
+            case string:lowercase(Raw) of
+                ~"asc" -> {ok, asc};
+                ~"desc" -> {ok, desc};
+                _ -> {error, {unknown_order, Raw}}
+            end;
+        _ ->
+            {ok, asc}
+    end.
+
+-spec deterministic(sort_spec()) -> sort_spec().
+deterministic(Orders) ->
+    case lists:keymember(id, 1, Orders) of
+        true -> Orders;
+        false -> Orders ++ [{id, desc}]
+    end.
+
+-doc """
+Build an `ILIKE` pattern for a free-text search parameter.
+
+Returns `none` when the parameter is absent, empty, or longer than 64 bytes.
+""".
+-spec like_pattern(params(), binary()) -> {ok, binary()} | none.
+like_pattern(Params, Key) ->
+    case maps:get(Key, Params, undefined) of
+        Term when is_binary(Term), Term =/= ~"", byte_size(Term) =< ?MAX_SEARCH_BYTES ->
+            {ok, iolist_to_binary([~"%", escape_like(Term), ~"%"])};
+        _ ->
+            none
+    end.
+
+%% `%` and `_` are ILIKE wildcards and `\` is its escape character, so an
+%% unescaped search term changes what the query means - a lone `%` matches
+%% every row. Escape the backslash first, or the escapes added below get
+%% escaped in turn.
+-spec escape_like(binary()) -> binary().
+escape_like(Term) ->
+    Backslashes = binary:replace(Term, ~"\\", ~"\\\\", [global]),
+    Percents = binary:replace(Backslashes, ~"%", ~"\\%", [global]),
+    binary:replace(Percents, ~"_", ~"\\_", [global]).
+
+-doc """
+Decode an opaque `?cursor=` token back to its keyset value.
+
+Cursors are base64url without padding so they survive a query string intact
+and carry no meaning a caller can hand-craft. Anything that is not a valid
+token is an error, never a silent fall back to the first page.
+""".
+-spec cursor(params()) -> {ok, binary()} | none | {error, invalid_cursor}.
+cursor(Params) ->
+    case maps:get(~"cursor", Params, undefined) of
+        Token when is_binary(Token), Token =/= ~"", byte_size(Token) =< ?MAX_CURSOR_BYTES ->
+            decode_cursor(Token);
+        undefined ->
+            none;
+        _ ->
+            {error, invalid_cursor}
+    end.
+
+-spec decode_cursor(binary()) -> {ok, binary()} | {error, invalid_cursor}.
+decode_cursor(Token) ->
+    try base64:decode(Token, #{mode => urlsafe, padding => false}) of
+        Value -> {ok, Value}
+    catch
+        _:_ -> {error, invalid_cursor}
+    end.
+
+-doc "Encode a keyset value as the opaque cursor token `cursor/1` accepts.".
+-spec encode_cursor(binary()) -> binary().
+encode_cursor(Value) when is_binary(Value) ->
+    base64:encode(Value, #{mode => urlsafe, padding => false}).

--- a/src/ops/asobi_ops_players.erl
+++ b/src/ops/asobi_ops_players.erl
@@ -1,0 +1,68 @@
+-module(asobi_ops_players).
+-moduledoc """
+Player list for the ops read plane: filter, search, sort, paginate.
+
+Search is `ILIKE` across `username` and `display_name`. The endpoints this
+replaces searched by exact equality on a single column, which meant an
+operator had to already know the username to find it.
+""".
+
+-include_lib("kura/include/kura.hrl").
+
+-export([query/1, project/1, sortable/0]).
+
+%% Sortable fields are a subset of the projection below. A column that is
+%% sorted on but not returned leaks its ordering to a caller who is not
+%% allowed to read it.
+-define(SORTABLE, [
+    {~"id", id},
+    {~"username", username},
+    {~"display_name", display_name},
+    {~"inserted_at", inserted_at},
+    {~"updated_at", updated_at}
+]).
+
+-doc "Wire-name to column mapping this endpoint accepts in `?sort=`.".
+-spec sortable() -> asobi_ops_params:sort_allowlist().
+sortable() -> ?SORTABLE.
+
+-spec query(asobi_ops_params:params()) ->
+    {ok, #kura_query{}} | {error, {unknown_sort, binary()} | {unknown_order, binary()}}.
+query(Params) ->
+    case asobi_ops_params:sort(Params, ?SORTABLE, [{inserted_at, desc}]) of
+        {ok, Orders} ->
+            Query = search(kura_query:from(asobi_player), Params),
+            {ok, kura_query:order_by(Query, Orders)};
+        {error, _} = Error ->
+            Error
+    end.
+
+-spec search(#kura_query{}, asobi_ops_params:params()) -> #kura_query{}.
+search(Query, Params) ->
+    case asobi_ops_params:like_pattern(Params, ~"q") of
+        none ->
+            Query;
+        {ok, Pattern} ->
+            kura_query:where(
+                Query,
+                {'or', [
+                    {username, ilike, Pattern},
+                    {display_name, ilike, Pattern}
+                ]}
+            )
+    end.
+
+-doc """
+Positive allowlist of the fields a player row may carry off this endpoint.
+
+Deliberately identical to `asobi_player_controller`'s projection: these routes
+sit behind the same player-scoped auth plugin, so they must not widen what an
+authenticated caller can already read. `hashed_password` must never appear
+here. Widening the projection waits on the capability model (ADR 0007).
+""".
+-spec project(map()) -> map().
+project(Player) ->
+    maps:with(
+        [id, username, display_name, avatar_url, metadata, inserted_at, updated_at],
+        Player
+    ).

--- a/test/asobi_ops_params_tests.erl
+++ b/test/asobi_ops_params_tests.erl
@@ -1,0 +1,203 @@
+-module(asobi_ops_params_tests).
+
+-include_lib("eunit/include/eunit.hrl").
+
+%%--------------------------------------------------------------------
+%% Limit / offset clamping
+%%--------------------------------------------------------------------
+
+page_defaults_test() ->
+    ?assertEqual(#{limit => 50, offset => 0}, asobi_ops_params:page(#{})).
+
+limit_is_honoured_test() ->
+    ?assertMatch(#{limit := 25}, asobi_ops_params:page(#{~"limit" => ~"25"})).
+
+limit_clamped_to_max_test() ->
+    ?assertMatch(#{limit := 200}, asobi_ops_params:page(#{~"limit" => ~"10000000"})).
+
+limit_clamped_to_min_test() ->
+    ?assertMatch(#{limit := 1}, asobi_ops_params:page(#{~"limit" => ~"0"})),
+    ?assertMatch(#{limit := 1}, asobi_ops_params:page(#{~"limit" => ~"-5"})).
+
+%% The regression this whole module exists for: raw binary_to_integer/1 on
+%% `abc` raises badarg, which cowboy turns into a 500.
+limit_garbage_falls_back_to_default_test() ->
+    ?assertMatch(#{limit := 50}, asobi_ops_params:page(#{~"limit" => ~"abc"})),
+    ?assertMatch(#{limit := 50}, asobi_ops_params:page(#{~"limit" => ~"12x"})),
+    ?assertMatch(#{limit := 50}, asobi_ops_params:page(#{~"limit" => ~""})).
+
+%% `?limit` with no value parses to the atom `true`, not a binary.
+limit_valueless_falls_back_to_default_test() ->
+    ?assertMatch(#{limit := 50}, asobi_ops_params:page(#{~"limit" => true})).
+
+offset_is_honoured_test() ->
+    ?assertEqual(
+        #{limit => 10, offset => 30},
+        asobi_ops_params:page(#{~"limit" => ~"10", ~"offset" => ~"30"})
+    ).
+
+offset_garbage_falls_back_to_zero_test() ->
+    ?assertMatch(#{offset := 0}, asobi_ops_params:page(#{~"offset" => ~"; DROP TABLE"})).
+
+offset_never_negative_test() ->
+    ?assertMatch(#{offset := 0}, asobi_ops_params:page(#{~"offset" => ~"-100"})).
+
+offset_clamped_to_max_test() ->
+    ?assertMatch(
+        #{offset := 100000}, asobi_ops_params:page(#{~"limit" => ~"100", ~"offset" => ~"9999999"})
+    ).
+
+%% Snapped down to a page boundary so the echoed offset is the one the query
+%% actually used.
+offset_snaps_to_page_boundary_test() ->
+    ?assertEqual(
+        #{limit => 50, offset => 50},
+        asobi_ops_params:page(#{~"limit" => ~"50", ~"offset" => ~"75"})
+    ).
+
+page_number_converts_to_offset_test() ->
+    ?assertEqual(
+        #{limit => 20, offset => 40},
+        asobi_ops_params:page(#{~"limit" => ~"20", ~"page" => ~"3"})
+    ).
+
+page_number_wins_over_offset_test() ->
+    ?assertEqual(
+        #{limit => 20, offset => 0},
+        asobi_ops_params:page(#{~"limit" => ~"20", ~"page" => ~"1", ~"offset" => ~"999"})
+    ).
+
+page_number_clamped_test() ->
+    ?assertMatch(
+        #{offset := 100000}, asobi_ops_params:page(#{~"limit" => ~"200", ~"page" => ~"99999"})
+    ),
+    ?assertMatch(#{offset := 0}, asobi_ops_params:page(#{~"page" => ~"0"})).
+
+%%--------------------------------------------------------------------
+%% Sort allowlist
+%%--------------------------------------------------------------------
+
+allowlist() ->
+    [{~"username", username}, {~"inserted_at", inserted_at}].
+
+sort_defaults_when_absent_test() ->
+    ?assertEqual(
+        {ok, [{inserted_at, desc}, {id, desc}]},
+        asobi_ops_params:sort(#{}, allowlist(), [{inserted_at, desc}])
+    ).
+
+sort_maps_allowed_field_to_atom_test() ->
+    ?assertEqual(
+        {ok, [{username, asc}, {id, desc}]},
+        asobi_ops_params:sort(#{~"sort" => ~"username"}, allowlist(), [{inserted_at, desc}])
+    ).
+
+sort_honours_order_test() ->
+    ?assertEqual(
+        {ok, [{username, desc}, {id, desc}]},
+        asobi_ops_params:sort(
+            #{~"sort" => ~"username", ~"order" => ~"desc"}, allowlist(), [{inserted_at, desc}]
+        )
+    ),
+    ?assertEqual(
+        {ok, [{username, desc}, {id, desc}]},
+        asobi_ops_params:sort(
+            #{~"sort" => ~"username", ~"order" => ~"DESC"}, allowlist(), [{inserted_at, desc}]
+        )
+    ).
+
+%% The injection guard: a field that is not on the allowlist is rejected, and
+%% never reaches order_by as a string.
+sort_rejects_unknown_field_test() ->
+    ?assertEqual(
+        {error, {unknown_sort, ~"hashed_password"}},
+        asobi_ops_params:sort(#{~"sort" => ~"hashed_password"}, allowlist(), [{inserted_at, desc}])
+    ).
+
+sort_rejects_injection_payload_test() ->
+    Payload = ~"id; DROP TABLE players--",
+    ?assertEqual(
+        {error, {unknown_sort, Payload}},
+        asobi_ops_params:sort(#{~"sort" => Payload}, allowlist(), [{inserted_at, desc}])
+    ).
+
+sort_rejects_unknown_order_test() ->
+    ?assertEqual(
+        {error, {unknown_order, ~"sideways"}},
+        asobi_ops_params:sort(
+            #{~"sort" => ~"username", ~"order" => ~"sideways"}, allowlist(), [{inserted_at, desc}]
+        )
+    ).
+
+sort_valueless_falls_back_to_default_test() ->
+    ?assertEqual(
+        {ok, [{inserted_at, desc}, {id, desc}]},
+        asobi_ops_params:sort(#{~"sort" => true}, allowlist(), [{inserted_at, desc}])
+    ).
+
+%% Offset pagination over a non-unique key is non-deterministic without a
+%% unique tie-breaker.
+sort_always_ends_on_unique_column_test() ->
+    {ok, Orders} = asobi_ops_params:sort(
+        #{~"sort" => ~"username"}, allowlist(), [{inserted_at, desc}]
+    ),
+    ?assertEqual({id, desc}, lists:last(Orders)).
+
+sort_does_not_duplicate_id_test() ->
+    ?assertEqual(
+        {ok, [{id, asc}]},
+        asobi_ops_params:sort(#{~"sort" => ~"id"}, [{~"id", id}], [{inserted_at, desc}])
+    ).
+
+%%--------------------------------------------------------------------
+%% Search patterns
+%%--------------------------------------------------------------------
+
+like_pattern_absent_test() ->
+    ?assertEqual(none, asobi_ops_params:like_pattern(#{}, ~"q")).
+
+like_pattern_empty_test() ->
+    ?assertEqual(none, asobi_ops_params:like_pattern(#{~"q" => ~""}, ~"q")).
+
+like_pattern_too_long_test() ->
+    Long = binary:copy(~"a", 65),
+    ?assertEqual(none, asobi_ops_params:like_pattern(#{~"q" => Long}, ~"q")).
+
+like_pattern_wraps_term_test() ->
+    ?assertEqual({ok, ~"%kaito%"}, asobi_ops_params:like_pattern(#{~"q" => ~"kaito"}, ~"q")).
+
+%% A bare `%` would otherwise match every row.
+like_pattern_escapes_wildcards_test() ->
+    ?assertEqual({ok, ~"%\\%%"}, asobi_ops_params:like_pattern(#{~"q" => ~"%"}, ~"q")),
+    ?assertEqual({ok, ~"%a\\_b%"}, asobi_ops_params:like_pattern(#{~"q" => ~"a_b"}, ~"q")).
+
+%% `\%` escapes to `\\` + `\%`: the backslash goes first, or the escape added
+%% for `%` would itself be escaped and the `%` would stay a wildcard.
+like_pattern_escapes_backslash_first_test() ->
+    ?assertEqual({ok, ~"%\\\\\\%%"}, asobi_ops_params:like_pattern(#{~"q" => ~"\\%"}, ~"q")).
+
+%%--------------------------------------------------------------------
+%% Cursors
+%%--------------------------------------------------------------------
+
+cursor_absent_test() ->
+    ?assertEqual(none, asobi_ops_params:cursor(#{})).
+
+cursor_round_trips_test() ->
+    Id = ~"0197f3d0-1c2b-7000-8000-000000000001",
+    Token = asobi_ops_params:encode_cursor(Id),
+    ?assertEqual({ok, Id}, asobi_ops_params:cursor(#{~"cursor" => Token})).
+
+cursor_is_url_safe_test() ->
+    Token = asobi_ops_params:encode_cursor(<<255, 254, 253, 252>>),
+    ?assertEqual(nomatch, binary:match(Token, [~"+", ~"/", ~"="])).
+
+cursor_rejects_garbage_test() ->
+    ?assertEqual({error, invalid_cursor}, asobi_ops_params:cursor(#{~"cursor" => ~"not*base64"})).
+
+cursor_rejects_oversized_token_test() ->
+    Token = asobi_ops_params:encode_cursor(binary:copy(~"a", 200)),
+    ?assertEqual({error, invalid_cursor}, asobi_ops_params:cursor(#{~"cursor" => Token})).
+
+cursor_rejects_valueless_param_test() ->
+    ?assertEqual({error, invalid_cursor}, asobi_ops_params:cursor(#{~"cursor" => true})).

--- a/test/asobi_ops_tests.erl
+++ b/test/asobi_ops_tests.erl
@@ -1,0 +1,289 @@
+-module(asobi_ops_tests).
+
+-include_lib("eunit/include/eunit.hrl").
+-include_lib("kura/include/kura.hrl").
+
+%%--------------------------------------------------------------------
+%% Envelope
+%%--------------------------------------------------------------------
+
+envelope_test_() ->
+    {setup, fun setup_paginator/0, fun cleanup_paginator/1, [
+        fun envelope_shape/0,
+        fun envelope_reports_total/0,
+        fun envelope_echoes_requested_window/0,
+        fun envelope_applies_projection/0,
+        fun envelope_translates_offset_to_page/0,
+        fun envelope_propagates_repo_error/0
+    ]}.
+
+setup_paginator() ->
+    meck:new(kura_paginator, [passthrough]),
+    ok.
+
+cleanup_paginator(_) ->
+    catch meck:unload(kura_paginator),
+    ok.
+
+expect_page(Entries, Total) ->
+    meck:expect(kura_paginator, paginate, fun(asobi_repo, _Query, Opts) ->
+        {ok, #{
+            entries => Entries,
+            page => maps:get(page, Opts),
+            page_size => maps:get(page_size, Opts),
+            total_entries => Total,
+            total_pages => 1
+        }}
+    end).
+
+envelope_shape() ->
+    expect_page([#{id => ~"a"}], 1),
+    {ok, Envelope} = asobi_ops_page:list(query(), #{limit => 50, offset => 0}, fun identity/1),
+    ?assertEqual([data, page], lists:sort(maps:keys(Envelope))),
+    #{page := Page} = Envelope,
+    ?assertEqual([limit, offset, total], lists:sort(maps:keys(Page))).
+
+envelope_reports_total() ->
+    expect_page([#{id => ~"a"}, #{id => ~"b"}], 137),
+    {ok, #{data := Data, page := Page}} = asobi_ops_page:list(
+        query(), #{limit => 2, offset => 0}, fun identity/1
+    ),
+    ?assertEqual(2, length(Data)),
+    ?assertEqual(137, maps:get(total, Page)).
+
+envelope_echoes_requested_window() ->
+    expect_page([], 0),
+    {ok, #{page := Page}} = asobi_ops_page:list(
+        query(), #{limit => 20, offset => 40}, fun identity/1
+    ),
+    ?assertEqual(#{limit => 20, offset => 40, total => 0}, Page).
+
+envelope_applies_projection() ->
+    expect_page([#{id => ~"a", hashed_password => ~"secret"}], 1),
+    {ok, #{data := [Row]}} = asobi_ops_page:list(
+        query(), #{limit => 50, offset => 0}, fun asobi_ops_players:project/1
+    ),
+    ?assertEqual(#{id => ~"a"}, Row).
+
+envelope_translates_offset_to_page() ->
+    expect_page([], 0),
+    meck:reset(kura_paginator),
+    {ok, _} = asobi_ops_page:list(query(), #{limit => 25, offset => 50}, fun identity/1),
+    [{_, {kura_paginator, paginate, [_, _, Opts]}, _}] = meck:history(kura_paginator),
+    ?assertEqual(#{page => 3, page_size => 25}, Opts).
+
+envelope_propagates_repo_error() ->
+    meck:expect(kura_paginator, paginate, fun(_, _, _) -> {error, closed} end),
+    ?assertEqual(
+        {error, closed},
+        asobi_ops_page:list(query(), #{limit => 50, offset => 0}, fun identity/1)
+    ).
+
+query() ->
+    kura_query:order_by(kura_query:from(asobi_player), [{id, desc}]).
+
+identity(Row) -> Row.
+
+%%--------------------------------------------------------------------
+%% Player query
+%%--------------------------------------------------------------------
+
+players_default_order_is_deterministic_test() ->
+    {ok, #kura_query{order_bys = Orders}} = asobi_ops_players:query(#{}),
+    ?assertEqual([{inserted_at, desc}, {id, desc}], Orders).
+
+players_sort_uses_allowlisted_atom_test() ->
+    {ok, #kura_query{order_bys = Orders}} = asobi_ops_players:query(#{~"sort" => ~"username"}),
+    ?assertEqual([{username, asc}, {id, desc}], Orders).
+
+players_reject_unknown_sort_test() ->
+    ?assertEqual(
+        {error, {unknown_sort, ~"hashed_password"}},
+        asobi_ops_players:query(#{~"sort" => ~"hashed_password"})
+    ).
+
+players_sortable_fields_are_all_projected_test() ->
+    Projected = maps:keys(asobi_ops_players:project(sample_player())),
+    [
+        ?assert(lists:member(Column, Projected))
+     || {_Wire, Column} <- asobi_ops_players:sortable()
+    ].
+
+players_search_uses_ilike_on_both_names_test() ->
+    {ok, #kura_query{wheres = Wheres}} = asobi_ops_players:query(#{~"q" => ~"kai"}),
+    ?assertEqual(
+        [{'or', [{username, ilike, ~"%kai%"}, {display_name, ilike, ~"%kai%"}]}],
+        Wheres
+    ).
+
+players_no_search_no_filter_test() ->
+    {ok, #kura_query{wheres = Wheres}} = asobi_ops_players:query(#{}),
+    ?assertEqual([], Wheres).
+
+%% The projection is a positive allowlist, so a credential column cannot leak
+%% even if a future schema change adds one.
+players_projection_drops_credentials_test() ->
+    Projected = asobi_ops_players:project(sample_player()),
+    ?assertNot(maps:is_key(hashed_password, Projected)),
+    ?assertNot(maps:is_key(password, Projected)),
+    ?assertNot(maps:is_key(banned_at, Projected)),
+    ?assertEqual(~"kaito", maps:get(username, Projected)).
+
+sample_player() ->
+    #{
+        id => ~"p1",
+        username => ~"kaito",
+        display_name => ~"Kaito",
+        avatar_url => ~"https://example.test/a.png",
+        metadata => #{},
+        hashed_password => ~"pbkdf2$secret",
+        password => ~"hunter2",
+        banned_at => undefined,
+        inserted_at => {{2026, 8, 3}, {12, 0, 0}},
+        updated_at => {{2026, 8, 3}, {12, 0, 0}}
+    }.
+
+%%--------------------------------------------------------------------
+%% Match query
+%%--------------------------------------------------------------------
+
+matches_default_order_is_deterministic_test() ->
+    {ok, #kura_query{order_bys = Orders}} = asobi_ops_matches:query(#{}),
+    ?assertEqual([{inserted_at, desc}, {id, desc}], Orders).
+
+matches_reject_unknown_sort_test() ->
+    ?assertEqual(
+        {error, {unknown_sort, ~"players"}},
+        asobi_ops_matches:query(#{~"sort" => ~"players"})
+    ).
+
+matches_reject_unknown_order_test() ->
+    ?assertEqual(
+        {error, {unknown_order, ~"random"}},
+        asobi_ops_matches:query(#{~"sort" => ~"mode", ~"order" => ~"random"})
+    ).
+
+matches_filters_are_equality_on_columns_test() ->
+    {ok, #kura_query{wheres = Wheres}} = asobi_ops_matches:query(#{
+        ~"mode" => ~"deathmatch", ~"status" => ~"finished"
+    }),
+    ?assertEqual([{mode, ~"deathmatch"}, {status, ~"finished"}], Wheres).
+
+matches_oversized_filter_is_dropped_test() ->
+    {ok, #kura_query{wheres = Wheres}} = asobi_ops_matches:query(#{
+        ~"mode" => binary:copy(~"m", 65)
+    }),
+    ?assertEqual([], Wheres).
+
+matches_projection_drops_roster_test() ->
+    Record = #{
+        id => ~"m1",
+        mode => ~"deathmatch",
+        status => ~"finished",
+        players => [~"p1", ~"p2"],
+        result => #{~"winner" => ~"p1"},
+        metadata => #{~"secret" => true},
+        started_at => undefined,
+        finished_at => undefined,
+        inserted_at => {{2026, 8, 3}, {12, 0, 0}}
+    },
+    Projected = asobi_ops_matches:project(Record),
+    ?assertNot(maps:is_key(players, Projected)),
+    ?assertNot(maps:is_key(metadata, Projected)),
+    ?assertEqual(#{~"winner" => ~"p1"}, maps:get(result, Projected)).
+
+matches_sortable_fields_are_all_projected_test() ->
+    Projected = maps:keys(
+        asobi_ops_matches:project(#{
+            id => ~"m1",
+            mode => ~"m",
+            status => ~"s",
+            result => #{},
+            started_at => undefined,
+            finished_at => undefined,
+            inserted_at => undefined
+        })
+    ),
+    [
+        ?assert(lists:member(Column, Projected))
+     || {_Wire, Column} <- asobi_ops_matches:sortable()
+    ].
+
+%%--------------------------------------------------------------------
+%% Routing
+%%--------------------------------------------------------------------
+
+%% The ops plane reuses core's bearer check rather than inventing one. If a
+%% later edit moves these routes to an unsecured group, this fails.
+ops_routes_are_mounted_behind_auth_test() ->
+    Groups = asobi_router:routes(dev),
+    [
+        ?assertEqual(
+            {fun asobi_auth_plugin:verify/1, [get, options]},
+            route(Groups, ~"/api/v1", Path)
+        )
+     || Path <- [~"/ops/players", ~"/ops/matches", ~"/ops/features"]
+    ].
+
+route(Groups, Prefix, Path) ->
+    [Found] = [
+        {maps:get(security, Group), maps:get(methods, Opts)}
+     || #{prefix := GroupPrefix, routes := Routes} = Group <- Groups,
+        GroupPrefix =:= Prefix,
+        {RoutePath, _Handler, Opts} <- Routes,
+        RoutePath =:= Path
+    ],
+    Found.
+
+%%--------------------------------------------------------------------
+%% Features
+%%--------------------------------------------------------------------
+
+features_shape_test() ->
+    #{data := Data} = asobi_ops_features:features(),
+    ?assertEqual([core, extensions], lists:sort(maps:keys(Data))),
+    #{core := Core} = Data,
+    ?assertEqual([capabilities, name, version], lists:sort(maps:keys(Core))),
+    ?assertEqual(~"asobi", maps:get(name, Core)),
+    ?assert(is_binary(maps:get(version, Core))).
+
+features_extensions_empty_until_registry_test() ->
+    #{data := #{extensions := Extensions}} = asobi_ops_features:features(),
+    ?assertEqual([], Extensions).
+
+features_capabilities_are_name_and_boolean_only_test() ->
+    Capabilities = asobi_ops_features:capabilities(),
+    ?assert(Capabilities =/= []),
+    [
+        begin
+            ?assertEqual([enabled, name], lists:sort(maps:keys(Capability))),
+            ?assert(is_binary(maps:get(name, Capability))),
+            ?assert(is_boolean(maps:get(enabled, Capability)))
+        end
+     || Capability <- Capabilities
+    ].
+
+features_capabilities_sorted_by_name_test() ->
+    Names = [maps:get(name, Capability) || Capability <- asobi_ops_features:capabilities()],
+    ?assertEqual(lists:sort(Names), Names).
+
+features_capability_reflects_configuration_test() ->
+    Original = application:get_env(asobi, steam_api_key),
+    try
+        application:unset_env(asobi, steam_api_key),
+        ?assertEqual(false, capability_enabled(~"steam")),
+        application:set_env(asobi, steam_api_key, ~"key"),
+        ?assertEqual(true, capability_enabled(~"steam"))
+    after
+        case Original of
+            {ok, Value} -> application:set_env(asobi, steam_api_key, Value);
+            undefined -> application:unset_env(asobi, steam_api_key)
+        end
+    end.
+
+capability_enabled(Name) ->
+    [Enabled] = [
+        E
+     || #{name := N, enabled := E} <- asobi_ops_features:capabilities(), N =:= Name
+    ],
+    Enabled.


### PR DESCRIPTION
## What was broken

The console-facing list endpoints across the fleet share one shape of defect: they hand back a bare array with no total, no sort, and a limit the caller controls but nobody clamps. `asobi_admin` (a separate repo, untouched here) has seven of them - none with a total, none with a sort, none clamping the limit, one parsing `?limit=` with a raw `binary_to_integer/1` so `?limit=abc` is a 500, one with no `order_by` at all so offset paging returns a different window each request, and search as exact equality on a single column.

I did not read `asobi_admin` - it is out of scope for this PR and I take that inventory as given. What I did verify is that core has the same shape in-tree, and it is the honest example of what this replaces:

- `src/controllers/asobi_match_controller.erl:65` - returns `#{matches => [...]}`. No total, so a console cannot render a pager.
- `src/controllers/asobi_match_controller.erl:63` - `order_by` is hard-coded to `[{inserted_at, desc}]`. No sort parameter, and `inserted_at` is not unique, so an offset window over rows sharing a timestamp is not stable.
- `src/controllers/asobi_match_controller.erl:62` - the limit *is* clamped here, via `asobi_qs:integer/5`. That helper (`src/asobi_qs.erl`) is the one piece of prior art worth keeping, and the new params module is built on it rather than reimplementing the parse.

There is no offset parameter anywhere in core today, so there is no second page of anything.

## What I changed

New `src/ops/` module family, read plane only.

**`asobi_ops_params`** - the query-string layer. Three rules:

1. Numbers are parsed through `asobi_qs:integer/5` and clamped. `?limit=abc`, `?limit=`, and a valueless `?limit` all fall back to 50; `?limit=10000000` becomes 200; `?offset=-100` becomes 0 and is capped at 100000 because a deeper offset is a sequential scan, not a page.
2. `order_by` is built only from a per-endpoint allowlist of `{WireName, ColumnAtom}` pairs. A user string never reaches `order_by`. An unknown field is `{error, {unknown_sort, Field}}` -> 400, deliberately *not* a silent fallback: a malformed number is harmless, a malformed sort silently returns the wrong rows.
3. Every sort ends on `{id, desc}` unless it already sorts on `id`. That is requirement 4 enforced in one place rather than per endpoint.

Also: opaque base64url (unpadded) cursor encode/decode, and `like_pattern/2`, which escapes `\`, `%`, `_` before wrapping the term in its own wildcards - an unescaped `%` in a search term otherwise matches every row.

**`asobi_ops_page`** - the single envelope, over `kura_paginator:paginate/3` (previously unused anywhere in the fleet). The paginator runs the count and the page as one unit, so the two can never describe different filters. It is page-based, so `list/3` converts `offset` to a page number, and `asobi_ops_params:page/1` snaps the requested offset down to a page boundary - the `offset` in the response is therefore always the offset the query ran with, not one the caller asked for and did not get.

```json
{ "data": [ ... ], "page": { "limit": 50, "offset": 0, "total": 137 } }
```

**`asobi_ops_players`** / **`asobi_ops_matches`** - query builders plus a positive field allowlist each. Players search `username` and `display_name` with `ILIKE`; matches filter on `mode`/`status` and search `mode`.

**`asobi_ops_features`** - `GET /api/v1/ops/features`. Core reports `#{name, version, capabilities}` and `extensions` is `[]`; the two are the same shape, so a registry fills `extensions/0` and nothing above it changes. Capabilities report what is *configured* rather than what is compiled in (a console needs to know whether Steam auth will work on this deployment), and carry a name and boolean only - never the configured value, which is usually a secret.

**Routes** - `src/asobi_router.erl:183-185`, inside the existing `/api/v1` group, so they inherit `asobi_auth_plugin:verify/1`. No new auth scheme.

**Docs** - `guides/rest-api.md` gains an Ops section; `rebar.config` gains an ex_doc module group.

### Security note on the projections

Because these routes sit behind the player-scoped bearer check, *any authenticated player* can read them today. So both projections are held to exactly what the equivalent public endpoint already exposes: `asobi_ops_players:project/1` mirrors `asobi_player_controller:sanitize/1` (no `hashed_password`, and no `banned_at` - which is not currently public), and `asobi_ops_matches:project/1` mirrors `asobi_match_controller:public_record/1` (no roster, no `metadata`). Sortable fields are a strict subset of the projection, enforced by a test - sorting on a column you cannot read leaks its ordering. Widening any of this waits on the operator capability model (ADR 0007), which is the follow-up.

## What the tests assert

`test/asobi_ops_params_tests.erl` and `test/asobi_ops_tests.erl`, 61 tests:

- **Clamping** - default 50; `?limit=10000000` -> 200; `?limit=0`/`-5` -> 1; `?limit=abc`, `12x`, `""`, and a valueless `?limit` -> default, not a crash; `?offset=; DROP TABLE` -> 0; offset capped at 100000; offset snapped to a page boundary (`limit=50&offset=75` -> 50); `?page=3&limit=20` -> offset 40; `page` wins over `offset`.
- **Sort allowlist** - an allowed name maps to its atom; `?sort=hashed_password` and `?sort=id; DROP TABLE players--` both return `{error, {unknown_sort, _}}` and never reach the query; `?order=sideways` returns `{error, {unknown_order, _}}`; `?order=DESC` is accepted case-insensitively; a valueless `?sort` falls back to the default.
- **Determinism** - every resolved sort ends on `{id, desc}`, and `id` is not duplicated when it is the requested sort. Both endpoints' default order asserted as `[{inserted_at, desc}, {id, desc}]`.
- **Envelope** - exact key sets (`data`/`page`, and `limit`/`offset`/`total`); the total is passed through; the requested window is echoed; the projection is applied to every row (a row carrying `hashed_password` comes out with it stripped); `offset=50, limit=25` reaches the paginator as `#{page => 3, page_size => 25}`; a repo error propagates rather than being swallowed. `kura_paginator` is mecked, so these run without a database.
- **Projections** - credentials and `banned_at` absent from the player projection; roster and `metadata` absent from the match projection; every sortable column is present in its own projection.
- **Search** - `q` wraps and escapes; `%` -> `\%`, `_` -> `\_`, and `\%` -> `\\` + `\%` (backslash escaped first, or the escape added for `%` would itself be escaped); an over-64-byte term is dropped; players search compiles to `{'or', [{username, ilike, _}, {display_name, ilike, _}]}`.
- **Cursors** - round trip, URL-safe alphabet (no `+`, `/`, `=`), garbage and oversized tokens rejected.
- **Routing** - all three ops routes are mounted under `/api/v1` with `asobi_auth_plugin:verify/1` as their security. Fails if a later edit moves them to an unsecured group.

## Checks

| Command | Result |
| --- | --- |
| `rebar3 fmt` / `rebar3 fmt --check` | clean - "All matched files use erlfmt code style!" |
| `rebar3 xref` | clean, no findings |
| `rebar3 eunit` | **634 tests, 0 failures** (61 of them new) |
| `rebar3 dialyzer` | clean, no warnings |

## What I could not verify

- **No integration test against a live database.** The envelope tests mock `kura_paginator`, so what is proven is the shape, the projection, and the offset-to-page translation - not that the generated SQL runs. The CT suites here need Docker Postgres and I did not stand one up. The pieces that touch SQL (`{'or', [...]}`, `ilike`, `{count, '*'}` aliased as `"count"`) were read out of `kura_dialect_pg` and confirmed parameterised, but they have not been executed. An `asobi_ops_SUITE` against real rows is the obvious follow-up.
- **`asobi_admin` itself.** Not read, not edited. The seven endpoints there stay broken until they are pointed at this module family; that migration is not in this PR.
- **Cursor helpers are not wired to a route.** `cursor/1` and `encode_cursor/1` are exported and tested, but every endpoint in this PR pages by offset because the envelope wants a total. The keyset path lands when a table gets big enough to need it.
- **The `ops/features` capability list is a judgement call.** It reports nine things I could determine honestly from config; it is not an exhaustive inventory of what core can do, and it will be replaced wholesale by the registry.
