### PR TITLE
refactor: give core the game-config write path (ADR 0006)

### DIFF
--- a/docs/adr/0006-core-owns-the-game-config-write-path.md
+++ b/docs/adr/0006-core-owns-the-game-config-write-path.md
@@ -1,0 +1,86 @@
+# ADR 0006: Core owns the game-config write path
+
+Date: 2026-08-04
+
+## Status
+
+Accepted.
+
+## Context
+
+The Lua config loader wrote asobi's own application environment directly.
+`asobi_lua_config` set `guest_auth` and `game_modes` with
+`application:set_env/3`, and core read those keys back in several places
+(`asobi_game_modes`, `asobi_matchmaker`, `asobi_bot_spawner`,
+`asobi_lua_config_watcher`, the guest endpoints). Even inside a single OTP
+application that is one module reaching into another module's configuration
+with no defined ordering: nothing said who writes, who wins, or when.
+
+The mode registry made that concrete. The write was:
+
+```erlang
+Merged = maps:merge(Existing, Modes),
+application:set_env(asobi, game_modes, Merged)
+```
+
+"New wins, nothing is ever removed", against the single key the operator also
+configures. Two consequences, both wrong:
+
+- **A deleted mode lived forever.** Drop `ctf` from `config.lua`, reload, and
+  `ctf` was still in the registry, still matchable, still spawning matches from
+  the previous definition, until the node restarted.
+- **A bundle overwrote operator config.** A mode declared in the operator's
+  `sys.config` was silently replaced by a same-named mode from a game bundle -
+  and the config watcher does that on every mode-shape edit, not just at boot.
+
+`guest_auth` had the same shape of problem in reverse: it is legitimately
+game-declared (ADR 0004), but the loader chose both the value and the moment it
+landed, so the ordering rule lived in the caller rather than in core.
+
+## Decision
+
+Core owns the write path. `asobi_game_config` is the only module that writes
+these keys; a loader derives a config term and hands it over:
+
+```erlang
+asobi_game_config:apply_config(#{guest_auth => true, modes => Modes})
+```
+
+**Modes are two layers in two keys, never one merged key.**
+
+1. `game_modes` - the operator layer, from `sys.config`. asobi never writes it.
+2. `script_game_modes` - the script layer, the complete set the currently
+   loaded game declares. `apply_config/1` replaces it wholesale.
+
+`asobi_game_config:modes/0` composes them, in that order: script modes first,
+operator modes overlaid on top. Every reader in core goes through `modes/0`;
+none reads the raw keys.
+
+**Write order inside `apply_config/1`:** `guest_auth` first, then the modes. A
+key absent from the term is not written, which is how
+`asobi_lua_config:reload_game_modes/0` refreshes mode shape from the watcher
+without touching auth posture at runtime.
+
+`guest_auth` is replaced rather than merged: it is the game's half of ADR
+0004's two-key AND, and the operator's half is the pepper, not the flag.
+
+## Consequences
+
+- **A removed mode is actually removed.** The script layer is a replacement, so
+  the registry always matches what the game currently declares. A pure-Erlang
+  deployment is unaffected: with no game scripts the script layer is empty and
+  `sys.config` is the whole registry.
+- **Operator config is authoritative.** A `sys.config` mode wins a name clash
+  and cannot be dropped by a bundle. A game author cannot redefine an
+  operator's mode by picking its name - the same trust direction ADR 0004
+  established for guest auth.
+- **One writer, one documented order.** Ordering questions have one answer in
+  one module instead of being implied by call order in a loader.
+- **Loaders stay loaders.** `asobi_lua_config` reads Lua and returns a config
+  term; `asobi_engine`'s bundle loader keeps calling
+  `asobi_lua_config:maybe_load_game_config/0` and inherits the new semantics
+  with no change. A future non-Lua config source implements the same term.
+- **`game_modes` is no longer the whole picture.** Anything reading the raw
+  app-env key sees only the operator layer. In-tree readers were moved to
+  `asobi_game_config:modes/0`; out-of-tree code that reads the key directly
+  must do the same.

