### PR TITLE
feat(ws): complete the S6 frame-type rename to module.message/module.error

### DIFF
--- a/guides/configuration.md
+++ b/guides/configuration.md
@@ -207,6 +207,25 @@ cannot be a CSWSH vector. The socket also does nothing until it presents a
 valid token in the first `session.connect` frame, so this is defence in depth,
 not the primary auth gate.
 
+## Deprecated `game.*` extension frames
+
+Extension-produced pushes go out as `module.message` and `module.error`. The
+pre-rename names `game.message` and `game.error` are emitted alongside them,
+with identical payloads, so SDK builds from before the rename keep working.
+They are removed at the 1.0 wire break.
+
+```erlang
+{ws_legacy_game_frames, false}
+```
+
+Set this once every client on the deployment dispatches on `module.*`, and
+each extension message drops from two frames to one. `game.message` is
+asobi_lua's `game.send/2`, which a script may call per player per tick, so on
+a chatty game the compat frame is a real doubling of that path. Any client
+still listening for `game.*` goes silent the moment you set it. Default
+`true`. See
+[the protocol guide](https://asobi.dev/docs/protocols/websocket).
+
 ## CORS
 
 CORS is handled by `nova_cors_plugin` in the Nova plugin chain — configure

--- a/guides/lua-scripting.md
+++ b/guides/lua-scripting.md
@@ -611,16 +611,21 @@ like the callback silently doing nothing. A common first-hour trap is
 fails every call with "bad arithmetic on nil".
 
 During development, set `ASOBI_DEV_ERRORS=true` on the container to have
-each failing `handle_input` also send a `game.error` event to the player
+each failing `handle_input` also send a `module.error` event to the player
 whose input triggered it:
 
 ```json
-{"type": "game.error", "payload": {
+{"type": "module.error", "payload": {
+    "module": "lua",
     "callback": "handle_input",
     "script": "match.lua",
     "message": "bad arithmetic + on nil, 1"
 }}
 ```
+
+The deprecated `game.error` name carries the same payload and is sent
+alongside it until the 1.0 wire break. See
+[WebSocket Protocol](websocket-protocol.md).
 
 Events are rate-limited to one per second per match. Leave the flag off in
 production (it is off by default): error messages can reveal script

--- a/guides/websocket-protocol.md
+++ b/guides/websocket-protocol.md
@@ -240,7 +240,7 @@ string in `details`, so script-supplied text can never mint a code:
 {"type": "error", "payload": {"reason": "party_is_full", "error": {"code": "ws.request_failed", "message": "The request failed. See `details.reason`.", "details": {"reason": "party_is_full"}}}}
 ```
 
-### `game.error` (server push)
+### `module.error` (server push)
 
 An extension callback error, sent to the player whose input triggered it.
 Only emitted when the extension runs with dev errors enabled (for
@@ -251,25 +251,54 @@ errors server-side.
 asobi owns; the rest of the payload is the extension's.
 
 ```json
-{"type": "game.error", "payload": {"module": "lua", "callback": "handle_input", "script": "match.lua", "message": "bad arithmetic + on nil, 1"}}
+{"type": "module.error", "payload": {"module": "lua", "callback": "handle_input", "script": "match.lua", "message": "bad arithmetic + on nil, 1"}}
 ```
 
-### `game.message` (server push)
+### `module.message` (server push)
 
 A message addressed to one player by an extension - asobi_lua's
 `game.send(player_id, message)`. The message is wrapped rather than sent
 raw, because it may be any scripting value (string, number, table).
 
 ```json
-{"type": "game.message", "payload": {"module": "lua", "message": "you are player 3"}}
+{"type": "module.message", "payload": {"module": "lua", "message": "you are player 3"}}
 ```
 
-Both frames are produced by extensions, not only by Lua, which is why the
-producer is a payload key rather than part of the wire type. `module` was
-added without a type change so existing SDK builds keep working; clients
-that care which extension spoke should read `payload.module` and treat a
-missing value as `"lua"`. Renaming the types to `module.error` and
-`module.message` is reserved for the 1.0 wire break.
+### `game.error` / `game.message` (server push, deprecated)
+
+The pre-rename names for the two frames above. Deprecated. **New SDK code
+dispatches on `module.error` and `module.message`.** The pair is removed
+at the 1.0 wire break and will not be replaced.
+
+They are still emitted, byte-identical payload and same reply as their
+`module.*` twin, so every SDK built before the rename keeps working with
+no change. Each message therefore produces two frames today: the legacy
+frame first, then the `module.*` frame.
+
+Do not dispatch on both - a client that handles `game.message` and
+`module.message` processes every message twice.
+
+Neither name was ever Lua-specific: both frames are produced by
+extensions in general, which is why the producer travels in the payload's
+`module` key. Clients that care which extension spoke read
+`payload.module` and treat a missing value as `"lua"`. `game.*` put one
+extension in the wire type, where no second extension could reuse it -
+that is what the rename fixes.
+
+**Wire history.** asobi v0.53.0 and earlier emit `game.error` /
+`game.message` only; `module.*` does not exist on the wire there, despite
+what the message on commit `a6bc2eb` says (its own follow-up commit in
+the same PR removed the dual-emit it describes, because Nova could not
+send two frames from one reply at the time - novaframework/nova#400).
+From this release both pairs are emitted.
+
+**Turning the legacy pair off.** Set `asobi.ws_legacy_game_frames` to
+`false` to emit only `module.*`. `game.message` is `game.send/2`, which a
+script may call per player per tick, so on a chatty game the compat frame
+doubles asobi's hottest extension-produced egress. Any client still
+dispatching on `game.*` goes silent when you do this, so flip it only
+once every client on the deployment reads `module.*`. It defaults to
+`true` and becomes a no-op at 1.0.
 
 ### `match.state` (server push)
 

--- a/guides/websocket-protocol.md
+++ b/guides/websocket-protocol.md
@@ -285,12 +285,13 @@ extensions in general, which is why the producer travels in the payload's
 extension in the wire type, where no second extension could reuse it -
 that is what the rename fixes.
 
-**Wire history.** asobi v0.53.0 and earlier emit `game.error` /
-`game.message` only; `module.*` does not exist on the wire there, despite
-what the message on commit `a6bc2eb` says (its own follow-up commit in
-the same PR removed the dual-emit it describes, because Nova could not
-send two frames from one reply at the time - novaframework/nova#400).
-From this release both pairs are emitted.
+**Wire history.** `module.*` did not exist on the wire in any release
+before this change: not in v0.54.0, and not in v0.53.0, where commit
+`a6bc2eb` says otherwise. That commit's message describes a dual-emit
+that its own follow-up commit in the same pull request removed, because
+Nova could not send two frames from one reply at the time
+(novaframework/nova#400). Every release up to v0.54.0 emits `game.error`
+and `game.message` only.
 
 **Turning the legacy pair off.** Set `asobi.ws_legacy_game_frames` to
 `false` to emit only `module.*`. `game.message` is `game.send/2`, which a

--- a/priv/protocol/fixtures/module.error.json
+++ b/priv/protocol/fixtures/module.error.json
@@ -1,0 +1,1 @@
+{"type":"module.error","payload":{"module":"lua","callback":"handle_input","script":"match.lua","message":"bad arithmetic + on nil, 1"}}

--- a/priv/protocol/fixtures/module.message.json
+++ b/priv/protocol/fixtures/module.message.json
@@ -1,0 +1,1 @@
+{"type":"module.message","payload":{"module":"lua","message":"jij bent speler nummer 3"}}

--- a/src/lua/asobi_lua_dev_errors.erl
+++ b/src/lua/asobi_lua_dev_errors.erl
@@ -4,8 +4,9 @@ Dev-mode surfacing of Lua callback errors to the triggering client.
 
 By default a failing callback is log + telemetry only, so script internals
 never reach arbitrary players in production. With dev errors enabled the
-player whose input triggered the failure also receives a `game.error`
-event carrying the callback name, script basename and Lua error message -
+player whose input triggered the failure also receives a `module.error`
+event (and its deprecated `game.error` twin, until the 1.0 wire break)
+carrying the callback name, script basename and Lua error message -
 without it a broken `handle_input` is indistinguishable client-side from
 one that never ran.
 

--- a/src/ws/asobi_ws_handler.erl
+++ b/src/ws/asobi_ws_handler.erl
@@ -26,17 +26,23 @@
 %% holding cowboy acceptors. Override via `asobi.ws_idle_auth_timeout_ms`.
 -define(DEFAULT_IDLE_AUTH_TIMEOUT_MS, 10000).
 
-%% `game.message` and `game.error` name their producer in the payload's
-%% `module` key, not in the wire type, so an extension can emit them
-%% without a new frame type per extension. A producer that sends the
-%% legacy two-element shape (`{game_message, Payload}`,
-%% `{script_error, Payload}`) predates that and can only be asobi_lua.
-%%
-%% The `module.`-prefixed type rename is deliberately deferred to the 1.0
-%% wire break: the payload key is the part SDKs dispatch on, and renaming
-%% the type now would either break every shipped SDK or double every
-%% frame on the hot path.
+%% Extension-produced frames name their producer in the payload's `module`
+%% key, not in the wire type, so an extension can emit them without a new
+%% frame type per extension. A producer that sends the legacy two-element
+%% shape (`{game_message, Payload}`, `{script_error, Payload}`) predates
+%% that and can only be asobi_lua.
 -define(DEFAULT_EXTENSION, lua).
+
+%% S6: the wire types are `module.message`/`module.error`. `game.message`/
+%% `game.error` are the pre-S6 names and are emitted alongside them so no
+%% shipped SDK build breaks; they are removed at the 1.0 wire break.
+%%
+%% Off drops the legacy pair. `game.message` is asobi_lua's `game.send/2`,
+%% which a script may call per player per tick, so the compat frame is the
+%% one doubling asobi's hottest extension-produced egress path. An operator
+%% whose clients all dispatch `module.*` sets `asobi.ws_legacy_game_frames`
+%% to `false` and gets that back without waiting for 1.0.
+-define(DEFAULT_LEGACY_GAME_FRAMES, true).
 
 %% #303: script-controlled `game.broadcast` event names share the wire
 %% namespace with asobi's own `match.*`/`world.*` events, so they must be
@@ -189,6 +195,7 @@ websocket_handle(_Frame, State) ->
 -spec websocket_info(term(), map()) ->
     {ok, map()}
     | {reply, {text, binary()}, map()}
+    | {reply, [{text, binary()}], map()}
     | {reply, {close, non_neg_integer(), binary()}, map()}
     | {stop, map()}.
 websocket_info({asobi_message, {match_state, MatchState}}, State) ->
@@ -275,7 +282,7 @@ websocket_info({asobi_message, {game_message, Extension, Payload}}, State) when
     %% convention and couldn't carry more fields later without a
     %% breaking change.
     Body = #{~"module" => atom_to_binary(Extension), ~"message" => Payload},
-    {reply, {text, encode_reply(undefined, ~"game.message", Body)}, State};
+    {reply, extension_frames(~"module.message", ~"game.message", Body), State};
 websocket_info({asobi_message, {script_error, Payload}}, State) when is_map(Payload) ->
     websocket_info({asobi_message, {script_error, ?DEFAULT_EXTENSION, Payload}}, State);
 websocket_info({asobi_message, {script_error, Extension, Payload}}, State) when
@@ -289,11 +296,11 @@ websocket_info({asobi_message, {script_error, Extension, Payload}}, State) when
     Body = Payload#{~"module" => atom_to_binary(Extension)},
     Reply =
         try
-            encode_reply(undefined, ~"game.error", Body)
+            extension_frames(~"module.error", ~"game.error", Body)
         catch
-            _:_ -> encode_error(undefined, ~"internal")
+            _:_ -> [{text, encode_error(undefined, ~"internal")}]
         end,
-    {reply, {text, Reply}, State};
+    {reply, Reply, State};
 websocket_info({session_revoked, Reason}, State) ->
     logger:notice(#{msg => ~"session_revoked", reason => Reason}),
     {stop, State#{session => undefined}};
@@ -919,6 +926,22 @@ encode_reply(Cid, Type, Payload) ->
             _ -> Msg0#{~"cid" => Cid}
         end,
     json:encode(Msg).
+
+%% The legacy frame goes first so a shipped client sees byte-identical
+%% ordering to before S6; the new type is purely additive behind it.
+-spec extension_frames(binary(), binary(), map()) -> [{text, binary()}].
+extension_frames(Type, LegacyType, Body) ->
+    New = {text, encode_reply(undefined, Type, Body)},
+    case legacy_game_frames() of
+        true -> [{text, encode_reply(undefined, LegacyType, Body)}, New];
+        false -> [New]
+    end.
+
+legacy_game_frames() ->
+    case application:get_env(asobi, ws_legacy_game_frames) of
+        {ok, Enabled} when is_boolean(Enabled) -> Enabled;
+        _ -> ?DEFAULT_LEGACY_GAME_FRAMES
+    end.
 
 %% Every error frame now carries both dialects. `reason` is the original
 %% WebSocket string and is unchanged, byte for byte, so existing clients keep

--- a/test/asobi_protocol_coverage_tests.erl
+++ b/test/asobi_protocol_coverage_tests.erl
@@ -85,7 +85,8 @@ list_fixture_event_names() ->
     [unicode:characters_to_binary(filename:basename(F, ".json")) || F <- Files].
 
 enumerate_emitted_events() ->
-    Static = scan_encode_reply_types(read_file(?WS_HANDLER)),
+    WsHandler = read_file(?WS_HANDLER),
+    Static = scan_encode_reply_types(WsHandler) ++ scan_extension_frame_types(WsHandler),
     MatchAtoms = collect_match_emit_atoms(),
     WorldAtoms = collect_world_emit_atoms(),
     lists:usort(
@@ -133,6 +134,18 @@ scan_encode_reply_types(Bin) ->
     Re = "encode_reply\\([^,]+,\\s*~\"([a-z][a-z._]*)\"",
     case re:run(Bin, Re, [global, {capture, all_but_first, binary}]) of
         {match, Matches} -> [B || [B] <- Matches];
+        nomatch -> []
+    end.
+
+%% S6: extension-produced frames go out through extension_frames/3, which
+%% names two wire types - the current one and the deprecated pre-rename
+%% one it is emitted alongside. Both reach clients, so both need a
+%% fixture, and neither is visible to scan_encode_reply_types/1 because
+%% the encode inside the helper takes a variable type.
+scan_extension_frame_types(Bin) ->
+    Re = "extension_frames\\(\\s*~\"([a-z][a-z._]*)\",\\s*~\"([a-z][a-z._]*)\"",
+    case re:run(Bin, Re, [global, {capture, all_but_first, binary}]) of
+        {match, Matches} -> lists:append(Matches);
         nomatch -> []
     end.
 

--- a/test/asobi_ws_SUITE.erl
+++ b/test/asobi_ws_SUITE.erl
@@ -10,7 +10,7 @@
     ws_idle_auth_timeout_closes/1,
     ws_match_input_not_in_match_hint/1,
     ws_match_input_hint_rate_limited/1,
-    ws_script_error_rendered_as_game_error/1,
+    ws_script_error_rendered_as_extension_error/1,
     ws_matchmaker_add_omitted_mode_rejected/1
 ]).
 
@@ -22,7 +22,7 @@ all() ->
         ws_idle_auth_timeout_closes,
         ws_match_input_not_in_match_hint,
         ws_match_input_hint_rate_limited,
-        ws_script_error_rendered_as_game_error,
+        ws_script_error_rendered_as_extension_error,
         ws_matchmaker_add_omitted_mode_rejected
     ].
 
@@ -111,9 +111,12 @@ ws_match_input_hint_rate_limited(Config) ->
     Config.
 
 %% asobi_lua#98: a {script_error, Payload} presence message (sent by the
-%% Lua runtime in dev-errors mode) must reach the client as a game.error
-%% wire event carrying the payload unchanged.
-ws_script_error_rendered_as_game_error(Config) ->
+%% Lua runtime in dev-errors mode) must reach the client as a
+%% module.error wire event carrying the payload unchanged. S6: the pre-S6
+%% game.error frame rides alongside it until the 1.0 wire break, and both
+%% must survive the socket as two separate frames - which is the part
+%% unit tests cannot prove, because the splice happens inside nova.
+ws_script_error_rendered_as_extension_error(Config) ->
     {PlayerId, Token} = register_player(~"scripterr", Config),
     Conn = ws_connect_authed(Token, Config),
     asobi_presence:send(
@@ -124,21 +127,23 @@ ws_script_error_rendered_as_game_error(Config) ->
             ~"message" => ~"bad arithmetic + on nil, 1"
         }}
     ),
-    {ok, Reply} = recv_until(
+    {ok, Legacy} = recv_until(
         fun(M) -> maps:get(~"type", M, undefined) =:= ~"game.error" end, Conn
     ),
-    nova_test_ws:close(Conn),
-    ?assertMatch(
-        #{
-            ~"payload" := #{
-                ~"module" := ~"lua",
-                ~"callback" := ~"handle_input",
-                ~"script" := ~"match.lua",
-                ~"message" := ~"bad arithmetic + on nil, 1"
-            }
-        },
-        Reply
+    {ok, Current} = recv_until(
+        fun(M) -> maps:get(~"type", M, undefined) =:= ~"module.error" end, Conn
     ),
+    nova_test_ws:close(Conn),
+    Expected = #{
+        ~"payload" => #{
+            ~"module" => ~"lua",
+            ~"callback" => ~"handle_input",
+            ~"script" => ~"match.lua",
+            ~"message" => ~"bad arithmetic + on nil, 1"
+        }
+    },
+    ?assertEqual(Expected, maps:with([~"payload"], Legacy)),
+    ?assertEqual(Expected, maps:with([~"payload"], Current)),
     Config.
 
 %% asobi#243: matchmaker.add with no `mode' defaults to "default"; the WS edge

--- a/test/asobi_ws_handler_tests.erl
+++ b/test/asobi_ws_handler_tests.erl
@@ -129,25 +129,24 @@ handled_message_is_not_logged_as_unhandled_test() ->
 
 %% S6: `game.message`/`game.error` named one extension (Lua) inside the
 %% client wire, which five of seven SDKs cannot extend at runtime. The
-%% producing extension now travels in the payload's `module` key, so any
-%% extension can emit these frames without a type per extension. The wire
-%% type is unchanged, so no shipped SDK breaks.
+%% producing extension travels in the payload's `module` key, and the wire
+%% type is now `module.message`/`module.error`. The pre-S6 pair is emitted
+%% alongside it so no shipped SDK breaks, and is removed at the 1.0 wire
+%% break.
 
 game_message_names_lua_by_default_test() ->
     Msg = {asobi_message, {game_message, ~"you are player 3"}},
-    {reply, Frame, _State1} = asobi_ws_handler:websocket_info(Msg, #{}),
-    ?assertEqual(
-        #{~"module" => ~"lua", ~"message" => ~"you are player 3"},
-        payload_of(~"game.message", Frame)
-    ).
+    {reply, Frames, _State1} = asobi_ws_handler:websocket_info(Msg, #{}),
+    Expected = #{~"module" => ~"lua", ~"message" => ~"you are player 3"},
+    ?assertEqual(Expected, payload_of(~"module.message", Frames)),
+    ?assertEqual(Expected, payload_of(~"game.message", Frames)).
 
 game_message_carries_the_producing_extension_test() ->
     Msg = {asobi_message, {game_message, wasm, #{~"n" => 1}}},
-    {reply, Frame, _State1} = asobi_ws_handler:websocket_info(Msg, #{}),
-    ?assertEqual(
-        #{~"module" => ~"wasm", ~"message" => #{~"n" => 1}},
-        payload_of(~"game.message", Frame)
-    ).
+    {reply, Frames, _State1} = asobi_ws_handler:websocket_info(Msg, #{}),
+    Expected = #{~"module" => ~"wasm", ~"message" => #{~"n" => 1}},
+    ?assertEqual(Expected, payload_of(~"module.message", Frames)),
+    ?assertEqual(Expected, payload_of(~"game.message", Frames)).
 
 script_error_names_lua_by_default_test() ->
     Payload = #{
@@ -156,16 +155,54 @@ script_error_names_lua_by_default_test() ->
         ~"message" => ~"bad arithmetic + on nil, 1"
     },
     Msg = {asobi_message, {script_error, Payload}},
-    {reply, Frame, _State1} = asobi_ws_handler:websocket_info(Msg, #{}),
-    ?assertEqual(Payload#{~"module" => ~"lua"}, payload_of(~"game.error", Frame)).
+    {reply, Frames, _State1} = asobi_ws_handler:websocket_info(Msg, #{}),
+    ?assertEqual(Payload#{~"module" => ~"lua"}, payload_of(~"module.error", Frames)),
+    ?assertEqual(Payload#{~"module" => ~"lua"}, payload_of(~"game.error", Frames)).
 
 script_error_carries_the_producing_extension_test() ->
     Msg = {asobi_message, {script_error, wasm, #{~"message" => ~"trap"}}},
-    {reply, Frame, _State1} = asobi_ws_handler:websocket_info(Msg, #{}),
+    {reply, Frames, _State1} = asobi_ws_handler:websocket_info(Msg, #{}),
+    Expected = #{~"module" => ~"wasm", ~"message" => ~"trap"},
+    ?assertEqual(Expected, payload_of(~"module.error", Frames)),
+    ?assertEqual(Expected, payload_of(~"game.error", Frames)).
+
+%% asobi#347: the dual-emit only works because novaframework/nova#400
+%% splices a list-valued reply into cowboy's command list. A nova without
+%% that fix turns both frames into one malformed cowboy command and kills
+%% the connection process - a failure no other asobi test would see,
+%% because it happens below websocket_info/2's return value.
+nova_splices_a_list_reply_into_separate_commands_test() ->
     ?assertEqual(
-        #{~"module" => ~"wasm", ~"message" => ~"trap"},
-        payload_of(~"game.error", Frame)
+        #{commands => [{text, ~"a"}, {text, ~"b"}], controller_data => st},
+        nova_basic_handler:handle_ws({reply, [{text, ~"a"}, {text, ~"b"}], st}, #{commands => []})
     ).
+
+%% The dual-emit is what asobi#347's nova pin bought: nova 0.15.1 consed a
+%% list-valued reply onto the command list as one cowboy command, so both
+%% frames arrived at cow_ws:frame/2 as a single frame and took the
+%% connection process down. Pin the frame count, not just the payloads —
+%% a regression to a single frame is exactly what shipped in #330.
+extension_frames_are_two_separate_frames_test() ->
+    Msg = {asobi_message, {game_message, ~"hi"}},
+    {reply, Frames, _State1} = asobi_ws_handler:websocket_info(Msg, #{}),
+    ?assertEqual(2, length(Frames)),
+    ?assertEqual([~"game.message", ~"module.message"], [type_of(F) || F <- Frames]).
+
+%% The legacy pair is the compat cost, and `game.message` is `game.send/2`
+%% - potentially one frame per player per tick. An operator whose clients
+%% all dispatch `module.*` must be able to stop paying for it before 1.0.
+legacy_game_frames_can_be_disabled_test() ->
+    ok = application:set_env(asobi, ws_legacy_game_frames, false),
+    try
+        MsgOk = {asobi_message, {game_message, ~"hi"}},
+        {reply, [Frame], _} = asobi_ws_handler:websocket_info(MsgOk, #{}),
+        ?assertEqual(~"module.message", type_of(Frame)),
+        MsgErr = {asobi_message, {script_error, #{~"message" => ~"boom"}}},
+        {reply, [ErrFrame], _} = asobi_ws_handler:websocket_info(MsgErr, #{}),
+        ?assertEqual(~"module.error", type_of(ErrFrame))
+    after
+        ok = application:unset_env(asobi, ws_legacy_game_frames)
+    end.
 
 %% The defensive encode path must still degrade to an `error` frame rather
 %% than crashing the connection process. Asserted on `reason` rather than the
@@ -174,14 +211,20 @@ script_error_carries_the_producing_extension_test() ->
 %% Nothing of the unencodable payload may reach the client either way.
 script_error_unencodable_payload_degrades_test() ->
     Msg = {asobi_message, {script_error, #{~"message" => {not_json}}}},
-    {reply, Frame, _State1} = asobi_ws_handler:websocket_info(Msg, #{}),
-    Payload = payload_of(~"error", Frame),
+    {reply, Frames, _State1} = asobi_ws_handler:websocket_info(Msg, #{}),
+    ?assertEqual(1, length(Frames)),
+    Payload = payload_of(~"error", Frames),
     ?assertEqual(~"internal", maps:get(~"reason", Payload)),
     ?assertEqual(~"internal", maps:get(~"code", maps:get(~"error", Payload))),
     ?assertEqual([~"error", ~"reason"], lists:sort(maps:keys(Payload))).
 
-payload_of(Type, {text, Raw}) ->
-    #{~"type" := Type, ~"payload" := Payload} = json:decode(iolist_to_binary(Raw)),
+type_of({text, Raw}) ->
+    #{~"type" := Type} = decode(Raw),
+    Type.
+
+payload_of(Type, Frames) when is_list(Frames) ->
+    [{text, Raw}] = [F || F <- Frames, type_of(F) =:= Type],
+    #{~"payload" := Payload} = decode(Raw),
     Payload.
 
 %% --- error frames carry both dialects ---

--- a/test/asobi_ws_handler_tests.erl
+++ b/test/asobi_ws_handler_tests.erl
@@ -180,7 +180,7 @@ nova_splices_a_list_reply_into_separate_commands_test() ->
 %% The dual-emit is what asobi#347's nova pin bought: nova 0.15.1 consed a
 %% list-valued reply onto the command list as one cowboy command, so both
 %% frames arrived at cow_ws:frame/2 as a single frame and took the
-%% connection process down. Pin the frame count, not just the payloads —
+%% connection process down. Pin the frame count, not just the payloads -
 %% a regression to a single frame is exactly what shipped in #330.
 extension_frames_are_two_separate_frames_test() ->
     Msg = {asobi_message, {game_message, ~"hi"}},


### PR DESCRIPTION
Plan item **S6**, the half of it that #330 could not ship.

## What S6 was for

`game.message` / `game.error` put ONE extension (Lua) in the wire type.
No second extension could reuse a type named after the first. #330 shipped
the mechanism - the producing extension travels in the payload's `module`
key - and deferred the type rename. The plan gives S6 a hard clock: before
the wire freeze.

## The constraint that deferred it is gone

nova 0.15.1's `nova_basic_handler:handle_ws/2` consed a list-valued reply
onto cowboy's command list as a single command, so `{reply, [F1, F2], S}`
reached `cow_ws:frame/2` as one frame and killed the connection process.
Dual-emit was therefore impossible, and a bare rename would have broken
every shipped SDK.

novaframework/nova#400 replaced the cons with a splice, and asobi carries
the fixed nova by git ref (#349). Verified before writing any of this:

```
> nova_basic_handler:handle_ws({reply, [{text, <<"a">>}, {text, <<"b">>}], st}, #{commands => []}).
#{commands => [{text,<<"a">>},{text,<<"b">>}], controller_data => st}
```

Two commands, order preserved, and `nova_ws_handler` hands `commands`
to cowboy untouched. `asobi_ws_SUITE` proves it end to end over a real
socket, which is the only place the splice is actually exercised.

## What this PR does

- Extension pushes are `module.message` and `module.error`.
- `game.message` and `game.error` are emitted alongside them, identical
  payload, same reply, legacy frame first. No shipped SDK breaks.
- Both new types get fixtures; both old ones keep theirs.
- The guide marks the `game.*` pair deprecated, says new SDK code
  dispatches on `module.*`, and says the pair is removed at the 1.0 wire
  break.

## The hot path, honestly

You asked for the reasoning rather than a default, so:

**`error` is free.** It is dev-mode only (`ASOBI_DEV_ERRORS=true`), rate
limited to one per second per match, and never emitted in production.
Dual-emitting it costs nothing an operator will ever measure.

**`message` is not free.** `game.message` is asobi_lua's `game.send/2`.
A script may call it per player per tick; at 30Hz with 8 players that is
240 frames/s per match becoming 480, each with its own `json:encode/1`
and its own cowboy frame. It is the hottest extension-produced egress
path asobi has, and dual-emit doubles it.

But the alternative is worse. Five of seven SDKs cannot dispatch an
unknown frame type at runtime, and Godot/LOVE users vendor by copying
source, so emitting only `module.message` makes per-player messages
vanish silently in every shipped build - the exact silent dev-facing
failure class we treat as a defect.

So the split is not "dual-emit error, rename message". It is: **dual-emit
both, and give the hot path an exit that does not require waiting for
1.0.** `asobi.ws_legacy_game_frames`, default `true`:

- Default: today's wire plus the new types. Nothing breaks, anywhere.
- `false`: only `module.*`. An operator whose clients all dispatch the
  new types stops paying the doubling immediately.

One flag, not two, and it governs `error` as well - not for the cost, but
because an SDK author verifying their new dispatch path wants the old
frame out of the way while they do it. At 1.0 the legacy pair goes and
the flag becomes a no-op.

If you would rather not carry a flag at all, the fallback is unconditional
dual-emit and a note in the performance-tuning guide. I did not pick that
because it leaves a real per-tick doubling with no operator remedy until
a major version.

## Ordering

Legacy frame first, `module.*` second, so a shipped client sees
byte-identical frame ordering to before this PR. The guide warns not to
dispatch on both - a client handling `game.message` *and* `module.message`
processes every message twice.

## The commit-message defect on main

Commit `a6bc2eb` ("refactor: generalise the two Lua-specific WebSocket
frames", #330) is a squash whose message says:

> Both are now also emitted as `module.message` and `module.error`

That is not what merged. The second commit inside the same squash
("fix: keep the extension frames to one wire frame per message") removed
the dual-emit because of the nova bug above, and its text is further down
the same message - so the message contradicts itself and the top half is
the part people read. **No release before this
change emits `module.*` - not v0.54.0, and not v0.53.0 where `a6bc2eb`
landed.**

A merged commit cannot be rewritten, so the correction lives where
somebody would actually look for it:
`guides/websocket-protocol.md` now has a "Wire history" paragraph naming
`a6bc2eb` and stating what each release actually emits.

## Coverage gate

`asobi_protocol_coverage_tests` scans `encode_reply(_, ~"type", _)`
literals in the handler. Both pairs now go out through
`extension_frames/3`, where the encode takes a variable, so the scanner
learns `extension_frames(~"new", ~"legacy", _)` too. Without that the
four fixtures read as stale (which is how I found it).

## Checks

`fmt --check`, `xref`, `dialyzer` clean. `eunit` 1236/1236. `ct
--suite=asobi_ws_SUITE` 8/8.

**Revert verification.** Reduced `extension_frames/3` to the pre-PR
single legacy frame: **6 eunit failures** (the four payload tests, the
frame-count test, the flag test) and **1 CT failure**
(`ws_script_error_rendered_as_extension_error`). Restored, all green.

One caveat I will not paper over: `no_stale_fixtures_test` did **not**
fail under that revert, because the `~"module.message"` literal is still
present as an argument in the source the scanner reads. The fixture gate
proves a type name appears at an emit site, not that the frame reaches a
socket. The frame-count eunit test and the CT case are what cover that.

`nova_splices_a_list_reply_into_separate_commands_test` is a pin guard,
not a test of asobi code - it fails if the nova pin is reverted to a
build without #400, which would otherwise only show up as a dead
connection at runtime.
