### PR TITLE
feat(ops): durable audit rows carrying the actor, and a partial-failure outcome

### DIFF
--- a/docs/adr/0007-durable-ops-audit-rows.md
+++ b/docs/adr/0007-durable-ops-audit-rows.md
@@ -1,0 +1,121 @@
+# ADR 0007: Ops mutations are audited as durable rows, with a partial-failure outcome
+
+Date: 2026-08-04
+
+## Status
+
+Accepted. Implements the audit half of the ecosystem's
+`0007-ops-identity-and-capabilities`, which introduced the actor record.
+
+## Context
+
+The actor record `#{id, display, source, caps, attested}` ships and resolves
+on every ops request, but nothing writes it anywhere durable. Attribution
+that lives only in the request is gone the moment the response is sent.
+
+The console's audit is structured logs, through one function:
+
+```erlang
+log_action(Action, Fields, {ok, term()} | {error, term()}) -> ok
+```
+
+Two defects, and they compound.
+
+**Logs cannot answer the question the audit exists for.** "Who banned this
+player six months ago" needs a query against something joinable to the
+players table, on a retention schedule the deployment controls. Shipped logs
+are neither.
+
+**The outcome type cannot express partial failure**, and there is a live
+instance. `asobi_admin_notifications_controller:broadcast/1` calls
+`log_action(~"broadcast", #{recipient_count => length(SentTo)}, {ok, SentTo})`
+where `SentTo` came from `do_broadcast/4` - a copy of
+`asobi_notify:send_many/4`, which dropped every failed insert on the floor
+and returned only the survivors. A broadcast that reached three of ten
+players was audited as a success with a count of three. Nothing recorded the
+seven.
+
+There is exactly one such call site today. There will be more as the write
+plane lands, and each one built against a binary outcome is a call site to
+rewrite.
+
+## Decision
+
+**Three things, together: a row, a widened outcome, and core doing the
+wrapping.**
+
+### 1. `ops_audit_entries`, a row per mutation
+
+Schema `asobi_ops_audit_entry`. The actor is four flattened columns -
+`actor_id`, `actor_display`, `actor_source`, `actor_attested` - not a foreign
+key. There is no actors table, and more importantly a row must keep saying
+what it said at the time after the actor's capabilities change or its token
+source is retired.
+
+`actor_attested` is load-bearing. A `static_secret` actor named by the
+`x-asobi-operator` header is self-declared and spoofable; the column is what
+stops every stored name from implying a verification that never happened.
+
+Indexes: `(actor_id, occurred_at)`, `(action, occurred_at)`, `(target_id)`.
+One per question - what did this operator do, who has performed this action,
+who has acted on this subject. No bare `occurred_at` index; both composites
+already answer a bounded time range.
+
+`target_id` carries no foreign key. A player deletion, GDPR erasure
+included, must not cascade away the record that someone banned them.
+
+Rows are append-only. Core never updates or deletes one, and ships no
+reaper: retention is a jurisdiction-dependent operator policy, and the
+leading `occurred_at` ordering makes a prune a single ranged delete.
+
+### 2. `{ok, Succeeded, Failed}`
+
+The outcome contract, adopted **before** the first bulk endpoint rather than
+after. `Failed` entries carry their reason. A single-subject mutation is the
+one-element case, not a second contract.
+
+Stored as an `outcome` column of `ok`, `partial` or `error` plus two counts,
+so "everything that did not fully succeed" is an index scan and not a jsonb
+parse. A bulk call where every subject failed is `error`, not `partial`.
+
+`asobi_notify:send_many/4` is widened to return it, which is where the
+survivors-only shape originated.
+
+### 3. Core wraps the mutation
+
+`asobi_ops_audit:mutation/4` runs the operation and builds the row from the
+operation's own return value. A call site cannot forget to audit, and cannot
+hand the audit an outcome the operation did not produce - which is precisely
+what the broadcast handler did.
+
+A core-wrapped mutation has no route in front of it, so it performs the
+capability check itself, through the same `asobi_ops_caps:authorised/2` the
+router's security callback calls. One function still authorises; it is called
+from whichever entry point the caller actually reaches. A refusal is audited
+as an `error` outcome, because a denied attempt is worth a row.
+
+**The audit never fails the operation.** It runs after the change has
+happened, so refusing the response cannot undo a ban; it would only invite a
+retry that applies the change twice. A write-ahead row could fail closed, but
+it would record intent, and outcome is the thing being asked for. When the
+insert fails - or raises - the row is emitted at error level with the same
+field names, so the record degrades from queryable to greppable rather than
+disappearing.
+
+## Consequences
+
+- **Attribution survives the request.** Every mutation is answerable months
+  later, and the answer carries whether the name was attested.
+- **The one existing lie is fixable in one call.**
+  `asobi_ops_notifications:broadcast/5` is the core-wrapped entry point the
+  console's mutation moves onto (widgrensit/asobi_admin#6). Until it does,
+  the console keeps its own copy and keeps lying; core cannot fix that from
+  here.
+- **No ops write routes were added.** The plane stays read-only. This is the
+  mechanism plus the one mutation that already existed, not a write surface.
+- **An audit row is a new failure mode with a documented outcome.** A
+  deployment whose database is degraded loses queryable audit rows and keeps
+  error-level log lines. That is a stated trade, not a silent one.
+- **`details` is diagnostic, not queryable.** Per-subject reasons are capped
+  at 50 entries and 200 bytes each; the counts are the queryable surface.
+  Anything a future consumer needs to filter on becomes a column.

--- a/guides/rest-api.md
+++ b/guides/rest-api.md
@@ -411,6 +411,36 @@ it never affects what a request may do, and it is recorded unattested. A
 label that is empty, multi-valued, over 64 bytes, or not printable ASCII is
 dropped rather than trusted.
 
+### Ops audit
+
+Every ops-plane mutation writes a row to `ops_audit_entries`, carrying the
+acting operator (`actor_id`, `actor_display`, `actor_source`,
+`actor_attested`), the action, its subject, and when it happened. Reads are
+not audited.
+
+The routes above are all reads, so nothing above writes a row yet. The table
+exists ahead of the write plane, and the one operator mutation that already
+exists - broadcasting a notification - goes through it.
+
+`actor_attested` is the important column. A name that came from
+`x-asobi-operator` is self-declared, so it is stored `false`; only a verified
+identity is stored `true`. Treat an unattested name as a hint, not evidence.
+
+`outcome` is `ok`, `partial` or `error`, with `succeeded_count` and
+`failed_count` beside it, so a fan-out that reached some of its subjects is
+never recorded as a success. Per-subject reasons sit in `details` and are
+diagnostic only; the counts are what you query.
+
+Rows are append-only and core never prunes them. Retention is yours to set:
+delete by `occurred_at`, which leads both composite indexes. Nothing cascades
+into the table either, so deleting a player does not erase the record of what
+was done to them.
+
+An audit write never fails the operation it describes. It runs after the
+change has already happened, so refusing the response could only invite a
+retry that applies the change twice. If the insert fails, the row is emitted
+instead at error level with the same field names, so ship your logs.
+
 ## Errors
 
 A failing request returns its HTTP status and one object:

