### PR TITLE
fix: hydrate leaderboards on start and flush them on shutdown

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -399,6 +399,8 @@ Hybrid ETS + PostgreSQL. ETS for hot reads, Kura for persistence.
 - `rank(BoardId, PlayerId)` — player's rank via ETS position
 - `reset(BoardId)` — snapshot to archive table, clear ETS, Shigoto job
 
+**Lifecycle:** a board hydrates its ETS tables from `leaderboard_entries` before it accepts reads, and flushes pending scores on shutdown, so a restart does not reset the board. Each flush writes only the players that changed since the previous flush; a player whose write fails stays pending and is retried on the next tick.
+
 **Time-scoped boards:** Shigoto schedules resets (daily/weekly/monthly). On reset, current entries archived to `asobi_leaderboard_archive` with period metadata.
 
 ### Chat Channel (`asobi_chat_channel` — gen_server)

--- a/src/leaderboards/asobi_leaderboard_server.erl
+++ b/src/leaderboards/asobi_leaderboard_server.erl
@@ -1,6 +1,8 @@
 -module(asobi_leaderboard_server).
 -behaviour(gen_server).
 
+-include_lib("kernel/include/logger.hrl").
+
 -export([start_link/1, submit/3, top/2, rank/2, around/3]).
 -export([init/1, handle_call/3, handle_cast/2, handle_info/2, terminate/2]).
 
@@ -96,17 +98,21 @@ whereis_board_optional(BoardId) ->
         [] -> not_found
     end.
 
+%% ETS is the source of truth for reads, so a board that starts empty
+%% serves an empty leaderboard even though the rows are still in
+%% Postgres. Load them back before the process becomes reachable.
 -spec init(binary()) -> {ok, map()}.
 init(BoardId) ->
     pg:join(?PG_SCOPE, {?MODULE, BoardId}, self()),
     Table = ets:new(leaderboard, [ordered_set, private]),
     PlayerIndex = ets:new(player_index, [set, private]),
+    hydrate(BoardId, Table, PlayerIndex),
     erlang:send_after(30000, self(), persist),
     {ok, #{
         board_id => BoardId,
         table => Table,
         player_index => PlayerIndex,
-        dirty => false
+        dirty => #{}
     }}.
 
 -spec handle_call(term(), gen_server:from(), map()) -> {reply, term(), map()}.
@@ -135,7 +141,9 @@ handle_call(_Request, _From, State) ->
     {reply, {error, unknown_request}, State}.
 
 -spec handle_cast(term(), map()) -> {noreply, map()}.
