### PR TITLE
feat(ops): operator identity and capability classes for the ops plane

### DIFF
--- a/guides/configuration.md
+++ b/guides/configuration.md
@@ -333,6 +333,33 @@ point `guest_verifier_key_id` at it; keep the old key ids for at least the
 retention window so existing guests can still resume. Guest creation is bounded
 by the per-IP auth limiter plus the global `guest_global` create limit.
 
+## Ops plane
+
+The `/api/v1/ops` routes are for a game-operations console, not a game client,
+and they carry their own credential. **Fails closed**: unset the key and every
+ops request is rejected, so a deployment that never reads this page is closed
+rather than open. There is no default credential.
+
+```erlang
+%% Required to use /api/v1/ops at all. Random, >= 32 bytes.
+{ops_secret, ~"a-32-byte-or-longer-random-secret"}
+```
+
+| Key | Default | Description |
+|-----|---------|-------------|
+| `ops_secret` | none | Operator bearer token for `/api/v1/ops`. Unset rejects every ops request |
+
+Send it as `Authorization: Bearer <ops_secret>`. It is compared in constant
+time and never leaves the server, so keep it in an env var or secret manager,
+never in source. Player and guest tokens are rejected here - the ops plane
+never consults the player token store.
+
+One secret is one privilege level: whoever holds it holds every ops capability
+class, including `config`. Restrict who can reach the console with a reverse
+proxy, and set `x-asobi-operator` per person for attribution in the audit
+trail - it is a label, never authority. See
+[REST API](rest-api.md#ops-authentication).
+
 ## Vote Templates
 
 Define reusable vote configurations:

--- a/guides/rest-api.md
+++ b/guides/rest-api.md
@@ -244,6 +244,9 @@ The game-operations read plane, for a console rather than a game client. The
 lists differ from the ones above in three ways: they report a total, they
 accept a sort, and they page by offset.
 
+These routes do **not** accept player tokens. They are their own auth plane -
+see [Ops authentication](#ops-authentication) below.
+
 Every list returns the same envelope:
 
 ```json
@@ -296,12 +299,42 @@ Capabilities report what is *configured*, not what is compiled in, and carry a
 boolean only - never the configured value. `extensions` is empty until an
 extension registry exists; entries will have the same shape as `core`.
 
-> #### Ops routes use player auth today {: .warning}
+### Ops authentication
+
+Ops routes sit behind an operator credential, never a player token. Send the
+configured operator secret as a bearer token:
+
+```
+GET /api/v1/ops/players
+Authorization: Bearer <ops_secret>
+```
+
+Configure it with the `ops_secret` application env (see
+[Configuration](configuration.md#ops-plane)). There is **no default**: a
+deployment that has not set one rejects every ops request. A player or guest
+token is rejected the same way - the ops plane never consults the player token
+store at all.
+
+Every rejection is `403` with `{"error": "forbidden"}`, whatever the cause. A
+caller cannot tell an unconfigured deployment from a wrong secret.
+
+Each route carries exactly one capability class - `read`, `player_data` or
+`config` - and a request is admitted only if the credential holds that class.
+Everything above is `read`. Role names never appear on the wire.
+
+> #### One secret means one privilege level {: .warning}
 >
-> These routes sit behind the same bearer check as the rest of `/api/v1`, so
-> any authenticated player can read them, and their fields are held to exactly
-> what the public endpoints already expose. An operator capability model is
-> the follow-up.
+> The static secret resolves to all three classes, so anyone holding it holds
+> `config`. A studio cannot hand a community manager `player_data` without
+> also handing over everything else. Restrict who reaches the console at all
+> with a reverse proxy; per-person capabilities arrive with managed cloud,
+> which mints a short-lived token carrying an explicit capability list.
+
+Optionally send `x-asobi-operator: <name>` to name the human behind a shared
+secret. It is attribution only: it is read after the credential is accepted,
+it never affects what a request may do, and it is recorded unattested. A
+label that is empty, multi-valued, over 64 bytes, or not printable ASCII is
+dropped rather than trusted.
 
 ## Errors
 

--- a/src/asobi_router.erl
+++ b/src/asobi_router.erl
@@ -15,6 +15,7 @@ routes(_Environment) ->
         auth_routes(),
         iap_routes(),
         api_routes(),
+        ops_routes(),
         ws_routes()
     ].
 
@@ -183,12 +184,6 @@ api_routes() ->
             {~"/saves/:slot", fun asobi_storage_controller:get_save/1, #{methods => [get, options]}},
             {~"/saves/:slot", fun asobi_storage_controller:put_save/1, #{methods => [put, options]}},
 
-            %% Ops - read plane. Mounted on the existing player-scoped auth
-            %% plugin; the operator capability model is ADR 0007 (follow-up).
-            {~"/ops/players", fun asobi_ops_controller:players/1, #{methods => [get, options]}},
-            {~"/ops/matches", fun asobi_ops_controller:matches/1, #{methods => [get, options]}},
-            {~"/ops/features", fun asobi_ops_controller:features/1, #{methods => [get, options]}},
-
             %% Storage - Generic
             {~"/storage/:collection", fun asobi_storage_controller:list_storage/1, #{
                 methods => [get, options]
@@ -202,6 +197,20 @@ api_routes() ->
             {~"/storage/:collection/:key", fun asobi_storage_controller:delete_storage/1, #{
                 methods => [delete, options]
             }}
+        ]
+    }.
+
+%% Ops - the game-operations plane. Its own group because it is its own
+%% identity: the operator capability check (ADR 0007), never the player-scoped
+%% one. Every route here must carry a class in `asobi_ops_caps:classes/0`.
+ops_routes() ->
+    #{
+        prefix => ~"/api/v1/ops",
+        security => fun asobi_ops_auth:verify/1,
+        routes => [
+            {~"/players", fun asobi_ops_controller:players/1, #{methods => [get, options]}},
+            {~"/matches", fun asobi_ops_controller:matches/1, #{methods => [get, options]}},
+            {~"/features", fun asobi_ops_controller:features/1, #{methods => [get, options]}}
         ]
     }.
 

--- a/src/ops/asobi_ops_auth.erl
+++ b/src/ops/asobi_ops_auth.erl
@@ -1,0 +1,165 @@
+-module(asobi_ops_auth).
+-moduledoc """
+Ops-plane identity: one actor per request, one membership check (ADR 0007).
+
+Every `/api/v1/ops` request resolves to an actor -
+`#{id, display, source, caps, attested}` - and is admitted only when the
+route's capability class is in the actor's `caps`. Nothing else in the plane
+authorises. The actor ships from the first release because it is the one part
+of an identity design that is expensive to retrofit: every audit row and every
+token consumer would have to be rewritten.
+
+`static_secret` is the only source built. It is the operator secret in the
+`ops_secret` application env, compared in constant time. **There is no default
+credential**: a deployment that has not configured one rejects every ops
+request, so an install that never reads the docs is closed rather than wide
+open.
+
+A player bearer token is not a credential here. This module never consults
+`asobi_auth_cache`, so no player - and no guest - can reach the plane, which
+is the whole point of taking these routes off the player-scoped check.
+
+`cloud` and `local_user` are reserved in `t:source/0` and not built. Cloud
+mints a short-lived env-scoped token in `asobi_saas` and maps its roles onto
+capability classes there.
+
+Every rejection is 403 with the same body whatever the cause, so a caller
+cannot tell "no secret configured" from "wrong secret" from "not authorised
+for this class".
+""".
+
+-include_lib("kernel/include/logger.hrl").
+
+-export([verify/1, resolve/1, display/1]).
+
+-define(LABEL_HEADER, ~"x-asobi-operator").
+-define(LABEL_MAX_BYTES, 64).
+-define(DEFAULT_DISPLAY, ~"operator").
+
+-type source() :: static_secret | cloud | local_user.
+-type actor() :: #{
+    id := binary(),
+    display := binary(),
+    source := source(),
+    caps := [asobi_ops_caps:class()],
+    attested := boolean()
+}.
+
+-export_type([source/0, actor/0]).
+
+-doc """
+Nova security callback for the ops route group.
+
+Admits with the actor in `auth_data`, or rejects with 403 and a flat error
+body.
+""".
+-spec verify(cowboy_req:req()) ->
+    {true, #{ops_actor := actor()}} | {false, 403, #{binary() => binary()}, binary()}.
+verify(Req) ->
+    Class = asobi_ops_caps:class(cowboy_req:method(Req), cowboy_req:path(Req)),
+    case resolve(Req) of
+        {ok, #{caps := Caps} = Actor} ->
+            case asobi_ops_caps:authorised(Class, Caps) of
+                true -> {true, #{ops_actor => Actor}};
+                false -> deny()
+            end;
+        {error, _Reason} ->
+            deny()
+    end.
+
+-doc """
+Resolve a request to an ops actor.
+
+`static_secret` is the only source built, and it fails closed: an unset or
+empty `ops_secret` rejects every request rather than admitting one.
+""".
+-spec resolve(cowboy_req:req()) -> {ok, actor()} | {error, atom()}.
+resolve(Req) ->
+    case secret() of
+        {ok, Secret} ->
+            case presented(Req) of
+                {ok, Presented} -> match(Secret, Presented, Req);
+                error -> {error, no_credential}
+            end;
+        error ->
+            ?LOG_WARNING(#{
+                msg => ~"ops request rejected: no ops_secret configured",
+                path => cowboy_req:path(Req)
+            }),
+            {error, not_configured}
+    end.
+
+-doc """
+The operator label from `x-asobi-operator`, or the default display name.
+
+Attribution, never authority: it is read only here, after the credential has
+already been accepted, and it never reaches the capability check. Spoofing it
+buys a wrong name in the audit trail and nothing else, which is why the actor
+carries it with `attested => false`.
+
+Dropped rather than trusted when it is multi-valued (cowboy joins repeated
+headers with a comma), empty, over 64 bytes, or carries anything outside
+printable ASCII - the value lands in audit rows and logs.
+""".
+-spec display(cowboy_req:req()) -> binary().
+display(Req) ->
+    case cowboy_req:header(?LABEL_HEADER, Req) of
+        undefined -> ?DEFAULT_DISPLAY;
+        Label -> label(Label)
+    end.
+
+-spec label(binary()) -> binary().
+label(Label) when byte_size(Label) > 0, byte_size(Label) =< ?LABEL_MAX_BYTES ->
+    case printable(Label) andalso binary:match(Label, ~",") =:= nomatch of
+        true -> Label;
+        false -> ?DEFAULT_DISPLAY
+    end;
+label(_Label) ->
+    ?DEFAULT_DISPLAY.
+
+-spec printable(binary()) -> boolean().
+printable(Label) ->
+    lists:all(fun(Char) -> Char >= 32 andalso Char =< 126 end, binary_to_list(Label)).
+
+-spec match(binary(), binary(), cowboy_req:req()) -> {ok, actor()} | {error, atom()}.
+match(Secret, Presented, Req) ->
+    case equal(Secret, Presented) of
+        true -> {ok, actor(Req)};
+        false -> {error, bad_credential}
+    end.
+
+-spec equal(binary(), binary()) -> boolean().
+equal(Secret, Presented) ->
+    %% Hash both first: crypto:hash_equals/2 raises on operands of different
+    %% size, so comparing the raw values would both crash and leak the
+    %% secret's length through the response.
+    crypto:hash_equals(crypto:hash(sha256, Secret), crypto:hash(sha256, Presented)).
+
+-spec actor(cowboy_req:req()) -> actor().
+actor(Req) ->
+    #{
+        id => ~"static_secret",
+        display => display(Req),
+        source => static_secret,
+        caps => [read, player_data, config],
+        attested => false
+    }.
+
+-spec secret() -> {ok, binary()} | error.
+secret() ->
+    case application:get_env(asobi, ops_secret) of
+        {ok, Secret} when is_binary(Secret), Secret =/= ~"" -> {ok, Secret};
+        _ -> error
+    end.
+
+-spec presented(cowboy_req:req()) -> {ok, binary()} | error.
+presented(Req) ->
+    case cowboy_req:header(~"authorization", Req) of
+        <<"Bearer ", Token/binary>> when Token =/= ~"" -> {ok, Token};
+        _ -> error
+    end.
+
+-spec deny() -> {false, 403, #{binary() => binary()}, binary()}.
+deny() ->
+    Body = iolist_to_binary(json:encode(#{error => ~"forbidden"})),
+    {false, 403, #{~"content-type" => ~"application/json"}, Body}.

--- a/src/ops/asobi_ops_caps.erl
+++ b/src/ops/asobi_ops_caps.erl
@@ -1,0 +1,75 @@
+-module(asobi_ops_caps).
+-moduledoc """
+Capability classes for the ops plane, and the table that tags every route with
+exactly one of them (ADR 0007).
+
+`read` is everything non-mutating, `player_data` is ban, grant, broadcast and
+roster edits, `config` is economy definitions, credentials and deploy-adjacent
+settings. The only authorisation decision anywhere in the plane is membership
+of a route's class in the actor's `caps`.
+
+Role names are deliberately absent. They are not stable wire surface -
+capability classes are, and adding a fourth class later is additive.
+`asobi_saas` maps its own roles onto these classes once, at token-mint time,
+so the string "owner" never reaches this plane.
+
+A route with no entry in `classes/0` has no class and `authorised/2` denies
+it, so an untagged or mis-mounted route is closed rather than open.
+""".
+
+-export([classes/0, class/2, authorised/2]).
+
+-type class() :: read | player_data | config.
+-type route() :: {atom(), [binary()], class()}.
+
+-export_type([class/0, route/0]).
+
+-doc """
+The route table: method, path segments below `/api/v1/ops`, and class.
+
+A router meta-test holds this table and the router's ops group to each other,
+so a new ops route cannot ship untagged.
+""".
+-spec classes() -> [route()].
+classes() ->
+    [
+        {get, [~"players"], read},
+        {get, [~"matches"], read},
+        {get, [~"features"], read}
+    ].
+
+-doc """
+The class of an ops route, from the request method and path.
+
+`undefined` for anything that is not a tagged ops route, including a path
+outside `/api/v1/ops` and a method the table does not carry.
+""".
+-spec class(binary(), binary()) -> class() | undefined.
+class(Method, Path) ->
+    %% Split the way routing_tree does (`trim_all` collapses `//` and edge
+    %% slashes) so a path variant that still routes cannot miss its tag.
+    case binary:split(Path, ~"/", [global, trim_all]) of
+        [~"api", ~"v1", ~"ops" | [_ | _] = Segments] -> lookup(method(Method), Segments);
+        _ -> undefined
+    end.
+
+-doc "Whether an actor holding `Caps` may call a route of class `Class`.".
+-spec authorised(class() | undefined, [class()]) -> boolean().
+authorised(undefined, _Caps) -> false;
+authorised(Class, Caps) -> lists:member(Class, Caps).
+
+-spec lookup(atom(), [binary()]) -> class() | undefined.
+lookup(undefined, _Segments) ->
+    undefined;
+lookup(Method, Segments) ->
+    case [Class || {M, S, Class} <- classes(), M =:= Method, S =:= Segments] of
+        [Class] -> Class;
+        _ -> undefined
+    end.
+
+-spec method(binary()) -> atom().
+method(~"GET") -> get;
+method(~"POST") -> post;
+method(~"PUT") -> put;
+method(~"DELETE") -> delete;
+method(_) -> undefined.

--- a/src/ops/asobi_ops_controller.erl
+++ b/src/ops/asobi_ops_controller.erl
@@ -6,10 +6,10 @@ Every list endpoint here returns the same envelope, clamps its own paging, and
 rejects a sort field it does not recognise with 400 rather than ordering by
 something the caller did not ask for.
 
-These routes are mounted behind `asobi_auth_plugin:verify/1`, the same
-player-scoped bearer check the rest of `/api/v1` uses. That is a placeholder,
-not the destination: ops calls want an operator capability, which is ADR 0007
-and a follow-up PR. Until then every projection here is held to exactly what
+These routes are mounted behind `asobi_ops_auth:verify/1`, the operator
+capability check (ADR 0007) - never the player-scoped bearer check the rest of
+`/api/v1` uses, which would let any authenticated player, guest included,
+enumerate the deployment. Every projection here is still held to exactly what
 the equivalent public endpoint already exposes.
 """.
 

--- a/test/asobi_api_SUITE.erl
+++ b/test/asobi_api_SUITE.erl
@@ -2,6 +2,8 @@
 
 -include_lib("nova_test/include/nova_test.hrl").
 
+-define(OPS_SECRET, ~"8e3a5d17c94b60f2ae81d3705c6f9b24d0a7e158b3c92f46071dab5e8c249f30").
+
 -export([
     all/0,
     groups/0,
@@ -25,11 +27,14 @@
     update_player_unauthorized/1,
     health_check/1,
     readiness_check/1,
-    liveness_check/1
+    liveness_check/1,
+    ops_rejects_a_player_token/1,
+    ops_rejects_an_anonymous_request/1,
+    ops_accepts_the_operator_secret/1
 ]).
 
 all() ->
-    [{group, auth}, {group, players}, {group, health}].
+    [{group, auth}, {group, players}, {group, health}, {group, ops}].
 
 groups() ->
     [
@@ -53,6 +58,11 @@ groups() ->
             health_check,
             readiness_check,
             liveness_check
+        ]},
+        {ops, [sequence], [
+            ops_rejects_a_player_token,
+            ops_rejects_an_anonymous_request,
+            ops_accepts_the_operator_secret
         ]}
     ].
 
