### PR TITLE
feat(extensions): the extension machinery - behaviour, registry, supervision, build gate

### DIFF
--- a/guides/extensions.md
+++ b/guides/extensions.md
@@ -193,11 +193,10 @@ Rules:
 
 ### Two gaps you hit today
 
-**Your migration will not run.** `kura_migrator` discovers migrations from
-exactly one OTP application. This is a live kura defect independent of
-extensions. `asobi_repo:migration_apps/0` is the seam kura 2.20.0 calls; asobi
-pins `{kura, "~> 2.17"}`, so until the pin moves the host writes one delegating
-migration file.
+**Your migration will not run.** On the pinned kura, `kura_migrator` discovers
+migrations from exactly one OTP application. `asobi_repo:migration_apps/0` is
+the seam kura 2.20 calls; asobi pins `{kura, "~> 2.17"}`, so until the pin
+moves the host writes one delegating migration file.
 
 **Your foreign key will not cascade.** `#kura_assoc` has no `on_delete` field
 and rebar3_kura hardcodes `no_action`, so the generated migration gives you

--- a/guides/extensions.md
+++ b/guides/extensions.md
@@ -1,0 +1,262 @@
+# Extensions
+
+An extension is an ordinary OTP application that depends on asobi, added as a
+dependency of your release, plus one small module telling asobi the few things
+it cannot discover.
+
+No new packaging concept, no new lifecycle, nothing to learn beyond OTP.
+
+> This contract is **experimental**. The wire freezes, because SDK users vendor
+> by copying source. This module does not, until a real second consumer has
+> said what it is missing.
+
+## Installing one
+
+```erlang
+%% your_game_app/rebar.config
+{deps, [
+    {asobi,        {git, "https://github.com/widgrensit/asobi.git", {tag, "v0.50.0"}}},
+    {asobi_quests, {git, "https://github.com/you/asobi_quests.git", {tag, "v1.0.0"}}}
+]}.
+
+{relx, [{release, {your_game, "1.0.0"},
+         [your_game_app, asobi_quests, asobi, sasl]}]}.
+```
+
+Two lines. Removing an extension is deleting them; its tables survive until
+deliberately purged, because destroying player progress on a dependency change
+is the wrong default.
+
+`asobi_quests` depends on `asobi`. Your app depends on both. asobi never
+depends on an extension: every extension depends on asobi, so the reverse edge
+is a cycle relx sorts into a build failure and Hex rejects outright.
+
+Validate the set before you boot it:
+
+```erlang
+{project_plugins, [{asobi, {git, "https://github.com/widgrensit/asobi.git", {tag, "v0.50.0"}}}]}.
+```
+
+```sh
+rebar3 asobi check
+```
+
+This is the gate. asobi validates the same set again at boot, but a boot-time
+failure is raised from inside Nova's route compilation and surfaces with Nova's
+crash context rather than a legible asobi error.
+
+## Who calls an extension
+
+Two consumption paths, and an extension wants both.
+
+| Caller | Path | For |
+|---|---|---|
+| Game logic, in-match, server-side | `game.quests.progress(player_id, 1)` | "player killed something, +1" |
+| Game client, over the network | `asobi.rpc("quests.claim", ...)` | "give me my reward" |
+
+An extension with only the wire cannot observe gameplay; one with only Lua
+cannot be triggered by a player action from the client.
+
+## What you declare
+
+```erlang
+-module(asobi_quests_extension).
+-behaviour(asobi_extension).
+-export([info/0, rpc/0, lua/0, sup/0, owns/0]).
+
+info() -> #{name => quests, extension_version => 1}.
+
+rpc()  -> #{~"quests.list"  => {asobi_quests_rpc, list,  2},
+            ~"quests.claim" => {asobi_quests_rpc, claim, 2}}.
+
+lua()  -> #{~"quests" =>
+              #{~"progress" => #{mfa     => {asobi_quests_lua, progress, 2},
+                                 args    => [binary, integer],
+                                 effects => write,
+                                 vms     => [match, world]},
+                ~"status"   => #{mfa     => {asobi_quests_lua, status, 2},
+                                 args    => [binary],
+                                 effects => none,
+                                 vms     => [match, world, bot]}}}.
+
+sup()  -> [#{id    => asobi_quests_tracker,
+             start => {asobi_quests_tracker, start_link, []}}].
+
+owns() -> #{tables => [~"quests", ~"quest_progress"],
+            rpc    => [~"quests"],
+            lua    => [~"quests"],
+            queues => [~"quests"]}.
+```
+
+Only `info/0` is required. The rest default to empty.
+
+- `rpc/0` - core cannot guess that `quests.claim` is `{asobi_quests_rpc, claim, 2}`.
+- `lua/0` - the `game.<ns>.*` surface a Lua game calls. `effects` is not
+  decoration: probe VMs re-run the whole script body to ask `phases()` and swap
+  every `write` function for an inert stub, so a `write` declared `none` fires
+  twice on every match creation.
+- `sup/0` - child specs, if you want asobi supervising them.
+- `owns/0` - the tokens this extension claims. It earns nothing with one
+  extension installed; it is the N >= 2 key.
+- `info/0` - the contract version, distinct from the package version, because a
+  minor release can change an experimental contract.
+
+## Most of it is discovered
+
+| Thing | How asobi finds it | You declare |
+|---|---|---|
+| Migrations | `application:get_key(App, modules)`, matched on `m<14 digits>_` | nothing |
+| Schemas | Same module list, filtered by "exports `table/0` and `fields/0`" | nothing |
+| Background jobs | Nothing at all. The job row names the worker module | nothing |
+| Domain logic | Nothing. They are modules; other code calls them | nothing |
+| RPC handlers | Cannot be inferred | `rpc/0` |
+| Lua namespace | Cannot be inferred | `lua/0` |
+| Supervised processes | Optional | `sup/0` |
+| Namespace ownership | Cannot be inferred | `owns/0` |
+
+Discovery walks the OTP application graph, filtering on "exports
+`<app>_extension`". Depending on asobi is not the filter: `asobi_lua`,
+`asobi_engine` and `asobi_admin` all have asobi in their closure and none is an
+extension.
+
+## Prefer a library application
+
+If your extension has processes, **omit `mod` from your `.app.src`** and
+declare children via `sup/0`.
+
+```
+asobi_sup  (one_for_one, 10/60)
+  `- asobi_extension_sup       (one_for_one, 3/60)
+       |- quests               (own restart budget)
+       `- clans
+```
+
+The reason is specific. Applications in a release are permanent by default, and
+in OTP a permanent application terminating takes the whole runtime with it. So
+a normal OTP app whose supervisor exceeds its restart intensity **kills the
+node** - matchmaking, presence, every live match. Under
+`asobi_extension_sup` an extension that exhausts its own budget goes dark,
+core logs which one, and the node survives.
+
+This is the ordinary BEAM pattern, not an invention: Ecto repos, Oban and
+Phoenix endpoints are all started in the host's tree rather than by the library.
+
+A normal OTP application with its own `mod` also works. You then own the
+failure mode, and the operator has to remember to mark it non-permanent in the
+release.
+
+**Consequence:** with no `mod` there is no `start/2` for one-time setup. ETS
+tables and config validation move into the `init/1` of a supervised worker, and
+`application:which_applications()` will not show the extension as running.
+
+Per-extension restart limits default to 5 in 60 and are settable:
+
+```erlang
+{asobi, [{extension_restart, #{intensity => 5, period => 60}}]}
+```
+
+## Namespaces
+
+`owns/0` reserves names. Two extensions claiming the same table, RPC prefix,
+Lua namespace or job queue is a build failure naming both claimants, and so is
+claiming a name core reserves.
+
+The claim set is `owns/0` plus what the manifest already implies: the prefixes
+in `rpc/0` and the namespaces in `lua/0`. So a collision is caught even before
+either extension has bothered with `owns/0`.
+
+Core's reserved names are derived from core itself: Lua namespaces from
+`asobi_lua_surface`, tables from core's schemas, queues from core's shigoto
+workers, and RPC prefixes from the domains of `asobi_error:codes/0` - an RPC
+prefix and an error-code domain are the same token, so owning `storage` would
+mint codes inside core's closed code set.
+
+## Tables
+
+Three distinct things, and only one creates a table:
+
+1. **The schema** - a `kura_schema` module. Describes.
+2. **The migration** - generated by `rebar3 kura compile`, never hand-written.
+   Creates.
+3. **`owns/0`** - reserves the name. Creates nothing.
+
+Rules:
+
+- An extension may foreign-key into core. **Core never foreign-keys into an
+  extension.**
+- **Extensions never alter core tables.** Use a sidecar table keyed on
+  `player_id`. Two extensions both adding `level` to `players` is
+  unrecoverable, and core adding the same column later is worse.
+- An extension FK into `players.id` must cascade or declare an erase path. A
+  blanket cascade was rejected: cascading `wallets` would erase the financial
+  ledger through `transactions.wallet_id`.
+
+### Two gaps you hit today
+
+**Your migration will not run.** `kura_migrator` discovers migrations from
+exactly one OTP application. This is a live kura defect independent of
+extensions. `asobi_repo:migration_apps/0` is the seam kura 2.20.0 calls; asobi
+pins `{kura, "~> 2.17"}`, so until the pin moves the host writes one delegating
+migration file.
+
+**Your foreign key will not cascade.** `#kura_assoc` has no `on_delete` field
+and rebar3_kura hardcodes `no_action`, so the generated migration gives you
+`NO ACTION` and the cascade rule cannot be satisfied by the documented
+workflow. With `no_action` the first `quest_progress` row makes that player
+undeletable, and the guest reaper swallows the violation as `skipped`.
+
+## Readiness
+
+The route table compiles during Nova's boot; migrations run afterwards, from
+`asobi_app:start/2`. An extension endpoint is therefore reachable before its
+tables exist, so core fails closed until migrations finish:
+
+```erlang
+case asobi_readiness:guard() of
+    ok -> dispatch(Method, Params);
+    {error, Object} -> {asobi_error, 503, Object}
+end.
+```
+
+The `not_ready` code is 503, because retrying works.
+
+## Where the logic goes
+
+```
+asobi_quests/
+  src/
+    asobi_quests.app.src           applications: [kernel, stdlib, asobi]
+    asobi_quests_extension.erl     the declarations
+    asobi_quests.erl               THE DOMAIN LOGIC - plain Erlang
+    asobi_quests_rpc.erl           thin: decode, call domain, encode
+    schemas/     asobi_quest.erl, asobi_quest_progress.erl
+    migrations/  m20260803174500_create_quests.erl   (generated)
+    workers/     asobi_quests_rollover_worker.erl
+```
+
+`asobi_quests.erl` knows nothing about HTTP, RPC, Lua or the console. Each of
+those is a thin adapter over it, which is what makes one implementation
+reachable from a client call, a background job and a Lua binding.
+
+## Installing versus consuming
+
+**Consuming** an installed extension from Lua or from a client works on every
+tier. A bundled first-party extension is callable as `game.quests.*` by any Lua
+game, including on managed hosting.
+
+**Installing a third-party extension** is where the tier matters:
+
+    Library / self-host from your own release ....... yes
+    Self-host from the published container image .... no
+    Managed hosting ................................ first-party only
+
+The published image and the managed service run a fixed application set decided
+at image build time.
+
+## Not sandboxed
+
+An extension runs in the same node, the same supervision tree and with the same
+database credentials as core. `asobi_repo` is unrestricted, and `os:cmd/1`,
+`open_port/2` and `load_nif/2` are all reachable. Its migrations run with full
+DDL privilege. Treat installing one as you would treat any dependency with
+production credentials.

--- a/rebar.config
+++ b/rebar.config
@@ -85,7 +85,10 @@
 {dialyzer, [
     {plt_apps, all_deps},
     {plt_extra_apps, [kura, inets, nova_auth, nova_auth_oidc]},
-    {warnings, [unknown, unmatched_returns]}
+    {warnings, [unknown, unmatched_returns]},
+    %% `rebar3 asobi check` runs inside rebar3, against rebar3's own modules.
+    %% Those are not deps of asobi and are absent from the PLT by construction.
+    {exclude_mods, [rebar3_asobi_check]}
 ]}.
 
 {project_plugins, [
@@ -140,6 +143,7 @@
         <<"guides/performance-tuning.md">>,
         <<"guides/phases.md">>,
         <<"guides/self-hosting.md">>,
+        <<"guides/extensions.md">>,
         <<"guides/security-threat-model.md">>,
         <<"guides/security-auth.md">>,
         <<"guides/security-known-limitations.md">>,
@@ -179,7 +183,8 @@
             <<"guides/large-worlds.md">>,
             <<"guides/performance-tuning.md">>,
             <<"guides/phases.md">>,
-            <<"guides/self-hosting.md">>
+            <<"guides/self-hosting.md">>,
+            <<"guides/extensions.md">>
         ]},
         {<<"Security">>, [
             <<"guides/security-threat-model.md">>,
@@ -277,6 +282,15 @@
             asobi_bot_spawner,
             asobi_bot_sup
         ]},
