### PR TITLE
refactor: core owns the reserved Lua namespace list and effect vocabulary

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -242,6 +242,7 @@
             asobi_lua_match_shared,
             asobi_lua_world,
             asobi_lua_api,
+            asobi_lua_surface,
             asobi_lua_phases,
             asobi_lua_reload,
             asobi_lua_validate,

--- a/src/lua/asobi_lua_api.erl
+++ b/src/lua/asobi_lua_api.erl
@@ -104,80 +104,80 @@ install_pure(Ctx, St0) ->
     St1 = create_tables(St0),
     install_fns(api_fns(Ctx, probe), St1).
 
-create_tables(St0) ->
-    %% Pre-create namespace tables
-    St1 = create_table([~"game"], St0),
-    St2 = create_table([~"game", ~"economy"], St1),
-    St3 = create_table([~"game", ~"leaderboard"], St2),
-    St4 = create_table([~"game", ~"storage"], St3),
-    St5a = create_table([~"game", ~"chat"], St4),
-    St5b = create_table([~"game", ~"spatial"], St5a),
-    St5c = create_table([~"game", ~"zone"], St5b),
-    create_table([~"game", ~"terrain"], St5c).
+create_tables(St) ->
+    create_namespaces(asobi_lua_surface:reserved_namespaces(), St).
+
+create_namespaces([], St) ->
+    St;
+create_namespaces([Namespace | Rest], St) ->
+    create_namespaces(Rest, create_table(Namespace, St)).
 
 %% Builds the {LuaPath, Fun} table install/2 and install_pure/2 both wire up.
-%% `zone.*`/`terrain.*` are omitted from the probe/live distinction below:
-%% they already gate on `zone_pid`/`terrain_store_pid` being present in Ctx
-%% (see fun_zone_spawn/1, fun_terrain_get_chunk/1 etc.), and a probe VM's Ctx
-%% never carries those keys, so they are already inert in probe mode without
-%% help from `pick/3`.
 api_fns(Ctx, Mode) ->