@@ -95,9 +105,19 @@ init_per_group(players, Config) ->
         {player_id, PlayerId}
         | Config
     ];
+init_per_group(ops, Config) ->
+    Original = application:get_env(asobi, ops_secret),
+    application:set_env(asobi, ops_secret, ?OPS_SECRET),
+    [{ops_secret_was, Original} | Config];
 init_per_group(_Group, Config) ->
     Config.
 
+end_per_group(ops, Config) ->
+    case lists:keyfind(ops_secret_was, 1, Config) of
+        {ops_secret_was, {ok, Value}} -> application:set_env(asobi, ops_secret, Value);
+        _ -> application:unset_env(asobi, ops_secret)
+    end,
+    Config;
 end_per_group(_Group, Config) ->
     Config.
 
@@ -342,4 +362,46 @@ liveness_check(Config) ->
     ?assertStatus(200, Resp),
     Body = nova_test:json(Resp),
     ?assertMatch(#{~"status" := ~"alive"}, Body),
+    Config.
+
+%% --- Ops Tests ---
+
+%% Before ADR 0007 these routes sat behind the player-scoped bearer check, so
+%% any authenticated player - a guest included - could page every player and
+%% every match record in the deployment. A player token must now be a 403.
+ops_rejects_a_player_token(Config) ->
+    {session_token, Token} = lists:keyfind(session_token, 1, Config),
+    true = is_binary(Token),
+    [
+        begin
+            {ok, Resp} = nova_test:get(
+                Path,
+                #{headers => [{~"authorization", <<"Bearer ", Token/binary>>}]},
+                Config
+            ),
+            ?assertStatus(403, Resp)
+        end
+     || Path <- ["/api/v1/ops/players", "/api/v1/ops/matches", "/api/v1/ops/features"]
+    ],
+    Config.
+
+ops_rejects_an_anonymous_request(Config) ->
+    {ok, Resp} = nova_test:get("/api/v1/ops/players", Config),
+    ?assertStatus(403, Resp),
+    ?assertMatch(#{~"error" := ~"forbidden"}, nova_test:json(Resp)),
+    Config.
+
+ops_accepts_the_operator_secret(Config) ->
+    {ok, Resp} = nova_test:get(
+        "/api/v1/ops/players",
+        #{
+            headers => [
+                {~"authorization", <<"Bearer ", ?OPS_SECRET/binary>>},
+                {~"x-asobi-operator", ~"kaito"}
+            ]
+        },
+        Config
+    ),
+    ?assertStatus(200, Resp),
+    ?assertMatch(#{~"data" := _, ~"page" := _}, nova_test:json(Resp)),
     Config.

--- a/test/asobi_ops_auth_tests.erl
+++ b/test/asobi_ops_auth_tests.erl
@@ -1,0 +1,260 @@
+-module(asobi_ops_auth_tests).
+
+-include_lib("eunit/include/eunit.hrl").
+
+%% The ops plane reads every player and every match record in the deployment.
+%% Before ADR 0007 it sat on the player-scoped bearer check, so any
+%% authenticated player - guest included - could enumerate it. These tests pin
+%% the two properties that closed that: a player token is not a credential
+%% here, and an unconfigured deployment admits nobody.
+
+-define(SECRET, ~"7f4c1b9a2e6d8053f1a4c7b0e9d2635847ac1fbe2093d75641c8ba0fe3729d15").
+
+%%--------------------------------------------------------------------
+%% Capability classes
+%%--------------------------------------------------------------------
+
+class_is_read_for_every_shipped_route_test() ->
+    [
+        ?assertEqual(read, asobi_ops_caps:class(~"GET", Path))
+     || Path <- [~"/api/v1/ops/players", ~"/api/v1/ops/matches", ~"/api/v1/ops/features"]
+    ].
+
+%% routing_tree collapses `//` and edge slashes, so a variant that still
+%% routes must still find its tag - otherwise it would be denied as untagged.
+class_survives_router_slash_normalisation_test() ->
+    [
+        ?assertEqual(read, asobi_ops_caps:class(~"GET", Path))
+     || Path <- [~"//api/v1/ops/players", ~"/api/v1//ops/players", ~"/api/v1/ops/players/"]
+    ].
+
+class_is_undefined_for_an_untagged_ops_path_test() ->
+    ?assertEqual(undefined, asobi_ops_caps:class(~"GET", ~"/api/v1/ops/economy")),
+    ?assertEqual(undefined, asobi_ops_caps:class(~"GET", ~"/api/v1/ops")).
+
+class_is_undefined_for_a_method_the_route_does_not_carry_test() ->
+    ?assertEqual(undefined, asobi_ops_caps:class(~"POST", ~"/api/v1/ops/players")),
+    ?assertEqual(undefined, asobi_ops_caps:class(~"OPTIONS", ~"/api/v1/ops/players")).
+
+class_is_undefined_outside_the_ops_prefix_test() ->
+    [
+        ?assertEqual(undefined, asobi_ops_caps:class(~"GET", Path))
+     || Path <- [~"/api/v1/players", ~"/api/v2/ops/players", ~"/ops/players", ~"/"]
+    ].
+
+authorised_is_membership_only_test() ->
+    ?assert(asobi_ops_caps:authorised(read, [read])),
+    ?assert(asobi_ops_caps:authorised(config, [read, player_data, config])),
+    ?assertNot(asobi_ops_caps:authorised(config, [read, player_data])),
+    ?assertNot(asobi_ops_caps:authorised(player_data, [read])),
+    ?assertNot(asobi_ops_caps:authorised(read, [])).
+
+%% An untagged route has no class, and that must deny rather than fall
+%% through to a permissive default.
+authorised_denies_an_untagged_route_test() ->
+    ?assertNot(asobi_ops_caps:authorised(undefined, [read, player_data, config])).
+
+every_shipped_route_carries_exactly_one_class_test() ->
+    Routes = [{M, S} || {M, S, _Class} <- asobi_ops_caps:classes()],
+    ?assertEqual(lists:usort(Routes), lists:sort(Routes)),
+    [
+        ?assert(lists:member(Class, [read, player_data, config]))
+     || {_M, _S, Class} <- asobi_ops_caps:classes()
+    ].
+
+%%--------------------------------------------------------------------
+%% verify/1
+%%--------------------------------------------------------------------
+
+verify_test_() ->
+    {foreach, fun setup/0, fun cleanup/1, [
+        fun admits_the_configured_secret/0,
+        fun admitted_actor_has_the_adr_shape/0,
+        fun rejects_a_player_bearer_token/0,
+        fun never_consults_the_player_token_cache/0,
+        fun rejects_a_wrong_secret/0,
+        fun rejects_a_secret_prefix/0,
+        fun rejects_a_missing_header/0,
+        fun rejects_a_non_bearer_scheme/0,
+        fun rejects_an_empty_bearer_token/0,
+        fun rejects_an_untagged_ops_route/0,
+        fun rejects_a_path_outside_the_ops_prefix/0,
+        fun denial_is_403_and_says_nothing_about_the_cause/0
+    ]}.
+
+setup() ->
+    Original = application:get_env(asobi, ops_secret),
+    application:set_env(asobi, ops_secret, ?SECRET),
+    meck:new(asobi_auth_cache, [passthrough]),
+    meck:expect(asobi_auth_cache, resolve_token, fun(_) -> {ok, #{id => ~"p1"}} end),
+    Original.
+
+cleanup(Original) ->
+    catch meck:unload(asobi_auth_cache),
+    case Original of
+        {ok, Value} -> application:set_env(asobi, ops_secret, Value);
+        undefined -> application:unset_env(asobi, ops_secret)
+    end.
+
+req(Path, Headers) -> #{method => ~"GET", path => Path, headers => Headers}.
+
+bearer(Token) -> #{~"authorization" => <<"Bearer ", Token/binary>>}.
+
+ops_req(Token) -> req(~"/api/v1/ops/players", bearer(Token)).
+
+admits_the_configured_secret() ->
+    ?assertMatch({true, #{ops_actor := #{}}}, asobi_ops_auth:verify(ops_req(?SECRET))).
+
+admitted_actor_has_the_adr_shape() ->
+    {true, #{ops_actor := Actor}} = asobi_ops_auth:verify(ops_req(?SECRET)),
+    ?assertEqual([attested, caps, display, id, source], lists:sort(maps:keys(Actor))),
+    ?assertEqual(static_secret, maps:get(source, Actor)),
+    ?assertEqual([read, player_data, config], maps:get(caps, Actor)),
+    ?assertEqual(false, maps:get(attested, Actor)),
+    ?assertEqual(~"operator", maps:get(display, Actor)).
+
+%% The hole this closes: `asobi_auth_cache:resolve_token/1` does not
+%% discriminate, so a player - or a guest - holding any live token could read
+%% the whole deployment while these routes sat on the player check.
+rejects_a_player_bearer_token() ->
+    ?assertMatch({false, 403, _, _}, asobi_ops_auth:verify(ops_req(~"a-live-player-token"))).
+
+never_consults_the_player_token_cache() ->
+    _ = asobi_ops_auth:verify(ops_req(~"a-live-player-token")),
+    _ = asobi_ops_auth:verify(ops_req(?SECRET)),
+    ?assertEqual(0, meck:num_calls(asobi_auth_cache, resolve_token, '_')).
+
+rejects_a_wrong_secret() ->
+    ?assertMatch({false, 403, _, _}, asobi_ops_auth:verify(ops_req(~"not-the-secret"))).
+
+rejects_a_secret_prefix() ->
+    <<Prefix:32/binary, _/binary>> = ?SECRET,
+    ?assertMatch({false, 403, _, _}, asobi_ops_auth:verify(ops_req(Prefix))).
+
+rejects_a_missing_header() ->
+    ?assertMatch({false, 403, _, _}, asobi_ops_auth:verify(req(~"/api/v1/ops/players", #{}))).
+
+rejects_a_non_bearer_scheme() ->
+    Req = req(~"/api/v1/ops/players", #{~"authorization" => <<"Basic ", ?SECRET/binary>>}),
+    ?assertMatch({false, 403, _, _}, asobi_ops_auth:verify(Req)).
+
+rejects_an_empty_bearer_token() ->
+    Req = req(~"/api/v1/ops/players", #{~"authorization" => ~"Bearer "}),
+    ?assertMatch({false, 403, _, _}, asobi_ops_auth:verify(Req)).
+
+%% A future ops route added to the router but not to the class table must be
+%% closed, not open.
+rejects_an_untagged_ops_route() ->
+    Req = req(~"/api/v1/ops/economy", bearer(?SECRET)),
+    ?assertMatch({false, 403, _, _}, asobi_ops_auth:verify(Req)).
+
+rejects_a_path_outside_the_ops_prefix() ->
+    Req = req(~"/api/v1/players/p1", bearer(?SECRET)),
+    ?assertMatch({false, 403, _, _}, asobi_ops_auth:verify(Req)).
+
+denial_is_403_and_says_nothing_about_the_cause() ->
+    Denials = [
+        asobi_ops_auth:verify(ops_req(~"not-the-secret")),
+        asobi_ops_auth:verify(req(~"/api/v1/ops/players", #{})),
+        asobi_ops_auth:verify(req(~"/api/v1/ops/economy", bearer(?SECRET)))
+    ],
+    ?assertEqual(1, length(lists:usort(Denials))),
+    [{false, Status, Headers, Body} | _] = Denials,
+    ?assertEqual(403, Status),
+    ?assertEqual(#{~"content-type" => ~"application/json"}, Headers),
+    ?assertEqual(#{~"error" => ~"forbidden"}, json:decode(Body)).
+
+%%--------------------------------------------------------------------
+%% Failing closed with no secret configured
+%%--------------------------------------------------------------------
+
+unconfigured_test_() ->
+    {foreach, fun unconfigured_setup/0, fun cleanup/1, [
+        fun rejects_every_request_when_no_secret_is_configured/0,
+        fun rejects_an_empty_secret/0,
+        fun rejects_a_non_binary_secret/0
+    ]}.
+
+unconfigured_setup() ->
+    Original = application:get_env(asobi, ops_secret),
+    application:unset_env(asobi, ops_secret),
+    Original.
+
+%% ADR 0007 ships no default credential. An operator who never configures one
+%% gets a plane nobody can read, not one everybody can.
+rejects_every_request_when_no_secret_is_configured() ->
+    ?assertMatch({false, 403, _, _}, asobi_ops_auth:verify(ops_req(~""))),
+    ?assertMatch({false, 403, _, _}, asobi_ops_auth:verify(ops_req(~"anything"))),
+    ?assertMatch({false, 403, _, _}, asobi_ops_auth:verify(req(~"/api/v1/ops/players", #{}))),
+    ?assertEqual({error, not_configured}, asobi_ops_auth:resolve(ops_req(~"anything"))).
+
+rejects_an_empty_secret() ->
+    application:set_env(asobi, ops_secret, ~""),
+    ?assertEqual({error, not_configured}, asobi_ops_auth:resolve(ops_req(~""))).
+
+rejects_a_non_binary_secret() ->
+    application:set_env(asobi, ops_secret, "a-string-not-a-binary"),
+    ?assertEqual(
+        {error, not_configured}, asobi_ops_auth:resolve(ops_req(~"a-string-not-a-binary"))
+    ).
+
+%%--------------------------------------------------------------------
+%% The x-asobi-operator label
+%%--------------------------------------------------------------------
+
+label_test_() ->
+    {foreach, fun setup/0, fun cleanup/1, [
+        fun label_names_the_actor_but_is_never_attested/0,
+        fun label_grants_no_capability/0,
+        fun multi_valued_label_is_dropped/0,
+        fun oversized_label_is_dropped/0,
+        fun control_characters_in_a_label_are_dropped/0,
+        fun empty_label_is_dropped/0,
+        fun label_is_ignored_without_a_credential/0
+    ]}.
+
+labelled(Token, Label) ->
+    req(~"/api/v1/ops/players", maps:put(~"x-asobi-operator", Label, bearer(Token))).
+
+display_of(Req) ->
+    {true, #{ops_actor := #{display := Display}}} = asobi_ops_auth:verify(Req),
+    Display.
+
+label_names_the_actor_but_is_never_attested() ->
+    {true, #{ops_actor := Actor}} = asobi_ops_auth:verify(labelled(?SECRET, ~"kaito")),
+    ?assertEqual(~"kaito", maps:get(display, Actor)),
+    ?assertEqual(false, maps:get(attested, Actor)).
+
+%% Spoofing the label must buy false attribution and never privilege: the caps
+%% are the same whether it is present, absent or forged.
+label_grants_no_capability() ->
+    {true, #{ops_actor := #{caps := Plain}}} = asobi_ops_auth:verify(ops_req(?SECRET)),
+    {true, #{ops_actor := #{caps := Labelled}}} = asobi_ops_auth:verify(
+        labelled(?SECRET, ~"root")
+    ),
+    ?assertEqual(Plain, Labelled).
+
+%% Cowboy joins repeated headers with a comma, so a comma is how a
+%% multi-valued label arrives.
+multi_valued_label_is_dropped() ->
+    ?assertEqual(~"operator", display_of(labelled(?SECRET, ~"kaito, mei"))).
+
+oversized_label_is_dropped() ->
+    ?assertEqual(~"operator", display_of(labelled(?SECRET, binary:copy(~"k", 65)))),
+    ?assertEqual(binary:copy(~"k", 64), display_of(labelled(?SECRET, binary:copy(~"k", 64)))).
+
+%% The label lands in audit rows and logs, so a newline or an escape sequence
+%% must not survive into them.
+control_characters_in_a_label_are_dropped() ->
+    [
+        ?assertEqual(~"operator", display_of(labelled(?SECRET, Label)))
+     || Label <- [~"kaito\nadmin", ~"kaito\r\nx", ~"kaito\e[31m", ~"kaito\0"]
+    ].
+
+empty_label_is_dropped() ->
+    ?assertEqual(~"operator", display_of(labelled(?SECRET, ~""))).
+
+label_is_ignored_without_a_credential() ->
+    ?assertMatch({false, 403, _, _}, asobi_ops_auth:verify(labelled(~"wrong", ~"kaito"))),
+    Req = req(~"/api/v1/ops/players", #{~"x-asobi-operator" => ~"kaito"}),
+    ?assertMatch({false, 403, _, _}, asobi_ops_auth:verify(Req)).

--- a/test/asobi_ops_tests.erl
+++ b/test/asobi_ops_tests.erl
@@ -213,17 +213,41 @@ matches_sortable_fields_are_all_projected_test() ->
 %% Routing
 %%--------------------------------------------------------------------
 
-%% The ops plane reuses core's bearer check rather than inventing one. If a
-%% later edit moves these routes to an unsecured group, this fails.
-ops_routes_are_mounted_behind_auth_test() ->
+%% The ops plane has its own identity (ADR 0007). If a later edit moves these
+%% routes back onto the player-scoped check - which admits any player, guest
+%% included - or into an unsecured group, this fails.
+ops_routes_are_mounted_behind_the_operator_check_test() ->
     Groups = asobi_router:routes(dev),
     [
         ?assertEqual(
-            {fun asobi_auth_plugin:verify/1, [get, options]},
-            route(Groups, ~"/api/v1", Path)
+            {fun asobi_ops_auth:verify/1, [get, options]},
+            route(Groups, ~"/api/v1/ops", Path)
         )
-     || Path <- [~"/ops/players", ~"/ops/matches", ~"/ops/features"]
+     || Path <- [~"/players", ~"/matches", ~"/features"]
     ].
+
+no_ops_route_sits_in_the_player_scoped_group_test() ->
+    [
+        ?assertEqual([], [Path || {Path, _Handler, _Opts} <- Routes, ops_path(Path)])
+     || #{prefix := Prefix, routes := Routes} <- asobi_router:routes(dev), Prefix =/= ~"/api/v1/ops"
+    ].
+
+ops_path(<<"/ops", _/binary>>) -> true;
+ops_path(_Path) -> false.
+
+%% Every ops route carries exactly one capability class, and the class table
+%% carries no route the router does not serve. An untagged route is denied at
+%% runtime, so this is the check that turns that denial into a build failure.
+ops_routes_and_capability_classes_agree_test() ->
+    Routed = lists:sort([
+        {Method, binary:split(Path, ~"/", [global, trim_all])}
+     || #{prefix := ~"/api/v1/ops", routes := Routes} <- asobi_router:routes(dev),
+        {Path, _Handler, Opts} <- Routes,
+        Method <- maps:get(methods, Opts),
+        Method =/= options
+    ]),
+    Tagged = lists:sort([{Method, Segments} || {Method, Segments, _} <- asobi_ops_caps:classes()]),
+    ?assertEqual(Tagged, Routed).
 
 route(Groups, Prefix, Path) ->
     [Found] = [


### PR DESCRIPTION
Plan items 2a.7 and 2a.9. Implements ADR 0007 (ops identity and capabilities).

## The hole this closes

`/api/v1/ops/*` sat in the `/api/v1` route group behind `asobi_auth_plugin:verify/1`. That plugin resolves any bearer token through `asobi_auth_cache:resolve_token/1`, which does not discriminate - so **any authenticated player, including a guest, could page every player and every match record in the deployment**. The routes shipped in #335 with that noted as a placeholder; this is the fix.

## What ships

**Capability classes, not role names** (`asobi_ops_caps`). Every ops route is tagged with exactly one of `read | player_data | config`, and the only authorisation decision anywhere in the plane is membership of that class in the actor's `caps`. A route with no tag has no class and is denied, so an untagged or mis-mounted route is closed rather than open - and a router meta-test holds the class table and the router's ops group to each other, so an untagged route is a build failure rather than a runtime 403. No role name appears on the wire; `asobi_saas` maps its own roles onto these classes once, at mint time.

**An actor per request** (`asobi_ops_auth`): `#{id, display, source, caps, attested}`, resolved before the membership check.

**Source `static_secret`**, the only one built. The `ops_secret` application env, compared in constant time (both sides hashed first - `crypto:hash_equals/2` raises on unequal sizes, and a raw compare would leak the secret's length). **No default credential**: an unconfigured deployment rejects every ops request. A player token is not a credential here at all - this module never calls `asobi_auth_cache`. Every rejection is `403 {"error":"forbidden"}` whatever the cause, so a caller cannot tell "not configured" from "wrong secret" from "wrong class".

`cloud` and `local_user` are reserved in `t:source/0` and not built. No users table, no roles table, no teams, no password reset - the ADR rejects all of those for self-host.

**The `x-asobi-operator` label** (item 2a.9). Read only after the credential is accepted, never part of the capability check, dropped when multi-valued (cowboy joins repeats with a comma), empty, over 64 bytes or not printable ASCII, and recorded with `attested => false`. Spoofing it yields false attribution, never privilege - pinned by a test asserting the caps are identical with and without it.

## Tests

`test/asobi_ops_auth_tests.erl` (new) covers the class table, the membership matrix including the untagged-route denial, credential handling, failing closed with no secret, and the label rules. `asobi_api_SUITE` gains an `ops` group that drives real HTTP through the router: a player token gets 403 on all three routes, an anonymous request gets 403, the configured secret gets 200.

Revert-checked: pointing the ops group back at `asobi_auth_plugin:verify/1` fails `ops_routes_are_mounted_behind_the_operator_check_test`.

## Docs

`guides/rest-api.md` loses the "ops routes use player auth today" warning and gains an **Ops authentication** section - how to send the secret, that there is no default, that classes are per-route, and the honest limitation the ADR names: one static secret means anyone holding it holds `config`, mitigated by a reverse proxy and the label header, with per-person capabilities arriving via managed cloud. `guides/configuration.md` gains the `ops_secret` key.

## Checks

`rebar3 fmt --check`, `xref`, `dialyzer`, full `eunit` (1158 tests) and the `asobi_api_SUITE` ops group all pass. `elp eqwalize-all` reports only pre-existing errors.

## Not in this PR

Item 2a.8, durable audit rows carrying the actor, is the follow-up; the actor is shaped for it.
