### PR TITLE
fix: count finished matches in player_stats (#329)

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -507,7 +507,10 @@ depends on Arizona.
 | `iap_reconcile` | Every 1h | Reconcile IAP receipts with store APIs |
 | `presence_cleanup` | Every 5m | Safety net for stale presence (pg handles most) |
 | `analytics_flush` | Every 1m | Flush telemetry events to analytics pipeline |
-| `player_stats_sync` | Every 5m | Aggregate match results into player stats |
+
+Player stats are not a background job: `asobi_match_server` folds a finished
+match into `player_stats` in the same transaction that writes the match
+record, so the counters and the match history can never disagree.
 
 ## Security
 

--- a/guides/websocket-protocol.md
+++ b/guides/websocket-protocol.md
@@ -248,6 +248,15 @@ Notification that a match has ended with results.
 {"type": "match.finished", "payload": {"match_id": "...", "result": {...}}}
 ```
 
+`result` is whatever your game returned with `{finished, Result, State}`;
+asobi does not interpret it, with one exception. It reads `winners` (a list
+of player ids) or `winner` (one id), and `losers` / `loser`, to move the
+`wins` and `losses` columns in `player_stats`. `games_played` moves for
+every player in the match either way. Declare winners without losers and
+every other player in the match takes the loss; declare `losers: []` to
+score a co-op run where nobody loses. `rating` and `rating_deviation` are
+not maintained by asobi.
+
 ### `match.leave`
 
 Leave the current match.

--- a/src/matches/asobi_match.erl
+++ b/src/matches/asobi_match.erl
@@ -81,6 +81,11 @@ races.
 Called on a fixed interval (default 10 Hz, configurable per mode). Advance
 time, run AI, and check win conditions. Return `{finished, Result, State}`
 to end the match. Optional: omit it if your game has no fixed time step.
+
+`Result` is yours - asobi stores it verbatim on the match record and pushes
+it to every player. It reads only the `winners`/`winner` and
+`losers`/`loser` keys, to move `wins` and `losses` in `player_stats`; see
+`asobi_player_stats:record_match/2`.
 """.
 -callback tick(GameState :: term()) ->
     {ok, GameState1 :: term()}

--- a/src/matches/asobi_match_record.erl
+++ b/src/matches/asobi_match_record.erl
@@ -4,6 +4,22 @@
 -include_lib("kura/include/kura.hrl").
 
 -export([table/0, fields/0, associations/0, indexes/0, generate_id/0]).
+-export([to_timestamp/1]).
+
+-doc """
+Convert a match server's monotonic-ish millisecond stamp into the
+`utc_datetime` the `started_at` / `finished_at` columns hold.
+
+Both servers keep their timers in `erlang:system_time(millisecond)`, and
+`kura_changeset:cast/4` rejects an integer for a `utc_datetime` field with
+`cannot cast to utc_datetime` - which is why every finished match failed to
+persist until asobi#329.
+""".
+-spec to_timestamp(integer() | undefined) -> calendar:datetime() | undefined.
+to_timestamp(undefined) ->
+    undefined;
+to_timestamp(Millis) when is_integer(Millis) ->
+    calendar:system_time_to_universal_time(Millis, millisecond).
 
 -spec table() -> binary().
 table() -> ~"match_records".

--- a/src/matches/asobi_match_server.erl
+++ b/src/matches/asobi_match_server.erl
@@ -786,7 +786,13 @@ notify_players(Event, #{players := Players, match_id := MatchId} = State) ->
         Players
     ).
 
+%% asobi#329: the match record row and the participants' stats counters are
+%% one write. `match_records.id` is the match id, so a second pass over a
+%% match that already finished (a recovered server re-entering `finished`)
+%% loses the insert on the primary key and rolls the counters back with it -
+%% that primary key is what makes games_played move exactly once per match.
 persist_result(#{match_id := MatchId, players := Players} = State) ->
+    Result = maps:get(result, State, #{}),
     CS = kura_changeset:cast(
         asobi_match_record,
         #{},
@@ -795,13 +801,22 @@ persist_result(#{match_id := MatchId, players := Players} = State) ->
             mode => maps:get(mode, State, undefined),
             status => ~"finished",
             players => maps:keys(Players),
-            result => maps:get(result, State, #{}),
-            started_at => maps:get(started_at, State, undefined),
-            finished_at => erlang:system_time(millisecond)
+            result => Result,
+            started_at => asobi_match_record:to_timestamp(maps:get(started_at, State, undefined)),
+            finished_at => asobi_match_record:to_timestamp(erlang:system_time(millisecond))
         },
         [id, mode, status, players, result, started_at, finished_at]
     ),
-    _ = asobi_repo:insert(CS),
+    _ = asobi_repo:transaction(fun() ->
+        case asobi_repo:insert(CS) of
+            {ok, _} ->
+                asobi_player_stats:record_match(maps:keys(Players), Result);
+            {error, Reason} ->
+                ?LOG_WARNING(#{
+                    event => match_record_persist_failed, match_id => MatchId, reason => Reason
+                })
+        end
+    end),
     ok.
 
 match_info(Status, State) ->

--- a/src/players/asobi_player_stats.erl
+++ b/src/players/asobi_player_stats.erl
@@ -4,7 +4,7 @@
 -include_lib("kura/include/kura.hrl").
 
 -export([table/0, fields/0, associations/0, generate_id/0]).
--export([init/1]).
+-export([init/1, record_match/2]).
 
 -include_lib("kernel/include/logger.hrl").
 
@@ -23,6 +23,42 @@ init(PlayerId) ->
             }),
             ok
     end.
+
+-doc """
+Fold one finished match into every participant's stats row (asobi#329).
+
+`games_played` moves for every participant. `wins` and `losses` come from
+the result map the game module returned with `{finished, Result, State}`,
+which asobi reads for exactly these keys - accepted as atoms or binaries,
+because a Lua game's result arrives with binary keys:
+
+- `winners` (list of player ids) or `winner` (one player id)
+- `losers` (list of player ids) or `loser` (one player id)
+
+Ids that are not in the match roster are ignored. When winners are
+declared and losers are not, every other participant is recorded as a
+loss; declare `losers => []` for a game where losing is not a thing. A
+result declaring neither only moves `games_played`, which is what a draw,
+a co-op run, or an unscored sandbox should do.
+
+`rating` and `rating_deviation` are deliberately untouched - asobi has no
+rating algorithm, and the column names imply a specific one.
+
+Must be called inside `asobi_repo:transaction/1` alongside the write that
+makes the match final, so the counters cannot drift from the match record.
+""".
+-spec record_match([binary()], map()) -> ok.
+record_match([], _Result) ->
+    ok;
+record_match(Participants, Result) ->
+    Winners = in_roster(Participants, declared(Result, winners, winner)),
+    Losers = losers(Participants, Winners, Result),
+    lists:foreach(
+        fun(PlayerId) ->
+            bump(PlayerId, tally(PlayerId, Winners), tally(PlayerId, Losers))
+        end,
+        Participants
+    ).
 
 -spec table() -> binary().
 table() -> ~"player_stats".
@@ -50,3 +86,63 @@ associations() ->
             name = player, type = belongs_to, schema = asobi_player, foreign_key = player_id
         }
     ].
+
+%% --- Internal ---
+
+%% A single UPDATE per participant, so the increment is relative to the
+%% committed row rather than to one this process read earlier - kura's
+%% update_all/2 can only SET literals, and a read-modify-write would need
+%% the wallet's advisory-lock dance to stay correct under concurrent
+%% matches.
+-spec bump(binary(), 0 | 1, 0 | 1) -> ok.
+bump(PlayerId, Win, Loss) ->
+    SQL = [
+        ~"UPDATE player_stats SET games_played = games_played + 1, ",
+        ~"wins = wins + $2, losses = losses + $3, updated_at = now() ",
+        ~"WHERE player_id = $1"
+    ],
+    case kura_db:query(asobi_repo, SQL, [PlayerId, Win, Loss]) of
+        #{num_rows := 0} ->
+            ?LOG_WARNING(#{event => player_stats_row_missing, player_id => PlayerId});
+        #{num_rows := _} ->
+            ok;
+        Other ->
+            ?LOG_WARNING(#{
+                event => player_stats_update_failed, player_id => PlayerId, reason => Other
+            })
+    end,
+    ok.
+
+-spec declared(map(), atom(), atom()) -> [dynamic()] | undefined.
+declared(Result, Plural, Singular) ->
+    case {value(Result, Plural), value(Result, Singular)} of
+        {Ids, _} when is_list(Ids) -> Ids;
+        {_, Id} when is_binary(Id) -> [Id];
+        _ -> undefined
+    end.
+
+-spec value(map(), atom()) -> dynamic().
+value(Result, Key) ->
+    case maps:get(Key, Result, undefined) of
+        undefined -> maps:get(atom_to_binary(Key, utf8), Result, undefined);
+        Value -> Value
+    end.
+
+-spec in_roster([binary()], [dynamic()] | undefined) -> [binary()].
+in_roster(_Participants, undefined) -> [];
+in_roster(Participants, Ids) -> [Id || Id <- Ids, lists:member(Id, Participants)].
+
+-spec losers([binary()], [binary()], map()) -> [binary()].
+losers(Participants, Winners, Result) ->
+    case declared(Result, losers, loser) of
+        undefined when Winners =/= [] -> Participants -- Winners;
+        undefined -> [];
+        Declared -> in_roster(Participants, Declared)
+    end.
+
+-spec tally(binary(), [binary()]) -> 0 | 1.
+tally(PlayerId, Ids) ->
+    case lists:member(PlayerId, Ids) of
+        true -> 1;
+        false -> 0
+    end.

--- a/src/world/asobi_world_server.erl
+++ b/src/world/asobi_world_server.erl
@@ -1486,6 +1486,11 @@ update_frustration(_Result, Frustration) ->
 
 %% --- Internal: Persistence ---
 
+%% asobi#329: the millisecond stamps used to go in raw and every insert
+%% failed the `utc_datetime` cast, silently - no world ever reached
+%% match_records. Player stats stay out of this path on purpose: a world is
+%% a persistent space, not a scored game, so "one world visit is one game
+%% played" is a product call rather than a bug fix.
 persist_result(#{world_id := WorldId, players := Players} = State) ->
     CS = kura_changeset:cast(
         asobi_match_record,
@@ -1496,13 +1501,20 @@ persist_result(#{world_id := WorldId, players := Players} = State) ->
             status => ~"finished",
             players => maps:keys(Players),
             result => maps:get(result, State, #{}),
-            started_at => maps:get(started_at, State, undefined),
-            finished_at => erlang:system_time(millisecond)
+            started_at => asobi_match_record:to_timestamp(maps:get(started_at, State, undefined)),
+            finished_at => asobi_match_record:to_timestamp(erlang:system_time(millisecond))
         },
         [id, mode, status, players, result, started_at, finished_at]
     ),
-    _ = asobi_repo:insert(CS),
-    ok.
+    case asobi_repo:insert(CS) of
+        {ok, _} ->
+            ok;
+        {error, Reason} ->
+            ?LOG_WARNING(#{
+                event => world_record_persist_failed, world_id => WorldId, reason => Reason
+            }),
+            ok
+    end.
 
 -doc """
 Fan a game-authored event out to every player in the world.

--- a/test/asobi_match_record_tests.erl
+++ b/test/asobi_match_record_tests.erl
@@ -1,0 +1,32 @@
+-module(asobi_match_record_tests).
+-include_lib("eunit/include/eunit.hrl").
+-include_lib("kura/include/kura.hrl").
+
+%% asobi#329: the match servers keep their clocks in
+%% erlang:system_time(millisecond), and feeding those integers straight into
+%% the utc_datetime columns made kura_changeset:cast/4 invalid - so every
+%% finished match failed to persist, silently.
+
+to_timestamp_produces_a_castable_datetime_test() ->
+    Millis = 1785791629064,
+    Datetime = asobi_match_record:to_timestamp(Millis),
+    ?assertEqual({{2026, 8, 3}, {21, 13, 49}}, Datetime),
+    CS = kura_changeset:cast(
+        asobi_match_record,
+        #{},
+        #{status => ~"finished", started_at => Datetime, finished_at => Datetime},
+        [status, started_at, finished_at]
+    ),
+    ?assertMatch(#kura_changeset{valid = true, errors = []}, CS).
+
+millisecond_integers_are_not_castable_test() ->
+    CS = kura_changeset:cast(
+        asobi_match_record,
+        #{},
+        #{status => ~"finished", finished_at => 1785791629064},
+        [status, finished_at]
+    ),
+    ?assertMatch(#kura_changeset{valid = false, errors = [{finished_at, _} | _]}, CS).
+
+to_timestamp_passes_undefined_through_test() ->
+    ?assertEqual(undefined, asobi_match_record:to_timestamp(undefined)).

--- a/test/asobi_match_server_tests.erl
+++ b/test/asobi_match_server_tests.erl
@@ -3,6 +3,8 @@
 
 -define(GAME, asobi_test_game).
 -define(BASE_CONFIG, #{game_module => ?GAME, min_players => 2, max_players => 4, tick_rate => 50}).
+%% One {PlayerId, WinDelta, LossDelta} per stats UPDATE the match server issued.
+-define(STATS_TAB, asobi_match_server_tests_stats).
 
 %% --- Setup / Teardown ---
 
@@ -11,6 +13,10 @@ setup() ->
         undefined -> ets:new(asobi_match_state, [named_table, public, set]);
         _ -> ok
     end,
+    case ets:whereis(?STATS_TAB) of
+        undefined -> ets:new(?STATS_TAB, [named_table, public, duplicate_bag]);
+        _ -> ets:delete_all_objects(?STATS_TAB)
+    end,
     case whereis(nova_scope) of
         undefined -> pg:start_link(nova_scope);
         _ -> ok
@@ -18,12 +24,19 @@ setup() ->
     meck:new(asobi_repo, [no_link]),
     meck:expect(asobi_repo, insert, fun(_CS) -> {ok, #{}} end),
     meck:expect(asobi_repo, insert, fun(_CS, _Opts) -> {ok, #{}} end),
+    meck:expect(asobi_repo, transaction, fun(Fun) -> Fun() end),
+    meck:new(kura_db, [passthrough, no_link]),
+    meck:expect(kura_db, query, fun(_Repo, _SQL, [PlayerId, Win, Loss]) ->
+        ets:insert(?STATS_TAB, {PlayerId, Win, Loss}),
+        #{num_rows => 1}
+    end),
     meck:new(asobi_presence, [non_strict, no_link]),
     meck:expect(asobi_presence, send, fun(_PlayerId, _Msg) -> ok end),
     ok.
 
 cleanup(_) ->
     meck:unload(asobi_presence),
+    meck:unload(kura_db),
     meck:unload(asobi_repo),
     ok.
 
@@ -862,6 +875,57 @@ empty_phases_does_not_finish_test() ->
     ?assertEqual(running, maps:get(status, asobi_match_server:get_info(Pid))),
     gen_statem:stop(Pid),
     meck:unload(asobi_test_game),
+    cleanup(ok).
+
+%% --- player stats on match completion (asobi#329) ---
+
+%% player_stats had an insert on signup, a delete on guest reap, and nothing
+%% in between: every account's games_played sat at 0 forever because no code
+%% path ever issued an UPDATE.
+
+finished_match_counts_each_participant_once_test() ->
+    setup(),
+    Pid = start_match(#{min_players => 2, max_players => 4, tick_rate => 10}),
+    ok = asobi_match_server:join(Pid, ~"p1"),
+    ok = asobi_match_server:join(Pid, ~"p2"),
+    wait_for_status(Pid, running, 60),
+    asobi_match_server:cancel(Pid),
+    wait_for_status(Pid, finished, 60),
+    gen_statem:stop(Pid),
+    %% One row per participant, no more: entering `finished` is the only
+    %% place that counts, and it happens once per match.
+    ?assertEqual([{~"p1", 0, 0}], ets:lookup(?STATS_TAB, ~"p1")),
+    ?assertEqual([{~"p2", 0, 0}], ets:lookup(?STATS_TAB, ~"p2")),
+    ?assertEqual(2, ets:info(?STATS_TAB, size)),
+    cleanup(ok).
+
+finished_match_records_winner_and_loser_test() ->
+    setup(),
+    meck:new(asobi_test_game, [passthrough, no_link]),
+    meck:expect(asobi_test_game, tick, fun(GS) -> {finished, #{winner => ~"p1"}, GS} end),
+    Pid = start_match(#{min_players => 2, max_players => 2, tick_rate => 10}),
+    ok = asobi_match_server:join(Pid, ~"p1"),
+    ok = asobi_match_server:join(Pid, ~"p2"),
+    wait_for_status(Pid, finished, 60),
+    gen_statem:stop(Pid),
+    meck:unload(asobi_test_game),
+    ?assertEqual([{~"p1", 1, 0}], ets:lookup(?STATS_TAB, ~"p1")),
+    ?assertEqual([{~"p2", 0, 1}], ets:lookup(?STATS_TAB, ~"p2")),
+    cleanup(ok).
+
+%% The match record's primary key is the match id, so a match that already
+%% finished loses the insert and must not move the counters a second time.
+duplicate_match_record_leaves_stats_alone_test() ->
+    setup(),
+    meck:expect(asobi_repo, insert, fun(_CS) -> {error, duplicate_key} end),
+    Pid = start_match(#{min_players => 2, max_players => 4, tick_rate => 10}),
+    ok = asobi_match_server:join(Pid, ~"p1"),
+    ok = asobi_match_server:join(Pid, ~"p2"),
+    wait_for_status(Pid, running, 60),
+    asobi_match_server:cancel(Pid),
+    wait_for_status(Pid, finished, 60),
+    gen_statem:stop(Pid),
+    ?assertEqual(0, ets:info(?STATS_TAB, size)),
     cleanup(ok).
 
 wait_for_status(_Pid, _Status, 0) ->

--- a/test/asobi_match_stats_SUITE.erl
+++ b/test/asobi_match_stats_SUITE.erl
@@ -1,0 +1,74 @@
+-module(asobi_match_stats_SUITE).
+
+-include_lib("nova_test/include/nova_test.hrl").
+-include_lib("stdlib/include/assert.hrl").
+
+-export([all/0, init_per_suite/1, end_per_suite/1]).
+-export([finished_match_updates_participant_stats/1]).
+
+%% asobi#329: player_stats never moved. The counters are raw SQL (kura's
+%% update_all/2 can only SET literals), so the statement and its uuid
+%% parameter only get exercised against a real Postgres here.
+
+all() -> [finished_match_updates_participant_stats].
+
+init_per_suite(Config) ->
+    Config0 = asobi_test_helpers:start(Config),
+    Winner = register_player(Config0),
+    Loser = register_player(Config0),
+    [{winner_id, Winner}, {loser_id, Loser} | Config0].
+
+end_per_suite(Config) ->
+    Config.
+
+register_player(Config) ->
+    Username = asobi_test_helpers:unique_username(~"stats"),
+    {ok, Resp} = nova_test:post(
+        "/api/v1/auth/register",
+        #{json => #{~"username" => Username, ~"password" => ~"testpass123"}},
+        Config
+    ),
+    #{~"player_id" := PlayerId} = nova_test:json(Resp),
+    PlayerId.
+
+finished_match_updates_participant_stats(Config) ->
+    {winner_id, Winner} = lists:keyfind(winner_id, 1, Config),
+    {loser_id, Loser} = lists:keyfind(loser_id, 1, Config),
+    ?assertMatch(#{games_played := 0, wins := 0, losses := 0}, stats(Winner)),
+
+    {ok, Pid} = asobi_match_sup:start_match(#{
+        game_module => asobi_stats_test_game,
+        min_players => 2,
+        max_players => 2,
+        tick_rate => 20,
+        game_config => #{winner => Winner}
+    }),
+    #{match_id := MatchId} = asobi_match_server:get_info(Pid),
+    ok = asobi_match_server:join(Pid, Winner),
+    ok = asobi_match_server:join(Pid, Loser),
+
+    ok = wait_for_games_played(Winner, 1, 100),
+    ?assertMatch(#{games_played := 1, wins := 1, losses := 0}, stats(Winner)),
+    ?assertMatch(#{games_played := 1, wins := 0, losses := 1}, stats(Loser)),
+
+    %% The counters ride on this insert, which used to fail its
+    %% started_at/finished_at cast on every single finished match.
+    {ok, Record} = asobi_repo:get(asobi_match_record, MatchId),
+    ?assertMatch(#{status := ~"finished"}, Record),
+    ?assertMatch({{_, _, _}, {_, _, _}}, maps:get(finished_at, Record)),
+    Config.
+
+stats(PlayerId) ->
+    {ok, Row} = asobi_repo:get(asobi_player_stats, PlayerId),
+    Row.
+
+wait_for_games_played(_PlayerId, _Expected, 0) ->
+    error(timeout_waiting_for_player_stats);
+wait_for_games_played(PlayerId, Expected, N) ->
+    case stats(PlayerId) of
+        #{games_played := Expected} ->
+            ok;
+        _ ->
+            timer:sleep(50),
+            wait_for_games_played(PlayerId, Expected, N - 1)
+    end.

--- a/test/asobi_player_stats_tests.erl
+++ b/test/asobi_player_stats_tests.erl
@@ -1,0 +1,97 @@
+-module(asobi_player_stats_tests).
+-include_lib("eunit/include/eunit.hrl").
+
+%% asobi#329: how a game-declared match result maps onto the wins/losses
+%% columns. The SQL itself is exercised against Postgres by
+%% asobi_match_stats_SUITE; here we only pin the outcome convention.
+
+-define(SQL_TAB, asobi_player_stats_tests_sql).
+
+setup() ->
+    case ets:whereis(?SQL_TAB) of
+        undefined -> ets:new(?SQL_TAB, [named_table, public, duplicate_bag]);
+        _ -> ets:delete_all_objects(?SQL_TAB)
+    end,
+    meck:new(kura_db, [passthrough, no_link]),
+    meck:expect(kura_db, query, fun(_Repo, SQL, [PlayerId, Win, Loss]) ->
+        ets:insert(?SQL_TAB, {PlayerId, Win, Loss, iolist_to_binary(SQL)}),
+        #{num_rows => 1}
+    end),
+    ok.
+
+cleanup(_) ->
+    meck:unload(kura_db),
+    ok.
+
+record(Participants, Result) ->
+    ok = asobi_player_stats:record_match(Participants, Result),
+    lists:sort([{P, W, L} || {P, W, L, _SQL} <- ets:tab2list(?SQL_TAB)]).
+
+record_match_test_() ->
+    {foreach, fun setup/0, fun cleanup/1, [
+        {"every participant gets exactly one games_played increment", fun counts_everyone_once/0},
+        {"an empty roster writes nothing", fun empty_roster/0},
+        {"a single winner makes every other participant a loser", fun single_winner/0},
+        {"binary result keys work, because Lua results have them", fun binary_keys/0},
+        {"a winners list is honoured verbatim", fun winners_list/0},
+        {"explicit losers override the everyone-else default", fun explicit_losers/0},
+        {"ids outside the roster are ignored", fun unknown_ids_ignored/0},
+        {"a result with no outcome only moves games_played", fun no_outcome/0},
+        {"the UPDATE increments rather than overwrites", fun sql_increments/0}
+    ]}.
+
+counts_everyone_once() ->
+    ?assertEqual(
+        [{~"p1", 0, 0}, {~"p2", 0, 0}, {~"p3", 0, 0}],
+        record([~"p1", ~"p2", ~"p3"], #{})
+    ).
+
+empty_roster() ->
+    ?assertEqual([], record([], #{winner => ~"p1"})).
+
+single_winner() ->
+    ?assertEqual(
+        [{~"p1", 1, 0}, {~"p2", 0, 1}, {~"p3", 0, 1}],
+        record([~"p1", ~"p2", ~"p3"], #{winner => ~"p1"})
+    ).
+
+binary_keys() ->
+    ?assertEqual(
+        [{~"p1", 0, 1}, {~"p2", 1, 0}],
+        record([~"p1", ~"p2"], #{~"winner" => ~"p2"})
+    ).
+
+winners_list() ->
+    ?assertEqual(
+        [{~"p1", 1, 0}, {~"p2", 1, 0}, {~"p3", 0, 1}],
+        record([~"p1", ~"p2", ~"p3"], #{winners => [~"p1", ~"p2"]})
+    ).
+
+explicit_losers() ->
+    %% A co-op game where two players survived and nobody is charged a loss.
+    ?assertEqual(
+        [{~"p1", 1, 0}, {~"p2", 1, 0}, {~"p3", 0, 0}],
+        record([~"p1", ~"p2", ~"p3"], #{winners => [~"p1", ~"p2"], losers => []})
+    ).
+
+unknown_ids_ignored() ->
+    %% A spectator or a player who already left is not in the roster, so it
+    %% must not make the remaining participants losers by omission either.
+    ?assertEqual(
+        [{~"p1", 0, 0}, {~"p2", 0, 0}],
+        record([~"p1", ~"p2"], #{winner => ~"ghost"})
+    ).
+
+no_outcome() ->
+    ?assertEqual(
+        [{~"p1", 0, 0}, {~"p2", 0, 0}],
+        record([~"p1", ~"p2"], #{status => ~"cancelled"})
+    ).
+
+sql_increments() ->
+    ok = asobi_player_stats:record_match([~"p1"], #{winner => ~"p1"}),
+    [{_, _, _, SQL}] = ets:tab2list(?SQL_TAB),
+    ?assertNotEqual(nomatch, binary:match(SQL, ~"games_played = games_played + 1")),
+    ?assertNotEqual(nomatch, binary:match(SQL, ~"wins = wins + $2")),
+    ?assertNotEqual(nomatch, binary:match(SQL, ~"losses = losses + $3")),
+    ?assertNotEqual(nomatch, binary:match(SQL, ~"WHERE player_id = $1")).

--- a/test/asobi_stats_test_game.erl
+++ b/test/asobi_stats_test_game.erl
@@ -1,0 +1,31 @@
+-module(asobi_stats_test_game).
+-behaviour(asobi_match).
+
+%% Ends the match on its first tick and declares the winner it was
+%% configured with, so asobi_match_stats_SUITE can assert wins/losses.
+
+-export([init/1, join/2, leave/2, handle_input/3, tick/1, get_state/2]).
+
+-spec init(map()) -> {ok, map()}.
+init(Config) ->
+    {ok, #{winner => maps:get(winner, Config, undefined)}}.
+
+-spec join(binary(), map()) -> {ok, map()}.
+join(_PlayerId, State) ->
+    {ok, State}.
+
+-spec leave(binary(), map()) -> {ok, map()}.
+leave(_PlayerId, State) ->
+    {ok, State}.
+
+-spec handle_input(binary(), map(), map()) -> {ok, map()}.
+handle_input(_PlayerId, _Input, State) ->
+    {ok, State}.
+
+-spec tick(map()) -> {finished, map(), map()}.
+tick(#{winner := Winner} = State) ->
+    {finished, #{winner => Winner}, State}.
+
+-spec get_state(binary(), map()) -> map().
+get_state(_PlayerId, State) ->
+    State.


### PR DESCRIPTION
Closes #329.

## What was broken

`player_stats` had a producer for account creation and a consumer for guest
reaping, and nothing at all in between. `games_played`, `wins` and `losses`
stayed at 0 and `rating` at 1500.0 for the life of every account, on every
deployment, since the table was created.

Fixing it surfaced a second, older defect in the same function:

**1. No stats producer** - `asobi_match_server:persist_result/1`
(`src/matches/asobi_match_server.erl:789` before this change) wrote the match
record and stopped there. Nothing anywhere issued an UPDATE against
`player_stats`.

**2. `match_records` has never been written either.** Both
`asobi_match_server:persist_result/1:799-800` and
`asobi_world_server:persist_result/1:1499-1500` passed
`erlang:system_time(millisecond)` **integers** into the `started_at` /
`finished_at` columns, which are `utc_datetime`. `kura_changeset:cast/4`
rejects that with `cannot cast to utc_datetime`, the changeset came back
invalid, and both call sites discarded the result with `_ =
asobi_repo:insert(CS)`. So every finished match and every finished world has
silently failed to persist. Verified on the dev database: `select count(*)
from match_records` is 0 despite matches having been run, and the CT run in
this branch reproduced the exact changeset error before the fix. The match API
suite never caught it because it inserts its fixture rows by hand with
`calendar:universal_time()`.

`docs/ARCHITECTURE.md:510` also advertised a `player_stats_sync` background
job that does not exist in the codebase.

## What I changed

- **`asobi_player_stats:record_match/2`** (new). One `UPDATE ... SET
  games_played = games_played + 1, wins = wins + $2, losses = losses + $3`
  per participant. It is raw SQL because kura's `update_all/2` can only SET
  literals - it has no expression form - and a read-modify-write would need
  the advisory-lock dance `asobi_economy` uses for wallets. A relative UPDATE
  is race-free without a lock.
- **`asobi_match_server:persist_result/1`** now runs the match-record insert
  and the stats update inside one `asobi_repo:transaction/1`, and only counts
  when the insert succeeded.
- **`asobi_match_record:to_timestamp/1`** (new) converts the servers'
  millisecond clocks to `calendar:datetime()`. Both `persist_result/1`
  functions use it, and both now log a failed insert instead of discarding it.

### Exactly-once

`match_records.id` **is** the match id. A second pass over an
already-finished match (a recovered server re-entering `finished`) loses that
insert on the primary key, the transaction rolls back, and the counters do
not move. That primary key is the whole idempotency mechanism - no extra
bookkeeping column.

### The one judgement call: what makes a win

`games_played` is unambiguous. `wins`/`losses` are not, because the result map
is game-defined and asobi had no convention for it, so I had to establish
one - deliberately the smallest possible:

- `winners` (list of player ids) or `winner` (one id)
- `losers` (list) or `loser` (one id)
- accepted as atom **or** binary keys, because a Lua game's result arrives
  with binary keys
- ids outside the match roster are ignored
- winners declared and losers not -> everyone else in the match takes the
  loss; declare `losers => []` for a co-op game where nobody loses
- neither declared -> `games_played` only (draw, cancelled, unscored sandbox)

Documented in the `asobi_player_stats:record_match/2` doc, the
`asobi_match:tick/1` callback doc, and `guides/websocket-protocol.md` under
`match.finished`. **If you want a different convention, this is the piece to
push back on** - it is contained to one function.

### Deliberately not done

- **`rating` / `rating_deviation` remain unwired.** The pair of column names
  (rating + deviation, defaults 1500.0 / 350.0) is Glicko's, and picking
  Glicko-1 vs Glicko-2 vs Elo, and when a rating period closes, is a product
  decision, not a bug fix. The matchmaker still does not read them either
  (`asobi_matchmaker_skill` reads a client-supplied `skill` property), so
  after this PR they are still a column with no producer and no consumer.
  Worth its own issue.
- **Worlds do not count towards player stats.** `asobi_world_server` writes
  the same `match_records` table and I fixed its timestamp bug, but a world is
  a persistent space, not a scored game - "one world visit is one game played"
  is a call for you, not for me. Noted in a comment at the call site.
- **No backfill.** Existing accounts keep their zeros, and matches that failed
  to persist are gone.

## What the tests assert

`test/asobi_player_stats_tests.erl` (new, 9 cases, eunit) pins the outcome
convention with `kura_db:query/3` mocked: everyone counted once, empty
roster writes nothing, single winner makes the rest losers, binary keys,
winners list, explicit `losers => []` overriding the default, out-of-roster
ids ignored, no-outcome result moving only `games_played`, and that the
statement increments rather than overwrites.

`test/asobi_match_server_tests.erl` (3 new cases) drives a real match server
to `finished` and asserts against the SQL it actually issued:
- **the case the issue asked for** - a finished 2-player match produces
  exactly one UPDATE per participant and no third row (`ets:lookup` on a
  duplicate_bag returns one entry each; total table size is 2);
- a match whose game returns `{finished, #{winner => p1}, State}` records
  `p1` win / `p2` loss;
- when the match-record insert fails on a duplicate key, **zero** stats
  writes happen.

`test/asobi_match_record_tests.erl` (new, 3 cases) pins the timestamp defect:
a millisecond integer produces an invalid changeset, `to_timestamp/1`
produces a valid one, `undefined` passes through.

`test/asobi_match_stats_SUITE.erl` (new, CT, real Postgres) is the one that
proves the raw SQL and its bound uuid parameter actually work: register two
players over the REST API, run a match to completion, and read
`games_played` / `wins` / `losses` back out of Postgres, plus assert the
`match_records` row now exists with a real `finished_at` datetime.

## Verification

| check | result |
|---|---|
| `rebar3 fmt` / `rebar3 fmt --check` | clean |
| `rebar3 xref` | clean |
| `rebar3 eunit` | **588 tests, 0 failures** (full suite) |
| `rebar3 dialyzer` | clean, exit 0 |
| `rebar3 ct --suite=test/asobi_match_stats_SUITE` | **passed** against a live Postgres |

### What I could not verify

- The CT suite passed on the run that proved the fix, but the **final** commit
  (which added the `match_records` row assertion to that same test case) could
  not be re-run: another session was holding port 8082 and the shared Postgres
  for the rest of my window. The added assertion is three lines against a row
  the test already depends on existing, but treat it as CI-verified rather
  than locally-verified.
- CT needs `--sys_config` with a smaller `pool_size` on this machine: asobi's
  config asks for 200 connections and the Postgres container occupying 5432
  was started by another project with `max_connections=100`. Nothing to do
  with this change, but `rebar3 ct` will fail with `sorry, too many clients
  already` until `make db-reset` brings up asobi's own container.
- `elp eqwalize-all` / `elp lint` were not run (elp not available here);
  dialyzer with `unmatched_returns` is clean.
- No `asobi_lua` end-to-end run, so the binary-key path (`~"winner"`) is
  covered by unit test only, not by a real Lua game.