+    [{Path, pick(Mode, Effect, Path, Fn)} || {Path, Effect, Fn} <- api_surface(Ctx)].
+
+%% Every installed function with its effect (asobi_lua_surface:effect/0):
+%% `write` mutates persistent state, broadcasts an event, or grants/deducts
+%% a resource; `none` only reads or computes.
+-spec api_surface(map()) -> [{[binary(), ...], asobi_lua_surface:effect(), function()}].
+api_surface(Ctx) ->
     [
         %% Core
-        {[~"game", ~"id"], fun_id()},
-        {[~"game", ~"log"], fun_log(Ctx)},
-        {[~"game", ~"broadcast"], pick(Mode, ~"game.broadcast", fun_broadcast(Ctx))},
-        {[~"game", ~"send"], pick(Mode, ~"game.send", fun_send())},
+        {[~"game", ~"id"], none, fun_id()},
+        {[~"game", ~"log"], none, fun_log(Ctx)},
+        {[~"game", ~"broadcast"], write, fun_broadcast(Ctx)},
+        {[~"game", ~"send"], write, fun_send()},
         %% Economy
-        {[~"game", ~"economy", ~"grant"], pick(Mode, ~"game.economy.grant", fun_economy_grant())},
-        {[~"game", ~"economy", ~"debit"], pick(Mode, ~"game.economy.debit", fun_economy_debit())},
-        {[~"game", ~"economy", ~"balance"], fun_economy_balance()},
-        {
-            [~"game", ~"economy", ~"purchase"],
-            pick(Mode, ~"game.economy.purchase", fun_economy_purchase())
-        },
+        {[~"game", ~"economy", ~"grant"], write, fun_economy_grant()},
+        {[~"game", ~"economy", ~"debit"], write, fun_economy_debit()},
+        {[~"game", ~"economy", ~"balance"], none, fun_economy_balance()},
+        {[~"game", ~"economy", ~"purchase"], write, fun_economy_purchase()},
         %% Leaderboard
-        {
-            [~"game", ~"leaderboard", ~"submit"],
-            pick(Mode, ~"game.leaderboard.submit", fun_lb_submit())
-        },
-        {[~"game", ~"leaderboard", ~"top"], fun_lb_top()},
-        {[~"game", ~"leaderboard", ~"rank"], fun_lb_rank()},
-        {[~"game", ~"leaderboard", ~"around"], fun_lb_around()},
+        {[~"game", ~"leaderboard", ~"submit"], write, fun_lb_submit()},
+        {[~"game", ~"leaderboard", ~"top"], none, fun_lb_top()},
+        {[~"game", ~"leaderboard", ~"rank"], none, fun_lb_rank()},
+        {[~"game", ~"leaderboard", ~"around"], none, fun_lb_around()},
         %% Notifications
-        {[~"game", ~"notify"], pick(Mode, ~"game.notify", fun_notify())},
-        {[~"game", ~"notify_many"], pick(Mode, ~"game.notify_many", fun_notify_many())},
+        {[~"game", ~"notify"], write, fun_notify()},
+        {[~"game", ~"notify_many"], write, fun_notify_many()},
         %% Storage
-        {[~"game", ~"storage", ~"get"], fun_storage_get()},
-        {[~"game", ~"storage", ~"set"], pick(Mode, ~"game.storage.set", fun_storage_set())},
-        {[~"game", ~"storage", ~"player_get"], fun_storage_player_get()},
-        {
-            [~"game", ~"storage", ~"player_set"],
-            pick(Mode, ~"game.storage.player_set", fun_storage_player_set())
-        },
+        {[~"game", ~"storage", ~"get"], none, fun_storage_get()},
+        {[~"game", ~"storage", ~"set"], write, fun_storage_set()},
+        {[~"game", ~"storage", ~"player_get"], none, fun_storage_player_get()},
+        {[~"game", ~"storage", ~"player_set"], write, fun_storage_player_set()},
         %% Chat
-        {[~"game", ~"chat", ~"send"], pick(Mode, ~"game.chat.send", fun_chat_send())},
+        {[~"game", ~"chat", ~"send"], write, fun_chat_send()},
         %% Spatial
-        {[~"game", ~"spatial", ~"query_radius"], fun_spatial_query_radius(Ctx)},
-        {[~"game", ~"spatial", ~"query_rect"], fun_spatial_query_rect(Ctx)},
-        {[~"game", ~"spatial", ~"nearest"], fun_spatial_nearest()},
-        {[~"game", ~"spatial", ~"in_range"], fun_spatial_in_range()},
-        {[~"game", ~"spatial", ~"distance"], fun_spatial_distance()},
+        {[~"game", ~"spatial", ~"query_radius"], none, fun_spatial_query_radius(Ctx)},
+        {[~"game", ~"spatial", ~"query_rect"], none, fun_spatial_query_rect(Ctx)},
+        {[~"game", ~"spatial", ~"nearest"], none, fun_spatial_nearest()},
+        {[~"game", ~"spatial", ~"in_range"], none, fun_spatial_in_range()},
+        {[~"game", ~"spatial", ~"distance"], none, fun_spatial_distance()},
         %% Zone spawning
-        {[~"game", ~"zone", ~"spawn"], fun_zone_spawn(Ctx)},
-        {[~"game", ~"zone", ~"despawn"], fun_zone_despawn(Ctx)},
+        {[~"game", ~"zone", ~"spawn"], zone_effect(Ctx), fun_zone_spawn(Ctx)},
+        {[~"game", ~"zone", ~"despawn"], zone_effect(Ctx), fun_zone_despawn(Ctx)},
         %% Terrain
-        {[~"game", ~"terrain", ~"get_chunk"], fun_terrain_get_chunk(Ctx)},
-        {[~"game", ~"terrain", ~"preload"], fun_terrain_preload(Ctx)}
+        {[~"game", ~"terrain", ~"get_chunk"], none, fun_terrain_get_chunk(Ctx)},
+        {[~"game", ~"terrain", ~"preload"], terrain_effect(Ctx), fun_terrain_preload(Ctx)}
     ].
 
