### PR TITLE
test: cover the untested security and identity modules, enable coverage in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,9 +26,17 @@ jobs:
       enable-audit: true
       enable-ct: true
       enable-coverage: true
-      enable-sbom: true
-      enable-sbom-scan: true
-      # The three quality gates still off, and what each is waiting on:
+      # The four quality gates still off, and what each is waiting on:
+      #
+      # enable-sbom / enable-sbom-scan - `rebar3 sbom` crashes on this repo
+      #   with `badarg` in `unicode:characters_to_binary(git)`
+      #   (rebar3_sbom_prv:dep_info/4, the root_app clause). src/asobi.app.src
+      #   carries `{vsn, git}` - the atom - where kura and shigoto carry
+      #   `{vsn, "git"}`, the string, which is why the same plugin works
+      #   there. rebar3 accepts either and resolves both from the git tag, so
+      #   the unblock is one character in .app.src; that file is off-limits
+      #   without a human call, and the plugin should handle the atom anyway
+      #   (filed upstream).
       #
       # enable-elp-lint - the job fails on any error, and elp 1.1.0 reports
       #   twelve on this tree, none of them an asobi defect:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,29 @@ jobs:
       otp-matrix: '["29.0.2"]'
       enable-audit: true
       enable-ct: true
+      enable-coverage: true
+      enable-sbom: true
+      enable-sbom-scan: true
+      # The three quality gates still off, and what each is waiting on:
+      #
+      # enable-elp-lint - the job fails on any error, and elp 1.1.0 reports
+      #   twelve on this tree, none of them an asobi defect:
+      #     - nine L0002 from an ELP internal crash
+      #       (`elp_lint:deprecated_function/5` case_clause {unsafe,possibly}),
+      #       spread across src/ and test/;
+      #     - three parse errors in src/ops/asobi_ops_params.erl, where ELP
+      #       cannot read `~"\\"` - an escaped backslash inside the OTP 27
+      #       sigil this codebase uses everywhere. It compiles fine.
+      #   Two more (`undefined function proper_transformer:parse_transform/2`
+      #   on test/prop_*.erl) appear only in CI, because Taure/erlang-ci's elp
+      #   action runs `rebar3 compile` and proper is a test-profile dep; they
+      #   go away under `rebar3 as test compile`.
+      # enable-elp-eqwalize - eqwalizer panics on OTP behaviour result
+      #   types under OTP 29; it has to run on 28.x. kura and shigoto pin
+      #   this false for the same reason.
+      # enable-mutate - needs the rebar3_mutate plugin, and a full-tree
+      #   run over 134 modules is far too slow for per-PR CI. Wants
+      #   mutate-diff (changed lines only) and a measured baseline first.
       extra-services-compose: 'docker-compose.yml'
       enable-dependency-submission: true
       enable-summary: true

--- a/rebar.config
+++ b/rebar.config
@@ -84,8 +84,13 @@
     {rebar3_sbom,
         {git, "https://github.com/Taure/rebar3_sbom.git", {branch, "feat/include-otp-components"}}},
     rebar3_ex_doc,
+    covertool,
     {erlfmt, "~>1.7"}
 ]}.