+        {<<"Extensions">>, [
+            asobi_extension,
+            asobi_extensions,
+            asobi_extension_sup,
+            asobi_extension_child_sup,
+            asobi_extension_watch,
+            asobi_extension_reserved,
+            asobi_readiness
+        ]},
         {<<"Core">>, [
             asobi_app,
             asobi_sup,
@@ -307,4 +321,18 @@
     locals_not_used,
     deprecated_function_calls,
     deprecated_functions
+]}.
+
+%% rebar3's own API, called by `rebar3 asobi check` and only ever present when
+%% rebar3 is the one running it.
+{xref_ignores, [
+    {providers, create, 1},
+    {rebar_api, error, 2},
+    {rebar_api, info, 2},
+    {rebar_api, warn, 2},
+    {rebar_app_info, ebin_dir, 1},
+    {rebar_app_info, name, 1},
+    {rebar_state, add_provider, 2},
+    {rebar_state, all_deps, 1},
+    {rebar_state, project_apps, 1}
 ]}.

--- a/src/asobi.app.src
+++ b/src/asobi.app.src
@@ -18,7 +18,11 @@
         shigoto,
         luerl
     ]},
-    {env, []},
+    %% `providers` is read by rebar3 when asobi is listed in a host's
+    %% `project_plugins`, and is what makes `rebar3 asobi check` available.
+    %% rebar3 looks here before falling back to a module named after the
+    %% application, so the provider module needs no special name.
+    {env, [{providers, [rebar3_asobi_check]}]},
     {modules, []},
     {licenses, ["Apache-2.0"]},
     {links, [{"GitHub", "https://github.com/widgrensit/asobi"}]}

--- a/src/asobi_app.erl
+++ b/src/asobi_app.erl
@@ -8,9 +8,11 @@ start(_StartType, _StartArgs) ->
     setup_telemetry(),
     asobi_error:register_handler(),
     register_lua_game_modes(),
+    report_extensions(),
     case kura_migrator:migrate(asobi_repo) of
         {ok, Applied} ->
