### PR TITLE
feat: port the four asobi_lua commits that landed after the merge snapshot

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -50,7 +50,9 @@ rebar3 shell               # dev node on port 8082, DB asobi_dev
 ```
 
 Postgres is Docker Compose only, never a system install. CT integration
-suites talk to that container.
+suites talk to that container. `asobi_lua_storage_SUITE` in particular runs
+`game.storage.*` against it with no mocks - a mock is only as good as its
+assumption about the driver, which is how #296 shipped.
 
 ## Pre-push checklist (mandatory)
 

--- a/guides/lua-scripting.md
+++ b/guides/lua-scripting.md
@@ -149,6 +149,7 @@ max_players  = 10                         -- optional: max per match (defaults t
 strategy     = "fill"                     -- optional: "fill" or "skill_based"
 bots         = { script = "bots/ai.lua" } -- optional: enable bot filling
 guest_auth   = true                       -- optional: allow anonymous guest play
+registration = "closed"                   -- optional: signup posture
 ```
 
 | Global | Required | Default | Description |
@@ -158,6 +159,7 @@ guest_auth   = true                       -- optional: allow anonymous guest pla
 | `strategy` | no | `"fill"` | Matchmaking strategy |
 | `bots` | no | none | Bot configuration (see [Bots](lua-bots.md)) |
 | `guest_auth` | no | `false` | Enable anonymous guest play. Also requires an operator-supplied pepper; on iff both are present (asobi ADR 0004) |
+| `registration` | no | `"open"` | Signup posture: `"open"`, `"oauth_only"` (no password signup), or `"closed"` (no new players at all). The operator layer wins: this applies only when the release's `sys.config` leaves `registration` unset |
 | `lazy_zones` | no | auto | On-demand zone loading (auto-enabled for grids > 100) |
 | `zone_idle_timeout` | no | 30000 | Milliseconds before an idle zone is reaped |
 | `max_active_zones` | no | 10000 | Maximum concurrent zones in memory |
@@ -166,7 +168,8 @@ guest_auth   = true                       -- optional: allow anonymous guest pla
 
 For a single-mode game these globals live in `match.lua`. In a multi-mode game
 (a `config.lua` manifest that maps modes to match scripts), deployment-wide
-settings such as `guest_auth` go in `config.lua`, not the per-mode scripts.
+settings such as `guest_auth` and `registration` go in `config.lua`, not the
+per-mode scripts.
 
 ## Using with Erlang Projects
 

--- a/src/asobi_game_config.erl
+++ b/src/asobi_game_config.erl
@@ -31,6 +31,15 @@ the pepper), so a declared value simply replaces the current flag. It is
 written before the modes so a reader waking on the mode change already sees
 the final auth posture.
 
+## registration is a second layer, like the modes
+
+A game may declare a signup posture, which lands in `script_registration` -
+never in `registration`, the operator's key from `sys.config`. `asobi_registration`
+composes the two the same way `modes/0` does: the operator layer wins whenever
+it is set. That is what lets an engine-hosted game with no `sys.config` of its
+own pick a posture (asobi_lua#122) without letting a game bundle widen an
+operator's `closed` deployment back to `open`.
+
 A term that omits a key leaves that key alone: `apply_config(#{modes => M})` is
 how the config watcher refreshes mode shape without letting a bundle write flip
 auth posture at runtime.
@@ -41,7 +50,11 @@ auth posture at runtime.
 -export([apply_config/1, modes/0]).
 
 -type modes() :: #{binary() => map() | module()}.
--type config() :: #{modes => modes(), guest_auth => boolean()}.
+-type config() :: #{
+    modes => modes(),
+    guest_auth => boolean(),
+    registration => asobi_registration:mode()
+}.
 
 -export_type([config/0, modes/0]).
 
@@ -54,12 +67,21 @@ modes() ->
 -spec apply_config(config()) -> ok.
 apply_config(Config) ->
     ok = write_guest_auth(Config),