-%% Selects the real function in live mode; in probe mode, swaps anything that
-%% mutates persistent state, broadcasts an event, or grants/deducts a
-%% resource for `inert/1`, so re-running a script's top-level body a second
-%% time (to ask it a question like "do you define phases()?") cannot re-fire
-%% that side effect.
-pick(live, _Name, RealFn) -> RealFn;
-pick(probe, Name, _RealFn) -> inert(Name).
+%% The effect belongs to the closure, not to the name: `zone.*`/`terrain.*`
+%% gate on a handle in Ctx (see fun_zone_spawn/1, fun_terrain_preload/1), and
+%% a probe VM's Ctx never carries one, so those closures can only answer with
+%% an error and need no stub of their own.
+zone_effect(#{zone_pid := _}) -> write;
+zone_effect(_) -> none.
+
+terrain_effect(#{terrain_store_pid := Pid}) when is_pid(Pid) -> write;
+terrain_effect(_) -> none.
+
+%% Selects the real function in live mode; in probe mode, swaps every `write`
+%% for `inert/1`, so re-running a script's top-level body a second time (to
+%% ask it a question like "do you define phases()?") cannot re-fire that side
+%% effect.
+pick(live, _Effect, _Path, RealFn) -> RealFn;
+pick(probe, none, _Path, RealFn) -> RealFn;
+pick(probe, write, Path, _RealFn) -> inert(asobi_lua_surface:name(Path)).
 
 %% See asobi_lua_match.erl / asobi_lua_world.erl `boot_throwaway_lua_state/2`.
 inert(Name) ->
@@ -283,6 +283,7 @@ log_report(Message, Meta, Ctx) ->
         _ -> Base#{meta => bound_meta(Meta)}
     end.
 
+-spec log_context(map()) -> asobi_lua_surface:vm_kind().
 log_context(#{zone_pid := ZonePid}) when is_pid(ZonePid) -> zone;
 log_context(_) -> match.
 

--- a/src/lua/asobi_lua_surface.erl
+++ b/src/lua/asobi_lua_surface.erl
@@ -1,0 +1,62 @@
+-module(asobi_lua_surface).
+-moduledoc """
+Owns the vocabulary of the `game.*` Lua API surface.
+
+Three things live here, and only here:
+
+- `reserved_namespaces/0` - the `game.*` tables the library owns.
+  `asobi_lua_api:install/2` creates exactly this list, and
+  `asobi_lua_api_tests` asserts that it does. Anything that later has to
+  decide whether a name belongs to the library - validating a
+  game-declared namespace, say - reads the list from here instead of
+  repeating it.
+- `t:effect/0` - what a `game.*` function does to the world. `write`
+  means it mutates durable state, fans an event out to players, or moves
+  a resource; `none` means it only reads or computes. Probe VMs
+  (`asobi_lua_api:install/2`) suppress every `write`.
+- `t:vm_kind/0` - the kinds of VM a Lua chunk runs in.
+""".
+
+-export([reserved_namespaces/0, is_reserved/1, name/1]).
+-export([effects/0]).
+-export([vm_kinds/0]).
+
+-export_type([namespace/0, effect/0, vm_kind/0]).
+
+-type namespace() :: [binary(), ...].
+-type effect() :: write | none.
+-type vm_kind() :: match | world | zone | bot.
+
+%% Parent before child: a table can only be set on a table that already
+%% exists, so the root leads and every nested namespace follows it.
+-define(RESERVED_NAMESPACES, [
+    [~"game"],
+    [~"game", ~"economy"],
+    [~"game", ~"leaderboard"],
+    [~"game", ~"storage"],
+    [~"game", ~"chat"],
+    [~"game", ~"spatial"],
+    [~"game", ~"zone"],
+    [~"game", ~"terrain"]
+]).
+
+-spec reserved_namespaces() -> [namespace()].
+reserved_namespaces() ->
+    ?RESERVED_NAMESPACES.
+
+-spec is_reserved(namespace()) -> boolean().
+is_reserved(Namespace) ->
+    lists:member(Namespace, ?RESERVED_NAMESPACES).
+
+-doc "Renders a namespace or function path as its Lua name, e.g. `game.economy.grant`.".
+-spec name([binary(), ...]) -> binary().
+name(Path) ->
+    iolist_to_binary(lists:join(~".", Path)).
+
+-spec effects() -> [effect(), ...].
+effects() ->
+    [write, none].
+
+-spec vm_kinds() -> [vm_kind(), ...].
+vm_kinds() ->
+    [match, world, zone, bot].

--- a/test/asobi_lua_api_tests.erl
+++ b/test/asobi_lua_api_tests.erl
@@ -88,7 +88,9 @@ api_test_() ->
         {"probe ctx: game.notify_many is inert", fun probe_notify_many_inert/0},
         {"probe ctx: game.storage.set is inert", fun probe_storage_set_inert/0},
         {"probe ctx: game.storage.get still runs for real", fun probe_storage_get_live/0},
-        {"probe ctx: game.chat.send is inert", fun probe_chat_send_inert/0}
+        {"probe ctx: game.chat.send is inert", fun probe_chat_send_inert/0},
+        {"install creates exactly the reserved namespaces", fun install_creates_reserved/0},
+        {"probe install creates the same namespaces", fun probe_install_creates_reserved/0}
     ]}.
 
 setup() ->
