### PR TITLE
feat(ops): complete the read plane - economy, chat, tournaments, notifications, lookup by id

### DIFF
--- a/guides/rest-api.md
+++ b/guides/rest-api.md
@@ -234,11 +234,22 @@ DELETE /api/v1/storage/:collection/:key        Delete object
 
 ```
 GET /api/v1/ops/players                      Paginated player list
+GET /api/v1/ops/players/:id                  One player
 GET /api/v1/ops/matches                      Paginated match-record list
+GET /api/v1/ops/matches/:id                  One match record
 GET /api/v1/ops/features                     Installed feature set
 GET /api/v1/ops/leaderboards                 Paginated board list
 GET /api/v1/ops/leaderboards/:id/entries     Paginated, ranked board entries
 GET /api/v1/ops/matchmaker                   Matchmaking queue, by mode
+GET /api/v1/ops/economy/items                Paginated item catalogue
+GET /api/v1/ops/economy/items/:id            One item definition
+GET /api/v1/ops/economy/listings             Paginated store listings
+GET /api/v1/ops/economy/listings/:id         One store listing
+GET /api/v1/ops/chat/channels                Live chat channels, by members
+GET /api/v1/ops/chat/channels/:id/messages   Paginated channel history
+GET /api/v1/ops/tournaments                  Paginated tournament list
+GET /api/v1/ops/tournaments/:id              One tournament
+GET /api/v1/ops/notifications                Paginated sent notifications
 ```
 
 The game-operations read plane, for a console rather than a game client. The
@@ -272,16 +283,109 @@ A malformed number is never an error: `?limit=abc` uses the default. A
 malformed *sort* always is, because ordering the wrong rows silently is worse
 than a 400.
 
+A filter is dropped when its value is empty or too long: you get a superset,
+and the rows show it. The exception is a filter on an **id** column
+(`player_id`, `sender_id`, `item_def_id`): a value that is not a uuid is
+`400 ops.invalid_filter`, because dropping it would answer a request scoped to
+one player with everybody's rows and nothing in the response would say so.
+
 Sorts always end on a unique column, so paging by offset cannot repeat or skip
 a row when the sort key has duplicates. That column is `id` on most lists,
-`board_id` for the board list, `player_id` within a board and `mode` for the
-queue.
+`board_id` for the board list, `player_id` within a board, `mode` for the
+queue and `channel_id` for the channel list.
+
+### Lookup by id
+
+Every list with a `:id` route beside it returns one row in the same envelope
+minus the page:
+
+```json
+{ "data": { "id": "0197...", "username": "kaito" } }
+```
+
+The row is passed through the list's own projection, so a lookup can never
+return a field the list withheld. An id that is not a uuid is
+`400 ops.invalid_id` and never reaches the database; a real miss is
+`404 ops.not_found`.
+
+### Players and matches
 
 `ops/players` sorts on `id`, `username`, `display_name`, `inserted_at`,
 `updated_at`, and searches username and display name. `ops/matches` sorts on
 `id`, `mode`, `status`, `started_at`, `finished_at`, `inserted_at`, filters on
 `mode` and `status`, and searches mode. Both return the same fields as their
 public counterparts - no roster, no credentials.
+
+### Economy
+
+`GET /api/v1/ops/economy/items` is the item catalogue. Sorts on `id`, `slug`,
+`name`, `category`, `rarity`, `inserted_at`, `updated_at`, filters on
+`category` and `rarity`, and searches slug and name.
+
+`GET /api/v1/ops/economy/listings` is the store. Sorts on `id`, `item_def_id`,
+`currency`, `price`, `active`, `valid_from`, `valid_until`, and filters on
+`item_def_id`, `currency` and `active` (`true` or `false` - nothing else
+filters).
+
+```json
+{
+  "data": [
+    { "id": "0198...", "item_def_id": "0197...", "currency": "gold",
+      "price": 250, "active": true, "valid_from": null, "valid_until": null,
+      "metadata": {} }
+  ],
+  "page": { "limit": 50, "offset": 0, "total": 38 }
+}
+```
+
+Listings carry no timestamp, so they default to `id` descending. Ids are
+UUIDv7, so that is still newest-first. There is no `q` on listings: nothing on
+a listing is prose. Search the catalogue and filter by the `item_def_id` it
+gives you.
+
+### Chat
+
+`GET /api/v1/ops/chat/channels` lists the channels running on this node with
+their current member count. Sorts on `channel_id` and `members`, busiest
+first, and searches the channel id. It is process state, so it is this node's
+view and it changes between reads.
+
+```json
+{
+  "data": [{ "channel_id": "room:lobby", "members": 14 }],
+  "page": { "limit": 50, "offset": 0, "total": 1 }
+}
+```
+
+`GET /api/v1/ops/chat/channels/:id/messages` pages one channel's persisted
+history. Sorts on `id`, `channel_type`, `sender_id`, `sent_at`, newest first,
+filters on `sender_id` and `channel_type`, and searches message content - the
+read a moderator acting on a report needs. `metadata` does not leave.
+
+A channel with history but no live process is still readable here; a live
+channel that has not been written to yet has no rows.
+
+### Tournaments
+
+`GET /api/v1/ops/tournaments` sorts on `id`, `name`, `leaderboard_id`,
+`status`, `start_at`, `end_at`, `inserted_at`, filters on `status` and
+`leaderboard_id`, and searches the name.
+
+Every row carries `live`: whether a tournament process is actually running for
+it. A row can say `"status": "active"` with `"live": false` after a node
+restart, and no other read shows that. `metadata` does not leave; `entry_fee`
+and `rewards` do.
+
+### Notifications
+
+`GET /api/v1/ops/notifications` is the send history. Sorts on `id`,
+`player_id`, `type`, `subject`, `read`, `sent_at`, newest first, filters on
+`player_id`, `type` and `read`, and searches the subject. It answers the
+question a broadcast raises: who received it, and how many have opened it.
+
+The ops plane is read-only, so there is no broadcast route here. The broadcast
+is an in-process entry point that writes an audit row - see
+[Ops audit](#ops-audit).
 
 ### Leaderboards
 

--- a/src/asobi_error.erl
+++ b/src/asobi_error.erl
@@ -147,6 +147,9 @@ working and a new one reads one place: see `legacy/2`.
 
     %% Ops read plane.
     {~"ops.invalid_board_id", 400, ~"The leaderboard id is missing or too long."},
+    {~"ops.invalid_id", 400, ~"The id is missing or not the shape this endpoint accepts."},
+    {~"ops.invalid_filter", 400, ~"That filter value is not the shape its column holds."},
+    {~"ops.not_found", 404, ~"No record exists with this id."},
     {~"ops.unknown_sort_field", 400, ~"That is not a field this endpoint sorts on."},
     {~"ops.unknown_sort_order", 400, ~"`order` must be \"asc\" or \"desc\"."},
     {~"ops.query_failed", 500, ~"The ops query failed."},

--- a/src/asobi_router.erl
+++ b/src/asobi_router.erl
@@ -216,7 +216,9 @@ ops_routes() ->
         security => fun asobi_ops_auth:verify/1,
         routes => [
             {~"/players", fun asobi_ops_controller:players/1, #{methods => [get, options]}},
+            {~"/players/:id", fun asobi_ops_controller:player/1, #{methods => [get, options]}},
             {~"/matches", fun asobi_ops_controller:matches/1, #{methods => [get, options]}},
+            {~"/matches/:id", fun asobi_ops_controller:match/1, #{methods => [get, options]}},
             {~"/features", fun asobi_ops_controller:features/1, #{methods => [get, options]}},
             {~"/leaderboards", fun asobi_ops_controller:leaderboards/1, #{
                 methods => [get, options]
@@ -224,7 +226,34 @@ ops_routes() ->
             {~"/leaderboards/:id/entries", fun asobi_ops_controller:leaderboard_entries/1, #{
                 methods => [get, options]
             }},
-            {~"/matchmaker", fun asobi_ops_controller:matchmaker/1, #{methods => [get, options]}}
+            {~"/matchmaker", fun asobi_ops_controller:matchmaker/1, #{methods => [get, options]}},
+            {~"/economy/items", fun asobi_ops_controller:economy_items/1, #{
+                methods => [get, options]
+            }},
+            {~"/economy/items/:id", fun asobi_ops_controller:economy_item/1, #{
+                methods => [get, options]
+            }},
+            {~"/economy/listings", fun asobi_ops_controller:economy_listings/1, #{
+                methods => [get, options]
+            }},
+            {~"/economy/listings/:id", fun asobi_ops_controller:economy_listing/1, #{
+                methods => [get, options]
+            }},
+            {~"/chat/channels", fun asobi_ops_controller:chat_channels/1, #{
+                methods => [get, options]
+            }},
+            {~"/chat/channels/:id/messages", fun asobi_ops_controller:chat_messages/1, #{
+                methods => [get, options]
+            }},
+            {~"/tournaments", fun asobi_ops_controller:tournaments/1, #{
+                methods => [get, options]
+            }},
+            {~"/tournaments/:id", fun asobi_ops_controller:tournament/1, #{
+                methods => [get, options]
+            }},
+            {~"/notifications", fun asobi_ops_controller:notifications/1, #{
+                methods => [get, options]
+            }}
         ]
     }.
 

