### PR TITLE
docs: fix two wrong published claims; test: enumerate router groups dynamically

### DIFF
--- a/guides/lua-bots.md
+++ b/guides/lua-bots.md
@@ -89,6 +89,35 @@ Since the bot only decides from `state`, difficulty is a property of the
 script, not a config knob: throttle a reaction-time delay or degrade the target
 selection by keying private per-bot state off `bot_id` in a module-level table.
 
+### What a bot script gets
+
+A bot script is loaded into the same hardened Luerl state a match script
+starts from, but **without** the `game.*` API. That namespace is installed
+only for match and world scripts; inside a bot's `think`, `game` is `nil`.
+There is no `game.economy`, `game.log`, `game.storage` or `game.leaderboard`
+for a bot.
+
+What is available:
+
+- The Lua standard library, minus what the sandbox clears. `io`, `package`,
+  `load`, `loadfile`, `loadstring`, `dofile`, `print`, `eprint` and
+  `os.execute` / `os.exit` / `os.getenv` / `os.remove` / `os.rename` /
+  `os.tmpname` are all `nil` (see [Sandbox model](security-sandbox.md)).
+- `require("module")`, resolved relative to the bot script's own directory --
+  `require("targeting")` reads `<bot script dir>/targeting.lua`. Dotted paths
+  work; parent traversal and absolute paths are rejected.
+- `math.random` and `math.sqrt`, backed by the BEAM's `rand` and `math`.
+- The two arguments of `think(bot_id, state)`, plus whatever the script
+  itself defines at the top level. `state` is the match state as broadcast to
+  players, so a bot sees what a client sees and nothing more.
+
+Anything else has to come through the match script: put the value in the
+state the match broadcasts, and the bot reads it from `state`.
+
+Each `think` call runs under a 50 ms wall-clock budget and a heap cap. A
+timeout, an error, or a missing `think` falls back to the built-in default AI
+(below).
+
 ```lua
 -- game/bots/chaser.lua
 
@@ -233,5 +262,6 @@ if you need the human answer.
 
 ## Next steps
 
-- [Lua scripting](lua-scripting.md) - the `game.*` API a bot's `think` shares with match logic.
+- [Lua scripting](lua-scripting.md) - the `game.*` API, which match and world
+  scripts get and bots do not (see [What a bot script gets](#what-a-bot-script-gets)).
 - [Trust model](security-trust-model.md) - a bot's `think` runs bounded, like any callback.

--- a/guides/security-lua-known-limitations.md
+++ b/guides/security-lua-known-limitations.md
@@ -7,20 +7,36 @@ who care about any of these should plan their deployment accordingly.
 
 ## Resource bounds
 
-### No reduction limit / hard CPU cap
+### The reduction limit Luerl offers is not applied
 
-The wall-clock timeout is the only resource bound today. A script can
-soak its full per-callback budget every tick without being throttled.
-Luerl upstream does not currently expose a "reduction limit" or
-"process-bound state" knob; a future hardening pass may add a soft
-budget on the Luerl scheduler.
+A wall-clock timeout and a per-eval heap cap are the only resource
+bounds asobi enforces. Neither bounds CPU: a script can soak its full
+per-callback budget every tick without being throttled.
 
-### No per-script heap cap
+Luerl does expose a reduction limit. `luerl_sandbox:run/3` takes
+`max_reductions` and kills the runner once its BEAM reduction count
+passes the limit (luerl 1.5.1, the version asobi pins). asobi does not
+use it, and it is not a drop-in:
 
-Lua tables grow inside the BEAM process heap. A pathological script
-that allocates 100 MB of tables and drops them every tick will pressure
-the OS memory allocator. The decode depth cap (64 levels) bounds
-recursion at the bridge boundary, but does not bound table *size*.
+- `luerl_sandbox:run/3` evaluates a chunk. asobi's hot path is
+  `luerl:call_function/3` against an already-loaded state, which that
+  entry point does not cover.
+- The check polls the runner's reduction count from the parent on a
+  fixed 100 ms interval. It bounds total work, not per-tick latency,
+  and cannot fire sooner than one poll.
+
+Tracked as [asobi#348](https://github.com/widgrensit/asobi/issues/348).
+
+### The heap cap is per eval, not per script
+
+Every callback runs in a child process carrying `max_heap_size` with
+`kill => true` (`asobi_lua.max_heap_words`, 5,000,000 words by
+default), so a single runaway allocation is killed and surfaces as
+`{error, heap_exhausted}`. Nothing caps a script's *steady* footprint:
+a state that stays just under the limit is copied into every later
+eval, and the total across concurrent matches is unbounded. The decode
+depth cap (64 levels) bounds recursion at the bridge boundary, not
+table size.
 
 ### Per-callback state copy cost is linear
 

--- a/test/asobi_bot_script_env_tests.erl
+++ b/test/asobi_bot_script_env_tests.erl
@@ -1,0 +1,114 @@
+-module(asobi_bot_script_env_tests).
+-include_lib("eunit/include/eunit.hrl").
+
+%% Locks the environment guides/lua-bots.md documents for a bot script.
+%% asobi_bot loads its script with asobi_lua_loader:new/1, whose PreInstall
+%% is the identity function, so a bot gets the hardened base state and NOT
+%% the `game.*` namespace that asobi_lua_match installs for match scripts.
+
+bot_state_has_no_game_namespace_test() ->
+    with_bot_script(~"probe = type(game)\n", fun(St) ->
+        ?assertEqual(nil, global(~"game", St)),
+        ?assertEqual(~"nil", global(~"probe", St))
+    end).
+
+%% Contrast case: the same script loaded the way asobi_lua_match loads a match
+%% script DOES have `game`. Without this the assertion above could pass because
+%% the probe is broken rather than because bots lack the namespace.
+match_state_does_have_game_namespace_test() ->
+    Ctx = #{match_id => ~"m1", match_pid => self(), script => ~"match.lua"},
+    PreInstall = fun(St) -> asobi_lua_api:install(Ctx, St) end,
+    Path = filename:join(temp_dir(), script_name()),
+    ok = file:write_file(Path, ~"probe = type(game)\n"),
+    try
+        {ok, St} = asobi_lua_loader:new(Path, 2000, PreInstall),
+        ?assertEqual(~"table", global(~"probe", St))
+    after
+        file:delete(Path)
+    end.
+
+bot_state_has_no_game_subtables_test() ->
+    Code =
+        ~"""
+        ok_pcall, err = pcall(function() return game.economy end)
+        """,
+    with_bot_script(Code, fun(St) ->
+        ?assertEqual(false, global(~"ok_pcall", St))
+    end).
+
+bot_state_strips_dangerous_globals_test() ->
+    with_bot_script(~"return nil\n", fun(St) ->
+        [
+            ?assertEqual(nil, global(Name, St))
+         || Name <- [
+                ~"io",
+                ~"package",
+                ~"load",
+                ~"loadfile",
+                ~"loadstring",
+                ~"dofile",
+                ~"print",
+                ~"eprint"
+            ]
+        ],
+        [
+            ?assertEqual(nil, path([~"os", Name], St))
+         || Name <- [~"execute", ~"exit", ~"getenv", ~"remove", ~"rename", ~"tmpname"]
+        ]
+    end).
+
+bot_state_keeps_math_helpers_test() ->
+    Code =
+        ~"""
+        root = math.sqrt(16)
+        roll = math.random(3, 3)
+        """,
+    with_bot_script(Code, fun(St) ->
+        ?assertEqual(4.0, global(~"root", St)),
+        ?assertEqual(3, global(~"roll", St))
+    end).
+
+bot_state_can_require_next_to_the_script_test() ->
+    Dir = temp_dir(),
+    ok = file:write_file(filename:join(Dir, "targeting.lua"), ~"return { pick = 7 }\n"),
+    Path = filename:join(Dir, "bot.lua"),
+    ok = file:write_file(Path, ~"picked = require(\"targeting\").pick\n"),
+    try
+        {ok, St} = asobi_lua_loader:new(Path),
+        ?assertEqual(7, global(~"picked", St))
+    after
+        file:delete(Path),
+        file:delete(filename:join(Dir, "targeting.lua"))
+    end.
+
+%% --- helpers ---
+
+-spec with_bot_script(binary(), fun((dynamic()) -> term())) -> term().
+with_bot_script(Code, Fun) ->
+    Path = filename:join(temp_dir(), script_name()),
+    ok = file:write_file(Path, Code),
+    try
+        {ok, St} = asobi_lua_loader:new(Path),
+        Fun(St)
+    after
+        file:delete(Path)
+    end.
+
+-spec temp_dir() -> file:filename_all().
+temp_dir() ->
+    Dir = filename:join(filename:basedir(user_cache, "asobi_bot_script_env_tests"), "game"),
+    ok = filelib:ensure_dir(filename:join(Dir, "keep")),
+    Dir.
+
+-spec script_name() -> string().
+script_name() ->
+    "bot_" ++ integer_to_list(erlang:unique_integer([positive])) ++ ".lua".
+
+-spec global(binary(), dynamic()) -> term().
+global(Name, St) ->
+    path([Name], St).
+
+-spec path([binary()], dynamic()) -> term().
+path(Keys, St) ->
+    {ok, Value, St1} = luerl:get_table_keys(Keys, St),
+    luerl:decode(Value, St1).

--- a/test/asobi_cors_SUITE.erl
+++ b/test/asobi_cors_SUITE.erl
@@ -7,7 +7,9 @@
 %% 405 from the router before the CORS plugin's OPTIONS short-circuit ever
 %% runs. asobi_router adds `options` to every route's methods list so the
 %% CORS plugin's `pre_request` sees the request and replies 200; these tests
-%% lock in that behaviour across auth, IAP, and authed API routes.
+%% lock in that behaviour on every route group the router declares. The
+%% router-level precondition (every route lists `options`) is checked without
+%% a running server in asobi_router_tests.
 
 -include_lib("nova_test/include/nova_test.hrl").
 
@@ -17,11 +19,7 @@
     end_per_suite/1
 ]).
 -export([
-    options_on_auth_register_returns_2xx/1,
-    options_on_auth_login_returns_2xx/1,
-    options_on_iap_apple_returns_2xx/1,
-    options_on_api_matches_returns_2xx/1,
-    options_on_api_wallets_returns_2xx/1,
+    options_on_every_route_group_returns_2xx/1,
     options_on_authed_route_skips_auth/1,
     options_preflight_includes_cors_headers/1,
     post_register_still_works/1
@@ -29,11 +27,7 @@
 
 all() ->
     [
-        options_on_auth_register_returns_2xx,
-        options_on_auth_login_returns_2xx,
-        options_on_iap_apple_returns_2xx,
-        options_on_api_matches_returns_2xx,
-        options_on_api_wallets_returns_2xx,
+        options_on_every_route_group_returns_2xx,
         options_on_authed_route_skips_auth,
         options_preflight_includes_cors_headers,
         post_register_still_works
@@ -47,27 +41,20 @@ end_per_suite(Config) ->
 
 %% --- OPTIONS preflight returns 2xx on every route group ---
 
-options_on_auth_register_returns_2xx(Config) ->
-    {ok, Resp} = nova_test:request(options, "/api/v1/auth/register", #{}, Config),
-    assert_preflight_ok(Resp).
-
-options_on_auth_login_returns_2xx(Config) ->
-    {ok, Resp} = nova_test:request(options, "/api/v1/auth/login", #{}, Config),
-    assert_preflight_ok(Resp).
-
-options_on_iap_apple_returns_2xx(Config) ->
-    %% IAP routes are auth-gated; preflight must still succeed without a token.
-    {ok, Resp} = nova_test:request(options, "/api/v1/iap/apple", #{}, Config),
-    assert_preflight_ok(Resp).
-
-options_on_api_matches_returns_2xx(Config) ->
-    %% Authed API route — preflight short-circuits before auth runs.
-    {ok, Resp} = nova_test:request(options, "/api/v1/matches", #{}, Config),
-    assert_preflight_ok(Resp).
-
-options_on_api_wallets_returns_2xx(Config) ->
-    {ok, Resp} = nova_test:request(options, "/api/v1/wallets", #{}, Config),
-    assert_preflight_ok(Resp).
+%% Derived from asobi_router:routes/1, not from a hand-kept list: a route
+%% group added later gets its preflight checked without touching this suite.
+%% Auth-gated groups (IAP, the authed API) are included and must answer 2xx
+%% without a token, because the CORS plugin short-circuits before auth runs.
+options_on_every_route_group_returns_2xx(Config) ->
+    Targets = asobi_test_helpers:preflight_targets(asobi_router:routes(dev)),
+    ?assert(length(Targets) >= 3),
+    [
+        begin
+            {ok, Resp} = nova_test:request(options, binary_to_list(Path), #{}, Config),
+            assert_preflight_ok(Path, Resp)
+        end
+     || {_Prefix, Path} <- Targets
+    ].
 
 %% --- Preflight explicitly bypasses auth (no Bearer token) ---
 
@@ -111,13 +98,17 @@ post_register_still_works(Config) ->
 %% --- Helpers ---
 
 -spec assert_preflight_ok(nova_test:response()) -> ok.
-assert_preflight_ok(#{status := Status} = Resp) ->
+assert_preflight_ok(Resp) ->
+    assert_preflight_ok(~"", Resp).
+
+-spec assert_preflight_ok(binary(), nova_test:response()) -> ok.
+assert_preflight_ok(Path, #{status := Status} = Resp) ->
     %% nova_cors_plugin replies 200 on OPTIONS short-circuit.
     case Status =:= 200 orelse Status =:= 204 of
         true ->
             ok;
         false ->
-            ct:fail({preflight_status_unexpected, Status, Resp})
+            ct:fail({preflight_status_unexpected, Path, Status, Resp})
     end.
 
 -spec header(binary(), nova_test:response()) -> binary() | undefined.

--- a/test/asobi_router_tests.erl
+++ b/test/asobi_router_tests.erl
@@ -3,11 +3,16 @@
 -include_lib("eunit/include/eunit.hrl").
 -include_lib("nova/include/nova_router.hrl").
 
+-import(asobi_test_helpers, [http_routes/1, routes_missing_options/1, sample_path/1]).
+
 dispatch() ->
     nova_router:compile([asobi]).
 
 resolve(Dispatch, Path) ->
-    case routing_tree:lookup('_', Path, ~"GET", Dispatch) of
+    resolve(Dispatch, Path, ~"GET").
+
+resolve(Dispatch, Path, Method) ->
+    case routing_tree:lookup('_', Path, Method, Dispatch) of
         {ok, Bindings, #nova_handler_value{callback = Callback}} -> {ok, Bindings, Callback};
         Other -> Other
     end.
@@ -37,3 +42,78 @@ match_votes_test() ->
             fun asobi_vote_controller:index/1},
         resolve(dispatch(), ~"/api/v1/matches/0198c0de-0000-7000-8000-000000000002/votes")
     ).
+
+%%--------------------------------------------------------------------
+%% Meta-tests over every declared route group
+%%
+%% These enumerate `asobi_router:routes/1` rather than a hand-kept list, so a
+%% route group added later is covered the moment it is declared. The pure
+%% helpers take the group list as an argument; `*_reports_*_test/0` below feed
+%% them a synthetic group to prove the checks actually fail on a bad one.
+%%--------------------------------------------------------------------
+
+every_route_group_is_well_formed_test() ->
+    Groups = asobi_router:routes(dev),
+    ?assert(Groups =/= []),
+    [
+        begin
+            ?assertMatch(#{prefix := _, security := _, routes := _}, Group),
+            ?assert(is_binary(maps:get(prefix, Group))),
+            ?assert(maps:get(routes, Group) =/= [])
+        end
+     || Group <- Groups
+    ].
+
+%% Nova runs `nova_router` before `nova_cors_plugin`, so a route that omits
+%% `options` answers 405 to a preflight before the plugin ever sees it. The
+%% live preflight assertions are in asobi_cors_SUITE; this is the cheap
+%% router-level precondition, checked on every group.
+every_http_route_accepts_options_test() ->
+    ?assertEqual([], routes_missing_options(asobi_router:routes(dev))).
+
+routes_missing_options_reports_a_bad_group_test() ->
+    Synthetic = #{
+        prefix => ~"/api/v1/extensions",
+        security => false,
+        routes => [
+            {~"/probe", fun asobi_match_controller:index/1, #{methods => [get]}},
+            {~"/fine", fun asobi_match_controller:index/1, #{methods => [get, options]}}
+        ]
+    },
+    Missing = routes_missing_options(asobi_router:routes(dev) ++ [Synthetic]),
+    ?assert(lists:member({~"/api/v1/extensions", ~"/probe"}, Missing)),
+    ?assertNot(lists:member({~"/api/v1/extensions", ~"/fine"}, Missing)).
+
+%% Every declared route must be reachable at its declared method. Declaration
+%% order decides this (asobi #326: `/matches/live` sat behind `/matches/:id`),
+%% and the trap is invisible until someone requests the shadowed path.
+every_http_route_resolves_to_its_handler_test() ->
+    Dispatch = dispatch(),
+    Routes = http_routes(asobi_router:routes(dev)),
+    ?assert(length(Routes) > 40),
+    [
+        ?assertEqual(
+            {ok, Handler},
+            resolved_handler(Dispatch, <<Prefix/binary, (sample_path(Path))/binary>>, Method)
+        )
+     || {Prefix, Path, Handler, Methods} <- Routes,
+        Method <- Methods,
+        Method =/= options
+    ].
+
+sample_path_substitutes_every_binding_test() ->
+    ?assertEqual(
+        ~"/groups/g-1/members/g-1/role", sample_path(~"/groups/:id/members/:player_id/role")
+    ),
+    ?assertEqual(~"/matches/live", sample_path(~"/matches/live")).
+
+%%--------------------------------------------------------------------
+%% Helpers
+%%--------------------------------------------------------------------
+
+-spec resolved_handler(term(), binary(), atom()) -> {ok, fun()} | term().
+resolved_handler(Dispatch, Path, Method) ->
+    case resolve(Dispatch, Path, string:uppercase(atom_to_binary(Method))) of
+        {ok, _Bindings, Callback} -> {ok, Callback};
+        Other -> Other
+    end.

--- a/test/asobi_test_helpers.erl
+++ b/test/asobi_test_helpers.erl
@@ -1,6 +1,7 @@
 -module(asobi_test_helpers).
 
 -export([start/1, unique_username/1]).
+-export([http_routes/1, routes_missing_options/1, preflight_targets/1, sample_path/1]).
 
 -spec start(list()) -> list().
 start(Config) ->
@@ -12,3 +13,53 @@ unique_username(_Prefix) ->
     Bytes = crypto:strong_rand_bytes(16),
     Hex = binary:encode_hex(Bytes, lowercase),
     binary:part(Hex, 0, 32).
+
+%% --- Router enumeration ---
+%%
+%% Tests that assert a property of "every route group" derive the groups from
+%% `asobi_router:routes/1` through these, so a group added later is covered
+%% without editing the test. Pure over the group list, so a suite can feed a
+%% synthetic group and check the property actually fails on a bad one.
+
+-spec http_routes([map()]) -> [{binary(), binary(), fun(), [atom()]}].
+http_routes(Groups) ->
+    [
+        {Prefix, Path, Handler, maps:get(methods, Opts)}
+     || #{prefix := Prefix, routes := Routes} <- Groups,
+        {Path, Handler, Opts} <- Routes,
+        is_map_key(methods, Opts)
+    ].
+
+-spec routes_missing_options([map()]) -> [{binary(), binary()}].
+routes_missing_options(Groups) ->
+    [
+        {Prefix, Path}
+     || {Prefix, Path, _Handler, Methods} <- http_routes(Groups),
+        not lists:member(options, Methods)
+    ].
+
+%% One concrete request path per group that serves HTTP. Groups that only
+%% carry a protocol handler (the WebSocket group) have no preflight to make.
+-spec preflight_targets([map()]) -> [{binary(), binary()}].
+preflight_targets(Groups) ->
+    lists:flatmap(fun first_http_route/1, Groups).
+
+-spec first_http_route(map()) -> [{binary(), binary()}].
+first_http_route(#{prefix := Prefix} = Group) ->
+    case http_routes([Group]) of
+        [{_, Path, _, _} | _] -> [{Prefix, <<Prefix/binary, (sample_path(Path))/binary>>}];
+        [] -> []
+    end.
+
+%% Concrete path for a declared route: every `:binding` segment becomes a
+%% value no literal sibling route uses.
+-spec sample_path(binary()) -> binary().
+sample_path(Path) ->
+    Segments = [
+        case Segment of
+            <<":", _/binary>> -> ~"g-1";
+            Literal -> Literal
+        end
+     || Segment <- binary:split(Path, ~"/", [global])
+    ],
+    iolist_to_binary(lists:join(~"/", Segments)).


### PR DESCRIPTION
Integration plan items **0.5** (two wrong published docs) and **2a.10** (router meta-test enumerates groups dynamically).

## 0.5a - bots do not get `game.*`

`guides/lua-bots.md` closed with "the `game.*` API a bot's `think` shares with match logic". It shares nothing. `asobi_bot:init/1` calls `asobi_lua_loader:new/1`, whose `PreInstall` is `fun(St) -> St end`, so the state a bot script runs in is `sandboxed_state/1` and nothing else. `asobi_lua_api:install/2` is only reached via `new/3`, which `asobi_lua_match` and `asobi_lua_world` use.

The guide now documents the subset a bot really gets, rather than dropping the sentence: the Lua stdlib minus the sandbox's cleared entries, `require` resolved against the bot script's own directory, the `math.random` / `math.sqrt` overrides, the two `think` arguments, and the 50 ms per-call budget with fallback to the default AI.

`test/asobi_bot_script_env_tests.erl` locks that. It includes a contrast case that loads the same script the way `asobi_lua_match` does and asserts `type(game) == "table"` there - without it, the `game is nil` assertions could pass because the probe is broken.

## 0.5b - luerl 1.5.1 does expose a reduction limit

`guides/security-lua-known-limitations.md` said "Luerl upstream does not currently expose a reduction limit". `_build/default/lib/luerl/src/luerl_sandbox.erl` in the pinned 1.5.1 takes `max_reductions` and kills the runner once `process_info(Runner, reductions)` passes it.

asobi does not use it, so the honest text is that the limit exists upstream and asobi does not apply it, plus the two reasons it is not a drop-in: `luerl_sandbox:run/3` evaluates a chunk while asobi's hot path is `luerl:call_function/3` on a loaded state, and the check is a parent-side poll on a fixed 100 ms interval. Follow-up filed as #348.

While in that section: the neighbouring "No per-script heap cap" heading was also stale - `asobi_lua_loader:bounded_eval/2` has carried `max_heap_size` with `kill => true` for a while. Reframed to what is actually unbounded (steady footprint, total across matches).

### The same wrong text is still in asobi_lua

Not edited here, since that repo is being retired:

- `asobi_lua/guides/security-known-limitations.md:10-16` - the reduction-limit claim
- `asobi_lua/guides/lua-bots.md:218` - the `game.*` sentence

## 2a.10 - router meta-tests enumerate groups

`asobi_cors_SUITE` carried the comment "OPTIONS preflight returns 2xx on every route group" over five hand-written per-group tests. A sixth group would have shipped with no preflight coverage and no failing test. It now derives one representative path per HTTP group from `asobi_router:routes/1` (groups that only carry a protocol handler, i.e. the WebSocket group, have no preflight to make).

Two eunit meta-tests join it in `asobi_router_tests`, both over the declared groups and neither needing a server:

- every route declares `options` - the router-level precondition the CORS suite depends on
- every route resolves to its declared handler at its declared method - the #326 shadowing trap, now checked on every group rather than only on `/matches/live`

The shared enumeration lives in `asobi_test_helpers` (`http_routes/1`, `routes_missing_options/1`, `preflight_targets/1`, `sample_path/1`), pure over the group list so a synthetic group can be injected.

### Proof the checks catch a new group

Temporarily added to `asobi_router:routes/1` (reverted before commit):

```erlang
temp_probe_routes() ->
    #{prefix => ~"/api/v1/probe", security => false,
      routes => [{~"/live", fun asobi_match_controller:live/1, #{methods => [get, options]}},
                 {~"/:id", fun asobi_match_controller:show/1, #{methods => [get, options]}}]}.
```

- with `/live` declared without `options`: `every_http_route_accepts_options_test` failed with `got: [{<<"/api/v1/probe">>,<<"/live">>}]`
- with `/live` declared before `/:id` (the #326 shape): `every_http_route_resolves_to_its_handler_test` failed with `expected {ok, fun asobi_match_controller:live/1}, got {ok, fun asobi_match_controller:show/1}`

The options check also keeps a permanent synthetic-group case so the failure path stays covered without editing the router.

## Checks

`rebar3 fmt --check`, `xref`, `dialyzer`, `ex_doc` clean. `rebar3 eunit` 1137 tests, 0 failures. `rebar3 ct --suite=test/asobi_cors_SUITE` 4/4.

Untouched: `src/lua/` and `test/asobi_lua_*` (concurrent branch).
