### PR TITLE
fix: track bots through asobi_presence, and make the presence message contract a type

### DIFF
--- a/guides/architecture.md
+++ b/guides/architecture.md
@@ -183,7 +183,11 @@ automatically replicates group membership across all connected nodes.
 
 **What works across nodes today:**
 - **Presence** — `pg:get_members(nova_scope, {player, Id})` returns pids on all
-  nodes. Sending messages to those pids works transparently.
+  nodes. Sending messages to those pids works transparently. Delivery targets
+  and the online set are separate: `asobi_presence:track/2` records both,
+  `track_bot/2` records only the delivery target, so bots receive broadcasts
+  without ever counting toward `online_count/0`. Everything `send/2` delivers
+  is one of the shapes in `t:asobi_presence:message/0`.
 - **Session revocation** — `asobi_presence:disconnect/2` reaches sessions on any
   node.
 - **Chat** — `nova_pubsub` uses `pg` underneath, so chat messages cross nodes.

--- a/guides/lua-bots.md
+++ b/guides/lua-bots.md
@@ -213,6 +213,24 @@ end
 Clients receive bot players in the normal game state. Whether to show them
 differently (e.g., "AI" tag) is up to the client.
 
+## Bots and presence
+
+A bot is tracked with `asobi_presence:track_bot/2`. That makes it a delivery
+target for everything the match server broadcasts -- state, match events,
+votes -- exactly like a connected player session.
+
+It deliberately does not make the bot *online*:
+
+- `asobi_presence:online_count/0` counts connected humans only. Bots are
+  never added to it, so your concurrency figure stays a real player count and
+  bot-fill (which is driven by how few humans are queued) cannot feed itself.
+- Bots emit no `player_online` / `player_offline` presence broadcasts, so
+  friend lists and presence subscribers never see a bot appear or disappear.
+
+`asobi_presence:get_status/1` on a bot id does answer `online`, because that
+function reports whether the id is addressable. Filter on the `bot_` prefix
+if you need the human answer.
+
 ## Next steps
 
 - [Lua scripting](lua-scripting.md) - the `game.*` API a bot's `think` shares with match logic.

--- a/src/lua/bots/asobi_bot.erl
+++ b/src/lua/bots/asobi_bot.erl
@@ -6,6 +6,11 @@ The bot joins a match as a player, receives game state updates,
 and sends input decisions based on the Lua `think(bot_id, state)` function.
 
 Also handles auto boon picking and auto voting.
