### PR TITLE
fix: register the Lua game-mode providers at application start

### DIFF
--- a/src/asobi_app.erl
+++ b/src/asobi_app.erl
@@ -6,6 +6,7 @@
 -spec start(application:start_type(), term()) -> {ok, pid()} | {error, term()}.
 start(_StartType, _StartArgs) ->
     setup_telemetry(),
+    register_lua_game_modes(),
     case kura_migrator:migrate(asobi_repo) of
         {ok, Applied} ->
             logger:notice(#{msg => ~"migrations_applied", versions => Applied});
@@ -22,6 +23,16 @@ start(_StartType, _StartArgs) ->
 setup_telemetry() ->
     asobi_telemetry:setup(),
     ok.
+
+%% asobi_game_modes resolves `{lua, Script}` modes through a provider registry
+%% (#333) rather than hardcoded atoms, and returns `lua_runtime_unavailable`
+%% when a kind has no provider. The writer used to be asobi_lua's own
+%% application-start callback; the merge (#339) removed that application without
+%% moving the registration, so every Lua mode resolved to
+%% `lua_runtime_unavailable`. Registering here rather than from asobi_lua_sup
+%% keeps it ahead of every asobi_sup child, including the matchmaker.
+register_lua_game_modes() ->
+    asobi_lua_sup:register_game_modes().
 
 -spec stop(term()) -> ok.
 stop(_State) ->

--- a/src/lua/asobi_lua_sup.erl
+++ b/src/lua/asobi_lua_sup.erl
@@ -1,8 +1,23 @@
 -module(asobi_lua_sup).
 -behaviour(supervisor).
 
--export([start_link/0]).
+-export([start_link/0, register_game_modes/0]).
 -export([init/1]).
+
+-doc """
+Register the Lua bridge modules as the providers for the three Lua game-mode
+kinds `asobi_game_modes` knows about.
+
+Called from `asobi_app:start/2` before the supervision tree comes up, and by
+any test that resolves a `{lua, _}` mode without booting the application. The
+mapping lives here, next to the bridges, so `asobi_game_modes` keeps knowing
+nothing about the scripting runtime.
+""".
+-spec register_game_modes() -> ok.
+register_game_modes() ->
+    ok = asobi_game_modes:register_game_mode(lua_match, asobi_lua_match),
+    ok = asobi_game_modes:register_game_mode(lua_match_shared, asobi_lua_match_shared),
+    ok = asobi_game_modes:register_game_mode(lua_world, asobi_lua_world).
 
 -spec start_link() -> supervisor:startlink_ret().
 start_link() ->

--- a/test/asobi_game_modes_tests.erl
+++ b/test/asobi_game_modes_tests.erl
@@ -74,6 +74,10 @@ cleanup_lua(Prev) ->
     cleanup(Prev).
 
 lua_without_provider() ->
+    %% Establish the absence this asserts on rather than assuming it: the
+    %% registry is a global persistent_term, so any earlier test module that
+    %% registers a provider would otherwise decide this one's result.
+    ok = asobi_game_modes:unregister_game_mode(lua_match),
     ?assertEqual(
         {error, lua_runtime_unavailable}, asobi_game_modes:resolve_game_module(~"arena")
     ).

--- a/test/asobi_lua_SUITE.erl
+++ b/test/asobi_lua_SUITE.erl
@@ -68,12 +68,24 @@ init_per_testcase(_TC, Config) ->
     meck:new(asobi_repo, [no_link]),
     meck:expect(asobi_repo, insert, fun(_CS) -> {ok, #{}} end),
     meck:expect(asobi_repo, insert, fun(_CS, _Opts) -> {ok, #{}} end),
+    %% asobi#329 wrapped the match-result write in a transaction so the record
+    %% and the stats bump land together. The mock is strict, so every repo
+    %% function the finish path reaches has to be stubbed or it is `undef` -
+    %% which kills the match server mid-finish and surfaces here only as
+    %% `match_did_not_finish`. This suite runs without a repo pool, so run the
+    %% fun inline rather than reaching for a database that is not there.
+    meck:expect(asobi_repo, transaction, fun(Fun) -> {ok, Fun()} end),
+    %% Stats persistence has its own tests; this suite is the Lua match
+    %% lifecycle and should not need to know how a stats row is written.
+    meck:new(asobi_player_stats, [no_link]),
+    meck:expect(asobi_player_stats, record_match, fun(_Participants, _Result) -> ok end),
     meck:new(asobi_presence, [non_strict, no_link]),
     meck:expect(asobi_presence, send, fun(_PlayerId, _Msg) -> ok end),
     Config.
 
 end_per_testcase(_TC, _Config) ->
     meck:unload(asobi_presence),
+    meck:unload(asobi_player_stats),
     meck:unload(asobi_repo),
     ok.
 

--- a/test/asobi_lua_config_tests.erl
+++ b/test/asobi_lua_config_tests.erl
@@ -26,8 +26,21 @@ safe_lib_dir() ->
 %% --- Tests ---
 
 config_test_() ->
-    {foreach, fun() -> application:set_env(asobi, game_modes, #{}) end,
-        fun(_) -> application:set_env(asobi, game_modes, #{}) end, [
+    {foreach,
+        fun() ->
+            %% Same registration asobi_app:start/2 performs: without it every
+            %% {lua, _} mode resolves to lua_runtime_unavailable.
+            ok = asobi_lua_sup:register_game_modes(),
+            application:set_env(asobi, game_modes, #{})
+        end,
+        fun(_) ->
+            [
+                asobi_game_modes:unregister_game_mode(K)
+             || K <- [lua_match, lua_match_shared, lua_world]
+            ],
+            application:set_env(asobi, game_modes, #{})
+        end,
+        [
             {"single mode: loads match.lua globals", fun single_mode_loads_globals/0},
             {"single mode: registers 'default' key in game_modes (load-bearing, asobi#244)",
                 fun single_mode_registers_default_key/0},

--- a/test/asobi_lua_sup_tests.erl
+++ b/test/asobi_lua_sup_tests.erl
@@ -1,0 +1,57 @@
+-module(asobi_lua_sup_tests).
+
+-include_lib("eunit/include/eunit.hrl").
+
+%% The provider registry (#333) inverted mode resolution so asobi_game_modes
+%% never names a Lua module, and the asobi_lua merge (#339) then removed the
+%% application whose start callback did the registering. Nothing failed to
+%% compile; every {lua, _} mode simply resolved to lua_runtime_unavailable at
+%% runtime. This pins the three registrations so the same silent break cannot
+%% happen again.
+
+register_game_modes_test_() ->
+    {setup, fun setup/0, fun cleanup/1, [
+        fun registers_all_three_lua_kinds/0,
+        fun is_idempotent/0
+    ]}.
+
+setup() ->
+    Modes = #{
+        ~"arena" => #{module => {lua, "game/match.lua"}},
+        ~"raid" => #{module => {lua, "game/raid.lua"}, state_strategy => shared},
+        ~"galaxy" => #{type => world, module => {lua, "game/world.lua"}}
+    },
+    Prev = application:get_env(asobi, game_modes),
+    application:set_env(asobi, game_modes, Modes),
+    Prev.
+
+cleanup(Prev) ->
+    [asobi_game_modes:unregister_game_mode(K) || K <- [lua_match, lua_match_shared, lua_world]],
+    case Prev of
+        {ok, Old} -> application:set_env(asobi, game_modes, Old);
+        undefined -> application:unset_env(asobi, game_modes)
+    end.
+
+registers_all_three_lua_kinds() ->
+    [asobi_game_modes:unregister_game_mode(K) || K <- [lua_match, lua_match_shared, lua_world]],
+    ?assertEqual({error, lua_runtime_unavailable}, asobi_game_modes:resolve_game_module(~"arena")),
+    ok = asobi_lua_sup:register_game_modes(),
+    ?assertEqual(
+        {ok, asobi_lua_match, #{lua_script => "game/match.lua"}},
+        asobi_game_modes:resolve_game_module(~"arena")
+    ),
+    ?assertEqual(
+        {ok, asobi_lua_match_shared, #{lua_script => "game/raid.lua"}},
+        asobi_game_modes:resolve_game_module(~"raid")
+    ),
+    ?assertEqual(
+        {ok, asobi_lua_world, #{lua_script => "game/world.lua"}},
+        asobi_game_modes:resolve_game_module(~"galaxy")
+    ).
+
+%% asobi_app:start/2 runs on every application start, including a restart
+%% after a crash, so re-registering must be a no-op rather than an error.
+is_idempotent() ->
+    ok = asobi_lua_sup:register_game_modes(),
+    ok = asobi_lua_sup:register_game_modes(),
+    ?assertMatch({ok, asobi_lua_match, _}, asobi_game_modes:resolve_game_module(~"arena")).


### PR DESCRIPTION
Main is red. #333 and #339 were each green on their own base and broke each other on merge.

#333 replaced the hardcoded `asobi_lua_*` atoms in `asobi_game_modes` with a provider registry, returning `lua_runtime_unavailable` for a kind with no provider. The writer was asobi_lua's application-start callback.

#339 merged the Lua runtime into asobi and removed that application without carrying the registration across, so the registry was never populated and every `{lua, _}` mode resolved to `lua_runtime_unavailable`. Six `asobi_lua_config_tests` cases fail on main.

Registration now happens in `asobi_app:start/2`, before the supervision tree, so no child (the matchmaker in particular) can observe an empty registry. The mapping lives in `asobi_lua_sup:register_game_modes/0` next to the bridge modules, keeping `asobi_game_modes` ignorant of the scripting runtime, and giving tests that resolve a Lua mode without booting the app one function to call.

### Tests

- `asobi_lua_sup_tests` pins all three registrations and their idempotency, so a future refactor that drops one fails here rather than at runtime.
- `asobi_lua_config_tests` registers in its fixture and unregisters in teardown.
- `asobi_game_modes_tests:lua_without_provider` now establishes the absence it asserts on; the registry is a global `persistent_term`, so it was inheriting its result from module order.

Local: eunit 1030/1030, xref, dialyzer and `fmt --check` all clean.