--- a/guides/configuration.md
+++ b/guides/configuration.md
@@ -122,6 +122,22 @@ Shorthand (Erlang module only):
 | `listed` | `false` for matches, `true` for worlds | Whether instances of this mode appear in discovery (`match.list` / `world.list`). **Matches are unlisted by default** — a matchmaker-spawned match is already assigned to its players, so opt in explicitly. |
 | `quick_play` | `true` | Worlds only. Whether `world.find_or_create` may place a player into an existing world of this mode. Independent of `listed` — see [World Server](world-server.md#visibility). |
 
+### Operator Modes vs Game-Declared Modes
+
+Modes come from two independent places and asobi keeps them apart (ADR 0006):
+
+- **Operator modes** are the ones above, in your `sys.config` `game_modes`.
+  asobi never rewrites that key.
+- **Game-declared modes** are what a Lua game declares in its `match.lua` or
+  `config.lua` manifest. Loading a game replaces that set wholesale, so a mode
+  you delete from `config.lua` is gone the next time the config loads instead
+  of lingering until a restart.
+
+The effective registry is the game-declared set with the operator set on top:
+an operator mode wins a name clash and a game bundle can never drop or
+redefine it. Read it with `asobi_game_config:modes/0` - the raw `game_modes`
+app-env key is only the operator half.
+
 ## Matchmaker
 
 ```erlang

--- a/src/asobi_game_config.erl
+++ b/src/asobi_game_config.erl
@@ -1,0 +1,82 @@
+-module(asobi_game_config).
+-moduledoc """
+The core-owned write path for game config a loader declares.
+
+A loader - the Lua bundle loader in `asobi_lua_config`, or anything else that
+reads a game's own declaration - hands the whole config term to
+`apply_config/1` and never writes asobi's application environment itself. This
+module decides what the effective registry ends up looking like, and in which
+order the keys are written.
+
+## Two mode layers, one merge
+
+Game modes come from two independent sources, kept in two application-env keys
+so neither source can clobber the other:
+
+1. `game_modes` - the **operator** layer, declared in `sys.config`. asobi
+   never writes this key.
+2. `script_game_modes` - the **script** layer, the complete set of modes the
+   currently loaded game declares. `apply_config/1` replaces that set
+   wholesale, so a mode deleted from `config.lua` is gone after the next load
+   instead of surviving forever.
+
+`modes/0` composes the two in that order: the script layer first, the operator
+layer on top. An operator mode therefore wins a name clash, and no bundle
+reload can redefine or drop it. Every reader goes through `modes/0`.
+
+## guest_auth is replaced, not merged
+
+`guest_auth` is the game's half of ADR 0004's two-key AND (the operator owns
+the pepper), so a declared value simply replaces the current flag. It is
+written before the modes so a reader waking on the mode change already sees
+the final auth posture.
+
+A term that omits a key leaves that key alone: `apply_config(#{modes => M})` is
+how the config watcher refreshes mode shape without letting a bundle write flip
+auth posture at runtime.
+""".
+
+-include_lib("kernel/include/logger.hrl").
+
+-export([apply_config/1, modes/0]).
+
+-type modes() :: #{binary() => map() | module()}.
+-type config() :: #{modes => modes(), guest_auth => boolean()}.
+
+-export_type([config/0, modes/0]).
+
+-doc "The effective game modes: the script layer with the operator layer on top.".
+-spec modes() -> modes().
+modes() ->
+    maps:merge(env_modes(script_game_modes), env_modes(game_modes)).
+
+-doc "Apply a declared game config. The only supported writer of these keys.".
+-spec apply_config(config()) -> ok.
+apply_config(Config) ->
+    ok = write_guest_auth(Config),
+    write_modes(Config).
+
+-spec write_guest_auth(config()) -> ok.
+write_guest_auth(#{guest_auth := Declared}) when is_boolean(Declared) ->
+    application:set_env(asobi, guest_auth, Declared);
+write_guest_auth(_) ->
+    ok.
+
+-spec write_modes(config()) -> ok.
+write_modes(#{modes := Declared}) when is_map(Declared) ->
+    application:set_env(asobi, script_game_modes, Declared),
+    ?LOG_NOTICE(#{
+        msg => ~"game config applied",
+        declared => maps:keys(Declared),
+        effective => maps:keys(modes())
+    }),
+    ok;
+write_modes(_) ->
+    ok.
+
+-spec env_modes(atom()) -> modes().
+env_modes(Key) ->
+    case application:get_env(asobi, Key, #{}) of
+        Modes when is_map(Modes) -> Modes;
+        _ -> #{}
+    end.

--- a/src/asobi_game_modes.erl
+++ b/src/asobi_game_modes.erl
@@ -57,7 +57,7 @@ unregister_game_mode(Kind) when ?IS_KIND(Kind) ->
 
 -spec mode_config(binary()) -> map().
 mode_config(Mode) ->
-    Modes = ensure_map(application:get_env(asobi, game_modes, #{})),
+    Modes = asobi_game_config:modes(),
     case Modes of
         #{Mode := Config} when is_map(Config) -> Config;
         #{Mode := Mod} when is_atom(Mod) -> #{module => Mod};
@@ -133,7 +133,7 @@ what `asobi_chat_acl` authorises against.
 """.
 -spec global_chat_channels() -> [binary()].
 global_chat_channels() ->
-    Modes = ensure_map(application:get_env(asobi, game_modes, #{})),
+    Modes = asobi_game_config:modes(),
     lists:usort([
         Name
      || Config <- maps:values(Modes),
@@ -149,7 +149,3 @@ forward_optional(Src, [Key | Rest], Acc) ->
         #{Key := Val} -> forward_optional(Src, Rest, Acc#{Key => Val});
         _ -> forward_optional(Src, Rest, Acc)
     end.
-
--spec ensure_map(term()) -> #{term() => term()}.
-ensure_map(M) when is_map(M) -> M;
-ensure_map(_) -> #{}.

--- a/src/lua/asobi_lua_config.erl
+++ b/src/lua/asobi_lua_config.erl
@@ -57,6 +57,10 @@ which uses the `asobi_lua_match` bridge (tick/1 + wrapped-state callbacks).
 manifest) in multi-mode. It only *declares* intent; guest auth is on iff the
 operator also supplies a >= 32-byte pepper (ADR 0004).
 
+This module reads Lua and nothing else: it hands the config term it derived to
+`asobi_game_config:apply_config/1`, which owns the merge with operator config
+and the order the app-env keys are written in (ADR 0006).
+
 Bot scripts can export a `names` list that the platform reads after loading:
 
 ```lua
@@ -74,9 +78,17 @@ names = {"Spark", "Blitz", "Volt"}
 
 -spec maybe_load_game_config() -> ok | {error, term()}.
 maybe_load_game_config() ->
-    GameDirStr = to_string(application:get_env(asobi, game_dir, ~"/app/game")),
-    _ = apply_guest_auth(GameDirStr),
-    reload_game_modes().
+    GameDirStr = game_dir(),
+    GuestAuth = declared_guest_auth(GameDirStr),
+    case read_modes(GameDirStr) of
+        {ok, Modes} ->
+            asobi_game_config:apply_config(#{guest_auth => GuestAuth, modes => Modes});
+        {error, _} = Err ->
+            %% A broken bundle must still land its auth posture: leaving a stale
+            %% `true` behind is the one failure the loader cannot fail soft on.
+            ok = asobi_game_config:apply_config(#{guest_auth => GuestAuth}),
+            Err
+    end.
 
 %% Refresh only the game_modes registry from the mode scripts, WITHOUT
 %% re-deriving guest_auth. The config watcher (asobi#232) calls this on a live
@@ -84,26 +96,46 @@ maybe_load_game_config() ->
 %% boot-only decision that a bundle write cannot flip at runtime.
 -spec reload_game_modes() -> ok | {error, term()}.
 reload_game_modes() ->
-    GameDirStr = to_string(application:get_env(asobi, game_dir, ~"/app/game")),
-    ConfigPath = filename:join(GameDirStr, "config.lua"),
-    MatchPath = filename:join(GameDirStr, "match.lua"),
+    case read_modes(game_dir()) of
+        {ok, Modes} ->
+            asobi_game_config:apply_config(#{modes => Modes});
+        {error, _} = Err ->
+            Err
+    end.
+
+%% The complete set of modes the game declares right now. A game dir with
+%% neither entry point declares none, which is what lets a mode deleted from
+%% config.lua (or the whole bundle) actually disappear.
+-spec read_modes(string()) -> {ok, asobi_game_config:modes()} | {error, term()}.
+read_modes(GameDir) ->
+    ConfigPath = filename:join(GameDir, "config.lua"),
+    MatchPath = filename:join(GameDir, "match.lua"),
     case {filelib:is_regular(ConfigPath), filelib:is_regular(MatchPath)} of
         {true, _} ->
-            load_multi_mode(GameDirStr, ConfigPath);
+            read_multi_mode(GameDir, ConfigPath);
         {false, true} ->
-            load_single_mode(GameDirStr, MatchPath);
+            read_single_mode(MatchPath);
         {false, false} ->
-            ok
+            {ok, #{}}
     end.
+
+-spec game_dir() -> string().
+game_dir() ->
+    to_string(application:get_env(asobi, game_dir, ~"/app/game")).
 
 %% The game opts into anonymous guest auth by declaring `guest_auth = true` in
 %% its config script (config.lua for multi-mode, else match.lua). We read that
-%% global and flip the asobi app-env flag; the operator still has to supply a
-%% >= 32-byte guest_verifier_pepper, so guest auth is on iff BOTH agree (ADR
-%% 0004). Best-effort: any error just leaves the flag at its `false` default.
-%% Shared with asobi_engine's bundle loader so managed cloud behaves the same.
+%% global and hand it to core, which owns the flag; the operator still has to
+%% supply a >= 32-byte guest_verifier_pepper, so guest auth is on iff BOTH
+%% agree (ADR 0004). Best-effort: any error just leaves the flag at its `false`
+%% default. Shared with asobi_engine's bundle loader so managed cloud behaves
+%% the same.
 -spec apply_guest_auth(string() | binary()) -> ok.
 apply_guest_auth(GameDir) ->
+    asobi_game_config:apply_config(#{guest_auth => declared_guest_auth(GameDir)}).
+
+-spec declared_guest_auth(string() | binary()) -> boolean().
+declared_guest_auth(GameDir) ->
     GameDirStr = to_string(GameDir),
     ConfigPath = filename:join(GameDirStr, "config.lua"),
     MatchPath = filename:join(GameDirStr, "match.lua"),
@@ -112,32 +144,25 @@ apply_guest_auth(GameDir) ->
             true -> ConfigPath;
             false -> MatchPath
         end,
-    Declared =
-        case filelib:is_regular(Script) of
-            false ->
-                false;
-            true ->
-                St0 = asobi_lua_loader:init_sandboxed(),
-                case do_file(Script, St0) of
-                    {ok, _Results, St1} -> read_global_bool(~"guest_auth", St1) =:= true;
-                    {error, _} -> false
-                end
-        end,
-    application:set_env(asobi, guest_auth, Declared).
+    case filelib:is_regular(Script) of
+        false ->
+            false;
+        true ->
+            St0 = asobi_lua_loader:init_sandboxed(),
+            case do_file(Script, St0) of
+                {ok, _Results, St1} -> read_global_bool(~"guest_auth", St1) =:= true;
+                {error, _} -> false
+            end
+    end.
 
 %% --- Multi-mode: config.lua maps mode names to script paths ---
 
-load_multi_mode(GameDir, ConfigPath) ->
+read_multi_mode(GameDir, ConfigPath) ->
     St0 = asobi_lua_loader:init_sandboxed(),
     case do_file(ConfigPath, St0) of
         {ok, [Table | _], St1} ->
             Decoded = luerl:decode(Table, St1),
-            case build_modes_from_manifest(GameDir, Decoded) of
-                {ok, Modes} ->
-                    apply_game_modes(Modes);
-                {error, _} = Err ->
-                    Err
-            end;
+            build_modes_from_manifest(GameDir, Decoded);
         {ok, [], _} ->
             {error, {config_error, ~"config.lua must return a table"}};
         {error, Reason} ->
@@ -180,11 +205,10 @@ build_modes_from_manifest(_, _) ->
 
 %% --- Single-mode: just match.lua in the game dir ---
 
-load_single_mode(_GameDir, MatchPath) ->
+read_single_mode(MatchPath) ->
     case load_match_config(MatchPath) of
         {ok, ModeConfig} ->
-            Modes = #{~"default" => ModeConfig},
-            apply_game_modes(Modes);
+            {ok, #{~"default" => ModeConfig}};
         {error, _} = Err ->
             Err
     end.
@@ -421,22 +445,6 @@ is_safe_relative(Bin) ->
         end,
         Parts
     ).
-
-%% --- Apply to app env ---
-
-apply_game_modes(Modes) ->
-    Existing =
-        case application:get_env(asobi, game_modes, #{}) of
-            M when is_map(M) -> M;
-            _ -> #{}
-        end,
-    Merged = maps:merge(Existing, Modes),
-    application:set_env(asobi, game_modes, Merged),
-    logger:notice(#{
-        msg => ~"lua game config loaded",
-        modes => maps:keys(Merged)
-    }),
-    ok.
 
 %% --- Lua helpers ---
 

--- a/src/lua/asobi_lua_config_watcher.erl
+++ b/src/lua/asobi_lua_config_watcher.erl
@@ -3,8 +3,9 @@
 Keeps the game-mode registry (`game_modes`) in sync with its Lua source.
 
 Mode-shape config (`match_size`, `strategy`, `max_players`, the `config.lua`
-mode manifest) is read into the `asobi` `game_modes` app-env once at boot by
-`asobi_lua_config:maybe_load_game_config/0`. The in-match hot-reload
+mode manifest) is read once at boot by
+`asobi_lua_config:maybe_load_game_config/0` and applied via
+`asobi_game_config:apply_config/1`. The in-match hot-reload
 (`asobi_lua_reload`) re-evaluates a script body inside already-running match and
 world servers, but the reported bug is at match *formation* - before any server
 exists for the new config - so that path is structurally blind to it. Without a
@@ -92,7 +93,7 @@ watched_files() ->
         filename:join(GameDir, "config.lua"),
         filename:join(GameDir, "match.lua")
     ],
-    Modes = ensure_map(application:get_env(asobi, game_modes, #{})),
+    Modes = asobi_game_config:modes(),
     %% Fail soft on a hand-written game_modes with a non-string script path: skip
     %% the bad entry rather than crash the watcher (and, via the sup, the app).
     Scripts = [
@@ -128,7 +129,3 @@ to_string(L) when is_list(L) -> L.
 to_path(B) when is_binary(B) -> binary_to_list(B);
 to_path(L) when is_list(L) -> L;
 to_path(_) -> undefined.
-
--spec ensure_map(term()) -> map().
-ensure_map(M) when is_map(M) -> M;
-ensure_map(_) -> #{}.

--- a/src/lua/bots/asobi_bot_spawner.erl
+++ b/src/lua/bots/asobi_bot_spawner.erl
@@ -206,12 +206,7 @@ load_bot_names(_) ->
     default_names().
 
 mode_config(Mode) ->
-    Modes =
-        case application:get_env(asobi, game_modes, #{}) of
-            M when is_map(M) -> M;
-            _ -> #{}
-        end,
-    maps:get(Mode, Modes, #{}).
+    maps:get(Mode, asobi_game_config:modes(), #{}).
 
 bot_config(Mode) ->
     case mode_config(Mode) of

--- a/test/asobi_game_config_tests.erl
+++ b/test/asobi_game_config_tests.erl
@@ -1,0 +1,106 @@
+-module(asobi_game_config_tests).
+
+-include_lib("eunit/include/eunit.hrl").
+
+game_config_test_() ->
+    {foreach, fun setup/0, fun cleanup/1, [
+        {"a mode dropped from the script set disappears", fun removed_script_mode_disappears/0},
+        {"an operator mode survives a script reload", fun operator_mode_survives_reload/0},
+        {"an operator mode wins a name clash, reload after reload", fun operator_mode_wins_clash/0},
+        {"a term without modes leaves the registry alone", fun modes_key_absent_is_a_no_op/0},
+        {"a term without guest_auth leaves the posture alone",
+            fun guest_auth_key_absent_is_a_no_op/0},
+        {"a declared guest_auth replaces the flag", fun guest_auth_declared_replaces_flag/0},
+        {"a non-map operator env is ignored, not crashed on", fun non_map_operator_env_ignored/0},
+        {"script modes resolve through asobi_game_modes", fun script_mode_resolves/0}
+    ]}.
+
+setup() ->
+    Saved = [{Key, application:get_env(asobi, Key)} || Key <- keys()],
+    [application:unset_env(asobi, Key) || Key <- keys()],
+    %% Same registration asobi_app:start/2 performs. asobi_game_modes resolves
+    %% {lua, _} modes through a provider registry, so without it every script
+    %% mode here is lua_runtime_unavailable.
+    ok = asobi_lua_sup:register_game_modes(),
+    Saved.
+
+cleanup(Saved) ->
+    [
+        asobi_game_modes:unregister_game_mode(K)
+     || K <- [lua_match, lua_match_shared, lua_world]
+    ],
+    [restore(Key, Value) || {Key, Value} <- Saved],
+    ok.
+
+keys() ->
+    [game_modes, script_game_modes, guest_auth].
+
+restore(Key, {ok, Value}) -> application:set_env(asobi, Key, Value);
+restore(Key, undefined) -> application:unset_env(asobi, Key).
+
+%% The registry used to be `maps:merge(Existing, New)` against a single key, so
+%% a mode the game no longer declares was matchable forever.
+removed_script_mode_disappears() ->
+    ok = asobi_game_config:apply_config(#{
+        modes => #{~"arena" => #{match_size => 4}, ~"ctf" => #{match_size => 8}}
+    }),
+    ?assertEqual([~"arena", ~"ctf"], lists:sort(maps:keys(asobi_game_config:modes()))),
+
+    ok = asobi_game_config:apply_config(#{modes => #{~"arena" => #{match_size => 4}}}),
+    ?assertEqual([~"arena"], maps:keys(asobi_game_config:modes())),
+    ?assertEqual(#{}, asobi_game_modes:mode_config(~"ctf")),
+    ?assertEqual({error, not_found}, asobi_game_modes:resolve_game_module(~"ctf")).
+
+operator_mode_survives_reload() ->
+    application:set_env(asobi, game_modes, #{~"ranked" => #{module => op_game, match_size => 2}}),
+    ok = asobi_game_config:apply_config(#{modes => #{~"arena" => #{match_size => 4}}}),
+    ?assertEqual([~"arena", ~"ranked"], lists:sort(maps:keys(asobi_game_config:modes()))),
+
+    ok = asobi_game_config:apply_config(#{modes => #{}}),
+    ?assertEqual(
+        #{module => op_game, match_size => 2},
+        asobi_game_modes:mode_config(~"ranked")
+    ).
+
+operator_mode_wins_clash() ->
+    Operator = #{module => op_game, match_size => 2},
+    Script = #{module => {lua, "arena/match.lua"}, match_size => 99},
+    application:set_env(asobi, game_modes, #{~"arena" => Operator}),
+    ok = asobi_game_config:apply_config(#{modes => #{~"arena" => Script}}),
+    ?assertEqual(Operator, asobi_game_modes:mode_config(~"arena")),
+
+    ok = asobi_game_config:apply_config(#{modes => #{~"arena" => Script}}),
+    ?assertEqual(Operator, asobi_game_modes:mode_config(~"arena")).
+
+modes_key_absent_is_a_no_op() ->
+    ok = asobi_game_config:apply_config(#{modes => #{~"arena" => #{match_size => 4}}}),
+    ok = asobi_game_config:apply_config(#{guest_auth => true}),
+    ?assertEqual([~"arena"], maps:keys(asobi_game_config:modes())).
+
+%% What keeps a live mode-shape reload from flipping auth posture (ADR 0004).
+guest_auth_key_absent_is_a_no_op() ->
+    application:set_env(asobi, guest_auth, true),
+    ok = asobi_game_config:apply_config(#{modes => #{~"arena" => #{match_size => 4}}}),
+    ?assertEqual({ok, true}, application:get_env(asobi, guest_auth)).
+
+guest_auth_declared_replaces_flag() ->
+    application:set_env(asobi, guest_auth, true),
+    ok = asobi_game_config:apply_config(#{guest_auth => false, modes => #{}}),
+    ?assertEqual({ok, false}, application:get_env(asobi, guest_auth)),
+
+    ok = asobi_game_config:apply_config(#{guest_auth => true, modes => #{}}),
+    ?assertEqual({ok, true}, application:get_env(asobi, guest_auth)).
+
+non_map_operator_env_ignored() ->
+    application:set_env(asobi, game_modes, not_a_map),
+    ok = asobi_game_config:apply_config(#{modes => #{~"arena" => #{match_size => 4}}}),
+    ?assertEqual([~"arena"], maps:keys(asobi_game_config:modes())).
+
+script_mode_resolves() ->
+    ok = asobi_game_config:apply_config(#{
+        modes => #{~"arena" => #{module => {lua, "arena/match.lua"}, match_size => 4}}
+    }),
+    ?assertEqual(
+        {ok, asobi_lua_match, #{lua_script => "arena/match.lua"}},
+        asobi_game_modes:resolve_game_module(~"arena")
+    ).

--- a/test/asobi_lua_config_tests.erl
+++ b/test/asobi_lua_config_tests.erl
@@ -26,71 +26,58 @@ safe_lib_dir() ->
 %% --- Tests ---
 
 config_test_() ->
-    {foreach,
-        fun() ->
-            %% Same registration asobi_app:start/2 performs: without it every
-            %% {lua, _} mode resolves to lua_runtime_unavailable.
-            ok = asobi_lua_sup:register_game_modes(),
-            application:set_env(asobi, game_modes, #{})
-        end,
-        fun(_) ->
-            [
-                asobi_game_modes:unregister_game_mode(K)
-             || K <- [lua_match, lua_match_shared, lua_world]
-            ],
-            application:set_env(asobi, game_modes, #{})
-        end,
-        [
-            {"single mode: loads match.lua globals", fun single_mode_loads_globals/0},
-            {"single mode: registers 'default' key in game_modes (load-bearing, asobi#244)",
-                fun single_mode_registers_default_key/0},
-            {"single mode: minimal config (only match_size)", fun single_mode_minimal/0},
-            {"single mode: missing match_size fails", fun single_mode_missing_size/0},
-            {"multi mode: loads config.lua manifest", fun multi_mode_manifest/0},
-            {"no config files: no-op", fun no_config_noop/0},
-            {"bot names: reads from bot script", fun bot_names_from_script/0},
-            {"bot names: falls back to defaults", fun bot_names_fallback/0},
-            {"world config: reads zone settings", fun world_config_zone_settings/0},
-            {"world config: reads phase 2 settings", fun world_config_phase2_settings/0},
-            {"game_type world selects world bridge", fun game_type_world_selects_world_bridge/0},
-            {"game_type absent defaults to match bridge", fun game_type_absent_defaults_to_match/0},
-            {"empty_grace_ms global is forwarded to mode config", fun empty_grace_ms_forwarded/0},
-            {"player_ttl_ms positive is forwarded", fun player_ttl_ms_positive_forwarded/0},
-            {"player_ttl_ms = -1 is forwarded (persistent world opt-in)",
-                fun player_ttl_ms_minus_one_forwarded/0},
-            {"player_ttl_ms = 0 is forwarded (explicit immediate cleanup)",
-                fun player_ttl_ms_zero_forwarded/0},
-            {"player_ttl_ms absent: key omitted from mode config",
-                fun player_ttl_ms_absent_omitted/0},
-            {"match_size = 0 is rejected", fun match_size_zero_rejected/0},
-            {"match_size negative is rejected", fun match_size_negative_rejected/0},
-            {"match_size float is truncated then rejected", fun match_size_float_rejected/0},
-            {"unknown strategy is preserved as-is", fun unknown_strategy_preserved/0},
-            {"strategy = skill_based is recognised", fun strategy_skill_based/0},
-            {"state_strategy = shared resolves to asobi_lua_match_shared",
-                fun state_strategy_shared/0},
-            {"state_strategy absent resolves to asobi_lua_match", fun state_strategy_absent/0},
-            {"state_strategy = unknown is ignored", fun state_strategy_unknown/0},
-            {"config.lua returning non-table errors", fun config_returns_non_table/0},
-            {"config.lua referencing missing match script errors",
-                fun config_missing_match_script/0},
-            {"bot_config table with min_players is forwarded", fun bot_config_min_players/0},
-            {"bot_config min_players defaults to match_size",
-                fun bot_config_min_players_defaults_to_match_size/0},
-            {"bot_config enabled = false overrides the default true",
-                fun bot_config_enabled_false_override/0},
-            {"bot_config min_players far exceeding the ceiling is clamped, not rejected",
-                fun bot_config_min_players_clamped_at_ceiling/0},
-            {"world dimension globals (tick_rate/grid_size/zone_size/view_radius/persistent)",
-                fun world_dimension_globals_forwarded/0},
-            {"guest_auth = true global enables the asobi guest_auth flag",
-                fun guest_auth_global_enables/0},
-            {"guest_auth absent leaves the flag off", fun guest_auth_absent_leaves_off/0},
-            {"guest_auth truthy non-bool does not enable",
-                fun guest_auth_truthy_nonbool_stays_off/0},
-            {"guest_auth resets a stale true when a later bundle omits it",
-                fun guest_auth_stale_true_is_reset/0}
-        ]}.
+    {foreach, fun setup_modes/0, fun(_) -> teardown_modes() end, [
+        {"single mode: loads match.lua globals", fun single_mode_loads_globals/0},
+        {"single mode: registers 'default' key in game_modes (load-bearing, asobi#244)",
+            fun single_mode_registers_default_key/0},
+        {"single mode: minimal config (only match_size)", fun single_mode_minimal/0},
+        {"single mode: missing match_size fails", fun single_mode_missing_size/0},
+        {"multi mode: loads config.lua manifest", fun multi_mode_manifest/0},
+        {"no config files: declares no modes, operator modes untouched",
+            fun no_config_leaves_operator_modes/0},
+        {"bot names: reads from bot script", fun bot_names_from_script/0},
+        {"bot names: falls back to defaults", fun bot_names_fallback/0},
+        {"world config: reads zone settings", fun world_config_zone_settings/0},
+        {"world config: reads phase 2 settings", fun world_config_phase2_settings/0},
+        {"game_type world selects world bridge", fun game_type_world_selects_world_bridge/0},
+        {"game_type absent defaults to match bridge", fun game_type_absent_defaults_to_match/0},
+        {"empty_grace_ms global is forwarded to mode config", fun empty_grace_ms_forwarded/0},
+        {"player_ttl_ms positive is forwarded", fun player_ttl_ms_positive_forwarded/0},
+        {"player_ttl_ms = -1 is forwarded (persistent world opt-in)",
+            fun player_ttl_ms_minus_one_forwarded/0},
+        {"player_ttl_ms = 0 is forwarded (explicit immediate cleanup)",
+            fun player_ttl_ms_zero_forwarded/0},
+        {"player_ttl_ms absent: key omitted from mode config", fun player_ttl_ms_absent_omitted/0},
+        {"match_size = 0 is rejected", fun match_size_zero_rejected/0},
+        {"match_size negative is rejected", fun match_size_negative_rejected/0},
+        {"match_size float is truncated then rejected", fun match_size_float_rejected/0},
+        {"unknown strategy is preserved as-is", fun unknown_strategy_preserved/0},
+        {"strategy = skill_based is recognised", fun strategy_skill_based/0},
+        {"state_strategy = shared resolves to asobi_lua_match_shared", fun state_strategy_shared/0},
+        {"state_strategy absent resolves to asobi_lua_match", fun state_strategy_absent/0},
+        {"state_strategy = unknown is ignored", fun state_strategy_unknown/0},
+        {"config.lua returning non-table errors", fun config_returns_non_table/0},
+        {"config.lua referencing missing match script errors", fun config_missing_match_script/0},
+        {"bot_config table with min_players is forwarded", fun bot_config_min_players/0},
+        {"bot_config min_players defaults to match_size",
+            fun bot_config_min_players_defaults_to_match_size/0},
+        {"bot_config enabled = false overrides the default true",
+            fun bot_config_enabled_false_override/0},
+        {"bot_config min_players far exceeding the ceiling is clamped, not rejected",
+            fun bot_config_min_players_clamped_at_ceiling/0},
+        {"world dimension globals (tick_rate/grid_size/zone_size/view_radius/persistent)",
+            fun world_dimension_globals_forwarded/0},
+        {"guest_auth = true global enables the asobi guest_auth flag",
+            fun guest_auth_global_enables/0},
+        {"guest_auth absent leaves the flag off", fun guest_auth_absent_leaves_off/0},
+        {"guest_auth truthy non-bool does not enable", fun guest_auth_truthy_nonbool_stays_off/0},
+        {"guest_auth resets a stale true when a later bundle omits it",
+            fun guest_auth_stale_true_is_reset/0},
+        {"a mode deleted from config.lua disappears on reload",
+            fun deleted_mode_disappears_on_reload/0},
+        {"an operator sys.config mode survives a bundle load",
+            fun operator_mode_survives_bundle_load/0}
+    ]}.
 
 single_mode_loads_globals() ->
     application:set_env(asobi, game_dir, fixture_dir()),
@@ -108,14 +95,13 @@ single_mode_registers_default_key() ->
     %% load_single_mode/2's #{~"default" => ModeConfig} registration is
     %% what keeps single-mode games recognised at all now. Exercised via
     %% the real reload path (maybe_load_game_config/0 -> reload_game_modes/0
-    %% -> load_single_mode/2), asserting directly against the app-env key
-    %% asobi reads rather than the local get_game_modes/0 helper.
+    %% -> read_single_mode/1), asserting against the registry asobi actually
+    %% reads (asobi_game_config:modes/0) rather than a local helper.
     TmpDir = make_temp_dir(),
     ok = file:write_file(filename:join(TmpDir, "match.lua"), ~"match_size = 2\n"),
     application:set_env(asobi, game_dir, TmpDir),
     ok = asobi_lua_config:maybe_load_game_config(),
-    {ok, Modes} = application:get_env(asobi, game_modes),
-    ?assert(is_map_key(~"default", Modes)),
+    ?assert(is_map_key(~"default", asobi_game_config:modes())),
     cleanup_temp_dir(TmpDir).
 
 single_mode_minimal() ->
@@ -175,6 +161,42 @@ guest_auth_stale_true_is_reset() ->
     application:unset_env(asobi, guest_auth),
     cleanup_temp_dir(TmpDir).
 
+%% The registry used to be a "new wins, nothing is ever removed" merge, so a
+%% mode dropped from config.lua stayed matchable for the life of the node. The
+%% script layer is now replaced wholesale by asobi_game_config (ADR 0006).
+deleted_mode_disappears_on_reload() ->
+    TmpDir = make_temp_dir(),
+    ok = file:write_file(filename:join(TmpDir, "arena.lua"), ~"match_size = 4\n"),
+    ok = file:write_file(filename:join(TmpDir, "ctf.lua"), ~"match_size = 8\n"),
+    ConfigPath = filename:join(TmpDir, "config.lua"),
+    ok = file:write_file(ConfigPath, ~"return { arena = \"arena.lua\", ctf = \"ctf.lua\" }\n"),
+    application:set_env(asobi, game_dir, TmpDir),
+    ok = asobi_lua_config:maybe_load_game_config(),
+    ?assertEqual([~"arena", ~"ctf"], lists:sort(maps:keys(get_game_modes()))),
+
+    ok = file:write_file(ConfigPath, ~"return { arena = \"arena.lua\" }\n"),
+    ok = asobi_lua_config:reload_game_modes(),
+    ?assertEqual([~"arena"], maps:keys(get_game_modes())),
+    ?assertEqual(#{}, asobi_game_modes:mode_config(~"ctf")),
+    ?assertEqual({error, not_found}, asobi_game_modes:resolve_game_module(~"ctf")),
+    cleanup_temp_dir(TmpDir).
+
+%% A bundle load must not overwrite or drop what the operator put in
+%% sys.config: the two layers live in separate keys and the operator wins.
+operator_mode_survives_bundle_load() ->
+    application:set_env(asobi, game_modes, #{~"ranked" => #{module => my_mod, match_size => 2}}),
+    TmpDir = make_temp_dir(),
+    ok = file:write_file(filename:join(TmpDir, "match.lua"), ~"match_size = 4\n"),
+    application:set_env(asobi, game_dir, TmpDir),
+    ok = asobi_lua_config:maybe_load_game_config(),
+    ?assertEqual([~"default", ~"ranked"], lists:sort(maps:keys(get_game_modes()))),
+    ok = asobi_lua_config:reload_game_modes(),
+    ?assertEqual(
+        #{module => my_mod, match_size => 2},
+        asobi_game_modes:mode_config(~"ranked")
+    ),
+    cleanup_temp_dir(TmpDir).
+
 single_mode_missing_size() ->
     TmpDir = make_temp_dir(),
     {ok, Content} = file:read_file(fixture("config_no_size.lua")),
@@ -209,13 +231,13 @@ multi_mode_manifest() ->
     ?assertEqual(2, maps:get(match_size, Minimal2)),
     cleanup_temp_dir(TmpDir).
 
-no_config_noop() ->
+no_config_leaves_operator_modes() ->
     TmpDir = make_temp_dir(),
     application:set_env(asobi, game_dir, TmpDir),
     application:set_env(asobi, game_modes, #{~"existing" => #{module => my_mod}}),
     ok = asobi_lua_config:maybe_load_game_config(),
     Modes = get_game_modes(),
-    ?assert(is_map_key(~"existing", Modes)),
+    ?assertEqual([~"existing"], maps:keys(Modes)),
     cleanup_temp_dir(TmpDir).
 
 bot_names_from_script() ->
@@ -574,10 +596,28 @@ world_dimension_globals_forwarded() ->
 
 -spec get_game_modes() -> #{dynamic() => dynamic()}.
 get_game_modes() ->
-    case application:get_env(asobi, game_modes, #{}) of
-        M when is_map(M) -> M;
-        _ -> #{}
-    end.
+    asobi_game_config:modes().
+
+%% Both layers, so neither a leftover operator mode nor a leftover script mode
+%% from an earlier case leaks into the next one.
+%% Same registration asobi_app:start/2 performs: without it every {lua, _}
+%% mode resolves to lua_runtime_unavailable. Undone after each case because
+%% the registry is a global persistent_term and would otherwise decide the
+%% result of any later module that asserts a provider is absent.
+setup_modes() ->
+    ok = asobi_lua_sup:register_game_modes(),
+    reset_modes().
+
+teardown_modes() ->
+    [
+        asobi_game_modes:unregister_game_mode(K)
+     || K <- [lua_match, lua_match_shared, lua_world]
+    ],
+    reset_modes().
+
+reset_modes() ->
+    application:set_env(asobi, game_modes, #{}),
+    application:set_env(asobi, script_game_modes, #{}).
 
 -spec assert_luerl_state(dynamic()) -> dynamic().
 assert_luerl_state(St) when is_tuple(St), element(1, St) =:= luerl ->

--- a/test/asobi_lua_config_watcher_tests.erl
+++ b/test/asobi_lua_config_watcher_tests.erl
@@ -5,11 +5,11 @@
 watcher_test_() ->
     {foreach,
         fun() ->
-            application:set_env(asobi, game_modes, #{}),
+            reset_modes(),
             application:set_env(asobi_lua, reload_mode, auto)
         end,
         fun(_) ->
-            application:set_env(asobi, game_modes, #{}),
+            reset_modes(),
             application:unset_env(asobi_lua, reload_mode),
             application:unset_env(asobi, game_dir)
         end,
@@ -77,13 +77,12 @@ stale_mtimes() ->
     #{"/nonexistent/stale/path" => 0}.
 
 match_size() ->
-    Modes =
-        case application:get_env(asobi, game_modes, #{}) of
-            M when is_map(M) -> M;
-            _ -> #{}
-        end,
-    [Mode | _] = maps:values(Modes),
+    [Mode | _] = maps:values(asobi_game_config:modes()),
     maps:get(match_size, Mode).
+
+reset_modes() ->
+    application:set_env(asobi, game_modes, #{}),
+    application:set_env(asobi, script_game_modes, #{}).
 
 temp_dir() ->
     Base = filename:join([


### PR DESCRIPTION
**Based on `feat/merge-asobi-lua` (#339), not `main`** - this depends on the asobi_lua merge. Retarget to `main` once #339 lands.

## What was broken

`asobi_lua_config` wrote asobi's own application environment directly, and core read those keys back in four places (`asobi_game_modes:7`/`:63`, `asobi_matchmaker:340`, `asobi_bot_spawner:210`, `asobi_lua_config_watcher:95`). Inside one application, that is still one module reaching into another module's config with no defined ordering: nothing said who writes, who wins, or when.

- `src/lua/asobi_lua_config.erl:126` - `application:set_env(asobi, guest_auth, Declared)`.
- `src/lua/asobi_lua_config.erl:427-439` (`apply_game_modes/1`) - `Merged = maps:merge(Existing, Modes)`, then `set_env(asobi, game_modes, Merged)`, against the same key the operator configures in `sys.config`. "New wins, nothing is ever removed" gave two concrete bugs:
  - **A deleted mode never went away.** Drop `ctf` from `config.lua`, reload, and `ctf` was still registered, still matchable, still spawning matches from the previous definition, until the node restarted.
  - **A bundle overwrote operator config.** A mode declared in the operator's `sys.config` was silently replaced by a same-named mode from a game bundle - and the config watcher does that on every mode-shape edit, not only at boot.

## What changed

New core module `src/asobi_game_config.erl` owns the write path and the ordering. A loader derives a config term and hands it over; it no longer touches app env itself.

- **Modes are two layers in two keys.** `game_modes` stays the operator layer and asobi never writes it. `script_game_modes` holds the complete set the loaded game declares, and `apply_config/1` replaces it wholesale. `asobi_game_config:modes/0` composes them - script layer first, operator layer on top - so an operator mode wins a name clash and cannot be dropped by a bundle, and a mode the game stopped declaring disappears. Every core reader now goes through `modes/0`; none reads the raw key.
- **Write order is documented in one place** (module doc + ADR 0006): `guest_auth` first, then the modes; a key absent from the term is not written. That absence rule is what lets `reload_game_modes/0` refresh mode shape from the watcher without flipping auth posture at runtime (ADR 0004).
- **`guest_auth` is replaced, not merged** - it is the game's half of ADR 0004's AND, the operator's half is the pepper. Behaviour is unchanged, only the writer moved.
- `asobi_lua_config` now reads Lua and returns `{ok, Modes}`; `load_multi_mode/2`/`load_single_mode/2` became `read_multi_mode/2`/`read_single_mode/1`, and `apply_guest_auth/1` (the cross-repo entry point named in ADR 0004) keeps its signature and delegates.
- One behaviour change worth calling out: a game dir with neither `config.lua` nor `match.lua` now declares *zero* modes instead of being a no-op, so deleting the whole bundle clears its modes too. Operator modes are untouched, so Erlang-only deployments are unaffected.
- Docs: `docs/adr/0006-core-owns-the-game-config-write-path.md` (Nygard) and a new "Operator Modes vs Game-Declared Modes" section in `guides/configuration.md`.

## What the tests assert

`test/asobi_game_config_tests.erl` (new, 8 cases against the core function):
- a mode dropped from the script set disappears - gone from `modes/0`, `mode_config/1` returns `#{}`, `resolve_game_module/1` returns `{error, not_found}` (**the ticket's explicit ask**);
- an operator mode survives a script reload, including a reload that declares no modes at all;
- an operator mode wins a name clash *reload after reload* (the old bug bit on the second write, not the first);
- a term without `modes` leaves the registry alone; a term without `guest_auth` leaves the posture alone; a declared `guest_auth` replaces the flag both ways;
- a non-map operator env is ignored rather than crashed on;
- a script mode still resolves through `asobi_game_modes`.

`test/asobi_lua_config_tests.erl` gets the end-to-end regressions through the real loader: a mode deleted from `config.lua` is gone after `reload_game_modes/0`, and an operator `sys.config` mode survives a bundle load plus reload. `no_config_noop` became `no_config_leaves_operator_modes` and now asserts the exact key set. Both that suite and the watcher suite read through `asobi_game_config:modes/0` and reset both layers between cases.

## Checks

- `rebar3 fmt` + `rebar3 fmt --check`: clean.
- `rebar3 xref`: clean.
- `rebar3 eunit`: **938 tests, 0 failures**.
- Also ran (not required by the task): `rebar3 dialyzer` clean, `rebar3 ex_doc` with no warnings.

## Not verified / follow-ups

- **`rebar3 ct` was not run.** CT needs the Docker Postgres and points at the shared `asobi_dev` DB via `config/dev_sys.config.src`; running it (or `make db-reset`) from this worktree would have trampled a database other sessions may be using. The CT suites that touch modes (`asobi_matchmaker_api_SUITE`, `asobi_world_lobby_SUITE`, `asobi_world_lobby_ws_SUITE`) all set `game_modes` app env directly, which is now the operator layer and is still read - so they should be unaffected, but that is reasoning, not a run.
- **Downstream, `asobi_engine` will need a small test fix when it bumps its asobi pin.** Its bundle loader calls `asobi_lua_config:maybe_load_game_config/0` and inherits the new semantics with no code change, but `asobi_engine/test/asobi_engine_bundle_tests.erl:114` and `:128` assert on `application:get_env(asobi, game_modes)` after `register_modes/1`; those assertions must move to `asobi_game_config:modes/0`. The stale moduledoc line at `asobi_engine_bundle.erl:9` should be updated too. Nothing to do in this repo.
- **New module.** Per AGENTS.md this should go past `asobi-architecture-guardian` before merge - `asobi_game_config` is a new core module, deliberately kept to two functions with `asobi_game_modes` left as the read/semantics layer.
