### PR TITLE
feat: finish the shared error object rollout across every route

### DIFF
--- a/guides/authentication.md
+++ b/guides/authentication.md
@@ -287,23 +287,24 @@ Player id, progress, wallets, and inventory are preserved.
 
 ### Errors
 
-| Status | `error` | Meaning |
-|--------|---------|---------|
-| `400`  | `missing_required_fields` | `device_id` / `device_secret` (or `username` / `password` on upgrade) absent |
-| `400`  | `weak_device_secret`      | Secret decodes to fewer than 32 bytes (or exceeds the size cap) |
-| `400`  | `invalid_device_id`       | `device_id` empty or over 255 bytes |
-| `401`  | `invalid_device_secret`   | Wrong secret for a known device |
-| `401`  | `guest_revoked`           | The device verifier was revoked |
-| `401`  | `guest_upgraded`          | The account was already claimed; log in with its real credentials |
-| `403`  | `guest_auth_disabled`     | Guest auth is off - the game did not declare `guest_auth`, or no pepper is present |
-| `404`  | `player_not_found`        | The upgrade token resolves to no player |
-| `409`  | `device_already_registered` | Two creates for the same device raced; retry - the retry resumes the existing guest |
-| `409`  | `not_an_unclaimed_guest`  | Upgrade target is not an unclaimed guest |
-| `409`  | `username_taken`          | Upgrade username is already in use |
-| `422`  | `validation_failed`       | Upgrade fields invalid (see `fields`) |
-| `500`  | `guest_create_failed`     | The player row could not be created |
-| `500`  | `guest_player_missing`    | The device resolves to an identity whose player no longer exists |
-| `503`  | `guest_capacity_reached`  | Global create limit or the unlinked-guest cap was hit |
+| Status | `error.code` | Meaning |
+|--------|--------------|---------|
+| `400`  | `missing_field`                    | `device_id` / `device_secret` (or `username` / `password` on upgrade) absent |
+| `400`  | `guest.weak_device_secret`         | Secret decodes to fewer than 32 bytes (or exceeds the size cap) |
+| `400`  | `guest.invalid_device_id`          | `device_id` empty or over 255 bytes |
+| `401`  | `guest.invalid_device_secret`      | Wrong secret for a known device |
+| `401`  | `guest.revoked`                    | The device verifier was revoked |
+| `401`  | `guest.already_upgraded`           | The account was already claimed; log in with its real credentials |
+| `403`  | `guest.disabled`                   | Guest auth is off - the game did not declare `guest_auth`, or no pepper is present |
+| `403`  | `auth.registration_closed`         | The deployment's registration posture refuses new accounts |
+| `404`  | `player.not_found`                 | The upgrade token resolves to no player |
+| `409`  | `guest.device_already_registered`  | Two creates for the same device raced; retry - the retry resumes the existing guest |
+| `409`  | `guest.not_unclaimed`              | Upgrade target is not an unclaimed guest |
+| `409`  | `auth.username_taken`              | Upgrade username is already in use |
+| `500`  | `auth.password_registration_disabled` | Upgrade needs the password path, which this deployment disabled |
+| `500`  | `guest.create_failed`              | The player row could not be created |
+| `500`  | `internal`                         | The device resolves to an identity whose player no longer exists, or another server-side failure |
+| `503`  | `guest.capacity_reached`           | Global create limit or the unlinked-guest cap was hit |
 
 ### Configuration
 

--- a/guides/rest-api.md
+++ b/guides/rest-api.md
@@ -230,8 +230,6 @@ PUT    /api/v1/storage/:collection/:key        Write object
 DELETE /api/v1/storage/:collection/:key        Delete object
 ```
 
-These routes return the [error object](#errors) below on failure.
-
 ## Ops
 
 ```
@@ -450,8 +448,11 @@ A failing request returns its HTTP status and one object:
 ```
 
 - `code` is the contract. It is stable, machine-readable, and namespaced by
-  domain (`storage.`, `save.`, `match.`, `world.`, `chat.`, `matchmaker.`) or
-  bare when it is cross-cutting (`rate_limited`, `internal`). Branch on this.
+  domain (`storage.`, `save.`, `auth.`, `guest.`, `player.`, `match.`,
+  `world.`, `matchmaker.`, `leaderboard.`, `economy.`, `inventory.`, `iap.`,
+  `social.`, `chat.`, `dm.`, `tournament.`, `notification.`, `vote.`, `ops.`)
+  or bare when it is cross-cutting (`rate_limited`, `forbidden`,
+  `validation_failed`, `internal`). Branch on this.
 - `message` is prose for a human reading a log. It may be reworded at any
   time. Do not parse it.
 - `details` is **always** an object, `{}` when there is nothing to add, so no
@@ -462,15 +463,31 @@ A failing request returns its HTTP status and one object:
 {"error": {"code": "save.version_conflict", "message": "The slot was written by another client.", "details": {"current_version": 4}}}
 ```
 
-Codes are a closed set. A string supplied by a client or by a Lua game script
-never becomes a code; it arrives inside `details` instead.
+Codes are a closed set. A string supplied by a client, by an identity
+provider, by a store's receipt verifier, or by a Lua game script never becomes
+a code; it arrives inside `details` instead. So a rejected sign-in reads:
+
+```json
+{"error": {"code": "auth.provider_rejected", "message": "The identity provider rejected the token.", "details": {"reason": "publisher_banned"}}}
+```
 
 > #### Rollout {: .info}
 >
-> The storage and cloud-save routes above return this shape today. Every other
-> route still returns its older, flat body (`{"error": "some_string"}`) or an
-> empty body with only a status. Those are converted in a follow-up; until
-> then, branch on the HTTP status outside `/saves` and `/storage`.
+> Every route returns this shape, as does every WebSocket `error` frame. There
+> is no route left on the older, flat body (`{"error": "some_string"}`) and
+> none that answers a failure with an empty body.
+>
+> The change is additive except for `error` itself, which went from a string
+> to the object. A route that already sent more than `error` still sends it,
+> unchanged and in the same place: `fields` and `errors` on a 422, `retry_after`
+> on a 429, `field` and `order` on an ops sort rejection, `reason` on a
+> registration-gate 403. Each of those is repeated inside `details`, so new
+> code can read one place. The one key that moved is the bespoke top-level
+> `message` on `POST /auth/guest` when guest auth is disabled; the same prose
+> is now `error.message`.
+>
+> Statuses did not change. Routes that used to answer 403 or 404 with no body
+> answer the same status, now with the object in it.
 
 ## Next steps
 

--- a/guides/websocket-protocol.md
+++ b/guides/websocket-protocol.md
@@ -223,9 +223,10 @@ request that caused it when there was one:
 ```
 
 - `error.code` is the contract - stable, machine-readable, and namespaced by
-  domain (`match.`, `world.`, `chat.`, `matchmaker.`) or bare when it is
-  cross-cutting (`rate_limited`, `unauthenticated`). Branch on this. It is the
-  same code set the [REST API](rest-api.md#errors) returns.
+  domain (`match.`, `world.`, `chat.`, `dm.`, `matchmaker.`) or bare when it is
+  cross-cutting (`rate_limited`, `unauthenticated`, `forbidden`). Branch on
+  this. It is the same code set the [REST API](rest-api.md#errors) returns, so
+  the same failure carries the same code on both surfaces.
 - `error.message` is prose for a human reading a log. Do not parse it.
 - `error.details` is **always** an object, `{}` when there is nothing to add.
 - `reason` is the original, flatter dialect. It is unchanged and still sent, so

--- a/scripts/check-error-drift.sh
+++ b/scripts/check-error-drift.sh
@@ -17,13 +17,36 @@ set -uo pipefail
 repo_root="$(cd "$(dirname "$0")/.." && pwd)"
 fail=0
 
-# Every "<status> <atom>" pair a module returns. Newlines are flattened and runs
+# The code -> status table, read out of asobi_error's ?CODES macro. Since the
+# shared error object landed (plan item 1b) a controller names a code and never
+# a status, so the status a client sees is asobi_error's business, not the call
+# site's - and this guard has to resolve it the same way.
+code_status() {
+	grep -oE '^\s*\{~"[a-z_.]+", ?[0-9]{3},' "$repo_root/src/asobi_error.erl" |
+		sed -E 's/^\s*\{~"([a-z_.]+)", ?([0-9]{3}),/\1 \2/'
+}
+
+# Every "<status> <code>" pair a module returns. Newlines are flattened and runs
 # of spaces squeezed first, so erlfmt reflowing a return across lines can never
-# hide it from the regex.
+# hide it from the regex. Both {asobi_error, Code} and {asobi_error, Code,
+# Details} are matched; the status comes from the table above.
 src_pairs() {
-	tr '\n' ' ' <"$1" | tr -s ' ' |
-		grep -oE '\{json, ?[0-9]+, ?#\{\}, ?#\{ ?error => ~"[a-z_]+"' |
-		sed -E 's/.*\{json, ?([0-9]+).*error => ~"([a-z_]+)"/\1 \2/'
+	local codes
+	codes=$(
+		tr '\n' ' ' <"$1" | tr -s ' ' |
+			grep -oE '\{asobi_error, ?~"[a-z_.]+"' |
+			sed -E 's/.*~"([a-z_.]+)"/\1/' | sort -u
+	)
+	[ -z "$codes" ] && return 0
+	# Join code -> status. A code with no ?CODES entry is a server bug that
+	# asobi_error answers 500 for, so report it as 500 rather than dropping it -
+	# dropping it would let an undefined code hide from this guard entirely.
+	local c st
+	while IFS= read -r c; do
+		[ -z "$c" ] && continue
+		st=$(code_status | awk -v k="$c" '$1 == k {print $2; exit}')
+		printf '%s %s\n' "${st:-500}" "$c"
+	done <<<"$codes"
 }
 
 # Every "<status> <atom>" row of the markdown error table inside one guide
@@ -34,8 +57,8 @@ doc_pairs() {
 	# single quotes are what keeps them literal.
 	# shellcheck disable=SC2016
 	awk -v heading="$2" '$0 == heading {f=1; next} /^## /{f=0} f' "$1" |
-		grep -oE '^\| `[0-9]{3}` *\| `[a-z_]+`' |
-		sed -E 's/^\| `([0-9]{3})` *\| `([a-z_]+)`/\1 \2/'
+		grep -oE '^\| `[0-9]{3}` *\| `[a-z_.]+`' |
+		sed -E 's/^\| `([0-9]{3})` *\| `([a-z_.]+)`/\1 \2/'
 }
 
 indent() {
@@ -109,4 +132,4 @@ if [ "$fail" -ne 0 ]; then
 	echo "DRIFT: a guide's error table no longer matches the controller it describes."
 	exit 1
 fi
-echo "OK: every documented error atom matches source."
+echo "OK: every documented error code matches source."

--- a/src/asobi_auth_error.erl
+++ b/src/asobi_auth_error.erl
@@ -8,18 +8,30 @@
 %% this once its 409 branch lands - see the register-409 change.)
 
 -export([from_changeset_fields/1, username_taken/1, provider_uid_taken/1]).
+-export([validation_failed/1, registration_denied/1]).
 
 %% kura's default message for a unique-index violation.
 -define(UNIQUE_MSG, ~"has already been taken").
 
--spec from_changeset_fields(map()) -> {json, integer(), map(), map()}.
+-spec from_changeset_fields(map()) ->
+    {json, integer(), map(), map()} | {asobi_error, asobi_error:code()}.
 from_changeset_fields(#{username := Msgs} = Fields) when is_list(Msgs) ->
     case lists:member(?UNIQUE_MSG, Msgs) of
-        true -> {json, 409, #{}, #{error => ~"username_taken"}};
+        true -> {asobi_error, ~"auth.username_taken"};
         false -> validation_failed(Fields)
     end;
 from_changeset_fields(Fields) ->
     validation_failed(Fields).
+
+%% `asobi_registration:check/1` reports a deny as a string. Map it to a code
+%% with explicit clauses rather than passing it through: a reason is a
+%% server-side label that may be reworded, and the catch-all means a future
+%% one lands on a defined code instead of minting an undefined one.
+-spec registration_denied(binary()) -> {asobi_error, asobi_error:code()}.
+registration_denied(~"password_registration_disabled") ->
+    {asobi_error, ~"auth.password_registration_disabled"};
+registration_denied(_Reason) ->
+    {asobi_error, ~"auth.registration_closed"}.
 
 %% Whether a raw #kura_changeset.errors list is specifically a username
 %% uniqueness conflict (the generated-username retry paths need to tell that
@@ -40,6 +52,8 @@ username_taken(Errors) ->
 provider_uid_taken(Errors) ->
     lists:keyfind(provider_uid, 1, Errors) =:= {provider_uid, ?UNIQUE_MSG}.
 
--spec validation_failed(map()) -> {json, 422, map(), map()}.
+%% `fields` stays a top-level key (form UIs read it) and is the object's
+%% `details` too - see asobi_error:legacy/2.
+-spec validation_failed(map()) -> {json, pos_integer(), map(), map()}.
 validation_failed(Fields) ->
-    {json, 422, #{}, #{error => ~"validation_failed", fields => Fields}}.
+    asobi_error:legacy(~"validation_failed", #{fields => Fields}).

--- a/src/asobi_error.erl
+++ b/src/asobi_error.erl
@@ -10,12 +10,12 @@ built on top of them - is describable as:
 ```
 
 `code` is the contract. It is machine-readable, namespaced by domain
-(`storage.`, `match.`, `world.`, `chat.`, `matchmaker.`) or bare when it is
-cross-cutting (`rate_limited`, `internal`), and drawn from the closed set in
-`codes/0` - a client may branch on it. `message` is prose for a human reading
-a log; it may be reworded at any time and must not be parsed. `details` is
-**always** a map, `#{}` when there is nothing to add, so no client needs a
-null branch.
+(`storage.`, `save.`, `auth.`, `social.`, `match.`, `world.`, `chat.`,
+`matchmaker.` and the rest) or bare when it is cross-cutting (`rate_limited`,
+`internal`), and drawn from the closed set in `codes/0` - a client may branch
+on it. `message` is prose for a human reading a log; it may be reworded at any
+time and must not be parsed. `details` is **always** a map, `#{}` when there is
+nothing to add, so no client needs a null branch.
 
 The code set is closed on purpose: script- and client-supplied strings never
 become codes. An unrecognised reason is reported under a known code with the
@@ -31,11 +31,17 @@ failure and never the number:
 
 `register_handler/0` installs `handle/3` as the Nova return handler for those
 tuples.