--- a/src/ops/asobi_ops_caps.erl
+++ b/src/ops/asobi_ops_caps.erl
@@ -35,11 +35,22 @@ so a new ops route cannot ship untagged.
 classes() ->
     [
         {get, [~"players"], read},
+        {get, [~"players", '_'], read},
         {get, [~"matches"], read},
+        {get, [~"matches", '_'], read},
         {get, [~"features"], read},
         {get, [~"leaderboards"], read},
         {get, [~"leaderboards", '_', ~"entries"], read},
-        {get, [~"matchmaker"], read}
+        {get, [~"matchmaker"], read},
+        {get, [~"economy", ~"items"], read},
+        {get, [~"economy", ~"items", '_'], read},
+        {get, [~"economy", ~"listings"], read},
+        {get, [~"economy", ~"listings", '_'], read},
+        {get, [~"chat", ~"channels"], read},
+        {get, [~"chat", ~"channels", '_', ~"messages"], read},
+        {get, [~"tournaments"], read},
+        {get, [~"tournaments", '_'], read},
+        {get, [~"notifications"], read}
     ].
 
 -doc """

--- a/src/ops/asobi_ops_chat.erl
+++ b/src/ops/asobi_ops_chat.erl
@@ -1,0 +1,113 @@
+-module(asobi_ops_chat).
+-moduledoc """
+Chat reads for the ops plane: the live channel list, and one channel's
+messages.
+
+Two different sources, and they answer two different questions. The channel
+list is process state - which rooms exist right now and how many players are
+in them - so it is sorted and paged in memory like the matchmaker queue. The
+message history is in Postgres and is paged by the database like every other
+list here, because moderation means reading past the last screenful.
+
+Searching message content is the reason this endpoint exists rather than a
+raw `LIMIT`: an operator acting on a report needs to find one message, and
+the console this replaces could only offer the newest fifty.
+""".
+
+-include_lib("kura/include/kura.hrl").
+
+-export([channels/1, messages_query/2]).
+-export([project_channel/1, project_message/1]).
+-export([channels_sortable/0, messages_sortable/0]).
+
+-define(CHANNELS_SORTABLE, [
+    {~"channel_id", channel_id},
+    {~"members", members}
+]).
+
+-define(MESSAGES_SORTABLE, [
+    {~"id", id},
+    {~"channel_type", channel_type},
+    {~"sender_id", sender_id},
+    {~"sent_at", sent_at}
+]).
+
+-define(MESSAGES_FILTERS, [
+    {~"sender_id", sender_id, uuid},
+    {~"channel_type", channel_type, equals},
+    {~"q", content, ilike}
+]).
+
+-doc "Wire-name to column mapping the channel list accepts in `?sort=`.".
+-spec channels_sortable() -> asobi_ops_params:sort_allowlist().
+channels_sortable() -> ?CHANNELS_SORTABLE.
+
+-doc "Wire-name to column mapping the message list accepts in `?sort=`.".
+-spec messages_sortable() -> asobi_ops_params:sort_allowlist().
+messages_sortable() -> ?MESSAGES_SORTABLE.
+
+-doc """
+The live channel rows and the order to page them in.
+
+Busiest first, since a channel with two hundred people in it is the one an
+operator is being asked about. `channel_id` is unique across the rows and
+ends the order, so the offset window cannot repeat one.
+""".
+-spec channels(asobi_ops_params:params()) ->
+    {ok, {[map()], asobi_ops_params:sort_spec()}}
+    | {error, {unknown_sort, binary()} | {unknown_order, binary()}}.
+channels(Params) ->
+    case asobi_ops_params:sort(Params, ?CHANNELS_SORTABLE, [{members, desc}], {channel_id, asc}) of
+        {ok, Orders} -> {ok, {search(asobi_chat_channel:channels(), Params), Orders}};
+        {error, _} = Error -> Error
+    end.
+
+%% `q` matches the channel id case-insensitively, the in-memory equivalent of
+%% the `ilike` the message list runs.
+-spec search([map()], asobi_ops_params:params()) -> [map()].
+search(Rows, Params) ->
+    case asobi_ops_params:search(Params, ~"q") of
+        none ->
+            Rows;
+        {ok, Term} ->
+            Needle = string:lowercase(Term),
+            [
+                Row
+             || #{channel_id := Id} = Row <- Rows,
+                string:find(string:lowercase(Id), Needle) =/= nomatch
+            ]
+    end.
+
+-doc "One channel's persisted messages as an ordered query for the shared paginator.".
+-spec messages_query(binary(), asobi_ops_params:params()) ->
+    {ok, #kura_query{}}
+    | {error, {unknown_sort, binary()} | {unknown_order, binary()} | {invalid_filter, binary()}}.
+messages_query(ChannelId, Params) ->
+    case asobi_ops_params:sort(Params, ?MESSAGES_SORTABLE, [{sent_at, desc}]) of
+        {ok, Orders} ->
+            Scoped = kura_query:where(
+                kura_query:from(asobi_chat_message), {channel_id, ChannelId}
+            ),
+            case asobi_ops_filters:build(Scoped, Params, ?MESSAGES_FILTERS) of
+                {ok, Query} -> {ok, kura_query:order_by(Query, Orders)};
+                {error, _} = Error -> Error
+            end;
+        {error, _} = Error ->
+            Error
+    end.
+
+-doc "Positive allowlist of the fields a channel row may carry off this endpoint.".
+-spec project_channel(map()) -> map().
+project_channel(Channel) ->
+    maps:with([channel_id, members], Channel).
+
+-doc """
+Positive allowlist of the fields a message may carry off this endpoint.
+
+`content` stays: a moderation screen that cannot show what was said is not
+one. `metadata` is game-authored and does not leave, the same rule
+`asobi_ops_matches` applies to a match record.
+""".
+-spec project_message(map()) -> map().
+project_message(Message) ->
+    maps:with([id, channel_type, channel_id, sender_id, content, sent_at], Message).

--- a/src/ops/asobi_ops_controller.erl
+++ b/src/ops/asobi_ops_controller.erl
@@ -16,24 +16,86 @@ the equivalent public endpoint already exposes.
 -include_lib("kernel/include/logger.hrl").
 -include_lib("kura/include/kura.hrl").
 
--export([players/1, matches/1, features/1, leaderboards/1, leaderboard_entries/1, matchmaker/1]).
+-export([players/1, player/1, matches/1, match/1, features/1]).
+-export([leaderboards/1, leaderboard_entries/1, matchmaker/1]).
+-export([economy_items/1, economy_item/1, economy_listings/1, economy_listing/1]).
+-export([chat_channels/1, chat_messages/1]).
+-export([tournaments/1, tournament/1, notifications/1]).
 
 -type response() ::
     {json, map()}
     | {json, integer(), map(), map()}
-    | {asobi_error, asobi_error:code()}.
+    | {asobi_error, asobi_error:code()}
+    | {asobi_error, asobi_error:code(), asobi_error:details()}.
 
 %% `leaderboard_id` is a VARCHAR(255); a longer binding matches no board, so
 %% it is answered as a bad request rather than paid for as a query.
 -define(MAX_BOARD_ID_BYTES, 255).
 
+%% `channel_id` is the same VARCHAR(255), and the same reasoning.
+-define(MAX_CHANNEL_ID_BYTES, 255).
+
 -spec players(cowboy_req:req()) -> response().
 players(Req) ->
     list(Req, fun asobi_ops_players:query/1, fun asobi_ops_players:project/1).
 
+-spec player(cowboy_req:req()) -> response().
+player(Req) ->
+    lookup(Req, asobi_player, fun asobi_ops_players:project/1).
+
 -spec matches(cowboy_req:req()) -> response().
 matches(Req) ->
     list(Req, fun asobi_ops_matches:query/1, fun asobi_ops_matches:project/1).
+
+-spec match(cowboy_req:req()) -> response().
+match(Req) ->
+    lookup(Req, asobi_match_record, fun asobi_ops_matches:project/1).
+
+-spec economy_items(cowboy_req:req()) -> response().
+economy_items(Req) ->
+    list(Req, fun asobi_ops_economy:items_query/1, fun asobi_ops_economy:project_item/1).
+
+-spec economy_item(cowboy_req:req()) -> response().
+economy_item(Req) ->
+    lookup(Req, asobi_item_def, fun asobi_ops_economy:project_item/1).
+
+-spec economy_listings(cowboy_req:req()) -> response().
+economy_listings(Req) ->
+    list(Req, fun asobi_ops_economy:listings_query/1, fun asobi_ops_economy:project_listing/1).
+
+-spec economy_listing(cowboy_req:req()) -> response().
+economy_listing(Req) ->
+    lookup(Req, asobi_store_listing, fun asobi_ops_economy:project_listing/1).
+
+-spec tournaments(cowboy_req:req()) -> response().
+tournaments(Req) ->
+    list(Req, fun asobi_ops_tournaments:query/1, fun asobi_ops_tournaments:project/1).
+
+-spec tournament(cowboy_req:req()) -> response().
+tournament(Req) ->
+    lookup(Req, asobi_tournament, fun asobi_ops_tournaments:project/1).
+
+-spec notifications(cowboy_req:req()) -> response().
+notifications(Req) ->
+    list(Req, fun asobi_ops_notifications:query/1, fun asobi_ops_notifications:project/1).
+
+-spec chat_channels(cowboy_req:req()) -> response().
+chat_channels(Req) ->
+    rows(Req, fun asobi_ops_chat:channels/1, fun asobi_ops_chat:project_channel/1).
+
+%% The channel id is a free-form string, not a uuid, so it is bounded rather
+%% than shape-checked.
+-spec chat_messages(cowboy_req:req()) -> response().
+chat_messages(#{bindings := #{~"id" := ChannelId}} = Req) when
+    is_binary(ChannelId), ChannelId =/= ~"", byte_size(ChannelId) =< ?MAX_CHANNEL_ID_BYTES
+->
+    list(
+        Req,
+        fun(Params) -> asobi_ops_chat:messages_query(ChannelId, Params) end,
+        fun asobi_ops_chat:project_message/1
+    );
+chat_messages(_Req) ->
+    {asobi_error, ~"ops.invalid_id"}.
 
 -spec features(cowboy_req:req()) -> response().
 features(_Req) ->
@@ -88,6 +150,17 @@ list(Req, BuildQuery, Project) ->
             error_response(Reason)
     end.
 
+%% The single-row envelope: `{"data": {...}}`, the list envelope minus the
+%% `page` key it has nothing to report. A console reads `data` either way.
+-spec lookup(cowboy_req:req(), module(), fun((map()) -> map())) -> response().
+lookup(#{bindings := #{~"id" := Id}}, Schema, Project) ->
+    case asobi_ops_lookup:fetch(Schema, Id, Project) of
+        {ok, Row} -> {json, #{data => Row}};
+        {error, Reason} -> error_response(Reason)
+    end;
+lookup(_Req, _Schema, _Project) ->
+    {asobi_error, ~"ops.invalid_id"}.
+
 -spec rows(
     cowboy_req:req(),
     fun(
@@ -127,6 +200,12 @@ error_response({unknown_sort, Field}) ->
     asobi_error:legacy(~"ops.unknown_sort_field", #{field => Field});
 error_response({unknown_order, Order}) ->
     asobi_error:legacy(~"ops.unknown_sort_order", #{order => Order});
+error_response({invalid_filter, Field}) ->
+    {asobi_error, ~"ops.invalid_filter", #{field => Field}};
+error_response(invalid_id) ->
+    {asobi_error, ~"ops.invalid_id"};
+error_response(not_found) ->
+    {asobi_error, ~"ops.not_found"};
 error_response({query_failed, Reason}) ->
     ?LOG_ERROR(#{msg => ~"ops list query failed", reason => Reason}),
     {asobi_error, ~"ops.query_failed"};

--- a/src/ops/asobi_ops_economy.erl
+++ b/src/ops/asobi_ops_economy.erl
@@ -1,0 +1,120 @@
+-module(asobi_ops_economy).
+-moduledoc """
+Economy reads for the ops plane: the item catalogue, and the store listings.
+
+`/economy/listings` is the endpoint the integration plan singles out. The
+console query it replaces had no `ORDER BY` at all, so Postgres was free to
+return the rows in whatever order the plan produced them and offset paging
+over that can repeat one row while skipping another - a store the operator
+scrolls past without ever seeing the listing they went looking for. Both
+orders here end on `id`.
+
+`store_listings` carries no `inserted_at`, so the default order is `id`
+descending rather than a timestamp. That is still newest-first: ids are
+UUIDv7 and their high bits are a millisecond clock (`asobi_id`).
+""".
+
+-include_lib("kura/include/kura.hrl").
+
+-export([items_query/1, listings_query/1]).
+-export([project_item/1, project_listing/1]).
+-export([items_sortable/0, listings_sortable/0]).
+
+-define(ITEMS_SORTABLE, [
+    {~"id", id},
+    {~"slug", slug},
+    {~"name", name},
+    {~"category", category},
+    {~"rarity", rarity},
+    {~"inserted_at", inserted_at},
+    {~"updated_at", updated_at}
+]).
+
+-define(ITEMS_FILTERS, [
+    {~"category", category, equals},
+    {~"rarity", rarity, equals},
+    {~"q", [slug, name], ilike}
+]).
+
+-define(LISTINGS_SORTABLE, [
+    {~"id", id},
+    {~"item_def_id", item_def_id},
+    {~"currency", currency},
+    {~"price", price},
+    {~"active", active},
+    {~"valid_from", valid_from},
+    {~"valid_until", valid_until}
+]).
+
+%% No `q` here on purpose: a listing holds no prose. Its columns are a
+%% foreign key, a currency name and two dates, and every one of them is
+%% better asked for exactly than matched case-insensitively. Search the
+%% catalogue instead and filter listings by the item id it returns.
+-define(LISTINGS_FILTERS, [
+    {~"item_def_id", item_def_id, uuid},
+    {~"currency", currency, equals},
+    {~"active", active, boolean}
+]).
+
+-doc "Wire-name to column mapping the item catalogue accepts in `?sort=`.".
+-spec items_sortable() -> asobi_ops_params:sort_allowlist().
+items_sortable() -> ?ITEMS_SORTABLE.
+
+-doc "Wire-name to column mapping the store listings accept in `?sort=`.".
+-spec listings_sortable() -> asobi_ops_params:sort_allowlist().
+listings_sortable() -> ?LISTINGS_SORTABLE.
+
+-spec items_query(asobi_ops_params:params()) ->
+    {ok, #kura_query{}}
+    | {error, {unknown_sort, binary()} | {unknown_order, binary()} | {invalid_filter, binary()}}.
+items_query(Params) ->
+    query(asobi_item_def, Params, ?ITEMS_SORTABLE, [{inserted_at, desc}], ?ITEMS_FILTERS).
+
+-spec listings_query(asobi_ops_params:params()) ->
+    {ok, #kura_query{}}
+    | {error, {unknown_sort, binary()} | {unknown_order, binary()} | {invalid_filter, binary()}}.
+listings_query(Params) ->
+    query(asobi_store_listing, Params, ?LISTINGS_SORTABLE, [{id, desc}], ?LISTINGS_FILTERS).
+
+-spec query(
+    module(),
+    asobi_ops_params:params(),
+    asobi_ops_params:sort_allowlist(),
+    asobi_ops_params:sort_spec(),
+    [asobi_ops_filters:spec()]
+) ->
+    {ok, #kura_query{}}
+    | {error, {unknown_sort, binary()} | {unknown_order, binary()} | {invalid_filter, binary()}}.
+query(Schema, Params, Sortable, Default, Filters) ->
+    case asobi_ops_params:sort(Params, Sortable, Default) of
+        {ok, Orders} ->
+            case asobi_ops_filters:build(kura_query:from(Schema), Params, Filters) of
+                {ok, Query} -> {ok, kura_query:order_by(Query, Orders)};
+                {error, _} = Error -> Error
+            end;
+        {error, _} = Error ->
+            Error
+    end.
+
+-doc """
+Positive allowlist of the fields an item definition may carry off this
+endpoint.
+
+`metadata` stays. On an item definition it is the operator-authored half of
+the catalogue - icons, tuning, whatever the game reads - and an economy
+screen that cannot show it cannot tell two items apart.
+""".
+-spec project_item(map()) -> map().
+project_item(Item) ->
+    maps:with(
+        [id, slug, name, category, rarity, stackable, metadata, inserted_at, updated_at],
+        Item
+    ).
+
+-doc "Positive allowlist of the fields a store listing may carry off this endpoint.".
+-spec project_listing(map()) -> map().
+project_listing(Listing) ->
+    maps:with(
+        [id, item_def_id, currency, price, active, valid_from, valid_until, metadata],
+        Listing
+    ).

--- a/src/ops/asobi_ops_filters.erl
+++ b/src/ops/asobi_ops_filters.erl
@@ -1,0 +1,81 @@
+-module(asobi_ops_filters).
+-moduledoc """
+The `WHERE` clauses an ops list endpoint builds from its query string.
+
+Each endpoint declares a spec list and this builds the query, so the rules
+below hold everywhere rather than once per module:
+
+* An absent or empty filter narrows nothing. A caller can see that: it gets a
+  superset and the rows to prove it.
+* A filter whose value cannot be the shape its column holds - a `player_id`
+  that is not a uuid - is a **400**, not a dropped clause. Dropping it would
+  answer a request scoped to one player with every player's rows, and that is
+  the failure a caller cannot see.
+* An oversized exact-match value is dropped rather than rejected, which is
+  what these endpoints did before this module existed.
+* `ilike` patterns come from `asobi_ops_params:like_pattern/2`, so `%` and `_`
+  inside a search term match literally instead of turning the search into a
+  scan of the whole table.
+
+Compare `asobi_ops_params:sort/3`, which *rejects* an unknown field: a wrong
+sort returns a page silently ordered by something else, which no response
+body reveals.
+""".
+
+-include_lib("kura/include/kura.hrl").
+
+-export([build/3]).
+
+-export_type([spec/0]).
+
+-type kind() :: equals | boolean | uuid | ilike.
+-type spec() :: {binary(), atom() | [atom()], kind()}.
+
+-doc """
+Apply `Specs` to `Query` in order, resolving each against `Params`.
+
+Named `build` rather than `apply` so it cannot be read as the BIF.
+""".
+-spec build(#kura_query{}, asobi_ops_params:params(), [spec()]) ->
+    {ok, #kura_query{}} | {error, {invalid_filter, binary()}}.
+build(Query, _Params, []) ->
+    {ok, Query};
+build(Query, Params, [Spec | Rest]) ->
+    case clause(Params, Spec) of
+        {ok, Where} -> build(kura_query:where(Query, Where), Params, Rest);
+        none -> build(Query, Params, Rest);
+        {error, _} = Error -> Error
+    end.
+
+-spec clause(asobi_ops_params:params(), spec()) ->
+    {ok, term()} | none | {error, {invalid_filter, binary()}}.
+clause(Params, {Key, Column, equals}) ->
+    case asobi_ops_params:filter(Params, Key) of
+        {ok, Value} -> {ok, {Column, Value}};
+        none -> none
+    end;
+clause(Params, {Key, Column, boolean}) ->
+    case asobi_ops_params:boolean(Params, Key) of
+        {ok, Value} -> {ok, {Column, Value}};
+        none -> none
+    end;
+clause(Params, {Key, Column, uuid}) ->
+    case asobi_ops_params:filter(Params, Key) of
+        {ok, Value} ->
+            case asobi_ops_params:uuid(Value) of
+                true -> {ok, {Column, Value}};
+                false -> {error, {invalid_filter, Key}}
+            end;
+        none ->
+            none
+    end;
+clause(Params, {Key, Columns, ilike}) ->
+    case asobi_ops_params:like_pattern(Params, Key) of
+        {ok, Pattern} -> {ok, ilike(Columns, Pattern)};
+        none -> none
+    end.
+
+-spec ilike(atom() | [atom()], binary()) -> term().
+ilike(Column, Pattern) when is_atom(Column) -> {Column, ilike, Pattern};
+ilike([Column], Pattern) -> {Column, ilike, Pattern};
+ilike(Columns, Pattern) -> {'or', [{Column, ilike, Pattern} || Column <- Columns]}.

--- a/src/ops/asobi_ops_lookup.erl
+++ b/src/ops/asobi_ops_lookup.erl
@@ -1,0 +1,37 @@
+-module(asobi_ops_lookup).
+-moduledoc """
+Fetch one row by primary key for the ops read plane.
+
+The list endpoints answer what exists; a console that renders a list then
+needs the row behind a click, and until now nothing in the plane could serve
+one - there was no `/ops/players/:id` and no `/ops/matches/:id` anywhere.
+
+The id is checked for uuid shape before it reaches the database
+(`asobi_ops_params:uuid/1`) and the row is passed through the endpoint's own
+projection on the way out, so a lookup can never return a field its list
+would have withheld.
+""".
+
+-export([fetch/3]).
+
+-doc """
+The row `Id` names in `Schema`, projected.
+
+`invalid_id` is a malformed binding, `not_found` a real miss, and
+`{query_failed, Reason}` anything else - three outcomes the caller answers
+with 400, 404 and 500 respectively, so a bad request is never reported as a
+server fault.
+""".
+-spec fetch(module(), term(), fun((map()) -> map())) ->
+    {ok, map()} | {error, invalid_id | not_found | {query_failed, term()}}.
+fetch(Schema, Id, Project) ->
+    case asobi_ops_params:uuid(Id) of
+        true -> project(asobi_repo:get(Schema, Id), Project);
+        false -> {error, invalid_id}
+    end.
+
+-spec project({ok, map()} | {error, term()}, fun((map()) -> map())) ->
+    {ok, map()} | {error, not_found | {query_failed, term()}}.
+project({ok, Row}, Project) -> {ok, Project(Row)};
+project({error, not_found}, _Project) -> {error, not_found};
+project({error, Reason}, _Project) -> {error, {query_failed, Reason}}.

--- a/src/ops/asobi_ops_matches.erl
+++ b/src/ops/asobi_ops_matches.erl
@@ -20,39 +20,28 @@ console can page through match history and know how much of it there is.
     {~"inserted_at", inserted_at}
 ]).
 
--define(MAX_FILTER_BYTES, 64).
+-define(FILTERS, [
+    {~"mode", mode, equals},
+    {~"status", status, equals},
+    {~"q", mode, ilike}
+]).
 
 -doc "Wire-name to column mapping this endpoint accepts in `?sort=`.".
 -spec sortable() -> asobi_ops_params:sort_allowlist().
 sortable() -> ?SORTABLE.
 
 -spec query(asobi_ops_params:params()) ->
-    {ok, #kura_query{}} | {error, {unknown_sort, binary()} | {unknown_order, binary()}}.
+    {ok, #kura_query{}}
+    | {error, {unknown_sort, binary()} | {unknown_order, binary()} | {invalid_filter, binary()}}.
 query(Params) ->
     case asobi_ops_params:sort(Params, ?SORTABLE, [{inserted_at, desc}]) of
         {ok, Orders} ->
-            Query0 = kura_query:from(asobi_match_record),
-            Query1 = equals(Query0, Params, ~"mode", mode),
-            Query2 = equals(Query1, Params, ~"status", status),
-            {ok, kura_query:order_by(search(Query2, Params), Orders)};
+            case asobi_ops_filters:build(kura_query:from(asobi_match_record), Params, ?FILTERS) of
+                {ok, Query} -> {ok, kura_query:order_by(Query, Orders)};
+                {error, _} = Error -> Error
+            end;
         {error, _} = Error ->
             Error
-    end.
-
--spec equals(#kura_query{}, asobi_ops_params:params(), binary(), atom()) -> #kura_query{}.
-equals(Query, Params, Key, Column) ->
-    case maps:get(Key, Params, undefined) of
-        Value when is_binary(Value), Value =/= ~"", byte_size(Value) =< ?MAX_FILTER_BYTES ->
-            kura_query:where(Query, {Column, Value});
-        _ ->
-            Query
-    end.
-
--spec search(#kura_query{}, asobi_ops_params:params()) -> #kura_query{}.
-search(Query, Params) ->
-    case asobi_ops_params:like_pattern(Params, ~"q") of
-        none -> Query;
-        {ok, Pattern} -> kura_query:where(Query, {mode, ilike, Pattern})
     end.
 
 -doc """

