### PR TITLE
feat(ops): leaderboard listing and matchmaker snapshot reads

### DIFF
--- a/guides/rest-api.md
+++ b/guides/rest-api.md
@@ -235,9 +235,12 @@ These routes return the [error object](#errors) below on failure.
 ## Ops
 
 ```
-GET /api/v1/ops/players     Paginated player list
-GET /api/v1/ops/matches     Paginated match-record list
-GET /api/v1/ops/features    Installed feature set
+GET /api/v1/ops/players                      Paginated player list
+GET /api/v1/ops/matches                      Paginated match-record list
+GET /api/v1/ops/features                     Installed feature set
+GET /api/v1/ops/leaderboards                 Paginated board list
+GET /api/v1/ops/leaderboards/:id/entries     Paginated, ranked board entries
+GET /api/v1/ops/matchmaker                   Matchmaking queue, by mode
 ```
 
 The game-operations read plane, for a console rather than a game client. The
@@ -256,7 +259,7 @@ Every list returns the same envelope:
 }
 ```
 
-Parameters shared by `ops/players` and `ops/matches`:
+Parameters shared by every ops list:
 
 | Parameter | Meaning |
 | --- | --- |
@@ -271,14 +274,86 @@ A malformed number is never an error: `?limit=abc` uses the default. A
 malformed *sort* always is, because ordering the wrong rows silently is worse
 than a 400.
 
-Sorts always end on `id`, so paging by offset cannot repeat or skip a row when
-the sort key has duplicates.
+Sorts always end on a unique column, so paging by offset cannot repeat or skip
+a row when the sort key has duplicates. That column is `id` on most lists,
+`board_id` for the board list, `player_id` within a board and `mode` for the
+queue.
 
 `ops/players` sorts on `id`, `username`, `display_name`, `inserted_at`,
 `updated_at`, and searches username and display name. `ops/matches` sorts on
 `id`, `mode`, `status`, `started_at`, `finished_at`, `inserted_at`, filters on
 `mode` and `status`, and searches mode. Both return the same fields as their
 public counterparts - no roster, no credentials.
+
+### Leaderboards
+
+`GET /api/v1/ops/leaderboards` lists boards rather than scores. Sorts on
+`board_id`, `entries`, `top_score`, `updated_at`, defaults to the largest
+board first, and searches `board_id`.
+
+```json
+{
+  "data": [
+    { "board_id": "arena_eu", "entries": 4120, "top_score": 98210,
+      "updated_at": "2026-08-03T12:00:00Z", "live": true }
+  ],
+  "page": { "limit": 50, "offset": 0, "total": 1 }
+}
+```
+
+`live` says whether the board currently has a process. A board is live without
+rows for its first 30 seconds - scores are flushed on an interval - and has
+rows without being live when nothing has written to it since the node started.
+Both cases are listed.
+
+`GET /api/v1/ops/leaderboards/:id/entries` pages one board. Sorts on `id`,
+`player_id`, `score`, `sub_score`, `updated_at`, and defaults to `score`
+descending, which is the board's own order.
+
+```json
+{
+  "data": [
+    { "id": "0198...", "leaderboard_id": "arena_eu", "player_id": "0197...",
+      "score": 98210, "sub_score": 0, "rank": 1,
+      "updated_at": "2026-08-03T12:00:00Z" }
+  ],
+  "page": { "limit": 50, "offset": 0, "total": 4120 }
+}
+```
+
+`rank` is the position on the whole board, not within the page: row 501 is
+rank 501. It stays the board's rank whatever you sort the page by, and it is
+computed over the same order the public `GET /api/v1/leaderboards/:id` uses,
+so the two agree on any flushed score.
+
+The read is of persisted scores. A score submitted seconds ago is on the
+public top-N endpoint before it is here.
+
+### Matchmaker
+
+`GET /api/v1/ops/matchmaker` reports the queue, one row per mode. Sorts on
+`mode`, `waiting`, `oldest_wait_ms`, `average_wait_ms`, deepest queue first.
+
+```json
+{
+  "data": [
+    { "mode": "ranked", "waiting": 14, "oldest_wait_ms": 21400, "average_wait_ms": 8300 }
+  ],
+  "page": { "limit": 50, "offset": 0, "total": 1 },
+  "queue": { "waiting": 14, "modes": 1, "sampled_at": 1785312000000, "age_ms": 420 }
+}
+```
+
+Counts come from a sample the matchmaker publishes on each tick, so they are
+up to one tick old - 1s by default - and `age_ms` says how old. Waits are
+measured from the reading, so they keep growing between ticks. The read never
+touches the matchmaker process itself; it cannot slow matchmaking down however
+often it is polled.
+
+No ticket, player id or ticket property appears here. Who is queued is player
+data and waits on the capability model.
+
+### Features
 
 `GET /api/v1/ops/features` reports what this deployment has installed:
 

--- a/src/asobi_router.erl
+++ b/src/asobi_router.erl
@@ -210,7 +210,14 @@ ops_routes() ->
         routes => [
             {~"/players", fun asobi_ops_controller:players/1, #{methods => [get, options]}},
             {~"/matches", fun asobi_ops_controller:matches/1, #{methods => [get, options]}},
-            {~"/features", fun asobi_ops_controller:features/1, #{methods => [get, options]}}
+            {~"/features", fun asobi_ops_controller:features/1, #{methods => [get, options]}},
+            {~"/leaderboards", fun asobi_ops_controller:leaderboards/1, #{
+                methods => [get, options]
+            }},
+            {~"/leaderboards/:id/entries", fun asobi_ops_controller:leaderboard_entries/1, #{
+                methods => [get, options]
+            }},
+            {~"/matchmaker", fun asobi_ops_controller:matchmaker/1, #{methods => [get, options]}}
         ]
     }.
 

--- a/src/leaderboards/asobi_leaderboard_server.erl
+++ b/src/leaderboards/asobi_leaderboard_server.erl
@@ -3,7 +3,7 @@
 
 -include_lib("kernel/include/logger.hrl").
 
--export([start_link/1, submit/3, top/2, rank/2, around/3]).
+-export([start_link/1, submit/3, top/2, rank/2, around/3, live_boards/0]).
 -export([init/1, handle_call/3, handle_cast/2, handle_info/2, terminate/2]).
 
 -define(PG_SCOPE, nova_scope).
@@ -63,6 +63,19 @@ around(BoardId, PlayerId, N) ->
             end;
         not_found ->
             []
+    end.
+
+%% The board ids that currently have a process, which is not the same set as
+%% the boards that have scores: a board is live before its first flush and
+%% stops being live when the node restarts. Enumerating the pg groups is the
+%% only mapping from board id to process that costs no message - the
+%% supervisor is simple_one_for_one, so its children carry no id.
+-spec live_boards() -> [binary()].
+live_boards() ->
+    try pg:which_groups(?PG_SCOPE) of
+        Groups -> [BoardId || {?MODULE, BoardId} <- Groups, is_binary(BoardId)]
+    catch
+        error:badarg -> []
     end.
 
 -spec validate_entries([term()]) -> [{binary(), number(), pos_integer()}].

--- a/src/leaderboards/asobi_leaderboards.erl
+++ b/src/leaderboards/asobi_leaderboards.erl
@@ -1,0 +1,116 @@
+-module(asobi_leaderboards).
+-moduledoc """
+Board-set reads: which boards exist, and one page of a board.
+
+`asobi_leaderboard_server` answers questions about *one* board it already
+holds in ETS - top N, a player's rank, the window around a player. Neither
+question here can be answered that way. A board only becomes a process when
+someone writes to it, so the process set is not the board set; and the ETS
+reads are deliberately capped at 100 rows so that a caller cannot walk a
+board, which is exactly what paging through one means.
+
+Both reads therefore go to Postgres, where the scores are already persisted,
+and the process layer contributes only the `live` flag. That flag is the
+interesting half for an operator: a board is live-but-absent for its first 30
+seconds (the flush interval), and present-but-not-live once nobody has
+written to it since the node started.
+
+Rank is computed by the database over the same total order the ETS table is
+keyed on - `score` descending, then `player_id` - so a rank read here and a
+rank from `asobi_leaderboard_server:rank/2` agree on any flushed score.
+""".
+
+-include_lib("kura/include/kura.hrl").
+
+-export([boards/0, entries_query/1, board_order/0]).
+
+%% Enumeration groups the whole entries table, so it is one aggregate scan
+%% whatever the paging - there is no window that makes it cheaper. The cap
+%% bounds the rows shipped back rather than the scan, and sits an order of
+%% magnitude above `leaderboard_max_boards`, the ceiling on live boards.
+-define(MAX_BOARDS, 1000).
+
+-doc """
+Every board with a persisted score, plus every board that is live without
+one yet.
+
+Each row is `#{board_id, entries, top_score, updated_at, live}`. Boards known
+only as a running process report `entries => 0` and null aggregates: they
+exist, they have simply not flushed.
+
+Capped at 1000 boards, ordered by id so the cut is stable between calls.
+""".
+-spec boards() -> {ok, [map()]} | {error, term()}.
+boards() ->
+    case asobi_repo:all(persisted_query()) of
+        {ok, Rows} -> {ok, merge_live(Rows)};
+        {error, _} = Error -> Error
+    end.
+
+-spec persisted_query() -> #kura_query{}.
+persisted_query() ->
+    Selected = kura_query:select_expr(kura_query:from(asobi_leaderboard_entry), [
+        {board_id, leaderboard_id},
+        {entries, {fragment, ~"count(*)", []}},
+        {top_score, {fragment, ~"max(score)", []}},
+        {updated_at, {fragment, ~"max(updated_at)", []}}
+    ]),
+    Grouped = kura_query:group_by(Selected, [leaderboard_id]),
+    kura_query:limit(kura_query:order_by(Grouped, [{leaderboard_id, asc}]), ?MAX_BOARDS).
+
+-spec merge_live([map()]) -> [map()].
+merge_live(Rows) ->
+    Live = maps:from_keys(asobi_leaderboard_server:live_boards(), true),
+    Persisted = [persisted_board(Row, Live) || Row <- Rows],
+    Seen = maps:from_keys([Id || #{board_id := Id} <- Persisted], true),
+    Persisted ++ [unflushed_board(Id) || Id <- maps:keys(Live), not maps:is_key(Id, Seen)].
+
+-spec persisted_board(map(), #{binary() => true}) -> map().
+persisted_board(Row, Live) ->
+    Id = maps:get(board_id, Row),
+    #{
+        board_id => Id,
+        entries => maps:get(entries, Row, 0),
+        top_score => maps:get(top_score, Row, null),
+        updated_at => maps:get(updated_at, Row, null),
+        live => maps:is_key(Id, Live)
+    }.
+
+-spec unflushed_board(binary()) -> map().
+unflushed_board(Id) ->
+    #{board_id => Id, entries => 0, top_score => null, updated_at => null, live => true}.
+
+-doc """
+One board's entries, ranked, as a query for the shared paginator.
+
+Returns a query rather than rows because the count and the page have to run
+as one unit against the same filter - `asobi_ops_page` owns that - and
+because the caller supplies the ordering. Rank is not the caller's to order
+by: it is a window over `board_order/0` computed before `LIMIT` applies, so
+row 501 reports rank 501 however the page itself is sorted. No partition is
+needed, the `WHERE` already narrows the window to one board.
+""".
+-spec entries_query(binary()) -> #kura_query{}.
+entries_query(BoardId) ->
+    Scoped = kura_query:where(
+        kura_query:from(asobi_leaderboard_entry), {leaderboard_id, BoardId}
+    ),
+    kura_query:select_expr(Scoped, [
+        {id, id},
+        {leaderboard_id, leaderboard_id},
+        {player_id, player_id},
+        {score, score},
+        {sub_score, sub_score},
+        {updated_at, updated_at},
+        {rank, kura_query:over(row_number, #{order_by => board_order()})}
+    ]).
+
+-doc """
+The total order a board is ranked in, shared by the rank window and the
+default listing order so the two cannot drift apart.
+
+`player_id` is unique within a board, so this is total, which is also what
+makes offset paging safe.
+""".
+-spec board_order() -> [{atom(), asc | desc}].
+board_order() -> [{score, desc}, {player_id, asc}].

--- a/src/matches/asobi_matchmaker.erl
+++ b/src/matches/asobi_matchmaker.erl
@@ -8,15 +8,36 @@ spawns a match, and pushes `match.matched` to each player. A single
 -behaviour(gen_server).
 
 -export([start_link/0, add/2, remove/2, get_ticket/1, get_ticket/2, get_queue_stats/0]).
--export([known_mode/1]).
+-export([known_mode/1, snapshot/0]).
 -export([init/1, handle_call/3, handle_cast/2, handle_info/2, terminate/2]).
 -ifdef(TEST).
--export([next_spawn_attempt/1, join_matched_players/3]).
+-export([next_spawn_attempt/1, join_matched_players/3, tally/1, render/3]).
 -endif.
+
+-export_type([snapshot/0, mode_queue/0]).
 
 -define(DEFAULT_TICK, 1000).
 -define(DEFAULT_MAX_QUEUE, 10000).
 -define(MAX_SPAWN_ATTEMPTS, 3).
+-define(SNAPSHOT_TABLE, asobi_matchmaker_snapshot).
+
+-type snapshot() :: #{
+    sampled_at := integer() | null,
+    age_ms := non_neg_integer() | null,
+    waiting := non_neg_integer(),
+    modes := [mode_queue()]
+}.
+
+-type mode_queue() :: #{
+    mode := binary(),
+    waiting := pos_integer(),
+    oldest_wait_ms := non_neg_integer(),
+    average_wait_ms := non_neg_integer()
+}.
+
+-type mode_tally() :: #{
+    waiting := pos_integer(), oldest := integer(), submitted_sum := integer()
+}.
 
 -spec start_link() -> gen_server:start_ret().
 start_link() ->
@@ -94,8 +115,99 @@ get_queue_stats() ->
         {ok, Stats} when is_map(Stats) -> {ok, Stats}
     end.
 
+-doc """
+The queue as an operator sees it: how many tickets are waiting, split by
+mode, and how long they have been waiting.
+
+Read from an ETS table this process publishes to on each tick, **not** by
+calling this process. The matchmaker is a single gen_server that runs every
+strategy and spawns every match inside its own tick, so a `gen_server:call`
+from an HTTP handler queues behind that work: the read would be slowest
+exactly when the queue is deepest and an operator most needs to look at it.
+The other direction is worse - HTTP concurrency is unbounded, so a console
+polling once a second, times however many operators, lands in the mailbox of
+the hottest process in the system. A read plane must not be able to slow the
+game path down, at any request rate.
+
+Publishing costs one `ets:insert/2` per tick over a fold the tick has already
+paid for. A reader pays one `ets:lookup/2` and sends no message at all.
+
+Waits are derived at read time from the sampled `submitted_at` values, so
+they keep ageing correctly between ticks; only the *counts* are as old as
+`age_ms`, at most one `tick_interval` (1s by default). Before the first tick,
+or with no matchmaker running, the result is an empty queue rather than an
+error - `null` timestamps say which.
+""".
+-spec snapshot() -> snapshot().
+snapshot() ->
+    Now = erlang:system_time(millisecond),
+    try ets:lookup(?SNAPSHOT_TABLE, queue) of
+        [{queue, SampledAt, Modes}] when is_integer(SampledAt), is_map(Modes) ->
+            render(SampledAt, Modes, Now);
+        _ ->
+            empty_snapshot()
+    catch
+        error:badarg -> empty_snapshot()
+    end.
+
+-spec empty_snapshot() -> snapshot().
+empty_snapshot() ->
+    #{sampled_at => null, age_ms => null, waiting => 0, modes => []}.
+
+-spec render(integer(), #{binary() => mode_tally()}, integer()) -> snapshot().
+render(SampledAt, Modes, Now) ->
+    Rows = [mode_queue(Mode, Tally, Now) || {Mode, Tally} <- maps:to_list(Modes)],
+    #{
+        sampled_at => SampledAt,
+        age_ms => waited(SampledAt, Now),
+        waiting => lists:sum([Waiting || #{waiting := Waiting} <- Rows]),
+        modes => Rows
+    }.
+
+-spec mode_queue(binary(), mode_tally(), integer()) -> mode_queue().
+mode_queue(Mode, #{waiting := Waiting, oldest := Oldest, submitted_sum := Sum}, Now) ->
+    #{
+        mode => Mode,
+        waiting => Waiting,
+        oldest_wait_ms => waited(Oldest, Now),
+        average_wait_ms => waited(Sum div Waiting, Now)
+    }.
+
+%% Clamped because system_time can step backwards; a negative wait would be
+%% read as a clock bug in the console rather than on the node.
+-spec waited(integer(), integer()) -> non_neg_integer().
+waited(At, Now) -> max(0, Now - At).
+
+-spec publish(map()) -> ok.
+publish(Tickets) ->
+    true = ets:insert(?SNAPSHOT_TABLE, {queue, erlang:system_time(millisecond), tally(Tickets)}),
+    ok.
+
+-spec tally(map()) -> #{binary() => mode_tally()}.
+tally(Tickets) ->
+    maps:fold(fun(_Id, Ticket, Acc) -> tally_ticket(Ticket, Acc) end, #{}, Tickets).
+
+-spec tally_ticket(term(), #{binary() => mode_tally()}) -> #{binary() => mode_tally()}.
+tally_ticket(#{mode := Mode, submitted_at := At}, Acc) when is_binary(Mode), is_integer(At) ->
+    case Acc of
+        #{Mode := #{waiting := Waiting, oldest := Oldest, submitted_sum := Sum}} ->
+            Acc#{
+                Mode => #{
+                    waiting => Waiting + 1,
+                    oldest => min(Oldest, At),
+                    submitted_sum => Sum + At
+                }
+            };
+        _ ->
+            Acc#{Mode => #{waiting => 1, oldest => At, submitted_sum => At}}
+    end;
+tally_ticket(_Ticket, Acc) ->
+    Acc.
+
 -spec init([]) -> {ok, map()}.
 init([]) ->
+    ?SNAPSHOT_TABLE = ets:new(?SNAPSHOT_TABLE, [named_table, protected, {read_concurrency, true}]),
+    ok = publish(#{}),
     Cfg = ensure_map(application:get_env(asobi, matchmaker, #{})),
     TickInterval =
         case maps:get(tick_interval, Cfg, ?DEFAULT_TICK) of
@@ -228,6 +340,7 @@ handle_info(tick, #{tickets := Tickets, tick_interval := Interval, max_wait := M
         lists:flatten(FailedGroups)
     ),
     erlang:send_after(Interval, self(), tick),
+    ok = publish(Remaining1),
     {noreply, State#{tickets => Remaining1}};
 handle_info(_Info, State) ->
     {noreply, State}.

--- a/src/ops/asobi_ops_caps.erl
+++ b/src/ops/asobi_ops_caps.erl
@@ -20,7 +20,8 @@ it, so an untagged or mis-mounted route is closed rather than open.
 -export([classes/0, class/2, authorised/2]).
 
 -type class() :: read | player_data | config.
--type route() :: {atom(), [binary()], class()}.
+-type segment() :: binary() | '_'.
+-type route() :: {atom(), [segment()], class()}.
 
 -export_type([class/0, route/0]).
 
@@ -35,7 +36,10 @@ classes() ->
     [
         {get, [~"players"], read},
         {get, [~"matches"], read},
-        {get, [~"features"], read}
+        {get, [~"features"], read},
+        {get, [~"leaderboards"], read},
+        {get, [~"leaderboards", '_', ~"entries"], read},
+        {get, [~"matchmaker"], read}
     ].
 
 -doc """