@@ -798,6 +800,61 @@ probe_chat_send_inert() ->
     Code = "return game.chat.send('match_123', 'p1', 'gg')",
     {ok, [false | _], _} = eval(Code, St),
     ?assertNot(meck:called(asobi_chat_channel, send_message, '_')).
+
+%% --- Reserved namespaces (asobi_lua_surface) ---
+%%
+%% asobi_lua_surface:reserved_namespaces/0 is the single source of truth for
+%% the `game.*` tables the library owns - the list a later game-declared
+%% namespace gets validated against. Both assertions read an installed VM
+%% back rather than trusting the list: the tables install/2 created, and the
+%% namespaces its function surface actually wired something into. A namespace
+%% added to the list but populated by nothing, or a function installed under
+%% a namespace the list never declared, breaks the second one.
+
+install_creates_reserved() ->
+    St = install_api_with_terrain(),
+    Reserved = lists:sort(asobi_lua_surface:reserved_namespaces()),
+    ?assertEqual(Reserved, lists:sort(namespace_tables(St))),
+    ?assertEqual(Reserved, lists:sort(populated_namespaces(St))).
+
+probe_install_creates_reserved() ->
+    St = install_api_probe(),
+    Reserved = lists:sort(asobi_lua_surface:reserved_namespaces()),
+    ?assertEqual(Reserved, lists:sort(namespace_tables(St))),
+    ?assertEqual(Reserved, lists:sort(populated_namespaces(St))).
+
+%% `game` itself plus every table-valued field on it.
+namespace_tables(St) ->
+    Code =
+        "local names = {}\n"
+        "for k, v in pairs(game) do\n"
+        "  if type(v) == 'table' then names[#names + 1] = k end\n"
+        "end\n"
+        "return names",
+    [[~"game"] | [[~"game", Name] || Name <- lua_strings(Code, St)]].
+
+%% Every namespace holding at least one installed function, named the way
+%% Lua sees it (`game`, `game.economy`, ...).
+populated_namespaces(St) ->
+    Code =
+        "local seen = {}\n"
+        "for k, v in pairs(game) do\n"
+        "  if type(v) == 'function' then\n"
+        "    seen['game'] = true\n"
+        "  elseif type(v) == 'table' then\n"
+        "    for _, nested in pairs(v) do\n"
+        "      if type(nested) == 'function' then seen['game.' .. k] = true end\n"
+        "    end\n"
+        "  end\n"
+        "end\n"
+        "local names = {}\n"
+        "for name in pairs(seen) do names[#names + 1] = name end\n"
+        "return names",
+    [binary:split(Name, ~".", [global]) || Name <- lua_strings(Code, St)].
+
+lua_strings(Code, St) ->
+    {ok, [Table | _], St1} = eval(Code, St),
+    [Value || {_Index, Value} <- luerl:decode(Table, St1)].
 
 %% --- Helpers ---
 

--- a/test/asobi_lua_surface_tests.erl
+++ b/test/asobi_lua_surface_tests.erl
@@ -1,0 +1,39 @@
+-module(asobi_lua_surface_tests).
+-include_lib("eunit/include/eunit.hrl").
+
+%% Parity with what asobi_lua_api:install/2 actually creates is asserted in
+%% asobi_lua_api_tests (install_creates_reserved/0) - these cover the
+%% vocabulary itself.
+
+root_namespace_leads_the_list_test() ->
+    [Root | Nested] = asobi_lua_surface:reserved_namespaces(),
+    ?assertEqual([~"game"], Root),
+    ?assert(
+        lists:all(
+            fun
+                ([~"game", _]) -> true;
+                (_) -> false
+            end,
+            Nested
+        )
+    ).
+
+reserved_namespaces_are_unique_test() ->
+    Reserved = asobi_lua_surface:reserved_namespaces(),
+    ?assertEqual(lists:usort(Reserved), lists:sort(Reserved)).
+
+is_reserved_test() ->
+    ?assert(asobi_lua_surface:is_reserved([~"game"])),
+    ?assert(asobi_lua_surface:is_reserved([~"game", ~"economy"])),
+    ?assertNot(asobi_lua_surface:is_reserved([~"game", ~"my_shop"])),
+    ?assertNot(asobi_lua_surface:is_reserved([~"economy"])).
+
+name_renders_the_lua_path_test() ->
+    ?assertEqual(~"game", asobi_lua_surface:name([~"game"])),
+    ?assertEqual(~"game.economy.grant", asobi_lua_surface:name([~"game", ~"economy", ~"grant"])).
+
+effects_test() ->
+    ?assertEqual([write, none], asobi_lua_surface:effects()).
+
+vm_kinds_test() ->
+    ?assertEqual([match, world, zone, bot], asobi_lua_surface:vm_kinds()).