--- a/src/ops/asobi_ops_notifications.erl
+++ b/src/ops/asobi_ops_notifications.erl
@@ -1,28 +1,82 @@
 -module(asobi_ops_notifications).
 -moduledoc """
-The operator-attributed notification broadcast.
+The notifications screen: the sent-notification list, and the
+operator-attributed broadcast.
 
-This is the mutation half of the console's notifications screen, moved into
-core so the audit wraps it rather than the handler remembering to. The
-console keeps parsing, deduplicating and capping the recipient list - those
-are presentation concerns - and calls this for the part that changes player
-state.
+`query/1` is the read half and it *is* a route, tagged `read` like every
+other list here. It answers the question a broadcast raises and nothing else
+could: which players actually received the last send, and how many of them
+have opened it.
 
-It is not a route. The ops plane is read-only, and this does not change that;
-it is the Erlang entry point the existing console mutation calls, which is
-what lets `{ok, Succeeded, Failed}` reach an audit row instead of being
-flattened into a list of survivors on the way out.
+`broadcast/5` is the mutation half, moved into core so the audit wraps it
+rather than the handler remembering to. The console keeps parsing,
+deduplicating and capping the recipient list - those are presentation
+concerns - and calls this for the part that changes player state.
 
-Because there is no route, there is no route-level capability check either -
-so the check happens here, through the same `asobi_ops_caps:authorised/2`
-that the router's security callback uses. One function still authorises; it
-is simply called from the entry point an in-process caller actually reaches.
+`broadcast/5` is deliberately *not* a route. The ops plane is read-only and
+this does not change that; it is the Erlang entry point the existing console
+mutation calls, which is what lets `{ok, Succeeded, Failed}` reach an audit
+row instead of being flattened into a list of survivors on the way out.
+
+Because it has no route, it gets no route-level capability check either - so
+the check happens inside it, through the same `asobi_ops_caps:authorised/2`
+the router's security callback uses. One function still authorises; it is
+simply called from the entry point an in-process caller actually reaches.
 """.
 