-handle_cast({submit, PlayerId, Score}, #{table := Table, player_index := Idx} = State) when
+handle_cast(
+    {submit, PlayerId, Score}, #{table := Table, player_index := Idx, dirty := Dirty} = State
+) when
     is_number(Score)
 ->
     case ets:lookup(Idx, PlayerId) of
@@ -146,28 +154,74 @@ handle_cast({submit, PlayerId, Score}, #{table := Table, player_index := Idx} = 
     end,
     ets:insert(Table, {{-Score, PlayerId}, Score}),
     ets:insert(Idx, {PlayerId, Score}),
-    {noreply, State#{dirty => true}};
+    {noreply, State#{dirty => Dirty#{PlayerId => true}}};
 handle_cast(_Msg, State) ->
     {noreply, State}.
 
 -spec handle_info(term(), map()) -> {noreply, map()}.
-handle_info(persist, #{dirty := true, board_id := BoardId, table := Table} = State) ->
-    flush_to_db(BoardId, Table),
+handle_info(persist, #{dirty := Dirty} = State) when map_size(Dirty) > 0 ->
+    Pending = flush_to_db(State),
     erlang:send_after(30000, self(), persist),
-    {noreply, State#{dirty => false}};
+    {noreply, State#{dirty => Pending}};
 handle_info(persist, State) ->
     erlang:send_after(30000, self(), persist),
     {noreply, State};
 handle_info(_Info, State) ->
     {noreply, State}.
 
+%% Best effort: terminate runs inside the supervisor's 5s shutdown
+%% budget, so a slow or unreachable database costs a brutal kill and the
+%% pending scores, not a hung shutdown.
 -spec terminate(term(), map()) -> ok.
-terminate(_Reason, #{table := Table, player_index := Idx}) ->
+terminate(_Reason, #{dirty := Dirty} = State) when map_size(Dirty) > 0 ->
+    _ = flush_to_db(State),
+    delete_tables(State);
+terminate(_Reason, State) ->
+    delete_tables(State).
+
+%% --- Internal ---
+
+delete_tables(#{table := Table, player_index := Idx}) ->
     ets:delete(Table),
     ets:delete(Idx),
     ok.
 
-%% --- Internal ---
+hydrate(BoardId, Table, Idx) ->
+    Q = kura_query:where(kura_query:from(asobi_leaderboard_entry), {leaderboard_id, BoardId}),
+    try asobi_repo:all(Q) of
+        {ok, Rows} ->
+            lists:foreach(fun(Row) -> hydrate_row(BoardId, Table, Idx, Row) end, Rows);
+        %% A board that cannot read its rows still starts, on empty
+        %% tables: flush_to_db/1 upserts per player and never deletes, so
+        %% the persisted board degrades to partial reads until the next
+        %% start rather than being erased.
+        {error, Reason} ->
+            log_hydrate_failure(BoardId, Reason)
+    catch
+        Class:CaughtReason ->
+            log_hydrate_failure(BoardId, {Class, CaughtReason})
+    end.
+
+hydrate_row(_BoardId, Table, Idx, #{player_id := PlayerId, score := Score}) when
+    is_binary(PlayerId), is_number(Score)
+->
+    ets:insert(Table, {{-Score, PlayerId}, Score}),
+    ets:insert(Idx, {PlayerId, Score}),
+    ok;
+hydrate_row(BoardId, _Table, _Idx, Row) ->
+    ?LOG_WARNING(#{
+        msg => ~"leaderboard hydrate skipped unusable row",
+        board_id => BoardId,
+        row => Row
+    }),
+    ok.
+
+log_hydrate_failure(BoardId, Reason) ->
+    ?LOG_ERROR(#{
+        msg => ~"leaderboard hydrate failed",
+        board_id => BoardId,
+        error => Reason
+    }).
 
 take_top(Table, N) ->
     take_top(Table, ets:first(Table), N, 1, []).
@@ -233,52 +287,74 @@ assign_ranks([], _Rank, Acc) ->
 assign_ranks([{PlayerId, Score, _} | Rest], Rank, Acc) ->
     assign_ranks(Rest, Rank + 1, [{PlayerId, Score, Rank} | Acc]).
 
-flush_to_db(BoardId, Table) ->
-    flush_entries(BoardId, Table, ets:first(Table)).
+%% Returns the players whose write failed so they stay dirty and are
+%% retried on the next tick instead of being silently dropped.
+flush_to_db(#{board_id := BoardId, player_index := Idx, dirty := Dirty}) ->
+    flush_players(BoardId, Idx, maps:keys(Dirty), #{}).
 
-flush_entries(_BoardId, _Table, '$end_of_table') ->
-    ok;
-flush_entries(BoardId, Table, {_NegScore, PlayerId} = Key) ->
-    [{_, Score}] = ets:lookup(Table, Key),
+flush_players(_BoardId, _Idx, [], Pending) ->
+    Pending;
+flush_players(BoardId, Idx, [PlayerId | Rest], Pending) ->
+    Next =
+        case ets:lookup(Idx, PlayerId) of
+            [{PlayerId, Score}] ->
+                case upsert_entry(BoardId, PlayerId, Score) of
+                    ok -> Pending;
+                    {error, _} -> Pending#{PlayerId => true}
+                end;
+            [] ->
+                Pending
+        end,
+    flush_players(BoardId, Idx, Rest, Next).
+
+upsert_entry(BoardId, PlayerId, Score) ->
+    try write_entry(BoardId, PlayerId, Score) of
+        {ok, _} ->
+            ok;
+        {error, Reason} ->
+            log_flush_failure(BoardId, PlayerId, Reason),
+            {error, Reason}
+    catch
+        Class:CaughtReason ->
+            log_flush_failure(BoardId, PlayerId, {Class, CaughtReason}),
+            {error, CaughtReason}
+    end.
+
+write_entry(BoardId, PlayerId, Score) ->
     Q = kura_query:where(
         kura_query:where(kura_query:from(asobi_leaderboard_entry), {leaderboard_id, BoardId}),
         {player_id, PlayerId}
     ),
-    Result =
-        case asobi_repo:all(Q) of
-            {ok, [Existing]} ->
-                CS = kura_changeset:cast(
-                    asobi_leaderboard_entry,
-                    Existing,
-                    #{score => Score},
-                    [score]
-                ),
-                asobi_repo:update(CS);
-            {ok, []} ->
-                CS = kura_changeset:cast(
-                    asobi_leaderboard_entry,
-                    #{},
-                    #{
-                        leaderboard_id => BoardId,
-                        player_id => PlayerId,
-                        score => Score,
-                        sub_score => 0
-                    },
-                    [leaderboard_id, player_id, score, sub_score]
-                ),
-                asobi_repo:insert(CS);
-            {error, Reason} ->
-                {error, Reason}
-        end,
-    case Result of
-        {ok, _} ->
-            ok;
-        {error, FlushErr} ->
-            logger:error(#{
-                msg => ~"leaderboard flush failed",
-                board_id => BoardId,
-                player_id => PlayerId,
-                error => FlushErr
-            })
-    end,
-    flush_entries(BoardId, Table, ets:next(Table, Key)).
+    case asobi_repo:all(Q) of
+        {ok, [Existing | _]} ->
+            CS = kura_changeset:cast(
+                asobi_leaderboard_entry,
+                Existing,
+                #{score => Score},
+                [score]
+            ),
+            asobi_repo:update(CS);
+        {ok, []} ->
+            CS = kura_changeset:cast(
+                asobi_leaderboard_entry,
+                #{},
+                #{
+                    leaderboard_id => BoardId,
+                    player_id => PlayerId,
+                    score => Score,
+                    sub_score => 0
+                },
+                [leaderboard_id, player_id, score, sub_score]
+            ),
+            asobi_repo:insert(CS);
+        {error, Reason} ->
+            {error, Reason}
+    end.
+
+log_flush_failure(BoardId, PlayerId, Reason) ->
+    ?LOG_ERROR(#{
+        msg => ~"leaderboard flush failed",
+        board_id => BoardId,
+        player_id => PlayerId,
+        error => Reason
+    }).

--- a/test/asobi_leaderboard_persistence_tests.erl
+++ b/test/asobi_leaderboard_persistence_tests.erl
@@ -1,0 +1,172 @@
+-module(asobi_leaderboard_persistence_tests).
+
+-include_lib("eunit/include/eunit.hrl").
+-include_lib("kura/include/kura.hrl").
+
+%% asobi#328: ETS is the source of truth for leaderboard reads, so a
+%% board that starts empty serves an empty board even though the rows
+%% are still in Postgres. These drive the real gen_server with
+%% asobi_repo mecked over an ETS stand-in for the table, so no DB is
+%% needed.
+
+-define(DB, leaderboard_persistence_fake_db).
+-define(SCOPE, nova_scope).
+
+setup() ->
+    case whereis(?SCOPE) of
+        undefined -> pg:start_link(?SCOPE);
+        _ -> ok
+    end,
+    ets:new(?DB, [named_table, public, set]),
+    ets:insert(?DB, {writes, 0}),
+    meck:new(asobi_repo, [passthrough]),
+    meck:expect(asobi_repo, all, fun fake_all/1),
+    meck:expect(asobi_repo, insert, fun fake_insert/1),
+    meck:expect(asobi_repo, update, fun fake_update/1),
+    ok.
+
+cleanup(_) ->
+    meck:unload(asobi_repo),
+    ets:delete(?DB),
+    ok.
+
+persistence_test_() ->
+    {foreach, fun setup/0, fun cleanup/1, [
+        {"a restarted board still serves the scores it persisted", fun restart_reloads_scores/0},
+        {"stopping a board flushes scores the 30s timer never reached",
+            fun shutdown_flushes_pending_scores/0},
+        {"a flush writes only the players that changed", fun flush_writes_only_changed_players/0},
+        {"a board whose hydrate fails still starts and deletes nothing",
+            fun hydrate_failure_starts_empty/0}
+    ]}.
+
+restart_reloads_scores() ->
+    BoardId = board_id(),
+    Alice = asobi_id:generate(),
+    Bob = asobi_id:generate(),
+    Pid = start_board(BoardId),
+    ok = asobi_leaderboard_server:submit(BoardId, Alice, 100),
+    ok = asobi_leaderboard_server:submit(BoardId, Bob, 200),
+    ?assertEqual(
+        [{Bob, 200, 1}, {Alice, 100, 2}],
+        asobi_leaderboard_server:top(BoardId, 10)
+    ),
+    stop_board(BoardId, Pid),
+
+    Restarted = start_board(BoardId),
+    ?assertEqual(
+        [{Bob, 200, 1}, {Alice, 100, 2}],
+        asobi_leaderboard_server:top(BoardId, 10)
+    ),
+    ?assertEqual({ok, 2}, asobi_leaderboard_server:rank(BoardId, Alice)),
+    %% Ranks are left out here: around/3 numbers its window from a
+    %% count_before/2 call that is passed a player id where an ETS key
+    %% belongs, so every rank it reports is offset. Pre-existing and
+    %% unrelated to hydration - asobi#334.
+    Around = asobi_leaderboard_server:around(BoardId, Alice, 5),
+    ?assertEqual([{Bob, 200}, {Alice, 100}], [{P, S} || {P, S, _} <- Around]),
+    stop_board(BoardId, Restarted).
+
+shutdown_flushes_pending_scores() ->
+    BoardId = board_id(),
+    Alice = asobi_id:generate(),
+    Pid = start_board(BoardId),
+    ok = asobi_leaderboard_server:submit(BoardId, Alice, 100),
+    %% Nothing is persisted yet: the persist timer is 30s away.
+    ?assertEqual(not_found, db_score(BoardId, Alice)),
+    stop_board(BoardId, Pid),
+    ?assertEqual(100, db_score(BoardId, Alice)).
+
+flush_writes_only_changed_players() ->
+    BoardId = board_id(),
+    Alice = asobi_id:generate(),
+    Bob = asobi_id:generate(),
+    Carol = asobi_id:generate(),
+    seed_row(BoardId, Alice, 100),
+    seed_row(BoardId, Bob, 200),
+    Pid = start_board(BoardId),
+    ets:insert(?DB, {writes, 0}),
+    ok = asobi_leaderboard_server:submit(BoardId, Carol, 150),
+    stop_board(BoardId, Pid),
+    ?assertEqual(1, writes()),
+    ?assertEqual(150, db_score(BoardId, Carol)),
+    ?assertEqual(100, db_score(BoardId, Alice)).
+
+hydrate_failure_starts_empty() ->
+    BoardId = board_id(),
+    Alice = asobi_id:generate(),
+    seed_row(BoardId, Alice, 100),
+    meck:expect(asobi_repo, all, fun(_Q) -> {error, db_down} end),
+    Pid = start_board(BoardId),
+    ?assertEqual([], asobi_leaderboard_server:top(BoardId, 10)),
+    stop_board(BoardId, Pid),
+    %% Degraded reads, but the persisted row is untouched: the flush
+    %% upserts per player and never deletes.
+    meck:expect(asobi_repo, all, fun fake_all/1),
+    ?assertEqual(100, db_score(BoardId, Alice)).
+
+%% --- Board lifecycle ---
+
+board_id() ->
+    iolist_to_binary([~"board_", integer_to_binary(erlang:unique_integer([positive]))]).
+
+start_board(BoardId) ->
+    {ok, Pid} = asobi_leaderboard_server:start_link(BoardId),
+    Pid.
+
+stop_board(BoardId, Pid) ->
+    ok = gen_server:stop(Pid),
+    wait_for_departure(BoardId, 100).
+
+%% pg removes a dead member asynchronously, so a restart racing the stop
+%% could otherwise call the previous pid.
+wait_for_departure(BoardId, 0) ->
+    ?assertEqual([], pg:get_members(?SCOPE, {asobi_leaderboard_server, BoardId}));
+wait_for_departure(BoardId, Retries) ->
+    case pg:get_members(?SCOPE, {asobi_leaderboard_server, BoardId}) of
+        [] ->
+            ok;
+        _ ->
+            timer:sleep(10),
+            wait_for_departure(BoardId, Retries - 1)
+    end.
+
+%% --- Fake repo over ?DB ---
+
+fake_all(#kura_query{from = asobi_leaderboard_entry, wheres = Wheres}) ->
+    Rows = [Row || {{row, _B, _P}, Row} <- ets:tab2list(?DB)],
+    {ok, [Row || Row <- Rows, matches(Row, Wheres)]}.
+
+matches(Row, Wheres) ->
+    lists:all(fun({Field, Value}) -> maps:get(Field, Row, undefined) =:= Value end, Wheres).
+
+fake_insert(#kura_changeset{valid = true, changes = Changes}) ->
+    store_row(Changes).
+
+fake_update(#kura_changeset{valid = true, data = Data, changes = Changes}) ->
+    store_row(maps:merge(Data, Changes)).
+
+store_row(#{leaderboard_id := BoardId, player_id := PlayerId} = Row) ->
+    ets:insert(?DB, {{row, BoardId, PlayerId}, Row}),
+    ets:update_counter(?DB, writes, 1),
+    {ok, Row}.
+
+seed_row(BoardId, PlayerId, Score) ->
+    Row = #{
+        id => asobi_id:generate(),
+        leaderboard_id => BoardId,
+        player_id => PlayerId,
+        score => Score,
+        sub_score => 0
+    },
+    ets:insert(?DB, {{row, BoardId, PlayerId}, Row}).
+
+db_score(BoardId, PlayerId) ->
+    case ets:lookup(?DB, {row, BoardId, PlayerId}) of
+        [{_, #{score := Score}}] -> Score;
+        [] -> not_found
+    end.
+
+writes() ->
+    [{writes, N}] = ets:lookup(?DB, writes),
+    N.


### PR DESCRIPTION
Closes #328.

## What was broken

`asobi_leaderboard_server` treats ETS as the source of truth for reads, but the tables had no lifecycle across a restart.

1. **`init/1` never hydrated** (`src/leaderboards/asobi_leaderboard_server.erl:99-111` at `db6c582`). It created two empty tables and armed the 30s persist timer, and nothing read `asobi_leaderboard_entry`. After any restart - deploy, roll, supervisor restart - `top/2`, `rank/2` and `around/3` served an empty or partial board although the rows were still in Postgres. It recovered only as players resubmitted; a player who never played again never reappeared.
2. **`terminate/2` discarded pending scores** (`:164-169`). It deleted both tables without flushing, so a clean shutdown lost up to 30 seconds of submissions.

As the issue notes, `flush_entries/3` upserts per entry and never deletes, so rows absent from ETS were **not** removed from Postgres. The data survived; it was simply never read back.

## What changed

**`init/1` hydrates** (`hydrate/3`): one `asobi_repo:all/1` for that `leaderboard_id`, loaded into both the `ordered_set` and the player index. It runs before `init/1` returns, so the process is never reachable in an unhydrated state - a caller that finds the board through `pg` blocks on the `gen_server` call until the load is done, rather than reading empty tables.

**`terminate/2` flushes first**, then deletes. Best effort by construction: `terminate` runs inside the supervisor's default 5s worker shutdown, so a slow or unreachable database costs a brutal kill and the pending scores, not a hung shutdown.

**A hydrate failure is not fatal.** The board starts on empty tables and logs. Because the flush upserts per player and never deletes, a board that could not read its rows degrades to partial reads until the next start; it does not erase what is persisted. Refusing to start would be worse - `submit/3` silently drops scores when no board process exists.

**Flush is now driven by a dirty set, not the whole table.** This is required by the hydration, not incidental: `dirty` was a boolean and `flush_to_db/2` walked every ETS row, so once a board holds its full history a single submission would turn each 30s tick into one SELECT plus one INSERT/UPDATE per entry on the whole board. `dirty` is now a set of player ids; `flush_to_db/1` writes only those. That also keeps the shutdown flush proportional to pending changes rather than to board size, which is what makes it fit the 5s budget.

**A failed write keeps its player pending** and is retried on the next tick instead of being dropped - previously `dirty` was reset to `false` regardless of the result. `upsert_entry/3` also catches exceptions from the repo (a dead pool exits rather than returning `{error, _}`), so a Postgres blip no longer crashes the board and, through the supervisor's 5-per-60s intensity, the whole `asobi_leaderboard_sup`.

Logging moved from `logger:error/1` to `?LOG_ERROR`/`?LOG_WARNING` per AGENTS.md.

### On bounding the hydrate

I did **not** bound it to a top-N window. Full load, one query. A bounded window makes `rank/2` wrong rather than merely incomplete: ranks are computed by walking the ETS table, so a player below the window either reports `{error, not_found}` or, once they resubmit and re-enter ETS, gets a rank counted only over the loaded window - a better rank than they hold. That is a silent wrong answer on the API's most-consumed field. The full load costs one query at start and holds in ETS exactly the board the process would have held before the restart. If a real board ever gets large enough for start latency to bite, the right fix is a bounded window *plus* a DB-side `count(*) where score > ?` for `rank/2`, which is a bigger change than this bug warrants.

## What the tests assert

New `test/asobi_leaderboard_persistence_tests.erl` - drives the real `gen_server`, with `asobi_repo` mecked over an ETS stand-in for the table, so no Postgres is needed:

- `restart_reloads_scores` - the issue's round trip. Submit two scores, `gen_server:stop`, wait for `pg` to drop the dead member, start a fresh board with the same id, and assert `top/2` returns both players with the right scores and order, `rank/2` returns 2 for the second-placed player, and `around/3` returns both.
- `shutdown_flushes_pending_scores` - asserts nothing is persisted while the board runs (the timer is 30s away), then that stopping the board writes the score.
- `flush_writes_only_changed_players` - seeds two rows, starts the board (hydrating both), resets the write counter, submits a third player, stops: exactly one write, and the hydrated rows are intact.
- `hydrate_failure_starts_empty` - `asobi_repo:all/1` returning `{error, db_down}` still starts the board, reads are empty, and the seeded row is still there afterwards.

Verified they are real regression tests: against `db6c582` the first three fail (`got: []`, `got: not_found`, `got: 0`) and pass on this branch. The fourth guards the new failure mode only, so it passes either way.

## Checks

- `rebar3 fmt` / `rebar3 fmt --check` - clean.
- `rebar3 xref` - clean.
- `rebar3 eunit` - **577 tests, 0 failures** (full suite).
- `rebar3 dialyzer` - clean (not requested, run because AGENTS.md mandates it).

## Not verified

- **`rebar3 ct` was not run.** The CT suites need the Docker Postgres and I did not have it up in this worktree. `asobi_leaderboard_SUITE` and `asobi_leaderboard_api_SUITE` never stop their boards, so neither reaches the new shutdown flush; the hydrate does run on every `start_board/1`, against a real empty-for-that-board table. Worth a CT run before merge.
- Those two suites submit non-UUID player ids (`~"alice"`). The `player_id` column is `uuid`, so their flushes were already failing the changeset cast before this change and still do; the only difference is that those players now stay in the dirty set and are retried each tick instead of being retried via a full-table walk each tick. Same volume of failing writes, same log line.
- The `#{dirty := Dirty}` state shape changed from a boolean. Nothing outside the module reads it (checked with grep); there is no hot code upgrade path in this repo.

## Found but not fixed

`around/3` attaches ranks that are offset by the size of the board: `entries_around/3` passes `element(1, FirstEntry)` - a player id - to `count_before/2`, which compares against `{-Score, PlayerId}` ETS keys, so the walk never matches and always returns the entry count. Pre-existing at `db6c582` and unrelated to persistence; filed as #334 and left alone here. It is why `restart_reloads_scores` asserts players and scores from `around/3` but not its ranks.