+
+A bot is tracked through `asobi_presence:track_bot/2`, so it is a delivery
+target for `asobi_presence:send/2` like any player session but is never
+counted by `asobi_presence:online_count/0`. The messages it consumes are the
+public `t:asobi_presence:message/0` contract, not an ad-hoc shape.
 """.
 
 -behaviour(gen_server).
@@ -13,7 +18,6 @@ Also handles auto boon picking and auto voting.
 -export([start_link/3]).
 -export([init/1, handle_info/2, handle_cast/2, handle_call/3, terminate/2]).
 
--define(PG_SCOPE, nova_scope).
 -define(TICK_INTERVAL, 100).
 
 -spec start_link(pid(), binary(), binary() | undefined) -> gen_server:start_ret().
@@ -30,7 +34,7 @@ start_link(MatchPid, BotId, LuaScript) ->
 
 -spec init(map()) -> {ok, map()} | {stop, term()}.
 init(#{match_pid := MatchPid, bot_id := BotId, lua_script := LuaScript}) ->
-    pg:join(?PG_SCOPE, {player, BotId}, self()),
+    asobi_presence:track_bot(BotId, self()),
     monitor(process, MatchPid),
     _ = asobi_match_server:join(MatchPid, BotId),
     erlang:send_after(?TICK_INTERVAL, self(), tick),
@@ -67,22 +71,31 @@ handle_info(tick, #{phase := playing} = State) ->
 handle_info(tick, State) ->
     erlang:send_after(?TICK_INTERVAL, self(), tick),
     {noreply, State};
-handle_info({asobi_message, {match_state, GameState}}, State) when is_map(GameState) ->
+handle_info({asobi_message, Message}, State) ->
+    handle_presence_message(Message, State);
+handle_info({'DOWN', _, process, MatchPid, _}, #{match_pid := MatchPid} = State) ->
+    {stop, normal, State};
+handle_info(_, State) ->
+    {noreply, State}.
+
+%% Spec'd against the presence contract rather than term(): these are named
+%% shapes core has to keep, not an ad-hoc guess at an internal protocol.
+%% Reshaping one means editing asobi_presence:message/0, which breaks
+%% dialyzer at the producing send/2 call.
+-spec handle_presence_message(asobi_presence:message(), map()) ->
+    {noreply, map()} | {stop, term(), map()}.
+handle_presence_message({match_state, GameState}, State) when is_map(GameState) ->
     Phase = extract_phase(GameState),
     State1 = State#{game_state => GameState, phase => Phase},
     State2 = maybe_auto_pick_boon(State1),
     {noreply, State2};
-handle_info({asobi_message, {match_event, vote_start, VotePayload}}, State) when
+handle_presence_message({match_event, vote_start, VotePayload}, State) when
     is_map(VotePayload)
 ->
     handle_vote_start(VotePayload, State);
-handle_info({asobi_message, {match_event, finished, _}}, State) ->
+handle_presence_message({match_event, finished, _}, State) ->
     {stop, normal, State};
-handle_info({asobi_message, _}, State) ->
-    {noreply, State};
-handle_info({'DOWN', _, process, MatchPid, _}, #{match_pid := MatchPid} = State) ->
-    {stop, normal, State};
-handle_info(_, State) ->
+handle_presence_message(_, State) ->
     {noreply, State}.
 
 -spec handle_cast(term(), map()) -> {noreply, map()}.
@@ -95,7 +108,7 @@ handle_call(_, _From, State) ->
 
 -spec terminate(term(), map()) -> ok.
 terminate(_Reason, #{bot_id := BotId, match_pid := MatchPid}) ->
-    pg:leave(?PG_SCOPE, {player, BotId}, self()),
+    asobi_presence:untrack_bot(BotId, self()),
     try
         asobi_match_server:leave(MatchPid, BotId)
     catch

--- a/src/social/asobi_presence.erl
+++ b/src/social/asobi_presence.erl
@@ -1,29 +1,104 @@
 -module(asobi_presence).
+-moduledoc """
+Who is reachable, and who counts as online.
+
+Those are two different facts and this module keeps them apart:
+
+- *addressable* - the process is a delivery target for `send/2`, keyed by
+  player id. Player sessions and bots are both addressable.
+- *online* - a connected human player. Only `track/2` records that, and
+  `online_count/0` counts exactly those.
+
+Bots (`asobi_bot`) are addressable but never online. `track_bot/2` joins the
+delivery group and nothing else: a bot does not count toward
+`online_count/0` and does not emit `player_online` / `player_offline`
+presence broadcasts. `online_count/0` is the operator-facing concurrency
+number, and bot fill is itself driven by how few humans are queued, so
+counting server-spawned bots would both inflate the figure and feed it back
+into its own input.
+
+## Message contract
+
+Everything `send/2` delivers arrives at the target process as
+`{asobi_message, message()}`. `message/0` is the contract between the core
+servers that produce those terms (`asobi_match_server`, `asobi_world_server`,
+`asobi_zone`, `asobi_matchmaker`, the Lua runtime) and the processes that
+pattern-match them (`asobi_ws_handler`, `asobi_player_session`, `asobi_bot`).
+
+It is a public type on purpose. `send/2` is spec'd with it, so a producer
+that invents a shape fails dialyzer instead of quietly emitting a term no
+consumer handles, and a consumer (`asobi_bot` does this) can spec its own
+clauses against the same named type rather than an ad-hoc guess.
+""".
 -behaviour(gen_server).
 
 -export([start_link/0]).
--export([track/2, untrack/1, update/2, get_status/1, send/2, online_count/0]).
+-export([track/2, track_bot/2, untrack/1, untrack_bot/2, update/2, get_status/1, send/2]).
+-export([online_count/0]).
 -export([disconnect/2, revoke_session/2]).
 -export([init/1, handle_call/3, handle_cast/2, handle_info/2]).
 
 -define(PRESENCE_GROUP, asobi_online).
 -define(PG_SCOPE, nova_scope).
 
+-type event_name() :: atom() | binary().
+-type message() ::
+    {match_joined, pid()}
+    | {match_state, map()}
+    | {match_state_raw, binary()}
+    | {match_event, event_name(), map()}
+    | {world_joined, pid(), pid() | undefined}
+    | {world_zone_changed, pid()}
+    | {world_event, event_name(), map()}
+    | {zone_delta, non_neg_integer(), [map()]}
+    | {zone_delta_raw, binary()}
+    | {terrain_chunk, {integer(), integer()}, binary()}
+    | {dm_message, map()}
+    | {notification, map()}
+    | {game_message, term()}
+    | {script_error, map()}.
+
+-export_type([event_name/0, message/0]).
+
 -spec start_link() -> gen_server:start_ret().
 start_link() ->
     gen_server:start_link({local, ?MODULE}, ?MODULE, [], []).
 
+-doc """
+Track a connected player session: addressable by `send/2` and counted by
+`online_count/0`.
+""".
 -spec track(binary(), pid()) -> ok.
 track(PlayerId, Pid) ->
     nova_pubsub:join(?PRESENCE_GROUP, Pid),
-    pg:join(?PG_SCOPE, {player, PlayerId}, Pid),
+    join_delivery_group(PlayerId, Pid),
     nova_pubsub:broadcast(presence, ~"player_online", #{player_id => PlayerId}),
+    ok.
+
+-doc """
+Track a bot process: addressable by `send/2`, deliberately not online.
+
+A bot never counts toward `online_count/0` and never emits a presence
+broadcast. See the module docs for why.
+""".
+-spec track_bot(binary(), pid()) -> ok.
+track_bot(BotId, Pid) ->
+    join_delivery_group(BotId, Pid),
     ok.
 
 -spec untrack(binary()) -> ok.
 untrack(PlayerId) ->
     nova_pubsub:broadcast(presence, ~"player_offline", #{player_id => PlayerId}),
     ok.
+
+-spec untrack_bot(binary(), pid()) -> ok.
+untrack_bot(BotId, Pid) ->
+    pg:leave(?PG_SCOPE, {player, BotId}, Pid),
+    ok.
+
+-spec join_delivery_group(binary(), pid()) -> ok.
+join_delivery_group(Id, Pid) ->
+    pg:join(?PG_SCOPE, {player, Id}, Pid).
 
 -spec update(binary(), map()) -> ok.
 update(PlayerId, Status) ->
@@ -37,7 +112,7 @@ get_status(PlayerId) ->
         _ -> online
     end.
 
--spec send(binary(), term()) -> ok.
+-spec send(binary(), message()) -> ok.
 send(PlayerId, Message) ->
     Members = pg:get_members(?PG_SCOPE, {player, PlayerId}),
     lists:foreach(fun(Pid) when is_pid(Pid) -> Pid ! {asobi_message, Message} end, Members),

--- a/test/asobi_bot_presence_tests.erl
+++ b/test/asobi_bot_presence_tests.erl
@@ -1,0 +1,206 @@
+-module(asobi_bot_presence_tests).
+-include_lib("eunit/include/eunit.hrl").
+
+%% S5: asobi_bot used to re-define core's ?PG_SCOPE and call pg:join/3
+%% itself, so a bot was a delivery target that asobi_presence knew nothing
+%% about. Bots now go through asobi_presence:track_bot/2, which joins the
+%% delivery group and nothing else: addressable by send/2, never counted by
+%% online_count/0.
+%%
+%% The match-server tests run against the real asobi_presence (no meck) so
+%% the producer shapes in asobi_presence:message/0 are exercised end to end:
+%% match server -> asobi_presence:send/2 -> pg -> bot.
+
+-define(BASE_CONFIG, #{
+    game_module => asobi_test_game,
+    min_players => 2,
+    max_players => 4,
+    tick_rate => 50
+}).
+
+presence_tracking_test_() ->
+    {foreach, fun setup/0, fun cleanup/1, [
+        {"a player session counts toward online_count/0", fun player_counts_online/0},
+        {"a bot is addressable but never counted online", fun bot_addressable_not_online/0},
+        {"untrack_bot/2 drops the delivery target and leaves the count alone",
+            fun untrack_bot_drops_target/0},
+        {"a live bot is tracked, uncounted, and found by the match server",
+            fun bot_tracked_and_uncounted/0},
+        {"match state reaches the bot through presence", fun bot_receives_match_state/0},
+        {"a vote_start match event reaches the bot", fun bot_receives_vote_start/0},
+        {"a finished bot leaves the delivery group", fun finished_bot_untracked/0}
+    ]}.
+
+setup() ->
+    case ets:whereis(asobi_match_state) of
+        undefined -> ets:new(asobi_match_state, [named_table, public, set]);
+        _ -> ok
+    end,
+    case whereis(nova_scope) of
+        undefined -> {ok, _} = pg:start(nova_scope);
+        _ -> ok
+    end,
+    meck:new(asobi_repo, [no_link]),
+    meck:expect(asobi_repo, insert, fun(_CS) -> {ok, #{}} end),
+    meck:expect(asobi_repo, insert, fun(_CS, _Opts) -> {ok, #{}} end),
+    ok.
+
+cleanup(_) ->
+    meck:unload(asobi_repo),
+    ok.
+
+%% --- track/2 vs track_bot/2 ---
+
+player_counts_online() ->
+    Before = asobi_presence:online_count(),
+    Pid = relay(),
+    ok = asobi_presence:track(~"presence_p1", Pid),
+    ?assertEqual(Before + 1, asobi_presence:online_count()),
+    ?assertEqual(online, asobi_presence:get_status(~"presence_p1")),
+    asobi_presence:send(~"presence_p1", {notification, #{~"id" => ~"n1"}}),
+    ?assertEqual({asobi_message, {notification, #{~"id" => ~"n1"}}}, next_relayed()),
+    stop_relay(Pid),
+    wait_until(fun() -> asobi_presence:online_count() =:= Before end).
+
+bot_addressable_not_online() ->
+    Before = asobi_presence:online_count(),
+    Pid = relay(),
+    ok = asobi_presence:track_bot(~"bot_Spark", Pid),
+    ?assertEqual(Before, asobi_presence:online_count()),
+    ?assertEqual(online, asobi_presence:get_status(~"bot_Spark")),
+    asobi_presence:send(~"bot_Spark", {match_state, #{~"tick" => 1}}),
+    ?assertEqual({asobi_message, {match_state, #{~"tick" => 1}}}, next_relayed()),
+    stop_relay(Pid).
+
+untrack_bot_drops_target() ->
+    Before = asobi_presence:online_count(),
+    Pid = relay(),
+    ok = asobi_presence:track_bot(~"bot_Blitz", Pid),
+    ok = asobi_presence:untrack_bot(~"bot_Blitz", Pid),
+    ?assertEqual(offline, asobi_presence:get_status(~"bot_Blitz")),
+    ?assertEqual(Before, asobi_presence:online_count()),
+    stop_relay(Pid).
+
+%% --- the bot process itself ---
+
+bot_tracked_and_uncounted() ->
+    Before = asobi_presence:online_count(),
+    MatchPid = start_match(#{}),
+    BotId = ~"bot_Volt",
+    BotPid = start_bot(MatchPid, BotId),
+    ?assertEqual([BotPid], pg:get_members(nova_scope, {player, BotId})),
+    ?assertEqual(Before, asobi_presence:online_count()),
+    %% asobi_match_server:find_player_pid/1 resolves the roster through the
+    %% same pg group, so tracking must happen before the bot's join/2 call.
+    ?assertEqual(BotPid, session_pid(MatchPid, BotId)),
+    stop_process(BotPid),
+    stop_process(MatchPid).
+
+bot_receives_match_state() ->
+    MatchPid = start_match(#{min_players => 1}),
+    BotPid = start_bot(MatchPid, ~"bot_Neon"),
+    wait_until(fun() -> maps:get(game_state, bot_state(BotPid)) =/= #{} end),
+    ?assertEqual(#{score => 0}, maps:get(game_state, bot_state(BotPid))),
+    stop_process(BotPid),
+    stop_process(MatchPid).
+
+bot_receives_vote_start() ->
+    %% min_players 2 keeps the match in `waiting`, so no state broadcast
+    %% races the phase assertion. An empty option list is deliberate: the
+    %% bot then recognises the vote without arming its 1-3s auto-vote timer.
+    MatchPid = start_match(#{}),
+    BotPid = start_bot(MatchPid, ~"bot_Pulse"),
+    ok = asobi_match_server:broadcast_event(MatchPid, vote_start, #{
+        vote_id => ~"v1",
+        options => [],
+        window_ms => 5000,
+        method => ~"plurality"
+    }),
+    wait_until(fun() -> maps:get(phase, bot_state(BotPid)) =:= voting end),
+    ?assertEqual(voting, maps:get(phase, bot_state(BotPid))),
+    stop_process(BotPid),
+    stop_process(MatchPid).
+
+finished_bot_untracked() ->
+    MatchPid = start_match(#{}),
+    BotId = ~"bot_Ember",
+    BotPid = start_bot(MatchPid, BotId),
+    Ref = monitor(process, BotPid),
+    asobi_presence:send(BotId, {match_event, finished, #{}}),
+    receive
+        {'DOWN', Ref, process, BotPid, normal} -> ok
+    after 2000 ->
+        error(bot_still_running)
+    end,
+    wait_until(fun() -> asobi_presence:get_status(BotId) =:= offline end),
+    ?assertEqual(offline, asobi_presence:get_status(BotId)),
+    stop_process(MatchPid).
+
+%% --- Helpers ---
+
+start_match(Overrides) ->
+    {ok, Pid} = asobi_match_server:start_link(maps:merge(?BASE_CONFIG, Overrides)),
+    unlink(Pid),
+    Pid.
+
+start_bot(MatchPid, BotId) ->
+    {ok, Pid} = asobi_bot:start_link(MatchPid, BotId, undefined),
+    unlink(Pid),
+    Pid.
+
+bot_state(BotPid) ->
+    sys:get_state(BotPid).
+
+session_pid(MatchPid, PlayerId) ->
+    {_StateName, #{players := Players}} = sys:get_state(MatchPid),
+    maps:get(session_pid, maps:get(PlayerId, Players)).
+
+relay() ->
+    Parent = self(),
+    spawn(fun Loop() ->
+        receive
+            stop ->
+                ok;
+            Msg ->
+                Parent ! {relayed, Msg},
+                Loop()
+        end
+    end).
+
+stop_relay(Pid) ->
+    Pid ! stop,
+    ok.
+
+next_relayed() ->
+    receive
+        {relayed, Msg} -> Msg
+    after 2000 ->
+        error(no_message_delivered)
+    end.
+
+stop_process(Pid) ->
+    case is_process_alive(Pid) of
+        true ->
+            Ref = monitor(process, Pid),
+            exit(Pid, shutdown),
+            receive
+                {'DOWN', Ref, process, Pid, _} -> ok
+            after 5000 -> ok
+            end;
+        false ->
+            ok
+    end.
+
+wait_until(Fun) ->
+    wait_until(Fun, 200).
+
+wait_until(_Fun, 0) ->
+    error(condition_never_held);
+wait_until(Fun, N) ->
+    case Fun() of
+        true ->
+            ok;
+        false ->
+            timer:sleep(25),
+            wait_until(Fun, N - 1)
+    end.

--- a/test/asobi_lua_SUITE.erl
+++ b/test/asobi_lua_SUITE.erl
@@ -81,6 +81,12 @@ init_per_testcase(_TC, Config) ->
     meck:expect(asobi_player_stats, record_match, fun(_Participants, _Result) -> ok end),
     meck:new(asobi_presence, [non_strict, no_link]),
     meck:expect(asobi_presence, send, fun(_PlayerId, _Msg) -> ok end),
+    %% Bots now register themselves as delivery targets. The mock replaces the
+    %% whole module, so anything asobi_bot reaches for and this suite has not
+    %% stubbed is `undef` and kills the bot at init - surfacing here as a bot
+    %% that never joined rather than as a missing stub.
+    meck:expect(asobi_presence, track_bot, fun(_BotId, _Pid) -> ok end),
+    meck:expect(asobi_presence, untrack_bot, fun(_BotId, _Pid) -> ok end),
     Config.
 
 end_per_testcase(_TC, _Config) ->


### PR DESCRIPTION
Base branch is `feat/merge-asobi-lua`, not `main` - the bot modules only exist there.

## What was broken

`src/lua/bots/asobi_bot.erl:16` re-defined core's `-define(PG_SCOPE, nova_scope)` and
`:33` called `pg:join(?PG_SCOPE, {player, BotId}, self())` directly (`:98` the matching
`pg:leave`). Two consequences:

- A bot was a `asobi_presence:send/2` delivery target that `asobi_presence` itself knew
  nothing about. Bots sat in the `{player, Id}` group but never in `asobi_online`, so
  `online_count/0` neither counted them nor had any say in the matter - the exclusion was
  an accident of which pg group the bot happened to pick, not a decision.
- `asobi_bot.erl:70-81` pattern-matched core's presence terms (`{match_state, _}`,
  `{match_event, vote_start, _}`, `{match_event, finished, _}`) as an unnamed, untyped
  internal protocol. Core could reshape them and nothing anywhere would say so.

## What changed

**`asobi_presence`**
- New `track_bot/2` and `untrack_bot/2`: join/leave the `{player, Id}` delivery group and
  nothing else. `track/2` is unchanged for player sessions (delivery group + `asobi_online`
  + `player_online` broadcast). The shared pg join is now one private helper, so player and
  bot tracking cannot drift apart.
- New public type `asobi_presence:message/0` (plus `event_name/0`), enumerating every shape
  that travels as `{asobi_message, Msg}`: match state/events, world joined/zone
  changed/events, zone deltas, terrain chunks, DMs, notifications, game messages, script
  errors. `send/2` is spec'd `-spec send(binary(), message()) -> ok.` instead of `term()`.
- Module doc states the decision and the reasoning.

**`asobi_bot`** - uses `asobi_presence:track_bot/2` in `init/1` and `untrack_bot/2` in
`terminate/2`; its `?PG_SCOPE` define is gone. The presence clauses moved out of
`handle_info/2` into `handle_presence_message/2`, spec'd `asobi_presence:message/0`, so the
shapes it depends on are named contract rather than a guess.

**Docs** - `guides/lua-bots.md` gains a "Bots and presence" section; `guides/architecture.md`
notes that delivery targets and the online set are separate facts.

## The decision: bots do NOT count toward `online_count/0`

Stated deliberately, and now enforced by a test rather than by accident.

- `online_count/0` is the operator-facing human concurrency number (capacity, dashboards).
  Server-spawned bots would inflate it.
- Bot fill is itself a function of how few humans are queued, so counting bots would feed
  the metric back into its own input.
- Bots emit no `player_online`/`player_offline` broadcasts, so friend lists and presence
  subscribers never see a bot appear.

Known consequence, documented in the guide rather than papered over: `get_status/1` answers
`online` for a bot id, because that function reports addressability. Callers wanting the
human answer filter on the `bot_` prefix.

## What the tests assert

New `test/asobi_bot_presence_tests.erl` (7 tests). The match-server tests run against the
**real** `asobi_presence` (no meck), so producer shapes are exercised end to end: match
server -> `asobi_presence:send/2` -> pg -> bot.

1. `track/2` raises `online_count/0` by one, reports `online`, and delivers.
2. `track_bot/2` leaves `online_count/0` unchanged, is still addressable, and delivers.
3. `untrack_bot/2` drops the delivery target and still does not move the count.
4. A live `asobi_bot` is in `{player, BotId}`, does not move `online_count/0`, and is the
   pid the match server bound as `session_pid` - which pins that tracking happens before
   the bot's `join/2` call, since `find_player_pid/1` resolves the roster through that group.
5. Real per-player `{match_state, _}` broadcast from a running match server reaches the bot.
6. A real `asobi_match_server:broadcast_event(Pid, vote_start, Payload)` moves the bot to
   the `voting` phase - the vote-start shape is pinned with the producer in the loop.
7. `{match_event, finished, _}` stops the bot and it leaves the delivery group.

Negative check performed before opening this PR: switching `asobi_bot:init/1` to
`asobi_presence:track/2` makes test 4 fail (`expected: 0, got: 1`), so the count assertion
genuinely holds the decision in place.

## Verification

- `rebar3 fmt` / `rebar3 fmt --check` - clean.
- `rebar3 xref` - clean.
- `rebar3 eunit` - **935 tests, 0 failures** (was 928 on this base; the 7 new ones are the
  delta).
- `rebar3 dialyzer` - clean. Also verified the new contract bites: temporarily renaming
  `{match_state, map()}` in `message/0` produced
  `The call asobi_presence:send(PlayerId::any(), {'match_state',_}) breaks the contract` at
  `asobi_match_server.erl:772`. Reverted before committing.
- `rebar3 ex_doc` - clean, no warnings.

## What I could not verify

- Dialyzer flags the **producer** when a shape changes, not the bot's clauses: because
  `handle_info/2` is spec'd `term()`, dialyzer does not report the bot's clauses as
  unmatchable when `message/0` changes. The comment in `asobi_bot` says only what is true.
  The bot's own end of the contract is held by tests 5-7 instead.
- No CT suites or Postgres-backed tests were run (no database in this worktree); the change
  touches no DB path.
- Not run: `elp eqwalize-all`, `elp lint`, mutation testing - not available in this
  environment.