@@ -62,10 +66,19 @@ authorised(Class, Caps) -> lists:member(Class, Caps).
 lookup(undefined, _Segments) ->
     undefined;
 lookup(Method, Segments) ->
-    case [Class || {M, S, Class} <- classes(), M =:= Method, S =:= Segments] of
+    case [Class || {M, S, Class} <- classes(), M =:= Method, matches(S, Segments)] of
         [Class] -> Class;
         _ -> undefined
     end.
+
+%% `'_'` stands for a bound segment (`:id`). It matches one segment and never
+%% zero or many, so a tag cannot widen to cover a path the router would not
+%% route to the same handler.
+-spec matches([segment()], [binary()]) -> boolean().
+matches([], []) -> true;
+matches(['_' | Pattern], [_ | Segments]) -> matches(Pattern, Segments);
+matches([Same | Pattern], [Same | Segments]) -> matches(Pattern, Segments);
+matches(_, _) -> false.
 
 -spec method(binary()) -> atom().
 method(~"GET") -> get;

--- a/src/ops/asobi_ops_controller.erl
+++ b/src/ops/asobi_ops_controller.erl
@@ -16,9 +16,13 @@ the equivalent public endpoint already exposes.
 -include_lib("kernel/include/logger.hrl").
 -include_lib("kura/include/kura.hrl").
 
--export([players/1, matches/1, features/1]).
+-export([players/1, matches/1, features/1, leaderboards/1, leaderboard_entries/1, matchmaker/1]).
 
 -type response() :: {json, map()} | {json, integer(), map(), map()}.
+
+%% `leaderboard_id` is a VARCHAR(255); a longer binding matches no board, so
+%% it is answered as a bad request rather than paid for as a query.
+-define(MAX_BOARD_ID_BYTES, 255).
 
 -spec players(cowboy_req:req()) -> response().
 players(Req) ->
@@ -32,6 +36,41 @@ matches(Req) ->
 features(_Req) ->
     {json, asobi_ops_features:features()}.
 