-            logger:notice(#{msg => ~"migrations_applied", versions => Applied});
+            logger:notice(#{msg => ~"migrations_applied", versions => Applied}),
+            asobi_readiness:mark_ready();
         {error, MigErr} ->
             logger:error(#{msg => ~"migration_failed", error => MigErr})
     end,
@@ -34,6 +36,18 @@ setup_telemetry() ->
 %% keeps it ahead of every asobi_sup child, including the matchmaker.
 register_lua_game_modes() ->
     asobi_lua_sup:register_game_modes().
+
+%% A host can add an extension to the release and forget the dependency, or
+%% the reverse. Reporting the resolved set makes the mismatch visible instead
+%% of silent. `resolve/0` is memoised and the router has usually called it
+%% already, from inside Nova's boot; this call is here so the set is also
+%% known before migrations run.
+report_extensions() ->
+    Extensions = [
+        #{name => Name, app => App, extension_version => Version}
+     || #{name := Name, app := App, extension_version := Version} <- asobi_extensions:resolve()
+    ],
+    logger:notice(#{msg => ~"extensions_resolved", extensions => Extensions}).
 
 -spec stop(term()) -> ok.
 stop(_State) ->

--- a/src/asobi_error.erl
+++ b/src/asobi_error.erl
@@ -71,6 +71,7 @@ working and a new one reads one place: see `legacy/2`.
     {~"validation_failed", 422, ~"One or more fields are invalid. See `details`."},
     {~"length_required", 411, ~"The request must declare a Content-Length."},
     {~"client_gate_denied", 403, ~"The registration gate rejected this request."},
+    {~"not_ready", 503, ~"The server is still starting. Retry shortly."},
 
     %% Accounts, providers, guests.
     {~"auth.registration_closed", 403, ~"This deployment is not accepting new players."},

--- a/src/asobi_readiness.erl
+++ b/src/asobi_readiness.erl
@@ -1,0 +1,69 @@
+-module(asobi_readiness).
+-moduledoc """
+Whether the node is ready to serve extension traffic.
+
+There is a window in which an extension endpoint exists but its tables do not.
+The dispatch tree is compiled during Nova's boot, inside `nova_sup:init/1`;
+`kura_migrator:migrate/1` runs later, from `asobi_app:start/2`. Anything
+listening in between would reach a handler whose tables have not been created.
+
+So core signals readiness once, after migrations, and the seam below fails
+closed until then.
+
+## The seam
+
+`guard/0` is what the RPC dispatcher calls before dispatching:
+
+```erlang
+case asobi_readiness:guard() of
+    ok -> dispatch(Method, Params);
+    {error, Object} -> {asobi_error, 503, Object}
+end.
+```
+
+The dispatcher itself is Wave 2b and does not exist yet. `guard/0` and the
+`not_ready` code do, and they are tested, so the dispatcher inherits a
+readiness contract rather than inventing one.
+
+`persistent_term` rather than a process: the read is on the dispatch path,
+it happens once per call, and the value is written exactly once at boot.
+""".
+
+-export([guard/0, ready/0, mark_ready/0]).
+-ifdef(TEST).
+-export([reset/0]).
+-endif.
+
+-define(KEY, {?MODULE, ready}).
+-define(CODE, ~"not_ready").
+
+-doc """
+`ok` when the node may serve extension traffic, otherwise the error object to
+return with HTTP 503.
+""".
+-spec guard() -> ok | {error, asobi_error:object()}.
+guard() ->
+    case ready() of
+        true -> ok;
+        false -> {error, asobi_error:object(?CODE)}
+    end.
+
+-doc "Whether migrations have run to completion on this node.".
+-spec ready() -> boolean().
+ready() ->
+    persistent_term:get(?KEY, false) =:= true.
+
+-doc """
+Called once from `asobi_app:start/2`, after `kura_migrator:migrate/1` returns
+`{ok, _}`. A failed migration deliberately leaves the node not ready.
+""".
+-spec mark_ready() -> ok.
+mark_ready() ->
+    persistent_term:put(?KEY, true).
+
+-ifdef(TEST).
+-spec reset() -> ok.
+reset() ->
+    _ = persistent_term:erase(?KEY),
+    ok.
+-endif.

--- a/src/asobi_repo.erl
+++ b/src/asobi_repo.erl
@@ -5,6 +5,7 @@
 
 -export([
     otp_app/0,
+    migration_apps/0,
     all/1,
     aggregate/2,
     get/2,
@@ -25,6 +26,26 @@
 
 -spec otp_app() -> asobi.
 otp_app() -> asobi.
+
+-doc """
+The applications kura discovers migrations from: core first, then each
+extension in dependency order.
+
+Inert today. `kura_migrator` discovers migrations from exactly one
+application - `application:get_application(RepoMod)` - so an extension's
+migrations do not run and its tables are created by nothing. That is a live
+kura defect independent of extensions: `asobi_gdpr` declares three schemas and
+no migration in any repo creates those tables.
+
+kura 2.20.0 adds multi-application discovery and calls this optional
+`kura_repo` callback. asobi pins `{kura, "~> 2.17"}`, where nothing calls it,
+so this is a seam and not yet a behaviour change. Moving the pin to
+`~> 2.20` is the whole of the change: extension migrations then run inside
+core's transaction, under one advisory lock, in this order.
+""".
+-spec migration_apps() -> [atom(), ...].
+migration_apps() ->
+    [asobi | [App || #{app := App} <- asobi_extensions:resolve()]].
 
 -spec all(#kura_query{}) -> {ok, [map()]} | {error, term()}.
 all(Q) -> kura_repo_worker:all(?MODULE, Q).

--- a/src/asobi_repo.erl
+++ b/src/asobi_repo.erl
@@ -28,24 +28,28 @@
 otp_app() -> asobi.
 
 -doc """
-The applications kura discovers migrations from: core first, then each
-extension in dependency order.
+The applications kura runs migrations from, beyond asobi itself: every
+installed extension.
 
-Inert today. `kura_migrator` discovers migrations from exactly one
-application - `application:get_application(RepoMod)` - so an extension's
-migrations do not run and its tables are created by nothing. That is a live
-kura defect independent of extensions: `asobi_gdpr` declares three schemas and
-no migration in any repo creates those tables.
+Inert on the pinned kura. `kura_migrator` there discovers migrations from
+exactly one application - `application:get_application(RepoMod)` - so an
+extension's migrations do not run and its tables are created by nothing. That
+is a kura defect independent of extensions: `asobi_gdpr` declares three
+schemas and no migration in any repo creates those tables.
 
-kura 2.20.0 adds multi-application discovery and calls this optional
-`kura_repo` callback. asobi pins `{kura, "~> 2.17"}`, where nothing calls it,
-so this is a seam and not yet a behaviour change. Moving the pin to
-`~> 2.20` is the whole of the change: extension migrations then run inside
-core's transaction, under one advisory lock, in this order.
+kura 2.20 adds multi-application discovery and calls this optional `kura_repo`
+callback. asobi pins `{kura, "~> 2.17"}`, where nothing calls it, so this is a
+seam and not yet a behaviour change. Moving the pin is the whole of the
+change: extension migrations then run inside core's transaction, under one
+advisory lock.
+
+kura adds the repo's own application and topologically sorts the result by
+each application's OTP `applications` key, so this returns the extensions
+only and does not restate an ordering kura already derives.
 """.
--spec migration_apps() -> [atom(), ...].
+-spec migration_apps() -> [atom()].
 migration_apps() ->
-    [asobi | [App || #{app := App} <- asobi_extensions:resolve()]].
+    [App || #{app := App} <- asobi_extensions:resolve()].
 
 -spec all(#kura_query{}) -> {ok, [map()]} | {error, term()}.
 all(Q) -> kura_repo_worker:all(?MODULE, Q).

--- a/src/asobi_router.erl
+++ b/src/asobi_router.erl
@@ -9,8 +9,15 @@
 %% short-circuit ever runs. Listing `options` lets the plugin intercept the
 %% preflight and reply 200 without the handler ever seeing it.
 
+%% The first caller of asobi_extensions:resolve/0, and the reason it is a pure
+%% memoised function rather than a process: nova is in asobi's `applications`
+%% list, so nova_sup:init/1 compiles this route table before asobi_app:start/2
+%% has run and before any asobi process exists. Resolving here validates the
+%% installed set at the earliest possible moment. Extensions contribute no
+%% routes (ADR 0003); core owns the whole table.
 -spec routes(atom()) -> [map()].
 routes(_Environment) ->
+    _ = asobi_extensions:resolve(),
     [
         auth_routes(),
         iap_routes(),

--- a/src/asobi_sup.erl
+++ b/src/asobi_sup.erl
@@ -36,7 +36,8 @@ init([]) ->
         season_manager_spec(),
         guest_reaper_spec(),
         lua_game_config_spec(),
-        lua_sup()
+        lua_sup(),
+        extension_sup()
     ],
     {ok, {SupFlags, Children}}.
 
@@ -74,6 +75,16 @@ lua_sup() ->
     #{
         id => asobi_lua_sup,
         start => {asobi_lua_sup, start_link, []},
+        type => supervisor
+    }.
+
+%% Last, so an extension's processes start after every core service they might
+%% call. With no extensions installed this is one idle supervisor with no
+%% children.
+extension_sup() ->
+    #{
+        id => asobi_extension_sup,
+        start => {asobi_extension_sup, start_link, []},
         type => supervisor
     }.
 

--- a/src/extensions/asobi_extension.erl
+++ b/src/extensions/asobi_extension.erl
@@ -1,0 +1,126 @@
+-module(asobi_extension).
+-moduledoc """
+The extension contract.
+
+An extension is an ordinary OTP application that depends on `asobi` and is a
+dependency of the **host** release, plus one module named `<app>_extension`
+implementing this behaviour. asobi never depends on an extension: every
+extension depends on asobi, so the reverse edge is a cycle relx and Hex both
+reject.
+
+Most of what an extension provides is discovered rather than declared.
+Migrations and schemas come from `application:get_key(App, modules)`, shigoto
+workers need no registration at all, and domain logic is just modules. This
+behaviour covers only what core cannot infer.
+
+```erlang
+-module(asobi_quests_extension).
+-behaviour(asobi_extension).
+-export([info/0, rpc/0, lua/0, sup/0, owns/0]).
+
+info() -> #{name => quests, extension_version => 1}.
+
+rpc()  -> #{~"quests.claim" => {asobi_quests_rpc, claim, 2}}.
+
+lua()  -> #{~"quests" =>
+              #{~"progress" => #{mfa     => {asobi_quests_lua, progress, 2},
+                                 args    => [binary, integer],
+                                 effects => write,
+                                 vms     => [match, world]}}}.
+
+sup()  -> [#{id => asobi_quests_tracker,
+             start => {asobi_quests_tracker, start_link, []}}].
+
+owns() -> #{tables => [~"quests"], rpc => [~"quests"],
+            lua => [~"quests"], queues => [~"quests"]}.
+```
+
+Only `info/0` is required. `rpc/0`, `lua/0`, `sup/0` and `owns/0` default to
+empty, because several are frequently empty: an extension with no processes
+has no `sup/0`, and `owns/0` earns nothing until a second extension exists to
+collide with.
+
+An extension declaring neither `rpc/0` nor `lua/0` is reachable by nobody:
+game logic calls `game.<ns>.*` from Lua, and clients call
+`asobi.rpc("<ns>.<method>")` over the wire. `rebar3 asobi check` warns about
+it rather than failing, because it is a legal state mid-development.
+
+`sup/0` exists so an extension can be a **library** application, with no `mod`
+in its `.app.src`. Applications in a release are permanent by default and a
+permanent application terminating takes the whole runtime with it, so an
+extension supervising itself can kill the node. See `m:asobi_extension_sup`.
+
+This contract is experimental and deliberately unfrozen. The wire freezes,
+because SDK users vendor by copying source; this module freezes when a real
+second consumer has said what it is missing.
+""".
+
+-export_type([
+    name/0,
+    info/0,
+    method/0,
+    rpc/0,
+    lua/0,
+    lua_namespace/0,
+    lua_function/0,
+    lua_arg/0,
+    owns/0,
+    token/0
+]).
+
+-doc "The extension's short name, and the root of everything it owns.".
+-type name() :: atom().
+
+-doc """
+The contract version, distinct from the package version: a minor release may
+change an experimental contract.
+""".
+-type info() :: #{name := name(), extension_version := pos_integer()}.
+
+-doc "An RPC method, `<prefix>.<method>`.".
+-type method() :: binary().
+
+-type rpc() :: #{method() => mfa()}.
+
+-doc "A `game.<ns>` table, without the `game.` root.".
+-type lua_namespace() :: binary().
+
+-type lua() :: #{lua_namespace() => #{binary() => lua_function()}}.
+
+-doc """
+One `game.<ns>.<fun>` binding.
+
+`effects` is not decoration. Probe VMs re-run the whole script body to ask
+`phases()`, and `asobi_lua_api` swaps every `write` function for an inert
+stub. An effectful function declared `none` fires twice on every match
+creation.
+
+`mfa` is called fully qualified rather than stored as a fun, so a code upgrade
+takes effect without waiting for every live match VM to end.
+""".
+-type lua_function() :: #{
+    mfa := mfa(),
+    args := [lua_arg()],
+    effects := asobi_lua_surface:effect(),
+    vms := [asobi_lua_surface:vm_kind()]
+}.
+
+-type lua_arg() :: binary | integer | number | boolean | table | any.
+
+-doc "A name claimed in one namespace: a table, an RPC prefix, a Lua namespace or a queue.".
+-type token() :: binary().
+
+-type owns() :: #{
+    tables => [token()],
+    rpc => [token()],
+    lua => [token()],
+    queues => [token()]
+}.
+
+-callback info() -> info().
+-callback rpc() -> rpc().
+-callback lua() -> lua().
+-callback sup() -> [supervisor:child_spec()].
+-callback owns() -> owns().
+
+-optional_callbacks([rpc/0, lua/0, sup/0, owns/0]).

--- a/src/extensions/asobi_extension_child_sup.erl
+++ b/src/extensions/asobi_extension_child_sup.erl
@@ -1,0 +1,47 @@
+-module(asobi_extension_child_sup).
+-moduledoc """
+One extension's processes, with their own restart budget.
+
+The budget is the point. `asobi_sup` is `one_for_one` with intensity 10 in 60
+over eighteen children including the matchmaker, presence and every match and
+world supervisor. Without a per-extension boundary one crash-looping
+extension exhausts that shared budget and takes all of it down with no
+attribution.
+
+`sup/0` is read here, at `init/1`, rather than cached at resolve time, so a
+code upgrade that changes an extension's children takes effect on the next
+restart.
+""".
+
+-behaviour(supervisor).
+
+-include_lib("kernel/include/logger.hrl").
+
+-export([start_link/2]).
+-export([init/1]).
+
+-define(DEFAULT_INTENSITY, 5).
+-define(DEFAULT_PERIOD, 60).
+
+-spec start_link(asobi_extension:name(), module()) -> supervisor:startlink_ret().
+start_link(Name, Module) ->
+    supervisor:start_link(?MODULE, [Name, Module]).
+
+-spec init([asobi_extension:name() | module()]) ->
+    {ok, {supervisor:sup_flags(), [supervisor:child_spec()]}}.
+init([Name, Module]) ->
+    Specs = asobi_extensions:sup_specs(Module),
+    ?LOG_INFO(#{msg => ~"extension_started", extension => Name, children => length(Specs)}),
+    {ok, {sup_flags(), Specs}}.
+
+sup_flags() ->
+    Configured =
+        case application:get_env(asobi, extension_restart, #{}) of
+            Map when is_map(Map) -> Map;
+            _ -> #{}
+        end,
+    #{
+        strategy => one_for_one,
+        intensity => maps:get(intensity, Configured, ?DEFAULT_INTENSITY),
+        period => maps:get(period, Configured, ?DEFAULT_PERIOD)
+    }.

--- a/src/extensions/asobi_extension_reserved.erl
+++ b/src/extensions/asobi_extension_reserved.erl
@@ -1,0 +1,90 @@
+-module(asobi_extension_reserved).
+-moduledoc """
+The names core keeps for itself.
+
+`asobi_extensions:validate/1` refuses an `owns/0` claim on anything in here,
+so an extension cannot shadow a core table, a core Lua namespace, a core error
+domain or a core job queue.
+
+Every list is derived from the live core source rather than restated, so it
+cannot drift:
+
+- **lua** from `asobi_lua_surface:reserved_namespaces/0`, the one place the
+  `game.*` vocabulary is written down.
+- **tables** from every core `kura_schema` module's `table/0`, found the same
+  way asobi finds an extension's schemas.
+- **queues** from every core `shigoto_worker` module's `queue/0`.
+- **rpc** from the domains of `asobi_error:codes/0`, plus the Lua namespaces.
+  An RPC prefix and an error domain are the same token by construction
+  (`{"code": "quests.name_taken"}`), so an extension owning the `storage`
+  prefix would mint codes inside core's closed code set.
+
+Deriving from modules costs one `code:ensure_loaded/1` sweep over core's
+module list. `asobi_extensions` only asks for it when at least one extension
+is installed, so a node with none pays nothing.
+""".
+
+-export([namespaces/0, kinds/0]).
+
+-type kind() :: tables | rpc | lua | queues.
+-export_type([kind/0]).
+
+-doc "The namespace kinds an extension may claim in `owns/0`.".
+-spec kinds() -> [kind(), ...].
+kinds() ->
+    [tables, rpc, lua, queues].
+
+-doc "Core's reserved token set, per namespace kind.".
+-spec namespaces() -> #{kind() := [asobi_extension:token()]}.
+namespaces() ->
+    Modules = core_modules(),
+    Lua = lua(),
+    #{
+        tables => exported_values(Modules, table, {fields, 0}),
+        queues => exported_values(Modules, queue, {perform, 1}),
+        lua => Lua,
+        rpc => lists:usort(error_domains() ++ Lua)
+    }.
+
+lua() ->
+    lists:usort([
+        Namespace
+     || Path <- asobi_lua_surface:reserved_namespaces(),
+        Namespace <- lua_namespace(Path)
+    ]).
+
+%% `game` itself is reserved: an extension owning it would claim the root
+%% table every other namespace hangs off.
+lua_namespace([~"game"]) -> [~"game"];
+lua_namespace([~"game", Namespace]) -> [Namespace];
+lua_namespace(_) -> [].
+
+error_domains() ->
+    lists:usort([Domain || Code <- asobi_error:codes(), Domain <- domain(Code)]).
+
+domain(Code) ->
+    case binary:split(Code, ~".") of
+        [Domain, _] -> [Domain];
+        _ -> []
+    end.
+
+%% An empty module list would silently reserve nothing, which is worse than a
+%% crash: an extension could then claim `players` and the check would pass.
+core_modules() ->
+    _ = application:load(asobi),
+    case application:get_key(asobi, modules) of
+        {ok, [_ | _] = Modules} -> Modules;
+        Other -> error({asobi_core_modules_unavailable, Other})
+    end.
+
+%% Every core module exporting Fun/0 alongside its companion - the pair that
+%% identifies a kura schema (`table/0` + `fields/0`) or a shigoto worker
+%% (`queue/0` + `perform/1`) - contributes Fun().
+exported_values(Modules, Fun, {Companion, Arity}) ->
+    lists:usort([
+        Module:Fun()
+     || Module <- Modules,
+        code:ensure_loaded(Module) =:= {module, Module},
+        erlang:function_exported(Module, Fun, 0),
+        erlang:function_exported(Module, Companion, Arity)
+    ]).

--- a/src/extensions/asobi_extension_sup.erl
+++ b/src/extensions/asobi_extension_sup.erl
@@ -1,0 +1,92 @@
+-module(asobi_extension_sup).
+-moduledoc """
+One supervisor per extension, under one supervisor for the lot.
+
+```
+asobi_sup  (one_for_one, 10/60)
+  |- ...core children...
+  `- asobi_extension_sup       (one_for_one, 3/60)
+       |- quests               (transient, own intensity)
+       |- clans                (transient, own intensity)
+       `- asobi_extension_watch
+```
+
+The reason `sup/0` is a contract key at all, rather than extensions being
+plain OTP applications with their own `mod`, is that applications in a release
+are **permanent** by default, and in OTP a permanent application terminating
+takes the whole runtime with it. An extension supervising itself and
+exceeding its restart intensity therefore kills matchmaking, presence and
+every live match. This is the ordinary BEAM pattern rather than an invention:
+Ecto repos, Oban and Phoenix endpoints are all started in the host's tree.
+
+Three deliberate choices:
+
+- **`one_for_one` at both levels.** Extensions are independent by
+  construction: they share only `asobi_repo`, and the wire seam between them
+  is RPC. One restarting is never a reason to restart another.
+- **Each extension's sub-supervisor is `transient`.** Exceeding a restart
+  intensity makes a supervisor exit with reason `shutdown`, which a transient
+  child is not restarted for. So an extension that has burned its own budget
+  goes dark and stays dark, attributed by name, instead of escalating.
+  Restarting it here would only relay the same crash loop upwards until it
+  reached `asobi_sup` and took the node with it, which is the exact outcome
+  this tree exists to prevent. Transient rather than temporary because a
+  sub-supervisor killed for any *other* abnormal reason is a core-side fault,
+  not an extension giving up, and should be restarted.
+- **Intensity 3 in 60 here.** Extension failures never consume it: a
+  transient child exiting `shutdown` is not a restart. The budget covers
+  `asobi_extension_watch` only, so nothing an extension does can exhaust it.
+
+Per-extension intensity defaults to 5 in 60 and is settable with
+`{extension_restart, #{intensity => I, period => P}}` in asobi's app env.
+""".
+
+-behaviour(supervisor).
+
+-export([start_link/0, running/0]).
+-export([init/1]).
+
+-spec start_link() -> supervisor:startlink_ret().
+start_link() ->
+    supervisor:start_link({local, ?MODULE}, ?MODULE, []).
+
+-doc "The extensions whose sub-supervisor is alive. An installed name missing here has gone dark.".
+-spec running() -> [asobi_extension:name()].
+running() ->
+    [
+        Id
+     || {Id, Pid, _Type, _Modules} <- supervisor:which_children(?MODULE),
+        is_pid(Pid),
+        Id =/= asobi_extension_watch
+    ].
+
+-spec init([]) -> {ok, {supervisor:sup_flags(), [supervisor:child_spec()]}}.
+init([]) ->
+    SupFlags = #{strategy => one_for_one, intensity => 3, period => 60},
+    {ok, {SupFlags, children(asobi_extensions:resolve())}}.
+
+%% With no extensions installed this is one idle supervisor process: no
+%% children, no timers, no tables, and nothing on any request path.
+children([]) ->
+    [];
+children(Extensions) ->
+    [sub_sup(Extension) || Extension <- Extensions] ++ [watch(Extensions)].
+
+sub_sup(#{name := Name, module := Module}) ->
+    #{
+        id => Name,
+        start => {asobi_extension_child_sup, start_link, [Name, Module]},
+        restart => transient,
+        shutdown => infinity,
+        type => supervisor
+    }.
+
+%% Started last, so every sub-supervisor it monitors already exists.
+watch(Extensions) ->
+    #{
+        id => asobi_extension_watch,
+        start => {asobi_extension_watch, start_link, [[N || #{name := N} <- Extensions]]},
+        restart => permanent,
+        shutdown => 5000,
+        type => worker
+    }.

--- a/src/extensions/asobi_extension_watch.erl
+++ b/src/extensions/asobi_extension_watch.erl
@@ -1,0 +1,67 @@
+-module(asobi_extension_watch).
+-moduledoc """
+Says which extension went dark.
+
+An extension that exhausts its own restart budget is not restarted (see
+`m:asobi_extension_sup`), so the node keeps serving with one feature missing.
+Without this the only trace is an OTP supervisor report, and "a feature
+stopped working and nothing said so" is the failure mode the whole tree
+exists to make legible.
+
+It monitors rather than links: a monitor cannot influence what it watches.
+""".
+
+-behaviour(gen_server).
+
+-include_lib("kernel/include/logger.hrl").
+
+-export([start_link/1]).
+-export([init/1, handle_call/3, handle_cast/2, handle_continue/2, handle_info/2]).
+
+-type state() :: #{names := [asobi_extension:name()], monitors := #{reference() => atom()}}.
+
+-spec start_link([asobi_extension:name()]) -> {ok, pid()} | {error, term()}.
+start_link(Names) ->
+    gen_server:start_link({local, ?MODULE}, ?MODULE, Names, []).
+
+%% Monitoring happens in handle_continue, not init: `which_children` is a call
+%% into the parent supervisor, and the parent is still inside its own init
+%% while it starts this child.
+-spec init([asobi_extension:name()]) -> {ok, state(), {continue, monitor}}.
+init(Names) ->
+    {ok, #{names => Names, monitors => #{}}, {continue, monitor}}.
+
+-spec handle_continue(monitor, state()) -> {noreply, state()}.
+handle_continue(monitor, #{names := Names} = State) ->
+    Monitors = maps:from_list([
+        {erlang:monitor(process, Pid), Id}
+     || {Id, Pid, _Type, _Modules} <- supervisor:which_children(asobi_extension_sup),
+        is_pid(Pid),
+        lists:member(Id, Names)
+    ]),
+    {noreply, State#{monitors => Monitors}}.
+
+-spec handle_info(term(), state()) -> {noreply, state()}.
+handle_info({'DOWN', Ref, process, _Pid, Reason}, #{monitors := Monitors} = State) ->
+    case maps:take(Ref, Monitors) of
+        {Name, Rest} ->
+            ?LOG_ERROR(#{
+                msg => ~"extension_down",
+                extension => Name,
+                reason => Reason,
+                detail => ~"this extension is no longer running; the node is otherwise unaffected"
+            }),
+            {noreply, State#{monitors => Rest}};
+        error ->
+            {noreply, State}
+    end;
+handle_info(_Message, State) ->
+    {noreply, State}.
+
+-spec handle_call(term(), gen_server:from(), state()) -> {reply, ok, state()}.
+handle_call(_Request, _From, State) ->
+    {reply, ok, State}.
+
+-spec handle_cast(term(), state()) -> {noreply, state()}.
+handle_cast(_Request, State) ->
+    {noreply, State}.

--- a/src/extensions/asobi_extensions.erl
+++ b/src/extensions/asobi_extensions.erl
@@ -1,0 +1,491 @@
+-module(asobi_extensions).
+-moduledoc """
+The extension registry: a pure memoised function, not a process.
+
+`resolve/0` loads the host's application closure, discovers every application
+exporting an `<app>_extension` module, reads its manifest, validates the set
+and writes the result to `persistent_term`. Whoever calls first pays for it;
+everybody after reads a term.
+
+It cannot be a process, and this is the constraint that decides the shape.
+`nova` is in asobi's `applications` list, so OTP starts Nova first, and
+`nova_sup:init/1` calls `setup_cowboy/1` -> `nova_router:compile/1` ->
+`asobi_router:routes/1` **before `asobi_app:start/2` ever runs**. The router
+is therefore the first caller, and at that moment no asobi process exists.
+A registry gen_server, a supervised child or a step in an asobi boot sequence
+would all be populated after the route table was already compiled.
+
+Its callers, in boot order:
+
+1. `asobi_router:routes/1`, inside Nova's boot.
+2. `asobi_app:start/2`, before migrations.
+3. `asobi_repo:migration_apps/0`, once the kura pin reaches 2.20.0.
+
+Discovery walks the **OTP application graph**, not Nova's `nova_apps`.
+`nova_apps` only sees Nova apps, so a Lua-only or jobs-only extension would be
+invisible, and Nova's own `resolve_nova_apps` reverses its accumulator at
+every nesting level so its output is neither depth-first nor declaration
+order. `application:get_key(App, applications)` is the authoritative start
+order, and the closure walk emits each application after everything it
+depends on, so the discovered list is already topologically ordered with ties
+in the host's declaration order. Nothing sorts it afterwards.
+
+Core loads the closure before discovering. In a release every application is
+loaded by the boot script before any start; under `rebar3 shell` and CT they
+load lazily, and without the sweep the discovered set would differ between
+dev and prod with no error.
+
+`rebar3 asobi check` is the primary gate and runs `check/0`, the same
+function, without memoising. Boot validation is a backstop, and it is a
+backstop specifically because a failure raised from inside `nova_sup:init/1`
+surfaces with Nova's crash context rather than a legible asobi error.
+""".
+
+-include_lib("kernel/include/logger.hrl").
+
+-export([resolve/0, check/0, validate/1, describe/1, sup_specs/1]).
+-ifdef(TEST).
+-export([reset/0]).
+-endif.
+
+-define(KEY, {?MODULE, resolved}).
+
+-doc "One resolved extension. `sup/0` is deliberately absent; see `sup_specs/1`.".
+-type extension() :: #{
+    app := atom(),
+    module := module(),
+    name := asobi_extension:name(),
+    extension_version := pos_integer(),
+    rpc := asobi_extension:rpc(),
+    lua := asobi_extension:lua(),
+    owns := asobi_extension:owns()
+}.
+
+-type problem() ::
+    {bad_manifest, atom(), module(), term()}
+    | {duplicate_name, asobi_extension:name(), atom(), atom()}
+    | {namespace_conflict, asobi_extension_reserved:kind(), asobi_extension:token(), atom(), atom()}
+    | {reserved_namespace, asobi_extension_reserved:kind(), asobi_extension:token(), atom()}
+    | {undeclared_claim, asobi_extension_reserved:kind(), asobi_extension:token(), atom()}.
+
+-export_type([extension/0, problem/0]).
+
+-doc """
+The installed extensions, in dependency order. Memoised.
+
+Raises `{asobi_extensions, Problems}` on an invalid set, after logging the
+same problems in prose. A node that cannot say which extension owns a
+namespace must not serve traffic under either.
+""".
+-spec resolve() -> [extension()].
+resolve() ->
+    case persistent_term:get(?KEY, undefined) of
+        undefined ->
+            Extensions = resolve_now(),
+            persistent_term:put(?KEY, Extensions),
+            Extensions;
+        Extensions ->
+            Extensions
+    end.
+
+%% Two concurrent first callers both compute and both write. The computation
+%% is a pure function of the loaded application set, so they write the same
+%% term and the race has no observable effect.
+resolve_now() ->
+    case check() of
+        {ok, Extensions} ->
+            Extensions;
+        {error, Problems} ->
+            ?LOG_ERROR(#{
+                msg => ~"extension_validation_failed",
+                problems => describe(Problems)
+            }),
+            error({asobi_extensions, Problems})
+    end.
+
+-doc """
+Discover, read and validate without memoising.
+
+The build-time gate (`rebar3 asobi check`) and the boot backstop run exactly
+this, so the two can never disagree.
+""".
+-spec check() -> {ok, [extension()]} | {error, [problem(), ...]}.
+check() ->
+    case read(discover()) of
+        {ok, []} ->
+            {ok, []};
+        {ok, Extensions} ->
+            case validate(Extensions) of
+                ok -> {ok, Extensions};
+                {error, _} = Error -> Error
+            end;
+        {error, _} = Error ->
+            Error
+    end.
+
+-doc """
+The child specs an extension wants asobi to supervise.
+
+Called from `asobi_extension_child_sup:init/1` rather than cached, so the
+running code always decides.
+""".
+-spec sup_specs(module()) -> [supervisor:child_spec()].
+sup_specs(Module) ->
+    case erlang:function_exported(Module, sup, 0) of
+        true -> Module:sup();
+        false -> []
+    end.
+
+-ifdef(TEST).
+-spec reset() -> ok.
+reset() ->
+    _ = persistent_term:erase(?KEY),
+    ok.
+-endif.
+
+%%====================================================================
+%% Discovery
+%%====================================================================
+
+discover() ->
+    [
+        {App, Module}
+     || App <- closure(),
+        App =/= asobi,
+        {true, Module} <- [manifest_module(App)]
+    ].
+
+%% The dependency-closure test is an optimisation only: asobi_lua, asobi_engine
+%% and asobi_admin all have asobi in their closure and none is an extension.
+%% Exporting `<app>_extension` is the filter.
+manifest_module(App) ->
+    Name = atom_to_list(App) ++ "_extension",
+    case [M || M <- modules(App), atom_to_list(M) =:= Name] of
+        [Module] -> {true, Module};
+        _ -> false
+    end.
+
+modules(App) ->
+    case application:get_key(App, modules) of
+        {ok, Modules} -> Modules;
+        undefined -> []
+    end.
+
+deps(App) ->
+    case application:get_key(App, applications) of
+        {ok, Applications} when is_list(Applications) -> Applications;
+        _ -> []
+    end.
+
+%% Post-order over the application graph: an application is emitted after
+%% everything it depends on, which is OTP's own start order. Loading happens
+%% in the same walk because an application's `applications` key is unreadable
+%% until it is loaded.
+closure() ->
+    {_Seen, Reversed} = walk(roots(), sets:new(), []),
+    lists:reverse(Reversed).
+
+walk([], Seen, Acc) ->
+    {Seen, Acc};
+walk([App | Rest], Seen, Acc) ->
+    case sets:is_element(App, Seen) of
+        true ->
+            walk(Rest, Seen, Acc);
+        false ->
+            _ = application:load(App),
+            {Seen1, Acc1} = walk(deps(App), sets:add_element(App, Seen), Acc),
+            walk(Rest, Seen1, [App | Acc1])
+    end.
+
+%% The bootstrap application leads, because it is the host - the only thing
+%% that depends on both asobi and its extensions - and its `applications` list
+%% is the host's declaration order.
+roots() ->
+    bootstrap() ++ lists:sort([App || {App, _Desc, _Vsn} <- application:loaded_applications()]).
+
+bootstrap() ->
+    case application:get_env(nova, bootstrap_application) of
+        {ok, App} when is_atom(App) -> [App];
+        _ -> []
+    end.
+
+%%====================================================================
+%% Reading manifests
+%%====================================================================
+
+read(Pairs) ->
+    Results = [read_one(App, Module) || {App, Module} <- Pairs],
+    case lists:append([Problems || {error, Problems} <- Results]) of
+        [] -> {ok, [Extension || {ok, Extension} <- Results]};
+        Problems -> {error, Problems}
+    end.
+
+read_one(App, Module) ->
+    case code:ensure_loaded(Module) of
+        {module, Module} -> read_manifest(App, Module);
+        {error, What} -> {error, [{bad_manifest, App, Module, {unloadable, What}}]}
+    end.
+
+read_manifest(App, Module) ->
+    Reads = [
+        {info, call(Module, info, undefined)},
+        {rpc, call(Module, rpc, #{})},
+        {lua, call(Module, lua, #{})},
+        {owns, call(Module, owns, #{})},
+        {sup, call(Module, sup, [])}
+    ],
+    case [{Key, Detail} || {Key, {error, Detail}} <- Reads] of
+        [] ->
+            Values = maps:from_list([{Key, Value} || {Key, {ok, Value}} <- Reads]),
+            build(App, Module, Values);
+        Failed ->
+            {error, [{bad_manifest, App, Module, {Key, Detail}} || {Key, Detail} <- Failed]}
+    end.
+
+call(Module, Function, Default) ->
+    case erlang:function_exported(Module, Function, 0) of
+        false ->
+            {ok, Default};
+        true ->
+            try
+                {ok, Module:Function()}
+            catch
+                Class:Reason -> {error, {raised, Class, Reason}}
+            end
+    end.
+
+build(App, Module, #{info := Info, rpc := Rpc, lua := Lua, owns := Owns, sup := Sup}) ->
+    case shape_problems(Info, Rpc, Lua, Owns, Sup) of
+        [] ->
+            #{name := Name, extension_version := Version} = Info,
+            {ok, #{
+                app => App,
+                module => Module,
+                name => Name,
+                extension_version => Version,
+                rpc => Rpc,
+                lua => Lua,
+                owns => Owns
+            }};
+        Details ->
+            {error, [{bad_manifest, App, Module, Detail} || Detail <- Details]}
+    end.
+
+shape_problems(Info, Rpc, Lua, Owns, Sup) ->
+    info_problems(Info) ++
+        rpc_problems(Rpc) ++
+        lua_problems(Lua) ++
+        owns_problems(Owns) ++
+        sup_problems(Sup).
+
+info_problems(#{name := Name, extension_version := Version}) when
+    is_atom(Name), Name =/= undefined, is_integer(Version), Version > 0
+->
+    [];
+info_problems(Info) ->
+    [{info, ~"must be #{name := atom(), extension_version := pos_integer()}", Info}].
+
+rpc_problems(Rpc) when is_map(Rpc) ->
+    [
+        {rpc, ~"method must be <prefix>.<method> mapped to {Module, Function, Arity}", Method}
+     || Method := Target <- Rpc, not is_rpc_entry(Method, Target)
+    ];
+rpc_problems(Rpc) ->
+    [{rpc, ~"must be a map", Rpc}].
+
+is_rpc_entry(Method, {M, F, A}) when is_atom(M), is_atom(F), is_integer(A), A >= 0 ->
+    is_dotted(Method);
+is_rpc_entry(_Method, _Target) ->
+    false.
+
+is_dotted(Method) when is_binary(Method) ->
+    case binary:split(Method, ~".") of
+        [Prefix, Rest] -> Prefix =/= ~"" andalso Rest =/= ~"" andalso not has_dot(Rest);
+        _ -> false
+    end;
+is_dotted(_) ->
+    false.
+
+has_dot(Binary) ->
+    binary:match(Binary, ~".") =/= nomatch.
+
+lua_problems(Lua) when is_map(Lua) ->
+    lists:append([
+        lua_namespace_problems(Namespace, Functions)
+     || Namespace := Functions <- Lua
+    ]);
+lua_problems(Lua) ->
+    [{lua, ~"must be a map of namespace => functions", Lua}].
+
+lua_namespace_problems(Namespace, Functions) when is_binary(Namespace), is_map(Functions) ->
+    [
+        {lua, ~"binding must be #{mfa, args, effects, vms}", {Namespace, Name}}
+     || Name := Binding <- Functions, not is_lua_binding(Name, Binding)
+    ];
+lua_namespace_problems(Namespace, _Functions) ->
+    [{lua, ~"namespace must be a binary mapped to a map of functions", Namespace}].
+
+is_lua_binding(Name, #{mfa := {M, F, A}, args := Args, effects := Effects, vms := Vms}) when
+    is_binary(Name), is_atom(M), is_atom(F), is_integer(A), A >= 0, is_list(Args), is_list(Vms)
+->
+    lists:member(Effects, asobi_lua_surface:effects()) andalso
+        Vms =/= [] andalso
+        lists:all(fun(Vm) -> lists:member(Vm, asobi_lua_surface:vm_kinds()) end, Vms);
+is_lua_binding(_Name, _Binding) ->
+    false.
+
+owns_problems(Owns) when is_map(Owns) ->
+    Kinds = asobi_extension_reserved:kinds(),
+    [
+        {owns, ~"unknown namespace kind", Kind}
+     || Kind := _ <- Owns, not lists:member(Kind, Kinds)
+    ] ++
+        [
+            {owns, ~"tokens must be a list of non-empty binaries", Kind}
+         || Kind := Tokens <- Owns, lists:member(Kind, Kinds), not is_token_list(Tokens)
+        ];
+owns_problems(Owns) ->
+    [{owns, ~"must be a map", Owns}].
+
+is_token_list(Tokens) when is_list(Tokens) ->
+    lists:all(fun(T) -> is_binary(T) andalso T =/= ~"" end, Tokens);
+is_token_list(_) ->
+    false.
+
+%% OTP already knows what a valid child spec is. Running its check here turns
+%% a boot-time supervisor crash into a build-time line naming the extension.
+sup_problems([]) ->
+    [];
+sup_problems(Specs) when is_list(Specs) ->
+    case supervisor:check_childspecs(Specs) of
+        ok -> [];
+        {error, Reason} -> [{sup, ~"invalid child specs", Reason}]
+    end;
+sup_problems(Specs) ->
+    [{sup, ~"must be a list of child specs", Specs}].
+
+%%====================================================================
+%% Validation
+%%====================================================================
+
+-doc """
+Namespace disjointness across the declared set, and against core's reserved
+names.
+
+The claim set per namespace is `owns/0` **plus** what the manifest already
+implies: the prefixes in `rpc/0` and the namespaces in `lua/0`. So two
+extensions installing the same `game.quests` collide even before either has
+bothered with `owns/0`, which earns nothing until there is a second
+extension.
+""".
+-spec validate([extension()]) -> ok | {error, [problem(), ...]}.
+validate([]) ->
+    ok;
+validate(Extensions) ->
+    Reserved = asobi_extension_reserved:namespaces(),
+    Problems =
+        duplicate_names(Extensions) ++
+            lists:append([
+                kind_problems(Kind, Extensions, maps:get(Kind, Reserved, []))
+             || Kind <- asobi_extension_reserved:kinds()
+            ]),
+    case Problems of
+        [] -> ok;
+        [_ | _] -> {error, Problems}
+    end.
+
+duplicate_names(Extensions) ->
+    [
+        {duplicate_name, Name, A, B}
+     || {Name, A, B} <- pairs([{Name, App} || #{name := Name, app := App} <- Extensions])
+    ].
+
+kind_problems(Kind, Extensions, ReservedTokens) ->
+    Claims = [{Token, App} || #{app := App} = E <- Extensions, Token <- claims(E, Kind)],
+    [{namespace_conflict, Kind, Token, A, B} || {Token, A, B} <- pairs(Claims)] ++
+        [
+            {reserved_namespace, Kind, Token, App}
+         || {Token, App} <- lists:usort(Claims), lists:member(Token, ReservedTokens)
+        ] ++
+        undeclared(Kind, Extensions).
+
+%% `owns/0` is the closed statement of what an extension claims. Once it names
+%% a kind at all, anything the manifest derives for that kind and the owned set
+%% does not contain is a typo or a land grab.
+undeclared(Kind, Extensions) ->
+    [
+        {undeclared_claim, Kind, Token, App}
+     || #{app := App, owns := Owns} = E <- Extensions,
+        Owned <- [maps:get(Kind, Owns, [])],
+        Owned =/= [],
+        Token <- derived(E, Kind),
+        not lists:member(Token, Owned)
+    ].
+
+claims(Extension, Kind) ->
+    #{owns := Owns} = Extension,
+    lists:usort(maps:get(Kind, Owns, []) ++ derived(Extension, Kind)).
+
+derived(#{rpc := Rpc}, rpc) ->
+    lists:usort([Prefix || Method := _ <- Rpc, Prefix <- prefix(Method)]);
+derived(#{lua := Lua}, lua) ->
+    lists:usort(maps:keys(Lua));
+derived(_Extension, _Kind) ->
+    [].
+
+prefix(Method) when is_binary(Method) ->
+    case binary:split(Method, ~".") of
+        [Prefix, _Rest] -> [Prefix];
+        _ -> []
+    end;
+prefix(_Method) ->
+    [].
+
+%% Every token claimed more than once, anchored on its first claimant so a
+%% three-way collision reports two pairs rather than one unhelpful set.
+pairs(Claims) ->
+    pairs(lists:usort(Claims), []).
+
+pairs([{Token, A}, {Token, B} | Rest], Acc) ->
+    pairs([{Token, A} | Rest], [{Token, A, B} | Acc]);
+pairs([_ | Rest], Acc) ->
+    pairs(Rest, Acc);
+pairs([], Acc) ->
+    lists:reverse(Acc).
+
+%%====================================================================
+%% Reporting
+%%====================================================================
+
+-doc "Renders validation problems as lines a human can act on.".
+-spec describe([problem()]) -> [binary()].
+describe(Problems) ->
+    [describe_one(Problem) || Problem <- Problems].
+
+describe_one({bad_manifest, App, Module, Detail}) ->
+    line("~s: ~s is not a valid manifest (~0p).", [App, Module, Detail]);
+describe_one({duplicate_name, Name, A, B}) ->
+    line(
+        "~s and ~s both call themselves \"~s\". info().name is the extension's identity.",
+        [A, B, Name]
+    );
+describe_one({namespace_conflict, Kind, Token, A, B}) ->
+    line(
+        "~s and ~s both claim the ~s \"~s\". Namespaces are exclusive; rename one.",
+        [A, B, singular(Kind), Token]
+    );
+describe_one({reserved_namespace, Kind, Token, App}) ->
+    line("~s claims the ~s \"~s\", which asobi reserves.", [App, singular(Kind), Token]);
+describe_one({undeclared_claim, Kind, Token, App}) ->
+    line(
+        "~s uses the ~s \"~s\" but does not list it in owns().~s.",
+        [App, singular(Kind), Token, Kind]
+    ).
+
+line(Format, Args) ->
+    iolist_to_binary(io_lib:format(Format, Args)).
+
+singular(tables) -> ~"table";
+singular(rpc) -> ~"RPC prefix";
+singular(lua) -> ~"Lua namespace";
+singular(queues) -> ~"queue".

--- a/src/extensions/rebar3_asobi_check.erl
+++ b/src/extensions/rebar3_asobi_check.erl
@@ -1,0 +1,117 @@
+-module(rebar3_asobi_check).
+-moduledoc """
+`rebar3 asobi check` - the primary validation gate for an extension set.
+
+```sh
+rebar3 asobi check     # 0 and a summary, or 1 and a report naming both claimants
+```
+
+Add it to a host release's `rebar.config`:
+
+```erlang
+{project_plugins, [{asobi, {git, "https://github.com/widgrensit/asobi.git", {tag, "v0.50.0"}}}]}.
+```
+
+This is the gate, not the backstop. asobi validates the same set again at
+boot, but a boot-time failure is raised from inside `nova_sup:init/1` - Nova
+compiles the route table before `asobi_app:start/2` runs - so it surfaces with
+Nova's crash context rather than a legible asobi error. Catching it in CI is
+the difference between "quests and clans both claim the Lua namespace
+\"quests\"" and a `function_clause` in somebody else's supervisor.
+
+It runs `asobi_extensions:check/0`, the same function the boot backstop runs,
+so build time and boot cannot disagree about what is valid.
+
+Core's reserved names come from the plugin's copy of asobi, which is the
+version in `project_plugins`. Pin it to the same tag as the dependency.
+""".
+
+-behaviour(provider).
+
+-export([init/1, do/1, format_error/1]).
+
+-define(PROVIDER, check).
+-define(NAMESPACE, asobi).
+-define(DEPS, [{default, app_discovery}]).
+
+-spec init(term()) -> {ok, term()}.
+init(State) ->
+    Provider = providers:create([
+        {name, ?PROVIDER},
+        {namespace, ?NAMESPACE},
+        {module, ?MODULE},
+        {bare, true},
+        {deps, ?DEPS},
+        {example, "rebar3 asobi check"},
+        {opts, []},
+        {short_desc, "Validate the installed asobi extension set"},
+        {desc,
+            "Discovers every application exporting an <app>_extension module, reads "
+            "each manifest and checks that no two extensions claim the same table, "
+            "RPC prefix, Lua namespace or job queue, and that none claims a name "
+            "asobi reserves. Exits non-zero with both claimants named."}
+    ]),
+    {ok, rebar_state:add_provider(State, Provider)}.
+
+-spec do(term()) -> {ok, term()} | {error, string()}.
+do(State) ->
+    ok = load_apps(rebar_state:project_apps(State) ++ rebar_state:all_deps(State)),
+    case asobi_extensions:check() of
+        {ok, []} ->
+            rebar_api:info("asobi: no extensions installed", []),
+            {ok, State};
+        {ok, Extensions} ->
+            report(Extensions),
+            {ok, State};
+        {error, Problems} ->
+            [rebar_api:error("asobi: ~ts", [Line]) || Line <- asobi_extensions:describe(Problems)],
+            {error, format_error(invalid_extension_set)}
+    end.
+
+-spec format_error(term()) -> string().
+format_error(invalid_extension_set) ->
+    "the installed extension set is not valid - see the report above; this "
+    "would fail at boot from inside Nova's route compilation";
+format_error(Reason) ->
+    lists:flatten(io_lib:format("~p", [Reason])).
+
+%%====================================================================
+%% Internal
+%%====================================================================
+
+%% Discovery reads `application:get_key/2`, so every candidate has to be a
+%% loaded application in this VM, and its modules have to be reachable for the
+%% manifest to be called.
+load_apps(AppInfos) ->
+    _ = [load_app(AppInfo) || AppInfo <- AppInfos],
+    ok.
+
+load_app(AppInfo) ->
+    _ = code:add_pathz(rebar_app_info:ebin_dir(AppInfo)),
+    _ = application:load(binary_to_atom(rebar_app_info:name(AppInfo), utf8)),
+    ok.
+
+report(Extensions) ->
+    rebar_api:info("asobi: ~b extension(s), in migration order", [length(Extensions)]),
+    _ = [rebar_api:info("  ~ts", [summarise(E)]) || E <- Extensions],
+    _ = [rebar_api:warn("asobi: ~ts", [unreachable(E)]) || E <- Extensions, is_unreachable(E)],
+    ok.
+
+summarise(#{name := Name, app := App, extension_version := Version, rpc := Rpc, lua := Lua}) ->
+    io_lib:format(
+        "~s (~s, contract v~b): ~b rpc method(s), ~b lua namespace(s)",
+        [Name, App, Version, map_size(Rpc), map_size(Lua)]
+    ).
+
+%% Not an error: it is a legal state halfway through writing an extension.
+%% But an extension with neither seam is reachable by nobody - game logic
+%% calls game.<ns>.*, clients call rpc - so saying nothing would be worse.
+is_unreachable(#{rpc := Rpc, lua := Lua}) ->
+    map_size(Rpc) =:= 0 andalso map_size(Lua) =:= 0.
+
+unreachable(#{app := App}) ->
+    io_lib:format(
+        "~s declares neither rpc/0 nor lua/0, so nothing can call it: "
+        "game logic reaches an extension through game.<ns>.*, clients through rpc",
+        [App]
+    ).

--- a/src/extensions/rebar3_asobi_check.erl
+++ b/src/extensions/rebar3_asobi_check.erl
@@ -32,7 +32,9 @@ version in `project_plugins`. Pin it to the same tag as the dependency.
 
 -define(PROVIDER, check).
 -define(NAMESPACE, asobi).
--define(DEPS, [{default, app_discovery}]).
+%% `compile`, not `app_discovery`: a manifest is a module, so it has to exist
+%% as a beam before it can be called.
+-define(DEPS, [{default, compile}]).
 
 -spec init(term()) -> {ok, term()}.
 init(State) ->

--- a/test/asobi_readiness_tests.erl
+++ b/test/asobi_readiness_tests.erl
@@ -1,0 +1,38 @@
+-module(asobi_readiness_tests).
+
+-include_lib("eunit/include/eunit.hrl").
+
+readiness_test_() ->
+    {foreach, fun setup/0, fun cleanup/1, [
+        fun closed_until_migrations_have_run/0,
+        fun open_once_migrations_have_run/0,
+        fun the_seam_returns_a_503_error_object/0
+    ]}.
+
+setup() ->
+    asobi_readiness:reset(),
+    ok.
+
+cleanup(_) ->
+    asobi_readiness:reset(),
+    ok.
+
+%% The route table compiles inside nova_sup:init/1; migrations run later, from
+%% asobi_app:start/2. Anything reachable in between must fail closed.
+closed_until_migrations_have_run() ->
+    ?assertNot(asobi_readiness:ready()),
+    ?assertMatch({error, #{error := #{code := ~"not_ready"}}}, asobi_readiness:guard()).
+
+open_once_migrations_have_run() ->
+    ok = asobi_readiness:mark_ready(),
+    ?assert(asobi_readiness:ready()),
+    ?assertEqual(ok, asobi_readiness:guard()).
+
+%% The Wave 2b RPC dispatcher returns this verbatim. 503 rather than 500,
+%% because retrying works.
+the_seam_returns_a_503_error_object() ->
+    {error, Object} = asobi_readiness:guard(),
+    #{error := #{code := Code, message := Message, details := Details}} = Object,
+    ?assertEqual(503, asobi_error:status(Code)),
+    ?assert(is_binary(Message)),
+    ?assertEqual(#{}, Details).

--- a/test/asobi_sup_lua_children_tests.erl
+++ b/test/asobi_sup_lua_children_tests.erl
@@ -19,9 +19,12 @@ lua_children_are_supervised_test() ->
     ?assert(lists:member(asobi_lua_config, Ids)),
     ?assert(lists:member(asobi_lua_sup, Ids)).
 
-lua_children_start_last_test() ->
+%% Extensions come after the Lua runtime, and the Lua runtime after every core
+%% child. An extension may call anything core provides, including Lua.
+lua_children_start_after_core_and_before_extensions_test() ->
     Ids = child_ids(asobi_sup),
-    ?assertEqual([asobi_lua_config, asobi_lua_sup], lists:nthtail(length(Ids) - 2, Ids)).
+    Tail = [asobi_lua_config, asobi_lua_sup, asobi_extension_sup],
+    ?assertEqual((Ids -- Tail) ++ Tail, Ids).
 
 guest_reaper_starts_before_game_config_test() ->
     Ids = child_ids(asobi_sup),

--- a/test/extensions/asobi_extension_reserved_tests.erl
+++ b/test/extensions/asobi_extension_reserved_tests.erl
@@ -1,0 +1,47 @@
+-module(asobi_extension_reserved_tests).
+
+-include_lib("eunit/include/eunit.hrl").
+
+kinds_are_the_four_namespaces_owns_declares_test() ->
+    ?assertEqual([lua, queues, rpc, tables], lists:sort(asobi_extension_reserved:kinds())).
+
+%% Derived from asobi_lua_surface, the one place the `game.*` vocabulary is
+%% written down, so adding a core namespace there reserves it here with no
+%% second edit.
+lua_namespaces_come_from_the_surface_module_test() ->
+    #{lua := Reserved} = asobi_extension_reserved:namespaces(),
+    Expected = [N || [~"game", N] <- asobi_lua_surface:reserved_namespaces()],
+    ?assertNotEqual([], Expected),
+    [?assert(lists:member(N, Reserved)) || N <- Expected],
+    ?assert(lists:member(~"economy", Reserved)),
+    %% `game` is the root every namespace hangs off; no extension may own it.
+    ?assert(lists:member(~"game", Reserved)).
+
+%% Derived from core's kura_schema modules, found the same way asobi finds an
+%% extension's schemas.
+tables_come_from_core_schemas_test() ->
+    #{tables := Reserved} = asobi_extension_reserved:namespaces(),
+    ?assert(lists:member(asobi_player:table(), Reserved)),
+    ?assert(lists:member(asobi_wallet:table(), Reserved)),
+    ?assertNot(lists:member(~"quests", Reserved)).
+
+queues_come_from_core_shigoto_workers_test() ->
+    #{queues := Reserved} = asobi_extension_reserved:namespaces(),
+    ?assertEqual([asobi_broadcast_worker:queue()], Reserved).
+
+%% An RPC prefix and an error-code domain are the same token by construction,
+%% so core's closed code set reserves the prefixes too.
+rpc_prefixes_cover_error_domains_and_lua_test() ->
+    #{rpc := Reserved, lua := Lua} = asobi_extension_reserved:namespaces(),
+    ?assert(lists:member(~"storage", Reserved)),
+    ?assert(lists:member(~"matchmaker", Reserved)),
+    [?assert(lists:member(N, Reserved)) || N <- Lua],
+    ?assertNot(lists:member(~"quests", Reserved)).
+
+%% Deleting this env key silently removes `rebar3 asobi check` from every host.
+the_build_time_gate_is_declared_to_rebar3_test() ->
+    _ = application:load(asobi),
+    {ok, Env} = application:get_key(asobi, env),
+    ?assertEqual([rebar3_asobi_check], proplists:get_value(providers, Env)),
+    Exports = rebar3_asobi_check:module_info(exports),
+    [?assert(lists:member(E, Exports)) || E <- [{init, 1}, {do, 1}, {format_error, 1}]].

--- a/test/extensions/asobi_extension_sup_tests.erl
+++ b/test/extensions/asobi_extension_sup_tests.erl
@@ -1,0 +1,100 @@
+-module(asobi_extension_sup_tests).
+
+-include_lib("eunit/include/eunit.hrl").
+
+-define(QUESTS, asobi_fixture_quests).
+-define(CLANS, asobi_fixture_clans).
+
+extension_sup_test_() ->
+    {foreach, fun setup/0, fun cleanup/1, [
+        fun no_extensions_means_no_children/0,
+        fun each_extension_gets_its_own_sub_supervisor/0,
+        fun a_spent_extension_goes_dark_alone/0
+    ]}.
+
+setup() ->
+    asobi_extensions:reset(),
+    ok.
+
+cleanup(_) ->
+    stop_sup(),
+    _ = [asobi_fixture_app:uninstall(A) || A <- [?QUESTS, ?CLANS]],
+    application:unset_env(asobi, extension_restart),
+    _ = logger:remove_handler(asobi_fixture_log),
+    asobi_extensions:reset(),
+    ok.
+
+%% Inert with nothing installed: one idle supervisor, no children, no timers,
+%% no tables.
+no_extensions_means_no_children() ->
+    {ok, Pid} = asobi_extension_sup:start_link(),
+    ?assertEqual([], supervisor:which_children(Pid)),
+    ?assertEqual([], asobi_extension_sup:running()).
+
+each_extension_gets_its_own_sub_supervisor() ->
+    install_both(),
+    {ok, _Pid} = asobi_extension_sup:start_link(),
+    ?assertEqual([clans, quests], lists:sort(asobi_extension_sup:running())),
+    ?assert(is_pid(whereis(asobi_fixture_quests_worker))),
+    ?assert(is_pid(whereis(asobi_fixture_clans_worker))),
+    %% Each sub-supervisor is a supervisor of its own, not a flat list of the
+    %% extensions' children under one shared restart budget.
+    [?assert(is_pid(sub_sup(Name))) || Name <- [quests, clans]].
+
+%% The whole point of the tree. quests burns its own restart budget; the node,
+%% asobi_extension_sup and clans are all untouched, and core says which one
+%% went dark.
+a_spent_extension_goes_dark_alone() ->
+    application:set_env(asobi, extension_restart, #{intensity => 0, period => 1}),
+    install_both(),
+    {ok, Top} = asobi_extension_sup:start_link(),
+    ok = logger:add_handler(asobi_fixture_log, asobi_fixture_log_handler, #{
+        level => all, config => #{pid => self()}
+    }),
+    QuestsSup = sub_sup(quests),
+    Ref = erlang:monitor(process, QuestsSup),
+    ok = asobi_fixture_worker:crash(asobi_fixture_quests_worker),
+    receive
+        {'DOWN', Ref, process, QuestsSup, _} -> ok
+    after 5000 -> erlang:error(sub_supervisor_survived_its_budget)
+    end,
+    ?assertEqual([quests], await_down_log()),
+    ?assert(is_process_alive(Top)),
+    ?assert(is_process_alive(whereis(asobi_extension_watch))),
+    ?assertEqual([clans], asobi_extension_sup:running()),
+    ?assert(is_pid(whereis(asobi_fixture_clans_worker))).
+
+%% --- Helpers ---
+
+install_both() ->
+    ok = asobi_fixture_app:install(?QUESTS, asobi_fixture_quests_extension, []),
+    ok = asobi_fixture_app:install(?CLANS, asobi_fixture_clans_extension, [?QUESTS]).
+
+sub_sup(Name) ->
+    {Name, Pid, _Type, _Modules} = lists:keyfind(
+        Name, 1, supervisor:which_children(asobi_extension_sup)
+    ),
+    Pid.
+
+await_down_log() ->
+    receive
+        {log_event, #{msg := {report, #{msg := ~"extension_down", extension := Name}}}} ->
+            [Name];
+        {log_event, _Other} ->
+            await_down_log()
+    after 5000 -> []
+    end.
+
+stop_sup() ->
+    case whereis(asobi_extension_sup) of
+        undefined ->
+            ok;
+        Pid ->
+            Ref = erlang:monitor(process, Pid),
+            unlink(Pid),
+            exit(Pid, shutdown),
+            receive
+                {'DOWN', Ref, process, Pid, _} -> ok
+            after 5000 -> ok
+            end
+    end.

--- a/test/extensions/asobi_extensions_tests.erl
+++ b/test/extensions/asobi_extensions_tests.erl
@@ -1,0 +1,236 @@
+-module(asobi_extensions_tests).
+
+-include_lib("eunit/include/eunit.hrl").
+
+-define(QUESTS, asobi_fixture_quests).
+-define(CLANS, asobi_fixture_clans).
+-define(TUNABLE, asobi_fixture_tunable).
+-define(MINIMAL, asobi_fixture_minimal).
+-define(PLAIN, asobi_fixture_plain).
+
+extensions_test_() ->
+    {foreach, fun setup/0, fun cleanup/1, [
+        fun inert_when_nothing_is_installed/0,
+        fun discovers_by_manifest_module/0,
+        fun an_app_in_asobis_closure_is_not_an_extension/0,
+        fun optional_callbacks_default_to_empty/0,
+        fun dependency_order_beats_alphabetical_order/0,
+        fun resolve_is_memoised/0,
+        fun one_lua_namespace_two_claimants/0,
+        fun one_table_two_claimants/0,
+        fun one_rpc_prefix_two_claimants/0,
+        fun one_queue_two_claimants/0,
+        fun an_extension_does_not_collide_with_itself/0,
+        fun reserved_lua_namespace_refused/0,
+        fun reserved_core_table_refused/0,
+        fun reserved_core_queue_refused/0,
+        fun reserved_rpc_prefix_refused/0,
+        fun claiming_outside_the_owned_set_refused/0,
+        fun duplicate_extension_names_refused/0,
+        fun malformed_info_refused/0,
+        fun a_raising_manifest_is_reported_not_propagated/0,
+        fun invalid_child_specs_caught_before_boot/0,
+        fun unknown_owns_key_refused/0,
+        fun resolve_raises_on_an_invalid_set/0
+    ]}.
+
+setup() ->
+    asobi_extensions:reset(),
+    asobi_fixture_tunable_extension:clear(),
+    ok.
+
+cleanup(_) ->
+    _ = [asobi_fixture_app:uninstall(A) || A <- [?QUESTS, ?CLANS, ?TUNABLE, ?MINIMAL, ?PLAIN]],
+    asobi_fixture_tunable_extension:clear(),
+    asobi_extensions:reset(),
+    ok.
+
+%% --- Discovery ---
+
+%% The machinery has to be free when nobody uses it. No extension installed
+%% means an empty list and nothing else: no processes, no tables, no error.
+inert_when_nothing_is_installed() ->
+    ?assertEqual([], asobi_extensions:resolve()),
+    ?assertEqual({ok, []}, asobi_extensions:check()).
+
+discovers_by_manifest_module() ->
+    install(?QUESTS),
+    [Extension] = asobi_extensions:resolve(),
+    ?assertMatch(
+        #{
+            app := ?QUESTS,
+            module := asobi_fixture_quests_extension,
+            name := quests,
+            extension_version := 1
+        },
+        Extension
+    ),
+    #{rpc := Rpc, lua := Lua, owns := Owns} = Extension,
+    ?assertEqual({asobi_fixture_quests_rpc, claim, 2}, maps:get(~"quests.claim", Rpc)),
+    ?assertEqual([~"quests"], maps:keys(Lua)),
+    ?assertEqual([~"quests", ~"quest_progress"], maps:get(tables, Owns)).
+
+%% asobi_lua, asobi_engine and asobi_admin all have asobi in their dependency
+%% closure and none of them is an extension. The filter is a module named after
+%% the application, not any module ending in `_extension` and not depending on
+%% asobi: this fixture carries a perfectly valid manifest module belonging to a
+%% different application and is still not an extension.
+an_app_in_asobis_closure_is_not_an_extension() ->
+    ok = asobi_fixture_app:install(?PLAIN, asobi_fixture_quests_extension, []),
+    ?assertEqual([], asobi_extensions:resolve()).
+
+optional_callbacks_default_to_empty() ->
+    install(?MINIMAL),
+    [Extension] = asobi_extensions:resolve(),
+    ?assertMatch(#{name := minimal, rpc := #{}, lua := #{}, owns := #{}}, Extension),
+    ?assertEqual([], asobi_extensions:sup_specs(asobi_fixture_minimal_extension)),
+    %% Nothing can call it: no Lua namespace for game logic, no RPC for a
+    %% client. `rebar3 asobi check` warns; it is not a boot failure.
+    #{rpc := Rpc, lua := Lua} = Extension,
+    ?assertEqual(0, map_size(Rpc) + map_size(Lua)).
+
+%% asobi_fixture_clans sorts before asobi_fixture_quests but depends on it, so
+%% only an ordering that reads OTP's `applications` key can produce this.
+dependency_order_beats_alphabetical_order() ->
+    install(?QUESTS),
+    ok = asobi_fixture_app:install(?CLANS, asobi_fixture_clans_extension, [?QUESTS]),
+    ?assertEqual([?CLANS, ?QUESTS], lists:sort([?QUESTS, ?CLANS])),
+    ?assertEqual([quests, clans], [Name || #{name := Name} <- asobi_extensions:resolve()]).
+
+%% The registry is memoised, not live. Installing an application after the
+%% first call is invisible until the term is cleared, which is the price of
+%% being callable from inside Nova's boot with no process to ask.
+resolve_is_memoised() ->
+    install(?QUESTS),
+    ?assertEqual(1, length(asobi_extensions:resolve())),
+    ok = asobi_fixture_app:install(?CLANS, asobi_fixture_clans_extension, [?QUESTS]),
+    ?assertEqual(1, length(asobi_extensions:resolve())),
+    asobi_extensions:reset(),
+    ?assertEqual(2, length(asobi_extensions:resolve())).
+
+%% --- Disjointness ---
+
+one_lua_namespace_two_claimants() ->
+    install(?QUESTS),
+    tunable(#{lua => #{~"quests" => #{}}}),
+    assert_conflict(lua, ~"quests").
+
+one_table_two_claimants() ->
+    install(?QUESTS),
+    tunable(#{owns => #{tables => [~"quest_progress"]}}),
+    assert_conflict(tables, ~"quest_progress").
+
+one_rpc_prefix_two_claimants() ->
+    install(?QUESTS),
+    tunable(#{rpc => #{~"quests.reset" => {tunable_rpc, reset, 2}}}),
+    assert_conflict(rpc, ~"quests").
+
+one_queue_two_claimants() ->
+    install(?QUESTS),
+    tunable(#{owns => #{queues => [~"quests"]}}),
+    assert_conflict(queues, ~"quests").
+
+%% The claim set is owns/0 plus what the manifest implies, so a well-formed
+%% extension declares its Lua namespace twice - once in lua/0 and once in
+%% owns.lua. It must not collide with itself.
+an_extension_does_not_collide_with_itself() ->
+    install(?QUESTS),
+    ok = asobi_fixture_app:install(?CLANS, asobi_fixture_clans_extension, [?QUESTS]),
+    ?assertMatch({ok, [_, _]}, asobi_extensions:check()).
+
+%% --- Core's reserved names ---
+
+reserved_lua_namespace_refused() ->
+    tunable(#{lua => #{~"economy" => #{}}}),
+    ?assert(lists:member({reserved_namespace, lua, ~"economy", ?TUNABLE}, check_problems())).
+
+reserved_core_table_refused() ->
+    tunable(#{owns => #{tables => [~"players"]}}),
+    ?assert(lists:member({reserved_namespace, tables, ~"players", ?TUNABLE}, check_problems())).
+
+reserved_core_queue_refused() ->
+    tunable(#{owns => #{queues => [~"broadcast"]}}),
+    ?assert(lists:member({reserved_namespace, queues, ~"broadcast", ?TUNABLE}, check_problems())).
+
+%% An RPC prefix and an error-code domain are the same token, so owning
+%% "storage" would mint codes inside core's closed code set.
+reserved_rpc_prefix_refused() ->
+    tunable(#{rpc => #{~"storage.get" => {tunable_rpc, get, 2}}}),
+    ?assert(lists:member({reserved_namespace, rpc, ~"storage", ?TUNABLE}, check_problems())).
+
+claiming_outside_the_owned_set_refused() ->
+    tunable(#{
+        owns => #{rpc => [~"tunable"]},
+        rpc => #{~"gold.grant" => {tunable_rpc, grant, 2}}
+    }),
+    ?assert(lists:member({undeclared_claim, rpc, ~"gold", ?TUNABLE}, check_problems())).
+
+duplicate_extension_names_refused() ->
+    install(?QUESTS),
+    tunable(#{info => #{name => quests, extension_version => 1}}),
+    ?assert(lists:member({duplicate_name, quests, ?QUESTS, ?TUNABLE}, check_problems())).
+
+%% --- Malformed manifests ---
+
+malformed_info_refused() ->
+    tunable(#{info => #{name => tunable}}),
+    ?assertMatch(
+        [{bad_manifest, ?TUNABLE, asobi_fixture_tunable_extension, {info, _, _}}],
+        check_problems()
+    ).
+
+a_raising_manifest_is_reported_not_propagated() ->
+    tunable(#{owns => {raise, boom}}),
+    ?assertMatch(
+        [{bad_manifest, ?TUNABLE, _, {owns, {raised, error, boom}}}],
+        check_problems()
+    ).
+
+%% supervisor:check_childspecs/1 at build time instead of a failed_to_start_child
+%% raised out of Nova's boot.
+invalid_child_specs_caught_before_boot() ->
+    tunable(#{sup => [#{id => no_start_key}]}),
+    ?assertMatch(
+        [{bad_manifest, ?TUNABLE, _, {sup, ~"invalid child specs", _}}],
+        check_problems()
+    ).
+
+unknown_owns_key_refused() ->
+    tunable(#{owns => #{telemetry => [~"tunable"]}}),
+    ?assertMatch(
+        [{bad_manifest, ?TUNABLE, _, {owns, ~"unknown namespace kind", telemetry}}],
+        check_problems()
+    ).
+
+%% The backstop. A node that cannot say which extension owns a namespace must
+%% not serve traffic under either.
+resolve_raises_on_an_invalid_set() ->
+    install(?QUESTS),
+    tunable(#{lua => #{~"quests" => #{}}}),
+    ?assertError({asobi_extensions, _}, asobi_extensions:resolve()).
+
+%% --- Helpers ---
+
+install(?QUESTS) ->
+    ok = asobi_fixture_app:install(?QUESTS, asobi_fixture_quests_extension, []);
+install(?MINIMAL) ->
+    ok = asobi_fixture_app:install(?MINIMAL, asobi_fixture_minimal_extension, []).
+
+tunable(Manifest) ->
+    ok = asobi_fixture_tunable_extension:set(Manifest),
+    ok = asobi_fixture_app:install(?TUNABLE, asobi_fixture_tunable_extension, []).
+
+check_problems() ->
+    case asobi_extensions:check() of
+        {error, Problems} -> Problems;
+        {ok, Resolved} -> erlang:error({expected_problems, [N || #{name := N} <- Resolved]})
+    end.
+
+%% Both claimants, by application name, in the message a human reads.
+assert_conflict(Kind, Token) ->
+    Problems = check_problems(),
+    ?assert(lists:member({namespace_conflict, Kind, Token, ?QUESTS, ?TUNABLE}, Problems)),
+    Text = iolist_to_binary(lists:join(~" ", asobi_extensions:describe(Problems))),
+    ?assertNotEqual(nomatch, binary:match(Text, atom_to_binary(?QUESTS, utf8))),
+    ?assertNotEqual(nomatch, binary:match(Text, atom_to_binary(?TUNABLE, utf8))),
+    ?assertNotEqual(nomatch, binary:match(Text, Token)).

--- a/test/extensions/asobi_extensions_tests.erl
+++ b/test/extensions/asobi_extensions_tests.erl
@@ -16,6 +16,7 @@ extensions_test_() ->
         fun optional_callbacks_default_to_empty/0,
         fun dependency_order_beats_alphabetical_order/0,
         fun resolve_is_memoised/0,
+        fun the_migration_seam_lists_the_extensions/0,
         fun one_lua_namespace_two_claimants/0,
         fun one_table_two_claimants/0,
         fun one_rpc_prefix_two_claimants/0,
@@ -107,6 +108,16 @@ resolve_is_memoised() ->
     ?assertEqual(1, length(asobi_extensions:resolve())),
     asobi_extensions:reset(),
     ?assertEqual(2, length(asobi_extensions:resolve())).
+
+%% kura 2.20 calls this optional kura_repo callback; the pinned 2.17 does not,
+%% so it is a seam. It names the extensions only: kura adds the repo's own
+%% application and sorts the result itself.
+the_migration_seam_lists_the_extensions() ->
+    ?assertEqual([], asobi_repo:migration_apps()),
+    install(?QUESTS),
+    ok = asobi_fixture_app:install(?CLANS, asobi_fixture_clans_extension, [?QUESTS]),
+    asobi_extensions:reset(),
+    ?assertEqual([?QUESTS, ?CLANS], asobi_repo:migration_apps()).
 
 %% --- Disjointness ---
 

--- a/test/extensions/asobi_fixture_app.erl
+++ b/test/extensions/asobi_fixture_app.erl
@@ -1,0 +1,34 @@
+-module(asobi_fixture_app).
+-moduledoc """
+Installs a fixture extension as a real, loaded OTP application.
+
+`application:load/1` takes an application spec directly, so a fixture needs no
+`.app` file on disk and no separate build. The manifest module is an ordinary
+test module: discovery matches on the application's `modules` key, which is
+exactly how it works for a real dependency.
+""".
+
+-export([install/3, uninstall/1]).
+
+-spec install(atom(), module() | none, [atom()]) -> ok | {error, term()}.
+install(App, Module, ExtraDeps) ->
+    Modules =
+        case Module of
+            none -> [];
+            _ -> [Module]
+        end,
+    application:load(
+        {application, App, [
+            {description, "asobi extension fixture"},
+            {vsn, "0.0.0"},
+            {registered, []},
+            {applications, [kernel, stdlib, asobi | ExtraDeps]},
+            {modules, Modules},
+            {env, []}
+        ]}
+    ).
+
+-spec uninstall(atom()) -> ok.
+uninstall(App) ->
+    _ = application:unload(App),
+    ok.

--- a/test/extensions/asobi_fixture_clans_extension.erl
+++ b/test/extensions/asobi_fixture_clans_extension.erl
@@ -1,0 +1,44 @@
+-module(asobi_fixture_clans_extension).
+-moduledoc "A second extension, whose application depends on the first, so ordering is observable.".
+-behaviour(asobi_extension).
+
+-export([info/0, rpc/0, lua/0, sup/0, owns/0]).
+
+-spec info() -> asobi_extension:info().
+info() ->
+    #{name => clans, extension_version => 2}.
+
+-spec rpc() -> asobi_extension:rpc().
+rpc() ->
+    #{~"clans.create" => {asobi_fixture_clans_rpc, create, 2}}.
+
+-spec lua() -> asobi_extension:lua().
+lua() ->
+    #{
+        ~"clans" => #{
+            ~"of" => #{
+                mfa => {asobi_fixture_clans_lua, of_player, 1},
+                args => [binary],
+                effects => none,
+                vms => [match, world, zone, bot]
+            }
+        }
+    }.
+
+-spec sup() -> [supervisor:child_spec()].
+sup() ->
+    [
+        #{
+            id => roster,
+            start => {asobi_fixture_worker, start_link, [asobi_fixture_clans_worker]}
+        }
+    ].
+
+-spec owns() -> asobi_extension:owns().
+owns() ->
+    #{
+        tables => [~"clans"],
+        rpc => [~"clans"],
+        lua => [~"clans"],
+        queues => [~"clans"]
+    }.

--- a/test/extensions/asobi_fixture_log_handler.erl
+++ b/test/extensions/asobi_fixture_log_handler.erl
@@ -1,0 +1,9 @@
+-module(asobi_fixture_log_handler).
+-moduledoc "Forwards log events to a test process, so a log line can be asserted on.".
+
+-export([log/2]).
+
+-spec log(logger:log_event(), logger:handler_config()) -> ok.
+log(Event, #{config := #{pid := Pid}}) ->
+    Pid ! {log_event, Event},
+    ok.

--- a/test/extensions/asobi_fixture_minimal_extension.erl
+++ b/test/extensions/asobi_fixture_minimal_extension.erl
@@ -1,0 +1,14 @@
+-module(asobi_fixture_minimal_extension).
+-moduledoc """
+The smallest legal manifest: `info/0` and nothing else.
+
+Exists to prove the optional callbacks really are optional, and that an
+extension nobody can call is a warning rather than a boot failure.
+""".
+-behaviour(asobi_extension).
+
+-export([info/0]).
+
+-spec info() -> asobi_extension:info().
+info() ->
+    #{name => minimal, extension_version => 1}.

--- a/test/extensions/asobi_fixture_quests_extension.erl
+++ b/test/extensions/asobi_fixture_quests_extension.erl
@@ -1,0 +1,53 @@
+-module(asobi_fixture_quests_extension).
+-moduledoc "A complete extension manifest, shaped exactly like the design's worked example.".
+-behaviour(asobi_extension).
+
+-export([info/0, rpc/0, lua/0, sup/0, owns/0]).
+
+-spec info() -> asobi_extension:info().
+info() ->
+    #{name => quests, extension_version => 1}.
+
+-spec rpc() -> asobi_extension:rpc().
+rpc() ->
+    #{
+        ~"quests.list" => {asobi_fixture_quests_rpc, list, 2},
+        ~"quests.claim" => {asobi_fixture_quests_rpc, claim, 2}
+    }.
+
+-spec lua() -> asobi_extension:lua().
+lua() ->
+    #{
+        ~"quests" => #{
+            ~"progress" => #{
+                mfa => {asobi_fixture_quests_lua, progress, 2},
+                args => [binary, integer],
+                effects => write,
+                vms => [match, world]
+            },
+            ~"status" => #{
+                mfa => {asobi_fixture_quests_lua, status, 2},
+                args => [binary],
+                effects => none,
+                vms => [match, world, bot]
+            }
+        }
+    }.
+
+-spec sup() -> [supervisor:child_spec()].
+sup() ->
+    [
+        #{
+            id => tracker,
+            start => {asobi_fixture_worker, start_link, [asobi_fixture_quests_worker]}
+        }
+    ].
+
+-spec owns() -> asobi_extension:owns().
+owns() ->
+    #{
+        tables => [~"quests", ~"quest_progress"],
+        rpc => [~"quests"],
+        lua => [~"quests"],
+        queues => [~"quests"]
+    }.

--- a/test/extensions/asobi_fixture_tunable_extension.erl
+++ b/test/extensions/asobi_fixture_tunable_extension.erl
@@ -1,0 +1,46 @@
+-module(asobi_fixture_tunable_extension).
+-moduledoc """
+A manifest whose contents the test sets, so one module covers every invalid
+and colliding shape instead of a file per case.
+""".
+-behaviour(asobi_extension).
+
+-export([info/0, rpc/0, lua/0, sup/0, owns/0]).
+-export([set/1, clear/0]).
+
+-define(KEY, {?MODULE, manifest}).
+
+-spec set(map()) -> ok.
+set(Manifest) ->
+    persistent_term:put(?KEY, Manifest).
+
+-spec clear() -> ok.
+clear() ->
+    _ = persistent_term:erase(?KEY),
+    ok.
+
+-spec info() -> asobi_extension:info().
+info() ->
+    value(info, #{name => tunable, extension_version => 1}).
+
+-spec rpc() -> asobi_extension:rpc().
+rpc() ->
+    value(rpc, #{}).
+
+-spec lua() -> asobi_extension:lua().
+lua() ->
+    value(lua, #{}).
+
+-spec sup() -> [supervisor:child_spec()].
+sup() ->
+    value(sup, []).
+
+-spec owns() -> asobi_extension:owns().
+owns() ->
+    value(owns, #{}).
+
+value(Key, Default) ->
+    case maps:get(Key, persistent_term:get(?KEY, #{}), Default) of
+        {raise, Reason} -> error(Reason);
+        Value -> Value
+    end.

--- a/test/extensions/asobi_fixture_worker.erl
+++ b/test/extensions/asobi_fixture_worker.erl
@@ -1,0 +1,28 @@
+-module(asobi_fixture_worker).
+-moduledoc "A supervised child an extension fixture can declare, and a test can crash on demand.".
+-behaviour(gen_server).
+
+-export([start_link/1, crash/1]).
+-export([init/1, handle_call/3, handle_cast/2]).
+
+-spec start_link(atom()) -> {ok, pid()} | {error, term()}.
+start_link(Name) ->
+    gen_server:start_link({local, Name}, ?MODULE, [], []).
+
+-spec crash(atom()) -> ok.
+crash(Name) ->
+    gen_server:cast(Name, crash).
+
+-spec init([]) -> {ok, #{}}.
+init([]) ->
+    {ok, #{}}.
+
+-spec handle_call(term(), gen_server:from(), #{}) -> {reply, ok, #{}}.
+handle_call(_Request, _From, State) ->
+    {reply, ok, State}.
+
+-spec handle_cast(term(), #{}) -> {noreply, #{}} | {stop, term(), #{}}.
+handle_cast(crash, State) ->
+    {stop, fixture_crash, State};
+handle_cast(_Request, State) ->
+    {noreply, State}.


### PR DESCRIPTION
Wave 3 of the extension architecture: the machinery an extension plugs into.
No extension exists yet (`asobi_quests` is Wave 4), so everything here is
exercised by fixture extensions under `test/extensions/`, and the whole thing
is inert when nothing is installed.

Built against `asobi-ecosystem/docs/design/extension-architecture.md` and ADRs
0002-0005.

## What is here

**`asobi_extension`** - the behaviour. `info/0` is required; `rpc/0`, `lua/0`,
`sup/0` and `owns/0` are `-optional_callbacks` defaulting to empty, because
several are frequently empty and `owns/0` earns nothing until a second
extension exists.

**`asobi_extensions:resolve/0`** - a pure memoised function over
`persistent_term`. Not a process, not a supervised child, not a step in a boot
sequence.

I verified the boot-order claim rather than taking it on trust:
`nova_sup:init/1` calls `setup_cowboy/1` -> `start_cowboy/1` ->
`nova_router:compile(...)`, all inside `init/1`
(`_build/default/lib/nova/src/nova_sup.erl:82` and `:145-152`), and `nova` is
in asobi's `applications` list, so the whole route table compiles before
`asobi_app:start/2` runs. The first caller is `asobi_router:routes/1`, at
which point no asobi process exists. It holds.

Ordering falls out of discovery rather than being applied afterwards: the
closure walk is post-order, so each application is emitted after everything it
depends on, which is OTP's own start order, with ties in the host's
declaration order. Nothing sorts it afterwards.

**`asobi_extension_sup`** + **`asobi_extension_child_sup`** - one
sub-supervisor per extension with its own restart budget (5 in 60 by default,
`{extension_restart, #{intensity, period}}` in app env).

Restart strategy, since you asked for the justification:

- `one_for_one` at both levels. Extensions are independent by construction;
  one restarting is never a reason to restart another.
- **The sub-supervisor is `transient`, not `permanent`.** A supervisor that
  exceeds its intensity exits `shutdown`, which a transient child is not
  restarted for. So an extension that has burned its own budget goes dark and
  stays dark, attributed by name. Restarting it would relay the same crash
  loop upwards until it reached `asobi_sup` (10 in 60, over eighteen children
  including the matchmaker and every live match) and took the node with it -
  the exact outcome this tree exists to prevent. Transient rather than
  temporary because a sub-supervisor killed for some *other* abnormal reason
  is a core-side fault, not an extension giving up.
- **Intensity 3 in 60 at the top level.** Extension failures never consume it,
  because a transient child exiting `shutdown` is not a restart. The budget
  covers `asobi_extension_watch` only, so nothing an extension does can
  exhaust it.

**`asobi_extension_watch`** - monitors the sub-supervisors and logs
`extension_down` with the extension's name, so "a feature stopped working and
nothing said so" is not a possible outcome. `asobi_extension_sup:running/0`
answers the same question on demand.

**Namespace disjointness** - `owns/0` **plus what the manifest already
implies**: the prefixes in `rpc/0` and the namespaces in `lua/0`. So two
extensions installing the same `game.quests` collide even before either has
bothered with `owns/0`. A conflict names both claimants by application name,
which is the thing a host edits.

Core's reserved list is derived from core rather than restated, so it cannot
drift:

- **lua** from `asobi_lua_surface:reserved_namespaces/0` - the S7 list, plus
  `game` itself.
- **tables** from every core `kura_schema` module's `table/0`, found the same
  way asobi finds an extension's schemas.
- **queues** from every core `shigoto_worker` module's `queue/0`.
- **rpc** from the domains of `asobi_error:codes/0`, plus the Lua namespaces.
  An RPC prefix and an error-code domain are the same token by construction
  (`{"code": "quests.name_taken"}`), so an extension owning `storage` would
  mint codes inside core's closed code set.

**`rebar3 asobi check`** - the primary gate, running the same
`asobi_extensions:check/0` the boot backstop runs, so the two cannot disagree.
Verified end to end against a scratch host project:

```
===> asobi: 3 extension(s), in migration order
===>   clans (game_clans, contract v1): 1 rpc method(s), 1 lua namespace(s)
===>   quests (game_quests, contract v1): 1 rpc method(s), 1 lua namespace(s)
===>   solo (game_solo, contract v1): 0 rpc method(s), 0 lua namespace(s)
===> asobi: game_solo declares neither rpc/0 nor lua/0, so nothing can call it
```

and on a collision, exit 1:

```
===> asobi: game_clans and game_quests both claim the table "quests". Namespaces are exclusive; rename one.
===> asobi: game_clans and game_quests both claim the RPC prefix "quests". ...
===> asobi: game_clans and game_quests both claim the Lua namespace "quests". ...
```

It also runs `supervisor:check_childspecs/1` over `sup/0`, so a malformed child
spec is a build-time line naming the extension rather than a
`failed_to_start_child` out of Nova's boot.

**`asobi_readiness`** - the 503 `not_ready` seam. The route table compiles
during Nova's boot; `kura_migrator:migrate/1` runs later, from
`asobi_app:start/2`, so an extension endpoint is reachable before its tables
exist. `asobi_readiness:guard/0` returns `ok` or the error object, and
`asobi_app:start/2` marks ready only on a successful migration. **The RPC
dispatcher is Wave 2b and is not built here** - `guard/0` and its tests are,
so the dispatcher inherits a readiness contract rather than inventing one.

**`asobi_repo:migration_apps/0`** - inert seam for kura's multi-application
migration discovery.

## Inertness

With nothing installed: `resolve/0` returns `[]` without computing the
reserved list at all, `asobi_extension_sup` is one idle supervisor with zero
children, no timers and no tables, and nothing sits on any request path. The
only always-on cost is one closure walk at boot, memoised.

All 1319 eunit tests pass, including the 1285 that predate this branch.

## Design deviations

Three places where the document and reality disagreed.

1. **kura 2.20 is published.** The brief said 2.20.0 was not on Hex; it is -
   2.20.1, with `migration_apps/0` as a documented optional `kura_repo`
   callback. I read the real implementation
   (`kura_migrator:resolve_migration_apps/2`) and found that kura **adds the
   repo's own application itself and topologically sorts the result**, so a
   callback returning `[asobi | Extensions]` restates an ordering kura already
   derives. `asobi_repo:migration_apps/0` therefore returns the extensions
   only. I did **not** move the pin: `~> 2.17` to `~> 2.20` is a three-minor
   upgrade of the ORM under every core migration and deserves its own PR with a
   real-Postgres migration run. When that pin moves, this is the entire change
   - extension migrations then run inside core's transaction, under one
   advisory lock, in dependency order. Nothing else here changes.

2. **`rebar3 asobi check` ships inside asobi, not as a `rebar3_asobi`
   package.** The design points at rebar3_kura's structure, which is a separate
   repo depending on kura. Duplicating the validator there would break the
   ADR's requirement that build time and boot validate *identically*, so the
   provider lives in `src/extensions/` and is declared to rebar3 through
   `{env, [{providers, [rebar3_asobi_check]}]}` in `asobi.app.src` - I
   confirmed empirically that rebar3 reads that key before falling back to a
   module named after the application, so the provider module needs no special
   name. The cost is real and should be said plainly: a host adding `asobi` to
   `project_plugins` builds asobi's whole dependency tree a second time under
   `_build/default/plugins`. Extracting a slim `rebar3_asobi` that depends on
   asobi is the follow-up if that cost bites. This also required two
   concessions in `rebar.config`: `xref_ignores` for rebar3's own API and
   `{exclude_mods, [rebar3_asobi_check]}` for dialyzer, both scoped to that one
   module.

3. **`rpc/0` and `lua/0` are optional callbacks, though the design says
   "neither is optional".** That sentence is about the design providing both
   consumption paths, not about the callback list; a half-written extension
   with neither is a legal state and failing the build on it would be hostile.
   `rebar3 asobi check` **warns** instead, naming the application and why
   nothing can call it. If the intent was a hard failure, say so and it is a
   one-line change.

Two smaller judgement calls worth flagging:

- **`asobi_extension_reserved` raises if core's module list is unreadable**
  rather than returning an empty reserved set. An empty set silently reserves
  nothing, which would let an extension claim `players` and pass the check.
  Fail closed and loud.
- **`asobi_router:routes/1` now calls `resolve/0`.** Extensions contribute no
  routes; the call is there because the router is the earliest possible
  validation point, which is the whole reason `resolve/0` has the shape it
  does.

## Tests

34 new tests, all verified to fail when the implementation is reverted:

| Reverted | Failing tests |
|---|---|
| `validate/1` never reports | 11 |
| manifest shape checks never report | 3 |
| pre-order closure instead of post-order | 1 (`dependency_order_beats_alphabetical_order`) |
| memoisation removed | 1 |
| manifest matched by `_extension` suffix only | 1 |
| no try/catch around manifest calls | 1 |
| a manifest's own claims not deduped | 4 |
| `sup_specs/1` always empty | 2 |
| sub-supervisor `permanent` instead of `transient` | 1 (`a_spent_extension_goes_dark_alone`) |
| `asobi_extension_watch` removed | 1 |
| readiness always open | 2 |
| reserved Lua list emptied | 1 |
| migration seam ignores extensions | 1 |

Two assertions carry their weight only because of how the fixtures are
arranged, so they are worth stating: `asobi_fixture_clans` sorts *before*
`asobi_fixture_quests` alphabetically but depends on it, so the ordering test
distinguishes dependency order from a sort; and the "an app in asobi's closure
is not an extension" fixture carries a perfectly valid manifest module
belonging to a *different* application, so it would pass a suffix match and
fails only the name match.

`asobi_sup_lua_children_tests:lua_children_start_last_test` was pinning the
Lua children as the final two entries. Extensions start after them, so it is
now `lua_children_start_after_core_and_before_extensions_test` and pins the
exact three-entry tail instead - the same guard, restated.

## Not built

- The RPC dispatcher (Wave 2b, explicitly out of scope). Only the readiness
  seam it will call.
- **The Lua injector.** The design's sequence lists it alongside
  `asobi_extension_sup` in step 3, but it was not in the brief's list and it
  means editing `asobi_lua_api:install/2`, the probe-VM `pick/3` path and the
  namespace pre-creation order. `lua/0` is fully validated here - shape,
  effects, VM kinds, disjointness, reserved names - so the injector consumes a
  checked declaration. It is the obvious next PR and it is not a one-liner.
- Moving the kura pin (see deviation 1).
- `asobi_bundle`.

## Checks

`rebar3 fmt --check`, `xref`, `dialyzer`, `ex_doc` (zero warnings), full
`eunit` (1319 tests, 0 failures), and `ct` for `asobi_api_SUITE` and
`asobi_lua_SUITE` against the shared Postgres. Rebased onto main after #356
landed; the only conflict was one line in `asobi_error`'s code table.