### PR DESCRIPTION
Base: `feat/merge-asobi-lua` (not `main`).

## What was broken

Two facts about the `game.*` Lua surface were hardcoded inside
`asobi_lua_api` with no owner:

- `src/lua/asobi_lua_api.erl:107-116` (`create_tables/1`) pre-created the
  eight namespace tables (`game`, `economy`, `leaderboard`, `storage`,
  `chat`, `spatial`, `zone`, `terrain`) as eight hand-threaded
  `create_table/2` calls. Nothing else could ask what the library-owned
  namespaces are, so the next consumer would copy the list.
- `src/lua/asobi_lua_api.erl:124-187`: whether a function is effectful was
  implicit in which of the 28 entries `api_fns/2` wrapped in `pick/3`, and
  the name passed to `inert/1` was a hand-written second spelling of the
  same path (`~"game.economy.grant"` next to
  `[~"game", ~"economy", ~"grant"]`). `zone.*`/`terrain.*` were left out of
  that wrapping entirely, explained only by a six-line comment.

## What changed

New `src/lua/asobi_lua_surface.erl` owns the vocabulary:

- `reserved_namespaces/0` + `is_reserved/1` - the library-owned `game.*`
  tables, root first (parent before child).
- `-type effect() :: write | none` + `effects/0` - `write` mutates durable
  state, fans an event out to players, or moves a resource; `none` only
  reads or computes.
- `-type vm_kind() :: match | world | zone | bot` + `vm_kinds/0`.
- `name/1` - path to Lua name, so `inert/1` no longer needs the path spelled
  twice.

`asobi_lua_api` now derives from it: `create_tables/1` walks
`reserved_namespaces/0`, `api_surface/1` carries `{Path, Effect, Fn}` and
`pick/4` swaps every `write` for `inert/1` in a probe VM. `log_context/1`
gained a spec returning `asobi_lua_surface:vm_kind()`. Added to the
`Lua Runtime` ex_doc group in `rebar.config`.

Behaviour is unchanged. Live mode installs the real function for every
entry, exactly as before. In probe mode the `write` set is the same eleven
functions `pick/3` used to swap, because `zone.*`/`terrain.*` classify their
effect from the Ctx handle they gate on (`zone_effect/1`, `terrain_effect/1`)
and no probe Ctx carries `zone_pid` or `terrain_store_pid` -
`asobi_lua_match.erl:359-363`, `asobi_lua_world.erl:911`. That is now data
rather than an omission: a probe Ctx that did carry a zone handle would get
the stub, which is what the old comment said it wanted.

## What the tests assert

- `asobi_lua_api_tests:install_creates_reserved/0` and
  `probe_install_creates_reserved/0` - the assertion this refactor exists
  for. Both read the namespaces back **out of an installed VM** (`pairs(game)`
  over the Luerl state) rather than trusting the list, twice over: the tables
  `install/2` created, and the namespaces its function surface actually wired
  something into. Verified they fail on drift in both directions - adding a
  namespace nothing installs into fails both new tests; removing one a
  function needs fails the whole suite on the `set_table_keys` badmatch.
- `asobi_lua_surface_tests` - root leads the list, entries unique,
  `is_reserved/1` rejects `[~"game", ~"my_shop"]`, `name/1` renders
  `game.economy.grant`, and the two vocabularies read back as declared.

## Checks

Green on this branch: `rebar3 fmt` / `fmt --check`, `rebar3 xref`,
`rebar3 dialyzer`, `rebar3 eunit` (936 tests, 0 failures), `rebar3 ex_doc`
(no warnings).

Not run: `rebar3 ct` - the CT suites need the Docker Postgres container,
which is not up in this worktree. Nothing here touches persistence.

Unrelated observation, left alone to avoid colliding with sibling PRs on
this base: `AGENTS.md:26` still says "Lua lives elsewhere. asobi has no
luerl or scripting deps", which the merge on this base branch made stale.
