### PR TITLE
fix(extensions): close three contract gaps found building the first extension

### DIFF
--- a/guides/extensions.md
+++ b/guides/extensions.md
@@ -62,7 +62,7 @@ cannot be triggered by a player action from the client.
 ```erlang
 -module(asobi_quests_extension).
 -behaviour(asobi_extension).
--export([info/0, rpc/0, lua/0, sup/0, owns/0]).
+-export([info/0, rpc/0, lua/0, sup/0, owns/0, codes/0]).
 
 info() -> #{name => quests, extension_version => 1}.
 
@@ -74,7 +74,7 @@ lua()  -> #{~"quests" =>
                                  args    => [binary, integer],
                                  effects => write,
                                  vms     => [match, world]},
-                ~"status"   => #{mfa     => {asobi_quests_lua, status, 2},
+                ~"status"   => #{mfa     => {asobi_quests_lua, status, 1},
                                  args    => [binary],
                                  effects => none,
                                  vms     => [match, world, bot]}}}.
@@ -86,6 +86,9 @@ owns() -> #{tables => [~"quests", ~"quest_progress"],
             rpc    => [~"quests"],
             lua    => [~"quests"],
             queues => [~"quests"]}.
+
+codes() -> #{~"quests.already_claimed" =>
+               #{status => 409, message => ~"This quest was already claimed."}}.
 ```
 
 Only `info/0` is required. The rest default to empty.
@@ -98,6 +101,8 @@ Only `info/0` is required. The rest default to empty.
 - `sup/0` - child specs, if you want asobi supervising them.
 - `owns/0` - the tokens this extension claims. It earns nothing with one
   extension installed; it is the N >= 2 key.
+- `codes/0` - the error codes this extension mints. Core's set is closed, so
+  an undeclared code answers 500 and logs as a core defect.
 - `info/0` - the contract version, distinct from the package version, because a
   minor release can change an experimental contract.
 
@@ -167,9 +172,31 @@ either extension has bothered with `owns/0`.
 
 Core's reserved names are derived from core itself: Lua namespaces from
 `asobi_lua_surface`, tables from core's schemas, queues from core's shigoto
-workers, and RPC prefixes from the domains of `asobi_error:codes/0` - an RPC
-prefix and an error-code domain are the same token, so owning `storage` would
-mint codes inside core's closed code set.
+workers, and RPC prefixes from the domains of `asobi_error:core_codes/0` - an
+RPC prefix and an error-code domain are the same token, so owning `storage`
+would mint codes inside core's closed code set.
+
+## Error codes
+
+`asobi_error`'s set is closed, so a code you have not declared answers 500 and
+logs as a core defect. Declare yours:
+
+```erlang
+codes() -> #{~"quests.already_claimed" =>
+               #{status => 409, message => ~"This quest was already claimed."},
+             ~"quests.not_found" =>
+               #{status => 404, message => ~"No quest exists with this id."}}.
+```
+
+`{asobi_error, ~"quests.already_claimed"}` then answers 409 with the shared
+object and logs nothing.
+
+Every code must be `<domain>.<name>`, and the domain is an RPC prefix you own:
+a code domain and an RPC prefix are the same token, so `rebar3 asobi check`
+refuses a code in core's namespace or in another extension's, and refuses a
+bare one. The set is read once at boot, from the manifest, so it stays closed
+per deployment - a string arriving in a request or a Lua script still cannot
+become a code.
 
 ## Tables
 
@@ -191,18 +218,32 @@ Rules:
   blanket cascade was rejected: cascading `wallets` would erase the financial
   ledger through `transactions.wallet_id`.
 
-### Two gaps you hit today
+Your migrations run from your own application: kura discovers them through
+`asobi_repo:migration_apps/0`, inside core's transaction and under one
+advisory lock. Declare `on_delete = cascade` on the `#kura_assoc` into
+`players.id` and the generated migration carries it.
 
-**Your migration will not run.** On the pinned kura, `kura_migrator` discovers
-migrations from exactly one OTP application. `asobi_repo:migration_apps/0` is
-the seam kura 2.20 calls; asobi pins `{kura, "~> 2.17"}`, so until the pin
-moves the host writes one delegating migration file.
+## Counters
 
-**Your foreign key will not cascade.** `#kura_assoc` has no `on_delete` field
-and rebar3_kura hardcodes `no_action`, so the generated migration gives you
-`NO ACTION` and the cascade rule cannot be satisfied by the documented
-workflow. With `no_action` the first `quest_progress` row makes that player
-undeletable, and the guest reaper swallows the violation as `skipped`.
+`update_all/2` SETs literals and kura's `on_conflict` overwrites, so neither
+accumulates. `asobi_repo:increment/3` is the primitive for the counter every
+progress-shaped extension needs:
+
+```erlang
+{ok, Row} = asobi_repo:increment(
+    asobi_quest_progress,
+    #{player_id => PlayerId, quest_id => QuestId},
+    #{counter => 1}
+).
+```
+
+One `INSERT ... ON CONFLICT ... DO UPDATE SET counter = t.counter + EXCLUDED.counter`,
+so two concurrent callers both land and the row is created if it is missing.
+The conflict target must be a primary key or covered by a unique index.
+
+There is no general `query/2`. Every identifier `increment/3` interpolates is
+a field of the schema you pass and every value is a bound parameter, which is
+a promise raw SQL through the seam could not make.
 
 ## Readiness
 

--- a/src/asobi_error.erl
+++ b/src/asobi_error.erl
@@ -21,6 +21,14 @@ The code set is closed on purpose: script- and client-supplied strings never
 become codes. An unrecognised reason is reported under a known code with the
 raw string in `details`.
 
+An installed extension widens the set by declaring `codes/0` in its manifest
+(see `m:asobi_extension`). That set is read once, at
+`asobi_extensions:resolve/0`, from validated manifests, so the set is still
+closed per deployment: nothing reachable from a request can add to it. Core's
+own codes are `core_codes/0`, which is what `m:asobi_extension_reserved`
+derives core's reserved namespaces from - an extension may only mint codes in
+a domain it owns.
+
 Codes carry their HTTP status (`status/1`), so a REST controller states the
 failure and never the number:
 
@@ -42,7 +50,7 @@ working and a new one reads one place: see `legacy/2`.
 
 -export([object/1, object/2, object/3]).
 -export([legacy/2, legacy_body/2]).
--export([status/1, message/1, codes/0]).
+-export([status/1, message/1, codes/0, core_codes/0]).
 -export([from_ws_reason/1, ws_reasons/0]).
 -export([handle/3, register_handler/0]).
 
@@ -272,9 +280,25 @@ message(Code) when is_binary(Code) ->
         false -> ?UNKNOWN_MESSAGE
     end.
 