+    ok = write_registration(Config),
     write_modes(Config).
 
 -spec write_guest_auth(config()) -> ok.
 write_guest_auth(#{guest_auth := Declared}) when is_boolean(Declared) ->
     application:set_env(asobi, guest_auth, Declared);
 write_guest_auth(_) ->
+    ok.
+
+-spec write_registration(config()) -> ok.
+write_registration(#{registration := Declared}) when
+    Declared =:= open; Declared =:= oauth_only; Declared =:= closed
+->
+    application:set_env(asobi, script_registration, Declared);
+write_registration(_) ->
     ok.
 
 -spec write_modes(config()) -> ok.

--- a/src/asobi_registration.erl
+++ b/src/asobi_registration.erl
@@ -9,11 +9,15 @@
 
 -export_type([mode/0, kind/0]).
 
-%% Registration posture is an operator deployment decision, not a game
-%% capability, so it reads from app env, not the game manifest. See ADR 0002
-%% for why `open` is the default and why an unrecognised value falls to `open`.
-%% mode/0 is on the per-request create path and stays silent; log_mode/0 emits
-%% the invalid-value signal once at boot.
+%% Registration posture has two layers, composed the way ADR 0006 composes the
+%% mode registry: `registration` is the operator's key from sys.config and wins
+%% whenever it is set, `script_registration` is what the loaded game declared
+%% (asobi_lua#122 - an engine-hosted game has no sys.config to edit, so without
+%% a script layer every hosted game silently ran `open`). A game bundle can
+%% therefore choose a posture for a deployment that states none, and can never
+%% widen one that does. See ADR 0002 for why `open` is the default and why an
+%% unrecognised value falls to `open`. mode/0 is on the per-request create path
+%% and stays silent; log_mode/0 emits the invalid-value signal once at boot.
 -spec mode() -> mode().
 mode() ->
     case classify() of
@@ -23,12 +27,16 @@ mode() ->
 
 -spec classify() -> {ok, mode()} | {invalid, term()}.
 classify() ->
-    case application:get_env(asobi, registration, open) of
-        open -> {ok, open};
-        oauth_only -> {ok, oauth_only};
-        closed -> {ok, closed};
-        Other -> {invalid, Other}
+    case application:get_env(asobi, registration) of
+        undefined -> classify_value(application:get_env(asobi, script_registration, open));
+        {ok, Value} -> classify_value(Value)
     end.
+
+-spec classify_value(term()) -> {ok, mode()} | {invalid, term()}.
+classify_value(open) -> {ok, open};
+classify_value(oauth_only) -> {ok, oauth_only};
+classify_value(closed) -> {ok, closed};
+classify_value(Other) -> {invalid, Other}.
 
 %% Whether a create path may mint a new player. `closed` freezes every public
 %% signup path (password, oauth-first-time, guest-first-time); `oauth_only`

--- a/src/lua/asobi_lua_api.erl
+++ b/src/lua/asobi_lua_api.erl
@@ -82,7 +82,7 @@ their value directly.
 -export([install/2]).
 -export([deep_decode/1, decode_to_map/2]).
 -export([to_storage_value/1]).
--export([atomize_entities/1]).
+-export([atomize_entities/1, atomize_keys/1]).
 
 -spec install(map(), dynamic()) -> dynamic().
 install(#{probe := true} = Ctx, St0) ->
@@ -814,7 +814,9 @@ fun_zone_spawn(#{zone_pid := ZonePid} = Ctx) ->
                         %% populated, string-keyed table already decodes to a map.
                         case Overrides0 of
                             Overrides when is_map(Overrides) ->
-                                asobi_zone:spawn_entity(ZonePid, TemplateId, {X, Y}, Overrides),
+                                asobi_zone:spawn_entity(
+                                    ZonePid, TemplateId, {X, Y}, atomize_keys(Overrides)
+                                ),
                                 {[true], St};
                             [] ->
                                 asobi_zone:spawn_entity(ZonePid, TemplateId, {X, Y}, #{}),
@@ -1193,6 +1195,11 @@ atomize_entities(Entities) ->
         Entities
     ).
 
+%% Same conversion for a single entity-shaped map: a spawn template's
+%% base_state and a game.zone.spawn override table both become entity fields
+%% inside asobi_zone_spawner:spawn_entity/5, so they have to arrive in the
+%% same key shape zone_tick results do. See widgrensit/asobi_lua#118.
+-spec atomize_keys(map()) -> map().
 atomize_keys(M) when is_map(M) ->
     maps:fold(
         fun(K, V, Acc) ->

--- a/src/lua/asobi_lua_api.erl
+++ b/src/lua/asobi_lua_api.erl
@@ -19,6 +19,8 @@ game.log(level, message, meta)                   -- with a metadata table
 
 -- Messaging
 game.broadcast(event, payload)                   -- broadcast to all match players
+                                                 -- event: 1-64 chars of [A-Za-z0-9_-],
+                                                 -- and not an asobi-reserved name
 game.send(player_id, message)                    -- send to specific player
 
 -- Economy
@@ -73,7 +75,11 @@ The persistence-style calls (`economy.*`, `storage.*`, `leaderboard.top/rank/aro
 success, `{ error = "reason" }` on failure (`ok_result/2` / `error_result/2` via
 `wrap_result/2`). Read `result.ok`. The plain calls (`broadcast`, `send`,
 `chat.send`, `zone.spawn`/`despawn`, `leaderboard.submit`, `spatial.*`) return
-their value directly.
+their value directly. `broadcast` is the exception on the failure side: an
+event name asobi rejects at the socket boundary (empty, over 64 bytes,
+outside `[A-Za-z0-9_-]`, or one of asobi's own reserved wire event names such
+as `state`/`tick`/`finished`) returns `{ error = "reason" }` rather than
+being silently dropped downstream.
 """.
 
 -include_lib("kernel/include/logger.hrl").
@@ -326,17 +332,40 @@ fun_broadcast(#{match_pid := MatchPid}) ->
     fun(Args, St) ->
         case decode_args(Args, St) of
             [Event, Payload] when is_binary(Event) ->
-                asobi_match_server:broadcast_event(MatchPid, Event, to_map(Payload)),
-                {[true], St};
+                do_broadcast(MatchPid, Event, to_map(Payload), St);
             [Event] when is_binary(Event) ->
-                asobi_match_server:broadcast_event(MatchPid, Event, #{}),
-                {[true], St};
+                do_broadcast(MatchPid, Event, #{}, St);
             _ ->
                 error_result(~"broadcast requires (event, payload)", St)
         end
     end;
 fun_broadcast(_) ->
     fun(_, St) -> error_result(~"broadcast not available (no match context)", St) end.
+
+%% #303 already rejects an out-of-shape name at the socket boundary, but the
+%% script only saw a server-side log line and a dropped event. Ask the same
+%% owner (asobi_ws_handler:event_name_binary/1) before the fan-out so the
+%% author gets `{ error = "..." }` at the game.broadcast call site - the rules
+%% themselves stay in one place.
+do_broadcast(MatchPid, Event, Payload, St) ->
+    case asobi_ws_handler:event_name_binary(Event) of
+        {ok, _} ->
+            asobi_match_server:broadcast_event(MatchPid, Event, Payload),
+            {[true], St};
+        {error, reserved_event_name} ->
+            error_result(
+                iolist_to_binary([
+                    ~"broadcast event name \"",
+                    Event,
+                    ~"\" is reserved by asobi (",
+                    lists:join(~", ", asobi_ws_handler:reserved_event_names()),
+                    ~")"
+                ]),
+                St
+            );
+        {error, invalid_event_name} ->
+            error_result(~"broadcast event name must be 1-64 chars of [A-Za-z0-9_-]", St)
+    end.
 
 fun_send() ->
     fun(Args, St) ->

--- a/src/lua/asobi_lua_config.erl
+++ b/src/lua/asobi_lua_config.erl
@@ -33,6 +33,7 @@ bots           = { script = "bots/ai.lua", min_players = 4 } -- optional; min_pl
 game_type      = "world"                    -- optional, "match" (default) or "world"
 state_strategy = "shared"                   -- optional, "shared" picks asobi_lua_match_shared (encode-once broadcast)
 guest_auth     = true                       -- optional, offer anonymous no-account play (needs an operator pepper; ADR 0004)
+registration   = "closed"                   -- optional, "open" | "oauth_only" | "closed" (operator sys.config wins)
 
 -- World mode config (large session games, game_type = "world"):
 tick_rate               = 50              -- optional, ms per world tick (default 50 = 20 Hz)
@@ -53,9 +54,13 @@ Setting `game_type = "world"` routes the script through the `asobi_lua_world`
 bridge (zone_tick/2 + handle_input/3 returning entities). Defaults to "match",
 which uses the `asobi_lua_match` bridge (tick/1 + wrapped-state callbacks).
 
-`guest_auth` is read from `match.lua` in single-mode and from `config.lua` (the
-manifest) in multi-mode. It only *declares* intent; guest auth is on iff the
-operator also supplies a >= 32-byte pepper (ADR 0004).
+`guest_auth` and `registration` are read from `match.lua` in single-mode and
+from `config.lua` (the manifest) in multi-mode. `guest_auth` only *declares*
+intent; guest auth is on iff the operator also supplies a >= 32-byte pepper
+(ADR 0004). `registration` declares a signup posture for a deployment that
+states none: it lands in the script layer `asobi_registration` reads only when
+the operator's `sys.config` leaves `registration` unset, and an unrecognised
+value is logged and dropped rather than downgrading the posture.
 
 This module reads Lua and nothing else: it hands the config term it derived to
 `asobi_game_config:apply_config/1`, which owns the merge with operator config
@@ -71,7 +76,12 @@ names = {"Spark", "Blitz", "Volt"}
 -include_lib("kernel/include/logger.hrl").
 -include("asobi_lua_bots.hrl").
 
--export([maybe_load_game_config/0, reload_game_modes/0, apply_guest_auth/1]).
+-export([
+    maybe_load_game_config/0,
+    reload_game_modes/0,
+    apply_guest_auth/1,
+    apply_registration_mode/1
+]).
 -ifdef(TEST).
 -export([safe_join/2]).
 -endif.
@@ -79,21 +89,22 @@ names = {"Spark", "Blitz", "Volt"}
 -spec maybe_load_game_config() -> ok | {error, term()}.
 maybe_load_game_config() ->
     GameDirStr = game_dir(),
-    GuestAuth = declared_guest_auth(GameDirStr),
+    Declared = declared_config(GameDirStr),
     case read_modes(GameDirStr) of
         {ok, Modes} ->
-            asobi_game_config:apply_config(#{guest_auth => GuestAuth, modes => Modes});
+            asobi_game_config:apply_config(Declared#{modes => Modes});
         {error, _} = Err ->
             %% A broken bundle must still land its auth posture: leaving a stale
             %% `true` behind is the one failure the loader cannot fail soft on.
-            ok = asobi_game_config:apply_config(#{guest_auth => GuestAuth}),
+            ok = asobi_game_config:apply_config(Declared),
             Err
     end.
 
 %% Refresh only the game_modes registry from the mode scripts, WITHOUT
-%% re-deriving guest_auth. The config watcher (asobi#232) calls this on a live
-%% mode-shape edit, so guest-auth posture (ADR 0004's two-key AND) stays a
-%% boot-only decision that a bundle write cannot flip at runtime.
+%% re-deriving guest_auth or the registration posture. The config watcher
+%% (asobi#232) calls this on a live mode-shape edit, so auth posture (ADR
+%% 0004's two-key AND, and the signup gate) stays a boot-only decision that a
+%% bundle write cannot flip at runtime.
 -spec reload_game_modes() -> ok | {error, term()}.
 reload_game_modes() ->
     case read_modes(game_dir()) of
@@ -132,10 +143,70 @@ game_dir() ->
 %% the same.
 -spec apply_guest_auth(string() | binary()) -> ok.
 apply_guest_auth(GameDir) ->
-    asobi_game_config:apply_config(#{guest_auth => declared_guest_auth(GameDir)}).
+    asobi_game_config:apply_config(
+        maps:with([guest_auth], declared_config(GameDir))
+    ).
 
--spec declared_guest_auth(string() | binary()) -> boolean().
-declared_guest_auth(GameDir) ->
+%% Registration posture (ADR 0002) used to be reachable only through the
+%% release's sys.config, which no engine-hosted game can edit - so every hosted
+%% game silently ran the `open` default (asobi_lua#122). Shared with
+%% asobi_engine's bundle loader so managed cloud behaves the same.
+-spec apply_registration_mode(string() | binary()) -> ok.
+apply_registration_mode(GameDir) ->
+    asobi_game_config:apply_config(
+        maps:with([registration], declared_config(GameDir))
+    ).
+
+%% The whole config term the game's script declares. `guest_auth` is always
+%% present because a stale `true` from a previous bundle has to be reset;
+%% `registration` is present only when the script declares a recognised value,
+%% since an absent key is what leaves the operator's layer alone (ADR 0006).
+-spec declared_config(string() | binary()) -> asobi_game_config:config().
+declared_config(GameDir) ->
+    case config_script_state(GameDir) of
+        error ->
+            #{guest_auth => false};
+        {ok, St} ->
+            Config = #{guest_auth => read_global_bool(~"guest_auth", St) =:= true},
+            case read_registration(St) of
+                undefined ->
+                    Config;
+                {ok, Mode} ->
+                    Config#{registration => Mode};
+                {invalid, Value} ->
+                    log_invalid_registration(Value),
+                    Config
+            end
+    end.
+
+-spec read_registration(dynamic()) ->
+    undefined | {ok, asobi_registration:mode()} | {invalid, term()}.
+read_registration(St) ->
+    case luerl:get_table_keys([~"registration"], St) of
+        {ok, nil, _} -> undefined;
+        {ok, ~"open", _} -> {ok, open};
+        {ok, ~"oauth_only", _} -> {ok, oauth_only};
+        {ok, ~"closed", _} -> {ok, closed};
+        {ok, Other, _} -> {invalid, Other};
+        _ -> undefined
+    end.
+
+-spec log_invalid_registration(term()) -> ok.
+log_invalid_registration(Value) ->
+    ?LOG_ERROR(#{
+        msg => ~"invalid registration global, keeping the configured mode",
+        value => describe(Value),
+        expected => [~"open", ~"oauth_only", ~"closed"]
+    }).
+
+-spec describe(term()) -> binary().
+describe(V) when is_binary(V) -> V;
+describe(V) -> iolist_to_binary(io_lib:format("~p", [V])).
+
+%% Evaluate the game's config script (config.lua when present, else match.lua)
+%% in a sandboxed Luerl state so the deployment-wide globals can be read off it.
+-spec config_script_state(string() | binary()) -> {ok, dynamic()} | error.
+config_script_state(GameDir) ->
     GameDirStr = to_string(GameDir),
     ConfigPath = filename:join(GameDirStr, "config.lua"),
     MatchPath = filename:join(GameDirStr, "match.lua"),
@@ -146,12 +217,12 @@ declared_guest_auth(GameDir) ->
         end,
     case filelib:is_regular(Script) of
         false ->
-            false;
+            error;
         true ->
             St0 = asobi_lua_loader:init_sandboxed(),
             case do_file(Script, St0) of
-                {ok, _Results, St1} -> read_global_bool(~"guest_auth", St1) =:= true;
-                {error, _} -> false
+                {ok, _Results, St1} -> {ok, St1};
+                {error, _} -> error
             end
     end.
 

--- a/src/lua/asobi_lua_world.erl
+++ b/src/lua/asobi_lua_world.erl
@@ -735,9 +735,14 @@ decode_spawn_templates_acc([{TemplateId, Props} | Rest], Acc) when
 ->
     Type = proplists:get_value(~"type", Props, ~"npc"),
     BaseState = deep_decode(proplists:get_value(~"base_state", Props, [])),
+    %% asobi_zone_spawner merges base_state straight into the new entity, and
+    %% every atom-keyed consumer in asobi_zone (snapshot_entities' `persistent`
+    %% read, the crossing clauses, asobi_spatial) then reads it. Without this
+    %% the entity is binary-keyed until the next zone_tick round-trip happens
+    %% to atomize it - the same gap asobi#270 closed for tick results.
     Base =
         case is_map(BaseState) of
-            true -> BaseState;
+            true -> asobi_lua_api:atomize_keys(BaseState);
             false -> #{}
         end,
     Template = #{

--- a/src/ws/asobi_ws_handler.erl
+++ b/src/ws/asobi_ws_handler.erl
@@ -5,8 +5,10 @@
 %% Exported for tests (pure allowlist predicate), mirroring deployable/1.
 -export([origin_allowed/1]).
 %% Exported so asobi_protocol_coverage_tests can assert every emitted
-%% match./world. event stays inside the reserved namespace (#303).
--export([reserved_event_names/0]).
+%% match./world. event stays inside the reserved namespace (#303), and so
+%% asobi_lua_api can reject a bad game.broadcast name against these same
+%% rules at the script's call site instead of re-stating them.
+-export([reserved_event_names/0, event_name_binary/1]).
 
 -include_lib("kernel/include/logger.hrl").
 

--- a/test/asobi_lua_api_tests.erl
+++ b/test/asobi_lua_api_tests.erl
@@ -22,6 +22,14 @@ api_test_() ->
     {foreach, fun setup/0, fun cleanup/1, [
         {"game.id returns binary", fun game_id/0},
         {"game.broadcast forwards to match server", fun game_broadcast/0},
+        {"game.broadcast accepts an underscore/hyphen/digit name",
+            fun game_broadcast_name_charset_ok/0},
+        {"game.broadcast rejects a reserved event name", fun game_broadcast_reserved_name/0},
+        {"game.broadcast rejects a dotted event name", fun game_broadcast_dotted_name/0},
+        {"game.broadcast rejects an empty event name", fun game_broadcast_empty_name/0},
+        {"game.broadcast rejects an over-long event name", fun game_broadcast_long_name/0},
+        {"game.broadcast rejects every core-reserved name",
+            fun game_broadcast_rejects_all_reserved/0},
         {"game.send forwards to presence", fun game_send/0},
         {"game.send preserves a plain string message", fun game_send_string/0},
         {"game.economy.grant calls engine", fun game_economy_grant/0},
@@ -177,6 +185,47 @@ game_broadcast() ->
     %% broadcast uses the live match_pid (self() in the test fixture),
     %% not the match_id binary.
     ?assert(meck:called(asobi_match_server, broadcast_event, [self(), ~"hello", '_'])).
+
+%% asobi_lua#125: #303 rejects out-of-shape broadcast event names at the
+%% socket boundary, so the script author must hear about it here rather than
+%% losing the event to a server-side log line.
+game_broadcast_name_charset_ok() ->
+    St = install_api(),
+    Code = "return game.broadcast('round_2-start', { msg = 'world' })",
+    {ok, [true | _], _} = eval(Code, St),
+    ?assert(meck:called(asobi_match_server, broadcast_event, [self(), ~"round_2-start", '_'])).
+
+game_broadcast_reserved_name() ->
+    assert_broadcast_rejected("return game.broadcast('tick', { msg = 'world' }).error").
+
+game_broadcast_dotted_name() ->
+    assert_broadcast_rejected("return game.broadcast('my.event', { msg = 'world' }).error").
+
+game_broadcast_empty_name() ->
+    assert_broadcast_rejected("return game.broadcast('', { msg = 'world' }).error").
+
+game_broadcast_long_name() ->
+    Name = lists:duplicate(65, $a),
+    assert_broadcast_rejected("return game.broadcast('" ++ Name ++ "', {}).error").
+
+%% The script-facing guard must stay in step with the wire-facing one: read
+%% the reserved list off its owner rather than restating it, so a name added
+%% to asobi_ws_handler is covered here without touching this file.
+game_broadcast_rejects_all_reserved() ->
+    lists:foreach(
+        fun(Name) ->
+            assert_broadcast_rejected(
+                "return game.broadcast('" ++ binary_to_list(Name) ++ "', {}).error"
+            )
+        end,
+        asobi_ws_handler:reserved_event_names()
+    ).
+
+assert_broadcast_rejected(Code) ->
+    St = install_api(),
+    {ok, [Error | _], _} = eval(Code, St),
+    ?assert(is_binary(Error)),
+    ?assertNot(meck:called(asobi_match_server, broadcast_event, '_')).
 
 game_send() ->
     St = install_api(),

--- a/test/asobi_lua_config_tests.erl
+++ b/test/asobi_lua_config_tests.erl
@@ -73,6 +73,16 @@ config_test_() ->
         {"guest_auth truthy non-bool does not enable", fun guest_auth_truthy_nonbool_stays_off/0},
         {"guest_auth resets a stale true when a later bundle omits it",
             fun guest_auth_stale_true_is_reset/0},
+        {"registration global sets the effective registration mode",
+            fun registration_global_sets_mode/0},
+        {"registration global is read from config.lua in multi-mode",
+            fun registration_global_from_manifest/0},
+        {"registration absent leaves the operator's app env alone",
+            fun registration_absent_keeps_app_env/0},
+        {"registration with an unrecognised value keeps the configured mode",
+            fun registration_invalid_keeps_app_env/0},
+        {"an operator sys.config registration mode beats the script's",
+            fun operator_registration_beats_script/0},
         {"a mode deleted from config.lua disappears on reload",
             fun deleted_mode_disappears_on_reload/0},
         {"an operator sys.config mode survives a bundle load",
@@ -160,6 +170,91 @@ guest_auth_stale_true_is_reset() ->
     ?assertEqual({ok, false}, application:get_env(asobi, guest_auth)),
     application:unset_env(asobi, guest_auth),
     cleanup_temp_dir(TmpDir).
+
+%% asobi_lua#122: an engine-hosted game has no sys.config, so a posture it
+%% cannot declare is a posture it never gets. Assert the effective mode
+%% asobi_registration resolves, not the raw key, since the script writes the
+%% script layer and only the composition is the observable behaviour.
+registration_global_sets_mode() ->
+    application:unset_env(asobi, registration),
+    application:unset_env(asobi, script_registration),
+    TmpDir = make_temp_dir(),
+    ok = file:write_file(
+        filename:join(TmpDir, "match.lua"),
+        ~"match_size = 2\nregistration = \"closed\"\n"
+    ),
+    application:set_env(asobi, game_dir, TmpDir),
+    ok = asobi_lua_config:maybe_load_game_config(),
+    ?assertEqual(closed, asobi_registration:mode()),
+    ?assertEqual({deny, ~"registration_closed"}, asobi_registration:check(password)),
+    reset_registration(),
+    cleanup_temp_dir(TmpDir).
+
+registration_global_from_manifest() ->
+    application:unset_env(asobi, registration),
+    application:unset_env(asobi, script_registration),
+    TmpDir = make_temp_dir(),
+    ok = file:write_file(
+        filename:join(TmpDir, "config.lua"),
+        ~"registration = \"oauth_only\"\nreturn { solo = \"solo.lua\" }\n"
+    ),
+    ok = file:write_file(filename:join(TmpDir, "solo.lua"), ~"match_size = 2\n"),
+    application:set_env(asobi, game_dir, TmpDir),
+    ok = asobi_lua_config:maybe_load_game_config(),
+    ?assertEqual(oauth_only, asobi_registration:mode()),
+    reset_registration(),
+    cleanup_temp_dir(TmpDir).
+
+registration_absent_keeps_app_env() ->
+    application:set_env(asobi, registration, closed),
+    application:unset_env(asobi, script_registration),
+    TmpDir = make_temp_dir(),
+    ok = file:write_file(filename:join(TmpDir, "match.lua"), ~"match_size = 2\n"),
+    application:set_env(asobi, game_dir, TmpDir),
+    ok = asobi_lua_config:maybe_load_game_config(),
+    ?assertEqual(closed, asobi_registration:mode()),
+    ?assertEqual(undefined, application:get_env(asobi, script_registration)),
+    reset_registration(),
+    cleanup_temp_dir(TmpDir).
+
+registration_invalid_keeps_app_env() ->
+    application:set_env(asobi, registration, closed),
+    application:unset_env(asobi, script_registration),
+    TmpDir = make_temp_dir(),
+    ok = file:write_file(
+        filename:join(TmpDir, "match.lua"),
+        ~"match_size = 2\nregistration = \"invite_only\"\n"
+    ),
+    application:set_env(asobi, game_dir, TmpDir),
+    ok = asobi_lua_config:maybe_load_game_config(),
+    ?assertEqual(closed, asobi_registration:mode()),
+    ?assertEqual(undefined, application:get_env(asobi, script_registration)),
+    reset_registration(),
+    cleanup_temp_dir(TmpDir).
+
+%% ADR 0006's trust direction, applied to the signup gate: a bundle may pick a
+%% posture for a deployment that states none, and may never widen one that
+%% does. Without the two layers this `open` would overwrite the operator's
+%% `closed` and reopen public signup.
+operator_registration_beats_script() ->
+    application:set_env(asobi, registration, closed),
+    application:unset_env(asobi, script_registration),
+    TmpDir = make_temp_dir(),
+    ok = file:write_file(
+        filename:join(TmpDir, "match.lua"),
+        ~"match_size = 2\nregistration = \"open\"\n"
+    ),
+    application:set_env(asobi, game_dir, TmpDir),
+    ok = asobi_lua_config:maybe_load_game_config(),
+    ?assertEqual({ok, open}, application:get_env(asobi, script_registration)),
+    ?assertEqual(closed, asobi_registration:mode()),
+    ?assertEqual({deny, ~"registration_closed"}, asobi_registration:check(password)),
+    reset_registration(),
+    cleanup_temp_dir(TmpDir).
+
+reset_registration() ->
+    application:unset_env(asobi, registration),
+    application:unset_env(asobi, script_registration).
 
 %% The registry used to be a "new wins, nothing is ever removed" merge, so a
 %% mode dropped from config.lua stayed matchable for the life of the node. The

--- a/test/asobi_lua_storage_SUITE.erl
+++ b/test/asobi_lua_storage_SUITE.erl
@@ -1,0 +1,221 @@
+-module(asobi_lua_storage_SUITE).
+
+-include_lib("common_test/include/ct.hrl").
+-include_lib("stdlib/include/assert.hrl").
+
+-export([all/0, init_per_suite/1, end_per_suite/1]).
+
+-export([
+    set_then_get/1,
+    set_twice_updates_the_row/1,
+    player_set_then_player_get/1,
+    global_write_does_not_clobber_player_row/1,
+    player_write_does_not_clobber_global_row/1
+]).
+
+all() ->
+    [
+        set_then_get,
+        set_twice_updates_the_row,
+        player_set_then_player_get,
+        global_write_does_not_clobber_player_row,
+        player_write_does_not_clobber_global_row
+    ].
+
+%% Real Postgres, no meck: `game.storage.*` is the one bridge path whose
+%% mocked coverage encoded a wrong belief about the driver (#296 -
+%% update_all/2 rejected a raw jsonb map, so a second set never landed and
+%% the mock happily agreed). Everything here goes through asobi_repo to the
+%% database `docker compose up -d` provides.
+init_per_suite(Config) ->
+    Config0 = asobi_test_helpers:start(Config),
+    {ok, LibDir} = safe_lib_dir(),
+    Script = filename:absname(
+        filename:join([LibDir, "test", "fixtures", "lua", "test_match.lua"])
+    ),
+    [{script, Script} | Config0].
+
+end_per_suite(_Config) ->
+    ok.
+
+%% --- Cases ---
+
+set_then_get(Config) ->
+    St = install_api(Config),
+    Collection = unique(~"settings"),
+    {[true], _} = eval(
+        [
+            "local w = game.storage.set('",
+            Collection,
+            "', 'theme', { mode = 'dark', size = 14 })\n",
+            "local r = game.storage.get('",
+            Collection,
+            "', 'theme')\n",
+            "return w.ok ~= nil and r.ok.mode == 'dark' and r.ok.size == 14\n"
+        ],
+        St
+    ),
+    [Row] = storage_rows(Collection, ~"theme"),
+    ?assertEqual(#{~"mode" => ~"dark", ~"size" => 14}, maps:get(value, Row)),
+    ?assertEqual(undefined, maps:get(player_id, Row, undefined)).
+
+%% #296: the second write is the one that used to be silently dropped.
+set_twice_updates_the_row(Config) ->
+    St = install_api(Config),
+    Collection = unique(~"saves"),
+    {[true], St1} = eval(
+        ["return game.storage.set('", Collection, "', 'slot1', { n = 1 }).ok ~= nil\n"], St
+    ),
+    {[true], _} = eval(
+        [
+            "local w = game.storage.set('",
+            Collection,
+            "', 'slot1', { n = 2 })\n",
+            "local r = game.storage.get('",
+            Collection,
+            "', 'slot1')\n",
+            "return w.ok ~= nil and r.ok.n == 2\n"
+        ],
+        St1
+    ),
+    [Row] = storage_rows(Collection, ~"slot1"),
+    ?assertEqual(#{~"n" => 2}, maps:get(value, Row)),
+    ?assertEqual(2, maps:get(version, Row)).
+
+player_set_then_player_get(Config) ->
+    St = install_api(Config),
+    Collection = unique(~"inventory"),
+    PlayerId = create_player(),
+    {[true], _} = eval(
+        [
+            "local w = game.storage.player_set('",
+            PlayerId,
+            "', '",
+            Collection,
+            "', 'gold', 50)\n",
+            "local r = game.storage.player_get('",
+            PlayerId,
+            "', '",
+            Collection,
+            "', 'gold')\n",
+            "return w.ok ~= nil and r.ok == 50\n"
+        ],
+        St
+    ),
+    [Row] = storage_rows(Collection, ~"gold"),
+    ?assertEqual(PlayerId, maps:get(player_id, Row)).
+
+%% #296 follow-up: global rows (player_id IS NULL) and player rows are
+%% separate namespaces sharing a collection+key. A write to one must never
+%% match the other's row - the class of bug an unscoped UPDATE reintroduces.
+%% The player row is written first on purpose: a lookup that forgets its
+%% `player_id IS NULL` predicate resolves to that row, so the global write
+%% below updates it instead of inserting its own.
+global_write_does_not_clobber_player_row(Config) ->
+    St = install_api(Config),
+    Collection = unique(~"save"),
+    PlayerId = create_player(),
+    {[true], St1} = eval(
+        [
+            "return game.storage.player_set('",
+            PlayerId,
+            "', '",
+            Collection,
+            "', 'flag', { owner = 'player' }).ok ~= nil\n"
+        ],
+        St
+    ),
+    {[true], _} = eval(
+        [
+            "local w = game.storage.set('",
+            Collection,
+            "', 'flag', { owner = 'global' })\n",
+            "local g = game.storage.get('",
+            Collection,
+            "', 'flag')\n",
+            "local p = game.storage.player_get('",
+            PlayerId,
+            "', '",
+            Collection,
+            "', 'flag')\n",
+            "return w.ok ~= nil and g.ok.owner == 'global' and p.ok.owner == 'player'\n"
+        ],
+        St1
+    ),
+    ?assertEqual(2, length(storage_rows(Collection, ~"flag"))).
+
+%% Mirror image, and the update path: the second player_set updates an
+%% existing row. An update scoped only by collection+key (the bulk
+%% update_all/2 #296 replaced) rewrites the global row too.
+player_write_does_not_clobber_global_row(Config) ->
+    St = install_api(Config),
+    Collection = unique(~"save"),
+    PlayerId = create_player(),
+    {[true], St1} = eval(
+        [
+            "local g = game.storage.set('",
+            Collection,
+            "', 'flag', { owner = 'global' })\n",
+            "local p = game.storage.player_set('",
+            PlayerId,
+            "', '",
+            Collection,
+            "', 'flag', { owner = 'player' })\n",
+            "return g.ok ~= nil and p.ok ~= nil\n"
+        ],
+        St
+    ),
+    {[true], _} = eval(
+        [
+            "local w = game.storage.player_set('",
+            PlayerId,
+            "', '",
+            Collection,
+            "', 'flag', { owner = 'player', n = 2 })\n",
+            "local g = game.storage.get('",
+            Collection,
+            "', 'flag')\n",
+            "local p = game.storage.player_get('",
+            PlayerId,
+            "', '",
+            Collection,
+            "', 'flag')\n",
+            "return w.ok ~= nil and g.ok.owner == 'global' and g.ok.n == nil\n",
+            "  and p.ok.owner == 'player' and p.ok.n == 2\n"
+        ],
+        St1
+    ),
+    ?assertEqual(2, length(storage_rows(Collection, ~"flag"))).
+
+%% --- Helpers ---
+
+install_api(Config) ->
+    {ok, St0} = asobi_lua_loader:new(?config(script, Config)),
+    asobi_lua_api:install(#{match_id => ~"storage-suite", match_pid => self()}, St0).
+
+eval(Code, St) ->
+    {ok, Results, St1} = luerl:do(unicode:characters_to_list(Code), St),
+    {Results, St1}.
+
+storage_rows(Collection, Key) ->
+    Q0 = kura_query:from(asobi_storage),
+    Q1 = kura_query:where(Q0, {collection, Collection}),
+    {ok, Rows} = asobi_repo:all(kura_query:where(Q1, {key, Key})),
+    Rows.
+
+create_player() ->
+    Now = calendar:universal_time(),
+    Params = #{username => unique(~"p"), inserted_at => Now, updated_at => Now},
+    CS = kura_changeset:cast(asobi_player, #{}, Params, maps:keys(Params)),
+    {ok, #{id := Id}} = asobi_repo:insert(CS),
+    Id.
+
+unique(Prefix) ->
+    Hex = binary:encode_hex(crypto:strong_rand_bytes(8), lowercase),
+    <<Prefix/binary, "_", Hex/binary>>.
+
+safe_lib_dir() ->
+    case code:lib_dir(asobi) of
+        {error, bad_name} -> error(asobi_not_loaded);
+        Dir -> {ok, Dir}
+    end.

--- a/test/asobi_lua_world_integration_tests.erl
+++ b/test/asobi_lua_world_integration_tests.erl
@@ -59,12 +59,10 @@ spawn_templates_reach_a_real_zone_test_() ->
             {ok, ZonePid} = asobi_zone_manager:get_zone(ZoneManagerPid, {0, 0}),
             %% zone_tick spawns on tick 1, the spawn cast lands on a
             %% following tick - poll rather than a fixed sleep.
-            %% The probe is inserted directly by game.zone.spawn, but the
-            %% whole entity map round-trips through zone_tick's return value
-            %% (decode_to_map + atomize_entities) on every subsequent tick
-            %% regardless of whether the script touches it - see
-            %% widgrensit/asobi#270 - so by the time this poll succeeds the
-            %% probe's own keys are atoms too.
+            %% The probe is inserted directly by game.zone.spawn, so its
+            %% base_state keys are atom-shaped at insertion (asobi_lua#118) -
+            %% this poll can never observe a half-converted entity, whichever
+            %% tick it lands on.
             Probes = poll_until(
                 fun() ->
                     Entities = asobi_zone:get_entities(ZonePid),

--- a/test/asobi_lua_world_tests.erl
+++ b/test/asobi_lua_world_tests.erl
@@ -284,7 +284,12 @@ spawn_templates_decodes_test() ->
         ?assertMatch(#{~"goblin" := _}, Templates),
         Goblin = maps:get(~"goblin", Templates),
         ?assertEqual(~"npc", maps:get(type, Goblin)),
-        ?assertEqual(true, maps:get(persistent, Goblin))
+        ?assertEqual(true, maps:get(persistent, Goblin)),
+        %% asobi_lua#118: base_state is merged straight into the spawned
+        %% entity by asobi_zone_spawner, so its keys must already be in the
+        %% atom shape asobi_zone reads - not binary until a later zone_tick
+        %% round-trip fixes them up.
+        ?assertEqual(#{hp => 10}, maps:get(base_state, Goblin))
     after
         file:delete(Path)
     end.

--- a/test/asobi_lua_zone_spawn_tests.erl
+++ b/test/asobi_lua_zone_spawn_tests.erl
@@ -124,10 +124,13 @@ lua_spawn_reaches_zone() ->
     ?assertEqual(2, length(Chests)),
 
     [Goblin] = Goblins,
-    ?assert(maps:get(~"health", Goblin) == 100),
-    ?assertEqual(~"patrol", maps:get(~"ai", Goblin)),
+    %% asobi_lua#118: base_state and override fields must land atom-keyed at
+    %% spawn time, not only after some later zone_tick round-trip re-atomizes
+    %% the entity. These reads happen before any tick has returned entities.
+    ?assert(maps:get(health, Goblin) == 100),
+    ?assertEqual(~"patrol", maps:get(ai, Goblin)),
 
-    ChestLoot = lists:sort([maps:get(~"loot", C) || C <- Chests]),
+    ChestLoot = lists:sort([maps:get(loot, C) || C <- Chests]),
     ?assertEqual([~"common", ~"rare"], ChestLoot),
 
     gen_server:stop(ZonePid),


### PR DESCRIPTION
asobi_lua was merged into asobi at 733cec4, snapshotting asobi_lua at b01c5dc. Four asobi_lua commits landed after that point and never made it across. asobi_lua#135 retires that repo and deletes its `src/`, so merging it without these first would regress the shipped runtime.

This ports all four, one commit each, in dependency order. Unblocks widgrensit/asobi_lua#135 and #346.

## What landed

| asobi_lua | Ported as | Applied |
|---|---|---|
| #131 `af391ff` atomize spawn-template `base_state` / `zone.spawn` overrides | `c8504e9` | clean |
| #134 `1bc28be` validate `game.broadcast` event names | `97ebac6` | reworked |
| #133 `3354e5e` real-Postgres CT for `game.storage.*` | `ed7a63a` | reworked |
| #132 `4b4bf8e` game-declared registration mode | `1736cd5` | reworked |

## The two reworks worth reviewing

**#134 - one owner instead of two copies.** In separate repos, asobi_lua had to restate the length, charset and reserved-name rules that `asobi_ws_handler` already enforces at the socket boundary (#303); its own comment said "both lists must move together". In one repo they do not have to. `asobi_ws_handler` now exports `event_name_binary/1` next to `reserved_event_names/0`, and `asobi_lua_api:do_broadcast/4` calls it. The core guard is unchanged and still the last line of defence; this is purely the script-facing half, so an author gets `{ error = "..." }` at the `game.broadcast` call site instead of a dropped event and a server-side log line. `game_broadcast_rejects_all_reserved` iterates `asobi_ws_handler:reserved_event_names()`, so a name added to core is covered without touching the Lua tests.

**#132 - registration is a second layer, not an overwrite.** The original called `application:set_env(asobi, registration, Mode)` straight from the loader. In this repo that is both an unowned writer (ADR 0006: `asobi_game_config` is the only one) and the exact trust inversion ADR 0006 exists to stop - a game bundle overwriting operator config. It is also a security posture, so a bundle widening a `closed` deployment back to `open` is not a trade worth making for a smaller diff.

So registration gets the same shape as the mode registry:

- `asobi_game_config:apply_config/1` writes the declared value to `script_registration`, never to the operator's `registration` key;
- `asobi_registration:classify/0` composes the two, operator layer on top.

A bundle can pick a posture for a deployment that states none - which is the actual bug, since an engine-hosted game has no `sys.config` to edit and every hosted game silently ran `open` - and can never widen one that does. Omitting the global leaves both keys alone; an unrecognised value is logged and dropped by the loader rather than downgrading to `open`.

## What proves each fix landed

Every ported fix was verified by reverting the source change and confirming the test fails.

- **#131** - `asobi_lua_zone_spawn_tests:lua_spawn_reaches_zone/0` reads `maps:get(health, Goblin)` (atom key) before any tick has returned entities; `asobi_lua_world_tests:spawn_templates_decodes_test/0` asserts `#{hp => 10}` for `base_state`. Reverting `asobi_lua_api.erl` + `asobi_lua_world.erl`: 2 failures.
- **#134** - `assert_broadcast_rejected/1` asserts a binary error came back *and* `?assertNot(meck:called(asobi_match_server, broadcast_event, '_'))`. Reverting `do_broadcast/4`: 5 failures.
- **#133** - two independent defect shapes, both re-checked here against the live database:
  - dropping the `player_id IS NULL` predicate from `storage_find/3` fails `global_write_does_not_clobber_player_row`;
  - restoring the unscoped `update_all/2` write fails `set_twice_updates_the_row` and `player_write_does_not_clobber_global_row`.
- **#132** - `registration_global_sets_mode/0` asserts `asobi_registration:mode() =:= closed` and `check(password) =:= {deny, ~"registration_closed"}` (the effective posture, not the raw key). Reverting all three source files: 3 failures. `operator_registration_beats_script/0` is the guard on the rework specifically - making `apply_config/1` write `registration` instead of `script_registration` fails it and nothing else.

## Notes

- `asobi_lua_storage_SUITE` uses `asobi_test_helpers:start/1` rather than the standalone `pgo`/`kura_migrator` boot the asobi_lua original needed, and `ci.yml` already passes `extra-services-compose`, so no CI change was required. No name clash with the existing `asobi_storage_SUITE`, which covers the core REST storage path rather than the Lua write path.
- Not ported: the asobi_lua `AGENTS.md` and `ci.yml` hunks from #133 (repo-specific; the equivalent asobi `AGENTS.md` line is included).

## Checks

`fmt --check`, `xref`, `dialyzer`, `ex_doc` clean. `eunit` 1137/1137. `ct` 297 passed, 1 failed: `asobi_iap_SUITE:apple_valid_jws_correct_bundle`, which fails identically on a clean `origin/main` worktree at a5e27d3 and is untouched by this branch.