+
+A handful of routes answered with more than `error` before the object existed
+(`fields`, `errors`, `retry_after`, `field`). Those keys stay exactly where
+they were and are also the object's `details`, so an existing client keeps
+working and a new one reads one place: see `legacy/2`.
 """.
 
 -include_lib("kernel/include/logger.hrl").
 
 -export([object/1, object/2, object/3]).
+-export([legacy/2, legacy_body/2]).
 -export([status/1, message/1, codes/0]).
 -export([from_ws_reason/1, ws_reasons/0]).
 -export([handle/3, register_handler/0]).
@@ -62,6 +68,87 @@ tuples.
     {~"unknown_type", 400, ~"No handler is registered for this message type."},
     {~"unauthenticated", 401, ~"The credentials are missing, expired, or invalid."},
     {~"forbidden", 403, ~"The caller may not perform this action."},
+    {~"validation_failed", 422, ~"One or more fields are invalid. See `details`."},
+    {~"length_required", 411, ~"The request must declare a Content-Length."},
+    {~"client_gate_denied", 403, ~"The registration gate rejected this request."},
+
+    %% Accounts, providers, guests.
+    {~"auth.registration_closed", 403, ~"This deployment is not accepting new players."},
+    {
+        ~"auth.password_registration_disabled",
+        403,
+        ~"This deployment accepts provider sign-in only."
+    },
+    {~"auth.username_taken", 409, ~"That username already belongs to another player."},
+    {~"auth.invalid_credentials", 401, ~"The username or password is wrong."},
+    {~"auth.unsupported_provider", 401, ~"No identity provider is configured under this name."},
+    {~"auth.provider_rejected", 401, ~"The identity provider rejected the token."},
+    {~"auth.provider_already_linked", 409, ~"That provider account is linked to another player."},
+    {~"auth.already_registering", 409, ~"A concurrent sign-in is already creating this player."},
+    {~"auth.identity_not_found", 404, ~"No linked identity exists for this provider."},
+    {~"auth.last_auth_method", 422, ~"Unlinking this provider would leave no way to sign in."},
+    {~"auth.registration_failed", 500, ~"The player could not be created."},
+    {~"auth.link_failed", 500, ~"The provider identity could not be linked."},
+    {~"auth.token_issue_failed", 500, ~"The session tokens could not be issued."},
+    {~"guest.disabled", 403, ~"Guest authentication is not enabled for this deployment."},
+    {~"guest.invalid_device_id", 400, ~"The device id is missing or too long."},
+    {~"guest.weak_device_secret", 400, ~"The device secret is not 32-128 base64-encoded bytes."},
+    {~"guest.invalid_device_secret", 401, ~"The device secret does not match this device."},
+    {~"guest.revoked", 401, ~"This device's guest credential has been revoked."},
+    {~"guest.already_upgraded", 401, ~"This account was claimed. Sign in with its credentials."},
+    {~"guest.capacity_reached", 503, ~"The deployment is not creating more guests right now."},
+    {~"guest.device_already_registered", 409, ~"Another guest already registered this device."},
+    {~"guest.not_unclaimed", 409, ~"Only an unclaimed guest account can be upgraded."},
+    {~"guest.create_failed", 500, ~"The guest player could not be created."},
+    {~"player.not_found", 404, ~"No player exists with this id."},
+
+    %% Sessions, worlds, matches, tickets.
+    {~"world.player_limit_reached", 429, ~"This player already owns as many worlds as allowed."},
+    {~"world.capacity_reached", 503, ~"The deployment is running as many worlds as allowed."},
+    {~"world.create_failed", 400, ~"The world could not be created. See `details.reason`."},
+    {~"matchmaker.ticket_not_found", 404, ~"No matchmaking ticket exists with this id."},
+    {~"vote.not_found", 404, ~"No vote exists with this id."},
+
+    %% Leaderboards, economy, inventory, purchases.
+    {~"leaderboard.client_submit_disabled", 403, ~"This board does not accept client submissions."},
+    {~"leaderboard.capacity_reached", 503, ~"This leaderboard holds as many entries as allowed."},
+    {~"economy.insufficient_funds", 402, ~"The wallet does not hold enough of this currency."},
+    {~"economy.listing_inactive", 400, ~"This store listing is not on sale."},
+    {~"economy.purchase_failed", 500, ~"The purchase could not be completed."},
+    {~"inventory.item_not_found", 404, ~"No inventory item exists with this id."},
+    {~"inventory.insufficient_quantity", 400, ~"The item stack holds fewer than the amount asked."},
+    {~"inventory.invalid_quantity", 400, ~"`quantity` must be a positive integer within the cap."},
+    {~"iap.verification_failed", 422, ~"The store rejected the receipt. See `details.reason`."},
+    {~"iap.missing_transaction_id", 422, ~"The verified receipt carries no transaction id."},
+    {~"iap.transaction_already_claimed", 409, ~"Another player already claimed this transaction."},
+    {~"iap.record_failed", 500, ~"The verified transaction could not be recorded."},
+
+    %% Friends, groups, direct messages.
+    {~"social.cannot_friend_self", 400, ~"A player cannot befriend themselves."},
+    {~"social.friend_not_found", 404, ~"No player exists with this friend id."},
+    {~"social.already_friend", 409, ~"This friendship already exists."},
+    {~"social.friendship_not_found", 404, ~"No friendship exists between these players."},
+    {~"social.group_not_found", 404, ~"No group exists with this id."},
+    {~"social.group_closed", 403, ~"This group is closed and needs an invite."},
+    {~"social.group_full", 409, ~"This group already holds as many members as allowed."},
+    {~"social.already_member", 409, ~"This player is already a member of the group."},
+    {~"social.invalid_role", 400, ~"That is not a role this group defines."},
+    {~"social.member_not_found", 404, ~"No such member in this group."},
+    {~"dm.blocked", 403, ~"The recipient blocked this sender."},
+    {~"dm.content_empty", 400, ~"A direct message needs content."},
+    {~"dm.content_too_large", 413, ~"The message is longer than the server accepts."},
+
+    %% Tournaments and notifications.
+    {~"tournament.not_found", 404, ~"No tournament exists with this id."},
+    {~"tournament.full", 409, ~"This tournament holds as many entrants as allowed."},
+    {~"tournament.already_joined", 409, ~"This player already entered the tournament."},
+    {~"notification.not_found", 404, ~"No notification exists with this id."},
+
+    %% Ops read plane.
+    {~"ops.invalid_board_id", 400, ~"The leaderboard id is missing or too long."},
+    {~"ops.unknown_sort_field", 400, ~"That is not a field this endpoint sorts on."},
+    {~"ops.unknown_sort_order", 400, ~"`order` must be \"asc\" or \"desc\"."},
+    {~"ops.query_failed", 500, ~"The ops query failed."},
 
     %% Cloud saves.
     {~"save.not_found", 404, ~"No cloud save exists in this slot."},
@@ -116,7 +203,11 @@ tuples.
     {~"invalid_channel_id", ~"chat.invalid_channel_id"},
     {~"too_many_channels", ~"chat.too_many_channels"},
     {~"unknown_mode", ~"matchmaker.unknown_mode"},
-    {~"queue_full", ~"matchmaker.queue_full"}
+    {~"queue_full", ~"matchmaker.queue_full"},
+    {~"not_owner", ~"forbidden"},
+    {~"blocked", ~"dm.blocked"},
+    {~"content_empty", ~"dm.content_empty"},
+    {~"content_too_large", ~"dm.content_too_large"}
 ]).
 
 -doc "The error object for `Code`, with no details.".
@@ -139,6 +230,27 @@ contract and cannot be translated or reused.
 -spec object(code(), binary(), details()) -> object().
 object(Code, Message, Details) when is_binary(Code), is_binary(Message), is_map(Details) ->
     #{error => #{code => Code, message => Message, details => Details}}.
+
+-doc """
+A Nova `{json, ...}` result carrying the object for `Code` plus `Extra`.
+
+For the routes that answered with more than an `error` string before the
+object existed. `Extra` is those top-level keys, unchanged, so a client reading
+`fields` or `retry_after` keeps working; the same map is the object's
+`details`. The status still comes from the code.
+""".
+-spec legacy(code(), details()) -> {json, pos_integer(), #{}, map()}.
+legacy(Code, Extra) ->
+    {json, status(Code), #{}, legacy_body(Code, Extra)}.
+
+-doc """
+`legacy/2`'s body, for a caller that writes the response itself.
+
+The plugins reply through `cowboy_req` rather than returning to Nova.
+""".
+-spec legacy_body(code(), details()) -> map().
+legacy_body(Code, Extra) when is_map(Extra) ->
+    maps:merge(Extra, object(Code, Extra)).
 
 -doc "The HTTP status for `Code`. An undefined code is a server bug: 500.".
 -spec status(code()) -> pos_integer().

--- a/src/auth/asobi_auth_tokens.erl
+++ b/src/auth/asobi_auth_tokens.erl
@@ -10,12 +10,14 @@ kills the presented access token on logout so it can't outlive the cache TTL.
 -export([issue/2, issue/3, revoke_access/1]).
 
 -doc "Issue an access + refresh pair for `Player` and build the JSON response.".
--spec issue(map(), integer()) -> {json, integer(), map(), map()}.
+-spec issue(map(), integer()) ->
+    {json, integer(), map(), map()} | {asobi_error, asobi_error:code()}.
 issue(Player, Status) ->
     issue(Player, Status, #{}).
 
 -doc "Like `issue/2` but merges `Extra` (e.g. username) into the response body.".
--spec issue(map(), integer(), map()) -> {json, integer(), map(), map()}.
+-spec issue(map(), integer(), map()) ->
+    {json, integer(), map(), map()} | {asobi_error, asobi_error:code()}.
 issue(Player, Status, Extra) ->
     case nova_auth_refresh:generate_pair(asobi_auth, Player) of
         {ok, #{access_token := Access, refresh_token := Refresh}} ->
@@ -30,7 +32,7 @@ issue(Player, Status, Extra) ->
             {json, Status, #{}, Body};
         {error, Reason} ->
             logger:error(#{msg => ~"token_issue_failed", reason => Reason}),
-            {json, 500, #{}, #{error => ~"token_issue_failed"}}
+            {asobi_error, ~"auth.token_issue_failed"}
     end.
 
 -doc "Revoke the Bearer access token on the request (logout of this device).".

--- a/src/controllers/asobi_auth_controller.erl
+++ b/src/controllers/asobi_auth_controller.erl
@@ -4,25 +4,30 @@
 
 -include_lib("kura/include/kura.hrl").
 
+-type response() ::
+    {json, map()}
+    | {json, integer(), map(), map()}
+    | {asobi_error, asobi_error:code()}
+    | {asobi_error, asobi_error:code(), asobi_error:details()}.
+
 %% kura's default message for a unique-index violation (asobi_player:indexes/0).
 %% The 409 contract keys off it; pin it here so the coupling is visible.
 -define(UNIQUE_MSG, ~"has already been taken").
 
--spec register(cowboy_req:req()) -> {json, map()} | {json, integer(), map(), map()}.
+-spec register(cowboy_req:req()) -> response().
 register(
     #{json := #{~"username" := Username, ~"password" := Password} = Params} = _Req
 ) when is_binary(Username), is_binary(Password) ->
     case asobi_registration:check(password) of
         {deny, Reason} ->
-            {json, 403, #{}, #{error => Reason}};
+            asobi_auth_error:registration_denied(Reason);
         ok ->
             register_player(Username, Password, Params)
     end;
 register(_Req) ->
-    {json, 400, #{}, #{error => ~"missing_required_fields"}}.
+    {asobi_error, ~"missing_field"}.
 
--spec register_player(binary(), binary(), map()) ->
-    {json, map()} | {json, integer(), map(), map()}.
+-spec register_player(binary(), binary(), map()) -> response().
 register_player(Username, Password, Params) ->
     RegParams = #{
         username => Username,
@@ -48,16 +53,13 @@ register_player(Username, Password, Params) ->
 %% is malformed input: 422 with per-field detail for form UIs.
 registration_error(#{username := Msgs} = Fields) when is_list(Msgs) ->
     case lists:member(?UNIQUE_MSG, Msgs) of
-        true -> {json, 409, #{}, #{error => ~"username_taken"}};
-        false -> validation_failed(Fields)
+        true -> {asobi_error, ~"auth.username_taken"};
+        false -> asobi_auth_error:validation_failed(Fields)
     end;
 registration_error(Fields) ->
-    validation_failed(Fields).
+    asobi_auth_error:validation_failed(Fields).
 
-validation_failed(Fields) ->
-    {json, 422, #{}, #{error => ~"validation_failed", fields => Fields}}.
-
--spec login(cowboy_req:req()) -> {json, map()} | {json, integer(), map(), map()}.
+-spec login(cowboy_req:req()) -> response().
 login(#{json := #{~"username" := Username, ~"password" := Password}} = _Req) when
     is_binary(Username), is_binary(Password)
 ->
@@ -65,21 +67,21 @@ login(#{json := #{~"username" := Username, ~"password" := Password}} = _Req) whe
         {ok, Player} ->
             asobi_auth_tokens:issue(Player, 200, #{username => maps:get(username, Player)});
         {error, invalid_credentials} ->
-            {json, 401, #{}, #{error => ~"invalid_credentials"}}
+            {asobi_error, ~"auth.invalid_credentials"}
     end;
 login(_Req) ->
-    {json, 400, #{}, #{error => ~"missing_required_fields"}}.
+    {asobi_error, ~"missing_field"}.
 
--spec refresh(cowboy_req:req()) -> {json, map()} | {json, integer(), map(), map()}.
+-spec refresh(cowboy_req:req()) -> response().
 refresh(#{json := #{~"refresh_token" := RefreshToken}} = _Req) when is_binary(RefreshToken) ->
     case nova_auth_refresh:refresh(asobi_auth, RefreshToken) of
         {ok, #{access_token := Access, refresh_token := Refresh}} ->
             {json, 200, #{}, #{access_token => Access, refresh_token => Refresh}};
         {error, _} ->
-            {json, 401, #{}, #{error => ~"invalid_token"}}
+            {asobi_error, ~"unauthenticated"}
     end;
 refresh(_Req) ->
-    {json, 400, #{}, #{error => ~"missing_required_fields"}}.
+    {asobi_error, ~"missing_field"}.
 
 -spec logout(cowboy_req:req()) -> {json, integer(), map(), map()}.
 logout(#{json := #{~"refresh_token" := RefreshToken}} = Req) when is_binary(RefreshToken) ->

--- a/src/controllers/asobi_chat_controller.erl
+++ b/src/controllers/asobi_chat_controller.erl
@@ -5,7 +5,7 @@
 -define(MAX_HISTORY_LIMIT, 200).
 -define(DEFAULT_HISTORY_LIMIT, 50).
 
--spec history(cowboy_req:req()) -> {json, map()} | {json, integer(), map(), map()} | {status, 403}.
+-spec history(cowboy_req:req()) -> {json, map()} | {asobi_error, asobi_error:code()}.
 history(
     #{
         bindings := #{~"channel_id" := ChannelId},
@@ -34,7 +34,7 @@ history(
             {ok, Messages} = asobi_repo:all(Q),
             {json, #{messages => lists:reverse(Messages)}};
         false ->
-            {status, 403}
+            {asobi_error, ~"forbidden"}
     end;
 history(_Req) ->
-    {json, 400, #{}, #{error => ~"invalid_request"}}.
+    {asobi_error, ~"invalid_payload"}.

--- a/src/controllers/asobi_dm_controller.erl
+++ b/src/controllers/asobi_dm_controller.erl
@@ -2,7 +2,8 @@
 
 -export([send/1, history/1]).
 
--spec send(cowboy_req:req()) -> {json, map()} | {json, integer(), map(), map()}.
+-spec send(cowboy_req:req()) ->
+    {json, integer(), map(), map()} | {asobi_error, asobi_error:code()}.
 send(#{
     json := #{~"recipient_id" := RecipientId, ~"content" := Content},
     auth_data := #{player_id := PlayerId}
@@ -13,16 +14,16 @@ send(#{
                 success => true, channel_id => asobi_dm:channel_id(PlayerId, RecipientId)
             }};
         {error, blocked} ->
-            {json, 403, #{}, #{error => ~"blocked"}};
+            {asobi_error, ~"dm.blocked"};
         {error, content_empty} ->
-            {json, 400, #{}, #{error => ~"content_empty"}};
+            {asobi_error, ~"dm.content_empty"};
         {error, content_too_large} ->
-            {json, 413, #{}, #{error => ~"content_too_large"}};
+            {asobi_error, ~"dm.content_too_large"};
         {error, _} ->
-            {json, 400, #{}, #{error => ~"invalid_input"}}
+            {asobi_error, ~"invalid_payload"}
     end;
 send(_Req) ->
-    {json, 400, #{}, #{error => ~"invalid_request"}}.
+    {asobi_error, ~"invalid_payload"}.
 
 -spec history(cowboy_req:req()) -> {json, map()}.
 history(#{

--- a/src/controllers/asobi_economy_controller.erl
+++ b/src/controllers/asobi_economy_controller.erl
@@ -29,7 +29,8 @@ store(#{qs := Qs} = _Req) ->
     {ok, Listings} = asobi_repo:all(Q1),
     {json, #{listings => Listings}}.
 
--spec purchase(cowboy_req:req()) -> {json, map()} | {json, integer(), map(), map()}.
+-spec purchase(cowboy_req:req()) ->
+    {json, integer(), map(), map()} | {asobi_error, asobi_error:code()}.
 purchase(
     #{json := #{~"listing_id" := ListingId}, auth_data := #{player_id := PlayerId}} = _Req
 ) when is_binary(PlayerId), is_binary(ListingId) ->
@@ -37,9 +38,9 @@ purchase(
         {ok, Item} ->
             {json, 200, #{}, #{success => true, item => Item}};
         {error, insufficient_funds} ->
-            {json, 402, #{}, #{error => ~"insufficient_funds"}};
+            {asobi_error, ~"economy.insufficient_funds"};
         {error, listing_inactive} ->
-            {json, 400, #{}, #{error => ~"listing_inactive"}};
+            {asobi_error, ~"economy.listing_inactive"};
         {error, _Reason} ->
-            {json, 500, #{}, #{error => ~"purchase_failed"}}
+            {asobi_error, ~"economy.purchase_failed"}
     end.

--- a/src/controllers/asobi_guest_controller.erl
+++ b/src/controllers/asobi_guest_controller.erl
@@ -22,6 +22,11 @@
 -include_lib("kernel/include/logger.hrl").
 -include_lib("kura/include/kura.hrl").
 
+-type response() ::
+    {json, integer(), map(), map()}
+    | {asobi_error, asobi_error:code()}
+    | {asobi_error, asobi_error:code(), asobi_error:details()}.
+
 -define(PROVIDER, ~"guest").
 -define(MIN_SECRET_BYTES, 32).
 %% Upper bounds on unauthenticated input: cap the HMAC work per request and keep
@@ -32,35 +37,32 @@
 -define(MAX_DEVICE_ID_BYTES, 255).
 -define(MAX_USERNAME_ATTEMPTS, 3).
 
--spec authenticate(cowboy_req:req()) -> {json, integer(), map(), map()}.
+-spec authenticate(cowboy_req:req()) -> response().
 authenticate(#{json := #{~"device_id" := DeviceId, ~"device_secret" := Secret}} = _Req) when
     is_binary(DeviceId), is_binary(Secret)
 ->
     case guest_enabled() of
         false ->
-            {json, 403, #{}, #{
-                error => ~"guest_auth_disabled",
-                message => ~"Guest authentication is not enabled for this deployment."
-            }};
+            {asobi_error, ~"guest.disabled"};
         true ->
             case decode_secret(Secret) of
                 {ok, SecretBin} ->
                     case valid_device_id(DeviceId) of
                         true -> resolve(DeviceId, SecretBin);
-                        false -> {json, 400, #{}, #{error => ~"invalid_device_id"}}
+                        false -> {asobi_error, ~"guest.invalid_device_id"}
                     end;
                 error ->
-                    {json, 400, #{}, #{error => ~"weak_device_secret"}}
+                    {asobi_error, ~"guest.weak_device_secret"}
             end
     end;
 authenticate(_Req) ->
-    {json, 400, #{}, #{error => ~"missing_required_fields"}}.
+    {asobi_error, ~"missing_field"}.
 
 %% POST /api/v1/auth/guest/upgrade - claim a guest account with real
 %% credentials. Authenticated as the guest (auth_data from the resumed token,
 %% so it can only upgrade the caller's own player); revokes the device verifier
 %% so the device secret can no longer log into the now-claimed account.
--spec upgrade(cowboy_req:req()) -> {json, integer(), map(), map()}.
+-spec upgrade(cowboy_req:req()) -> response().
 upgrade(
     #{
         json := #{~"username" := Username, ~"password" := Password},
@@ -77,15 +79,15 @@ upgrade(
             %% password and rename itself - a side door around update_changeset.
             case is_unclaimed_guest(Player, PlayerId) of
                 true -> do_upgrade(Player, PlayerId, Username, Password);
-                false -> {json, 409, #{}, #{error => ~"not_an_unclaimed_guest"}}
+                false -> {asobi_error, ~"guest.not_unclaimed"}
             end;
         {error, _} ->
-            {json, 404, #{}, #{error => ~"player_not_found"}}
+            {asobi_error, ~"player.not_found"}
     end;
 upgrade(_Req) ->
-    {json, 400, #{}, #{error => ~"missing_required_fields"}}.
+    {asobi_error, ~"missing_field"}.
 
--spec do_upgrade(map(), binary(), binary(), binary()) -> {json, integer(), map(), map()}.
+-spec do_upgrade(map(), binary(), binary(), binary()) -> response().
 do_upgrade(Player, PlayerId, Username, Password) ->
     CS = asobi_player:registration_changeset(Player, #{
         username => Username,
@@ -158,7 +160,7 @@ has_guest_identity(PlayerId) ->
 
 %% --- Create-or-resume (fail closed) ---
 
--spec resolve(binary(), binary()) -> {json, integer(), map(), map()}.
+-spec resolve(binary(), binary()) -> response().
 resolve(DeviceId, SecretBin) ->
     case find_identity(DeviceId) of
         {ok, Identity} ->
@@ -167,12 +169,12 @@ resolve(DeviceId, SecretBin) ->
             create(DeviceId, SecretBin)
     end.
 
--spec resume(map(), binary()) -> {json, integer(), map(), map()}.
+-spec resume(map(), binary()) -> response().
 resume(Identity, SecretBin) ->
     Meta = maps:get(provider_metadata, Identity, #{}),
     case maps:get(~"revoked", Meta, false) of
         true ->
-            {json, 401, #{}, #{error => ~"guest_revoked"}};
+            {asobi_error, ~"guest.revoked"};
         _ ->
             case verify(SecretBin, Meta) of
                 true ->
@@ -180,11 +182,11 @@ resume(Identity, SecretBin) ->
                 false ->
                     %% Wrong secret for a known device: reject. Never create a
                     %% second player, never overwrite the stored verifier.
-                    {json, 401, #{}, #{error => ~"invalid_device_secret"}}
+                    {asobi_error, ~"guest.invalid_device_secret"}
             end
     end.
 
--spec create(binary(), binary()) -> {json, integer(), map(), map()}.
+-spec create(binary(), binary()) -> response().
 create(DeviceId, SecretBin) ->
     %% Row-spam defence (asobi#157): a global throughput bound (caps total
     %% guest-creates regardless of source IP - the per-IP auth limiter can't),
@@ -196,23 +198,22 @@ create(DeviceId, SecretBin) ->
     %% sustained stream is the signal to distinguish an attack from real growth.
     case asobi_registration:check(guest) of
         {deny, Reason} ->
-            {json, 403, #{}, #{error => Reason}};
+            asobi_auth_error:registration_denied(Reason);
         ok ->
             case global_create_allowed() andalso within_unlinked_cap() of
                 false ->
                     ?LOG_WARNING(#{event => guest_capacity_reached}),
-                    {json, 503, #{}, #{error => ~"guest_capacity_reached"}};
+                    {asobi_error, ~"guest.capacity_reached"};
                 true ->
                     insert_player_and_identity(DeviceId, SecretBin)
             end
     end.
 
--spec insert_player_and_identity(binary(), binary()) -> {json, integer(), map(), map()}.
+-spec insert_player_and_identity(binary(), binary()) -> response().
 insert_player_and_identity(DeviceId, SecretBin) ->
     insert_player_and_identity(DeviceId, SecretBin, 1).
 
--spec insert_player_and_identity(binary(), binary(), pos_integer()) ->
-    {json, integer(), map(), map()}.
+-spec insert_player_and_identity(binary(), binary(), pos_integer()) -> response().
 insert_player_and_identity(DeviceId, SecretBin, Attempt) ->
     Username = generate_username(),
     PlayerCS = kura_changeset:validate_required(
@@ -233,7 +234,7 @@ insert_player_and_identity(DeviceId, SecretBin, Attempt) ->
                     %% just-created player so a concurrent create can't leave an
                     %% orphan row.
                     _ = asobi_repo:delete(asobi_player, Player),
-                    {json, 409, #{}, #{error => ~"device_already_registered"}}
+                    {asobi_error, ~"guest.device_already_registered"}
             end;
         {error, #kura_changeset{errors = Errors}} when Attempt < ?MAX_USERNAME_ATTEMPTS ->
             case asobi_auth_error:username_taken(Errors) of
@@ -243,13 +244,13 @@ insert_player_and_identity(DeviceId, SecretBin, Attempt) ->
                     }),
                     insert_player_and_identity(DeviceId, SecretBin, Attempt + 1);
                 false ->
-                    {json, 500, #{}, #{error => ~"guest_create_failed"}}
+                    {asobi_error, ~"guest.create_failed"}
             end;
         {error, _} ->
-            {json, 500, #{}, #{error => ~"guest_create_failed"}}
+            {asobi_error, ~"guest.create_failed"}
     end.
 
--spec issue_for_player(binary()) -> {json, integer(), map(), map()}.
+-spec issue_for_player(binary()) -> response().
 issue_for_player(PlayerId) ->
     case asobi_repo:get(asobi_player, PlayerId) of
         {ok, Player} ->
@@ -262,10 +263,10 @@ issue_for_player(PlayerId) ->
                         username => maps:get(username, Player), guest => true
                     });
                 _ ->
-                    {json, 401, #{}, #{error => ~"guest_upgraded"}}
+                    {asobi_error, ~"guest.already_upgraded"}
             end;
         {error, _} ->
-            {json, 500, #{}, #{error => ~"guest_player_missing"}}
+            {asobi_error, ~"internal"}
     end.
 
 %% --- Verifier (salted + peppered keyed HMAC; secret never stored) ---

--- a/src/controllers/asobi_iap_controller.erl
+++ b/src/controllers/asobi_iap_controller.erl
@@ -2,9 +2,14 @@
 
 -export([verify_apple/1, verify_google/1]).
 
+-type response() ::
+    {json, integer(), map(), map()}
+    | {asobi_error, asobi_error:code()}
+    | {asobi_error, asobi_error:code(), asobi_error:details()}.
+
 %% POST /api/v1/iap/apple
 %% Body: {"signed_transaction": "<JWS string>"}
--spec verify_apple(cowboy_req:req()) -> {json, integer(), map(), map()}.
+-spec verify_apple(cowboy_req:req()) -> response().
 verify_apple(
     #{json := #{~"signed_transaction" := SignedTxn}, auth_data := #{player_id := PlayerId}} = _Req
 ) when is_binary(SignedTxn), is_binary(PlayerId) ->
@@ -12,14 +17,14 @@ verify_apple(
         {ok, Result} ->
             record(PlayerId, ~"apple", maps:get(transaction_id, Result, undefined), Result);
         {error, Reason} ->
-            {json, 422, #{}, #{error => Reason}}
+            verification_failed(Reason)
     end;
 verify_apple(_Req) ->
-    {json, 400, #{}, #{error => ~"missing_required_fields"}}.
+    {asobi_error, ~"missing_field"}.
 
 %% POST /api/v1/iap/google
 %% Body: {"product_id": "...", "purchase_token": "..."}
--spec verify_google(cowboy_req:req()) -> {json, integer(), map(), map()}.
+-spec verify_google(cowboy_req:req()) -> response().
 verify_google(#{json := Params, auth_data := #{player_id := PlayerId}} = _Req) when
     is_map(Params), is_binary(PlayerId)
 ->
@@ -27,30 +32,39 @@ verify_google(#{json := Params, auth_data := #{player_id := PlayerId}} = _Req) w
         {ok, Result} ->
             record(PlayerId, ~"google", maps:get(order_id, Result, undefined), Result);
         {error, Reason} ->
-            {json, 422, #{}, #{error => Reason}}
+            verification_failed(Reason)
     end;
 verify_google(_Req) ->
-    {json, 400, #{}, #{error => ~"missing_required_fields"}}.
+    {asobi_error, ~"missing_field"}.
 
 %% --- Internal ---
+
+%% `asobi_iap` reports why a receipt failed with a string that names an
+%% internal step (`invalid_x5c`, `google_token_exchange_failed`, ...). Those
+%% are diagnostics, not a contract, so they ride in `details` under one code
+%% rather than becoming ~40 codes that would change whenever the verifier does.
+-spec verification_failed(binary()) ->
+    {asobi_error, asobi_error:code(), asobi_error:details()}.
+verification_failed(Reason) when is_binary(Reason) ->
+    {asobi_error, ~"iap.verification_failed", #{reason => Reason}}.
 
 %% Persist the verified transaction bound to the player, exactly once.
 %% Re-submitting the same receipt is idempotent for the owner (`duplicate` =>
 %% true) and rejected for anyone else — a receipt can be claimed by one player.
--spec record(binary(), binary(), binary() | undefined, map()) -> {json, integer(), map(), map()}.
+-spec record(binary(), binary(), binary() | undefined, map()) -> response().
 record(_PlayerId, _Provider, undefined, _Result) ->
-    {json, 422, #{}, #{error => ~"missing_transaction_id"}};
+    {asobi_error, ~"iap.missing_transaction_id"};
 record(PlayerId, Provider, TxnId, Result) when is_binary(TxnId) ->
     case existing(Provider, TxnId) of
         {ok, #{player_id := PlayerId}} ->
             {json, 200, #{}, Result#{duplicate => true}};
         {ok, _Other} ->
-            {json, 409, #{}, #{error => ~"transaction_already_claimed"}};
+            {asobi_error, ~"iap.transaction_already_claimed"};
         none ->
             insert_new(PlayerId, Provider, TxnId, Result)
     end.
 
--spec insert_new(binary(), binary(), binary(), map()) -> {json, integer(), map(), map()}.
+-spec insert_new(binary(), binary(), binary(), map()) -> response().
 insert_new(PlayerId, Provider, TxnId, Result) ->
     CS = asobi_iap_transaction:changeset(#{}, #{
         player_id => PlayerId,
@@ -67,8 +81,8 @@ insert_new(PlayerId, Provider, TxnId, Result) ->
             %% same receipt. Re-check: if it now exists it was a race, else a
             %% genuine store failure.
             case existing(Provider, TxnId) of
-                {ok, _} -> {json, 409, #{}, #{error => ~"transaction_already_claimed"}};
-                none -> {json, 500, #{}, #{error => ~"record_failed"}}
+                {ok, _} -> {asobi_error, ~"iap.transaction_already_claimed"};
+                none -> {asobi_error, ~"iap.record_failed"}
             end
     end.
 

--- a/src/controllers/asobi_inventory_controller.erl
+++ b/src/controllers/asobi_inventory_controller.erl
@@ -19,7 +19,7 @@ index(#{auth_data := #{player_id := PlayerId}, qs := Qs} = _Req) when
 -define(MAX_CONSUME_QTY, 1000000).
 
 -spec consume(cowboy_req:req()) ->
-    {json, integer(), map(), map()} | {status, integer()}.
+    {json, integer(), map(), map()} | {asobi_error, asobi_error:code()}.
 consume(
     #{json := #{~"item_id" := ItemId, ~"quantity" := Qty}, auth_data := #{player_id := PlayerId}} =
         _Req
@@ -39,12 +39,12 @@ consume(
                         success => true, remaining_quantity => maps:get(quantity, Updated)
                     }};
                 false ->
-                    {json, 400, #{}, #{error => ~"insufficient_quantity"}}
+                    {asobi_error, ~"inventory.insufficient_quantity"}
             end;
         {ok, _} ->
-            {status, 403};
+            {asobi_error, ~"forbidden"};
         {error, not_found} ->
-            {status, 404}
+            {asobi_error, ~"inventory.item_not_found"}
     end;
 consume(_) ->
-    {json, 400, #{}, #{error => ~"invalid_quantity"}}.
+    {asobi_error, ~"inventory.invalid_quantity"}.

--- a/src/controllers/asobi_leaderboard_controller.erl
+++ b/src/controllers/asobi_leaderboard_controller.erl
@@ -21,13 +21,14 @@ around(#{bindings := #{~"id" := BoardId, ~"player_id" := PlayerId}, qs := Qs} = 
     Entries = asobi_leaderboard_server:around(BoardId, PlayerId, Range),
     {json, #{entries => format_entries(BoardId, Entries)}}.
 
--spec submit(cowboy_req:req()) -> {json, integer(), map(), map()}.
+-spec submit(cowboy_req:req()) ->
+    {json, integer(), map(), map()} | {asobi_error, asobi_error:code()}.
 submit(
     #{bindings := #{~"id" := BoardId}, json := Params, auth_data := #{player_id := PlayerId}} = _Req
 ) when is_binary(BoardId), is_binary(PlayerId), is_map(Params) ->
     case client_submit_allowed(BoardId) of
         false ->
-            {json, 403, #{}, #{error => ~"client_submit_disabled"}};
+            {asobi_error, ~"leaderboard.client_submit_disabled"};
         true ->
             Score =
                 case maps:get(~"score", Params) of
@@ -37,7 +38,7 @@ submit(
             SubScore = maps:get(~"sub_score", Params, 0),
             case asobi_leaderboard_server:submit(BoardId, PlayerId, Score) of
                 {error, capacity_reached} ->
-                    {json, 503, #{}, #{error => ~"leaderboard_capacity_reached"}};
+                    {asobi_error, ~"leaderboard.capacity_reached"};
                 _ ->
                     Rank =
                         case asobi_leaderboard_server:rank(BoardId, PlayerId) of

--- a/src/controllers/asobi_match_controller.erl
+++ b/src/controllers/asobi_match_controller.erl
@@ -38,11 +38,11 @@ live(#{qs := Qs} = _Req) when is_binary(Qs) ->
 live(_Req) ->
     {json, #{matches => asobi_match_lobby:list_matches_cached(#{})}}.
 
--spec show(cowboy_req:req()) -> {json, map()} | {status, integer()}.
+-spec show(cowboy_req:req()) -> {json, map()} | {asobi_error, asobi_error:code()}.
 show(#{bindings := #{~"id" := MatchId}} = _Req) ->
     case asobi_repo:get(asobi_match_record, MatchId) of
         {ok, Record} -> {json, public_record(Record)};
-        {error, not_found} -> {status, 404}
+        {error, not_found} -> {asobi_error, ~"match.not_found"}
     end.
 
 -spec index(cowboy_req:req()) -> {json, map()}.

--- a/src/controllers/asobi_matchmaker_controller.erl
+++ b/src/controllers/asobi_matchmaker_controller.erl
@@ -2,14 +2,15 @@
 
 -export([add/1, remove/1, status/1]).
 
--spec add(cowboy_req:req()) -> {json, integer(), map(), map()}.
+-spec add(cowboy_req:req()) ->
+    {json, integer(), map(), map()} | {asobi_error, asobi_error:code()}.
 add(#{json := Params, auth_data := #{player_id := PlayerId}} = _Req) when
     is_map(Params), is_binary(PlayerId)
 ->
     Mode = maps:get(~"mode", Params, ~"default"),
     case asobi_matchmaker:known_mode(Mode) of
         false ->
-            {json, 400, #{}, #{error => ~"unknown_mode"}};
+            {asobi_error, ~"matchmaker.unknown_mode"};
         true ->
             MatchParams = #{
                 mode => Mode,
@@ -19,21 +20,21 @@ add(#{json := Params, auth_data := #{player_id := PlayerId}} = _Req) when
                 {ok, TicketId, Meta} ->
                     {json, 200, #{}, Meta#{ticket_id => TicketId, status => ~"pending"}};
                 {error, queue_full} ->
-                    {json, 503, #{}, #{error => ~"queue_full"}}
+                    {asobi_error, ~"matchmaker.queue_full"}
             end
     end.
 
--spec remove(cowboy_req:req()) -> {json, map()} | {status, integer()}.
+-spec remove(cowboy_req:req()) -> {json, map()} | {asobi_error, asobi_error:code()}.
 remove(
     #{bindings := #{~"ticket_id" := TicketId}, auth_data := #{player_id := PlayerId}} = _Req
 ) when is_binary(PlayerId), is_binary(TicketId) ->
     case asobi_matchmaker:remove(PlayerId, TicketId) of
         ok -> {json, #{success => true}};
-        {error, not_owner} -> {status, 403};
-        {error, not_found} -> {status, 404}
+        {error, not_owner} -> {asobi_error, ~"forbidden"};
+        {error, not_found} -> {asobi_error, ~"matchmaker.ticket_not_found"}
     end.
 
--spec status(cowboy_req:req()) -> {json, map()} | {status, integer()}.
+-spec status(cowboy_req:req()) -> {json, map()} | {asobi_error, asobi_error:code()}.
 status(
     #{bindings := #{~"ticket_id" := TicketId}, auth_data := #{player_id := PlayerId}} = _Req
 ) when is_binary(PlayerId), is_binary(TicketId) ->
@@ -50,7 +51,7 @@ status(
                 submitted_at => maps:get(submitted_at, Ticket)
             }};
         {error, not_owner} ->
-            {status, 403};
+            {asobi_error, ~"forbidden"};
         {error, not_found} ->
-            {status, 404}
+            {asobi_error, ~"matchmaker.ticket_not_found"}
     end.

--- a/src/controllers/asobi_notification_controller.erl
+++ b/src/controllers/asobi_notification_controller.erl
@@ -19,7 +19,7 @@ index(#{auth_data := #{player_id := PlayerId}, qs := Qs} = _Req) when
     {ok, Notifications} = asobi_repo:all(Q2),
     {json, #{notifications => Notifications}}.
 
--spec mark_read(cowboy_req:req()) -> {json, map()} | {status, integer()}.
+-spec mark_read(cowboy_req:req()) -> {json, map()} | {asobi_error, asobi_error:code()}.
 mark_read(#{bindings := #{~"id" := NotifId}, auth_data := #{player_id := PlayerId}} = _Req) ->
     case asobi_repo:get(asobi_notification, NotifId) of
         {ok, #{player_id := PlayerId} = Notif} ->
@@ -27,19 +27,19 @@ mark_read(#{bindings := #{~"id" := NotifId}, auth_data := #{player_id := PlayerI
             {ok, Updated} = asobi_repo:update(CS),
             {json, Updated};
         {ok, _} ->
-            {status, 403};
+            {asobi_error, ~"forbidden"};
         {error, not_found} ->
-            {status, 404}
+            {asobi_error, ~"notification.not_found"}
     end.
 
--spec delete(cowboy_req:req()) -> {json, map()} | {status, integer()}.
+-spec delete(cowboy_req:req()) -> {json, map()} | {asobi_error, asobi_error:code()}.
 delete(#{bindings := #{~"id" := NotifId}, auth_data := #{player_id := PlayerId}} = _Req) ->
     case asobi_repo:get(asobi_notification, NotifId) of
         {ok, #{player_id := PlayerId} = Notif} ->
             _ = asobi_repo:delete(asobi_notification, Notif),
             {json, #{success => true}};
         {ok, _} ->
-            {status, 403};
+            {asobi_error, ~"forbidden"};
         {error, not_found} ->
-            {status, 404}
+            {asobi_error, ~"notification.not_found"}
     end.

--- a/src/controllers/asobi_oauth_controller.erl
+++ b/src/controllers/asobi_oauth_controller.erl
@@ -11,9 +11,14 @@
 
 -define(MAX_USERNAME_ATTEMPTS, 3).
 
+-type response() ::
+    {json, integer(), map(), map()}
+    | {asobi_error, asobi_error:code()}
+    | {asobi_error, asobi_error:code(), asobi_error:details()}.
+
 %% POST /api/v1/auth/oauth
 %% Body: {"provider": "google", "token": "<id_token>"}
--spec authenticate(cowboy_req:req()) -> {json, integer(), map(), map()}.
+-spec authenticate(cowboy_req:req()) -> response().
 authenticate(#{json := #{~"provider" := Provider, ~"token" := Token}} = _Req) when
     is_binary(Provider), is_binary(Token)
 ->
@@ -25,19 +30,19 @@ authenticate(#{json := #{~"provider" := Provider, ~"token" := Token}} = _Req) wh
                     login_existing_player(Identity);
                 {error, not_found} ->
                     case asobi_registration:check(oauth) of
-                        {deny, Reason} -> {json, 403, #{}, #{error => Reason}};
+                        {deny, Reason} -> asobi_auth_error:registration_denied(Reason);
                         ok -> create_player_with_identity(Provider, Claims)
                     end
             end;
         {error, Reason} ->
-            {json, 401, #{}, #{error => Reason}}
+            provider_rejected(Reason)
     end;
 authenticate(_Req) ->
-    {json, 400, #{}, #{error => ~"missing_required_fields"}}.
+    {asobi_error, ~"missing_field"}.
 
 %% POST /api/v1/auth/link
 %% Body: {"provider": "discord", "token": "<id_token>"}
--spec link(cowboy_req:req()) -> {json, integer(), map(), map()}.
+-spec link(cowboy_req:req()) -> response().
 link(
     #{json := #{~"provider" := Provider, ~"token" := Token}, auth_data := #{player_id := PlayerId}} =
         _Req
@@ -47,18 +52,18 @@ link(
             ProviderUid = maps:get(provider_uid, Claims),
             case find_identity(Provider, ProviderUid) of
                 {ok, _} ->
-                    {json, 409, #{}, #{error => ~"provider_already_linked"}};
+                    {asobi_error, ~"auth.provider_already_linked"};
                 {error, not_found} ->
                     create_identity(PlayerId, Provider, Claims)
             end;
         {error, Reason} ->
-            {json, 401, #{}, #{error => Reason}}
+            provider_rejected(Reason)
     end;
 link(_Req) ->
-    {json, 400, #{}, #{error => ~"missing_required_fields"}}.
+    {asobi_error, ~"missing_field"}.
 
 %% DELETE /api/v1/auth/unlink?provider=discord
--spec unlink(cowboy_req:req()) -> {json, integer(), map(), map()}.
+-spec unlink(cowboy_req:req()) -> response().
 unlink(
     #{parsed_qs := #{~"provider" := Provider}, auth_data := #{player_id := PlayerId}} = _Req
 ) when is_binary(Provider), is_binary(PlayerId) ->
@@ -69,15 +74,26 @@ unlink(
                     _ = asobi_repo:delete(asobi_player_identity, Identity),
                     {json, 200, #{}, #{success => true}};
                 false ->
-                    {json, 422, #{}, #{error => ~"cannot_remove_last_auth_method"}}
+                    {asobi_error, ~"auth.last_auth_method"}
             end;
         {error, not_found} ->
-            {json, 404, #{}, #{error => ~"identity_not_found"}}
+            {asobi_error, ~"auth.identity_not_found"}
     end;
 unlink(_Req) ->
-    {json, 400, #{}, #{error => ~"missing_required_fields"}}.
+    {asobi_error, ~"missing_field"}.
 
 %% --- Internal ---
+
+%% `Reason` here is not ours to publish as a code: for Steam it is lifted
+%% straight out of the provider's own error response, so a third party would
+%% be minting asobi codes. It goes in `details` under one code the client can
+%% branch on, and `unsupported_provider` keeps its own code because that one
+%% is a deployment-configuration answer, not the provider talking.
+-spec provider_rejected(binary()) -> {asobi_error, asobi_error:code(), asobi_error:details()}.
+provider_rejected(~"unsupported_provider") ->
+    {asobi_error, ~"auth.unsupported_provider", #{}};
+provider_rejected(Reason) when is_binary(Reason) ->
+    {asobi_error, ~"auth.provider_rejected", #{reason => Reason}}.
 
 -spec validate_provider_token(binary(), binary()) -> {ok, map()} | {error, binary()}.
 validate_provider_token(~"steam", Ticket) ->
@@ -169,22 +185,23 @@ find_player_identity(PlayerId, Provider) ->
         _ -> {error, not_found}
     end.
 
--spec login_existing_player(map()) -> {json, integer(), map(), map()}.
+-spec login_existing_player(map()) -> response().
 login_existing_player(Identity) ->
     PlayerId = maps:get(player_id, Identity),
     case asobi_repo:get(asobi_player, PlayerId) of
         {ok, Player} ->
             asobi_auth_tokens:issue(Player, 200, #{username => maps:get(username, Player)});
         {error, _} ->
-            {json, 500, #{}, #{error => ~"player_not_found"}}
+            %% The identity outlived its player row: an internal inconsistency,
+            %% not something the caller can act on.
+            {asobi_error, ~"internal"}
     end.
 
--spec create_player_with_identity(binary(), map()) -> {json, integer(), map(), map()}.
+-spec create_player_with_identity(binary(), map()) -> response().
 create_player_with_identity(Provider, Claims) ->
     create_player_with_identity(Provider, Claims, 1).
 
--spec create_player_with_identity(binary(), map(), pos_integer()) ->
-    {json, integer(), map(), map()}.
+-spec create_player_with_identity(binary(), map(), pos_integer()) -> response().
 create_player_with_identity(Provider, Claims, Attempt) ->
     ProviderUid = maps:get(provider_uid, Claims),
     DisplayName = maps:get(provider_display_name, Claims, undefined),
@@ -228,7 +245,7 @@ create_player_with_identity(Provider, Claims, Attempt) ->
         {error, identity, {error, #kura_changeset{errors = IErrors}}} ->
             case asobi_auth_error:provider_uid_taken(IErrors) of
                 true ->
-                    {json, 409, #{}, #{error => ~"already_registering"}};
+                    {asobi_error, ~"auth.already_registering"};
                 false ->
                     %% A real failure (e.g. a provider claim over a column
                     %% limit), not the identity race - do not log Claims,
@@ -238,13 +255,13 @@ create_player_with_identity(Provider, Claims, Attempt) ->
                         provider => Provider,
                         errors => IErrors
                     }),
-                    {json, 500, #{}, #{error => ~"registration_failed"}}
+                    {asobi_error, ~"auth.registration_failed"}
             end;
         {error, identity, IErr} ->
             ?LOG_ERROR(#{
                 event => oauth_identity_insert_failed, provider => Provider, reason => IErr
             }),
-            {json, 500, #{}, #{error => ~"registration_failed"}};
+            {asobi_error, ~"auth.registration_failed"};
         {error, player, {error, #kura_changeset{errors = Errors}}} when
             Attempt < ?MAX_USERNAME_ATTEMPTS
         ->
@@ -255,13 +272,13 @@ create_player_with_identity(Provider, Claims, Attempt) ->
                     }),
                     create_player_with_identity(Provider, Claims, Attempt + 1);
                 false ->
-                    {json, 500, #{}, #{error => ~"registration_failed"}}
+                    {asobi_error, ~"auth.registration_failed"}
             end;
         {error, player, _} ->
-            {json, 500, #{}, #{error => ~"registration_failed"}}
+            {asobi_error, ~"auth.registration_failed"}
     end.
 
--spec create_identity(binary(), binary(), map()) -> {json, integer(), map(), map()}.
+-spec create_identity(binary(), binary(), map()) -> response().
 create_identity(PlayerId, Provider, Claims) ->
     case insert_identity(PlayerId, Provider, Claims) of
         {ok, Identity} ->
@@ -271,7 +288,7 @@ create_identity(PlayerId, Provider, Claims) ->
                 linked => true
             }};
         {error, _} ->
-            {json, 500, #{}, #{error => ~"link_failed"}}
+            {asobi_error, ~"auth.link_failed"}
     end.
 
 -spec insert_identity(binary(), binary(), map()) -> {ok, map()} | {error, term()}.

--- a/src/controllers/asobi_social_controller.erl
+++ b/src/controllers/asobi_social_controller.erl
@@ -35,7 +35,12 @@ friends(#{auth_data := #{player_id := PlayerId}, qs := Qs} = _Req) when
     {ok, Friendships} = asobi_repo:all(Q2),
     {json, #{friends => Friendships}}.
 
--spec add_friend(cowboy_req:req()) -> {json, map()} | {json, integer(), map(), map()}.
+-type response() ::
+    {json, map()}
+    | {json, integer(), map(), map()}
+    | {asobi_error, asobi_error:code()}.
+
+-spec add_friend(cowboy_req:req()) -> response().
 add_friend(
     #{json := #{~"friend_id" := FriendId}, auth_data := #{player_id := PlayerId}} = _Req
 ) when
@@ -44,21 +49,21 @@ add_friend(
     %% F-23: reject self-add and verify the target player actually exists.
     case FriendId =:= PlayerId of
         true ->
-            {json, 400, #{}, #{error => ~"cannot_friend_self"}};
+            {asobi_error, ~"social.cannot_friend_self"};
         false ->
             case asobi_repo:get(asobi_player, FriendId) of
                 {error, not_found} ->
-                    {json, 404, #{}, #{error => ~"friend_not_found"}};
+                    {asobi_error, ~"social.friend_not_found"};
                 {ok, _} ->
                     insert_friendship(PlayerId, FriendId)
             end
     end;
 add_friend(_Req) ->
-    {json, 400, #{}, #{error => ~"invalid_request"}}.
+    {asobi_error, ~"invalid_payload"}.
 
 %% F-23: idempotent — re-adding an existing friendship returns the row
 %% rather than producing an opaque insert error.
--spec insert_friendship(binary(), binary()) -> {json, integer(), map(), map()}.
+-spec insert_friendship(binary(), binary()) -> response().
 insert_friendship(PlayerId, FriendId) ->
     Q = kura_query:where(
         kura_query:where(kura_query:from(asobi_friendship), {player_id, PlayerId}),
@@ -77,15 +82,13 @@ insert_friendship(PlayerId, FriendId) ->
                 {ok, Friendship} ->
                     {json, 200, #{}, Friendship};
                 {error, CS1} when is_record(CS1, kura_changeset) ->
-                    {json, 422, #{}, #{
-                        errors => kura_changeset:traverse_errors(CS1, fun(_F, M) -> M end)
-                    }};
+                    changeset_errors(CS1);
                 {error, _Other} ->
-                    {json, 409, #{}, #{error => ~"already_friend"}}
+                    {asobi_error, ~"social.already_friend"}
             end
     end.
 
--spec update_friend(cowboy_req:req()) -> {json, map()} | {status, integer()}.
+-spec update_friend(cowboy_req:req()) -> response().
 update_friend(
     #{
         bindings := #{~"friend_id" := FriendId},
@@ -103,10 +106,10 @@ update_friend(
             {ok, Updated} = asobi_repo:update(CS),
             {json, Updated};
         _ ->
-            {status, 404}
+            {asobi_error, ~"social.friendship_not_found"}
     end.
 
--spec remove_friend(cowboy_req:req()) -> {json, map()} | {status, integer()}.
+-spec remove_friend(cowboy_req:req()) -> response().
 remove_friend(
     #{bindings := #{~"friend_id" := FriendId}, auth_data := #{player_id := PlayerId}} = _Req
 ) ->
@@ -119,12 +122,12 @@ remove_friend(
             _ = asobi_repo:delete(asobi_friendship, Friendship),
             {json, #{success => true}};
         _ ->
-            {status, 404}
+            {asobi_error, ~"social.friendship_not_found"}
     end.
 
 %% --- Groups ---
 
--spec create_group(cowboy_req:req()) -> {json, map()} | {json, integer(), map(), map()}.
+-spec create_group(cowboy_req:req()) -> response().
 create_group(#{json := Params, auth_data := #{player_id := PlayerId}} = _Req) when
     is_map(Params), is_binary(PlayerId)
 ->
@@ -152,17 +155,17 @@ create_group(#{json := Params, auth_data := #{player_id := PlayerId}} = _Req) wh
             _ = asobi_repo:insert(MemberCS),
             {json, 200, #{}, Group};
         {error, CS1} when is_record(CS1, kura_changeset) ->
-            {json, 422, #{}, #{errors => kura_changeset:traverse_errors(CS1, fun(_F, M) -> M end)}}
+            changeset_errors(CS1)
     end.
 
--spec show_group(cowboy_req:req()) -> {json, map()} | {status, integer()}.
+-spec show_group(cowboy_req:req()) -> response().
 show_group(#{bindings := #{~"id" := GroupId}} = _Req) ->
     case asobi_repo:get(asobi_group, GroupId) of
         {ok, Group} -> {json, Group};
-        {error, not_found} -> {status, 404}
+        {error, not_found} -> {asobi_error, ~"social.group_not_found"}
     end.
 
--spec join_group(cowboy_req:req()) -> {json, map()} | {json, integer(), map(), map()}.
+-spec join_group(cowboy_req:req()) -> response().
 join_group(
     #{bindings := #{~"id" := GroupId}, auth_data := #{player_id := PlayerId}} = _Req
 ) when is_binary(GroupId), is_binary(PlayerId) ->
@@ -170,23 +173,23 @@ join_group(
     %% — for now reject with 403); enforce `max_members` via a count query.
     case asobi_repo:get(asobi_group, GroupId) of
         {error, not_found} ->
-            {json, 404, #{}, #{error => ~"group_not_found"}};
+            {asobi_error, ~"social.group_not_found"};
         {ok, Group} ->
             case maps:get(open, Group, false) of
                 false ->
-                    {json, 403, #{}, #{error => ~"group_closed"}};
+                    {asobi_error, ~"social.group_closed"};
                 true ->
                     Max = maps:get(max_members, Group, 50),
                     case current_member_count(GroupId) >= Max of
                         true ->
-                            {json, 409, #{}, #{error => ~"group_full"}};
+                            {asobi_error, ~"social.group_full"};
                         false ->
                             insert_group_member(GroupId, PlayerId)
                     end
             end
     end.
 
--spec insert_group_member(binary(), binary()) -> {json, integer(), map(), map()}.
+-spec insert_group_member(binary(), binary()) -> response().
 insert_group_member(GroupId, PlayerId) ->
     CS = kura_changeset:cast(
         asobi_group_member,
@@ -203,7 +206,7 @@ insert_group_member(GroupId, PlayerId) ->
         {ok, _Member} ->
             {json, 200, #{}, #{success => true, group_id => GroupId}};
         {error, _} ->
-            {json, 409, #{}, #{error => ~"already_member"}}
+            {asobi_error, ~"social.already_member"}
     end.
 
 -spec current_member_count(binary()) -> non_neg_integer().
@@ -230,15 +233,15 @@ leave_group(#{bindings := #{~"id" := GroupId}, auth_data := #{player_id := Playe
 
 %% --- Group Management ---
 
--spec list_members(cowboy_req:req()) -> {json, map()} | {status, integer()}.
+-spec list_members(cowboy_req:req()) -> response().
 list_members(#{bindings := #{~"id" := GroupId}} = _Req) ->
     Q = kura_query:where(kura_query:from(asobi_group_member), {group_id, GroupId}),
     case asobi_repo:all(Q) of
         {ok, Members} -> {json, #{members => Members}};
-        _ -> {status, 404}
+        _ -> {asobi_error, ~"social.group_not_found"}
     end.
 
--spec update_member_role(cowboy_req:req()) -> {json, map()} | {json, integer(), map(), map()}.
+-spec update_member_role(cowboy_req:req()) -> response().
 update_member_role(#{
     bindings := #{~"id" := GroupId, ~"player_id" := TargetPlayerId},
     json := #{~"role" := NewRole},
@@ -246,7 +249,7 @@ update_member_role(#{
 }) when is_binary(NewRole) ->
     case asobi_group_roles:valid_role(NewRole) of
         false ->
-            {json, 400, #{}, #{error => ~"invalid_role"}};
+            {asobi_error, ~"social.invalid_role"};
         true ->
             case {get_member(GroupId, ActorId), get_member(GroupId, TargetPlayerId)} of
                 {{ok, #{role := ActorRole}}, {ok, #{role := TargetRole} = Target}} ->
@@ -258,14 +261,14 @@ update_member_role(#{
                             {ok, Updated} = asobi_repo:update(CS),
                             {json, 200, #{}, Updated};
                         false ->
-                            {json, 403, #{}, #{error => ~"insufficient_permissions"}}
+                            {asobi_error, ~"forbidden"}
                     end;
                 _ ->
-                    {json, 404, #{}, #{error => ~"member_not_found"}}
+                    {asobi_error, ~"social.member_not_found"}
             end
     end.
 
--spec kick_member(cowboy_req:req()) -> {json, map()} | {json, integer(), map(), map()}.
+-spec kick_member(cowboy_req:req()) -> response().
 kick_member(#{
     bindings := #{~"id" := GroupId, ~"player_id" := TargetPlayerId},
     auth_data := #{player_id := ActorId}
@@ -277,13 +280,13 @@ kick_member(#{
                     _ = asobi_repo:delete(asobi_group_member, Target),
                     {json, 200, #{}, #{success => true}};
                 false ->
-                    {json, 403, #{}, #{error => ~"insufficient_permissions"}}
+                    {asobi_error, ~"forbidden"}
             end;
         _ ->
-            {json, 404, #{}, #{error => ~"member_not_found"}}
+            {asobi_error, ~"social.member_not_found"}
     end.
 
--spec update_group(cowboy_req:req()) -> {json, map()} | {json, integer(), map(), map()}.
+-spec update_group(cowboy_req:req()) -> response().
 update_group(#{
     bindings := #{~"id" := GroupId},
     json := Params,
@@ -303,16 +306,23 @@ update_group(#{
                             {ok, Updated} = asobi_repo:update(CS),
                             {json, 200, #{}, Updated};
                         _ ->
-                            {json, 404, #{}, #{error => ~"group_not_found"}}
+                            {asobi_error, ~"social.group_not_found"}
                     end;
                 false ->
-                    {json, 403, #{}, #{error => ~"insufficient_permissions"}}
+                    {asobi_error, ~"forbidden"}
             end;
         _ ->
-            {json, 403, #{}, #{error => ~"not_a_member"}}
+            {asobi_error, ~"forbidden"}
     end.
 
 %% --- Internal ---
+
+%% `errors` was the whole body before the shared object existed and stays a
+%% top-level key; it is the object's `details` too (asobi_error:legacy/2).
+-spec changeset_errors(#kura_changeset{}) -> {json, integer(), map(), map()}.
+changeset_errors(CS) ->
+    Errors = kura_changeset:traverse_errors(CS, fun(_F, M) -> M end),
+    asobi_error:legacy(~"validation_failed", #{errors => Errors}).
 
 get_member(GroupId, PlayerId) ->
     Q = kura_query:where(

--- a/src/controllers/asobi_tournament_controller.erl
+++ b/src/controllers/asobi_tournament_controller.erl
@@ -16,15 +16,15 @@ index(#{qs := Qs} = _Req) when is_binary(Qs) ->
     {ok, Tournaments} = asobi_repo:all(Q2),
     {json, #{tournaments => Tournaments}}.
 
--spec show(cowboy_req:req()) -> {json, map()} | {status, integer()}.
+-spec show(cowboy_req:req()) -> {json, map()} | {asobi_error, asobi_error:code()}.
 show(#{bindings := #{~"id" := TournamentId}} = _Req) ->
     case asobi_repo:get(asobi_tournament, TournamentId) of
         {ok, Tournament} -> {json, Tournament};
-        {error, not_found} -> {status, 404}
+        {error, not_found} -> {asobi_error, ~"tournament.not_found"}
     end.
 
 -spec join(cowboy_req:req()) ->
-    {json, integer(), map(), map()} | {status, integer()}.
+    {json, integer(), map(), map()} | {asobi_error, asobi_error:code()}.
 join(#{bindings := #{~"id" := TournamentId}, auth_data := #{player_id := PlayerId}} = _Req) when
     is_binary(TournamentId), is_binary(PlayerId)
 ->
@@ -32,9 +32,9 @@ join(#{bindings := #{~"id" := TournamentId}, auth_data := #{player_id := PlayerI
         ok ->
             {json, 200, #{}, #{success => true, tournament_id => TournamentId}};
         {error, tournament_full} ->
-            {json, 409, #{}, #{error => ~"tournament_full"}};
+            {asobi_error, ~"tournament.full"};
         {error, already_joined} ->
-            {json, 409, #{}, #{error => ~"already_joined"}};
+            {asobi_error, ~"tournament.already_joined"};
         {error, not_found} ->
-            {status, 404}
+            {asobi_error, ~"tournament.not_found"}
     end.

--- a/src/controllers/asobi_world_controller.erl
+++ b/src/controllers/asobi_world_controller.erl
@@ -13,18 +13,20 @@ index(_Req) ->
     Worlds = asobi_world_lobby:list_worlds_cached(),
     {json, #{worlds => Worlds}}.
 
--spec show(map()) -> {json, map()} | {status, 404}.
+-spec show(map()) -> {json, map()} | {asobi_error, asobi_error:code()}.
 show(#{bindings := #{~"id" := WorldId}}) ->
     case asobi_world_server:whereis(WorldId) of
         {ok, Pid} ->
             Info = asobi_world_server:get_info(Pid),
             {json, asobi_world_server:listing_info(Info)};
         error ->
-            {status, 404}
+            {asobi_error, ~"world.not_found"}
     end.
 
 -spec create(map()) ->
-    {json, map(), integer()} | {json, integer(), map(), map()} | {status, 400}.
+    {json, map(), integer()}
+    | {asobi_error, asobi_error:code()}
+    | {asobi_error, asobi_error:code(), asobi_error:details()}.
 create(#{json := #{~"mode" := Mode}, auth_data := #{player_id := PlayerId}}) when
     is_binary(PlayerId)
 ->
@@ -32,18 +34,26 @@ create(#{json := #{~"mode" := Mode}, auth_data := #{player_id := PlayerId}}) whe
         {ok, _Pid, Info} ->
             {json, Info, 201};
         {error, player_world_limit_reached} ->
-            {json, 429, #{}, #{error => ~"player_world_limit_reached"}};
+            {asobi_error, ~"world.player_limit_reached"};
         {error, world_capacity_reached} ->
-            {json, 503, #{}, #{error => ~"world_capacity_reached"}};
+            {asobi_error, ~"world.capacity_reached"};
         {error, Reason} ->
-            {json, #{error => Reason}, 400}
+            %% Anything else - including a refusal the loaded game's own mode
+            %% config produced - is reported under one code with the raw reason
+            %% in `details`. A script must not be able to mint a code.
+            {asobi_error, ~"world.create_failed", #{reason => reason(Reason)}}
     end;
 create(_Req) ->
-    {status, 400}.
+    {asobi_error, ~"invalid_payload"}.
 
 %%--------------------------------------------------------------------
 %% Internal
 %%--------------------------------------------------------------------
+
+-spec reason(term()) -> binary().
+reason(Reason) when is_atom(Reason) -> atom_to_binary(Reason, utf8);
+reason(Reason) when is_binary(Reason) -> Reason;
+reason(Reason) -> iolist_to_binary(io_lib:format(~"~p", [Reason])).
 
 -spec build_filters(map()) -> map().
 build_filters(QS) ->

--- a/src/ops/asobi_ops_auth.erl
+++ b/src/ops/asobi_ops_auth.erl
@@ -161,5 +161,5 @@ presented(Req) ->
 
 -spec deny() -> {false, 403, #{binary() => binary()}, binary()}.
 deny() ->
-    Body = iolist_to_binary(json:encode(#{error => ~"forbidden"})),
+    Body = iolist_to_binary(json:encode(asobi_error:object(~"forbidden"))),
     {false, 403, #{~"content-type" => ~"application/json"}, Body}.

--- a/src/ops/asobi_ops_controller.erl
+++ b/src/ops/asobi_ops_controller.erl
@@ -18,7 +18,10 @@ the equivalent public endpoint already exposes.
 
 -export([players/1, matches/1, features/1, leaderboards/1, leaderboard_entries/1, matchmaker/1]).
 
--type response() :: {json, map()} | {json, integer(), map(), map()}.
+-type response() ::
+    {json, map()}
+    | {json, integer(), map(), map()}
+    | {asobi_error, asobi_error:code()}.
 
 %% `leaderboard_id` is a VARCHAR(255); a longer binding matches no board, so
 %% it is answered as a bad request rather than paid for as a query.
@@ -50,7 +53,7 @@ leaderboard_entries(#{bindings := #{~"id" := BoardId}} = Req) when
         fun asobi_ops_leaderboards:project_entry/1
     );
 leaderboard_entries(_Req) ->
-    {json, 400, #{}, #{error => ~"invalid_board_id"}}.
+    {asobi_error, ~"ops.invalid_board_id"}.
 
 %% The snapshot is read once and used for both halves of the response, so the
 %% totals and the rows can never describe two different samples.
@@ -115,13 +118,17 @@ params(_Req) -> #{}.
 
 %% A rejected parameter is the caller's fault and says which one; a failed
 %% read is ours and says nothing beyond that, with the reason in the log.
+%%
+%% `field` and `order` were top-level keys before the shared object existed
+%% and stay there; they are the object's `details` too. Both are echoed back
+%% from the caller's own query string, so neither can become a code.
 -spec error_response(term()) -> response().
 error_response({unknown_sort, Field}) ->
-    {json, 400, #{}, #{error => ~"unknown_sort_field", field => Field}};
+    asobi_error:legacy(~"ops.unknown_sort_field", #{field => Field});
 error_response({unknown_order, Order}) ->
-    {json, 400, #{}, #{error => ~"unknown_sort_order", order => Order}};
+    asobi_error:legacy(~"ops.unknown_sort_order", #{order => Order});
 error_response({query_failed, Reason}) ->
     ?LOG_ERROR(#{msg => ~"ops list query failed", reason => Reason}),
-    {json, 500, #{}, #{error => ~"query_failed"}};
+    {asobi_error, ~"ops.query_failed"};
 error_response(_) ->
-    {json, 400, #{}, #{error => ~"bad_request"}}.
+    {asobi_error, ~"invalid_payload"}.

--- a/src/players/asobi_player_controller.erl
+++ b/src/players/asobi_player_controller.erl
@@ -2,23 +2,23 @@
 
 -export([show/1, update/1]).
 
--spec show(cowboy_req:req()) -> {json, map()} | {status, integer()}.
+-spec show(cowboy_req:req()) -> {json, map()} | {asobi_error, asobi_error:code()}.
 show(#{bindings := #{~"id" := PlayerId}} = _Req) ->
     case asobi_repo:get(asobi_player, PlayerId) of
         {ok, Player} ->
             {json, sanitize(Player)};
         {error, not_found} ->
-            {status, 404}
+            {asobi_error, ~"player.not_found"}
     end.
 
 -spec update(cowboy_req:req()) ->
-    {json, map()} | {json, integer(), map(), map()} | {status, integer()}.
+    {json, map()} | {json, integer(), map(), map()} | {asobi_error, asobi_error:code()}.
 update(
     #{bindings := #{~"id" := PlayerId}, json := Params, auth_data := #{player_id := AuthId}} = _Req
 ) when is_map(Params) ->
     case PlayerId =:= AuthId of
         false ->
-            {status, 403};
+            {asobi_error, ~"forbidden"};
         true ->
             case asobi_repo:get(asobi_player, PlayerId) of
                 {ok, Player} ->
@@ -27,10 +27,14 @@ update(
                         {ok, Updated} ->
                             {json, sanitize(Updated)};
                         {error, CS1} ->
-                            {json, 422, #{}, #{errors => format_errors(CS1)}}
+                            %% `errors` keeps its top-level place for form UIs
+                            %% and doubles as the object's `details`.
+                            asobi_error:legacy(~"validation_failed", #{
+                                errors => format_errors(CS1)
+                            })
                     end;
                 {error, not_found} ->
-                    {status, 404}
+                    {asobi_error, ~"player.not_found"}
             end
     end.
 

--- a/src/plugins/asobi_body_cap_plugin.erl
+++ b/src/plugins/asobi_body_cap_plugin.erl
@@ -55,11 +55,11 @@ needs_check(Req) ->
 check_size(Req, Max, RequireCL, State) ->
     case cowboy_req:body_length(Req) of
         undefined when RequireCL ->
-            reject(411, ~"length_required", Req, State);
+            reject(411, asobi_error:object(~"length_required"), Req, State);
         undefined ->
             {ok, Req, State};
         N when is_integer(N), N > Max ->
-            reject(413, ~"payload_too_large", Req, State);
+            reject(413, asobi_error:object(~"payload_too_large"), Req, State);
         _ ->
             {ok, Req, State}
     end.
@@ -69,14 +69,13 @@ check_size(Req, Max, RequireCL, State) ->
 %% has no clause for (case_clause -> request-process crash + crash report on
 %% every rejection - log/CPU amplification on the path meant to reduce DoS).
 %% {stop, ...} maps to {stop, Req}, which cowboy handles cleanly.
--spec reject(integer(), binary(), cowboy_req:req(), term()) ->
+-spec reject(pos_integer(), asobi_error:object(), cowboy_req:req(), term()) ->
     {stop, cowboy_req:req(), term()}.
-reject(Status, Reason, Req, State) ->
-    Body = json:encode(#{~"error" => Reason}),
+reject(Status, Object, Req, State) ->
     Req1 = cowboy_req:reply(
         Status,
         #{~"content-type" => ~"application/json"},
-        Body,
+        json:encode(Object),
         Req
     ),
     {stop, Req1, State}.

--- a/src/plugins/asobi_client_gate_plugin.erl
+++ b/src/plugins/asobi_client_gate_plugin.erl
@@ -22,7 +22,14 @@ pre_request(Req, _Env, _Options, State) ->
         pass ->
             {ok, Req, State};
         {deny, Reason} ->
-            Body = json:encode(#{~"error" => ~"registration_gate_denied", ~"reason" => Reason}),
+            %% `Reason` comes from the configured gate module - a third party
+            %% as far as this plugin is concerned - so it stays data: the
+            %% top-level key it always had, and the object's `details`.
+            Body = json:encode(
+                asobi_error:legacy_body(~"client_gate_denied", #{
+                    ~"reason" => Reason
+                })
+            ),
             Req1 = cowboy_req:reply(
                 403, #{~"content-type" => ~"application/json"}, Body, Req
             ),

--- a/src/plugins/asobi_rate_limit_plugin.erl
+++ b/src/plugins/asobi_rate_limit_plugin.erl
@@ -25,10 +25,13 @@ pre_request(Req, _Env, Options, State) ->
             Req2 = cowboy_req:set_resp_header(~"x-ratelimit-reset", integer_to_binary(Reset), Req1),
             {ok, Req2, State};
         {deny, #{retry_after := RetryAfter}} ->
-            Body = json:encode(#{
-                ~"error" => ~"rate_limited",
-                ~"retry_after" => RetryAfter div 1000
-            }),
+            %% `retry_after` stays a top-level key and is the object's
+            %% `details` too - see asobi_error:legacy_body/2.
+            Body = json:encode(
+                asobi_error:legacy_body(~"rate_limited", #{
+                    ~"retry_after" => RetryAfter div 1000
+                })
+            ),
             Req1 = cowboy_req:set_resp_header(
                 ~"retry-after", integer_to_binary(RetryAfter div 1000), Req
             ),

--- a/src/votes/asobi_vote_controller.erl
+++ b/src/votes/asobi_vote_controller.erl
@@ -3,7 +3,7 @@
 
 -export([index/1, show/1]).
 
--spec index(cowboy_req:req()) -> {json, map()} | {status, integer()}.
+-spec index(cowboy_req:req()) -> {json, map()} | {asobi_error, asobi_error:code()}.
 index(#{bindings := #{~"id" := MatchId}, auth_data := #{player_id := PlayerId}} = _Req) when
     is_binary(MatchId), is_binary(PlayerId)
 ->
@@ -11,7 +11,7 @@ index(#{bindings := #{~"id" := MatchId}, auth_data := #{player_id := PlayerId}} 
     %% up the match record (or live match server) and reject non-players.
     case is_match_participant(MatchId, PlayerId) of
         false ->
-            {status, 403};
+            {asobi_error, ~"forbidden"};
         true ->
             Q0 = kura_query:from(asobi_vote),
             Q1 = kura_query:where(Q0, {match_id, MatchId}),
@@ -21,7 +21,7 @@ index(#{bindings := #{~"id" := MatchId}, auth_data := #{player_id := PlayerId}} 
                 {ok, Votes} ->
                     {json, #{votes => [strip_hidden(V) || V <- Votes]}};
                 {error, _} ->
-                    {status, 500}
+                    {asobi_error, ~"internal"}
             end
     end.
 
@@ -56,11 +56,11 @@ strip_hidden(#{visibility := ~"hidden", status := S} = Vote) when S =/= ~"resolv
 strip_hidden(Vote) ->
     Vote.
 
--spec show(cowboy_req:req()) -> {json, map()} | {status, integer()}.
+-spec show(cowboy_req:req()) -> {json, map()} | {asobi_error, asobi_error:code()}.
 show(#{bindings := #{~"id" := VoteId}, auth_data := #{player_id := _PlayerId}} = _Req) ->
     case asobi_repo:get(asobi_vote, VoteId) of
         {ok, Vote} ->
             {json, Vote};
         {error, not_found} ->
-            {status, 404}
+            {asobi_error, ~"vote.not_found"}
     end.

--- a/test/asobi_api_SUITE.erl
+++ b/test/asobi_api_SUITE.erl
@@ -25,6 +25,7 @@
     get_player/1,
     update_player/1,
     update_player_unauthorized/1,
+    get_missing_player/1,
     health_check/1,
     readiness_check/1,
     liveness_check/1,
@@ -52,7 +53,8 @@ groups() ->
         {players, [sequence], [
             get_player,
             update_player,
-            update_player_unauthorized
+            update_player_unauthorized,
+            get_missing_player
         ]},
         {health, [], [
             health_check,
@@ -154,7 +156,7 @@ register_duplicate_username(Config) ->
         Config
     ),
     ?assertStatus(409, Resp),
-    ?assertMatch(#{~"error" := ~"username_taken"}, nova_test:json(Resp)),
+    ?assertMatch(#{~"error" := #{~"code" := ~"auth.username_taken"}}, nova_test:json(Resp)),
     Config.
 
 register_short_username(Config) ->
@@ -169,8 +171,15 @@ register_short_username(Config) ->
         Config
     ),
     ?assertStatus(422, Resp),
+    %% `fields` keeps its top-level place and is repeated in `details`.
     ?assertMatch(
-        #{~"error" := ~"validation_failed", ~"fields" := #{~"username" := _}},
+        #{
+            ~"error" := #{
+                ~"code" := ~"validation_failed",
+                ~"details" := #{~"fields" := #{~"username" := _}}
+            },
+            ~"fields" := #{~"username" := _}
+        },
         nova_test:json(Resp)
     ),
     Config.
@@ -188,7 +197,10 @@ register_short_password(Config) ->
     ),
     ?assertStatus(422, Resp),
     ?assertMatch(
-        #{~"error" := ~"validation_failed", ~"fields" := #{~"password" := _}},
+        #{
+            ~"error" := #{~"code" := ~"validation_failed"},
+            ~"fields" := #{~"password" := _}
+        },
         nova_test:json(Resp)
     ),
     Config.
@@ -223,6 +235,10 @@ login_invalid_credentials(Config) ->
         Config
     ),
     ?assertStatus(401, Resp),
+    ?assertMatch(
+        #{~"error" := #{~"code" := ~"auth.invalid_credentials", ~"details" := #{}}},
+        nova_test:json(Resp)
+    ),
     Config.
 
 refresh_token(Config) ->
@@ -339,6 +355,25 @@ update_player_unauthorized(Config) ->
         Config
     ),
     ?assertStatus(403, Resp),
+    %% A 403 used to be an empty body with nothing to branch on.
+    ?assertMatch(
+        #{~"error" := #{~"code" := ~"forbidden", ~"details" := #{}}}, nova_test:json(Resp)
+    ),
+    Config.
+
+%% A 404 used to be an empty body too.
+get_missing_player(Config) ->
+    {session_token, Token} = lists:keyfind(session_token, 1, Config),
+    {ok, Resp} = nova_test:get(
+        "/api/v1/players/00000000-0000-0000-0000-000000000000",
+        #{headers => [{~"authorization", <<"Bearer ", Token/binary>>}]},
+        Config
+    ),
+    ?assertStatus(404, Resp),
+    ?assertMatch(
+        #{~"error" := #{~"code" := ~"player.not_found", ~"message" := _, ~"details" := #{}}},
+        nova_test:json(Resp)
+    ),
     Config.
 
 %% --- Health Tests ---
@@ -388,7 +423,9 @@ ops_rejects_a_player_token(Config) ->
 ops_rejects_an_anonymous_request(Config) ->
     {ok, Resp} = nova_test:get("/api/v1/ops/players", Config),
     ?assertStatus(403, Resp),
-    ?assertMatch(#{~"error" := ~"forbidden"}, nova_test:json(Resp)),
+    ?assertMatch(
+        #{~"error" := #{~"code" := ~"forbidden", ~"details" := #{}}}, nova_test:json(Resp)
+    ),
     Config.
 
 ops_accepts_the_operator_secret(Config) ->

--- a/test/asobi_auth_tokens_tests.erl
+++ b/test/asobi_auth_tokens_tests.erl
@@ -59,7 +59,8 @@ issue_lets_extra_override_the_base_body() ->
 issue_degrades_to_500_on_generate_failure() ->
     meck:expect(nova_auth_refresh, generate_pair, fun(_, _) -> {error, redis_down} end),
     Result = asobi_auth_tokens:issue(#{id => ~"p1"}, 200),
-    ?assertEqual({json, 500, #{}, #{error => ~"token_issue_failed"}}, Result).
+    ?assertEqual({asobi_error, ~"auth.token_issue_failed"}, Result),
+    ?assertEqual(500, asobi_error:status(~"auth.token_issue_failed")).
 
 revoke_test_() ->
     {setup, fun setup_revoke/0, fun cleanup/1, [

--- a/test/asobi_body_cap_plugin_tests.erl
+++ b/test/asobi_body_cap_plugin_tests.erl
@@ -23,8 +23,8 @@ body_cap_test_() ->
 
 setup() ->
     meck:new(cowboy_req, [no_link, passthrough]),
-    meck:expect(cowboy_req, reply, fun(Status, _Hdrs, _Body, Req) ->
-        Req#{reply_status => Status}
+    meck:expect(cowboy_req, reply, fun(Status, _Hdrs, Body, Req) ->
+        Req#{reply_status => Status, reply_body => Body}
     end),
     ok.
 
@@ -56,7 +56,11 @@ oversized_body_rejected_413() ->
     {stop, ReplyReq, undefined} = asobi_body_cap_plugin:pre_request(
         Req, #{}, #{max_body => 1048576}, undefined
     ),
-    ?assertEqual(413, maps:get(reply_status, ReplyReq)).
+    ?assertEqual(413, maps:get(reply_status, ReplyReq)),
+    ?assertMatch(
+        #{~"error" := #{~"code" := ~"payload_too_large", ~"details" := #{}}},
+        reply_body(ReplyReq)
+    ).
 
 chunked_without_length_rejected_411() ->
     meck:expect(cowboy_req, has_body, fun(_) -> true end),
@@ -65,7 +69,16 @@ chunked_without_length_rejected_411() ->
     {stop, ReplyReq, undefined} = asobi_body_cap_plugin:pre_request(
         Req, #{}, #{require_content_length => true}, undefined
     ),
-    ?assertEqual(411, maps:get(reply_status, ReplyReq)).
+    ?assertEqual(411, maps:get(reply_status, ReplyReq)),
+    %% This rejection never reaches a controller, so the plugin has to speak
+    %% the shared dialect itself or the 411 is the one status with no code.
+    ?assertMatch(
+        #{~"error" := #{~"code" := ~"length_required", ~"message" := _}},
+        reply_body(ReplyReq)
+    ).
+
+reply_body(#{reply_body := Body}) ->
+    json:decode(iolist_to_binary(Body)).
 
 chunked_allowed_when_opt_off() ->
     meck:expect(cowboy_req, has_body, fun(_) -> true end),

--- a/test/asobi_error_contract_tests.erl
+++ b/test/asobi_error_contract_tests.erl
@@ -1,0 +1,309 @@
+-module(asobi_error_contract_tests).
+
+%% The regression guard for the shared error object (asobi#338 / plan 1b).
+%%
+%% Converting every controller is a one-off; keeping them converted is not. A
+%% new route that answers `{status, 404}` or `#{error => ~"nope"}` is a silent
+%% return to the old dialects, and no per-route test would catch it because
+%% the route itself would be new. So this reads the compiled abstract code of
+%% every module in the application and rejects the shapes:
+%%
+%%   flat_error_body   an error response whose body is a map with an `error`
+%%                     key that is not an `asobi_error` object.
+%%   status_only       a returned `{status, N}`, N >= 400: a status with no
+%%                     body, so a client has nothing to branch on.
+%%   bypasses_asobi_error
+%%                     a module that writes an error response and never builds
+%%                     an error object at all. Catches the body that reaches
+%%                     the response through a variable.
+%%   undefined_code / code_is_not_a_literal
+%%                     a code outside the closed set, or one computed at run
+%%                     time. The second is what enforces "a client- or
+%%                     script-supplied string never becomes a code": passing a
+%%                     reason where a code belongs does not get past here.
+%%
+%% An error response is `{json, Status, _, Body}` or `{false, Status, _, Body}`
+%% (the Nova security-callback shape) or `{json, Body, Status}` in return
+%% position, or any `cowboy_req:reply/4` - the plugins answer without returning
+%% to Nova. Return position means the last expression of a clause or block
+%% body, which is how a controller states its response; a `{status, 401}` in a
+%% config map (asobi_oidc_config) is not a response and is not flagged.
+
+-include_lib("eunit/include/eunit.hrl").
+
+-define(ERROR_BUILDERS, [object, legacy, legacy_body]).
+
+%% --- The contract ---
+
+every_error_response_uses_the_shared_object_test() ->
+    Violations = lists:append([violations(M, forms(M)) || M <- app_modules()]),
+    ?assertEqual([], Violations).
+
+%% A scanner that silently read nothing would pass the test above forever.
+%% Pin that it really reaches the converted call sites.
+the_scan_reaches_real_code_test() ->
+    Modules = app_modules(),
+    ?assert(length(Modules) > 50),
+    Producers = [M || M <- Modules, lists:any(fun produces_error/1, expr_nodes(forms(M)))],
+    ?assert(length(Producers) >= 15).
+
+%% Every module the router can dispatch to must be one the scan covers. The
+%% route table is the source of truth, so a controller that lives outside
+%% `src/controllers/` - as `asobi_player_controller` and `asobi_vote_controller`
+%% already do - cannot escape by sitting somewhere unexpected.
+every_routed_module_is_scanned_test() ->
+    Routed = routed_modules(),
+    ?assert(length(Routed) >= 15),
+    ?assertEqual([], Routed -- app_modules()).
+
+%% --- The scanner itself ---
+
+%% The deliverable is that this fails on a regression, so prove that it does.
+%% Each snippet is a shape that was somewhere in the tree before this change.
+scanner_rejects_the_old_dialects_test_() ->
+    [
+        ?_assert(
+            flags(
+                flat_error_body,
+                ~"f(X) -> case X of a -> {json, 404, #{}, #{error => <<\"nope\">>}} end."
+            )
+        ),
+        ?_assert(flags(flat_error_body, ~"f(R) -> {json, 403, #{}, #{error => R}}.")),
+        ?_assert(flags(flat_error_body, ~"f() -> {json, #{error => <<\"nope\">>}, 400}.")),
+        ?_assert(
+            flags(
+                flat_error_body,
+                ~"f(R) -> cowboy_req:reply(429, #{}, json:encode(#{error => <<\"x\">>}), R)."
+            )
+        ),
+        ?_assert(flags(status_only, ~"f(X) -> case X of a -> {status, 403} end.")),
+        ?_assert(flags(bypasses_asobi_error, ~"f(B, R) -> cowboy_req:reply(500, #{}, B, R).")),
+        ?_assert(flags(undefined_code, ~"f() -> {asobi_error, <<\"storage.not_fund\">>}.")),
+        ?_assert(flags(code_is_not_a_literal, ~"f(Reason) -> {asobi_error, Reason}.")),
+        ?_assert(flags(code_is_not_a_literal, ~"f(Reason) -> asobi_error:object(Reason, #{}).")),
+        %% The status override form keeps the code in the third position.
+        ?_assert(flags(undefined_code, ~"f() -> {asobi_error, 418, <<\"nope\">>, #{}}."))
+    ].
+
+%% ...and passes on the shapes the tree uses now, or it is just noise that the
+%% next author deletes.
+scanner_accepts_the_shared_object_test_() ->
+    [
+        ?_assertEqual([], check(~"f() -> {asobi_error, <<\"storage.not_found\">>}.")),
+        ?_assertEqual(
+            [], check(~"f(V) -> {asobi_error, <<\"save.version_conflict\">>, #{v => V}}.")
+        ),
+        ?_assertEqual([], check(~"f() -> {asobi_error, 418, <<\"internal\">>, #{}}.")),
+        ?_assertEqual(
+            [], check(~"f(F) -> asobi_error:legacy(<<\"validation_failed\">>, #{fields => F}).")
+        ),
+        ?_assertEqual(
+            [],
+            check(
+                ~"f(R) -> B = json:encode(asobi_error:object(<<\"rate_limited\">>)), cowboy_req:reply(429, #{}, B, R)."
+            )
+        ),
+        %% A status below 400 is not an error response.
+        ?_assertEqual([], check(~"f() -> {status, 204}.")),
+        %% A `{status, N}` that is not a return value is not a response at all
+        %% - asobi_oidc_config's `on_failure` is a setting for a dependency.
+        ?_assertEqual([], check(~"f() -> C = #{on_failure => {status, 401}}, C."))
+    ].
+
+%% --- Scanning ---
+
+violations(Module, Forms) ->
+    Nodes = expr_nodes(Forms),
+    Responses = error_responses(Nodes),
+    [{Module, V} || V <- body_violations(Responses) ++ code_violations(Module, Nodes)] ++
+        bypass_violations(Module, Responses, Nodes).
+
+%% `{Status, BodyExpr}` for every error response the module writes.
+error_responses(Nodes) ->
+    Returned = [response(E) || E <- returns(Nodes)],
+    Replied = [reply(N) || N <- Nodes],
+    [R || {ok, R} <- Returned ++ Replied].
+
+response({tuple, _, [{atom, _, status}, Status]}) ->
+    with_status(Status, status_only);
+response({tuple, _, [{atom, _, Tag}, Status, _Headers, Body]}) when Tag =:= json; Tag =:= false ->
+    with_status(Status, Body);
+response({tuple, _, [{atom, _, json}, Body, Status]}) ->
+    with_status(Status, Body);
+response(_Other) ->
+    none.
+
+reply({call, _, {remote, _, {atom, _, cowboy_req}, {atom, _, reply}}, [Status, _H, Body, _Req]}) ->
+    with_status(Status, Body);
+reply(_Other) ->
+    none.
+
+with_status(Status, Body) ->
+    case literal(Status) of
+        {ok, N} when is_integer(N), N >= 400 -> {ok, {N, Body}};
+        _ -> none
+    end.
+
+body_violations(Responses) ->
+    lists:append([body_violation(R) || R <- Responses]).
+
+body_violation({Status, status_only}) ->
+    [{status_only, Status}];
+body_violation({Status, Body}) ->
+    case lists:filter(fun is_flat_error_map/1, expr_nodes(Body)) of
+        [] -> [];
+        [_ | _] -> [{flat_error_body, Status}]
+    end.
+
+%% `#{error => Something}` where Something is not an error object: the
+%% pre-#338 dialect, whether the value is a literal or a runtime reason.
+is_flat_error_map({map, _, Assocs}) ->
+    lists:any(fun is_flat_error_assoc/1, Assocs);
+is_flat_error_map(_Other) ->
+    false.
+
+is_flat_error_assoc({Assoc, _, Key, Value}) when
+    Assoc =:= map_field_assoc; Assoc =:= map_field_exact
+->
+    (literal(Key) =:= {ok, error} orelse literal(Key) =:= {ok, ~"error"}) andalso
+        not builds_error(Value);
+is_flat_error_assoc(_Other) ->
+    false.
+
+%% A module that writes an error response must build the object somewhere,
+%% even when the body reaches the response through a variable.
+bypass_violations(Module, [], _Nodes) ->
+    _ = Module,
+    [];
+bypass_violations(Module, [_ | _], Nodes) ->
+    case lists:any(fun builds_error/1, Nodes) of
+        true -> [];
+        false -> [{Module, bypasses_asobi_error}]
+    end.
+
+builds_error({call, _, {remote, _, {atom, _, asobi_error}, {atom, _, F}}, _Args}) ->
+    lists:member(F, ?ERROR_BUILDERS);
+builds_error(_Other) ->
+    false.
+
+%% Most call sites state the failure as a `{asobi_error, Code}` result for the
+%% Nova return handler rather than building the object themselves.
+produces_error({tuple, _, [{atom, _, asobi_error} | _]}) -> true;
+produces_error(Node) -> builds_error(Node).
+
+%% Every code reaching the wire must be a binary literal from the closed set:
+%% a computed one could carry a reason a client or a Lua script supplied.
+%% `asobi_error` itself is the definition site, not a call site: it builds the
+%% `{asobi_error, Code, ...}` result on its way to `handle/3` with `Code` still
+%% a variable, and its own MFA tuples begin with the module's name. Its
+%% behaviour is pinned by asobi_error_tests instead.
+code_violations(asobi_error, _Nodes) ->
+    [];
+code_violations(_Module, Nodes) ->
+    Codes = asobi_error:codes(),
+    [V || Node <- Nodes, {violation, V} <- [code_violation(Node, Codes)]].
+
+code_violation({call, _, {remote, _, {atom, _, asobi_error}, {atom, _, F}}, [Code | _]}, Codes) ->
+    case lists:member(F, ?ERROR_BUILDERS) of
+        true -> known_code(Code, Codes);
+        false -> ok
+    end;
+code_violation({tuple, _, [{atom, _, asobi_error} | Rest]}, Codes) when Rest =/= [] ->
+    %% `{asobi_error, Code}`, `{asobi_error, Code, Details}` and
+    %% `{asobi_error, Status, Code, Details}`: the code is the first element
+    %% past the optional status override.
+    case lists:dropwhile(fun is_status_override/1, Rest) of
+        [Code | _] -> known_code(Code, Codes);
+        [] -> {violation, {code_is_not_a_literal, 0}}
+    end;
+code_violation(_Node, _Codes) ->
+    ok.
+
+is_status_override(Node) ->
+    case literal(Node) of
+        {ok, N} -> is_integer(N);
+        error -> false
+    end.
+
+known_code(Node, Codes) ->
+    case literal(Node) of
+        {ok, Code} when is_binary(Code) ->
+            case lists:member(Code, Codes) of
+                true -> ok;
+                false -> {violation, {undefined_code, Code}}
+            end;
+        _ ->
+            {violation, {code_is_not_a_literal, erl_anno:line(element(2, Node))}}
+    end.
+
+%% --- Walking ---
+
+%% The last expression of every clause and block body: what the function, or
+%% the case arm, actually answers with.
+returns(Nodes) ->
+    [lists:last(Body) || Node <- Nodes, Body <- body_of(Node), Body =/= []].
+
+body_of({clause, _, _, _, Body}) -> [Body];
+body_of({block, _, Body}) -> [Body];
+body_of(_Other) -> [].
+
+%% Every node except a clause's patterns. `asobi_error:handle/3` matches on
+%% `{asobi_error, Code}` with `Code` unbound - consuming the shape, not minting
+%% a code - and a pattern must not be read as a call site.
+expr_nodes({clause, _, _Patterns, _Guards, Body} = Node) -> [Node | expr_nodes(Body)];
+expr_nodes(Node) when is_tuple(Node) -> [Node | expr_nodes(tuple_to_list(Node))];
+expr_nodes(List) when is_list(List) -> lists:append([expr_nodes(E) || E <- List]);
+expr_nodes(_Other) -> [].
+
+literal(Node) ->
+    try
+        {ok, erl_parse:normalise(Node)}
+    catch
+        _:_ -> error
+    end.
+
+%% --- Fixtures ---
+
+app_modules() ->
+    _ = application:load(asobi),
+    {ok, Modules} = application:get_key(asobi, modules),
+    Modules.
+
+%% `code:get_object_code/1` rather than `code:which/1`: under cover the latter
+%% answers `cover_compiled` and the scan would read nothing.
+forms(Module) ->
+    {Module, Beam, _Path} = code:get_object_code(Module),
+    {ok, {Module, [{abstract_code, {raw_abstract_v1, Forms}}]}} =
+        beam_lib:chunks(Beam, [abstract_code]),
+    Forms.
+
+routed_modules() ->
+    lists:usort([
+        M
+     || Group <- asobi_router:routes(test), M <- group_modules(Group), M =/= undefined
+    ]).
+
+group_modules(#{routes := Routes} = Group) ->
+    [handler_module(maps:get(security, Group, false)) | [handler_module(H) || {_, H, _} <- Routes]].
+
+handler_module(Handler) when is_function(Handler) ->
+    {module, Module} = erlang:fun_info(Handler, module),
+    Module;
+handler_module(Handler) when is_atom(Handler), Handler =/= false -> Handler;
+handler_module(_Other) ->
+    undefined.
+
+%% Parse a snippet as one function and run the same scanner over it.
+check(Source) ->
+    {ok, Tokens, _} = erl_scan:string(binary_to_list(Source)),
+    {ok, Form} = erl_parse:parse_form(Tokens),
+    violations(snippet, [Form]).
+
+flags(Kind, Source) ->
+    lists:any(
+        fun
+            ({_Module, {K, _}}) -> K =:= Kind;
+            ({_Module, K}) -> K =:= Kind
+        end,
+        check(Source)
+    ).

--- a/test/asobi_error_tests.erl
+++ b/test/asobi_error_tests.erl
@@ -31,6 +31,34 @@ explicit_message_overrides_the_registered_one_test() ->
         asobi_error:object(~"internal", ~"Bespoke.", #{}),
     ?assertEqual(~"Bespoke.", Message).
 
+%% --- Keys a route already sent stay where they were ---
+
+%% The one compatibility rule of the rollout: converting a route replaces
+%% `error` and touches nothing else. A client reading `fields` keeps reading
+%% `fields`, and the same map is the object's `details` for new code.
+legacy_keeps_the_top_level_keys_test() ->
+    Body = asobi_error:legacy_body(~"validation_failed", #{fields => #{username => [~"taken"]}}),
+    ?assertEqual(#{username => [~"taken"]}, maps:get(fields, Body)),
+    ?assertMatch(
+        #{error := #{code := ~"validation_failed", details := #{fields := _}}},
+        Body
+    ),
+    ?assertEqual([error, fields], lists:sort(maps:keys(Body))).
+
+legacy_takes_its_status_from_the_code_test() ->
+    ?assertMatch(
+        {json, 429, #{}, #{error := #{code := ~"rate_limited"}, retry_after := 30}},
+        asobi_error:legacy(~"rate_limited", #{retry_after => 30})
+    ).
+
+%% A legacy body with nothing to add is still the plain object, `details` and
+%% all - no empty extra keys, no missing ones.
+legacy_with_no_extra_keys_is_the_object_test() ->
+    ?assertEqual(
+        asobi_error:object(~"forbidden"),
+        asobi_error:legacy_body(~"forbidden", #{})
+    ).
+
 %% --- The code table ---
 
 status_comes_from_the_code_test() ->
@@ -81,6 +109,20 @@ known_ws_reason_maps_to_its_code_test() ->
         #{error := #{code := ~"world.not_found"}},
         asobi_error:from_ws_reason(~"world_not_found")
     ).
+
+%% The guide promises one code set across both surfaces: the same failure must
+%% not be `dm.blocked` over REST and `ws.request_failed` on the socket.
+ws_reason_and_rest_agree_on_the_code_test() ->
+    Shared = [
+        {~"blocked", ~"dm.blocked"},
+        {~"content_empty", ~"dm.content_empty"},
+        {~"content_too_large", ~"dm.content_too_large"},
+        {~"not_owner", ~"forbidden"}
+    ],
+    [
+        ?assertMatch(#{error := #{code := Code}}, asobi_error:from_ws_reason(Reason))
+     || {Reason, Code} <- Shared
+    ].
 
 ws_reason_accepts_an_atom_test() ->
     ?assertEqual(

--- a/test/asobi_guest_controller_tests.erl
+++ b/test/asobi_guest_controller_tests.erl
@@ -83,7 +83,7 @@ authenticate_disabled_returns_403_test() ->
         }
     }),
     ?assertMatch(
-        {json, 403, _, #{error := ~"guest_auth_disabled", message := _}},
+        {asobi_error, ~"guest.disabled"},
         asobi_guest_controller:authenticate(Req)
     ).
 

--- a/test/asobi_iap_SUITE.erl
+++ b/test/asobi_iap_SUITE.erl
@@ -97,7 +97,13 @@ apple_root_not_configured(Config) ->
         Config
     ),
     ?assertStatus(422, Resp),
-    #{~"error" := ~"apple_root_cert_not_configured"} = nova_test:json(Resp),
+    #{
+        ~"error" := #{
+            ~"code" := ~"iap.verification_failed",
+            ~"details" := #{~"reason" := ~"apple_root_cert_not_configured"}
+        }
+    } =
+        nova_test:json(Resp),
     cleanup_apple_env(),
     Config.
 
@@ -130,7 +136,12 @@ apple_unsupported_alg(Config) ->
         Config
     ),
     ?assertStatus(422, Resp),
-    #{~"error" := ~"unsupported_alg"} = nova_test:json(Resp),
+    #{
+        ~"error" := #{
+            ~"code" := ~"iap.verification_failed", ~"details" := #{~"reason" := ~"unsupported_alg"}
+        }
+    } =
+        nova_test:json(Resp),
     cleanup_apple_env(),
     Config.
 
@@ -148,7 +159,12 @@ apple_missing_x5c(Config) ->
         Config
     ),
     ?assertStatus(422, Resp),
-    #{~"error" := ~"invalid_x5c"} = nova_test:json(Resp),
+    #{
+        ~"error" := #{
+            ~"code" := ~"iap.verification_failed", ~"details" := #{~"reason" := ~"invalid_x5c"}
+        }
+    } =
+        nova_test:json(Resp),
     cleanup_apple_env(),
     Config.
 
@@ -170,7 +186,13 @@ apple_signature_invalid(Config) ->
         Config
     ),
     ?assertStatus(422, Resp),
-    #{~"error" := ~"signature_invalid"} = nova_test:json(Resp),
+    #{
+        ~"error" := #{
+            ~"code" := ~"iap.verification_failed",
+            ~"details" := #{~"reason" := ~"signature_invalid"}
+        }
+    } =
+        nova_test:json(Resp),
     cleanup_apple_env(),
     Config.
 
@@ -191,7 +213,13 @@ apple_chain_validation_failed(Config) ->
         Config
     ),
     ?assertStatus(422, Resp),
-    #{~"error" := ~"chain_validation_failed"} = nova_test:json(Resp),
+    #{
+        ~"error" := #{
+            ~"code" := ~"iap.verification_failed",
+            ~"details" := #{~"reason" := ~"chain_validation_failed"}
+        }
+    } =
+        nova_test:json(Resp),
     cleanup_apple_env(),
     Config.
 
@@ -209,7 +237,13 @@ apple_valid_jws_wrong_bundle(Config) ->
         Config
     ),
     ?assertStatus(422, Resp),
-    #{~"error" := ~"bundle_id_mismatch"} = nova_test:json(Resp),
+    #{
+        ~"error" := #{
+            ~"code" := ~"iap.verification_failed",
+            ~"details" := #{~"reason" := ~"bundle_id_mismatch"}
+        }
+    } =
+        nova_test:json(Resp),
     cleanup_apple_env(),
     Config.
 
@@ -259,7 +293,13 @@ google_not_configured(Config) ->
         Config
     ),
     ?assertStatus(422, Resp),
-    #{~"error" := ~"google_iap_not_configured"} = nova_test:json(Resp),
+    #{
+        ~"error" := #{
+            ~"code" := ~"iap.verification_failed",
+            ~"details" := #{~"reason" := ~"google_iap_not_configured"}
+        }
+    } =
+        nova_test:json(Resp),
     Config.
 
 %% --- Helpers ---

--- a/test/asobi_iap_controller_tests.erl
+++ b/test/asobi_iap_controller_tests.erl
@@ -46,18 +46,20 @@ cross_account_replay_rejected() ->
     stub_apple(#{transaction_id => ~"t1", product_id => ~"coins"}),
     meck:expect(asobi_repo, all, fun(_Q) -> {ok, [#{player_id => ~"someone-else"}]} end),
     ?assertMatch(
-        {json, 409, _, #{error := ~"transaction_already_claimed"}},
+        {asobi_error, ~"iap.transaction_already_claimed"},
         asobi_iap_controller:verify_apple(apple_req(~"p1"))
     ).
 
 unauthenticated_rejected() ->
     Req = fake_req(#{json => #{~"signed_transaction" => ~"jws"}}),
-    ?assertMatch({json, 400, _, _}, asobi_iap_controller:verify_apple(Req)).
+    ?assertMatch({asobi_error, ~"missing_field"}, asobi_iap_controller:verify_apple(Req)).
 
 verify_failure_surfaced() ->
     meck:expect(asobi_iap, verify_apple, fun(_) -> {error, ~"bundle_id_mismatch"} end),
+    %% The verifier's own string is a diagnostic, so it lands in `details`
+    %% rather than becoming a code a client could branch on.
     ?assertMatch(
-        {json, 422, _, #{error := ~"bundle_id_mismatch"}},
+        {asobi_error, ~"iap.verification_failed", #{reason := ~"bundle_id_mismatch"}},
         asobi_iap_controller:verify_apple(apple_req(~"p1"))
     ).
 

--- a/test/asobi_leaderboard_api_SUITE.erl
+++ b/test/asobi_leaderboard_api_SUITE.erl
@@ -143,7 +143,7 @@ submit_score_disabled(Config) ->
         Config
     ),
     ?assertStatus(403, Resp),
-    ?assertJson(#{~"error" := ~"client_submit_disabled"}, Resp),
+    ?assertJson(#{~"error" := #{~"code" := ~"leaderboard.client_submit_disabled"}}, Resp),
     Config.
 
 submit_score(Config) ->
@@ -283,5 +283,15 @@ ops_board_entries_reject_unknown_sort(Config) ->
         Config
     ),
     ?assertStatus(400, Resp),
-    ?assertJson(#{~"error" := ~"unknown_sort_field"}, Resp),
+    %% `field` keeps its top-level place and is repeated in `details`.
+    ?assertJson(
+        #{
+            ~"error" := #{
+                ~"code" := ~"ops.unknown_sort_field",
+                ~"details" := #{~"field" := ~"metadata"}
+            },
+            ~"field" := ~"metadata"
+        },
+        Resp
+    ),
     Config.

--- a/test/asobi_matchmaker_api_SUITE.erl
+++ b/test/asobi_matchmaker_api_SUITE.erl
@@ -125,7 +125,9 @@ add_ticket_omitted_mode_rejected(Config) ->
         Config
     ),
     ?assertStatus(400, Resp),
-    ?assertMatch(#{~"error" := ~"unknown_mode"}, nova_test:json(Resp)),
+    ?assertMatch(
+        #{~"error" := #{~"code" := ~"matchmaker.unknown_mode"}}, nova_test:json(Resp)
+    ),
     Config.
 
 get_ticket(Config) ->

--- a/test/asobi_oauth_SUITE.erl
+++ b/test/asobi_oauth_SUITE.erl
@@ -297,7 +297,7 @@ create_player_no_retry_on_non_unique_username_error(Config) ->
     end),
     try
         Claims = #{provider_uid => ~"reserved_uid", provider_display_name => undefined},
-        {json, 500, _, #{error := ~"registration_failed"}} =
+        {asobi_error, ~"auth.registration_failed"} =
             asobi_oauth_controller:create_player_with_identity(~"discord", Claims),
         ?assertEqual(1, meck:num_calls(asobi_repo, insert, '_'))
     after
@@ -334,7 +334,7 @@ create_player_deletes_orphan_on_identity_race_loss(Config) ->
         ]),
         Claims = #{provider_uid => ProviderUid, provider_display_name => undefined},
         ?assertEqual(
-            {json, 409, #{}, #{error => ~"already_registering"}},
+            {asobi_error, ~"auth.already_registering"},
             asobi_oauth_controller:create_player_with_identity(~"discord", Claims)
         ),
         PlayerId =
@@ -369,7 +369,7 @@ create_player_identity_insert_real_failure_returns_500(Config) ->
             provider_email => ~"not-an-email"
         },
         ?assertEqual(
-            {json, 500, #{}, #{error => ~"registration_failed"}},
+            {asobi_error, ~"auth.registration_failed"},
             asobi_oauth_controller:create_player_with_identity(~"discord", Claims)
         )
     after

--- a/test/asobi_ops_auth_tests.erl
+++ b/test/asobi_ops_auth_tests.erl
@@ -188,7 +188,10 @@ denial_is_403_and_says_nothing_about_the_cause() ->
     [{false, Status, Headers, Body} | _] = Denials,
     ?assertEqual(403, Status),
     ?assertEqual(#{~"content-type" => ~"application/json"}, Headers),
-    ?assertEqual(#{~"error" => ~"forbidden"}, json:decode(Body)).
+    ?assertMatch(
+        #{~"error" := #{~"code" := ~"forbidden", ~"message" := _, ~"details" := #{}}},
+        json:decode(Body)
+    ).
 
 %%--------------------------------------------------------------------
 %% Failing closed with no secret configured

--- a/test/asobi_registration_tests.erl
+++ b/test/asobi_registration_tests.erl
@@ -59,7 +59,7 @@ register_controller_denies_before_db() ->
     application:set_env(asobi, registration, closed),
     Req = fake_req(#{json => #{~"username" => ~"validname", ~"password" => ~"longenough1"}}),
     ?assertEqual(
-        {json, 403, #{}, #{error => ~"registration_closed"}},
+        {asobi_error, ~"auth.registration_closed"},
         asobi_auth_controller:register(Req)
     ).
 
@@ -68,7 +68,7 @@ register_controller_denies_before_db() ->
 guest_controller_denies_before_capacity() ->
     application:set_env(asobi, registration, closed),
     ?assertEqual(
-        {json, 403, #{}, #{error => ~"registration_closed"}},
+        {asobi_error, ~"auth.registration_closed"},
         asobi_guest_controller:create(~"device-abc", ~"secret-abc")
     ).
 


### PR DESCRIPTION
Plan item 1b. `asobi_error` shipped in #338 with one worked example - 7 of 64
REST routes. Every other controller still answered in its own dialect, so
nothing outside `/saves` and `/storage` could branch on a failure. This
finishes the rollout and adds the guard that keeps it finished.

## What changed

Every controller now states its failure as `{asobi_error, Code}` (or
`{asobi_error, Code, Details}`) and lets the Nova return handler pick the
status from the code. That includes the two controllers that do not live in
`src/controllers/` - `asobi_player_controller` and `asobi_vote_controller` -
plus `asobi_ops_controller`, `asobi_ops_auth`'s deny body, `asobi_auth_tokens`,
and the three plugins that write their own 4xx/5xx body without ever reaching
a controller (body cap, rate limiter, client gate).

Codes are namespaced per domain: `auth.`, `guest.`, `player.`, `world.`,
`matchmaker.`, `leaderboard.`, `economy.`, `inventory.`, `iap.`, `social.`,
`dm.`, `tournament.`, `notification.`, `vote.`, `ops.`, alongside the existing
`storage.`, `save.`, `match.`, `chat.` and the bare cross-cutting ones.

Where the reason is not ours to publish it stays data. Steam hands back the
string from its own error response, `asobi_iap` names an internal verification
step, and `asobi_world_lobby` can refuse for a reason the loaded game's mode
config produced. Each of those lands under one code with the raw string in
`details.reason`, never as a code.

## Compatibility

Additive except for `error` itself, which was already a string and is now the
object - the same swap #338 made for storage.

Every other top-level key a route already sent survives untouched: `fields` and
`errors` on a 422, `retry_after` on a 429, `field` and `order` on an ops sort
rejection, `reason` on a registration-gate 403. Each is repeated inside
`details` so new code reads one place. `asobi_error:legacy/2` is the single
funnel for that, so a converted site cannot quietly drop one.

Statuses are unchanged throughout. Routes that answered 403 or 404 with an
empty body answer the same status with the object in it.

One key moved: the bespoke top-level `message` on `POST /auth/guest` when guest
auth is disabled. The identical prose is now `error.message`. The rollout note
in `guides/rest-api.md` says so.

## The meta-test

`test/asobi_error_contract_tests.erl` reads the compiled abstract code of every
module in the application and fails on:

- an error response whose body is a map with an `error` key that is not the
  object;
- a returned `{status, N}` with N >= 400 - a status with nothing to branch on;
- a module that writes an error response and never builds an object at all;
- a code outside the closed set, or one that is not a binary literal.

That last one is what mechanically enforces "a client- or script-supplied
string never becomes a code": passing a reason where a code belongs does not
get past the test.

It derives its own module set from the application and cross-checks it against
`asobi_router:routes/1`, so a controller added anywhere is covered whether or
not anyone remembers this test exists. Only expressions in return position are
checked for the response shapes, so `asobi_oidc_config`'s `on_failure =>
{status, 401}` - a setting for a dependency, not a response - is not a false
positive. It is verified in both directions: ten snippets of the old dialects
that must be flagged, seven of the current shapes that must not, and a guard
that the scan reached real code rather than silently reading nothing.

Confirmed failing on real reverts: putting `{status, 403}` back in
`asobi_chat_controller` and `#{error => ~"insufficient_funds"}` back in
`asobi_economy_controller` each produce exactly one violation.

## WebSocket

The WS surface was already consistent and stays that way. Every `error` frame
goes through one `encode_error/2,3` funnel that sends the legacy `reason`
byte-for-byte alongside the object, so there is nothing left to convert there.

The only gap was mappings: four reasons asobi already emits had no code and
were falling back to `ws.request_failed`. `blocked`, `content_empty` and
`content_too_large` now map to the same `dm.*` codes their REST equivalents
return, and `not_owner` to `forbidden` - so the same failure carries the same
code on both surfaces, which is what the guide claims. `game.message` and
`game.error` are untouched (S6 owns those).

## Checks

`rebar3 fmt --check`, `xref`, `dialyzer` and `ex_doc` clean. `rebar3 eunit`
1284 tests, 0 failures. CT: `asobi_api`, `asobi_storage`, `asobi_oauth`,
`asobi_ops_audit`, `asobi_leaderboard_api`, `asobi_matchmaker_api`,
`asobi_social_api`, `asobi_match_api`, `asobi_tournament_api`,
`asobi_notification`, `asobi_economy`, `asobi_store`, `asobi_chat`,
`asobi_vote`, `asobi_rate_limit`, `asobi_cors`, `asobi_ws`,
`asobi_world_lobby` all pass.

Two pre-existing failures on this shared database are unrelated and reproduce
on a clean `origin/main`: `asobi_guest_SUITE` (8 cases) and
`asobi_iap_SUITE:apple_valid_jws_correct_bundle`, which reads a leftover row
and gets 409 instead of 200.