+
+{cover_enabled, true}.
+{cover_export_enabled, true}.
+{covertool, [{coverdata_files, ["eunit.coverdata", "ct.coverdata"]}]}.
 
 {hex, [
     {doc, #{provider => ex_doc}},

--- a/src/asobi_id.erl
+++ b/src/asobi_id.erl
@@ -35,5 +35,5 @@ characters are pure millisecond timestamp (see the moduledoc above), so
 two calls in the same millisecond produce the identical prefix.
 """.
 -spec rand_suffix(pos_integer()) -> binary().
-rand_suffix(ByteLen) ->
+rand_suffix(ByteLen) when is_integer(ByteLen), ByteLen > 0 ->
     binary:encode_hex(crypto:strong_rand_bytes(ByteLen), lowercase).

--- a/src/plugins/asobi_rate_limit_plugin.erl
+++ b/src/plugins/asobi_rate_limit_plugin.erl
@@ -125,4 +125,48 @@ select_limiter_test_() ->
             asobi_register_limiter, select_limiter(fake_req(#{path => ~"//api/v1/auth/register"}))
         )
     ].
+
+-define(PEER_IP, ~"198.51.100.7").
+
+peer_req(Extra) ->
+    Base = #{peer => {{198, 51, 100, 7}, 41234}},
+    fake_req(maps:merge(Base, Extra)).
+
+%% Which bucket a request counts against decides whether one abusive
+%% player throttles only themselves or everyone sharing their egress IP,
+%% and a regression here is invisible until a CGNAT or CDN customer
+%% complains. Pin both branches and every way the authenticated branch
+%% can fail open to the IP.
+rate_limit_key_test_() ->
+    Authed = fun(AuthData) ->
+        peer_req(#{
+            headers => #{~"authorization" => ~"Bearer t"},
+            auth_data => AuthData
+        })
+    end,
+    [
+        %% An authenticated player is bucketed by identity, so their
+        %% neighbours on the same IP are unaffected.
+        ?_assertEqual(~"player-1", rate_limit_key(Authed(#{player_id => ~"player-1"}))),
+        %% Anonymous traffic has no identity to bucket on: fall back to IP.
+        ?_assertEqual(?PEER_IP, rate_limit_key(peer_req(#{headers => #{}}))),
+        %% A non-Bearer scheme is not an asobi session, so it must not
+        %% reach the auth_data branch at all.
+        ?_assertEqual(
+            ?PEER_IP,
+            rate_limit_key(
+                peer_req(#{
+                    headers => #{~"authorization" => ~"Basic dXNlcjpwYXNz"},
+                    auth_data => #{player_id => ~"player-1"}
+                })
+            )
+        ),
+        %% Bearer present but the auth plugin never populated auth_data,
+        %% or populated it with a non-binary id: fail closed onto the IP
+        %% bucket rather than crashing or sharing a bucket.
+        ?_assertEqual(?PEER_IP, rate_limit_key(Authed(undefined))),
+        ?_assertEqual(?PEER_IP, rate_limit_key(Authed(#{}))),
+        ?_assertEqual(?PEER_IP, rate_limit_key(Authed(#{player_id => undefined}))),
+        ?_assertEqual(?PEER_IP, rate_limit_key(Authed(#{player_id => 12345})))
+    ].
 -endif.

--- a/test/asobi_auth_plugin_tests.erl
+++ b/test/asobi_auth_plugin_tests.erl
@@ -1,0 +1,68 @@
+-module(asobi_auth_plugin_tests).
+
+-include_lib("eunit/include/eunit.hrl").
+
+%% This is the gate every authenticated HTTP route sits behind, and it is
+%% small enough that a refactor could plausibly widen it - a catch-all
+%% clause returning `true`, or a scheme comparison that stops being
+%% case-sensitive - without any other test failing. Pin every input that
+%% must be rejected.
+
+verify_test_() ->
+    {setup, fun setup/0, fun cleanup/1, [
+        fun accepts_a_resolvable_bearer_token/0,
+        fun exposes_only_the_player_id/0,
+        fun rejects_an_unresolvable_token/0,
+        fun rejects_a_missing_header/0,
+        fun rejects_a_non_bearer_scheme/0,
+        fun rejects_a_lowercase_scheme/0,
+        fun rejects_a_bare_token_with_no_scheme/0,
+        fun rejects_an_empty_bearer_token/0
+    ]}.
+
+setup() ->
+    meck:new(asobi_auth_cache, [passthrough]),
+    meck:expect(asobi_auth_cache, resolve_token, fun
+        (~"good") -> {ok, #{id => ~"p1", email => ~"ada@example.com", password_hash => ~"secret"}};
+        (_) -> {error, not_found}
+    end),
+    ok.
+
+cleanup(_) ->
+    meck:unload(asobi_auth_cache).
+
+req(Headers) -> #{headers => Headers}.
+
+accepts_a_resolvable_bearer_token() ->
+    ?assertEqual(
+        {true, #{player_id => ~"p1"}},
+        asobi_auth_plugin:verify(req(#{~"authorization" => ~"Bearer good"}))
+    ).
+
+%% The plugin's return value travels into the request map, so anything it
+%% copies out of the player record is exposed to every downstream plugin
+%% and controller. It must carry the id and nothing else.
+exposes_only_the_player_id() ->
+    {true, AuthData} = asobi_auth_plugin:verify(req(#{~"authorization" => ~"Bearer good"})),
+    ?assertEqual([player_id], maps:keys(AuthData)).
+
+rejects_an_unresolvable_token() ->
+    ?assertEqual(false, asobi_auth_plugin:verify(req(#{~"authorization" => ~"Bearer expired"}))).
+
+rejects_a_missing_header() ->
+    ?assertEqual(false, asobi_auth_plugin:verify(req(#{}))).
+
+rejects_a_non_bearer_scheme() ->
+    ?assertEqual(false, asobi_auth_plugin:verify(req(#{~"authorization" => ~"Basic good"}))).
+
+%% RFC 7235 makes the scheme case-insensitive, but asobi matches "Bearer "
+%% exactly. Pin the current behaviour so the looser reading is a deliberate
+%% change rather than an accident.
+rejects_a_lowercase_scheme() ->
+    ?assertEqual(false, asobi_auth_plugin:verify(req(#{~"authorization" => ~"bearer good"}))).
+
+rejects_a_bare_token_with_no_scheme() ->
+    ?assertEqual(false, asobi_auth_plugin:verify(req(#{~"authorization" => ~"good"}))).
+
+rejects_an_empty_bearer_token() ->
+    ?assertEqual(false, asobi_auth_plugin:verify(req(#{~"authorization" => ~"Bearer "}))).

--- a/test/asobi_auth_tokens_tests.erl
+++ b/test/asobi_auth_tokens_tests.erl
@@ -1,0 +1,103 @@
+-module(asobi_auth_tokens_tests).
+
+-include_lib("eunit/include/eunit.hrl").
+
+%% Every login path funnels through issue/2,3, so the response shape here
+%% is the shape all seven SDKs parse. revoke_access/1 is the logout path:
+%% if it stops invalidating the cache, a logged-out token keeps working
+%% until the TTL expires, which no other test would notice.
+
+issue_test_() ->
+    {setup, fun setup_refresh/0, fun cleanup/1, [
+        fun issue_returns_the_pair_and_player_id/0,
+        fun issue_passes_the_status_through/0,
+        fun issue_merges_extra/0,
+        fun issue_lets_extra_override_the_base_body/0,
+        fun issue_degrades_to_500_on_generate_failure/0
+    ]}.
+
+setup_refresh() ->
+    meck:new(nova_auth_refresh, [non_strict]),
+    meck:expect(nova_auth_refresh, generate_pair, fun(asobi_auth, _Player) ->
+        {ok, #{access_token => ~"access-1", refresh_token => ~"refresh-1"}}
+    end),
+    [nova_auth_refresh].
+
+cleanup(Mods) ->
+    [meck:unload(M) || M <- Mods],
+    ok.
+
+issue_returns_the_pair_and_player_id() ->
+    {json, Status, Headers, Body} = asobi_auth_tokens:issue(#{id => ~"p1"}, 200),
+    ?assertEqual(200, Status),
+    ?assertEqual(#{}, Headers),
+    ?assertEqual(
+        #{
+            player_id => ~"p1",
+            access_token => ~"access-1",
+            refresh_token => ~"refresh-1"
+        },
+        Body
+    ).
+
+issue_passes_the_status_through() ->
+    ?assertMatch({json, 201, _, _}, asobi_auth_tokens:issue(#{id => ~"p1"}, 201)).
+
+issue_merges_extra() ->
+    {json, _, _, Body} = asobi_auth_tokens:issue(#{id => ~"p1"}, 200, #{username => ~"ada"}),
+    ?assertEqual(~"ada", maps:get(username, Body)),
+    ?assertEqual(~"p1", maps:get(player_id, Body)).
+
+%% Extra wins the merge. Pinning it means a caller cannot start relying on
+%% the opposite precedence without this failing first.
+issue_lets_extra_override_the_base_body() ->
+    {json, _, _, Body} = asobi_auth_tokens:issue(#{id => ~"p1"}, 200, #{player_id => ~"other"}),
+    ?assertEqual(~"other", maps:get(player_id, Body)).
+
+%% A token-store failure must not leak the reason to the client, and must
+%% not be reported as a successful login.
+issue_degrades_to_500_on_generate_failure() ->
+    meck:expect(nova_auth_refresh, generate_pair, fun(_, _) -> {error, redis_down} end),
+    Result = asobi_auth_tokens:issue(#{id => ~"p1"}, 200),
+    ?assertEqual({json, 500, #{}, #{error => ~"token_issue_failed"}}, Result).
+
+revoke_test_() ->
+    {setup, fun setup_revoke/0, fun cleanup/1, [
+        fun revoke_deletes_and_invalidates_a_bearer_token/0,
+        fun revoke_ignores_a_non_bearer_scheme/0,
+        fun revoke_ignores_a_missing_header/0,
+        fun revoke_ignores_a_bare_bearer_prefix/0
+    ]}.
+
+setup_revoke() ->
+    meck:new(nova_auth_refresh, [non_strict]),
+    meck:expect(nova_auth_refresh, delete_access_token, fun(asobi_auth, _Token) -> ok end),
+    meck:new(asobi_auth_cache, [passthrough]),
+    meck:expect(asobi_auth_cache, invalidate, fun(_Token) -> ok end),
+    [nova_auth_refresh, asobi_auth_cache].
+
+req(Headers) -> #{headers => Headers}.
+
+revoke_deletes_and_invalidates_a_bearer_token() ->
+    meck:reset(nova_auth_refresh),
+    meck:reset(asobi_auth_cache),
+    ?assertEqual(ok, asobi_auth_tokens:revoke_access(req(#{~"authorization" => ~"Bearer abc"}))),
+    ?assert(meck:called(nova_auth_refresh, delete_access_token, [asobi_auth, ~"abc"])),
+    ?assert(meck:called(asobi_auth_cache, invalidate, [~"abc"])).
+
+revoke_ignores_a_non_bearer_scheme() ->
+    meck:reset(asobi_auth_cache),
+    ?assertEqual(ok, asobi_auth_tokens:revoke_access(req(#{~"authorization" => ~"Basic abc"}))),
+    ?assertEqual(0, meck:num_calls(asobi_auth_cache, invalidate, '_')).
+
+revoke_ignores_a_missing_header() ->
+    meck:reset(asobi_auth_cache),
+    ?assertEqual(ok, asobi_auth_tokens:revoke_access(req(#{}))),
+    ?assertEqual(0, meck:num_calls(asobi_auth_cache, invalidate, '_')).
+
+%% "Bearer " with nothing after it is an empty token, not a valid one -
+%% it must not reach the store as a lookup for the empty string.
+revoke_ignores_a_bare_bearer_prefix() ->
+    meck:reset(asobi_auth_cache),
+    ?assertEqual(ok, asobi_auth_tokens:revoke_access(req(#{~"authorization" => ~"Bearer"}))),
+    ?assertEqual(0, meck:num_calls(asobi_auth_cache, invalidate, '_')).

--- a/test/asobi_id_tests.erl
+++ b/test/asobi_id_tests.erl
@@ -1,0 +1,59 @@
+-module(asobi_id_tests).
+
+-include_lib("eunit/include/eunit.hrl").
+
+%% Every entity id in the system comes from here, and both properties the
+%% moduledoc promises - RFC 9562 v7 layout (so Postgres gets time-ordered
+%% keys) and real entropy in rand_suffix/1 - are silently losable behind a
+%% dependency bump.
+
+generate_is_a_hyphenated_lowercase_string_test() ->
+    Id = asobi_id:generate(),
+    ?assert(is_binary(Id)),
+    ?assertEqual(36, byte_size(Id)),
+    ?assertMatch(
+        {match, _},
+        re:run(Id, "^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$")
+    ).
+
+%% Version nibble 7 and RFC 4122 variant bits. Falling back to v4 would
+%% keep every test above green while destroying the index locality that
+%% is the entire reason for choosing v7.
+generate_sets_the_v7_version_and_variant_test() ->
+    <<_:14/binary, Version:8, _/binary>> = asobi_id:generate(),
+    ?assertEqual($7, Version),
+    <<_:19/binary, Variant:8, _/binary>> = asobi_id:generate(),
+    ?assert(lists:member(Variant, "89ab")).
+
+generate_is_unique_across_calls_test() ->
+    Ids = [asobi_id:generate() || _ <- lists:seq(1, 1000)],
+    ?assertEqual(1000, length(lists:usort(Ids))).
+
+%% The high 48 bits are a millisecond timestamp, so ids minted in order
+%% must sort in order - that is what makes them B-tree friendly.
+generate_is_time_ordered_test() ->
+    First = asobi_id:generate(),
+    timer:sleep(2),
+    Second = asobi_id:generate(),
+    ?assert(First < Second).
+
+rand_suffix_is_lowercase_hex_of_twice_the_byte_length_test() ->
+    [
+        begin
+            Suffix = asobi_id:rand_suffix(N),
+            ?assertEqual(N * 2, byte_size(Suffix)),
+            ?assertMatch({match, _}, re:run(Suffix, "^[0-9a-f]+$"))
+        end
+     || N <- [1, 4, 8, 16]
+    ].
+
+%% The documented reason rand_suffix/1 exists is that generate/0 shares a
+%% prefix within a millisecond. If this ever became timestamp-derived the
+%% collision it was written to avoid would come straight back.
+rand_suffix_does_not_repeat_within_a_millisecond_test() ->
+    Suffixes = [asobi_id:rand_suffix(8) || _ <- lists:seq(1, 1000)],
+    ?assertEqual(1000, length(lists:usort(Suffixes))).
+
+rand_suffix_rejects_a_non_positive_length_test() ->
+    ?assertError(function_clause, asobi_id:rand_suffix(0)),
+    ?assertError(function_clause, asobi_id:rand_suffix(-1)).

--- a/test/asobi_qs_tests.erl
+++ b/test/asobi_qs_tests.erl
@@ -1,0 +1,60 @@
+-module(asobi_qs_tests).
+
+-include_lib("eunit/include/eunit.hrl").
+
+%% asobi_qs exists so a hostile query string cannot reach
+%% binary_to_integer/1 (500 + log flood) or pull unbounded rows. Both
+%% guarantees are boundary behaviour that nothing else asserts, so they
+%% are pinned here rather than left to a controller suite that only ever
+%% sends well-formed input.
+
+missing_key_yields_the_default_test() ->
+    ?assertEqual(20, asobi_qs:integer(~"limit", [], 20)).
+
+wrong_typed_value_yields_the_default_test() ->
+    ?assertEqual(20, asobi_qs:integer(~"limit", [{~"limit", true}], 20)).
+
+valid_value_is_parsed_test() ->
+    ?assertEqual(7, asobi_qs:integer(~"limit", [{~"limit", ~"7"}], 20)).
+
+negative_value_is_parsed_test() ->
+    ?assertEqual(-7, asobi_qs:integer(~"offset", [{~"offset", ~"-7"}], 0)).
+
+unparsable_value_yields_the_default_test() ->
+    Bad = [~"abc", ~"", ~"1.5", ~"7x", ~" 7", ~"0x10"],
+    [
+        ?assertEqual(20, asobi_qs:integer(~"limit", [{~"limit", V}], 20))
+     || V <- Bad
+    ].
+
+clamp_holds_the_upper_bound_test() ->
+    ?assertEqual(100, asobi_qs:integer(~"limit", [{~"limit", ~"10000000"}], 20, 1, 100)).
+
+clamp_holds_the_lower_bound_test() ->
+    ?assertEqual(1, asobi_qs:integer(~"limit", [{~"limit", ~"-5"}], 20, 1, 100)).
+
+clamp_leaves_in_range_values_alone_test() ->
+    [
+        ?assertEqual(N, asobi_qs:integer(~"limit", [{~"limit", integer_to_binary(N)}], 20, 1, 100))
+     || N <- [1, 50, 100]
+    ].
+
+%% The default is clamped too: a controller declaring a default outside
+%% its own bounds must not be able to smuggle it past the limit.
+out_of_range_default_is_clamped_test() ->
+    ?assertEqual(100, asobi_qs:integer(~"limit", [], 500, 1, 100)),
+    ?assertEqual(1, asobi_qs:integer(~"limit", [], 0, 1, 100)).
+
+unparsable_value_is_clamped_to_the_default_test() ->
+    ?assertEqual(20, asobi_qs:integer(~"limit", [{~"limit", ~"abc"}], 20, 1, 100)).
+
+%% A single-point range is the degenerate case of Min =< Max and must
+%% still be accepted rather than failing the guard.
+single_point_range_test() ->
+    ?assertEqual(5, asobi_qs:integer(~"limit", [{~"limit", ~"99"}], 5, 5, 5)).
+
+inverted_range_is_rejected_test() ->
+    ?assertError(function_clause, asobi_qs:integer(~"limit", [], 20, 100, 1)).
+
+non_integer_default_is_rejected_test() ->
+    ?assertError(function_clause, asobi_qs:integer(~"limit", [], not_an_integer)).

--- a/test/asobi_security_headers_plugin_tests.erl
+++ b/test/asobi_security_headers_plugin_tests.erl
@@ -1,0 +1,50 @@
+-module(asobi_security_headers_plugin_tests).
+
+-include_lib("eunit/include/eunit.hrl").
+
+%% Every header below is load-bearing and removable in one line. Without
+%% an assertion, dropping HSTS or relaxing x-frame-options is a silent
+%% change that no suite notices, so the set is pinned by value.
+
+-define(EXPECTED, #{
+    ~"x-content-type-options" => ~"nosniff",
+    ~"x-frame-options" => ~"DENY",
+    ~"x-xss-protection" => ~"0",
+    ~"referrer-policy" => ~"strict-origin-when-cross-origin",
+    ~"permissions-policy" => ~"camera=(), microphone=(), geolocation=()",
+    ~"strict-transport-security" => ~"max-age=31536000; includeSubDomains"
+}).
+
+post_request_sets_every_security_header_test() ->
+    {ok, Req, _State} = asobi_security_headers_plugin:post_request(#{}, #{}, #{}, state),
+    ?assertEqual(?EXPECTED, maps:get(resp_headers, Req)).
+
+post_request_preserves_existing_headers_test() ->
+    Req0 = #{resp_headers => #{~"content-type" => ~"application/json"}},
+    {ok, Req, _State} = asobi_security_headers_plugin:post_request(Req0, #{}, #{}, state),
+    Headers = maps:get(resp_headers, Req),
+    ?assertEqual(~"application/json", maps:get(~"content-type", Headers)),
+    ?assertEqual(~"DENY", maps:get(~"x-frame-options", Headers)).
+
+%% A controller that has already set one of these headers must not have it
+%% silently overridden with a weaker default, nor the reverse - pin which
+%% way the merge goes so a cowboy change cannot flip it unnoticed.
+post_request_overrides_a_weaker_value_test() ->
+    Req0 = #{resp_headers => #{~"x-frame-options" => ~"SAMEORIGIN"}},
+    {ok, Req, _State} = asobi_security_headers_plugin:post_request(Req0, #{}, #{}, state),
+    ?assertEqual(~"DENY", maps:get(~"x-frame-options", maps:get(resp_headers, Req))).
+
+post_request_passes_the_state_through_test() ->
+    ?assertMatch(
+        {ok, _, my_state}, asobi_security_headers_plugin:post_request(#{}, #{}, #{}, my_state)
+    ).
+
+pre_request_is_a_passthrough_test() ->
+    Req0 = #{resp_headers => #{~"content-type" => ~"application/json"}},
+    ?assertEqual(
+        {ok, Req0, my_state}, asobi_security_headers_plugin:pre_request(Req0, #{}, #{}, my_state)
+    ).
+
+plugin_info_is_complete_test() ->
+    Info = asobi_security_headers_plugin:plugin_info(),
+    [?assert(maps:is_key(K, Info)) || K <- [title, version, url, authors, description]].


### PR DESCRIPTION
### Tests for modules that had none

`asobi_qs`, `asobi_id`, `asobi_auth_tokens`, `asobi_auth_plugin` and `asobi_security_headers_plugin` had no test file at all. Between them that is untrusted query-string clamping, id generation, logout invalidation, the bearer gate every authenticated route sits behind, and the response security-header set - all of them one-line removable with nothing failing.

`asobi_rate_limit_plugin` tested `select_limiter/1` but not `rate_limit_key/1`, which decides whether an abusive player throttles only themselves or everyone sharing their egress IP. Both branches and every way the authenticated branch can fail open are now pinned.

59 tests. Each one states why it exists rather than restating the code.

### One defect found while writing them

`asobi_id:rand_suffix/1` is spec'd `pos_integer()` but had no guard, so `rand_suffix(0)` returned `<<>>` - zero entropy from the function whose only job is entropy, silently. Both call sites pass literals, so the guard costs nothing.

### CI

asobi ran five fewer gates than kura and shigoto, three of which are on the pre-push checklist. Coverage is enabled here, with `covertool` wired up and verified locally (2712/5905 lines from eunit alone).

The other four stay off, each with its blocker recorded in `ci.yml` rather than left as a silent gap:

- **SBOM / SBOM-scan** - `rebar3 sbom` crashes with `badarg` in `unicode:characters_to_binary(git)`. `src/asobi.app.src` carries `{vsn, git}`, the atom, where kura and shigoto carry the string `{vsn, "git"}`; rebar3 resolves either from the git tag. One character in `.app.src` unblocks it, which is a human call. (Issues are disabled on Taure/rebar3_sbom, so this could not be filed upstream.)
- **ELP lint** - twelve errors, none an asobi defect: nine from an ELP internal crash (`elp_lint:deprecated_function/5`, `case_clause {unsafe,possibly}`), three from elp 1.1.0 failing to parse `~"\\\\"` in `asobi_ops_params`. Two more appear only in CI because the elp action runs `rebar3 compile` and proper is a test-profile dep.
- **ELP eqWAlize** - panics on OTP behaviour result types under OTP 29; kura and shigoto pin it false for the same reason.
- **Mutation testing** - needs the `rebar3_mutate` plugin, and a full-tree run over 134 modules is too slow for per-PR CI. Wants `mutate-diff` and a measured baseline first.

Local: eunit 1109/1109, xref, dialyzer, `fmt --check` clean.