--doc "Every defined code. The client-facing contract, enumerated.".
+-doc """
+Every defined code: core's, plus every installed extension's.
+
+The client-facing contract, enumerated. Use `core_codes/0` when the question
+is what asobi itself defines.
+""".
 -spec codes() -> [code()].
 codes() ->
+    core_codes() ++ lists:sort(maps:keys(asobi_extensions:error_codes())).
+
+-doc """
+The codes asobi itself defines.
+
+`m:asobi_extension_reserved` derives core's reserved RPC prefixes from these
+domains, and must not see extension codes: an extension would then be told it
+claims a namespace it owns.
+""".
+-spec core_codes() -> [code()].
+core_codes() ->
     [Code || {Code, _, _} <- ?CODES].
 
 -doc """
@@ -331,7 +355,16 @@ register_handler() ->
 
 -spec entry(code()) -> {code(), pos_integer(), binary()} | false.
 entry(Code) ->
-    lists:keyfind(Code, 1, ?CODES).
+    case lists:keyfind(Code, 1, ?CODES) of
+        false -> extension_entry(Code);
+        Entry -> Entry
+    end.
+
+extension_entry(Code) ->
+    case maps:find(Code, asobi_extensions:error_codes()) of
+        {ok, {Status, Message}} -> {Code, Status, Message};
+        error -> false
+    end.
 
 %% A code outside ?CODES reached a client: the contract says clients may
 %% branch on `code`, so an undefined one is a defect that must not stay

--- a/src/asobi_repo.erl
+++ b/src/asobi_repo.erl
@@ -21,7 +21,8 @@
     reload/2,
     transaction/1,
     multi/1,
-    preload/3
+    preload/3,
+    increment/3
 ]).
 
 -spec otp_app() -> asobi.
@@ -31,16 +32,8 @@ otp_app() -> asobi.
 The applications kura runs migrations from, beyond asobi itself: every
 installed extension.
 
-Inert on the pinned kura. `kura_migrator` there discovers migrations from
-exactly one application - `application:get_application(RepoMod)` - so an
-extension's migrations do not run and its tables are created by nothing. That
-is a kura defect independent of extensions: `asobi_gdpr` declares three
-schemas and no migration in any repo creates those tables.
-
-kura 2.20 adds multi-application discovery and calls this optional `kura_repo`
-callback. asobi pins `{kura, "~> 2.17"}`, where nothing calls it, so this is a
-seam and not yet a behaviour change. Moving the pin is the whole of the
-change: extension migrations then run inside core's transaction, under one
+kura calls this optional `kura_repo` callback for multi-application migration
+discovery, so extension migrations run inside core's transaction, under one
 advisory lock.
 
 kura adds the repo's own application and topologically sorts the result by
@@ -101,3 +94,145 @@ multi(M) -> kura_repo_worker:multi(?MODULE, M).
 
 -spec preload(module(), map() | [map()], [atom()]) -> map() | [map()].
 preload(Schema, Records, Assocs) -> kura_repo_worker:preload(?MODULE, Schema, Records, Assocs).
+
+-doc """
+Add to integer counters on one row atomically, creating the row if absent.
+
+`Key` is the conflict target; `Deltas` the counters to accumulate. One
+statement:
+
+```sql
+INSERT INTO quest_progress (player_id, quest_id, counter, inserted_at, updated_at)
+VALUES ($1, $2, $3, now(), now())
+ON CONFLICT (player_id, quest_id) DO UPDATE
+   SET counter = quest_progress.counter + EXCLUDED.counter, updated_at = now()
+RETURNING *
+```
+
+Neither half is expressible otherwise: `update_all/2` SETs literals, and
+kura's `on_conflict` overwrites with the excluded value rather than adding to
+the stored one. A read-modify-write instead needs the wallet's advisory-lock
+dance to stay correct under concurrency.
+
+This is the whole of asobi's raw-SQL surface, and the shape is the point.
+Every identifier in the statement is a field of `Schema`, matched against
+`Schema:fields()` and rejected unless it is a plain SQL name; every caller
+value is a bound parameter. So no caller-supplied string can reach the
+statement, which is a promise a general `query/2` could not make and the
+reason there is not one.
+
+`Key` must be a primary key or covered by a unique index, or Postgres rejects
+the conflict target. The returned map is the database row, decoded but not
+cast through the schema; use `get/2` when the cast matters.
+
+Timestamps are set when the schema declares them: `inserted_at` on the insert,
+`updated_at` on both paths.
+""".
+-spec increment(module(), #{atom() => term()}, #{atom() => integer()}) ->
+    {ok, map()} | {error, term()}.
+increment(Schema, Key, Deltas) when
+    is_atom(Schema), is_map(Key), is_map(Deltas), map_size(Key) > 0, map_size(Deltas) > 0
+->
+    case increment_statement(Schema, Key, Deltas) of
+        {ok, SQL, Params} -> increment_row(SQL, Params);
+        {error, _} = Error -> Error
+    end;
+increment(Schema, Key, Deltas) ->
+    {error, {invalid_increment, Schema, Key, Deltas}}.
+
+increment_row(SQL, Params) ->
+    case kura_repo_worker:query(?MODULE, SQL, Params) of
+        {ok, [Row]} -> {ok, Row};
+        {ok, Rows} -> {error, {unexpected_rows, length(Rows)}};
+        {error, _} = Error -> Error
+    end.
+
+increment_statement(Schema, Key, Deltas) ->
+    Columns = columns(Schema),
+    KeyFields = lists:sort(maps:keys(Key)),
+    DeltaFields = lists:sort(maps:keys(Deltas)),
+    case increment_problems(Schema, Columns, Key, KeyFields, Deltas, DeltaFields) of
+        [] -> {ok, increment_sql(Schema, Columns, KeyFields, DeltaFields), values(Key, Deltas)};
+        [Problem | _] -> {error, Problem}
+    end.
+
+values(Key, Deltas) ->
+    [maps:get(F, Key) || F <- lists:sort(maps:keys(Key))] ++
+        [maps:get(F, Deltas) || F <- lists:sort(maps:keys(Deltas))].
+
+increment_problems(Schema, Columns, Key, KeyFields, Deltas, DeltaFields) ->
+    [{unknown_field, Schema, F} || F <- KeyFields ++ DeltaFields, not is_map_key(F, Columns)] ++
+        [{conflict_target_is_also_a_counter, F} || F <- DeltaFields, is_map_key(F, Key)] ++
+        [{not_an_integer_delta, F, V} || F := V <- Deltas, not is_integer(V)] ++
+        [
+            {unsafe_identifier, Name}
+         || Name <- identifiers(Schema, Columns, KeyFields ++ DeltaFields), not is_plain_name(Name)
+        ].
+
+identifiers(Schema, Columns, Fields) ->
+    [Schema:table() | [maps:get(F, Columns, ~"") || F <- Fields]] ++
+        [maps:get(S, Columns) || S <- [inserted_at, updated_at], is_map_key(S, Columns)].
+
+increment_sql(Schema, Columns, KeyFields, DeltaFields) ->
+    Table = Schema:table(),
+    Stamps = [S || S <- [inserted_at, updated_at], is_map_key(S, Columns)],
+    Inserted =
+        [quote(maps:get(F, Columns)) || F <- KeyFields ++ DeltaFields] ++
+            [quote(maps:get(S, Columns)) || S <- Stamps],
+    Placeholders =
+        [[$$, integer_to_binary(I)] || I <- lists:seq(1, length(KeyFields) + length(DeltaFields))] ++
+            [~"now()" || _ <- Stamps],
+    Updates =
+        [accumulate(Table, maps:get(F, Columns)) || F <- DeltaFields] ++
+            [
+                [quote(maps:get(updated_at, Columns)), ~" = now()"]
+             || lists:member(updated_at, Stamps)
+            ],
+    [
+        ~"INSERT INTO ",
+        quote(Table),
+        ~" (",
+        commas(Inserted),
+        ~") VALUES (",
+        commas(Placeholders),
+        ~") ON CONFLICT (",
+        commas([quote(maps:get(F, Columns)) || F <- KeyFields]),
+        ~") DO UPDATE SET ",
+        commas(Updates),
+        ~" RETURNING *"
+    ].
+
+accumulate(Table, Column) ->
+    [quote(Column), ~" = ", quote(Table), $., quote(Column), ~" + EXCLUDED.", quote(Column)].
+
+columns(Schema) ->
+    maps:from_list([
+        {Name, column_name(Field)}
+     || #kura_field{name = Name, virtual = false} = Field <- Schema:fields()
+    ]).
+
+column_name(#kura_field{name = Name, column = undefined}) -> atom_to_binary(Name, utf8);
+column_name(#kura_field{column = Column}) -> Column.
+
+quote(Name) -> [$", Name, $"].
+
+commas(Parts) -> lists:join(~", ", Parts).
+
+%% Identifiers are interpolated, not bound, so anything a quoted name could
+%% not survive is refused rather than escaped.
+is_plain_name(<<C, Rest/binary>>) when
+    (C >= $a andalso C =< $z) orelse (C >= $A andalso C =< $Z) orelse C =:= $_
+->
+    is_plain_tail(Rest);
+is_plain_name(_Name) ->
+    false.
+
+is_plain_tail(<<>>) ->
+    true;
+is_plain_tail(<<C, Rest/binary>>) when
+    (C >= $a andalso C =< $z) orelse (C >= $A andalso C =< $Z) orelse
+        (C >= $0 andalso C =< $9) orelse C =:= $_
+->
+    is_plain_tail(Rest);
+is_plain_tail(_Name) ->
+    false.

--- a/src/extensions/asobi_extension.erl
+++ b/src/extensions/asobi_extension.erl
@@ -16,11 +16,14 @@ behaviour covers only what core cannot infer.
 ```erlang
 -module(asobi_quests_extension).
 -behaviour(asobi_extension).
--export([info/0, rpc/0, lua/0, sup/0, owns/0]).
+-export([info/0, rpc/0, lua/0, sup/0, owns/0, codes/0]).
 
 info() -> #{name => quests, extension_version => 1}.
 
 rpc()  -> #{~"quests.claim" => {asobi_quests_rpc, claim, 2}}.
+
+codes() -> #{~"quests.already_claimed" =>
+               #{status => 409, message => ~"This quest was already claimed."}}.
 
 lua()  -> #{~"quests" =>
               #{~"progress" => #{mfa     => {asobi_quests_lua, progress, 2},
@@ -35,10 +38,10 @@ owns() -> #{tables => [~"quests"], rpc => [~"quests"],
             lua => [~"quests"], queues => [~"quests"]}.
 ```
 
-Only `info/0` is required. `rpc/0`, `lua/0`, `sup/0` and `owns/0` default to
-empty, because several are frequently empty: an extension with no processes
-has no `sup/0`, and `owns/0` earns nothing until a second extension exists to
-collide with.
+Only `info/0` is required. `rpc/0`, `lua/0`, `sup/0`, `owns/0` and `codes/0`
+default to empty, because several are frequently empty: an extension with no
+processes has no `sup/0`, and `owns/0` earns nothing until a second extension
+exists to collide with.
 
 An extension declaring neither `rpc/0` nor `lua/0` is reachable by nobody:
 game logic calls `game.<ns>.*` from Lua, and clients call
@@ -65,7 +68,9 @@ second consumer has said what it is missing.
     lua_function/0,
     lua_arg/0,
     owns/0,
-    token/0
+    token/0,
+    code_spec/0,
+    codes/0
 ]).
 
 -doc "The extension's short name, and the root of everything it owns.".
@@ -117,10 +122,28 @@ takes effect without waiting for every live match VM to end.
     queues => [token()]
 }.
 
+-doc "The HTTP status and human-readable message one code carries.".
+-type code_spec() :: #{status := 100..599, message := binary()}.
+
+-doc """
+The error codes this extension mints.
+
+`asobi_error`'s own set is closed, so without this an ordinary domain failure
+answers 500 and logs as a core defect. Every code must be
+`<domain>.<name>` and every domain must be an RPC prefix this extension owns:
+a code domain and an RPC prefix are the same token, so `rebar3 asobi check`
+refuses a code in core's namespace or in another extension's.
+
+The set is read once, at resolve time, from this manifest - so it is closed
+per deployment and nothing reachable from a request can widen it.
+""".
+-type codes() :: #{asobi_error:code() => code_spec()}.
+
 -callback info() -> info().
 -callback rpc() -> rpc().
 -callback lua() -> lua().
 -callback sup() -> [supervisor:child_spec()].
 -callback owns() -> owns().
+-callback codes() -> codes().
 
--optional_callbacks([rpc/0, lua/0, sup/0, owns/0]).
+-optional_callbacks([rpc/0, lua/0, sup/0, owns/0, codes/0]).

--- a/src/extensions/asobi_extension_reserved.erl
+++ b/src/extensions/asobi_extension_reserved.erl
@@ -14,10 +14,14 @@ cannot drift:
 - **tables** from every core `kura_schema` module's `table/0`, found the same
   way asobi finds an extension's schemas.
 - **queues** from every core `shigoto_worker` module's `queue/0`.
-- **rpc** from the domains of `asobi_error:codes/0`, plus the Lua namespaces.
-  An RPC prefix and an error domain are the same token by construction
-  (`{"code": "quests.name_taken"}`), so an extension owning the `storage`
-  prefix would mint codes inside core's closed code set.
+- **rpc** from the domains of `asobi_error:core_codes/0`, plus the Lua
+  namespaces. An RPC prefix and an error domain are the same token by
+  construction (`{"code": "quests.name_taken"}`), so an extension owning the
+  `storage` prefix would mint codes inside core's closed code set.
+
+  `core_codes/0` rather than `codes/0` on purpose: `codes/0` includes the codes
+  the installed extensions declare, and reserving those would tell an extension
+  it may not claim the namespace it just claimed.
 
 Deriving from modules costs one `code:ensure_loaded/1` sweep over core's
 module list. `asobi_extensions` only asks for it when at least one extension
@@ -60,7 +64,7 @@ lua_namespace([~"game", Namespace]) -> [Namespace];
 lua_namespace(_) -> [].
 
 error_domains() ->
-    lists:usort([Domain || Code <- asobi_error:codes(), Domain <- domain(Code)]).
+    lists:usort([Domain || Code <- asobi_error:core_codes(), Domain <- domain(Code)]).
 
 domain(Code) ->
     case binary:split(Code, ~".") of

--- a/src/extensions/asobi_extensions.erl
+++ b/src/extensions/asobi_extensions.erl
@@ -19,7 +19,7 @@ Its callers, in boot order:
 
 1. `asobi_router:routes/1`, inside Nova's boot.
 2. `asobi_app:start/2`, before migrations.
-3. `asobi_repo:migration_apps/0`, once the kura pin reaches 2.20.0.
+3. `asobi_repo:migration_apps/0`, when kura discovers migrations.
 
 Discovery walks the **OTP application graph**, not Nova's `nova_apps`.
 `nova_apps` only sees Nova apps, so a Lua-only or jobs-only extension would be
@@ -43,12 +43,13 @@ surfaces with Nova's crash context rather than a legible asobi error.
 
 -include_lib("kernel/include/logger.hrl").
 
--export([resolve/0, check/0, validate/1, describe/1, sup_specs/1]).
+-export([resolve/0, check/0, validate/1, describe/1, sup_specs/1, error_codes/0]).
 -ifdef(TEST).
 -export([reset/0]).
 -endif.
 
 -define(KEY, {?MODULE, resolved}).
+-define(CODES_KEY, {?MODULE, error_codes}).
 
 -doc "One resolved extension. `sup/0` is deliberately absent; see `sup_specs/1`.".
 -type extension() :: #{
@@ -58,7 +59,8 @@ surfaces with Nova's crash context rather than a legible asobi error.
     extension_version := pos_integer(),
     rpc := asobi_extension:rpc(),
     lua := asobi_extension:lua(),
-    owns := asobi_extension:owns()
+    owns := asobi_extension:owns(),
+    codes := asobi_extension:codes()
 }.
 
 -type problem() ::
@@ -82,11 +84,33 @@ resolve() ->
     case persistent_term:get(?KEY, undefined) of
         undefined ->
             Extensions = resolve_now(),
+            persistent_term:put(?CODES_KEY, error_code_table(Extensions)),
             persistent_term:put(?KEY, Extensions),
             Extensions;
         Extensions ->
             Extensions
     end.
+
+-doc """
+Every error code the installed extensions mint, as `Code => {Status, Message}`.
+
+`asobi_error` reads this rather than resolving, so building an error object
+never triggers discovery and never raises: before `resolve/0` has run there
+are no extension codes, and `resolve/0` runs inside Nova's boot, long before
+any request can fail.
+""".
+-spec error_codes() -> #{asobi_error:code() => {pos_integer(), binary()}}.
+error_codes() ->
+    persistent_term:get(?CODES_KEY, #{}).
+
+%% The codes term is written before the resolved term, so a concurrent second
+%% caller that sees ?KEY populated also sees the codes it implies.
+error_code_table(Extensions) ->
+    maps:from_list([
+        {Code, {Status, Message}}
+     || #{codes := Codes} <- Extensions,
+        Code := #{status := Status, message := Message} <- Codes
+    ]).
 
 %% Two concurrent first callers both compute and both write. The computation
 %% is a pure function of the loaded application set, so they write the same
@@ -140,6 +164,7 @@ sup_specs(Module) ->
 -spec reset() -> ok.
 reset() ->
     _ = persistent_term:erase(?KEY),
+    _ = persistent_term:erase(?CODES_KEY),
     ok.
 -endif.
 
@@ -232,6 +257,7 @@ read_manifest(App, Module) ->
         {rpc, call(Module, rpc, #{})},
         {lua, call(Module, lua, #{})},
         {owns, call(Module, owns, #{})},
+        {codes, call(Module, codes, #{})},
         {sup, call(Module, sup, [])}
     ],
     case [{Key, Detail} || {Key, {error, Detail}} <- Reads] of
@@ -254,8 +280,9 @@ call(Module, Function, Default) ->
             end
     end.
 
-build(App, Module, #{info := Info, rpc := Rpc, lua := Lua, owns := Owns, sup := Sup}) ->
-    case shape_problems(Info, Rpc, Lua, Owns, Sup) of
+build(App, Module, Values) ->
+    #{info := Info, rpc := Rpc, lua := Lua, owns := Owns, codes := Codes, sup := Sup} = Values,
+    case shape_problems(Info, Rpc, Lua, Owns, Codes, Sup) of
         [] ->
             #{name := Name, extension_version := Version} = Info,
             {ok, #{
@@ -265,17 +292,19 @@ build(App, Module, #{info := Info, rpc := Rpc, lua := Lua, owns := Owns, sup := 
                 extension_version => Version,
                 rpc => Rpc,
                 lua => Lua,
-                owns => Owns
+                owns => Owns,
+                codes => Codes
             }};
         Details ->
             {error, [{bad_manifest, App, Module, Detail} || Detail <- Details]}
     end.
 
-shape_problems(Info, Rpc, Lua, Owns, Sup) ->
+shape_problems(Info, Rpc, Lua, Owns, Codes, Sup) ->
     info_problems(Info) ++
         rpc_problems(Rpc) ++
         lua_problems(Lua) ++
         owns_problems(Owns) ++
+        codes_problems(Codes) ++
         sup_problems(Sup).
 
 info_problems(#{name := Name, extension_version := Version}) when
@@ -319,20 +348,30 @@ lua_problems(Lua) ->
 
 lua_namespace_problems(Namespace, Functions) when is_binary(Namespace), is_map(Functions) ->
     [
-        {lua, ~"binding must be #{mfa, args, effects, vms}", {Namespace, Name}}
+        {lua, binding_problem(Binding), {Namespace, Name}}
      || Name := Binding <- Functions, not is_lua_binding(Name, Binding)
     ];
 lua_namespace_problems(Namespace, _Functions) ->
     [{lua, ~"namespace must be a binary mapped to a map of functions", Namespace}].
 
+%% `args` is what the injector decodes off the Lua stack and `mfa` is what it
+%% then applies, so a binding whose lengths disagree cannot be called at all.
 is_lua_binding(Name, #{mfa := {M, F, A}, args := Args, effects := Effects, vms := Vms}) when
     is_binary(Name), is_atom(M), is_atom(F), is_integer(A), A >= 0, is_list(Args), is_list(Vms)
 ->
-    lists:member(Effects, asobi_lua_surface:effects()) andalso
+    length(Args) =:= A andalso
+        lists:member(Effects, asobi_lua_surface:effects()) andalso
         Vms =/= [] andalso
         lists:all(fun(Vm) -> lists:member(Vm, asobi_lua_surface:vm_kinds()) end, Vms);
 is_lua_binding(_Name, _Binding) ->
     false.
+
+binding_problem(#{mfa := {_, _, A}, args := Args}) when
+    is_integer(A), is_list(Args), length(Args) =/= A
+->
+    ~"args must declare one type per mfa argument";
+binding_problem(_Binding) ->
+    ~"binding must be #{mfa, args, effects, vms}".
 
 owns_problems(Owns) when is_map(Owns) ->
     Kinds = asobi_extension_reserved:kinds(),
@@ -350,6 +389,24 @@ owns_problems(Owns) ->
 is_token_list(Tokens) when is_list(Tokens) ->
     lists:all(fun(T) -> is_binary(T) andalso T =/= ~"" end, Tokens);
 is_token_list(_) ->
+    false.
+
+%% A bare code would sit in core's cross-cutting namespace (`internal`,
+%% `forbidden`), which no extension owns and the reserved set cannot protect.
+%% Requiring a domain is what makes an extension code checkable at all.
+codes_problems(Codes) when is_map(Codes) ->
+    [
+        {codes, ~"code must be <domain>.<name> mapped to #{status, message}", Code}
+     || Code := Spec <- Codes, not is_code_spec(Code, Spec)
+    ];
+codes_problems(Codes) ->
+    [{codes, ~"must be a map", Codes}].
+
+is_code_spec(Code, #{status := Status, message := Message}) when
+    is_integer(Status), Status >= 100, Status =< 599, is_binary(Message), Message =/= ~""
+->
+    is_dotted(Code);
+is_code_spec(_Code, _Spec) ->
     false.
 
 %% OTP already knows what a valid child spec is. Running its check here turns
@@ -373,10 +430,10 @@ Namespace disjointness across the declared set, and against core's reserved
 names.
 
 The claim set per namespace is `owns/0` **plus** what the manifest already
-implies: the prefixes in `rpc/0` and the namespaces in `lua/0`. So two
-extensions installing the same `game.quests` collide even before either has
-bothered with `owns/0`, which earns nothing until there is a second
-extension.
+implies: the prefixes in `rpc/0`, the domains in `codes/0` and the namespaces
+in `lua/0`. So two extensions installing the same `game.quests` collide even
+before either has bothered with `owns/0`, which earns nothing until there is a
+second extension.
 """.
 -spec validate([extension()]) -> ok | {error, [problem(), ...]}.
 validate([]) ->