+-include_lib("kura/include/kura.hrl").
+
 -export([broadcast/5]).
+-export([query/1, project/1, sortable/0]).
 
 -define(ACTION, ~"notifications.broadcast").
 -define(CLASS, player_data).
+
+-define(SORTABLE, [
+    {~"id", id},
+    {~"player_id", player_id},
+    {~"type", type},
+    {~"subject", subject},
+    {~"read", read},
+    {~"sent_at", sent_at}
+]).
+
+-define(FILTERS, [
+    {~"player_id", player_id, uuid},
+    {~"type", type, equals},
+    {~"read", read, boolean},
+    {~"q", subject, ilike}
+]).
+
+-doc "Wire-name to column mapping this endpoint accepts in `?sort=`.".
+-spec sortable() -> asobi_ops_params:sort_allowlist().
+sortable() -> ?SORTABLE.
+
+-spec query(asobi_ops_params:params()) ->
+    {ok, #kura_query{}}
+    | {error, {unknown_sort, binary()} | {unknown_order, binary()} | {invalid_filter, binary()}}.
+query(Params) ->
+    case asobi_ops_params:sort(Params, ?SORTABLE, [{sent_at, desc}]) of
+        {ok, Orders} ->
+            case asobi_ops_filters:build(kura_query:from(asobi_notification), Params, ?FILTERS) of
+                {ok, Query} -> {ok, kura_query:order_by(Query, Orders)};
+                {error, _} = Error -> Error
+            end;
+        {error, _} = Error ->
+            Error
+    end.
+
+-doc """
+Positive allowlist of the fields a notification may carry off this endpoint.
+
+`content` stays. It is the body of a message an operator or the game sent,
+and the same field the receiving player already reads back from
+`asobi_notification_controller:index/1`; a send-history screen that cannot
+show what was sent cannot answer the one question it exists for.
+""".
+-spec project(map()) -> map().
+project(Notification) ->
+    maps:with([id, player_id, type, subject, content, read, sent_at], Notification).
 
 -doc """
 Send `Subject` to every id in `PlayerIds` as `Actor`, and audit the result.

--- a/src/ops/asobi_ops_params.erl
+++ b/src/ops/asobi_ops_params.erl
@@ -1,6 +1,7 @@
 -module(asobi_ops_params).
 -moduledoc """
-Query-string parsing for the ops read plane.
+Request-input parsing for the ops read plane: query string, and the id in a
+bound path segment.
 
 Three rules, each of them load-bearing:
 
@@ -22,6 +23,7 @@ given. The offset returned is the one the query actually used - see `page/1`.
 """.
 
 -export([page/1, sort/3, sort/4, search/2, like_pattern/2, cursor/1, encode_cursor/1]).
+-export([filter/2, boolean/2, uuid/1]).
 
 -export_type([params/0, page_spec/0, sort_spec/0, sort_allowlist/0, tie_break/0]).
 
@@ -37,6 +39,7 @@ given. The offset returned is the one the query actually used - see `page/1`.
 -define(MAX_OFFSET, 100000).
 -define(MAX_PAGE, 10000).
 -define(MAX_SEARCH_BYTES, 64).
+-define(MAX_FILTER_BYTES, 64).
 -define(MAX_CURSOR_BYTES, 128).
 
 -doc """
@@ -161,6 +164,56 @@ escape_like(Term) ->
     Backslashes = binary:replace(Term, ~"\\", ~"\\\\", [global]),
     Percents = binary:replace(Backslashes, ~"%", ~"\\%", [global]),
     binary:replace(Percents, ~"_", ~"\\_", [global]).
+
+-doc """
+Read an exact-match filter parameter.
+
+`none` when the parameter is absent, empty, valueless, or longer than 64
+bytes - the same soft drop `search/2` applies, and for the same reason: a
+value no column of this size can hold is not worth a query.
+""".
+-spec filter(params(), binary()) -> {ok, binary()} | none.
+filter(Params, Key) ->
+    case maps:get(Key, Params, undefined) of
+        Value when is_binary(Value), Value =/= ~"", byte_size(Value) =< ?MAX_FILTER_BYTES ->
+            {ok, Value};
+        _ ->
+            none
+    end.
+
+-doc """
+Read a boolean filter parameter.
+
+Only `true` and `false` are values. `?active=1` is a typo, and reading it as
+`false` would answer with the exact opposite of what was asked for, so
+anything else is `none` and the filter does not apply.
+""".
+-spec boolean(params(), binary()) -> {ok, boolean()} | none.
+boolean(Params, Key) ->
+    case maps:get(Key, Params, undefined) of
+        ~"true" -> {ok, true};
+        ~"false" -> {ok, false};
+        _ -> none
+    end.
+
+-doc """
+Whether `Id` is a canonical lowercase hyphenated uuid.
+
+Every primary key in this plane is a `uuid` column. Postgres *raises* on a
+value that is not one, so an id checked only by the database turns a
+malformed request into a 500 and a log line. Checking the shape first makes
+it the 400 it is, and costs no query.
+""".
+-spec uuid(term()) -> boolean().
+uuid(<<A:8/binary, $-, B:4/binary, $-, C:4/binary, $-, D:4/binary, $-, E:12/binary>>) ->
+    lists:all(fun is_hex/1, binary_to_list(<<A/binary, B/binary, C/binary, D/binary, E/binary>>));
+uuid(_Id) ->
+    false.
+
+-spec is_hex(term()) -> boolean().
+is_hex(Char) when Char >= $0, Char =< $9 -> true;
+is_hex(Char) when Char >= $a, Char =< $f -> true;
+is_hex(_Char) -> false.
 
 -doc """
 Decode an opaque `?cursor=` token back to its keyset value.

--- a/src/ops/asobi_ops_players.erl
+++ b/src/ops/asobi_ops_players.erl
@@ -26,30 +26,22 @@ operator had to already know the username to find it.
 -spec sortable() -> asobi_ops_params:sort_allowlist().
 sortable() -> ?SORTABLE.
 
+-define(FILTERS, [
+    {~"q", [username, display_name], ilike}
+]).
+
 -spec query(asobi_ops_params:params()) ->
-    {ok, #kura_query{}} | {error, {unknown_sort, binary()} | {unknown_order, binary()}}.
+    {ok, #kura_query{}}
+    | {error, {unknown_sort, binary()} | {unknown_order, binary()} | {invalid_filter, binary()}}.
 query(Params) ->
     case asobi_ops_params:sort(Params, ?SORTABLE, [{inserted_at, desc}]) of
         {ok, Orders} ->
-            Query = search(kura_query:from(asobi_player), Params),
-            {ok, kura_query:order_by(Query, Orders)};
+            case asobi_ops_filters:build(kura_query:from(asobi_player), Params, ?FILTERS) of
+                {ok, Query} -> {ok, kura_query:order_by(Query, Orders)};
+                {error, _} = Error -> Error
+            end;
         {error, _} = Error ->
             Error
-    end.
-
--spec search(#kura_query{}, asobi_ops_params:params()) -> #kura_query{}.
-search(Query, Params) ->
-    case asobi_ops_params:like_pattern(Params, ~"q") of
-        none ->
-            Query;
-        {ok, Pattern} ->
-            kura_query:where(
-                Query,
-                {'or', [
-                    {username, ilike, Pattern},
-                    {display_name, ilike, Pattern}
-                ]}
-            )
     end.
 
 -doc """

--- a/src/ops/asobi_ops_tournaments.erl
+++ b/src/ops/asobi_ops_tournaments.erl
@@ -1,0 +1,84 @@
+-module(asobi_ops_tournaments).
+-moduledoc """
+Tournament reads for the ops plane: the list, and one tournament.
+
+The public route answers a player's question - what can I enter - and returns
+a bare list with a fixed order and no total. An operator's question is
+whether a tournament that says it is running actually is, which is the `live`
+flag: a row can be `status => "active"` with no process behind it after a
+node restart, and that difference is invisible to every other read.
+
+`live` is read from the global registry, never by calling the tournament
+process. A list of forty tournaments must not be forty `gen_server:call`s,
+and a lookup must not be able to hang on one busy tournament.
+""".
+
+-include_lib("kura/include/kura.hrl").
+
+-export([query/1, project/1, sortable/0]).
+
+-define(SORTABLE, [
+    {~"id", id},
+    {~"name", name},
+    {~"leaderboard_id", leaderboard_id},
+    {~"status", status},
+    {~"start_at", start_at},
+    {~"end_at", end_at},
+    {~"inserted_at", inserted_at}
+]).
+
+-define(FILTERS, [
+    {~"status", status, equals},
+    {~"leaderboard_id", leaderboard_id, equals},
+    {~"q", name, ilike}
+]).
+
+-doc "Wire-name to column mapping this endpoint accepts in `?sort=`.".
+-spec sortable() -> asobi_ops_params:sort_allowlist().
+sortable() -> ?SORTABLE.
+
+-spec query(asobi_ops_params:params()) ->
+    {ok, #kura_query{}}
+    | {error, {unknown_sort, binary()} | {unknown_order, binary()} | {invalid_filter, binary()}}.
+query(Params) ->
+    case asobi_ops_params:sort(Params, ?SORTABLE, [{start_at, desc}]) of
+        {ok, Orders} ->
+            case asobi_ops_filters:build(kura_query:from(asobi_tournament), Params, ?FILTERS) of
+                {ok, Query} -> {ok, kura_query:order_by(Query, Orders)};
+                {error, _} = Error -> Error
+            end;
+        {error, _} = Error ->
+            Error
+    end.
+
+-doc """
+Positive allowlist of the fields a tournament may carry off this endpoint,
+plus the `live` flag.
+
+Narrower than the public `asobi_tournament_controller:show/1`, which returns
+the whole row: `metadata` is game-authored and does not leave. `entry_fee`
+and `rewards` do - they are the operator's own configuration and the point of
+the screen.
+""".
+-spec project(map()) -> map().
+project(Tournament) ->
+    Projected = maps:with(
+        [
+            id,
+            name,
+            leaderboard_id,
+            max_entries,
+            entry_fee,
+            rewards,
+            status,
+            start_at,
+            end_at,
+            inserted_at
+        ],
+        Tournament
+    ),
+    Projected#{live => live(maps:get(id, Tournament, undefined))}.
+
+-spec live(binary() | undefined) -> boolean().
+live(undefined) -> false;
+live(Id) -> is_pid(global:whereis_name({asobi_tournament_server, Id})).

--- a/src/social/asobi_chat_channel.erl
+++ b/src/social/asobi_chat_channel.erl
@@ -1,7 +1,7 @@
 -module(asobi_chat_channel).
 -behaviour(gen_server).
 
--export([start_link/2, join/2, leave/2, send_message/3, get_history/2]).
+-export([start_link/2, join/2, leave/2, send_message/3, get_history/2, channels/0]).
 -export([init/1, handle_call/3, handle_cast/2, handle_info/2, terminate/2]).
 
 -define(MAX_BUFFER, 100).
@@ -10,6 +10,7 @@
 %% F-16: stop channels with no live members after this many ms so an
 %% attacker who joins-then-disconnects cannot leak channel processes.
 -define(IDLE_TIMEOUT_MS, 60000).
+-define(MAX_CHANNELS, 1000).
 
 -spec start_link(binary(), binary()) -> gen_server:start_ret().
 start_link(ChannelId, ChannelType) ->
@@ -49,6 +50,49 @@ get_history(ChannelId, Limit) when is_integer(Limit) ->
         error ->
             []
     end.
+
+-doc """
+Every chat channel running on this node, with its current member count.
+
+Two ETS reads and one `pg` lookup per channel: no channel process is called,
+so an operator listing channels cannot block behind one that is busy.
+
+The registry is the source rather than `pg:which_groups/1`, which the console
+this replaces used. `pg` drops a group when its last member leaves, so a
+running channel nobody is currently joined to is simply absent there - and
+the console asked the wrong scope besides, so its channel list was always
+empty.
+
+Capped at 1000 channels, the same ceiling `asobi_leaderboards:boards/0`
+enumerates under, so the in-memory sort behind this stays bounded. `[]`
+before the chat supervisor has started, and `members => 0` for every channel
+when `pg` has not.
+""".
+-spec channels() -> [#{channel_id := binary(), members := non_neg_integer()}].
+channels() ->
+    case ets:whereis(?REGISTRY) of
+        undefined -> [];
+        _ -> live_channels(ets:whereis(?PG_SCOPE))
+    end.
+
+-spec live_channels(ets:table() | undefined) -> [map()].
+live_channels(Scope) ->
+    case ets:match_object(?REGISTRY, {'_', '_'}, ?MAX_CHANNELS) of
+        {Rows, _Continuation} ->
+            [
+                #{channel_id => ChannelId, members => members(Scope, ChannelId)}
+             || {ChannelId, Pid} <- Rows,
+                is_binary(ChannelId),
+                is_pid(Pid),
+                is_process_alive(Pid)
+            ];
+        '$end_of_table' ->
+            []
+    end.
+
+-spec members(ets:table() | undefined, binary()) -> non_neg_integer().
+members(undefined, _ChannelId) -> 0;
+members(_Scope, ChannelId) -> length(pg:get_members(?PG_SCOPE, {chat, ChannelId})).
 
 -spec init({binary(), binary()}) -> {ok, map(), pos_integer()}.
 init({ChannelId, ChannelType}) ->

--- a/test/asobi_ops_chat_tests.erl
+++ b/test/asobi_ops_chat_tests.erl
@@ -1,0 +1,168 @@
+-module(asobi_ops_chat_tests).
+
+-include_lib("eunit/include/eunit.hrl").
+-include_lib("kura/include/kura.hrl").
+
+%%--------------------------------------------------------------------
+%% Messages
+%%--------------------------------------------------------------------
+
+messages_default_order_is_deterministic_test() ->
+    {ok, #kura_query{order_bys = Orders}} = asobi_ops_chat:messages_query(~"lobby", #{}),
+    ?assertEqual([{sent_at, desc}, {id, desc}], Orders).
+
+every_message_sort_ends_on_the_unique_key_test() ->
+    [
+        begin
+            {ok, #kura_query{order_bys = Orders}} = asobi_ops_chat:messages_query(
+                ~"lobby", #{~"sort" => Wire}
+            ),
+            ?assertMatch({id, _Direction}, lists:last(Orders))
+        end
+     || {Wire, _Column} <- asobi_ops_chat:messages_sortable()
+    ].
+
+%% The channel binding scopes the read and is not the caller's to sort on or
+%% override, so it is the first clause and is always present.
+messages_are_always_scoped_to_the_channel_test() ->
+    {ok, #kura_query{wheres = Wheres}} = asobi_ops_chat:messages_query(~"lobby", #{
+        ~"q" => ~"hello"
+    }),
+    ?assertEqual({channel_id, ~"lobby"}, hd(Wheres)).
+
+messages_search_is_ilike_on_content_test() ->
+    {ok, #kura_query{wheres = Wheres}} = asobi_ops_chat:messages_query(~"lobby", #{
+        ~"q" => ~"slur"
+    }),
+    ?assertEqual([{channel_id, ~"lobby"}, {content, ilike, ~"%slur%"}], Wheres).
+
+messages_sender_filter_must_be_a_uuid_test() ->
+    ?assertEqual(
+        {error, {invalid_filter, ~"sender_id"}},
+        asobi_ops_chat:messages_query(~"lobby", #{~"sender_id" => ~"kaito"})
+    ).
+
+messages_reject_unknown_sort_test() ->
+    ?assertEqual(
+        {error, {unknown_sort, ~"content"}},
+        asobi_ops_chat:messages_query(~"lobby", #{~"sort" => ~"content"})
+    ).
+
+messages_projection_drops_game_authored_metadata_test() ->
+    Projected = asobi_ops_chat:project_message(sample_message()),
+    ?assertNot(maps:is_key(metadata, Projected)),
+    ?assertEqual(~"hello", maps:get(content, Projected)).
+
+messages_sortable_fields_are_all_projected_test() ->
+    Projected = maps:keys(asobi_ops_chat:project_message(sample_message())),
+    [
+        ?assert(lists:member(Column, Projected))
+     || {_Wire, Column} <- asobi_ops_chat:messages_sortable()
+    ].
+
+sample_message() ->
+    #{
+        id => ~"0197f3d0-1c2b-7000-8000-0000000000b1",
+        channel_type => ~"room",
+        channel_id => ~"lobby",
+        sender_id => ~"0197f3d0-1c2b-7000-8000-0000000000b2",
+        content => ~"hello",
+        metadata => #{~"client" => ~"godot"},
+        sent_at => {{2026, 8, 3}, {12, 0, 0}}
+    }.
+
+%%--------------------------------------------------------------------
+%% Live channels
+%%--------------------------------------------------------------------
+
+channels_test_() ->
+    {setup, fun setup_channels/0, fun cleanup_channels/1, [
+        fun channels_are_busiest_first/0,
+        fun channels_order_ends_on_the_channel_id/0,
+        fun channels_search_matches_the_id_case_insensitively/0,
+        fun channels_reject_unknown_sort/0
+    ]}.
+
+setup_channels() ->
+    meck:new(asobi_chat_channel, [passthrough]),
+    meck:expect(asobi_chat_channel, channels, fun() ->
+        [
+            #{channel_id => ~"Lobby", members => 2},
+            #{channel_id => ~"arena", members => 9},
+            #{channel_id => ~"coop", members => 2}
+        ]
+    end),
+    ok.
+
+cleanup_channels(_) ->
+    catch meck:unload(asobi_chat_channel),
+    ok.
+
+channels_are_busiest_first() ->
+    {ok, {_Rows, Orders}} = asobi_ops_chat:channels(#{}),
+    ?assertEqual([{members, desc}, {channel_id, asc}], Orders).
+
+channels_order_ends_on_the_channel_id() ->
+    [
+        begin
+            {ok, {_Rows, Orders}} = asobi_ops_chat:channels(#{~"sort" => Wire}),
+            ?assertEqual({channel_id, asc}, lists:last(Orders))
+        end
+     || {Wire, _Column} <- asobi_ops_chat:channels_sortable()
+    ].
+
+channels_search_matches_the_id_case_insensitively() ->
+    {ok, {Rows, _Orders}} = asobi_ops_chat:channels(#{~"q" => ~"LOB"}),
+    ?assertEqual([~"Lobby"], [Id || #{channel_id := Id} <- Rows]).
+
+channels_reject_unknown_sort() ->
+    ?assertEqual(
+        {error, {unknown_sort, ~"pid"}},
+        asobi_ops_chat:channels(#{~"sort" => ~"pid"})
+    ).
+
+channels_projection_is_an_allowlist_test() ->
+    ?assertEqual(
+        #{channel_id => ~"lobby", members => 3},
+        asobi_ops_chat:project_channel(#{
+            channel_id => ~"lobby", members => 3, pid => self(), buffer => [~"secret"]
+        })
+    ).
+
+%%--------------------------------------------------------------------
+%% The registry read behind the channel list
+%%--------------------------------------------------------------------
+
+%% The console this replaces read `pg:which_groups/1`, which forgets a
+%% channel the moment its last member leaves. This reads the registry, so a
+%% running channel nobody is joined to still appears - with zero members.
+registry_lists_a_running_channel_with_no_members_test() ->
+    Table = ets:new(asobi_chat_registry, [named_table, public, set]),
+    try
+        ets:insert(Table, {~"lobby", self()}),
+        ?assertEqual(
+            [#{channel_id => ~"lobby", members => 0}],
+            asobi_chat_channel:channels()
+        )
+    after
+        ets:delete(Table)
+    end.
+
+registry_drops_a_dead_channel_test() ->
+    Dead = spawn(fun() -> ok end),
+    Ref = monitor(process, Dead),
+    receive
+        {'DOWN', Ref, process, Dead, _} -> ok
+    after 1000 -> ?assert(false)
+    end,
+    Table = ets:new(asobi_chat_registry, [named_table, public, set]),
+    try
+        ets:insert(Table, {~"gone", Dead}),
+        ?assertEqual([], asobi_chat_channel:channels())
+    after
+        ets:delete(Table)
+    end.
+
+no_registry_is_an_empty_list_not_a_crash_test() ->
+    ?assertEqual(undefined, ets:whereis(asobi_chat_registry)),
+    ?assertEqual([], asobi_chat_channel:channels()).

--- a/test/asobi_ops_economy_tests.erl
+++ b/test/asobi_ops_economy_tests.erl
@@ -1,0 +1,123 @@
+-module(asobi_ops_economy_tests).
+
+-include_lib("eunit/include/eunit.hrl").
+-include_lib("kura/include/kura.hrl").
+
+%%--------------------------------------------------------------------
+%% Item catalogue
+%%--------------------------------------------------------------------
+
+items_default_order_is_deterministic_test() ->
+    {ok, #kura_query{order_bys = Orders}} = asobi_ops_economy:items_query(#{}),
+    ?assertEqual([{inserted_at, desc}, {id, desc}], Orders).
+
+items_sort_uses_allowlisted_atom_test() ->
+    {ok, #kura_query{order_bys = Orders}} = asobi_ops_economy:items_query(#{~"sort" => ~"slug"}),
+    ?assertEqual([{slug, asc}, {id, desc}], Orders).
+
+items_reject_unknown_sort_test() ->
+    ?assertEqual(
+        {error, {unknown_sort, ~"price"}},
+        asobi_ops_economy:items_query(#{~"sort" => ~"price"})
+    ).
+
+items_search_covers_slug_and_name_test() ->
+    {ok, #kura_query{wheres = Wheres}} = asobi_ops_economy:items_query(#{~"q" => ~"sword"}),
+    ?assertEqual(
+        [{'or', [{slug, ilike, ~"%sword%"}, {name, ilike, ~"%sword%"}]}],
+        Wheres
+    ).
+
+items_filters_are_equality_on_columns_test() ->
+    {ok, #kura_query{wheres = Wheres}} = asobi_ops_economy:items_query(#{
+        ~"category" => ~"weapon", ~"rarity" => ~"epic"
+    }),
+    ?assertEqual([{category, ~"weapon"}, {rarity, ~"epic"}], Wheres).
+
+items_sortable_fields_are_all_projected_test() ->
+    Projected = maps:keys(asobi_ops_economy:project_item(sample_item())),
+    [
+        ?assert(lists:member(Column, Projected))
+     || {_Wire, Column} <- asobi_ops_economy:items_sortable()
+    ].
+
+sample_item() ->
+    #{
+        id => ~"0197f3d0-1c2b-7000-8000-000000000001",
+        slug => ~"iron-sword",
+        name => ~"Iron Sword",
+        category => ~"weapon",
+        rarity => ~"common",
+        stackable => false,
+        metadata => #{~"damage" => 7},
+        inserted_at => {{2026, 8, 3}, {12, 0, 0}},
+        updated_at => {{2026, 8, 3}, {12, 0, 0}}
+    }.
+
+%%--------------------------------------------------------------------
+%% Store listings
+%%--------------------------------------------------------------------
+
+%% The endpoint the plan singles out: it had no `ORDER BY` at all, so offset
+%% paging over it could repeat one row and skip another. `store_listings`
+%% carries no timestamp, so the order ends - and starts - on the id.
+listings_have_a_deterministic_order_test() ->
+    {ok, #kura_query{order_bys = Orders}} = asobi_ops_economy:listings_query(#{}),
+    ?assertEqual([{id, desc}], Orders).
+
+listings_every_sort_still_ends_on_the_unique_key_test() ->
+    [
+        begin
+            {ok, #kura_query{order_bys = Orders}} = asobi_ops_economy:listings_query(#{
+                ~"sort" => Wire
+            }),
+            ?assertMatch({id, _Direction}, lists:last(Orders))
+        end
+     || {Wire, _Column} <- asobi_ops_economy:listings_sortable()
+    ].
+
+listings_reject_unknown_sort_test() ->
+    ?assertEqual(
+        {error, {unknown_sort, ~"metadata"}},
+        asobi_ops_economy:listings_query(#{~"sort" => ~"metadata"})
+    ).
+
+listings_reject_unknown_order_test() ->
+    ?assertEqual(
+        {error, {unknown_order, ~"sideways"}},
+        asobi_ops_economy:listings_query(#{~"sort" => ~"price", ~"order" => ~"sideways"})
+    ).
+
+listings_active_filter_is_a_boolean_test() ->
+    {ok, #kura_query{wheres = Wheres}} = asobi_ops_economy:listings_query(#{~"active" => ~"true"}),
+    ?assertEqual([{active, true}], Wheres).
+
+listings_item_filter_must_be_a_uuid_test() ->
+    ?assertEqual(
+        {error, {invalid_filter, ~"item_def_id"}},
+        asobi_ops_economy:listings_query(#{~"item_def_id" => ~"iron-sword"})
+    ).
+
+listings_item_filter_accepts_a_uuid_test() ->
+    Id = asobi_id:generate(),
+    {ok, #kura_query{wheres = Wheres}} = asobi_ops_economy:listings_query(#{~"item_def_id" => Id}),
+    ?assertEqual([{item_def_id, Id}], Wheres).
+
+listings_sortable_fields_are_all_projected_test() ->
+    Projected = maps:keys(asobi_ops_economy:project_listing(sample_listing())),
+    [
+        ?assert(lists:member(Column, Projected))
+     || {_Wire, Column} <- asobi_ops_economy:listings_sortable()
+    ].
+
+sample_listing() ->
+    #{
+        id => ~"0197f3d0-1c2b-7000-8000-000000000002",
+        item_def_id => ~"0197f3d0-1c2b-7000-8000-000000000001",
+        currency => ~"gold",
+        price => 250,
+        active => true,
+        valid_from => undefined,
+        valid_until => undefined,
+        metadata => #{}
+    }.

--- a/test/asobi_ops_filters_tests.erl
+++ b/test/asobi_ops_filters_tests.erl
@@ -1,0 +1,122 @@
+-module(asobi_ops_filters_tests).
+
+-include_lib("eunit/include/eunit.hrl").
+-include_lib("kura/include/kura.hrl").
+
+build(Params, Specs) ->
+    asobi_ops_filters:build(kura_query:from(asobi_player), Params, Specs).
+
+wheres(Params, Specs) ->
+    {ok, #kura_query{wheres = Wheres}} = build(Params, Specs),
+    Wheres.
+
+%%--------------------------------------------------------------------
+%% Absent and empty
+%%--------------------------------------------------------------------
+
+no_params_no_clauses_test() ->
+    ?assertEqual([], wheres(#{}, [{~"mode", mode, equals}, {~"q", username, ilike}])).
+
+empty_value_does_not_filter_test() ->
+    ?assertEqual([], wheres(#{~"mode" => ~""}, [{~"mode", mode, equals}])).
+
+%%--------------------------------------------------------------------
+%% Exact match
+%%--------------------------------------------------------------------
+
+equals_builds_one_clause_test() ->
+    ?assertEqual(
+        [{mode, ~"deathmatch"}],
+        wheres(#{~"mode" => ~"deathmatch"}, [{~"mode", mode, equals}])
+    ).
+
+%% Spec order is clause order, so an endpoint's `WHERE` list is stable and
+%% its tests can assert on it.
+clauses_follow_spec_order_test() ->
+    ?assertEqual(
+        [{mode, ~"duel"}, {status, ~"finished"}],
+        wheres(
+            #{~"mode" => ~"duel", ~"status" => ~"finished"},
+            [{~"mode", mode, equals}, {~"status", status, equals}]
+        )
+    ).
+
+oversized_equals_is_dropped_test() ->
+    ?assertEqual([], wheres(#{~"mode" => binary:copy(~"m", 65)}, [{~"mode", mode, equals}])).
+
+%%--------------------------------------------------------------------
+%% Boolean
+%%--------------------------------------------------------------------
+
+boolean_builds_a_boolean_clause_test() ->
+    ?assertEqual(
+        [{active, false}], wheres(#{~"active" => ~"false"}, [{~"active", active, boolean}])
+    ).
+
+unparseable_boolean_does_not_filter_test() ->
+    ?assertEqual([], wheres(#{~"active" => ~"1"}, [{~"active", active, boolean}])).
+
+%%--------------------------------------------------------------------
+%% Uuid
+%%--------------------------------------------------------------------
+
+uuid_builds_an_equality_clause_test() ->
+    Id = asobi_id:generate(),
+    ?assertEqual(
+        [{player_id, Id}],
+        wheres(#{~"player_id" => Id}, [{~"player_id", player_id, uuid}])
+    ).
+
+%% The one filter that is rejected rather than dropped. Dropping it would
+%% answer a request scoped to one player with every player's rows, and no
+%% part of the response would say so.
+malformed_uuid_is_rejected_not_dropped_test() ->
+    ?assertEqual(
+        {error, {invalid_filter, ~"player_id"}},
+        build(#{~"player_id" => ~"'; drop table players --"}, [{~"player_id", player_id, uuid}])
+    ).
+
+rejection_stops_the_build_test() ->
+    ?assertEqual(
+        {error, {invalid_filter, ~"player_id"}},
+        build(
+            #{~"player_id" => ~"nope", ~"type" => ~"system"},
+            [{~"type", type, equals}, {~"player_id", player_id, uuid}]
+        )
+    ).
+
+absent_uuid_does_not_filter_test() ->
+    ?assertEqual([], wheres(#{}, [{~"player_id", player_id, uuid}])).
+
+%%--------------------------------------------------------------------
+%% ilike
+%%--------------------------------------------------------------------
+
+ilike_one_column_is_a_bare_clause_test() ->
+    ?assertEqual(
+        [{mode, ilike, ~"%duel%"}],
+        wheres(#{~"q" => ~"duel"}, [{~"q", mode, ilike}])
+    ).
+
+ilike_many_columns_is_a_disjunction_test() ->
+    ?assertEqual(
+        [{'or', [{username, ilike, ~"%kai%"}, {display_name, ilike, ~"%kai%"}]}],
+        wheres(#{~"q" => ~"kai"}, [{~"q", [username, display_name], ilike}])
+    ).
+
+ilike_a_single_column_list_is_not_a_disjunction_test() ->
+    ?assertEqual(
+        [{username, ilike, ~"%kai%"}],
+        wheres(#{~"q" => ~"kai"}, [{~"q", [username], ilike}])
+    ).
+
+%% A lone `%` in a search term matches every row unless it is escaped, which
+%% turns a search box into a full scan.
+ilike_escapes_wildcards_test() ->
+    ?assertEqual(
+        [{username, ilike, ~"%100\\%\\_off%"}],
+        wheres(#{~"q" => ~"100%_off"}, [{~"q", username, ilike}])
+    ).
+
+oversized_search_does_not_filter_test() ->
+    ?assertEqual([], wheres(#{~"q" => binary:copy(~"a", 65)}, [{~"q", username, ilike}])).

--- a/test/asobi_ops_notifications_tests.erl
+++ b/test/asobi_ops_notifications_tests.erl
@@ -86,3 +86,73 @@ an_actor_without_player_data_sends_nothing() ->
     ),
     ?assertNot(meck:called(asobi_notify, send_many, '_')),
     ?assertEqual(~"error", maps:get(outcome, row())).
+
+%%--------------------------------------------------------------------
+%% The read half
+%%--------------------------------------------------------------------
+
+default_order_is_deterministic_test() ->
+    {ok, #kura_query{order_bys = Orders}} = asobi_ops_notifications:query(#{}),
+    ?assertEqual([{sent_at, desc}, {id, desc}], Orders).
+
+every_sort_ends_on_the_unique_key_test() ->
+    [
+        begin
+            {ok, #kura_query{order_bys = Orders}} = asobi_ops_notifications:query(#{
+                ~"sort" => Wire
+            }),
+            ?assertMatch({id, _Direction}, lists:last(Orders))
+        end
+     || {Wire, _Column} <- asobi_ops_notifications:sortable()
+    ].
+
+reject_unknown_sort_test() ->
+    ?assertEqual(
+        {error, {unknown_sort, ~"content"}},
+        asobi_ops_notifications:query(#{~"sort" => ~"content"})
+    ).
+
+read_filter_is_a_boolean_test() ->
+    {ok, #kura_query{wheres = Wheres}} = asobi_ops_notifications:query(#{~"read" => ~"false"}),
+    ?assertEqual([{read, false}], Wheres).
+
+search_is_ilike_on_the_subject_test() ->
+    {ok, #kura_query{wheres = Wheres}} = asobi_ops_notifications:query(#{~"q" => ~"maintenance"}),
+    ?assertEqual([{subject, ilike, ~"%maintenance%"}], Wheres).
+
+%% Dropping a malformed `player_id` would answer "who did this broadcast
+%% reach" with every notification in the deployment.
+malformed_player_filter_is_rejected_test() ->
+    ?assertEqual(
+        {error, {invalid_filter, ~"player_id"}},
+        asobi_ops_notifications:query(#{~"player_id" => ~"kaito"})
+    ).
+
+player_filter_accepts_a_uuid_test() ->
+    Id = asobi_id:generate(),
+    {ok, #kura_query{wheres = Wheres}} = asobi_ops_notifications:query(#{~"player_id" => Id}),
+    ?assertEqual([{player_id, Id}], Wheres).
+
+sortable_fields_are_all_projected_test() ->
+    Projected = maps:keys(asobi_ops_notifications:project(sample_notification())),
+    [
+        ?assert(lists:member(Column, Projected))
+     || {_Wire, Column} <- asobi_ops_notifications:sortable()
+    ].
+
+projection_is_an_allowlist_test() ->
+    Projected = asobi_ops_notifications:project(sample_notification()),
+    ?assertNot(maps:is_key(hashed_password, Projected)),
+    ?assertEqual(~"Maintenance", maps:get(subject, Projected)).
+
+sample_notification() ->
+    #{
+        id => ~"0197f3d0-1c2b-7000-8000-0000000000c1",
+        player_id => ~"0197f3d0-1c2b-7000-8000-0000000000c2",
+        type => ~"system",
+        subject => ~"Maintenance",
+        content => #{~"body" => ~"back at 10"},
+        read => false,
+        sent_at => {{2026, 8, 3}, {12, 0, 0}},
+        hashed_password => ~"never"
+    }.

--- a/test/asobi_ops_params_tests.erl
+++ b/test/asobi_ops_params_tests.erl
@@ -264,3 +264,69 @@ cursor_rejects_oversized_token_test() ->
 
 cursor_rejects_valueless_param_test() ->
     ?assertEqual({error, invalid_cursor}, asobi_ops_params:cursor(#{~"cursor" => true})).
+
+%%--------------------------------------------------------------------
+%% Exact-match and boolean filters
+%%--------------------------------------------------------------------
+
+filter_reads_a_value_test() ->
+    ?assertEqual({ok, ~"gold"}, asobi_ops_params:filter(#{~"currency" => ~"gold"}, ~"currency")).
+
+filter_absent_is_none_test() ->
+    ?assertEqual(none, asobi_ops_params:filter(#{}, ~"currency")).
+
+filter_empty_is_none_test() ->
+    ?assertEqual(none, asobi_ops_params:filter(#{~"currency" => ~""}, ~"currency")).
+
+filter_valueless_param_is_none_test() ->
+    ?assertEqual(none, asobi_ops_params:filter(#{~"currency" => true}, ~"currency")).
+
+filter_oversized_is_none_test() ->
+    Long = binary:copy(~"c", 65),
+    ?assertEqual(none, asobi_ops_params:filter(#{~"currency" => Long}, ~"currency")).
+
+filter_at_the_limit_is_kept_test() ->
+    Limit = binary:copy(~"c", 64),
+    ?assertEqual({ok, Limit}, asobi_ops_params:filter(#{~"currency" => Limit}, ~"currency")).
+
+boolean_reads_true_and_false_test() ->
+    ?assertEqual({ok, true}, asobi_ops_params:boolean(#{~"active" => ~"true"}, ~"active")),
+    ?assertEqual({ok, false}, asobi_ops_params:boolean(#{~"active" => ~"false"}, ~"active")).
+
+%% `?active=1` reading as `false` would answer with the opposite of what was
+%% asked for, so anything that is not the two words does not filter at all.
+boolean_rejects_anything_else_test() ->
+    [
+        ?assertEqual(none, asobi_ops_params:boolean(#{~"active" => Value}, ~"active"))
+     || Value <- [~"1", ~"0", ~"TRUE", ~"yes", ~"", true]
+    ].
+
+boolean_absent_is_none_test() ->
+    ?assertEqual(none, asobi_ops_params:boolean(#{}, ~"active")).
+
+%%--------------------------------------------------------------------
+%% Uuid shape
+%%--------------------------------------------------------------------
+
+uuid_accepts_a_generated_id_test() ->
+    ?assert(asobi_ops_params:uuid(asobi_id:generate())).
+
+uuid_rejects_a_malformed_id_test() ->
+    [
+        ?assertNot(asobi_ops_params:uuid(Id))
+     || Id <- [
+            ~"",
+            ~"not-a-uuid",
+            ~"0197f3d0-1c2b-7000-8000-00000000000",
+            ~"0197f3d0-1c2b-7000-8000-0000000000012",
+            ~"0197f3d01c2b70008000000000000001",
+            ~"0197F3D0-1C2B-7000-8000-000000000001",
+            ~"0197f3d0-1c2b-7000-8000-00000000000g",
+            ~"0197f3d0'-1c2b-7000-8000-00000000001"
+        ]
+    ].
+
+%% A non-binary binding must not crash the shape check.
+uuid_rejects_a_non_binary_test() ->
+    ?assertNot(asobi_ops_params:uuid(undefined)),
+    ?assertNot(asobi_ops_params:uuid(42)).

--- a/test/asobi_ops_tests.erl
+++ b/test/asobi_ops_tests.erl
@@ -287,22 +287,26 @@ matches_sortable_fields_are_all_projected_test() ->
 %% The ops plane has its own identity (ADR 0007). If a later edit moves these
 %% routes back onto the player-scoped check - which admits any player, guest
 %% included - or into an unsecured group, this fails.
+%%
+%% Enumerated from the group rather than listed, so a route added without a
+%% thought for its security is caught here rather than merged.
 ops_routes_are_mounted_behind_the_operator_check_test() ->
-    Groups = asobi_router:routes(dev),
-    [
-        ?assertEqual(
-            {fun asobi_ops_auth:verify/1, [get, options]},
-            route(Groups, ~"/api/v1/ops", Path)
-        )
-     || Path <- [
-            ~"/players",
-            ~"/matches",
-            ~"/features",
-            ~"/leaderboards",
-            ~"/leaderboards/:id/entries",
-            ~"/matchmaker"
-        ]
-    ].
+    #{security := Security, routes := Routes} = ops_group(),
+    ?assertEqual(fun asobi_ops_auth:verify/1, Security),
+    ?assert(Routes =/= []),
+    [?assertEqual([get, options], maps:get(methods, Opts)) || {_Path, _Handler, Opts} <- Routes].
+
+%% Read-only means read-only: the plane must not grow a write route by
+%% accident, and `asobi_ops_notifications:broadcast/5` is deliberately not one.
+ops_plane_serves_no_write_method_test() ->
+    #{routes := Routes} = ops_group(),
+    Methods = lists:usort([M || {_Path, _Handler, Opts} <- Routes, M <- maps:get(methods, Opts)]),
+    ?assertEqual([get, options], Methods),
+    ?assertEqual([], [Class || {_M, _S, Class} <- asobi_ops_caps:classes(), Class =/= read]).
+
+ops_group() ->
+    [Group] = [G || #{prefix := ~"/api/v1/ops"} = G <- asobi_router:routes(dev)],
+    Group.
 
 no_ops_route_sits_in_the_player_scoped_group_test() ->
     [
@@ -333,15 +337,65 @@ ops_routes_and_capability_classes_agree_test() ->
 binding_or_literal(<<":", _/binary>>) -> '_';
 binding_or_literal(Segment) -> Segment.
 
-route(Groups, Prefix, Path) ->
-    [Found] = [
-        {maps:get(security, Group), maps:get(methods, Opts)}
-     || #{prefix := GroupPrefix, routes := Routes} = Group <- Groups,
-        GroupPrefix =:= Prefix,
-        {RoutePath, _Handler, Opts} <- Routes,
-        RoutePath =:= Path
-    ],
-    Found.
+%%--------------------------------------------------------------------
+%% Lookup by id
+%%--------------------------------------------------------------------
+
+lookup_test_() ->
+    {setup, fun setup_repo/0, fun cleanup_repo/1, [
+        fun lookup_projects_the_row/0,
+        fun lookup_reports_a_miss_as_not_found/0,
+        fun lookup_reports_a_failed_read_separately/0
+    ]}.
+
+setup_repo() ->
+    meck:new(asobi_repo, [passthrough]),
+    ok.
+
+cleanup_repo(_) ->
+    catch meck:unload(asobi_repo),
+    ok.
+
+%% The lookup must not be able to return a field the list would have
+%% withheld, so it runs the same projection.
+lookup_projects_the_row() ->
+    meck:expect(asobi_repo, get, fun(asobi_player, _Id) -> {ok, sample_player()} end),
+    {ok, Row} = asobi_ops_lookup:fetch(
+        asobi_player, ~"0197f3d0-1c2b-7000-8000-000000000001", fun asobi_ops_players:project/1
+    ),
+    ?assertNot(maps:is_key(hashed_password, Row)),
+    ?assertEqual(~"kaito", maps:get(username, Row)).
+
+lookup_reports_a_miss_as_not_found() ->
+    meck:expect(asobi_repo, get, fun(_Schema, _Id) -> {error, not_found} end),
+    ?assertEqual(
+        {error, not_found},
+        asobi_ops_lookup:fetch(
+            asobi_player, ~"0197f3d0-1c2b-7000-8000-000000000001", fun identity/1
+        )
+    ).
+
+%% A dropped connection is a 500 and a miss is a 404; collapsing the two
+%% would report the database being down as "no such player".
+lookup_reports_a_failed_read_separately() ->
+    meck:expect(asobi_repo, get, fun(_Schema, _Id) -> {error, closed} end),
+    ?assertEqual(
+        {error, {query_failed, closed}},
+        asobi_ops_lookup:fetch(
+            asobi_player, ~"0197f3d0-1c2b-7000-8000-000000000001", fun identity/1
+        )
+    ).
+
+%% A binding that is not uuid-shaped must not reach Postgres: it raises
+%% there, which would turn a malformed request into a 500.
+lookup_rejects_a_malformed_id_without_a_query_test() ->
+    ?assertEqual(
+        {error, invalid_id},
+        asobi_ops_lookup:fetch(asobi_player, ~"'; drop table players --", fun identity/1)
+    ).
+
+lookup_rejects_a_missing_id_test() ->
+    ?assertEqual({error, invalid_id}, asobi_ops_lookup:fetch(asobi_player, ~"", fun identity/1)).
 
 %%--------------------------------------------------------------------
 %% Features

--- a/test/asobi_ops_tournaments_tests.erl
+++ b/test/asobi_ops_tournaments_tests.erl
@@ -1,0 +1,80 @@
+-module(asobi_ops_tournaments_tests).
+
+-include_lib("eunit/include/eunit.hrl").
+-include_lib("kura/include/kura.hrl").
+
+default_order_is_deterministic_test() ->
+    {ok, #kura_query{order_bys = Orders}} = asobi_ops_tournaments:query(#{}),
+    ?assertEqual([{start_at, desc}, {id, desc}], Orders).
+
+every_sort_ends_on_the_unique_key_test() ->
+    [
+        begin
+            {ok, #kura_query{order_bys = Orders}} = asobi_ops_tournaments:query(#{~"sort" => Wire}),
+            ?assertMatch({id, _Direction}, lists:last(Orders))
+        end
+     || {Wire, _Column} <- asobi_ops_tournaments:sortable()
+    ].
+
+reject_unknown_sort_test() ->
+    ?assertEqual(
+        {error, {unknown_sort, ~"metadata"}},
+        asobi_ops_tournaments:query(#{~"sort" => ~"metadata"})
+    ).
+
+status_filter_is_equality_test() ->
+    {ok, #kura_query{wheres = Wheres}} = asobi_ops_tournaments:query(#{~"status" => ~"active"}),
+    ?assertEqual([{status, ~"active"}], Wheres).
+
+search_is_ilike_on_the_name_test() ->
+    {ok, #kura_query{wheres = Wheres}} = asobi_ops_tournaments:query(#{~"q" => ~"summer"}),
+    ?assertEqual([{name, ilike, ~"%summer%"}], Wheres).
+
+projection_drops_game_authored_metadata_test() ->
+    Projected = asobi_ops_tournaments:project(sample()),
+    ?assertNot(maps:is_key(metadata, Projected)),
+    ?assertEqual(#{~"gold" => 100}, maps:get(rewards, Projected)).
+
+%% Sorting on a column that never leaves would leak its ordering to a caller
+%% who cannot read it.
+sortable_fields_are_all_projected_test() ->
+    Projected = maps:keys(asobi_ops_tournaments:project(sample())),
+    [
+        ?assert(lists:member(Column, Projected))
+     || {_Wire, Column} <- asobi_ops_tournaments:sortable()
+    ].
+
+%% A row can say `active` with no process behind it - after a node restart,
+%% that is exactly what the flag is for. Nothing is registered here, so every
+%% row is honestly not live.
+live_is_false_when_no_process_is_registered_test() ->
+    ?assertEqual(false, maps:get(live, asobi_ops_tournaments:project(sample()))).
+
+live_is_true_while_the_tournament_runs_test() ->
+    Id = maps:get(id, sample()),
+    yes = global:register_name({asobi_tournament_server, Id}, self()),
+    try
+        ?assertEqual(true, maps:get(live, asobi_ops_tournaments:project(sample())))
+    after
+        global:unregister_name({asobi_tournament_server, Id})
+    end.
+
+%% `project/1` runs per row from the paginator, so it must not assume the row
+%% it is handed carries every column.
+live_survives_a_row_without_an_id_test() ->
+    ?assertEqual(false, maps:get(live, asobi_ops_tournaments:project(#{name => ~"Cup"}))).
+
+sample() ->
+    #{
+        id => ~"0197f3d0-1c2b-7000-8000-0000000000aa",
+        name => ~"Summer Cup",
+        leaderboard_id => ~"summer",
+        max_entries => 64,
+        entry_fee => #{~"gold" => 10},
+        rewards => #{~"gold" => 100},
+        status => ~"active",
+        start_at => {{2026, 8, 1}, {12, 0, 0}},
+        end_at => {{2026, 8, 8}, {12, 0, 0}},
+        metadata => #{~"secret" => true},
+        inserted_at => {{2026, 7, 30}, {12, 0, 0}}
+    }.


### PR DESCRIPTION
Plan items **2a.3** (remaining list endpoints on `kura_paginator` with a deterministic order) and **2a.4** (lookup by id, `ilike` search), plus the `asobi_admin` parity gap that makes the archive decision possible.

## What is new

Eleven routes, every one `read`, every one tagged in `asobi_ops_caps:classes/0`:

| Route | Sorts on | Filters | `q` searches |
| --- | --- | --- | --- |
| `GET /ops/players/:id` | - | - | - |
| `GET /ops/matches/:id` | - | - | - |
| `GET /ops/economy/items` | `id` `slug` `name` `category` `rarity` `inserted_at` `updated_at` | `category` `rarity` | slug, name |
| `GET /ops/economy/items/:id` | - | - | - |
| `GET /ops/economy/listings` | `id` `item_def_id` `currency` `price` `active` `valid_from` `valid_until` | `item_def_id` `currency` `active` | - |
| `GET /ops/economy/listings/:id` | - | - | - |
| `GET /ops/chat/channels` | `channel_id` `members` | - | channel id |
| `GET /ops/chat/channels/:id/messages` | `id` `channel_type` `sender_id` `sent_at` | `sender_id` `channel_type` | content |
| `GET /ops/tournaments` | `id` `name` `leaderboard_id` `status` `start_at` `end_at` `inserted_at` | `status` `leaderboard_id` | name |
| `GET /ops/tournaments/:id` | - | - | - |
| `GET /ops/notifications` | `id` `player_id` `type` `subject` `read` `sent_at` | `player_id` `type` `read` | subject |

Conventions from #335 and #352 hold throughout: the `{data, page}` envelope, `asobi_ops_params` for limit/offset/sort, a sort allowlist of atoms so no user string reaches `order_by`, an order that always ends on a unique key, `ilike` with `%` and `_` escaped, and `asobi_error` for every failure.

## `/economy/listings` - the ordering bug the plan names

The console query had **no `ORDER BY` at all**, so Postgres could return rows in any order it liked and offset paging over that can repeat one row while skipping another. `store_listings` carries no `inserted_at`, so the default here is `id` descending - still newest-first, because ids are UUIDv7 and their high bits are a millisecond clock.

## Two shared pieces, so this was not copied five times

**`asobi_ops_filters`** builds every `WHERE` from a declarative spec. One rule changed: a filter on an **id** column whose value is not a uuid is now `400 ops.invalid_filter` rather than a dropped clause. Dropping it answers a request scoped to one player with every player's rows, and no part of the response says so. Everything else keeps the existing soft drop (`asobi_ops_matches`'s oversized-filter behaviour is unchanged and still pinned by its test). `asobi_ops_players` and `asobi_ops_matches` are refactored onto it, with their existing assertions untouched.

**`asobi_ops_lookup`** checks uuid shape *before* the query - Postgres raises on a malformed uuid, which would report a bad request as a 500 - and runs the list's own projection, so a detail view cannot return a field the list withheld. Three outcomes, three statuses: `ops.invalid_id` 400, `ops.not_found` 404, `ops.query_failed` 500.

## One core fix

`asobi_chat_channel:channels/0` reads the channel registry, not `pg:which_groups/1`. `pg` drops a group the moment its last member leaves, so a running channel nobody is currently joined to is invisible there - and the console asked scope `asobi_chat` while the code joins `nova_scope`, so its channel list was **always empty**. Bounded at 1000 channels, matching `asobi_leaderboards:boards/0`, so `asobi_ops_page:slice/4`'s stated "both sources are bounded" invariant still holds. No channel process is called.

## Tests

**+81 tests, 1402 total, 0 failures.** Each group verified to fail when reverted:

| Mutation | Tests that caught it |
| --- | --- |
| Drop one route from `asobi_ops_caps:classes/0` | 1 (`ops_routes_and_capability_classes_agree_test`) |
| Strip the economy `ORDER BY` | 4 |
| Silently drop a malformed uuid filter instead of rejecting | 5 |
| Read channels from `pg:which_groups/1` again | 2 |
| Skip the uuid check before the lookup query | 2 |
| Collapse `query_failed` into `not_found` | 1 |
| Stop appending the tie-break in `deterministic/2` | 10 |

The router meta-test now **enumerates** the ops group rather than listing paths, so a route added without a security or method decision fails the build; a second test asserts the plane serves no method beyond `get`/`options` and that every capability class in the table is `read`.

## Checks

`fmt --check` · `xref` · `dialyzer` · `eqwalize-all` (230, and a per-file diff against `origin/main` shows **no new errors** - the delta is 4 pre-existing ones re-counted, since every touched and new module reports NO ERRORS except the one pre-existing `asobi_ops_params` finding) · `eunit` 1402/0 · `ct` on `asobi_chat_SUITE`, `asobi_economy_SUITE`, `asobi_ops_audit_SUITE`, `asobi_api_SUITE`, `asobi_notification_SUITE` (38/38) · `ex_doc` clean.

## `asobi_admin` parity

**Now servable by `asobi_ops`:** players list, player detail, player search, matches list, match detail, economy items, economy listings, tournaments list, tournament detail, chat channels, chat messages, notifications (read), leaderboards, matchmaker, features.

**Not servable, and deliberately so:** every `asobi_admin` *mutation* (ban, unban, grant currency, create item, create listing, create tournament, broadcast) - this plane is read-only; the dashboard and system pages (`erlang:memory/0`, scheduler counts, connected nodes); the login controller; static assets.

**Not servable, and a real gap:** `asobi_admin_players:show/1` returns the player **joined with** stats, wallets, friends and presence in one response. `GET /ops/players/:id` returns the player row alone. Worth a follow-up ticket before the archive - it is either extra round trips for the console or an expansion parameter, and it is a design call, not a mechanical one. `asobi_admin_economy:index/1`'s counts are derivable from the envelope totals (`/economy/items` and `/economy/listings?active=true`), so that one needs no new route.

Read-only throughout. No write endpoints added.