+-spec leaderboards(cowboy_req:req()) -> response().
+leaderboards(Req) ->
+    rows(Req, fun asobi_ops_leaderboards:boards/1, fun asobi_ops_leaderboards:project_board/1).
+
+-spec leaderboard_entries(cowboy_req:req()) -> response().
+leaderboard_entries(#{bindings := #{~"id" := BoardId}} = Req) when
+    is_binary(BoardId), BoardId =/= ~"", byte_size(BoardId) =< ?MAX_BOARD_ID_BYTES
+->
+    list(
+        Req,
+        fun(Params) -> asobi_ops_leaderboards:entries_query(BoardId, Params) end,
+        fun asobi_ops_leaderboards:project_entry/1
+    );
+leaderboard_entries(_Req) ->
+    {json, 400, #{}, #{error => ~"invalid_board_id"}}.
+
+%% The snapshot is read once and used for both halves of the response, so the
+%% totals and the rows can never describe two different samples.
+-spec matchmaker(cowboy_req:req()) -> response().
+matchmaker(Req) ->
+    Params = params(Req),
+    Snapshot = asobi_matchmaker:snapshot(),
+    case asobi_ops_matchmaker:rows(Snapshot, Params) of
+        {ok, {Rows, Orders}} ->
+            Envelope = asobi_ops_page:slice(
+                Rows,
+                Orders,
+                asobi_ops_params:page(Params),
+                fun asobi_ops_matchmaker:project/1
+            ),
+            {json, Envelope#{queue => asobi_ops_matchmaker:summary(Snapshot)}};
+        {error, Reason} ->
+            error_response(Reason)
+    end.
+
 -spec list(
     cowboy_req:req(),
     fun((asobi_ops_params:params()) -> {ok, #kura_query{}} | {error, term()}),
@@ -43,24 +82,46 @@ list(Req, BuildQuery, Project) ->
         {ok, Query} ->
             page(Query, asobi_ops_params:page(Params), Project);
         {error, Reason} ->
-            {json, 400, #{}, error_body(Reason)}
+            error_response(Reason)
+    end.
+
+-spec rows(
+    cowboy_req:req(),
+    fun(
+        (asobi_ops_params:params()) ->
+            {ok, {[map()], asobi_ops_params:sort_spec()}} | {error, term()}
+    ),
+    fun((map()) -> map())
+) -> response().
+rows(Req, BuildRows, Project) ->
+    Params = params(Req),
+    case BuildRows(Params) of
+        {ok, {Rows, Orders}} ->
+            {json, asobi_ops_page:slice(Rows, Orders, asobi_ops_params:page(Params), Project)};
+        {error, Reason} ->
+            error_response(Reason)
     end.
 
 -spec page(#kura_query{}, asobi_ops_params:page_spec(), fun((map()) -> map())) -> response().
 page(Query, PageSpec, Project) ->
     case asobi_ops_page:list(Query, PageSpec, Project) of
-        {ok, Envelope} ->
-            {json, Envelope};
-        {error, Reason} ->
-            ?LOG_ERROR(#{msg => ~"ops list query failed", reason => Reason}),
-            {json, 500, #{}, #{error => ~"query_failed"}}
+        {ok, Envelope} -> {json, Envelope};
+        {error, Reason} -> error_response({query_failed, Reason})
     end.
 
 -spec params(cowboy_req:req()) -> asobi_ops_params:params().
 params(#{parsed_qs := Params}) when is_map(Params) -> Params;
 params(_Req) -> #{}.
 
--spec error_body(term()) -> map().
-error_body({unknown_sort, Field}) -> #{error => ~"unknown_sort_field", field => Field};
-error_body({unknown_order, Order}) -> #{error => ~"unknown_sort_order", order => Order};
-error_body(_) -> #{error => ~"bad_request"}.
+%% A rejected parameter is the caller's fault and says which one; a failed
+%% read is ours and says nothing beyond that, with the reason in the log.
+-spec error_response(term()) -> response().
+error_response({unknown_sort, Field}) ->
+    {json, 400, #{}, #{error => ~"unknown_sort_field", field => Field}};
+error_response({unknown_order, Order}) ->
+    {json, 400, #{}, #{error => ~"unknown_sort_order", order => Order}};
+error_response({query_failed, Reason}) ->
+    ?LOG_ERROR(#{msg => ~"ops list query failed", reason => Reason}),
+    {json, 500, #{}, #{error => ~"query_failed"}};
+error_response(_) ->
+    {json, 400, #{}, #{error => ~"bad_request"}}.

--- a/src/ops/asobi_ops_leaderboards.erl
+++ b/src/ops/asobi_ops_leaderboards.erl
@@ -1,0 +1,109 @@
+-module(asobi_ops_leaderboards).
+-moduledoc """
+Leaderboard reads for the ops plane: the board list, and one board's entries.
+
+The public leaderboard routes answer a player's question - my rank, the top
+100, who is near me. Neither of them can tell an operator which boards exist,
+and neither can reach past row 100 of one. Both of those are
+`asobi_leaderboards`; this module is the allowlist and the paging in front of
+it.
+
+The board list is sorted and paged in memory because its source is one
+grouped aggregate that has to run whole whatever page is asked for - see
+`asobi_leaderboards:boards/0`. The entries list is a query, paged by the
+database like every other list here.
+""".
+
+-include_lib("kura/include/kura.hrl").
+
+-export([boards/1, entries_query/2, project_board/1, project_entry/1]).
+-export([boards_sortable/0, entries_sortable/0]).
+
+-define(BOARDS_SORTABLE, [
+    {~"board_id", board_id},
+    {~"entries", entries},
+    {~"top_score", top_score},
+    {~"updated_at", updated_at}
+]).
+
+%% `rank` is deliberately absent: it is a window over the board's own order,
+%% so sorting by it can only reproduce the default, and ordering by a window
+%% alias would tie the endpoint to that being legal SQL.
+-define(ENTRIES_SORTABLE, [
+    {~"id", id},
+    {~"player_id", player_id},
+    {~"score", score},
+    {~"sub_score", sub_score},
+    {~"updated_at", updated_at}
+]).
+
+-doc "Wire-name to column mapping the board list accepts in `?sort=`.".
+-spec boards_sortable() -> asobi_ops_params:sort_allowlist().
+boards_sortable() -> ?BOARDS_SORTABLE.
+
+-doc "Wire-name to column mapping the entries list accepts in `?sort=`.".
+-spec entries_sortable() -> asobi_ops_params:sort_allowlist().
+entries_sortable() -> ?ENTRIES_SORTABLE.
+
+-doc """
+The board list, filtered and ordered, ready to page.
+
+Ordered by size first, because the operator question behind this endpoint is
+usually which board is being written to. The order ends on `board_id`, which
+is what makes the offset window stable.
+""".
+-spec boards(asobi_ops_params:params()) ->
+    {ok, {[map()], asobi_ops_params:sort_spec()}}
+    | {error, {unknown_sort, binary()} | {unknown_order, binary()} | {query_failed, term()}}.
+boards(Params) ->
+    case asobi_ops_params:sort(Params, ?BOARDS_SORTABLE, [{entries, desc}], {board_id, asc}) of
+        {ok, Orders} ->
+            case asobi_leaderboards:boards() of
+                {ok, Rows} -> {ok, {search(Rows, Params), Orders}};
+                {error, Reason} -> {error, {query_failed, Reason}}
+            end;
+        {error, _} = Error ->
+            Error
+    end.
+
+%% `q` matches the board id case-insensitively, the in-memory equivalent of
+%% the `ilike` the other list endpoints run.
+-spec search([map()], asobi_ops_params:params()) -> [map()].
+search(Rows, Params) ->
+    case asobi_ops_params:search(Params, ~"q") of
+        none ->
+            Rows;
+        {ok, Term} ->
+            Needle = string:lowercase(Term),
+            [Row || #{board_id := Id} = Row <- Rows, contains(string:lowercase(Id), Needle)]
+    end.
+
+-spec contains(binary() | string(), binary() | string()) -> boolean().
+contains(Haystack, Needle) -> string:find(Haystack, Needle) =/= nomatch.
+
+-doc "One board's entries as an ordered query for the shared paginator.".
+-spec entries_query(binary(), asobi_ops_params:params()) ->
+    {ok, #kura_query{}} | {error, {unknown_sort, binary()} | {unknown_order, binary()}}.
+entries_query(BoardId, Params) ->
+    Default = asobi_leaderboards:board_order(),
+    case asobi_ops_params:sort(Params, ?ENTRIES_SORTABLE, Default, {player_id, asc}) of
+        {ok, Orders} ->
+            {ok, kura_query:order_by(asobi_leaderboards:entries_query(BoardId), Orders)};
+        {error, _} = Error ->
+            Error
+    end.
+
+-doc "Positive allowlist of the fields a board summary may carry off this endpoint.".
+-spec project_board(map()) -> map().
+project_board(Board) ->
+    maps:with([board_id, entries, top_score, updated_at, live], Board).
+
+-doc """
+Positive allowlist of the fields a board entry may carry off this endpoint.
+
+The same fields `asobi_leaderboard_controller` already returns to any player,
+plus the row id. `metadata` is game-authored and does not leave.
+""".
+-spec project_entry(map()) -> map().
+project_entry(Entry) ->
+    maps:with([id, leaderboard_id, player_id, score, sub_score, rank, updated_at], Entry).

--- a/src/ops/asobi_ops_matchmaker.erl
+++ b/src/ops/asobi_ops_matchmaker.erl
@@ -1,0 +1,62 @@
+-module(asobi_ops_matchmaker).
+-moduledoc """
+The matchmaking queue for the ops plane: one row per mode.
+
+The rows come from `asobi_matchmaker:snapshot/0`, an ETS read that never
+touches the matchmaker's mailbox - the reason is on that function, and it is
+the whole design of this endpoint.
+
+No ticket, player or property ever appears here. An operator asking about the
+queue is asking whether a mode is filling, which is a count and two waits;
+who is waiting is player data and belongs behind a capability, not behind the
+same bearer token the game client already holds.
+""".
+
+-export([rows/2, summary/1, project/1, sortable/0]).
+
+-define(SORTABLE, [
+    {~"mode", mode},
+    {~"waiting", waiting},
+    {~"oldest_wait_ms", oldest_wait_ms},
+    {~"average_wait_ms", average_wait_ms}
+]).
+
+-doc "Wire-name to column mapping this endpoint accepts in `?sort=`.".
+-spec sortable() -> asobi_ops_params:sort_allowlist().
+sortable() -> ?SORTABLE.
+
+-doc """
+The per-mode rows and the order to page them in.
+
+Deepest queue first, since that is the mode in trouble. `mode` is unique
+across the rows and ends the order, so the offset window cannot repeat a row.
+""".
+-spec rows(asobi_matchmaker:snapshot(), asobi_ops_params:params()) ->
+    {ok, {[map()], asobi_ops_params:sort_spec()}}
+    | {error, {unknown_sort, binary()} | {unknown_order, binary()}}.
+rows(#{modes := Modes}, Params) ->
+    case asobi_ops_params:sort(Params, ?SORTABLE, [{waiting, desc}], {mode, asc}) of
+        {ok, Orders} -> {ok, {Modes, Orders}};
+        {error, _} = Error -> Error
+    end.
+
+-doc """
+Queue-wide totals, reported alongside the page.
+
+`sampled_at` and `age_ms` are part of the answer, not decoration: the counts
+are as old as the last matchmaker tick, and a console that renders them as
+live would show a queue that never quite settles.
+""".
+-spec summary(asobi_matchmaker:snapshot()) -> map().
+summary(#{sampled_at := SampledAt, age_ms := AgeMs, waiting := Waiting, modes := Modes}) ->
+    #{
+        waiting => Waiting,
+        modes => length(Modes),
+        sampled_at => SampledAt,
+        age_ms => AgeMs
+    }.
+
+-doc "Positive allowlist of the fields a queue row may carry off this endpoint.".
+-spec project(map()) -> map().
+project(Row) ->
+    maps:with([mode, waiting, oldest_wait_ms, average_wait_ms], Row).

--- a/src/ops/asobi_ops_page.erl
+++ b/src/ops/asobi_ops_page.erl
@@ -14,11 +14,16 @@ as one unit, so the two can never describe different filters.
 `Project` is applied to every row on the way out. It is the endpoint's field
 allowlist, not a formatter - see the projections in `asobi_ops_players` and
 `asobi_ops_matches`.
+
+`list/3` pages a database query; `slice/4` pages rows already in hand, for
+the reads the database cannot page - a queue held in a process, and a board
+list whose one grouped aggregate has to run whole either way. Both produce
+the identical envelope, so a console cannot tell them apart.
 """.
 
 -include_lib("kura/include/kura.hrl").
 
--export([list/3]).
+-export([list/3, slice/4]).
 
 -doc """
 Run `Query` as one page and wrap it in the envelope.
@@ -40,4 +45,45 @@ list(Query, #{limit := Limit, offset := Offset}, Project) when
             }};
         {error, _} = Error ->
             Error
+    end.
+
+-doc """
+Wrap an in-memory row list in the same envelope, sorting it first.
+
+`Orders` comes from `asobi_ops_params:sort/4` exactly as it would for a
+query, so it ends on a unique key and the window is stable between requests.
+Rows sort by Erlang term order rather than a database collation - these row
+sets are counts, timestamps and identifiers, never prose - and a missing key
+sorts as `undefined`, so a row is never dropped for lacking one.
+
+This never fails: the data is already read. Both sources it serves are
+bounded (a queue by `max_queue`, a board set by its enumeration cap), so
+sorting the whole list to return one page of it is not the cost that matters.
+""".
+-spec slice(
+    [map()], asobi_ops_params:sort_spec(), asobi_ops_params:page_spec(), fun((map()) -> map())
+) -> map().
+slice(Rows, Orders, #{limit := Limit, offset := Offset}, Project) when
+    is_integer(Limit), Limit > 0, is_integer(Offset), Offset >= 0
+->
+    Total = length(Rows),
+    Sorted = lists:sort(fun(A, B) -> precedes(Orders, A, B) end, Rows),
+    Window = lists:sublist(lists:nthtail(min(Offset, Total), Sorted), Limit),
+    #{
+        data => [Project(Row) || Row <- Window],
+        page => #{limit => Limit, offset => Offset, total => Total}
+    }.
+
+-spec precedes(asobi_ops_params:sort_spec(), map(), map()) -> boolean().
+precedes([], _A, _B) ->
+    true;
+precedes([{Key, Direction} | Rest], A, B) ->
+    Left = maps:get(Key, A, undefined),
+    Right = maps:get(Key, B, undefined),
+    if
+        %% `==`, not `=:=`: an integer and a float score that compare equal
+        %% must fall through to the tie-breaker, not to an arbitrary order.
+        Left == Right -> precedes(Rest, A, B);
+        Direction =:= asc -> Left < Right;
+        true -> Left > Right
     end.

--- a/src/ops/asobi_ops_params.erl
+++ b/src/ops/asobi_ops_params.erl
@@ -14,20 +14,22 @@ Three rules, each of them load-bearing:
   default would hide the mistake from the caller.
 * Every sort ends on a unique column. Offset pagination over a non-unique key
   can return one row twice and skip another between pages, so `sort/3` appends
-  the primary key as a tie-breaker.
+  the primary key as a tie-breaker, and `sort/4` takes the unique column for
+  a row set that is not keyed on `id`.
 
 `?page=N` and `?offset=N` both select a window. `page` wins when both are
 given. The offset returned is the one the query actually used - see `page/1`.
 """.
 
--export([page/1, sort/3, like_pattern/2, cursor/1, encode_cursor/1]).
+-export([page/1, sort/3, sort/4, search/2, like_pattern/2, cursor/1, encode_cursor/1]).
 
--export_type([params/0, page_spec/0, sort_spec/0, sort_allowlist/0]).
+-export_type([params/0, page_spec/0, sort_spec/0, sort_allowlist/0, tie_break/0]).
 
 -type params() :: #{binary() => binary() | true}.
 -type page_spec() :: #{limit := pos_integer(), offset := non_neg_integer()}.
 -type sort_spec() :: [{atom(), asc | desc}].
 -type sort_allowlist() :: [{binary(), atom()}].
+-type tie_break() :: {atom(), asc | desc}.
 
 -define(DEFAULT_LIMIT, 50).
 -define(MIN_LIMIT, 1).
@@ -77,20 +79,34 @@ completed with `{id, desc}` so the ordering is total.
 -spec sort(params(), sort_allowlist(), sort_spec()) ->
     {ok, sort_spec()} | {error, {unknown_sort, binary()} | {unknown_order, binary()}}.
 sort(Params, Allowed, Default) ->
+    sort(Params, Allowed, Default, {id, desc}).
+
+-doc """
+`sort/3` for a row set whose unique key is not `id`.
+
+A board's entries are unique on `player_id` within the board, a queue has one
+row per `mode`: those are the columns the order has to end on there. Passing
+the wrong one is not a syntax error, it is a page that can repeat a row, so
+the tie-breaker is named by the endpoint rather than assumed.
+""".
+-spec sort(params(), sort_allowlist(), sort_spec(), tie_break()) ->
+    {ok, sort_spec()} | {error, {unknown_sort, binary()} | {unknown_order, binary()}}.
+sort(Params, Allowed, Default, TieBreak) ->
     case maps:get(~"sort", Params, undefined) of
         Field when is_binary(Field), Field =/= ~"" ->
             case lists:keyfind(Field, 1, Allowed) of
-                {_, Column} -> sorted_by(Column, Params);
+                {_, Column} -> sorted_by(Column, Params, TieBreak);
                 false -> {error, {unknown_sort, Field}}
             end;
         _ ->
-            {ok, deterministic(Default)}
+            {ok, deterministic(Default, TieBreak)}
     end.
 
--spec sorted_by(atom(), params()) -> {ok, sort_spec()} | {error, {unknown_order, binary()}}.
-sorted_by(Column, Params) ->
+-spec sorted_by(atom(), params(), tie_break()) ->
+    {ok, sort_spec()} | {error, {unknown_order, binary()}}.
+sorted_by(Column, Params, TieBreak) ->
     case order(Params) of
-        {ok, Direction} -> {ok, deterministic([{Column, Direction}])};
+        {ok, Direction} -> {ok, deterministic([{Column, Direction}], TieBreak)};
         {error, _} = Error -> Error
     end.
 
@@ -107,25 +123,33 @@ order(Params) ->
             {ok, asc}
     end.
 
--spec deterministic(sort_spec()) -> sort_spec().
-deterministic(Orders) ->
-    case lists:keymember(id, 1, Orders) of
+-spec deterministic(sort_spec(), tie_break()) -> sort_spec().
+deterministic(Orders, {Column, _Direction} = TieBreak) ->
+    case lists:keymember(Column, 1, Orders) of
         true -> Orders;
-        false -> Orders ++ [{id, desc}]
+        false -> Orders ++ [TieBreak]
     end.
 
 -doc """
-Build an `ILIKE` pattern for a free-text search parameter.
+Read a free-text search parameter.
 
-Returns `none` when the parameter is absent, empty, or longer than 64 bytes.
+Returns `none` when the parameter is absent, empty, valueless, or longer than
+64 bytes. The one place the length rule lives, so a search that reaches the
+database and a search matched in memory accept the same input.
 """.
+-spec search(params(), binary()) -> {ok, binary()} | none.
+search(Params, Key) ->
+    case maps:get(Key, Params, undefined) of
+        Term when is_binary(Term), Term =/= ~"", byte_size(Term) =< ?MAX_SEARCH_BYTES -> {ok, Term};
+        _ -> none
+    end.
+
+-doc "Build an `ILIKE` pattern from the search parameter `search/2` accepts.".
 -spec like_pattern(params(), binary()) -> {ok, binary()} | none.
 like_pattern(Params, Key) ->
-    case maps:get(Key, Params, undefined) of
-        Term when is_binary(Term), Term =/= ~"", byte_size(Term) =< ?MAX_SEARCH_BYTES ->
-            {ok, iolist_to_binary([~"%", escape_like(Term), ~"%"])};
-        _ ->
-            none
+    case search(Params, Key) of
+        {ok, Term} -> {ok, iolist_to_binary([~"%", escape_like(Term), ~"%"])};
+        none -> none
     end.
 
 %% `%` and `_` are ILIKE wildcards and `\` is its escape character, so an

--- a/test/asobi_leaderboard_api_SUITE.erl
+++ b/test/asobi_leaderboard_api_SUITE.erl
@@ -9,7 +9,10 @@
     get_top/1,
     get_top_with_limit/1,
     get_around/1,
-    get_top_empty/1
+    get_top_empty/1,
+    ops_board_listing/1,
+    ops_board_entries_are_ranked_across_pages/1,
+    ops_board_entries_reject_unknown_sort/1
 ]).
 
 all() -> [{group, leaderboard_api}].
@@ -22,7 +25,10 @@ groups() ->
             submit_score,
             get_top,
             get_top_with_limit,
-            get_around
+            get_around,
+            ops_board_listing,
+            ops_board_entries_are_ranked_across_pages,
+            ops_board_entries_reject_unknown_sort
         ]}
     ].
 
@@ -54,9 +60,20 @@ init_per_suite(Config) ->
     %% Whitelist this board for client submits — submit_score_disabled
     %% deliberately uses an un-whitelisted board to confirm the gate.
     application:set_env(asobi, leaderboard_client_submit, [BoardId]),
+    %% The ops reads are database reads. Seed rows straight into the table
+    %% rather than waiting out the 30s flush, and out of rank order so the
+    %% ranking is proven rather than inherited from the insert order.
+    OpsBoardId = iolist_to_binary([
+        ~"ops_board_", integer_to_binary(erlang:unique_integer([positive]))
+    ]),
+    [{Pa, _}, {Pb, _}, {Pc, _} | _] = Players,
+    ok = seed_entry(OpsBoardId, Pb, 100),
+    ok = seed_entry(OpsBoardId, Pa, 300),
+    ok = seed_entry(OpsBoardId, Pc, 200),
     [
         {board_id, BoardId},
         {disabled_board_id, DisabledBoardId},
+        {ops_board_id, OpsBoardId},
         {player1_id, P1Id},
         {player1_token, P1Token},
         {players, Players}
@@ -69,6 +86,16 @@ end_per_suite(Config) ->
 
 auth(Token) when is_binary(Token) ->
     [{~"authorization", <<"Bearer ", Token/binary>>}].
+
+seed_entry(BoardId, PlayerId, Score) ->
+    Changeset = kura_changeset:cast(
+        asobi_leaderboard_entry,
+        #{},
+        #{leaderboard_id => BoardId, player_id => PlayerId, score => Score, sub_score => 0},
+        [leaderboard_id, player_id, score, sub_score]
+    ),
+    {ok, _} = asobi_repo:insert(Changeset),
+    ok.
 
 get_top_empty(Config) ->
     {board_id, BoardId} = lists:keyfind(board_id, 1, Config),
@@ -175,4 +202,67 @@ get_around(Config) ->
     #{~"entries" := Entries} = nova_test:json(Resp),
     true = is_list(Entries),
     ?assert(length(Entries) >= 1),
+    Config.
+
+%% Enumerating boards is the read core had no way to answer: the grouped
+%% aggregate has to compile and run, not just build.
+ops_board_listing(Config) ->
+    {ops_board_id, BoardId} = lists:keyfind(ops_board_id, 1, Config),
+    {player1_token, Token} = lists:keyfind(player1_token, 1, Config),
+    true = is_binary(BoardId),
+    true = is_binary(Token),
+    {ok, Resp} = nova_test:get(
+        "/api/v1/ops/leaderboards?q=" ++ binary_to_list(BoardId),
+        #{headers => auth(Token)},
+        Config
+    ),
+    ?assertStatus(200, Resp),
+    #{~"data" := [Board], ~"page" := Page} = nova_test:json(Resp),
+    ?assertEqual(BoardId, maps:get(~"board_id", Board)),
+    ?assertEqual(3, maps:get(~"entries", Board)),
+    ?assertEqual(300, maps:get(~"top_score", Board)),
+    ?assertEqual(false, maps:get(~"live", Board)),
+    ?assertEqual(1, maps:get(~"total", Page)),
+    Config.
+
+%% Rank is a window over the whole board, so page two carries rank 3 - not
+%% rank 1 restarted. That is the difference between a paged leaderboard and
+%% three unrelated pages of rows.
+ops_board_entries_are_ranked_across_pages(Config) ->
+    {ops_board_id, BoardId} = lists:keyfind(ops_board_id, 1, Config),
+    {player1_token, Token} = lists:keyfind(player1_token, 1, Config),
+    true = is_binary(BoardId),
+    true = is_binary(Token),
+    Path = "/api/v1/ops/leaderboards/" ++ binary_to_list(BoardId) ++ "/entries",
+    {ok, First} = nova_test:get(Path ++ "?limit=2", #{headers => auth(Token)}, Config),
+    ?assertStatus(200, First),
+    #{~"data" := FirstRows, ~"page" := FirstPage} = nova_test:json(First),
+    ?assertEqual(3, maps:get(~"total", FirstPage)),
+    ?assertEqual([{300, 1}, {200, 2}], [
+        {maps:get(~"score", R), maps:get(~"rank", R)}
+     || R <- FirstRows
+    ]),
+    {ok, Second} = nova_test:get(
+        Path ++ "?limit=2&offset=2", #{headers => auth(Token)}, Config
+    ),
+    ?assertStatus(200, Second),
+    #{~"data" := SecondRows} = nova_test:json(Second),
+    ?assertEqual([{100, 3}], [
+        {maps:get(~"score", R), maps:get(~"rank", R)}
+     || R <- SecondRows
+    ]),
+    Config.
+
+ops_board_entries_reject_unknown_sort(Config) ->
+    {ops_board_id, BoardId} = lists:keyfind(ops_board_id, 1, Config),
+    {player1_token, Token} = lists:keyfind(player1_token, 1, Config),
+    true = is_binary(BoardId),
+    true = is_binary(Token),
+    {ok, Resp} = nova_test:get(
+        "/api/v1/ops/leaderboards/" ++ binary_to_list(BoardId) ++ "/entries?sort=metadata",
+        #{headers => auth(Token)},
+        Config
+    ),
+    ?assertStatus(400, Resp),
+    ?assertJson(#{~"error" := ~"unknown_sort_field"}, Resp),
     Config.

--- a/test/asobi_leaderboard_api_SUITE.erl
+++ b/test/asobi_leaderboard_api_SUITE.erl
@@ -2,6 +2,8 @@
 
 -include_lib("nova_test/include/nova_test.hrl").
 
+-define(OPS_SECRET, ~"8e3a5d17c94b60f2ae81d3705c6f9b24d0a7e158b3c92f46071dab5e8c249f30").
+
 -export([all/0, groups/0, init_per_suite/1, end_per_suite/1]).
 -export([
     submit_score/1,
@@ -34,6 +36,10 @@ groups() ->
 
 init_per_suite(Config) ->
     Config0 = asobi_test_helpers:start(Config),
+    %% The ops plane authenticates as an operator, not as a player (ADR 0007).
+    %% Without this the reads below get a correct 403 rather than their data.
+    OpsSecretWas = application:get_env(asobi, ops_secret),
+    application:set_env(asobi, ops_secret, ?OPS_SECRET),
     Players = lists:map(
         fun(I) when is_integer(I) ->
             U = asobi_test_helpers:unique_username(
@@ -76,16 +82,29 @@ init_per_suite(Config) ->
         {ops_board_id, OpsBoardId},
         {player1_id, P1Id},
         {player1_token, P1Token},
-        {players, Players}
+        {players, Players},
+        {ops_secret_was, OpsSecretWas}
         | Config0
     ].
 
 end_per_suite(Config) ->
     application:unset_env(asobi, leaderboard_client_submit),
+    restore_ops_secret(Config),
     Config.
+
+restore_ops_secret(Config) ->
+    case lists:keyfind(ops_secret_was, 1, Config) of
+        {ops_secret_was, {ok, Value}} -> application:set_env(asobi, ops_secret, Value);
+        _ -> application:unset_env(asobi, ops_secret)
+    end.
 
 auth(Token) when is_binary(Token) ->
     [{~"authorization", <<"Bearer ", Token/binary>>}].
+
+%% The ops plane takes the operator credential, never a player token - a player
+%% token is a correct 403 here (ADR 0007), which is asserted in asobi_api_SUITE.
+ops_auth() ->
+    [{~"authorization", <<"Bearer ", (?OPS_SECRET)/binary>>}].
 
 seed_entry(BoardId, PlayerId, Score) ->
     Changeset = kura_changeset:cast(
@@ -213,7 +232,7 @@ ops_board_listing(Config) ->
     true = is_binary(Token),
     {ok, Resp} = nova_test:get(
         "/api/v1/ops/leaderboards?q=" ++ binary_to_list(BoardId),
-        #{headers => auth(Token)},
+        #{headers => ops_auth()},
         Config
     ),
     ?assertStatus(200, Resp),
@@ -234,7 +253,7 @@ ops_board_entries_are_ranked_across_pages(Config) ->
     true = is_binary(BoardId),
     true = is_binary(Token),
     Path = "/api/v1/ops/leaderboards/" ++ binary_to_list(BoardId) ++ "/entries",
-    {ok, First} = nova_test:get(Path ++ "?limit=2", #{headers => auth(Token)}, Config),
+    {ok, First} = nova_test:get(Path ++ "?limit=2", #{headers => ops_auth()}, Config),
     ?assertStatus(200, First),
     #{~"data" := FirstRows, ~"page" := FirstPage} = nova_test:json(First),
     ?assertEqual(3, maps:get(~"total", FirstPage)),
@@ -243,7 +262,7 @@ ops_board_entries_are_ranked_across_pages(Config) ->
      || R <- FirstRows
     ]),
     {ok, Second} = nova_test:get(
-        Path ++ "?limit=2&offset=2", #{headers => auth(Token)}, Config
+        Path ++ "?limit=2&offset=2", #{headers => ops_auth()}, Config
     ),
     ?assertStatus(200, Second),
     #{~"data" := SecondRows} = nova_test:json(Second),
@@ -260,7 +279,7 @@ ops_board_entries_reject_unknown_sort(Config) ->
     true = is_binary(Token),
     {ok, Resp} = nova_test:get(
         "/api/v1/ops/leaderboards/" ++ binary_to_list(BoardId) ++ "/entries?sort=metadata",
-        #{headers => auth(Token)},
+        #{headers => ops_auth()},
         Config
     ),
     ?assertStatus(400, Resp),

--- a/test/asobi_matchmaker_SUITE.erl
+++ b/test/asobi_matchmaker_SUITE.erl
@@ -17,7 +17,9 @@
     remove_then_readd_new_ticket/1,
     selfmatch_group_rejected/1,
     add_reply_reports_players_needed/1,
-    spawn_retry_bounded_then_gives_up/1
+    spawn_retry_bounded_then_gives_up/1,
+    queue_snapshot_reports_waiting_by_mode/1,
+    queue_snapshot_never_waits_on_the_matchmaker/1
 ]).
 
 all() ->
@@ -35,7 +37,9 @@ all() ->
         remove_then_readd_new_ticket,
         selfmatch_group_rejected,
         add_reply_reports_players_needed,
-        spawn_retry_bounded_then_gives_up
+        spawn_retry_bounded_then_gives_up,
+        queue_snapshot_reports_waiting_by_mode,
+        queue_snapshot_never_waits_on_the_matchmaker
     ].
 
 init_per_suite(Config) ->
@@ -194,3 +198,52 @@ spawn_retry_bounded_then_gives_up(Config) ->
     %% a missing/garbage attempts field defaults to 0
     ?assertEqual({retry, 1}, asobi_matchmaker:next_spawn_attempt([#{}])),
     Config.
+
+%% The ops read, end to end through a real tick: a queued ticket shows up as a
+%% waiting count against its mode, with a wait that is at least as old as the
+%% ticket. A mode of its own so the shared queue in this suite cannot flatter
+%% or spoil the count.
+queue_snapshot_reports_waiting_by_mode(Config) ->
+    {ok, TicketId, _} = asobi_matchmaker:add(~"player_snap", #{mode => ~"snapmode"}),
+    try
+        Row = await_mode(~"snapmode", 20),
+        ?assertEqual(1, maps:get(waiting, Row)),
+        ?assert(maps:get(oldest_wait_ms, Row) >= 0),
+        ?assertEqual(maps:get(oldest_wait_ms, Row), maps:get(average_wait_ms, Row)),
+        #{sampled_at := SampledAt, age_ms := AgeMs, waiting := Waiting} =
+            asobi_matchmaker:snapshot(),
+        ?assert(is_integer(SampledAt)),
+        ?assert(is_integer(AgeMs)),
+        ?assert(Waiting >= 1)
+    after
+        asobi_matchmaker:remove(~"player_snap", TicketId)
+    end,
+    Config.
+
+%% The reason the snapshot is an ETS read and not a call. With the matchmaker
+%% suspended - which is what a deep queue mid-tick looks like to a caller - the
+%% read still answers immediately. A `gen_server:call` here would block until
+%% the default 5s timeout and then exit.
+queue_snapshot_never_waits_on_the_matchmaker(Config) ->
+    ok = sys:suspend(asobi_matchmaker),
+    {Elapsed, Snapshot} =
+        try
+            timer:tc(fun() -> asobi_matchmaker:snapshot() end)
+        after
+            ok = sys:resume(asobi_matchmaker)
+        end,
+    ?assert(is_map(Snapshot)),
+    ?assert(Elapsed < 1000000),
+    Config.
+
+await_mode(_Mode, 0) ->
+    ct:fail(mode_never_appeared_in_snapshot);
+await_mode(Mode, Attempts) ->
+    #{modes := Modes} = asobi_matchmaker:snapshot(),
+    case [Row || #{mode := M} = Row <- Modes, M =:= Mode] of
+        [Row] ->
+            Row;
+        [] ->
+            timer:sleep(200),
+            await_mode(Mode, Attempts - 1)
+    end.

--- a/test/asobi_ops_auth_tests.erl
+++ b/test/asobi_ops_auth_tests.erl
@@ -17,8 +17,34 @@
 class_is_read_for_every_shipped_route_test() ->
     [
         ?assertEqual(read, asobi_ops_caps:class(~"GET", Path))
-     || Path <- [~"/api/v1/ops/players", ~"/api/v1/ops/matches", ~"/api/v1/ops/features"]
+     || Path <- [
+            ~"/api/v1/ops/players",
+            ~"/api/v1/ops/matches",
+            ~"/api/v1/ops/features",
+            ~"/api/v1/ops/leaderboards",
+            ~"/api/v1/ops/matchmaker"
+        ]
     ].
+
+%% A bound segment is tagged `'_'` and the request carries a real value, so
+%% any id must resolve. Without this the route is untagged at runtime and
+%% denied, which is the safe failure but still a broken endpoint.
+class_resolves_a_bound_segment_test() ->
+    [
+        ?assertEqual(read, asobi_ops_caps:class(~"GET", Path))
+     || Path <- [
+            ~"/api/v1/ops/leaderboards/global/entries",
+            ~"/api/v1/ops/leaderboards/019fca02-8553-792c-93e0-a0c7f803bc98/entries"
+        ]
+    ].
+
+%% The wildcard must not widen: it stands for exactly one segment, so neither
+%% a missing nor an extra segment may borrow the tag.
+class_wildcard_matches_exactly_one_segment_test() ->
+    ?assertEqual(undefined, asobi_ops_caps:class(~"GET", ~"/api/v1/ops/leaderboards/entries")),
+    ?assertEqual(
+        undefined, asobi_ops_caps:class(~"GET", ~"/api/v1/ops/leaderboards/a/b/entries")
+    ).
 
 %% routing_tree collapses `//` and edge slashes, so a variant that still
 %% routes must still find its tag - otherwise it would be denied as untagged.

--- a/test/asobi_ops_leaderboards_tests.erl
+++ b/test/asobi_ops_leaderboards_tests.erl
@@ -1,0 +1,218 @@
+-module(asobi_ops_leaderboards_tests).
+
+-include_lib("eunit/include/eunit.hrl").
+-include_lib("kura/include/kura.hrl").
+
+%%--------------------------------------------------------------------
+%% Board enumeration
+%%--------------------------------------------------------------------
+
+boards_test_() ->
+    {setup, fun setup_repo/0, fun cleanup_repo/1, [
+        fun enumeration_is_grouped_and_capped/0,
+        fun persisted_board_is_summarised/0,
+        fun live_board_without_rows_is_listed/0,
+        fun persisted_board_is_flagged_live/0,
+        fun repo_error_is_reported_not_swallowed/0
+    ]}.
+
+setup_repo() ->
+    meck:new(asobi_repo, [passthrough]),
+    meck:new(asobi_leaderboard_server, [passthrough]),
+    meck:expect(asobi_leaderboard_server, live_boards, fun() -> [] end),
+    ok.
+
+cleanup_repo(_) ->
+    catch meck:unload(asobi_repo),
+    catch meck:unload(asobi_leaderboard_server),
+    ok.
+
+expect_groups(Rows) ->
+    meck:expect(asobi_repo, all, fun(_Query) -> {ok, Rows} end).
+
+group_row(Id, Entries, TopScore) ->
+    #{
+        board_id => Id,
+        entries => Entries,
+        top_score => TopScore,
+        updated_at => {{2026, 8, 3}, {12, 0, 0}}
+    }.
+
+%% Counting every board is one aggregate scan whatever page is asked for, so
+%% the query has to group and has to be capped - an uncapped enumeration would
+%% ship a row per board id ever written.
+enumeration_is_grouped_and_capped() ->
+    expect_groups([]),
+    meck:reset(asobi_repo),
+    {ok, _} = asobi_leaderboards:boards(),
+    [{_, {asobi_repo, all, [Query]}, _}] = meck:history(asobi_repo),
+    ?assertEqual([leaderboard_id], Query#kura_query.group_bys),
+    ?assertEqual([{leaderboard_id, asc}], Query#kura_query.order_bys),
+    ?assertEqual(1000, Query#kura_query.limit).
+
+persisted_board_is_summarised() ->
+    expect_groups([group_row(~"arena", 12, 900)]),
+    {ok, [Board]} = asobi_leaderboards:boards(),
+    ?assertEqual(~"arena", maps:get(board_id, Board)),
+    ?assertEqual(12, maps:get(entries, Board)),
+    ?assertEqual(900, maps:get(top_score, Board)),
+    ?assertEqual(false, maps:get(live, Board)).
+
+%% A board is a process before it is a row: nothing is flushed for the first 30
+%% seconds. Enumerating only the table would tell an operator a board they can
+%% already read from does not exist.
+live_board_without_rows_is_listed() ->
+    expect_groups([]),
+    meck:expect(asobi_leaderboard_server, live_boards, fun() -> [~"fresh"] end),
+    {ok, [Board]} = asobi_leaderboards:boards(),
+    ?assertEqual(
+        #{board_id => ~"fresh", entries => 0, top_score => null, updated_at => null, live => true},
+        Board
+    ).
+
+persisted_board_is_flagged_live() ->
+    expect_groups([group_row(~"arena", 12, 900), group_row(~"duel", 3, 10)]),
+    meck:expect(asobi_leaderboard_server, live_boards, fun() -> [~"arena"] end),
+    {ok, Boards} = asobi_leaderboards:boards(),
+    ?assertEqual(2, length(Boards)),
+    ?assertEqual([{~"arena", true}, {~"duel", false}], [
+        {Id, Live}
+     || #{board_id := Id, live := Live} <- Boards
+    ]).
+
+repo_error_is_reported_not_swallowed() ->
+    meck:expect(asobi_repo, all, fun(_Query) -> {error, closed} end),
+    ?assertEqual({error, closed}, asobi_leaderboards:boards()),
+    ?assertEqual(
+        {error, {query_failed, closed}}, asobi_ops_leaderboards:boards(#{})
+    ).
+
+%%--------------------------------------------------------------------
+%% Board list paging
+%%--------------------------------------------------------------------
+
+board_list_test_() ->
+    {setup, fun setup_repo/0, fun cleanup_repo/1, [
+        fun boards_default_order_is_deterministic/0,
+        fun boards_sort_uses_allowlisted_atom/0,
+        fun boards_reject_unknown_sort/0,
+        fun boards_search_matches_id_case_insensitively/0
+    ]}.
+
+boards_default_order_is_deterministic() ->
+    expect_groups([]),
+    {ok, {_Rows, Orders}} = asobi_ops_leaderboards:boards(#{}),
+    ?assertEqual([{entries, desc}, {board_id, asc}], Orders).
+
+%% Boards have no `id` column, so the default tie-breaker would order by a
+%% field that is not there and leave the window unstable.
+boards_sort_uses_allowlisted_atom() ->
+    expect_groups([]),
+    {ok, {_Rows, Orders}} = asobi_ops_leaderboards:boards(#{~"sort" => ~"top_score"}),
+    ?assertEqual([{top_score, asc}, {board_id, asc}], Orders).
+
+boards_reject_unknown_sort() ->
+    expect_groups([]),
+    ?assertEqual(
+        {error, {unknown_sort, ~"metadata"}},
+        asobi_ops_leaderboards:boards(#{~"sort" => ~"metadata"})
+    ).
+
+boards_search_matches_id_case_insensitively() ->
+    expect_groups([group_row(~"Arena_EU", 1, 1), group_row(~"duel", 1, 1)]),
+    {ok, {Rows, _Orders}} = asobi_ops_leaderboards:boards(#{~"q" => ~"arena"}),
+    ?assertEqual([~"Arena_EU"], [Id || #{board_id := Id} <- Rows]).
+
+%%--------------------------------------------------------------------
+%% Entries query
+%%--------------------------------------------------------------------
+
+entries_scoped_to_one_board_test() ->
+    {ok, Query} = asobi_ops_leaderboards:entries_query(~"arena", #{}),
+    ?assertEqual([{leaderboard_id, ~"arena"}], Query#kura_query.wheres).
+
+entries_default_order_is_the_board_order_test() ->
+    {ok, Query} = asobi_ops_leaderboards:entries_query(~"arena", #{}),
+    ?assertEqual([{score, desc}, {player_id, asc}], Query#kura_query.order_bys).
+
+%% The invariant that keeps a paged rank honest: the window the database ranks
+%% in is the same total order the rows come back in, and the same one
+%% `asobi_leaderboard_server` keys its ETS table on.
+entries_rank_window_matches_the_board_order_test() ->
+    {ok, Query} = asobi_ops_leaderboards:entries_query(~"arena", #{}),
+    {exprs, Exprs} = Query#kura_query.select,
+    {rank, {over, row_number, #{order_by := WindowOrder}}} = lists:keyfind(rank, 1, Exprs),
+    ?assertEqual(asobi_leaderboards:board_order(), WindowOrder),
+    ?assertEqual(WindowOrder, Query#kura_query.order_bys).
+
+%% `player_id` is unique within a board, so it is what the order must end on;
+%% a sort on `score` alone repeats rows across pages whenever scores tie.
+entries_order_ends_on_the_unique_key_test() ->
+    {ok, Query} = asobi_ops_leaderboards:entries_query(~"arena", #{~"sort" => ~"score"}),
+    ?assertEqual([{score, asc}, {player_id, asc}], Query#kura_query.order_bys).
+
+entries_reject_unknown_sort_test() ->
+    ?assertEqual(
+        {error, {unknown_sort, ~"metadata"}},
+        asobi_ops_leaderboards:entries_query(~"arena", #{~"sort" => ~"metadata"})
+    ).
+
+entries_reject_unknown_order_test() ->
+    ?assertEqual(
+        {error, {unknown_order, ~"random"}},
+        asobi_ops_leaderboards:entries_query(~"arena", #{
+            ~"sort" => ~"score", ~"order" => ~"random"
+        })
+    ).
+
+%%--------------------------------------------------------------------
+%% Projections
+%%--------------------------------------------------------------------
+
+entry_projection_drops_game_authored_metadata_test() ->
+    Projected = asobi_ops_leaderboards:project_entry(#{
+        id => ~"e1",
+        leaderboard_id => ~"arena",
+        player_id => ~"p1",
+        score => 900,
+        sub_score => 2,
+        rank => 1,
+        updated_at => undefined,
+        metadata => #{~"secret" => true}
+    }),
+    ?assertNot(maps:is_key(metadata, Projected)),
+    ?assertEqual(1, maps:get(rank, Projected)).
+
+board_projection_is_an_allowlist_test() ->
+    Projected = asobi_ops_leaderboards:project_board(
+        (group_row(~"arena", 1, 1))#{live => false, secret => ~"no"}
+    ),
+    ?assertEqual(
+        [board_id, entries, live, top_score, updated_at], lists:sort(maps:keys(Projected))
+    ).
+
+boards_sortable_fields_are_all_projected_test() ->
+    Projected = maps:keys(
+        asobi_ops_leaderboards:project_board((group_row(~"arena", 1, 1))#{live => false})
+    ),
+    [
+        ?assert(lists:member(Column, Projected))
+     || {_Wire, Column} <- asobi_ops_leaderboards:boards_sortable()
+    ].
+
+entries_sortable_fields_are_all_projected_test() ->
+    Projected = maps:keys(
+        asobi_ops_leaderboards:project_entry(#{
+            id => ~"e1",
+            leaderboard_id => ~"arena",
+            player_id => ~"p1",
+            score => 1,
+            sub_score => 0,
+            rank => 1,
+            updated_at => undefined
+        })
+    ),
+    [
+        ?assert(lists:member(Column, Projected))
+     || {_Wire, Column} <- asobi_ops_leaderboards:entries_sortable()
+    ].

--- a/test/asobi_ops_matchmaker_tests.erl
+++ b/test/asobi_ops_matchmaker_tests.erl
@@ -1,0 +1,142 @@
+-module(asobi_ops_matchmaker_tests).
+
+-include_lib("eunit/include/eunit.hrl").
+
+%%--------------------------------------------------------------------
+%% Snapshot sampling
+%%--------------------------------------------------------------------
+
+ticket(Mode, SubmittedAt) ->
+    #{mode => Mode, submitted_at => SubmittedAt, player_id => ~"p", id => ~"t"}.
+
+tally_groups_by_mode_test() ->
+    Tickets = #{
+        ~"t1" => ticket(~"arena", 1000),
+        ~"t2" => ticket(~"arena", 3000),
+        ~"t3" => ticket(~"duel", 2000)
+    },
+    ?assertEqual(
+        #{
+            ~"arena" => #{waiting => 2, oldest => 1000, submitted_sum => 4000},
+            ~"duel" => #{waiting => 1, oldest => 2000, submitted_sum => 2000}
+        },
+        asobi_matchmaker:tally(Tickets)
+    ).
+
+tally_of_empty_queue_test() ->
+    ?assertEqual(#{}, asobi_matchmaker:tally(#{})).
+
+%% A ticket shape the matchmaker never mints is skipped rather than crashing the
+%% tick: publishing runs inside the tick, so a bad row must not stop matchmaking.
+tally_skips_unusable_ticket_test() ->
+    Tickets = #{~"t1" => #{mode => ~"arena"}, ~"t2" => ticket(~"arena", 1000)},
+    ?assertEqual(
+        #{~"arena" => #{waiting => 1, oldest => 1000, submitted_sum => 1000}},
+        asobi_matchmaker:tally(Tickets)
+    ).
+
+modes() ->
+    #{~"arena" => #{waiting => 2, oldest => 1000, submitted_sum => 4000}}.
+
+render_reports_totals_test() ->
+    Snapshot = asobi_matchmaker:render(5000, modes(), 6000),
+    ?assertEqual([age_ms, modes, sampled_at, waiting], lists:sort(maps:keys(Snapshot))),
+    ?assertEqual(5000, maps:get(sampled_at, Snapshot)),
+    ?assertEqual(1000, maps:get(age_ms, Snapshot)),
+    ?assertEqual(2, maps:get(waiting, Snapshot)).
+
+render_waits_are_relative_to_the_reader_test() ->
+    [#{oldest_wait_ms := Oldest, average_wait_ms := Average}] =
+        maps:get(modes, asobi_matchmaker:render(5000, modes(), 6000)),
+    ?assertEqual(5000, Oldest),
+    ?assertEqual(4000, Average).
+
+%% The reason waits are derived at read time and not at publish time: between
+%% ticks the counts hold still but the waits must keep growing, or a queue that
+%% is not moving looks like a queue nobody is waiting in.
+render_waits_age_between_ticks_test() ->
+    [#{oldest_wait_ms := Early}] = maps:get(modes, asobi_matchmaker:render(5000, modes(), 6000)),
+    [#{oldest_wait_ms := Later}] = maps:get(modes, asobi_matchmaker:render(5000, modes(), 9000)),
+    ?assertEqual(3000, Later - Early).
+
+%% system_time can step backwards. A negative wait would be read as a broken
+%% console rather than a corrected clock.
+render_clamps_a_backward_clock_test() ->
+    Future = #{~"arena" => #{waiting => 1, oldest => 9000, submitted_sum => 9000}},
+    Snapshot = asobi_matchmaker:render(9000, Future, 5000),
+    ?assertEqual(0, maps:get(age_ms, Snapshot)),
+    [#{oldest_wait_ms := Oldest, average_wait_ms := Average}] = maps:get(modes, Snapshot),
+    ?assertEqual(0, Oldest),
+    ?assertEqual(0, Average).
+
+%% Reading the queue is total: no matchmaker, or no tick yet, is an empty queue
+%% with null timestamps, never an exit and never a blocked caller.
+snapshot_is_total_test() ->
+    Snapshot = asobi_matchmaker:snapshot(),
+    ?assertEqual([age_ms, modes, sampled_at, waiting], lists:sort(maps:keys(Snapshot))),
+    ?assert(is_list(maps:get(modes, Snapshot))),
+    ?assert(is_integer(maps:get(waiting, Snapshot))).
+
+%%--------------------------------------------------------------------
+%% Ops projection
+%%--------------------------------------------------------------------
+
+snapshot(Modes) ->
+    #{sampled_at => 5000, age_ms => 900, waiting => 3, modes => Modes}.
+
+row(Mode, Waiting) ->
+    #{mode => Mode, waiting => Waiting, oldest_wait_ms => 100, average_wait_ms => 50}.
+
+rows_default_order_is_deepest_queue_first_test() ->
+    {ok, {_Rows, Orders}} = asobi_ops_matchmaker:rows(snapshot([]), #{}),
+    ?assertEqual([{waiting, desc}, {mode, asc}], Orders).
+
+%% One row per mode, so `mode` is the unique key the order has to end on -
+%% `id`, the default tie-breaker, does not exist on these rows at all.
+rows_order_ends_on_the_unique_key_test() ->
+    {ok, {_Rows, Orders}} = asobi_ops_matchmaker:rows(snapshot([]), #{~"sort" => ~"waiting"}),
+    ?assertEqual({mode, asc}, lists:last(Orders)).
+
+rows_sort_uses_allowlisted_atom_test() ->
+    {ok, {_Rows, Orders}} = asobi_ops_matchmaker:rows(
+        snapshot([]), #{~"sort" => ~"oldest_wait_ms", ~"order" => ~"desc"}
+    ),
+    ?assertEqual([{oldest_wait_ms, desc}, {mode, asc}], Orders).
+
+rows_reject_unknown_sort_test() ->
+    ?assertEqual(
+        {error, {unknown_sort, ~"player_id"}},
+        asobi_ops_matchmaker:rows(snapshot([]), #{~"sort" => ~"player_id"})
+    ).
+
+rows_reject_unknown_order_test() ->
+    ?assertEqual(
+        {error, {unknown_order, ~"sideways"}},
+        asobi_ops_matchmaker:rows(snapshot([]), #{~"sort" => ~"mode", ~"order" => ~"sideways"})
+    ).
+
+rows_pass_the_modes_through_test() ->
+    Modes = [row(~"arena", 2), row(~"duel", 1)],
+    ?assertMatch({ok, {Modes, _}}, asobi_ops_matchmaker:rows(snapshot(Modes), #{})).
+
+summary_reports_staleness_test() ->
+    Summary = asobi_ops_matchmaker:summary(snapshot([row(~"arena", 3)])),
+    ?assertEqual(#{waiting => 3, modes => 1, sampled_at => 5000, age_ms => 900}, Summary).
+
+%% Who is queued is player data. The queue endpoint answers how many and how
+%% long, and a ticket or player id must not survive the projection even if the
+%% snapshot ever starts carrying one.
+project_drops_ticket_detail_test() ->
+    Projected = asobi_ops_matchmaker:project(
+        (row(~"arena", 2))#{player_id => ~"p1", ticket_id => ~"t1", properties => #{}}
+    ),
+    ?assertEqual(
+        [average_wait_ms, mode, oldest_wait_ms, waiting], lists:sort(maps:keys(Projected))
+    ).
+
+sortable_fields_are_all_projected_test() ->
+    Projected = maps:keys(asobi_ops_matchmaker:project(row(~"arena", 1))),
+    [
+        ?assert(lists:member(Column, Projected))
+     || {_Wire, Column} <- asobi_ops_matchmaker:sortable()
+    ].

--- a/test/asobi_ops_params_tests.erl
+++ b/test/asobi_ops_params_tests.erl
@@ -150,6 +150,69 @@ sort_does_not_duplicate_id_test() ->
     ).
 
 %%--------------------------------------------------------------------
+%% Sort with an explicit tie-breaker
+%%--------------------------------------------------------------------
+
+%% A row set that is not keyed on `id` - a queue keyed on `mode`, a board's
+%% entries keyed on `player_id` - must end on *its* unique column. Appending
+%% `id` there orders by a field the rows do not have, which is the
+%% repeat-a-row bug the tie-breaker exists to prevent.
+sort_ends_on_the_given_tie_break_test() ->
+    ?assertEqual(
+        {ok, [{waiting, desc}, {mode, asc}]},
+        asobi_ops_params:sort(
+            #{~"sort" => ~"waiting", ~"order" => ~"desc"},
+            [{~"waiting", waiting}],
+            [{waiting, desc}],
+            {mode, asc}
+        )
+    ).
+
+sort_default_also_ends_on_the_tie_break_test() ->
+    ?assertEqual(
+        {ok, [{entries, desc}, {board_id, asc}]},
+        asobi_ops_params:sort(#{}, [{~"entries", entries}], [{entries, desc}], {board_id, asc})
+    ).
+
+sort_does_not_duplicate_the_tie_break_test() ->
+    ?assertEqual(
+        {ok, [{score, desc}, {player_id, asc}]},
+        asobi_ops_params:sort(
+            #{},
+            [{~"score", score}],
+            [{score, desc}, {player_id, asc}],
+            {player_id, asc}
+        )
+    ).
+
+sort_with_tie_break_still_rejects_unknown_field_test() ->
+    ?assertEqual(
+        {error, {unknown_sort, ~"properties"}},
+        asobi_ops_params:sort(
+            #{~"sort" => ~"properties"}, [{~"mode", mode}], [{mode, asc}], {mode, asc}
+        )
+    ).
+
+%%--------------------------------------------------------------------
+%% Search terms
+%%--------------------------------------------------------------------
+
+search_absent_test() ->
+    ?assertEqual(none, asobi_ops_params:search(#{}, ~"q")).
+
+search_valueless_test() ->
+    ?assertEqual(none, asobi_ops_params:search(#{~"q" => true}, ~"q")).
+
+search_too_long_test() ->
+    ?assertEqual(none, asobi_ops_params:search(#{~"q" => binary:copy(~"a", 65)}, ~"q")).
+
+%% The in-memory search and the `ilike` search take the same input, so the
+%% length rule is checked once for both.
+search_returns_the_raw_term_test() ->
+    ?assertEqual({ok, ~"kai%to"}, asobi_ops_params:search(#{~"q" => ~"kai%to"}, ~"q")),
+    ?assertEqual({ok, ~"%kai\\%to%"}, asobi_ops_params:like_pattern(#{~"q" => ~"kai%to"}, ~"q")).
+
+%%--------------------------------------------------------------------
 %% Search patterns
 %%--------------------------------------------------------------------
 

--- a/test/asobi_ops_tests.erl
+++ b/test/asobi_ops_tests.erl
@@ -318,7 +318,7 @@ ops_path(_Path) -> false.
 %% runtime, so this is the check that turns that denial into a build failure.
 ops_routes_and_capability_classes_agree_test() ->
     Routed = lists:sort([
-        {Method, binary:split(Path, ~"/", [global, trim_all])}
+        {Method, [binding_or_literal(S) || S <- binary:split(Path, ~"/", [global, trim_all])]}
      || #{prefix := ~"/api/v1/ops", routes := Routes} <- asobi_router:routes(dev),
         {Path, _Handler, Opts} <- Routes,
         Method <- maps:get(methods, Opts),
@@ -326,6 +326,12 @@ ops_routes_and_capability_classes_agree_test() ->
     ]),
     Tagged = lists:sort([{Method, Segments} || {Method, Segments, _} <- asobi_ops_caps:classes()]),
     ?assertEqual(Tagged, Routed).
+
+%% The router spells a bound segment `:id`; the class table spells it `'_'`,
+%% because it matches against a real request path where the binding is already
+%% a value. Normalise so the two are comparable without weakening the check.
+binding_or_literal(<<":", _/binary>>) -> '_';
+binding_or_literal(Segment) -> Segment.
 
 route(Groups, Prefix, Path) ->
     [Found] = [

--- a/test/asobi_ops_tests.erl
+++ b/test/asobi_ops_tests.erl
@@ -85,6 +85,77 @@ query() ->
 identity(Row) -> Row.
 
 %%--------------------------------------------------------------------
+%% In-memory envelope
+%%--------------------------------------------------------------------
+
+slice_rows() ->
+    [
+        #{mode => ~"duel", waiting => 2},
+        #{mode => ~"arena", waiting => 9},
+        #{mode => ~"coop", waiting => 2}
+    ].
+
+%% A console must not be able to tell a process-backed list from a
+%% table-backed one.
+slice_envelope_matches_the_query_envelope_test() ->
+    Envelope = asobi_ops_page:slice(
+        slice_rows(), [{waiting, desc}, {mode, asc}], #{limit => 50, offset => 0}, fun identity/1
+    ),
+    ?assertEqual([data, page], lists:sort(maps:keys(Envelope))),
+    ?assertEqual(#{limit => 50, offset => 0, total => 3}, maps:get(page, Envelope)).
+
+slice_orders_before_it_windows_test() ->
+    #{data := Data} = asobi_ops_page:slice(
+        slice_rows(), [{waiting, desc}, {mode, asc}], #{limit => 2, offset => 0}, fun identity/1
+    ),
+    ?assertEqual([~"arena", ~"coop"], [Mode || #{mode := Mode} <- Data]).
+
+%% The tie-breaker earning its place: `coop` and `duel` are both waiting 2, and
+%% the second page must continue where the first stopped rather than repeat a
+%% row the map happened to yield first.
+slice_offset_does_not_repeat_a_tied_row_test() ->
+    Orders = [{waiting, desc}, {mode, asc}],
+    #{data := First} = asobi_ops_page:slice(
+        slice_rows(), Orders, #{limit => 2, offset => 0}, fun identity/1
+    ),
+    #{data := Second} = asobi_ops_page:slice(
+        slice_rows(), Orders, #{limit => 2, offset => 2}, fun identity/1
+    ),
+    ?assertEqual([~"arena", ~"coop", ~"duel"], [Mode || #{mode := Mode} <- First ++ Second]).
+
+slice_total_counts_every_row_not_the_page_test() ->
+    #{page := Page} = asobi_ops_page:slice(
+        slice_rows(), [{mode, asc}], #{limit => 1, offset => 0}, fun identity/1
+    ),
+    ?assertEqual(3, maps:get(total, Page)).
+
+slice_offset_past_the_end_is_an_empty_page_test() ->
+    Envelope = asobi_ops_page:slice(
+        slice_rows(), [{mode, asc}], #{limit => 10, offset => 100}, fun identity/1
+    ),
+    ?assertEqual(#{data => [], page => #{limit => 10, offset => 100, total => 3}}, Envelope).
+
+slice_applies_projection_test() ->
+    #{data := [Row | _]} = asobi_ops_page:slice(
+        [#{mode => ~"arena", waiting => 1, player_id => ~"p1"}],
+        [{mode, asc}],
+        #{limit => 10, offset => 0},
+        fun asobi_ops_matchmaker:project/1
+    ),
+    ?assertNot(maps:is_key(player_id, Row)).
+
+%% Sorting a row set that has gained a field must not drop the rows that
+%% predate it.
+slice_treats_a_missing_key_as_undefined_test() ->
+    #{data := Data} = asobi_ops_page:slice(
+        [#{mode => ~"arena"}, #{mode => ~"duel", waiting => 1}],
+        [{waiting, asc}, {mode, asc}],
+        #{limit => 10, offset => 0},
+        fun identity/1
+    ),
+    ?assertEqual(2, length(Data)).
+
+%%--------------------------------------------------------------------
 %% Player query
 %%--------------------------------------------------------------------
 
@@ -223,7 +294,14 @@ ops_routes_are_mounted_behind_the_operator_check_test() ->
             {fun asobi_ops_auth:verify/1, [get, options]},
             route(Groups, ~"/api/v1/ops", Path)
         )
-     || Path <- [~"/players", ~"/matches", ~"/features"]
+     || Path <- [
+            ~"/players",
+            ~"/matches",
+            ~"/features",
+            ~"/leaderboards",
+            ~"/leaderboards/:id/entries",
+            ~"/matchmaker"
+        ]
     ].
 
 no_ops_route_sits_in_the_player_scoped_group_test() ->


### PR DESCRIPTION
Plan item **2a.5** - the two ops reads the integration plan singles out because they need core work, not just an endpoint, and names as the blockers for a managed console.

## Leaderboards

`asobi_leaderboard_server` answers questions about *one* board it already holds in ETS, capped at 100 rows precisely so a caller cannot walk it. Neither "which boards exist" nor "rows 500-550 of this board" can be answered that way, so a new `asobi_leaderboards` reads both from Postgres and takes only the `live` flag from the process layer.

`live` is the interesting half for an operator: a board is live without rows for its first 30 seconds (the flush interval) and has rows without being live once nothing has written to it since the node started. Both cases are enumerated - the DB groups, `pg` supplies the rest.

`rank` is a `row_number` window over the board's own total order - `score` desc then `player_id`, the same order the ETS table is keyed on - computed before `LIMIT` applies. Page two therefore carries ranks 51-100 rather than restarting at 1, and a rank read here agrees with `asobi_leaderboard_server:rank/2` on any flushed score.

```
GET /api/v1/ops/leaderboards                 board list, live flag, entry counts
GET /api/v1/ops/leaderboards/:id/entries     one board, ranked, paged
```

## Matchmaker

The queue is published to a protected ETS table on each tick and read from there, **never** by calling the matchmaker.

The matchmaker is a single gen_server that runs every strategy and spawns every match inside its own tick, so a `gen_server:call` from an HTTP handler queues behind that work - the read would be slowest exactly when the queue is deepest and an operator most needs it. The other direction is worse: HTTP concurrency is unbounded, so a console polling once a second, times however many operators, lands in the mailbox of the hottest process in the system. Publishing costs one `ets:insert/2` over a fold the tick already pays for; a reader pays one `ets:lookup/2` and sends no message.

Waits are derived at read time from the sampled `submitted_at` values, so they keep ageing correctly between ticks; only the counts are stale, and `age_ms` says by how much.

```
GET /api/v1/ops/matchmaker                   waiting, by mode, with waits
```

No ticket, player id or ticket property leaves this endpoint. Who is queued is player data and waits on the capability model (ADR 0007).

## Conventions

Both follow #335: the `{data, page}` envelope, clamped paging, a sort allowlist of atoms so no user string reaches `order_by`, and an order that ends on a unique key. Neither row set is keyed on `id`, so `asobi_ops_params:sort/4` now takes the tie-breaker (`board_id`, `player_id` within a board, `mode` for the queue) instead of assuming one. `asobi_ops_page:slice/4` pages the two row sets the database cannot page, into the identical envelope.

Routes keep the exact shape of the existing three, so the concurrent capability-tagging pass stays mechanical.

## Tests

- `asobi_ops_leaderboards_tests`, `asobi_ops_matchmaker_tests`: new. Enumeration is grouped and capped, a live board with no rows is listed, waits age between ticks, a backward clock clamps, the rank window and the default listing order cannot drift apart.
- `asobi_leaderboard_api_SUITE`: the grouped aggregate and the window rank against real Postgres, including rank 3 landing on page two. Verified load-bearing - changing the window order fails it.
- `asobi_matchmaker_SUITE`: a queued ticket appears in the snapshot after a real tick, and the snapshot still answers with the matchmaker suspended, which a `gen_server:call` would not.
- `asobi_ops_params_tests`, `asobi_ops_tests`: tie-breaker, search term, in-memory envelope. Verified load-bearing by reverting `sort/4` to the fixed `id` tie-breaker: 11 failures.

`fmt --check`, `xref`, `dialyzer`, `ex_doc` and the full `eunit` (1177 tests) are clean.

No write endpoints. This is the read plane.