--- a/rebar.config
+++ b/rebar.config
@@ -211,7 +211,8 @@
             asobi_storage,
             asobi_leaderboard_entry,
             asobi_player_identity,
-            asobi_vote
+            asobi_vote,
+            asobi_ops_audit_entry
         ]},
         {<<"Controllers">>, [
             asobi_auth_controller,
@@ -236,7 +237,9 @@
             asobi_ops_page,
             asobi_ops_players,
             asobi_ops_matches,
-            asobi_ops_features
+            asobi_ops_features,
+            asobi_ops_audit,
+            asobi_ops_notifications
         ]},
         {<<"Real-Time">>, [
             asobi_ws_handler,

--- a/src/lua/asobi_lua_api.erl
+++ b/src/lua/asobi_lua_api.erl
@@ -543,13 +543,13 @@ fun_notify_many() ->
                 is_list(PlayerIds), is_binary(Type), is_binary(Subject)
             ->
                 Ids = [Id || Id <- PlayerIds, is_binary(Id)],
-                Sent = asobi_notify:send_many(Ids, Type, Subject, to_map(Data)),
+                {ok, Sent, _Failed} = asobi_notify:send_many(Ids, Type, Subject, to_map(Data)),
                 ok_result(Sent, St);
             [PlayerIds, Type, Subject] when
                 is_list(PlayerIds), is_binary(Type), is_binary(Subject)
             ->
                 Ids = [Id || Id <- PlayerIds, is_binary(Id)],
-                Sent = asobi_notify:send_many(Ids, Type, Subject, #{}),
+                {ok, Sent, _Failed} = asobi_notify:send_many(Ids, Type, Subject, #{}),
                 ok_result(Sent, St);
             _ ->
                 error_result(~"notify_many requires (player_ids, type, subject[, data])", St)

--- a/src/migrations/m20260804063533_create_ops_audit_entries.erl
+++ b/src/migrations/m20260804063533_create_ops_audit_entries.erl
@@ -1,0 +1,37 @@
+-module(m20260804063533_create_ops_audit_entries).
+-moduledoc false.
+-behaviour(kura_migration).
+-include_lib("kura/include/kura.hrl").
+-export([up/0, down/0]).
+
+-spec up() -> [kura_migration:operation()].
+up() ->
+    [
+        {create_table, ~"ops_audit_entries", [
+            #kura_column{name = id, type = uuid, primary_key = true, nullable = false},
+            #kura_column{name = actor_id, type = string, nullable = false},
+            #kura_column{name = actor_display, type = string, nullable = false},
+            #kura_column{name = actor_source, type = string, nullable = false},
+            #kura_column{name = actor_attested, type = boolean, nullable = false, default = false},
+            #kura_column{name = action, type = string, nullable = false},
+            #kura_column{name = target_type, type = string},
+            #kura_column{name = target_id, type = string},
+            #kura_column{name = outcome, type = string, nullable = false},
+            #kura_column{name = succeeded_count, type = integer, nullable = false, default = 0},
+            #kura_column{name = failed_count, type = integer, nullable = false, default = 0},
+            #kura_column{name = details, type = jsonb, default = #{}},
+            #kura_column{name = occurred_at, type = utc_datetime, nullable = false}
+        ]},
+        {create_index, ~"ops_audit_entries", [actor_id, occurred_at], #{}},
+        {create_index, ~"ops_audit_entries", [action, occurred_at], #{}},
+        {create_index, ~"ops_audit_entries", [target_id], #{}}
+    ].
+
+-spec down() -> [kura_migration:operation()].
+down() ->
+    [
+        {drop_table, ~"ops_audit_entries"},
+        {drop_index, ~"ops_audit_entries_actor_id_occurred_at_index"},
+        {drop_index, ~"ops_audit_entries_action_occurred_at_index"},
+        {drop_index, ~"ops_audit_entries_target_id_index"}
+    ].

--- a/src/notifications/asobi_notify.erl
+++ b/src/notifications/asobi_notify.erl
@@ -1,4 +1,15 @@
 -module(asobi_notify).
+-moduledoc """
+Delivery of notifications to players.
+
+`send_many/4` returns `{ok, Succeeded, Failed}` rather than the list of
+recipients it managed to reach. The old shape could not express partial
+failure at all - it dropped failed inserts on the floor - and its one
+operator-facing caller then audited a half-delivered broadcast as a success.
+The widened shape is `asobi_ops_audit`'s outcome contract, so an
+operator-attributed fan-out is auditable without the call site
+reconstructing what happened.
+""".
 
 -export([send/4, send_many/4]).
 
@@ -24,14 +35,28 @@ send(PlayerId, Type, Subject, Content) ->
             Err
     end.
 
--spec send_many([binary()], binary(), binary(), map()) -> [binary()].
+-doc """
+Send one notification to each of `PlayerIds`.
+
+Every recipient is attempted; one failure does not abandon the rest. Returns
+`{ok, Succeeded, Failed}`, `Failed` carrying each recipient with the reason
+it could not be delivered.
+""".
+-spec send_many([binary()], binary(), binary(), map()) ->
+    {ok, [binary()], [{binary(), term()}]}.
 send_many(PlayerIds, Type, Subject, Content) ->
-    lists:filtermap(
-        fun(PlayerId) ->
-            case send(PlayerId, Type, Subject, Content) of
-                {ok, _} -> {true, PlayerId};
-                {error, _} -> false
-            end
-        end,
-        PlayerIds
-    ).
+    {Succeeded, Failed} = lists:partition(
+        fun({_PlayerId, Result}) -> Result =:= ok end,
+        [{PlayerId, attempt(PlayerId, Type, Subject, Content)} || PlayerId <- PlayerIds]
+    ),
+    {ok, [PlayerId || {PlayerId, _} <- Succeeded], [
+        {PlayerId, Reason}
+     || {PlayerId, {error, Reason}} <- Failed
+    ]}.
+
+-spec attempt(binary(), binary(), binary(), map()) -> ok | {error, term()}.
+attempt(PlayerId, Type, Subject, Content) ->
+    case send(PlayerId, Type, Subject, Content) of
+        {ok, _Notif} -> ok;
+        {error, Reason} -> {error, Reason}
+    end.

--- a/src/ops/asobi_ops_audit.erl
+++ b/src/ops/asobi_ops_audit.erl
@@ -1,0 +1,209 @@
+-module(asobi_ops_audit).
+-moduledoc """
+Core-wrapped audit for ops-plane mutations (ADR 0007).
+
+`mutation/4` runs the operation and writes the row from the operation's own
+return value. A call site therefore cannot forget to audit and cannot
+misreport the outcome, which is the whole point: the console's broadcast
+handler used to pass a hand-built `{ok, SentTo}` to its logger while the
+backing function had silently dropped every failed insert, so a
+half-delivered broadcast was recorded as a success.
+
+## The outcome contract
+
+    {ok, Succeeded, Failed} | {error, Reason}
+
+`Succeeded` and `Failed` are lists of subjects the operation acted on -
+`Failed` entries carry their reason. A single-subject mutation is the
+one-element case, not a different contract, so nothing has to widen later
+when the first bulk endpoint lands. The stored `outcome` column is `ok`,
+`partial` or `error`, which is what makes "show me everything that did not
+fully succeed" an index scan rather than a jsonb parse.
+
+`{error, Reason}` is the operation that never got as far as having subjects -
+a rejected parameter, a lost connection.
+
+## When the audit write itself fails
+
+**The audit never fails the operation.** It runs after the mutation has
+already happened, so refusing the response cannot undo a ban or un-send a
+notification; it would only invite a retry that applies the change twice.
+A write-ahead row could fail closed, but it would record intent rather than
+outcome, and outcome - specifically partial failure - is what ADR 0007 asks
+for.
+
+The cost of that choice is paid where it is cheapest: a failed insert is
+re-emitted at error level with every field the row would have carried, so
+the record degrades from queryable to greppable rather than disappearing.
+Nothing is dropped silently. A raise inside the audit path is caught for the
+same reason - the audit must not be able to fail an operation that already
+happened.
+
+Successful writes are not also logged. The row is the record, and mirroring
+it into logs would double the retention surface holding player ids for no
+new information.
+
+A mutation that raises is audited as an error and then re-raised with its
+original stacktrace. A crash is an outcome, and the plane should not be able
+to hide one by exploding.
+""".
+
+-include_lib("kernel/include/logger.hrl").
+
+-export([mutation/4, record/4]).
+
+-type subject() :: binary().
+-type failure() :: {subject(), term()}.
+-type outcome() :: {ok, [subject()], [failure()]} | {error, term()}.
+-type target() :: {binary(), subject() | undefined} | undefined.
+
+-export_type([subject/0, failure/0, outcome/0, target/0]).
+
+%% Bounds on the diagnostic `details` payload. An operator picks the fan-out
+%% size, so an unbounded failure list is a lever for an oversized jsonb value
+%% (asobi#169, asobi#216) - and the counts, not the list, are what anyone
+%% queries.
+-define(MAX_DETAIL_FAILURES, 50).
+-define(MAX_REASON_BYTES, 200).
+
+-doc """
+Run `Fun` and audit whatever it returns.
+
+Returns `Fun`'s own value unchanged, so wrapping a call site is a
+substitution rather than a rewrite.
+""".
+-spec mutation(asobi_ops_auth:actor(), binary(), target(), fun(() -> outcome())) -> outcome().
+mutation(Actor, Action, Target, Fun) ->
+    try Fun() of
+        Outcome ->
+            record(Actor, Action, Target, Outcome),
+            Outcome
+    catch
+        Class:Reason:Stack ->
+            record(Actor, Action, Target, {error, {Class, Reason}}),
+            erlang:raise(Class, Reason, Stack)
+    end.
+
+-doc """
+Write one audit row for an outcome the caller already has.
+
+Prefer `mutation/4`. This exists for a call site that performs its own
+sequencing and genuinely holds the real outcome; it can still be handed a
+lie, which `mutation/4` cannot.
+""".
+-spec record(asobi_ops_auth:actor(), binary(), target(), outcome()) -> ok.
+record(Actor, Action, Target, Outcome) ->
+    %% Never let the audit path itself decide the fate of the operation it
+    %% describes: a raise here - a lost connection, an unexpected reason term -
+    %% would turn a completed mutation into a 500 the caller would retry.
+    try write(Actor, Action, Target, Outcome) of
+        ok -> ok
+    catch
+        Class:Reason:Stack ->
+            ?LOG_ERROR(#{
+                msg => ~"ops audit row not written",
+                action => Action,
+                class => Class,
+                reason => Reason,
+                stacktrace => Stack
+            }),
+            ok
+    end.
+
+-spec write(asobi_ops_auth:actor(), binary(), target(), outcome()) -> ok.
+write(Actor, Action, Target, Outcome) ->
+    Params = params(Actor, Action, Target, Outcome),
+    CS = kura_changeset:cast(
+        asobi_ops_audit_entry, #{}, Params, maps:keys(Params)
+    ),
+    case asobi_repo:insert(CS) of
+        {ok, _Row} ->
+            ok;
+        {error, Reason} ->
+            ?LOG_ERROR((loggable(Params))#{
+                msg => ~"ops audit row not persisted",
+                reason => Reason
+            }),
+            ok
+    end.
+
+%% The row's own field names, so a grep for the lost row reads the same as a
+%% query for a stored one. `occurred_at` is rendered because a calendar
+%% datetime tuple does not survive a JSON log formatter.
+-spec loggable(map()) -> map().
+loggable(#{occurred_at := {{Y, Mo, D}, {H, Mi, S}}} = Params) ->
+    Rendered = iolist_to_binary(
+        io_lib:format("~4..0b-~2..0b-~2..0bT~2..0b:~2..0b:~2..0bZ", [Y, Mo, D, H, Mi, S])
+    ),
+    Params#{occurred_at => Rendered}.
+
+-spec params(asobi_ops_auth:actor(), binary(), target(), outcome()) -> map().
+params(Actor, Action, Target, Outcome) ->
+    #{
+        id := ActorId,
+        display := Display,
+        source := Source,
+        attested := Attested
+    } = Actor,
+    {SucceededCount, FailedCount} = counts(Outcome),
+    Base = #{
+        actor_id => ActorId,
+        actor_display => Display,
+        actor_source => atom_to_binary(Source),
+        actor_attested => Attested,
+        action => Action,
+        outcome => classify(Outcome),
+        succeeded_count => SucceededCount,
+        failed_count => FailedCount,
+        details => details(Outcome),
+        occurred_at => calendar:universal_time()
+    },
+    maps:merge(Base, target(Target)).
+
+%% An absent target is an absent key rather than an `undefined` value: the
+%% cast would reject the atom, and a missing column reads back as NULL, which
+%% is what "this action had no single subject" means.
+-spec target(target()) -> map().
+target(undefined) -> #{};
+target({Type, undefined}) -> #{target_type => Type};
+target({Type, Id}) -> #{target_type => Type, target_id => Id}.
+
+-spec counts(outcome()) -> {non_neg_integer(), non_neg_integer()}.
+counts({ok, Succeeded, Failed}) -> {length(Succeeded), length(Failed)};
+counts({error, _Reason}) -> {0, 0}.
+
+%% A bulk call where every subject failed is not a partial success. It is
+%% recorded as `error` so the "did not fully succeed" query and the "nothing
+%% happened" query are answerable separately.
+-spec classify(outcome()) -> binary().
+classify({ok, _Succeeded, []}) -> ~"ok";
+classify({ok, [], [_ | _]}) -> ~"error";
+classify({ok, [_ | _], [_ | _]}) -> ~"partial";
+classify({error, _Reason}) -> ~"error".
+
+-spec details(outcome()) -> map().
+details({ok, _Succeeded, []}) ->
+    #{};
+details({ok, _Succeeded, Failed}) ->
+    Shown = lists:sublist(Failed, ?MAX_DETAIL_FAILURES),
+    #{
+        failures => [
+            #{subject => Subject, reason => reason(Reason)}
+         || {Subject, Reason} <- Shown
+        ],
+        failures_omitted => length(Failed) - length(Shown)
+    };
+details({error, Reason}) ->
+    #{reason => reason(Reason)}.
+
+-spec reason(term()) -> binary().
+reason(Reason) when is_binary(Reason) ->
+    truncate(Reason);
+reason(Reason) when is_atom(Reason) ->
+    atom_to_binary(Reason);
+reason(Reason) ->
+    truncate(iolist_to_binary(io_lib:format("~0p", [Reason]))).
+
+-spec truncate(binary()) -> binary().
+truncate(Bin) when byte_size(Bin) =< ?MAX_REASON_BYTES -> Bin;
+truncate(Bin) -> <<(binary:part(Bin, 0, ?MAX_REASON_BYTES))/binary, "...">>.

--- a/src/ops/asobi_ops_audit_entry.erl
+++ b/src/ops/asobi_ops_audit_entry.erl
@@ -1,0 +1,91 @@
+-module(asobi_ops_audit_entry).
+-moduledoc """
+The durable ops audit row: who acted, what they did, what to, and how it ended.
+
+Structured logs cannot answer "who banned this player" six months later - they
+are shipped somewhere else, rotated on someone else's schedule and not
+joinable against the players table. ADR 0007 makes the audit a row for that
+reason, so this schema is written for the queries an incident actually asks.
+
+## Shape
+
+The actor is flattened into four columns rather than a foreign key. There is
+no actors table and, per ADR 0007, there will not be one for self-host; more
+importantly a row must keep saying what it said at the time even after the
+actor's capabilities change or its token source is retired. The audit is a
+statement about the past, not a view of the present.
+
+`actor_attested` carries the honesty of the name. A `static_secret` actor
+labelled only by the `x-asobi-operator` header is self-declared and
+spoofable, so the row records `false` and a reader can tell an asserted name
+from a verified one. Dropping the flag would make every row imply a
+confidence the plane does not have.
+
+`outcome` is one of `ok`, `partial` or `error`, with `succeeded_count` and
+`failed_count` beside it, because the interesting query is "show me
+everything that did not fully succeed" and that must not require parsing
+`details`. `details` holds the per-subject failure reasons, which are
+diagnostic rather than queryable.
+
+## Indexes
+
+Three, each answering one question and no more:
+
+- `(actor_id, occurred_at)` - "what did this operator do, most recent first".
+- `(action, occurred_at)` - "who has banned anyone lately", the audit's
+  reason to exist.
+- `(target_id)` - "who has acted on this player", the support-ticket query.
+
+`occurred_at` is the second column of two composites rather than an index of
+its own: a bare time index would only serve retention pruning, and either
+composite already answers a bounded time range.
+
+## Retention
+
+Rows are append-only - never updated, never deleted by application code. An
+audit row that a later operation can rewrite is not evidence. Pruning is an
+operator policy decision (jurisdiction and incident-response window differ
+per deployment), so core ships no reaper; the leading `occurred_at` ordering
+in both composites makes a prune a single ranged delete when one is added.
+
+`target_id` deliberately carries no foreign key. A player deletion - GDPR
+erasure included - must not cascade away the record that someone banned them.
+Erasing the subject of an audit row is a separate, deliberate operation.
+""".
+-behaviour(kura_schema).
+
+-include_lib("kura/include/kura.hrl").
+
+-export([table/0, fields/0, indexes/0, generate_id/0]).
+
+-spec table() -> binary().
+table() -> ~"ops_audit_entries".
+
+-spec generate_id() -> binary().
+generate_id() -> asobi_id:generate().
+
+-spec fields() -> [#kura_field{}].
+fields() ->
+    [
+        #kura_field{name = id, type = uuid, primary_key = true, nullable = false},
+        #kura_field{name = actor_id, type = string, nullable = false},
+        #kura_field{name = actor_display, type = string, nullable = false},
+        #kura_field{name = actor_source, type = string, nullable = false},
+        #kura_field{name = actor_attested, type = boolean, default = false, nullable = false},
+        #kura_field{name = action, type = string, nullable = false},
+        #kura_field{name = target_type, type = string},
+        #kura_field{name = target_id, type = string},
+        #kura_field{name = outcome, type = string, nullable = false},
+        #kura_field{name = succeeded_count, type = integer, default = 0, nullable = false},
+        #kura_field{name = failed_count, type = integer, default = 0, nullable = false},
+        #kura_field{name = details, type = jsonb, default = #{}},
+        #kura_field{name = occurred_at, type = utc_datetime, nullable = false}
+    ].
+
+-spec indexes() -> [{[atom()], map()}].
+indexes() ->
+    [
+        {[actor_id, occurred_at], #{}},
+        {[action, occurred_at], #{}},
+        {[target_id], #{}}
+    ].

--- a/src/ops/asobi_ops_notifications.erl
+++ b/src/ops/asobi_ops_notifications.erl
@@ -1,0 +1,42 @@
+-module(asobi_ops_notifications).
+-moduledoc """
+The operator-attributed notification broadcast.
+
+This is the mutation half of the console's notifications screen, moved into
+core so the audit wraps it rather than the handler remembering to. The
+console keeps parsing, deduplicating and capping the recipient list - those
+are presentation concerns - and calls this for the part that changes player
+state.
+
+It is not a route. The ops plane is read-only, and this does not change that;
+it is the Erlang entry point the existing console mutation calls, which is
+what lets `{ok, Succeeded, Failed}` reach an audit row instead of being
+flattened into a list of survivors on the way out.
+
+Because there is no route, there is no route-level capability check either -
+so the check happens here, through the same `asobi_ops_caps:authorised/2`
+that the router's security callback uses. One function still authorises; it
+is simply called from the entry point an in-process caller actually reaches.
+""".
+
+-export([broadcast/5]).
+
+-define(ACTION, ~"notifications.broadcast").
+-define(CLASS, player_data).
+
+-doc """
+Send `Subject` to every id in `PlayerIds` as `Actor`, and audit the result.
+
+Returns the widened outcome unchanged, so a caller can report exactly what
+happened. The audit row is written whatever the outcome, including the
+all-failed case and the refusal.
+""".
+-spec broadcast(asobi_ops_auth:actor(), binary(), binary(), map(), [binary()]) ->
+    asobi_ops_audit:outcome().
+broadcast(#{caps := Caps} = Actor, Type, Subject, Content, PlayerIds) ->
+    asobi_ops_audit:mutation(Actor, ?ACTION, {~"player", undefined}, fun() ->
+        case asobi_ops_caps:authorised(?CLASS, Caps) of
+            true -> asobi_notify:send_many(PlayerIds, Type, Subject, Content);
+            false -> {error, forbidden}
+        end
+    end).

--- a/test/asobi_lua_api_tests.erl
+++ b/test/asobi_lua_api_tests.erl
@@ -42,6 +42,7 @@ api_test_() ->
         {"game.leaderboard.around returns entries", fun game_lb_around/0},
         {"game.notify sends notification", fun game_notify/0},
         {"game.notify_many forwards ids", fun game_notify_many/0},
+        {"game.notify_many reports only the recipients reached", fun game_notify_many_partial/0},
         {"game.storage.get reads doc", fun game_storage_get/0},
         {"game.storage.set writes doc", fun game_storage_set/0},
         {"game.storage.player_get reads player doc", fun game_storage_player_get/0},
@@ -132,7 +133,7 @@ setup() ->
     end),
     meck:new(asobi_notify, [no_link]),
     meck:expect(asobi_notify, send, fun(_, _, _, _) -> {ok, #{}} end),
-    meck:expect(asobi_notify, send_many, fun(Ids, _, _, _) -> Ids end),
+    meck:expect(asobi_notify, send_many, fun(Ids, _, _, _) -> {ok, Ids, []} end),
     meck:new(asobi_repo, [no_link]),
     meck:expect(asobi_repo, all, fun(_) -> {ok, []} end),
     meck:expect(asobi_repo, insert, fun(_) -> {ok, #{value => #{}}} end),
@@ -283,6 +284,17 @@ game_notify_many() ->
     {ok, [Count | _], _} = eval(Code, St),
     ?assertEqual(2, trunc(Count)),
     ?assert(meck:called(asobi_notify, send_many, '_')).
+
+%% The Lua surface still returns the recipients that were reached, so a script
+%% comparing that count against the ids it passed can see a partial send.
+game_notify_many_partial() ->
+    meck:expect(asobi_notify, send_many, fun([First | _], _, _, _) ->
+        {ok, [First], [{~"p2", connection_closed}]}
+    end),
+    St = install_api(),
+    Code = "local r = game.notify_many({'p1','p2'}, 'reward', 'gg')\nreturn #r.ok",
+    {ok, [Count | _], _} = eval(Code, St),
+    ?assertEqual(1, trunc(Count)).
 
 game_storage_get() ->
     St = install_api(),

--- a/test/asobi_notify_tests.erl
+++ b/test/asobi_notify_tests.erl
@@ -1,0 +1,75 @@
+-module(asobi_notify_tests).
+
+-include_lib("eunit/include/eunit.hrl").
+-include_lib("kura/include/kura.hrl").
+
+send_many_test_() ->
+    {setup, fun setup/0, fun cleanup/1, [
+        fun every_recipient_succeeds/0,
+        fun partial_failure_is_reported_not_dropped/0,
+        fun a_failure_does_not_abandon_the_rest/0,
+        fun only_reachable_recipients_are_pushed/0
+    ]}.
+
+setup() ->
+    meck:new(asobi_repo, [passthrough]),
+    meck:new(asobi_presence, [passthrough]),
+    meck:expect(asobi_presence, send, fun(_PlayerId, _Message) -> ok end),
+    ok.
+
+cleanup(_) ->
+    catch meck:unload(asobi_repo),
+    catch meck:unload(asobi_presence),
+    ok.
+
+%% `player_id` is a uuid column, so the changeset only carries it when the id
+%% really is one.
+players() ->
+    [asobi_id:generate() || _ <- lists:seq(1, 3)].
+
+%% Fail the insert for the listed player ids, succeed for the rest.
+expect_inserts_failing_for(Failing) ->
+    meck:expect(asobi_repo, insert, fun(#kura_changeset{changes = Changes}) ->
+        PlayerId = maps:get(player_id, Changes),
+        case lists:member(PlayerId, Failing) of
+            true -> {error, connection_closed};
+            false -> {ok, Changes#{id => PlayerId}}
+        end
+    end).
+
+send_many(Ids) ->
+    asobi_notify:send_many(Ids, ~"system", ~"Maintenance", #{}).
+
+every_recipient_succeeds() ->
+    [P1, P2, _P3] = players(),
+    expect_inserts_failing_for([]),
+    ?assertEqual({ok, [P1, P2], []}, send_many([P1, P2])).
+
+%% The old shape returned only the survivors, so the caller could not tell a
+%% half-delivered broadcast from a complete one.
+partial_failure_is_reported_not_dropped() ->
+    [P1, P2, P3] = players(),
+    expect_inserts_failing_for([P2]),
+    ?assertEqual(
+        {ok, [P1, P3], [{P2, connection_closed}]},
+        send_many([P1, P2, P3])
+    ).
+
+a_failure_does_not_abandon_the_rest() ->
+    [P1, P2, P3] = players(),
+    expect_inserts_failing_for([P1]),
+    meck:reset(asobi_repo),
+    {ok, Succeeded, Failed} = send_many([P1, P2, P3]),
+    ?assertEqual(3, length(Succeeded) + length(Failed)),
+    ?assertEqual(3, length(meck:history(asobi_repo))).
+
+only_reachable_recipients_are_pushed() ->
+    [P1, P2, P3] = players(),
+    expect_inserts_failing_for([P2]),
+    meck:reset(asobi_presence),
+    {ok, _Succeeded, _Failed} = send_many([P1, P2, P3]),
+    Pushed = [
+        PlayerId
+     || {_, {asobi_presence, send, [PlayerId, _]}, _} <- meck:history(asobi_presence)
+    ],
+    ?assertEqual([P1, P3], Pushed).

--- a/test/asobi_ops_audit_SUITE.erl
+++ b/test/asobi_ops_audit_SUITE.erl
@@ -1,0 +1,103 @@
+-module(asobi_ops_audit_SUITE).
+
+-include_lib("nova_test/include/nova_test.hrl").
+-include_lib("kura/include/kura.hrl").
+
+-export([all/0, groups/0, init_per_suite/1, end_per_suite/1]).
+-export([
+    clean_broadcast_is_stored_as_ok/1,
+    half_failed_broadcast_is_stored_as_partial/1,
+    row_carries_the_unattested_actor/1
+]).
+
+all() -> [{group, ops_audit}].
+
+groups() ->
+    [
+        {ops_audit, [], [
+            clean_broadcast_is_stored_as_ok,
+            half_failed_broadcast_is_stored_as_partial,
+            row_carries_the_unattested_actor
+        ]}
+    ].
+
+init_per_suite(Config) ->
+    Config0 = asobi_test_helpers:start(Config),
+    Username = asobi_test_helpers:unique_username(~"audit_p1"),
+    {ok, Resp} = nova_test:post(
+        "/api/v1/auth/register",
+        #{json => #{~"username" => Username, ~"password" => ~"testpass123"}},
+        Config0
+    ),
+    #{~"player_id" := PlayerId} = nova_test:json(Resp),
+    [{player_id, PlayerId} | Config0].
+
+end_per_suite(Config) ->
+    Config.
+
+%% A display name unique to the calling test, so the row it wrote is the row
+%% read back even when other suites are broadcasting on the same database.
+actor(Display) ->
+    #{
+        id => ~"static_secret",
+        display => Display,
+        source => static_secret,
+        caps => [read, player_data, config],
+        attested => false
+    }.
+
+label(Case) ->
+    <<(atom_to_binary(Case))/binary, "_", (asobi_id:rand_suffix(6))/binary>>.
+
+row(Display) ->
+    Query = kura_query:where(kura_query:from(asobi_ops_audit_entry), {actor_display, '=', Display}),
+    {ok, [Row]} = asobi_repo:all(Query),
+    Row.
+
+player_id(Config) ->
+    {player_id, PlayerId} = lists:keyfind(player_id, 1, Config),
+    PlayerId.
+
+clean_broadcast_is_stored_as_ok(Config) ->
+    Display = label(?FUNCTION_NAME),
+    {ok, [_], []} = asobi_ops_notifications:broadcast(
+        actor(Display), ~"system", ~"Maintenance", #{}, [player_id(Config)]
+    ),
+    Row = row(Display),
+    ?assertEqual(~"ok", maps:get(outcome, Row)),
+    ?assertEqual(1, maps:get(succeeded_count, Row)),
+    ?assertEqual(0, maps:get(failed_count, Row)),
+    ?assertEqual(~"notifications.broadcast", maps:get(action, Row)),
+    Config.
+
+%% The whole reason for the widened contract, against a real database: the
+%% unknown recipient fails the notifications foreign key, and the row has to
+%% say so rather than reporting the one delivery that worked as a success.
+half_failed_broadcast_is_stored_as_partial(Config) ->
+    Display = label(?FUNCTION_NAME),
+    Unknown = asobi_id:generate(),
+    {ok, Succeeded, Failed} = asobi_ops_notifications:broadcast(
+        actor(Display), ~"system", ~"Maintenance", #{}, [player_id(Config), Unknown]
+    ),
+    ?assertEqual([player_id(Config)], Succeeded),
+    ?assertMatch([{Unknown, _Reason}], Failed),
+    Row = row(Display),
+    ?assertEqual(~"partial", maps:get(outcome, Row)),
+    ?assertEqual(1, maps:get(succeeded_count, Row)),
+    ?assertEqual(1, maps:get(failed_count, Row)),
+    #{~"failures" := [#{~"subject" := Subject}]} = maps:get(details, Row),
+    ?assertEqual(Unknown, Subject),
+    Config.
+
+row_carries_the_unattested_actor(Config) ->
+    Display = label(?FUNCTION_NAME),
+    {ok, _, _} = asobi_ops_notifications:broadcast(
+        actor(Display), ~"system", ~"Maintenance", #{}, [player_id(Config)]
+    ),
+    Row = row(Display),
+    ?assertEqual(Display, maps:get(actor_display, Row)),
+    ?assertEqual(~"static_secret", maps:get(actor_id, Row)),
+    ?assertEqual(~"static_secret", maps:get(actor_source, Row)),
+    ?assertEqual(false, maps:get(actor_attested, Row)),
+    ?assertEqual(~"player", maps:get(target_type, Row)),
+    Config.

--- a/test/asobi_ops_audit_tests.erl
+++ b/test/asobi_ops_audit_tests.erl
@@ -1,0 +1,186 @@
+-module(asobi_ops_audit_tests).
+
+-include_lib("eunit/include/eunit.hrl").
+-include_lib("kura/include/kura.hrl").
+
+audit_test_() ->
+    {setup, fun setup/0, fun cleanup/1, [
+        fun clean_outcome_is_ok/0,
+        fun partial_outcome_is_not_a_success/0,
+        fun total_failure_is_not_partial/0,
+        fun error_outcome_records_its_reason/0,
+        fun unattested_actor_is_recorded_as_unattested/0,
+        fun attested_actor_is_recorded_as_attested/0,
+        fun target_is_recorded_when_there_is_one/0,
+        fun absent_target_writes_no_target_columns/0,
+        fun mutation_records_the_operations_own_outcome/0,
+        fun crashing_mutation_is_audited_and_re_raised/0,
+        fun failed_audit_write_does_not_fail_the_operation/0,
+        fun crashing_audit_write_does_not_fail_the_operation/0,
+        fun failure_details_are_bounded/0,
+        fun oversized_reason_is_truncated/0
+    ]}.
+
+setup() ->
+    meck:new(asobi_repo, [passthrough]),
+    meck:expect(asobi_repo, insert, fun(_CS) -> {ok, #{}} end),
+    ok.
+
+cleanup(_) ->
+    catch meck:unload(asobi_repo),
+    ok.
+
+actor() ->
+    #{
+        id => ~"static_secret",
+        display => ~"operator",
+        source => static_secret,
+        caps => [read, player_data, config],
+        attested => false
+    }.
+
+%% The changes map of the single changeset the call handed to the repo.
+row() ->
+    [{_, {asobi_repo, insert, [#kura_changeset{changes = Changes}]}, _}] = meck:history(asobi_repo),
+    Changes.
+
+record(Outcome) ->
+    record(actor(), undefined, Outcome).
+
+record(Actor, Target, Outcome) ->
+    meck:reset(asobi_repo),
+    ok = asobi_ops_audit:record(Actor, ~"notifications.broadcast", Target, Outcome),
+    row().
+
+clean_outcome_is_ok() ->
+    Row = record({ok, [~"p1", ~"p2"], []}),
+    ?assertEqual(~"ok", maps:get(outcome, Row)),
+    ?assertEqual(2, maps:get(succeeded_count, Row)),
+    ?assertEqual(0, maps:get(failed_count, Row)),
+    ?assertEqual(#{}, maps:get(details, Row)).
+
+%% The defect this whole contract exists for: a send that reached some of its
+%% recipients must not be stored as a success.
+partial_outcome_is_not_a_success() ->
+    Row = record({ok, [~"p1"], [{~"p2", timeout}]}),
+    ?assertEqual(~"partial", maps:get(outcome, Row)),
+    ?assertEqual(1, maps:get(succeeded_count, Row)),
+    ?assertEqual(1, maps:get(failed_count, Row)),
+    ?assertMatch(
+        #{failures := [#{subject := ~"p2", reason := ~"timeout"}]},
+        maps:get(details, Row)
+    ).
+
+total_failure_is_not_partial() ->
+    Row = record({ok, [], [{~"p1", timeout}, {~"p2", timeout}]}),
+    ?assertEqual(~"error", maps:get(outcome, Row)),
+    ?assertEqual(0, maps:get(succeeded_count, Row)),
+    ?assertEqual(2, maps:get(failed_count, Row)).
+
+error_outcome_records_its_reason() ->
+    Row = record({error, invalid_subject}),
+    ?assertEqual(~"error", maps:get(outcome, Row)),
+    ?assertEqual(#{reason => ~"invalid_subject"}, maps:get(details, Row)).
+
+%% An actor named only by the `x-asobi-operator` label is self-declared. The
+%% row has to say so, or every stored name implies a verification that never
+%% happened.
+unattested_actor_is_recorded_as_unattested() ->
+    Row = record(actor(), undefined, {ok, [~"p1"], []}),
+    ?assertEqual(~"static_secret", maps:get(actor_id, Row)),
+    ?assertEqual(~"operator", maps:get(actor_display, Row)),
+    ?assertEqual(~"static_secret", maps:get(actor_source, Row)),
+    ?assertEqual(false, maps:get(actor_attested, Row)).
+
+attested_actor_is_recorded_as_attested() ->
+    Cloud = (actor())#{
+        id => ~"user_7",
+        display => ~"kaito",
+        source => cloud,
+        attested => true
+    },
+    Row = record(Cloud, undefined, {ok, [~"p1"], []}),
+    ?assertEqual(~"user_7", maps:get(actor_id, Row)),
+    ?assertEqual(~"cloud", maps:get(actor_source, Row)),
+    ?assertEqual(true, maps:get(actor_attested, Row)).
+
+target_is_recorded_when_there_is_one() ->
+    Row = record(actor(), {~"player", ~"p1"}, {ok, [~"p1"], []}),
+    ?assertEqual(~"player", maps:get(target_type, Row)),
+    ?assertEqual(~"p1", maps:get(target_id, Row)).
+
+%% A fan-out has a subject type but no single subject. The column is absent
+%% rather than carrying an atom the cast would reject.
+absent_target_writes_no_target_columns() ->
+    Row = record(actor(), undefined, {ok, [~"p1"], []}),
+    ?assertNot(maps:is_key(target_type, Row)),
+    ?assertNot(maps:is_key(target_id, Row)).
+
+mutation_records_the_operations_own_outcome() ->
+    meck:reset(asobi_repo),
+    Outcome = {ok, [~"p1"], [{~"p2", db_down}]},
+    ?assertEqual(
+        Outcome,
+        asobi_ops_audit:mutation(actor(), ~"notifications.broadcast", undefined, fun() ->
+            Outcome
+        end)
+    ),
+    ?assertEqual(~"partial", maps:get(outcome, row())).
+
+crashing_mutation_is_audited_and_re_raised() ->
+    meck:reset(asobi_repo),
+    ?assertError(
+        badarg,
+        asobi_ops_audit:mutation(actor(), ~"notifications.broadcast", undefined, fun() ->
+            erlang:error(badarg)
+        end)
+    ),
+    Row = row(),
+    ?assertEqual(~"error", maps:get(outcome, Row)),
+    ?assertMatch(#{reason := <<"{error,badarg}">>}, maps:get(details, Row)).
+
+%% The mutation already happened. Refusing the caller cannot undo it and only
+%% invites a retry that applies it twice.
+failed_audit_write_does_not_fail_the_operation() ->
+    meck:expect(asobi_repo, insert, fun(_CS) -> {error, connection_closed} end),
+    try
+        Outcome = {ok, [~"p1"], []},
+        ?assertEqual(
+            Outcome,
+            asobi_ops_audit:mutation(actor(), ~"notifications.broadcast", undefined, fun() ->
+                Outcome
+            end)
+        )
+    after
+        meck:expect(asobi_repo, insert, fun(_CS) -> {ok, #{}} end)
+    end.
+
+%% Same policy, harsher failure: the audit path must not be able to turn a
+%% completed mutation into a crash the caller retries.
+crashing_audit_write_does_not_fail_the_operation() ->
+    meck:expect(asobi_repo, insert, fun(_CS) -> erlang:error(pool_gone) end),
+    try
+        Outcome = {ok, [~"p1"], []},
+        ?assertEqual(
+            Outcome,
+            asobi_ops_audit:mutation(actor(), ~"notifications.broadcast", undefined, fun() ->
+                Outcome
+            end)
+        )
+    after
+        meck:expect(asobi_repo, insert, fun(_CS) -> {ok, #{}} end)
+    end.
+
+failure_details_are_bounded() ->
+    Failed = [{integer_to_binary(N), timeout} || N <- lists:seq(1, 60)],
+    Row = record({ok, [], Failed}),
+    #{failures := Failures, failures_omitted := Omitted} = maps:get(details, Row),
+    ?assertEqual(50, length(Failures)),
+    ?assertEqual(10, Omitted),
+    ?assertEqual(60, maps:get(failed_count, Row)).
+
+oversized_reason_is_truncated() ->
+    Row = record({error, binary:copy(~"x", 500)}),
+    #{reason := Reason} = maps:get(details, Row),
+    ?assertEqual(203, byte_size(Reason)),
+    ?assertEqual(~"...", binary:part(Reason, byte_size(Reason) - 3, 3)).

--- a/test/asobi_ops_notifications_tests.erl
+++ b/test/asobi_ops_notifications_tests.erl
@@ -1,0 +1,88 @@
+-module(asobi_ops_notifications_tests).
+
+-include_lib("eunit/include/eunit.hrl").
+-include_lib("kura/include/kura.hrl").
+
+broadcast_test_() ->
+    {setup, fun setup/0, fun cleanup/1, [
+        fun half_delivered_broadcast_is_audited_as_partial/0,
+        fun complete_broadcast_is_audited_as_ok/0,
+        fun broadcast_row_carries_the_actor/0,
+        fun outcome_reaches_the_caller_unchanged/0,
+        fun an_actor_without_player_data_sends_nothing/0
+    ]}.
+
+setup() ->
+    meck:new(asobi_repo, [passthrough]),
+    meck:new(asobi_notify, [passthrough]),
+    meck:expect(asobi_repo, insert, fun(_CS) -> {ok, #{}} end),
+    ok.
+
+cleanup(_) ->
+    catch meck:unload(asobi_repo),
+    catch meck:unload(asobi_notify),
+    ok.
+
+actor() ->
+    #{
+        id => ~"static_secret",
+        display => ~"kaito",
+        source => static_secret,
+        caps => [read, player_data, config],
+        attested => false
+    }.
+
+expect_send_many(Outcome) ->
+    meck:expect(asobi_notify, send_many, fun(_Ids, _Type, _Subject, _Content) -> Outcome end),
+    meck:reset(asobi_repo),
+    meck:reset(asobi_notify).
+
+broadcast() ->
+    asobi_ops_notifications:broadcast(actor(), ~"system", ~"Maintenance", #{}, [~"p1", ~"p2"]).
+
+row() ->
+    [{_, {asobi_repo, insert, [#kura_changeset{changes = Changes}]}, _}] = meck:history(asobi_repo),
+    Changes.
+
+%% The bug the widened contract exists to close: the console used to hand its
+%% logger a hand-built `{ok, SentTo}` built from the survivors alone.
+half_delivered_broadcast_is_audited_as_partial() ->
+    expect_send_many({ok, [~"p1"], [{~"p2", connection_closed}]}),
+    _ = broadcast(),
+    Row = row(),
+    ?assertEqual(~"partial", maps:get(outcome, Row)),
+    ?assertEqual(1, maps:get(succeeded_count, Row)),
+    ?assertEqual(1, maps:get(failed_count, Row)),
+    ?assertEqual(~"notifications.broadcast", maps:get(action, Row)).
+
+complete_broadcast_is_audited_as_ok() ->
+    expect_send_many({ok, [~"p1", ~"p2"], []}),
+    _ = broadcast(),
+    ?assertEqual(~"ok", maps:get(outcome, row())).
+
+broadcast_row_carries_the_actor() ->
+    expect_send_many({ok, [~"p1", ~"p2"], []}),
+    _ = broadcast(),
+    Row = row(),
+    ?assertEqual(~"kaito", maps:get(actor_display, Row)),
+    ?assertEqual(~"static_secret", maps:get(actor_source, Row)),
+    ?assertEqual(false, maps:get(actor_attested, Row)),
+    ?assertEqual(~"player", maps:get(target_type, Row)).
+
+outcome_reaches_the_caller_unchanged() ->
+    Outcome = {ok, [~"p1"], [{~"p2", connection_closed}]},
+    expect_send_many(Outcome),
+    ?assertEqual(Outcome, broadcast()).
+
+%% There is no route in front of this, so the capability check has to be here
+%% or an in-process caller has none at all. The refusal is audited too - a
+%% denied attempt is worth a row.
+an_actor_without_player_data_sends_nothing() ->
+    expect_send_many({ok, [~"p1", ~"p2"], []}),
+    ReadOnly = (actor())#{caps => [read]},
+    ?assertEqual(
+        {error, forbidden},
+        asobi_ops_notifications:broadcast(ReadOnly, ~"system", ~"Maintenance", #{}, [~"p1"])
+    ),
+    ?assertNot(meck:called(asobi_notify, send_many, '_')),
+    ?assertEqual(~"error", maps:get(outcome, row())).


### PR DESCRIPTION
Plan item **2a.8** - durable audit rows carrying the actor, and the widened
`{ok, Succeeded, Failed}` contract. New ADR: `docs/adr/0007-durable-ops-audit-rows.md`.

## The claim, verified

The plan says "the notifications broadcast currently audits a half-failed
send as a success". It does, and the defect is in two places.

`asobi_admin_notifications_controller:broadcast/1`:

```erlang
SentTo = asobi_admin_notifications:do_broadcast(Type, Subject, #{}, PlayerIds),
asobi_admin_ui_audit:log_action(~"broadcast", #{recipient_count => length(SentTo)}, {ok, SentTo})
```

The `{ok, SentTo}` is built by the handler, not returned by the operation.
`do_broadcast/4` is a copy of core's `asobi_notify:send_many/4`, which used
`lists:filtermap/2` to return only the recipients whose insert succeeded -
failures were dropped with no reason kept anywhere. A broadcast to ten
players that reached three logged `outcome => ok, recipient_count => 3`.
`log_action/3`'s type could not have expressed the truth even if the handler
had it.

The console lives in `asobi_admin`, so this PR fixes the shape at its source
in core and opens widgrensit/asobi_admin#6 for the adoption.

## What lands

**`ops_audit_entries` + `asobi_ops_audit_entry`.** The actor is four
flattened columns rather than a foreign key: there is no actors table, and a
row must keep saying what it said at the time after the actor's capabilities
change. `actor_attested` is the load-bearing one - a name from
`x-asobi-operator` is self-declared, and without the column every stored name
implies a verification that never happened.

Indexes are `(actor_id, occurred_at)`, `(action, occurred_at)` and
`(target_id)` - one per question the audit is actually asked. No bare
`occurred_at` index, because both composites already answer a bounded range.
`target_id` carries no FK: a GDPR erasure must not cascade away the record
that someone banned that player.

Rows are append-only and core ships no reaper. Retention is jurisdictional,
so it is operator policy; the composite ordering makes a prune one ranged
delete.

**Failure policy, stated and tested.** The audit never fails the operation.
It runs after the change has happened, so refusing the response cannot undo a
ban and would only invite a retry that double-applies. A write-ahead row
could fail closed, but it would record intent, and outcome - specifically
partial failure - is the thing being asked for. A failed insert, or a raise
anywhere in the audit path, is re-emitted at error level with the row's own
field names, so the record degrades from queryable to greppable rather than
vanishing.

**`{ok, Succeeded, Failed}`.** `asobi_notify:send_many/4` now returns it,
with per-recipient reasons. Stored as `outcome` (`ok` / `partial` / `error`)
plus two counts, so "everything that did not fully succeed" is an index scan
rather than a jsonb parse. A bulk call where every subject failed is `error`,
not `partial`. `details` is diagnostic only and bounded - 50 failures, 200
bytes per reason.

**`asobi_ops_audit:mutation/4`** builds the row from the operation's own
return value. A call site cannot forget, and cannot hand the audit an outcome
the operation did not produce, which is exactly what the broadcast handler
did.

## Wiring

`asobi_ops_notifications:broadcast/5` - the one operator mutation that
already exists, moved into core so the audit wraps it. **No route is added
and the ops plane stays read-only**; this is the Erlang entry point the
console's existing mutation calls, which is the Stage 3 shape in
`operator-api.md`. Because there is no route, the capability check runs in
the function, through the same `asobi_ops_caps:authorised/2` the router's
security callback uses - one function still authorises. A refusal is audited
as an `error` outcome.

Nothing else in core mutates player-visible state on an operator's behalf, so
nothing else is wired. No ops write endpoints were invented to have something
to audit.

The Lua `game.notify_many` surface is unchanged: it still returns the
recipients reached, so a script comparing that count to the ids it passed can
see a partial send.

## Tests

31 new, plus one added to `asobi_lua_api_tests`.

- `asobi_ops_audit_tests` (14): outcome classification including
  all-failed-is-not-partial, actor fields and attestation, absent target,
  `mutation/4` returning the operation's own value, a crashing mutation
  audited and re-raised, a failed insert and a *raising* insert both leaving
  the operation intact, bounded details, truncated reasons.
- `asobi_notify_tests` (4): partial failure reported rather than dropped, one
  failure not abandoning the rest, presence pushed only for the reached.
- `asobi_ops_notifications_tests` (5): half-delivered broadcast audited
  `partial`, actor on the row, outcome unchanged to the caller, a `read`-only
  actor sending nothing.
- `asobi_ops_audit_SUITE` (3): against real Postgres, no mocks. The unknown
  recipient fails the notifications foreign key, so the partial case is a
  genuine half-failed broadcast and the row read back says `partial`.

Revert checks:

| Reverted | Failures |
|---|---|
| `partial` classified as `ok` | 3 eunit, 1 CT |
| `send_many/4` back to survivors-only | 4 eunit |
| `try/catch` removed from `mutation/4` and `record/4`, target keys always written | 3 eunit |
| capability check removed from `broadcast/5` | 1 eunit |

## Checks

`fmt --check`, `xref`, `dialyzer`, `ex_doc` all clean. Full `eunit`: 1256
tests, 0 failures. `ct --suite=test/asobi_ops_audit_SUITE`: 3 passed.

## Follow-up

widgrensit/asobi_admin#6 - delete `do_broadcast/4`, call
`asobi_ops_notifications:broadcast/5`, drop the hand-built `{ok, SentTo}`,
and decide what the UI shows on a partial send (the redirect carries only
`?sent=N`, which reads as a success). Until that lands the console keeps its
own copy and keeps lying; core cannot fix that from here.