@@ -426,8 +483,15 @@ claims(Extension, Kind) ->
     #{owns := Owns} = Extension,
     lists:usort(maps:get(Kind, Owns, []) ++ derived(Extension, Kind)).
 
-derived(#{rpc := Rpc}, rpc) ->
-    lists:usort([Prefix || Method := _ <- Rpc, Prefix <- prefix(Method)]);
+%% An error-code domain and an RPC prefix are the same token by construction,
+%% so `codes/0` claims the rpc namespace exactly as `rpc/0` does. That is what
+%% keeps an extension from minting codes inside core's set, or another
+%% extension's, without a second reservation mechanism.
+derived(#{rpc := Rpc, codes := Codes}, rpc) ->
+    lists:usort(
+        [Prefix || Method := _ <- Rpc, Prefix <- prefix(Method)] ++
+            [Domain || Code := _ <- Codes, Domain <- prefix(Code)]
+    );
 derived(#{lua := Lua}, lua) ->
     lists:usort(maps:keys(Lua));
 derived(_Extension, _Kind) ->

--- a/test/asobi_repo_increment_SUITE.erl
+++ b/test/asobi_repo_increment_SUITE.erl
@@ -1,0 +1,67 @@
+-module(asobi_repo_increment_SUITE).
+
+-include_lib("nova_test/include/nova_test.hrl").
+-include_lib("stdlib/include/assert.hrl").
+
+-export([all/0, init_per_suite/1, end_per_suite/1]).
+-export([accumulates_rather_than_overwrites/1, creates_the_row_when_it_is_missing/1]).
+
+%% asobi#362: an extension counter needs SET c = c + EXCLUDED.c, which neither
+%% update_all/2 nor kura's on_conflict expresses. The statement and its uuid
+%% parameter only get exercised against a real Postgres here.
+
+all() -> [accumulates_rather_than_overwrites, creates_the_row_when_it_is_missing].
+
+init_per_suite(Config) ->
+    Config0 = asobi_test_helpers:start(Config),
+    [{player_id, register_player(Config0)} | Config0].
+
+end_per_suite(Config) ->
+    Config.
+
+register_player(Config) ->
+    Username = asobi_test_helpers:unique_username(~"increment"),
+    {ok, Resp} = nova_test:post(
+        "/api/v1/auth/register",
+        #{json => #{~"username" => Username, ~"password" => ~"testpass123"}},
+        Config
+    ),
+    #{~"player_id" := PlayerId} = nova_test:json(Resp),
+    PlayerId.
+
+player_id(Config) ->
+    {player_id, PlayerId} = lists:keyfind(player_id, 1, Config),
+    PlayerId.
+
+increment(PlayerId, Deltas) ->
+    asobi_repo:increment(asobi_player_stats, #{player_id => PlayerId}, Deltas).
+
+accumulates_rather_than_overwrites(Config) ->
+    PlayerId = player_id(Config),
+    ?assertMatch({ok, _}, asobi_repo:get(asobi_player_stats, PlayerId)),
+
+    {ok, First} = increment(PlayerId, #{games_played => 1, wins => 1}),
+    ?assertMatch(#{games_played := 1, wins := 1}, First),
+
+    %% An overwrite would leave games_played at 2. Accumulation makes it 3.
+    {ok, Second} = increment(PlayerId, #{games_played => 2, losses => 1}),
+    ?assertMatch(#{games_played := 3, wins := 1, losses := 1}, Second),
+
+    ?assertMatch(
+        #{games_played := 3, wins := 1, losses := 1},
+        element(2, asobi_repo:get(asobi_player_stats, PlayerId))
+    ),
+    Config.
+
+%% The insert half. An extension's progress row does not exist until the first
+%% event, and needing a separate insert-then-retry is the race the primitive
+%% exists to remove.
+creates_the_row_when_it_is_missing(Config) ->
+    PlayerId = player_id(Config),
+    {ok, Row} = asobi_repo:get(asobi_player_stats, PlayerId),
+    {ok, _} = asobi_repo:delete(asobi_player_stats, Row),
+    ?assertMatch({error, _}, asobi_repo:get(asobi_player_stats, PlayerId)),
+
+    {ok, Created} = increment(PlayerId, #{games_played => 5}),
+    ?assertMatch(#{games_played := 5, wins := 0}, Created),
+    Config.

--- a/test/asobi_repo_increment_tests.erl
+++ b/test/asobi_repo_increment_tests.erl
@@ -1,0 +1,108 @@
+-module(asobi_repo_increment_tests).
+-include_lib("eunit/include/eunit.hrl").
+
+%% asobi#362: the statement shape, and everything the seam refuses before it
+%% reaches Postgres. Accumulation against a real database is
+%% asobi_repo_increment_SUITE.
+
+-define(TAB, asobi_repo_increment_tests_sql).
+
+setup() ->
+    case ets:whereis(?TAB) of
+        undefined -> ets:new(?TAB, [named_table, public, duplicate_bag]);
+        _ -> ets:delete_all_objects(?TAB)
+    end,
+    meck:new(kura_db, [passthrough, no_link]),
+    meck:expect(kura_db, query, fun(_Repo, SQL, Params) ->
+        ets:insert(?TAB, {iolist_to_binary(SQL), Params}),
+        #{rows => [#{games_played => 1}]}
+    end),
+    ok.
+
+cleanup(_) ->
+    meck:unload(kura_db),
+    ok.
+
+increment_test_() ->
+    {foreach, fun setup/0, fun cleanup/1, [
+        {"the statement accumulates rather than overwrites", fun accumulates/0},
+        {"the conflict target is the key, and timestamps ride along", fun conflict_target/0},
+        {"every caller value is a bound parameter", fun values_are_parameters/0},
+        {"a column outside the schema never reaches SQL", fun unknown_field/0},
+        {"a non-integer delta is refused", fun non_integer_delta/0},
+        {"a counter cannot also be the conflict target", fun overlapping_key/0},
+        {"an empty key or empty deltas is refused", fun empty_maps/0}
+    ]}.
+
+increment() ->
+    asobi_repo:increment(
+        asobi_player_stats,
+        #{player_id => ~"p1"},
+        #{games_played => 1, wins => 2}
+    ).
+
+sql() ->
+    [{SQL, _}] = ets:tab2list(?TAB),
+    SQL.
+
+contains(SQL, Fragment) ->
+    ?assertNotEqual(nomatch, binary:match(SQL, Fragment)).
+
+%% The whole point: kura's on_conflict replaces with the excluded value, which
+%% loses every concurrent increment but the last.
+accumulates() ->
+    ?assertMatch({ok, #{games_played := 1}}, increment()),
+    SQL = sql(),
+    contains(
+        SQL, ~"\"games_played\" = \"player_stats\".\"games_played\" + EXCLUDED.\"games_played\""
+    ),
+    contains(SQL, ~"\"wins\" = \"player_stats\".\"wins\" + EXCLUDED.\"wins\""),
+    contains(SQL, ~"DO UPDATE SET").
+
+conflict_target() ->
+    {ok, _} = increment(),
+    SQL = sql(),
+    contains(SQL, ~"INSERT INTO \"player_stats\""),
+    contains(SQL, ~"ON CONFLICT (\"player_id\")"),
+    contains(SQL, ~"\"updated_at\" = now()"),
+    contains(SQL, ~"RETURNING *").
+
+%% Nothing the caller supplies is interpolated: the id is $1, never text.
+values_are_parameters() ->
+    {ok, _} = increment(),
+    [{SQL, Params}] = ets:tab2list(?TAB),
+    ?assertEqual([~"p1", 1, 2], Params),
+    ?assertEqual(nomatch, binary:match(SQL, ~"p1")),
+    contains(SQL, ~"$1").
+
+unknown_field() ->
+    ?assertEqual(
+        {error, {unknown_field, asobi_player_stats, robert}},
+        asobi_repo:increment(asobi_player_stats, #{player_id => ~"p1"}, #{robert => 1})
+    ),
+    ?assertEqual([], ets:tab2list(?TAB)).
+
+non_integer_delta() ->
+    ?assertEqual(
+        {error, {not_an_integer_delta, wins, ~"1"}},
+        asobi_repo:increment(asobi_player_stats, #{player_id => ~"p1"}, #{wins => ~"1"})
+    ),
+    ?assertEqual([], ets:tab2list(?TAB)).
+
+overlapping_key() ->
+    ?assertEqual(
+        {error, {conflict_target_is_also_a_counter, wins}},
+        asobi_repo:increment(asobi_player_stats, #{wins => 1}, #{wins => 1})
+    ),
+    ?assertEqual([], ets:tab2list(?TAB)).
+
+empty_maps() ->
+    ?assertMatch(
+        {error, {invalid_increment, _, _, _}},
+        asobi_repo:increment(asobi_player_stats, #{}, #{wins => 1})
+    ),
+    ?assertMatch(
+        {error, {invalid_increment, _, _, _}},
+        asobi_repo:increment(asobi_player_stats, #{player_id => ~"p1"}, #{})
+    ),
+    ?assertEqual([], ets:tab2list(?TAB)).

--- a/test/extensions/asobi_extensions_tests.erl
+++ b/test/extensions/asobi_extensions_tests.erl
@@ -32,7 +32,16 @@ extensions_test_() ->
         fun a_raising_manifest_is_reported_not_propagated/0,
         fun invalid_child_specs_caught_before_boot/0,
         fun unknown_owns_key_refused/0,
-        fun resolve_raises_on_an_invalid_set/0
+        fun resolve_raises_on_an_invalid_set/0,
+        fun lua_args_must_match_the_mfa_arity/0,
+        fun a_declared_code_carries_its_status_and_message/0,
+        fun an_undeclared_code_is_still_a_server_bug/0,
+        fun core_codes_stay_core_only/0,
+        fun a_code_in_a_reserved_domain_refused/0,
+        fun a_code_outside_the_owned_set_refused/0,
+        fun one_code_domain_two_claimants/0,
+        fun a_bare_code_refused/0,
+        fun a_malformed_code_spec_refused/0
     ]}.
 
 setup() ->
@@ -109,9 +118,8 @@ resolve_is_memoised() ->
     asobi_extensions:reset(),
     ?assertEqual(2, length(asobi_extensions:resolve())).
 
-%% kura 2.20 calls this optional kura_repo callback; the pinned 2.17 does not,
-%% so it is a seam. It names the extensions only: kura adds the repo's own
-%% application and sorts the result itself.
+%% kura calls this optional kura_repo callback. It names the extensions only:
+%% kura adds the repo's own application and sorts the result itself.
 the_migration_seam_lists_the_extensions() ->
     ?assertEqual([], asobi_repo:migration_apps()),
     install(?QUESTS),
@@ -220,6 +228,113 @@ resolve_raises_on_an_invalid_set() ->
     tunable(#{lua => #{~"quests" => #{}}}),
     ?assertError({asobi_extensions, _}, asobi_extensions:resolve()).
 
+%% --- Lua bindings ---
+
+%% asobi#361. `args` is what the injector decodes and `mfa` is what it applies,
+%% so a binding whose lengths disagree cannot be called at all. Core's own
+%% quests fixture shipped one of these.
+lua_args_must_match_the_mfa_arity() ->
+    tunable(#{
+        lua => #{
+            ~"tunable" => #{
+                ~"status" => #{
+                    mfa => {tunable_lua, status, 2},
+                    args => [binary],
+                    effects => none,
+                    vms => [match]
+                }
+            }
+        }
+    }),
+    ?assertMatch(
+        [{bad_manifest, ?TUNABLE, _, {lua, ~"args must declare one type per mfa argument", _}}],
+        check_problems()
+    ),
+    retune(#{
+        lua => #{
+            ~"tunable" => #{
+                ~"status" => #{
+                    mfa => {tunable_lua, status, 1},
+                    args => [binary],
+                    effects => none,
+                    vms => [match]
+                }
+            }
+        }
+    }),
+    ?assertMatch({ok, [_]}, asobi_extensions:check()).
+
+%% --- Error codes ---
+
+%% asobi#360. An extension reporting an ordinary domain condition must not
+%% answer 500 and page somebody.
+a_declared_code_carries_its_status_and_message() ->
+    install(?QUESTS),
+    _ = asobi_extensions:resolve(),
+    ?assertEqual(409, asobi_error:status(~"quests.already_claimed")),
+    ?assertEqual(404, asobi_error:status(~"quests.not_found")),
+    ?assertEqual(
+        ~"This quest was already claimed.", asobi_error:message(~"quests.already_claimed")
+    ),
+    ?assertMatch(
+        #{error := #{code := ~"quests.already_claimed", details := #{}}},
+        asobi_error:object(~"quests.already_claimed")
+    ),
+    ?assert(lists:member(~"quests.already_claimed", asobi_error:codes())).
+
+%% The set stays closed. Owning the domain does not mint every code inside it.
+an_undeclared_code_is_still_a_server_bug() ->
+    install(?QUESTS),
+    _ = asobi_extensions:resolve(),
+    ?assertEqual(500, asobi_error:status(~"quests.invented_at_runtime")),
+    ?assertNotEqual(
+        asobi_error:message(~"quests.already_claimed"),
+        asobi_error:message(~"quests.invented_at_runtime")
+    ).
+
+%% asobi_extension_reserved derives core's reserved RPC prefixes from
+%% core_codes/0. If it saw the extension's own codes it would tell the
+%% extension it may not claim the namespace it just claimed.
+core_codes_stay_core_only() ->
+    install(?QUESTS),
+    _ = asobi_extensions:resolve(),
+    ?assertNot(lists:member(~"quests.already_claimed", asobi_error:core_codes())),
+    %% Re-validating a node whose extension codes are already installed - what
+    %% `rebar3 asobi check` does against a booted release - must not now tell
+    %% quests it claims a namespace core reserves.
+    ?assertMatch({ok, [_]}, asobi_extensions:check()).
+
+a_code_in_a_reserved_domain_refused() ->
+    tunable(#{codes => #{~"storage.wedged" => #{status => 409, message => ~"No."}}}),
+    ?assert(lists:member({reserved_namespace, rpc, ~"storage", ?TUNABLE}, check_problems())).
+
+a_code_outside_the_owned_set_refused() ->
+    tunable(#{
+        owns => #{rpc => [~"tunable"]},
+        codes => #{~"gold.spent" => #{status => 402, message => ~"No gold."}}
+    }),
+    ?assert(lists:member({undeclared_claim, rpc, ~"gold", ?TUNABLE}, check_problems())).
+
+one_code_domain_two_claimants() ->
+    install(?QUESTS),
+    tunable(#{codes => #{~"quests.stalled" => #{status => 409, message => ~"Stalled."}}}),
+    assert_conflict(rpc, ~"quests").
+
+%% A bare code sits in core's cross-cutting namespace, which no extension owns
+%% and the reserved set cannot protect.
+a_bare_code_refused() ->
+    tunable(#{codes => #{~"already_claimed" => #{status => 409, message => ~"No."}}}),
+    ?assertMatch(
+        [{bad_manifest, ?TUNABLE, _, {codes, _, ~"already_claimed"}}],
+        check_problems()
+    ).
+
+a_malformed_code_spec_refused() ->
+    tunable(#{codes => #{~"tunable.nope" => #{status => 4090, message => ~"No."}}}),
+    ?assertMatch([{bad_manifest, ?TUNABLE, _, {codes, _, ~"tunable.nope"}}], check_problems()),
+    retune(#{codes => #{~"tunable.nope" => #{status => 409}}}),
+    ?assertMatch([{bad_manifest, ?TUNABLE, _, {codes, _, ~"tunable.nope"}}], check_problems()).
+
 %% --- Helpers ---
 
 install(?QUESTS) ->
@@ -230,6 +345,10 @@ install(?MINIMAL) ->
 tunable(Manifest) ->
     ok = asobi_fixture_tunable_extension:set(Manifest),
     ok = asobi_fixture_app:install(?TUNABLE, asobi_fixture_tunable_extension, []).
+
+%% The application is already loaded; only the manifest changes.
+retune(Manifest) ->
+    ok = asobi_fixture_tunable_extension:set(Manifest).
 
 check_problems() ->
     case asobi_extensions:check() of

--- a/test/extensions/asobi_fixture_quests_extension.erl
+++ b/test/extensions/asobi_fixture_quests_extension.erl
@@ -2,7 +2,7 @@
 -moduledoc "A complete extension manifest, shaped exactly like the design's worked example.".
 -behaviour(asobi_extension).
 
--export([info/0, rpc/0, lua/0, sup/0, owns/0]).
+-export([info/0, rpc/0, lua/0, sup/0, owns/0, codes/0]).
 
 -spec info() -> asobi_extension:info().
 info() ->
@@ -26,7 +26,7 @@ lua() ->
                 vms => [match, world]
             },
             ~"status" => #{
-                mfa => {asobi_fixture_quests_lua, status, 2},
+                mfa => {asobi_fixture_quests_lua, status, 1},
                 args => [binary],
                 effects => none,
                 vms => [match, world, bot]
@@ -42,6 +42,15 @@ sup() ->
             start => {asobi_fixture_worker, start_link, [asobi_fixture_quests_worker]}
         }
     ].
+
+-spec codes() -> asobi_extension:codes().
+codes() ->
+    #{
+        ~"quests.already_claimed" => #{
+            status => 409, message => ~"This quest was already claimed."
+        },
+        ~"quests.not_found" => #{status => 404, message => ~"No quest exists with this id."}
+    }.
 
 -spec owns() -> asobi_extension:owns().
 owns() ->

--- a/test/extensions/asobi_fixture_tunable_extension.erl
+++ b/test/extensions/asobi_fixture_tunable_extension.erl
@@ -5,7 +5,7 @@ and colliding shape instead of a file per case.
 """.
 -behaviour(asobi_extension).
 
--export([info/0, rpc/0, lua/0, sup/0, owns/0]).
+-export([info/0, rpc/0, lua/0, sup/0, owns/0, codes/0]).
 -export([set/1, clear/0]).
 
 -define(KEY, {?MODULE, manifest}).
@@ -38,6 +38,10 @@ sup() ->
 -spec owns() -> asobi_extension:owns().
 owns() ->
     value(owns, #{}).
+
+-spec codes() -> asobi_extension:codes().
+codes() ->
+    value(codes, #{}).
 
 value(Key, Default) ->
     case maps:get(Key, persistent_term:get(?KEY, #{}), Default) of


### PR DESCRIPTION
Three gaps `asobi_quests` hit as the first real extension built against the
machinery merged in #359. Closes #360, closes #361, closes #362.

## #360 - an extension cannot mint an error code

`asobi_extension` gains an optional `codes/0`:

```erlang
codes() -> #{~"quests.already_claimed" =>
               #{status => 409, message => ~"This quest was already claimed."}}.
```

**Shape, and why.** The ticket offered a `register_codes/1` call or a manifest
callback. The callback wins because it is checkable before boot and needs no
process, but the merge direction matters more than the declaration:

- `asobi_extensions:resolve/0` builds one `Code => {Status, Message}` map into
  `persistent_term` from validated manifests. `asobi_error` reads it; it never
  calls `resolve/0`. Nothing pushes into `asobi_error`, so the only writer is
  the resolve path and the set is closed per deployment - a string arriving in
  a request or a Lua script still cannot become a code. The literal-code rule
  `asobi_error_contract_tests` enforces over core is unchanged.
- A code domain now claims the `rpc` namespace exactly as an RPC prefix does,
  since they are the same token by construction. That gets the whole
  reservation for free: `storage.wedged` is refused as reserved, a domain
  outside `owns.rpc` is an undeclared claim, and two extensions in one domain
  collide. No second mechanism.
- `asobi_error:core_codes/0` is new and is what `asobi_extension_reserved`
  derives from. Deriving from `codes/0` once extension codes are installed
  would tell quests it may not claim `quests` - latent today because `check/0`
  runs before the term is written, live the moment anything re-validates a
  booted node.

A code the extension did not declare is still 500 and still logs
`undefined_error_code`. Owning the domain does not mint every code inside it.

## #362 - no raw-query escape hatch

`asobi_repo:increment/3`, not `query/2`:

```erlang
{ok, Row} = asobi_repo:increment(asobi_quest_progress,
                                 #{player_id => P, quest_id => Q},
                                 #{counter => 1}).
```

One `INSERT ... ON CONFLICT ... DO UPDATE SET counter = t.counter +
EXCLUDED.counter`, with the insert half so the first event does not need an
insert-then-retry - which is the race the primitive exists to remove.

**Why not the two-line `query/2` the ticket proposed.** A raw-SQL hole in the
data seam is an injection surface the moment any part of it takes a
caller-supplied string, and on a library that surface is permanent. The shape
here makes it structurally impossible: every identifier is a field of the
schema you pass, matched against `Schema:fields()` and rejected unless it is a
plain SQL name; every caller value is a bound parameter. `query/2` could not
make that promise, and once it existed every extension would reach for it
rather than the safe primitive. If something else is not expressible, that is
a ticket against core, not a hole in the seam.

**Where core has the same problem.** Two sites, both named in the PR body
rather than changed:

- `asobi_economy:acquire_wallet_lock/2` - `pg_advisory_xact_lock`, not a
  counter and not something a counter primitive should grow to cover.
- `asobi_player_stats:bump/3` - the exact twin of the quests case. Left
  deliberately: `bump/3` runs inside the transaction that makes a match final,
  and today a missing stats row is a 0-row UPDATE and a warning. Under an
  upsert a deleted player becomes a foreign-key violation, which in Postgres
  aborts the enclosing transaction and would take the match record with it.
  Worth doing, but behind its own change with its own test.

## #361 - args length never checked against mfa arity

Confirmed: one guard clause. `length(Args) =:= A` in `is_lua_binding/2`, plus a
`binding_problem/1` that names the mismatch instead of reporting it as a
generic malformed binding. Core's own `asobi_fixture_quests_extension` declared
`status` with `args => [binary]` and arity 2 - fixed to arity 1, and the same
mistake fixed in the guide's worked example.

## Documentation drift

`guides/extensions.md`'s "Two gaps you hit today" is gone: kura is pinned at
2.20.1, migrations run through `asobi_repo:migration_apps/0` and
`#kura_assoc.on_delete` exists. The same stale claim in
`asobi_repo:migration_apps/0`'s moduledoc and one test comment went with it.
The guide gains sections for error codes and counters.

## Tests

12 new tests, each verified to fail when its fix is reverted:

| Revert | Failing tests |
|---|---|
| `entry/1` extension lookup | 2 |
| code domains claim `rpc` | 3 |
| `codes_problems/1` | 2 |
| `core_codes/0` in the reserved set | 1 |
| `length(Args) =:= A` | 1 |
| `+ EXCLUDED` -> replace | 1 eunit, 1 ct |

`asobi_repo_increment_SUITE` runs against real Postgres. Its second case
(`creates_the_row_when_it_is_missing`) covers the insert half and passes under
the accumulate-revert, since only the conflict branch changes there.

fmt, xref, dialyzer, ex_doc clean. Full eunit 1418/0. ct for
`asobi_repo_increment_SUITE`, `asobi_match_stats_SUITE` and
`asobi_economy_SUITE` green.