### PR TITLE
fix: clear the open defect backlog (#334, #348, #312, #313, #357)

### DIFF
--- a/docs/adr/0005-telemetry-event-surface.md
+++ b/docs/adr/0005-telemetry-event-surface.md
@@ -66,7 +66,7 @@ building an exporter safely - not a step to defer until after one is built.
   cardinality cap.
 - **Unbounded metadata** - per-entity identifiers, client-controlled values,
   or free-form data: `match_id`, `world_id`, `player_id`, `sender_id`,
-  `vote_id`, `peer_ip`, `channel_id`, `details`, `result`, and `type` on
+  `vote_id`, `peer_ip`, `channel_id`, `coords`, `details`, `result`, and `type` on
   `ws/message_in` and `ws/message_out`. **Never** route these into a metric
   label. They stay on the raw event for tracing/audit sinks (e.g.
   `opentelemetry_asobi` spans) that can afford per-entity cardinality.
@@ -79,12 +79,34 @@ building an exporter safely - not a step to defer until after one is built.
 - `finished`: measurements add `duration_ms`; metadata `#{match_id, result :: map()}`
 - `player_joined` / `player_left`: metadata `#{match_id, player_id}`
 
-#### World - `[asobi, world, started | finished | player_joined | player_left | phase_changed]`
+#### World - `[asobi, world, started | finished | player_joined | player_left | phase_changed | tick]`
 
 - `started`: metadata `#{world_id, mode}`
 - `finished`: measurements add `duration_ms`; metadata `#{world_id, result :: map()}`
 - `player_joined` / `player_left`: metadata `#{world_id, player_id}`
 - `phase_changed`: metadata `#{world_id, from_phase, to_phase}`
+- `tick`: measurements `#{duration_ms, max_duration_ms, zone_count, count}`;
+  metadata `#{world_id}`. A world tick is the fan-out from
+  `asobi_world_ticker` to every zone plus the fan-in of their `tick_done`
+  replies, so `duration_ms` is the saturation signal that degrades first
+  under entity load. **Sampled, not per tick**: at the default 50 ms tick
+  rate a raw per-tick event is 20/s per world, so the ticker emits roughly
+  once a second (`tick_sample_interval_ms`, default 1000, divided by the
+  tick rate) and carries `max_duration_ms` - the worst tick in the sampled
+  window - alongside the sampled tick's own `duration_ms`. Alert on the max;
+  a sampled duration alone hides exactly the spikes worth paging on. A tick
+  that never fans in (a zone died mid-tick) is not sampled at all rather
+  than being reported with a fabricated duration.
+
+#### Zone - `[asobi, zone, opened | closed]`
+
+- Both: metadata `#{world_id, coords :: {integer(), integer()}}`, both
+  unbounded (one per live world, one per grid cell) - never a label. Zones
+  are lazy, so a live-zone count is not derivable from world count; subtract
+  the two counters for a gauge. `closed` is gated on the zone still being in
+  the manager's table, so it fires exactly once per `opened` even though
+  `cleanup_zone/2` is reachable more than once for the same coords - a gauge
+  built from the pair does not drift negative.
 
 #### Matchmaker - `[asobi, matchmaker, queued | removed | formed | failed]`
 
@@ -185,10 +207,18 @@ building an exporter safely - not a step to defer until after one is built.
 - `hit` / `miss`: metadata `#{kind :: positive | negative}`
 - `sweep`: no metadata
 
-That is 35 events across 13 domains (match, world, matchmaker, session, ws,
-join, rehome, anticheat, error, economy, store, chat, vote, auth_cache - 14
-domains if `join`/`rehome` are counted separately from `ws`, as they are
+That is 38 events across 14 domains (match, world, zone, matchmaker, session,
+ws, join, rehome, anticheat, error, economy, store, chat, vote, auth_cache -
+15 domains if `join`/`rehome` are counted separately from `ws`, as they are
 distinct top-level event-name prefixes).
+
+`asobi_telemetry:events/0` returns the list, so a consumer attaches to the
+whole surface without restating it. Restating it is what let the built-in
+debug logger and `opentelemetry_asobi` drift to the same stale 24-name
+subset; `opentelemetry_asobi` should switch to `events/0` rather than keep
+its own copy. `asobi_telemetry_tests` asserts `events/0` against the event
+names actually passed to `telemetry:execute/3` in the module's compiled
+abstract code, so an emitter added without a matching entry fails the build.
 
 ### Stability
 
@@ -206,20 +236,21 @@ minor release.
 
 ### Known gaps (documented, not fixed by this ADR)
 
-- `asobi_telemetry:setup/0` (the built-in debug logger) attaches to only 24
-  of the 35 events. Missing: `matchmaker/failed`, `join/rate_limited`,
-  `ws/connect_rate_limited`, `rehome/rate_limited`, `ws/idle_auth_timeout`,
-  `ws/origin_rejected`, `anticheat/violation`, `error`, and all three
-  `auth_cache/*` events. `opentelemetry_asobi` mirrors the same stale list.
-  Tracked in asobi#312, not addressed here.
-- No event exists for world-tick duration or live zone/world count -
-  `asobi_world_ticker`, `asobi_zone_manager`, and `asobi_zone_spawner` emit
-  nothing today. This is the one genuine instrumentation gap identified
-  against the "world/ECS/network/RPC/DB/queue/scheduler" scope proposed
-  alongside `asobi_metrics`; ECS and RPC don't exist in asobi, and DB/queue
-  are kura's and shigoto's telemetry surfaces respectively, not asobi's.
-  Tracked in asobi#313, not addressed here.
-- Four of the 35 events are declared API with no in-tree emitter today -
+- ~~`asobi_telemetry:setup/0` (the built-in debug logger) attaches to only 24
+  of the 35 events.~~ Closed by asobi#312: `setup/0` attaches
+  `asobi_telemetry:events/0`, the whole surface, and a test pins that list
+  against the emitters. `opentelemetry_asobi` still carries its own copy of
+  the stale list and should move to `events/0`.
+- ~~No event exists for world-tick duration or live zone/world count.~~
+  Closed by asobi#313, which added `[asobi, world, tick]` and the
+  `[asobi, zone, opened | closed]` pair above. This was the one genuine
+  instrumentation gap identified against the
+  "world/ECS/network/RPC/DB/queue/scheduler" scope proposed alongside
+  `asobi_metrics`; ECS and RPC don't exist in asobi, and DB/queue are kura's
+  and shigoto's telemetry surfaces respectively, not asobi's.
+  `asobi_zone_spawner` is a pure entity-template registry, not a zone
+  lifecycle owner, and still emits nothing by design.
+- Four of the 38 events are declared API with no in-tree emitter today -
   the `asobi_telemetry` function exists and is exported, but nothing in
   `src/` or `test/` calls it: `session_disconnected/2`
   (`[asobi, session, disconnected]`), `ws_message_out/1`
@@ -231,8 +262,9 @@ minor release.
   the one to be careful with: an alert built on it never fires, and reads as
   "no cheating detected" when it actually means "no detector is wired up".
   Do not build a cheating alert on this event until core emits it. Wiring
-  emitters (or dropping the unused functions) is a follow-up to this ADR,
-  alongside asobi#312 and asobi#313.
+  emitters (or dropping the unused functions) is still a follow-up to this
+  ADR. Note that they are now attached by `setup/0` along with everything
+  else, so "attached" is not evidence that anything emits them.
 
 ## Consequences
 

--- a/docs/adr/0005-telemetry-event-surface.md
+++ b/docs/adr/0005-telemetry-event-surface.md
@@ -106,7 +106,15 @@ building an exporter safely - not a step to defer until after one is built.
   the two counters for a gauge. `closed` is gated on the zone still being in
   the manager's table, so it fires exactly once per `opened` even though
   `cleanup_zone/2` is reachable more than once for the same coords - a gauge
-  built from the pair does not drift negative.
+  built from the pair does not drift negative. It **can** drift upward: a
+  world teardown emits no `closed` at all, because `asobi_zone_manager` does
+  not trap exits (so a supervisor shutdown never runs its `terminate/2`) and
+  `asobi_world_instance` stops the manager before the zone supervisor (so it
+  never processes the zones' `DOWN`s). Key the gauge on `world_id` and drop a
+  world's counters when `[asobi, world, finished]` arrives, rather than
+  keeping one global counter pair. Making the manager trap exits to close the
+  difference is a supervision-tree change with its own shutdown-latency cost
+  and was deliberately not made here.
 
 #### Matchmaker - `[asobi, matchmaker, queued | removed | formed | failed]`
 

--- a/guides/security-lua-known-limitations.md
+++ b/guides/security-lua-known-limitations.md
@@ -33,8 +33,8 @@ Two limits are worth knowing:
 - asobi does not use `luerl_sandbox:run/3`, which offers the same idea
   upstream: it evaluates a chunk, whereas asobi's hot path is
   `luerl:call_function/3` against an already-loaded state. The polling
-  loop lives in `asobi_lua_loader:bounded_eval/2` instead, which
-  already spawned and monitored the worker.
+  loop lives in the `bounded_eval` helper in `asobi_lua_loader`
+  instead, which already spawned and monitored the worker.
 
 `handle_input/3` is the exception: per ADR 0002 it runs in the calling
 process with no child, so none of the three bounds apply to it.

--- a/guides/security-lua-known-limitations.md
+++ b/guides/security-lua-known-limitations.md
@@ -7,25 +7,37 @@ who care about any of these should plan their deployment accordingly.
 
 ## Resource bounds
 
-### The reduction limit Luerl offers is not applied
+### The CPU bound is sampled, not exact
 
-A wall-clock timeout and a per-eval heap cap are the only resource
-bounds asobi enforces. Neither bounds CPU: a script can soak its full
-per-callback budget every tick without being throttled.
+asobi enforces three resource bounds on every callback that runs in a
+child process: a wall-clock timeout, a per-eval heap cap, and a
+reduction budget. The reduction budget is the CPU bound - without it a
+script could soak its full per-callback wall-clock budget every tick,
+because the timeout bounds latency, not work.
 
-Luerl does expose a reduction limit. `luerl_sandbox:run/3` takes
-`max_reductions` and kills the runner once its BEAM reduction count
-passes the limit (luerl 1.5.1, the version asobi pins). asobi does not
-use it, and it is not a drop-in:
+The budget is `asobi_lua.max_reductions_per_ms` (50,000 by default)
+multiplied by that callback's own wall-clock budget, so it scales with
+the callback: `tick` (500 ms) gets 25,000,000 reductions, a bot's
+`think` (50 ms) gets 2,500,000. Overrun surfaces as
+`{error, reductions_exhausted}`, distinct from `timeout` and
+`heap_exhausted`. As with the other two, the callback's result is
+discarded and the previous Lua state is kept - a match or zone is never
+torn down because one callback overran. Set the rate to `0` to disable
+the check.
 
-- `luerl_sandbox:run/3` evaluates a chunk. asobi's hot path is
-  `luerl:call_function/3` against an already-loaded state, which that
-  entry point does not cover.
-- The check polls the runner's reduction count from the parent on a
-  fixed 100 ms interval. It bounds total work, not per-tick latency,
-  and cannot fire sooner than one poll.
+Two limits are worth knowing:
 
-Tracked as [asobi#348](https://github.com/widgrensit/asobi/issues/348).
+- The parent samples the child's reduction count every 10 ms, so a
+  script can overshoot by up to one interval's work before it is
+  killed. The budget bounds sustained CPU, not the instantaneous peak.
+- asobi does not use `luerl_sandbox:run/3`, which offers the same idea
+  upstream: it evaluates a chunk, whereas asobi's hot path is
+  `luerl:call_function/3` against an already-loaded state. The polling
+  loop lives in `asobi_lua_loader:bounded_eval/2` instead, which
+  already spawned and monitored the worker.
+
+`handle_input/3` is the exception: per ADR 0002 it runs in the calling
+process with no child, so none of the three bounds apply to it.
 
 ### The heap cap is per eval, not per script
 

--- a/guides/self-hosting.md
+++ b/guides/self-hosting.md
@@ -183,6 +183,7 @@ These are read at start time from your `sys.config`.
 | Key | Default | What it does |
 |---|---|---|
 | `asobi_lua.max_heap_words` | `5_000_000` | Per-eval heap cap (in Erlang words) for every Lua callback the runtime invokes. If a single eval allocates past this, the eval process is killed by the VM and the runtime returns `{error, heap_exhausted}`. Persistent state held by the gen_server is not touched — only the runaway eval. Raise only if a single tick legitimately constructs a very large local structure; long-lived tables belong in the persistent Luerl state and cost nothing per eval. |
+| `asobi_lua.max_reductions_per_ms` | `50_000` | Per-eval CPU cap, as BEAM reductions allowed per millisecond of that callback's own wall-clock budget — so `tick` (500 ms) gets 25,000,000 and a bot's `think` (50 ms) gets 2,500,000. The timeout bounds latency but not work: without this, a script that spins is killed at its deadline and does it again next tick, holding a scheduler indefinitely. Overrun returns `{error, reductions_exhausted}`; the callback's result is discarded and the previous Lua state kept, exactly as for a timeout, so the match or zone survives. Sampled every 10 ms, so overshoot is bounded by one interval. Set to `0` to disable. |
 | `asobi_lua.reload_mode` (or env `ASOBI_LUA_RELOAD`) | `auto` | `auto` mtime-polls the script on every tick. `off` skips the poll entirely — appropriate for sealed-bundle prod where new code is a container restart, not a file change. Anything we don't recognise falls back to `auto` so a typo doesn't silently disable reload. |
 
 ```erlang
@@ -190,6 +191,7 @@ These are read at start time from your `sys.config`.
 [
   {asobi_lua, [
     {max_heap_words, 10_000_000},
+    {max_reductions_per_ms, 50_000},
     {reload_mode, off}
   ]}
 ].

--- a/src/asobi_telemetry.erl
+++ b/src/asobi_telemetry.erl
@@ -33,8 +33,8 @@
 -export([events/0]).
 
 -doc """
-Every event name this module emits - the surface locked by
-[ADR 0005](docs/adr/0005-telemetry-event-surface.md).
+Every event name this module emits - the surface locked by ADR 0005
+(`docs/adr/0005-telemetry-event-surface.md`).
 
 Exported so a consumer attaches to the whole surface without restating it.
 Restating it is what let the built-in debug logger and `opentelemetry_asobi`

--- a/src/asobi_telemetry.erl
+++ b/src/asobi_telemetry.erl
@@ -3,7 +3,8 @@
 -export([setup/0]).
 -export([match_started/2, match_finished/3, match_player_joined/2, match_player_left/2]).
 -export([world_started/2, world_finished/3, world_player_joined/2, world_player_left/2]).
--export([world_phase_changed/3]).
+-export([world_phase_changed/3, world_tick/4]).
+-export([zone_opened/2, zone_closed/2]).
 -export([matchmaker_queued/2, matchmaker_removed/2, matchmaker_formed/3, matchmaker_failed/2]).
 -export([session_connected/1, session_disconnected/2]).
 -export([
@@ -29,37 +30,67 @@
 -export([vote_started/2, vote_cast/2, vote_resolved/3]).
 -export([auth_cache_hit/1, auth_cache_miss/1, auth_cache_sweep/0]).
 -export([handle_event/4]).
+-export([events/0]).
+
+-doc """
+Every event name this module emits - the surface locked by
+[ADR 0005](docs/adr/0005-telemetry-event-surface.md).
+
+Exported so a consumer attaches to the whole surface without restating it.
+Restating it is what let the built-in debug logger and `opentelemetry_asobi`
+both drift to the same stale 24-name subset, leaving the failure and abuse
+signals (rate limits, anticheat, `[asobi, error]`) invisible in dev (#312).
+`asobi_telemetry_tests` asserts this list against the names actually passed
+to `telemetry:execute/3` in this module, so the two cannot drift again.
+""".
+-spec events() -> [telemetry:event_name()].
+events() ->
+    [
+        [asobi, match, started],
+        [asobi, match, finished],
+        [asobi, match, player_joined],
+        [asobi, match, player_left],
+        [asobi, world, started],
+        [asobi, world, finished],
+        [asobi, world, player_joined],
+        [asobi, world, player_left],
+        [asobi, world, phase_changed],
+        [asobi, world, tick],
+        [asobi, zone, opened],
+        [asobi, zone, closed],
+        [asobi, matchmaker, queued],
+        [asobi, matchmaker, removed],
+        [asobi, matchmaker, formed],
+        [asobi, matchmaker, failed],
+        [asobi, session, connected],
+        [asobi, session, disconnected],
+        [asobi, ws, connected],
+        [asobi, ws, disconnected],
+        [asobi, ws, message_in],
+        [asobi, ws, message_out],
+        [asobi, ws, connect_rate_limited],
+        [asobi, ws, idle_auth_timeout],
+        [asobi, ws, origin_rejected],
+        [asobi, join, rate_limited],
+        [asobi, rehome, rate_limited],
+        [asobi, anticheat, violation],
+        [asobi, error],
+        [asobi, economy, transaction],
+        [asobi, store, purchase],
+        [asobi, chat, message_sent],
+        [asobi, vote, started],
+        [asobi, vote, cast],
+        [asobi, vote, resolved],
+        [asobi, auth_cache, hit],
+        [asobi, auth_cache, miss],
+        [asobi, auth_cache, sweep]
+    ].
 
 -spec setup() -> ok.
 setup() ->
     ok = telemetry:attach_many(
         <<"asobi-metrics-logger">>,
-        [
-            [asobi, match, started],
-            [asobi, match, finished],
-            [asobi, match, player_joined],
-            [asobi, match, player_left],
-            [asobi, world, started],
-            [asobi, world, finished],
-            [asobi, world, player_joined],
-            [asobi, world, player_left],
-            [asobi, world, phase_changed],
-            [asobi, matchmaker, queued],
-            [asobi, matchmaker, removed],
-            [asobi, matchmaker, formed],
-            [asobi, session, connected],
-            [asobi, session, disconnected],
-            [asobi, ws, connected],
-            [asobi, ws, disconnected],
-            [asobi, ws, message_in],
-            [asobi, ws, message_out],
-            [asobi, economy, transaction],
-            [asobi, store, purchase],
-            [asobi, chat, message_sent],
-            [asobi, vote, started],
-            [asobi, vote, cast],
-            [asobi, vote, resolved]
-        ],
+        events(),
         fun ?MODULE:handle_event/4,
         #{}
     ),
@@ -121,6 +152,52 @@ world_player_left(WorldId, PlayerId) ->
 world_phase_changed(WorldId, FromPhase, ToPhase) ->
     telemetry:execute([asobi, world, phase_changed], #{count => 1}, #{
         world_id => WorldId, from_phase => FromPhase, to_phase => ToPhase
+    }).
+
+-doc """
+asobi#313: how long a world tick took, sampled.
+
+A world tick is the fan-out to every zone plus the fan-in of their
+`tick_done` replies, so this is the saturation signal that degrades first
+under entity load. Emitting it at the world tick rate (20 Hz by default) is
+too hot for a raw sink, so `asobi_world_ticker` samples roughly once a second
+and carries `max_duration_ms` - the worst tick in the sampled window -
+alongside the sampled tick's own `duration_ms`. Alert on the max; a sampled
+duration alone hides exactly the spikes worth paging on.
+
+`zone_count` is how many zones that tick fanned out to. `world_id` is
+unbounded (one per live world) - never a metric label.
+""".
+-spec world_tick(binary() | undefined, non_neg_integer(), non_neg_integer(), non_neg_integer()) ->
+    ok.
+world_tick(WorldId, DurationMs, MaxDurationMs, ZoneCount) ->
+    telemetry:execute(
+        [asobi, world, tick],
+        #{
+            duration_ms => DurationMs,
+            max_duration_ms => MaxDurationMs,
+            zone_count => ZoneCount,
+            count => 1
+        },
+        #{world_id => WorldId}
+    ).
+
+-doc """
+asobi#313: a zone process started. Zones are lazy, so live-zone count is not
+derivable from world count; pair this with `zone_closed/2` and track the
+difference as a gauge. Both metadata keys are unbounded - never a label.
+""".
+-spec zone_opened(binary() | undefined, {integer(), integer()}) -> ok.
+zone_opened(WorldId, Coords) ->
+    telemetry:execute([asobi, zone, opened], #{count => 1}, #{
+        world_id => WorldId, coords => Coords
+    }).
+
+-doc "asobi#313: a zone process went away (reaped, crashed, or world shutdown). See `zone_opened/2`.".
+-spec zone_closed(binary() | undefined, {integer(), integer()}) -> ok.
+zone_closed(WorldId, Coords) ->
+    telemetry:execute([asobi, zone, closed], #{count => 1}, #{
+        world_id => WorldId, coords => Coords
     }).
 
 %% --- Matchmaker Events ---

--- a/src/leaderboards/asobi_leaderboard_server.erl
+++ b/src/leaderboards/asobi_leaderboard_server.erl
@@ -264,8 +264,12 @@ entries_around(Table, Key, N) ->
     Self = [{PlayerId, Score, 0}],
     After = walk_forward(Table, Key, N),
     Entries = Before ++ Self ++ After,
-    [FirstEntry | _] = Entries,
-    StartRank = count_before(Table, element(1, FirstEntry)) + 1,
+    %% Rank the window from the queried player's own rank, walking back by
+    %% however many entries precede them in it. Deriving the start rank from
+    %% the first entry instead needs that entry's ETS key ({-Score, PlayerId}),
+    %% not its player id - passing the id made count_before/2 walk to the end
+    %% of the table and offset every rank by the size of the board (#334).
+    StartRank = count_before(Table, Key) + 1 - length(Before),
     assign_ranks(Entries, StartRank, []).
 
 walk_back(Table, Key, N) ->

--- a/src/lua/asobi_lua_env.erl
+++ b/src/lua/asobi_lua_env.erl
@@ -3,8 +3,8 @@
 Reads a Lua-runtime setting from the application environment.
 
 The Lua runtime used to ship as its own OTP application, so its knobs
-(`dev_errors`, `reload_mode`, `max_heap_words`, `terrain_providers`,
-`config_watch_interval`, `rate_limits`) were configured under the `asobi_lua`
+(`dev_errors`, `reload_mode`, `max_heap_words`, `max_reductions_per_ms`,
+`terrain_providers`, `config_watch_interval`, `rate_limits`) were configured under the `asobi_lua`
 application key. After the asobi_lua merge there is no `asobi_lua`
 application, and `application:get_env/3` on an application that is never loaded
 silently returns the default - every existing `{asobi_lua, [...]}` block in a

--- a/src/lua/asobi_lua_game_error.erl
+++ b/src/lua/asobi_lua_game_error.erl
@@ -78,6 +78,8 @@ format_reason(timeout) ->
     ~"callback timed out";
 format_reason(heap_exhausted) ->
     ~"callback exhausted its memory budget";
+format_reason(reductions_exhausted) ->
+    ~"callback exhausted its CPU budget";
 format_reason({lua_error, LuaErr}) ->
     Msg =
         try

--- a/src/lua/asobi_lua_loader.erl
+++ b/src/lua/asobi_lua_loader.erl
@@ -57,6 +57,25 @@ load a specific script and pin its base directory for `require`.
 %% distinguish heap-blow from timeout.
 -define(DEFAULT_MAX_HEAP_WORDS, 5_000_000).
 
+%% #348: CPU bound, expressed as reductions allowed per millisecond of the
+%% callback's own wall-clock budget. The timeout bounds latency but not work:
+%% a script that spins is killed at its deadline and then does it again on the
+%% next tick, burning a whole scheduler indefinitely.
+%%
+%% The rate is per-ms rather than absolute because the budgets it has to serve
+%% span two orders of magnitude (50 ms for `think`, 5000 ms for
+%% `generate_world`); scaling keeps their relative weights. 50,000 is measured
+%% against Luerl on this workload: a 200-entity tick costs ~24k reductions
+%% total, while a spin sustains ~284k reductions/ms, so the budget sits ~1000x
+%% above a normal tick and cuts a spin at ~18% of its wall-clock window. Set
+%% `asobi_lua.max_reductions_per_ms` to 0 to disable the check.
+-define(DEFAULT_MAX_REDUCTIONS_PER_MS, 50_000).
+
+%% How often the parent samples the worker's reduction count. Overshoot is
+%% bounded by one interval's worth of work (~2.8M reductions at the rate
+%% above), an order of magnitude under the smallest budget this produces.
+-define(REDUCTION_POLL_MS, 10).
+
 -spec new(binary() | string()) -> {ok, dynamic()} | {error, term()}.
 new(ScriptPath) ->
     new(ScriptPath, ?DEFAULT_INIT_TIMEOUT_MS, fun(St) -> St end).
@@ -160,17 +179,24 @@ call(FuncPath, Args, St) ->
 call(FuncPath, Args, St, TimeoutMs) ->
     bounded_eval(fun() -> call(FuncPath, Args, St) end, TimeoutMs).
 
-%% Spawn the work in a child with a bounded wall-clock budget AND a
-%% bounded heap, monitor it, and translate the three terminal states
-%% the parent might observe into return values:
+%% Spawn the work in a child with a bounded wall-clock budget, a bounded
+%% heap AND a bounded reduction count, monitor it, and translate the four
+%% terminal states the parent might observe into return values:
 %%   - normal exit + {Ref, Result} message    → Result
 %%   - timeout (we kill it, exit reason `kill`) → {error, timeout}
 %%   - VM kills it for heap (exit reason `killed`) → {error, heap_exhausted}
+%%   - reduction budget passed (we kill it) → {error, reductions_exhausted}
 %% A heap kill happens *before* the worker can send {Ref, _}, so the
 %% DOWN message races. We give the message a tiny grace window in case
 %% it is in flight.
+%%
+%% Callers treat all three failures the same way - discard the result, keep
+%% the previous Luerl state, log, carry on - so a callback that overruns
+%% costs its tick, never the match or the zone. `reductions_exhausted` is a
+%% distinct tag only so an operator can tell "burned CPU" apart from "was
+%% slow" and from "allocated too much" in the logs.
 -spec bounded_eval(fun(() -> R), non_neg_integer()) ->
-    R | {error, timeout | heap_exhausted | {worker_exit, term()}}.
+    R | {error, timeout | heap_exhausted | reductions_exhausted | {worker_exit, term()}}.
 bounded_eval(Fun, TimeoutMs) ->
     Self = self(),
     Ref = make_ref(),
@@ -190,6 +216,10 @@ bounded_eval(Fun, TimeoutMs) ->
             end,
             SpawnOpts
         ),
+    Deadline = erlang:monotonic_time(millisecond) + TimeoutMs,
+    await_eval(Pid, Ref, MonRef, Deadline, reduction_budget(TimeoutMs)).
+
+await_eval(Pid, Ref, MonRef, Deadline, Budget) ->
     receive
         {Ref, Result} ->
             erlang:demonitor(MonRef, [flush]),
@@ -198,18 +228,58 @@ bounded_eval(Fun, TimeoutMs) ->
             {error, heap_exhausted};
         {'DOWN', MonRef, process, Pid, Reason} ->
             {error, {worker_exit, Reason}}
-    after TimeoutMs ->
-        exit(Pid, kill),
-        receive
-            {Ref, Result} ->
-                erlang:demonitor(MonRef, [flush]),
-                Result;
-            {'DOWN', MonRef, process, Pid, _} ->
-                {error, timeout}
-        after 0 ->
-            erlang:demonitor(MonRef, [flush]),
-            {error, timeout}
+    after wait_slice(Deadline, Budget) ->
+        case erlang:monotonic_time(millisecond) >= Deadline of
+            true ->
+                kill_and_settle(Pid, Ref, MonRef, timeout);
+            false ->
+                case over_budget(Pid, Budget) of
+                    true -> kill_and_settle(Pid, Ref, MonRef, reductions_exhausted);
+                    false -> await_eval(Pid, Ref, MonRef, Deadline, Budget)
+                end
         end
+    end.
+
+%% With no reduction budget this is one receive for the whole window, exactly
+%% as before the budget existed - the poll costs nothing when it is disabled,
+%% and nothing when the eval returns inside the first slice.
+wait_slice(Deadline, infinity) ->
+    max(0, Deadline - erlang:monotonic_time(millisecond));
+wait_slice(Deadline, _Budget) ->
+    min(?REDUCTION_POLL_MS, max(0, Deadline - erlang:monotonic_time(millisecond))).
+
+over_budget(Pid, Budget) ->
+    case process_info(Pid, reductions) of
+        {reductions, N} -> N > Budget;
+        %% Already gone: the DOWN is in flight, let the next receive take it.
+        undefined -> false
+    end.
+
+kill_and_settle(Pid, Ref, MonRef, Reason) ->
+    exit(Pid, kill),
+    receive
+        {Ref, Result} ->
+            erlang:demonitor(MonRef, [flush]),
+            Result;
+        {'DOWN', MonRef, process, Pid, _} ->
+            {error, Reason}
+    after 0 ->
+        erlang:demonitor(MonRef, [flush]),
+        {error, Reason}
+    end.
+
+-spec reduction_budget(non_neg_integer()) -> pos_integer() | infinity.
+reduction_budget(TimeoutMs) ->
+    case max_reductions_per_ms() of
+        0 -> infinity;
+        Rate -> Rate * max(TimeoutMs, 1)
+    end.
+
+-spec max_reductions_per_ms() -> non_neg_integer().
+max_reductions_per_ms() ->
+    case asobi_lua_env:get_env(max_reductions_per_ms) of
+        {ok, N} when is_integer(N), N >= 0 -> N;
+        _ -> ?DEFAULT_MAX_REDUCTIONS_PER_MS
     end.
 
 -spec max_heap_words() -> pos_integer().

--- a/src/world/asobi_world_instance.erl
+++ b/src/world/asobi_world_instance.erl
@@ -47,6 +47,7 @@ init(Config) ->
     },
     TickerConfig = #{
         tick_rate => maps:get(tick_rate, Config, 50),
+        world_id => maps:get(world_id, Config, undefined),
         world_pid => self()
     },
     WorldConfig = Config#{

--- a/src/world/asobi_world_ticker.erl
+++ b/src/world/asobi_world_ticker.erl
@@ -6,6 +6,14 @@
 -export([promote_zone/2, demote_zone/2, remove_zone/2]).
 -export([init/1, handle_call/3, handle_cast/2, handle_info/2]).
 
+%% #313: a world tick is the fan-out to every zone plus the fan-in of their
+%% tick_done replies, which is the saturation signal an operator watching a
+%% world server wants. At the default 50ms tick rate that is 20 events per
+%% second per world - too hot for a raw sink - so sample roughly once a second
+%% and carry the window's worst tick alongside the sampled one. Override with
+%% `tick_sample_interval_ms` in the ticker config.
+-define(DEFAULT_TICK_SAMPLE_INTERVAL_MS, 1000).
+
 %% --- Public API ---
 
 -spec start_link(map()) -> gen_server:start_ret().
@@ -53,6 +61,7 @@ init(Config) ->
     {ok, #{
         tick => 0,
         tick_rate => TickRate,
+        world_id => maps:get(world_id, Config, undefined),
         world_pid => WorldPid,
         zone_manager => ZoneManager,
         hot_zones => [],
@@ -60,8 +69,19 @@ init(Config) ->
         cold_tick_divisor => ColdTickDivisor,
         tick_count => 0,
         pending => #{},
-        running => false
+        running => false,
+        tick_started_at => undefined,
+        tick_zone_count => 0,
+        max_duration_ms => 0,
+        sampled_ticks => 0,
+        sample_every => sample_every(TickRate, Config)
     }}.
+
+sample_every(TickRate, Config) ->
+    IntervalMs = maps:get(
+        tick_sample_interval_ms, Config, ?DEFAULT_TICK_SAMPLE_INTERVAL_MS
+    ),
+    max(1, IntervalMs div max(TickRate, 1)).
 
 -spec handle_call(term(), gen_server:from(), map()) -> {reply, term(), map()}.
 handle_call(get_tick, _From, #{tick := Tick} = State) ->
@@ -111,7 +131,7 @@ handle_cast(
             case map_size(Pending1) of
                 0 ->
                     asobi_world_server:post_tick(WorldPid, TickN),
-                    {noreply, State#{pending => #{}}};
+                    {noreply, complete_tick(State#{pending => #{}})};
                 _ ->
                     {noreply, State#{pending => Pending1}}
             end;
@@ -155,15 +175,51 @@ handle_info(
     Pending = maps:from_keys(ZonesToTick, true),
     tick_zones(ZonesToTick, NextTick),
     erlang:send_after(TickRate, self(), tick),
+    State1 = State#{
+        tick => NextTick,
+        tick_count => NextTickCount,
+        tick_started_at => erlang:monotonic_time(millisecond),
+        tick_zone_count => length(ZonesToTick)
+    },
     case map_size(Pending) of
         0 ->
             asobi_world_server:post_tick(maps:get(world_pid, State), NextTick),
-            {noreply, State#{tick => NextTick, tick_count => NextTickCount, pending => #{}}};
+            {noreply, complete_tick(State1#{pending => #{}})};
         _ ->
-            {noreply, State#{tick => NextTick, tick_count => NextTickCount, pending => Pending}}
+            {noreply, State1#{pending => Pending}}
     end;
 handle_info(_Info, State) ->
     {noreply, State}.
+
+%% A tick that never fans in (a zone died mid-tick) is simply never sampled -
+%% the next fan-out overwrites tick_started_at. Emitting a bogus duration for
+%% it would be worse than the gap, and the zone's own DOWN is the signal for
+%% that failure.
+complete_tick(#{tick_started_at := undefined} = State) ->
+    State;
+complete_tick(
+    #{
+        tick_started_at := StartedAt,
+        tick_zone_count := ZoneCount,
+        max_duration_ms := MaxSoFar,
+        sampled_ticks := Sampled,
+        sample_every := SampleEvery,
+        world_id := WorldId
+    } = State
+) ->
+    DurationMs = erlang:monotonic_time(millisecond) - StartedAt,
+    MaxDurationMs = max(MaxSoFar, DurationMs),
+    case Sampled + 1 >= SampleEvery of
+        true ->
+            asobi_telemetry:world_tick(WorldId, DurationMs, MaxDurationMs, ZoneCount),
+            State#{tick_started_at => undefined, max_duration_ms => 0, sampled_ticks => 0};
+        false ->
+            State#{
+                tick_started_at => undefined,
+                max_duration_ms => MaxDurationMs,
+                sampled_ticks => Sampled + 1
+            }
+    end.
 
 -spec tick_zones([term()], non_neg_integer()) -> ok.
 tick_zones([], _NextTick) ->

--- a/src/world/asobi_zone_manager.erl
+++ b/src/world/asobi_zone_manager.erl
@@ -299,6 +299,12 @@ handle_info(
 handle_info(_Info, State) ->
     {noreply, State}.
 
+%% No zone/closed events here on purpose: this process does not trap exits, so
+%% a supervisor shutdown kills it without running terminate/2 at all, and the
+%% instance supervisor stops the manager before the zone supervisor, so the
+%% zones' DOWNs are never processed either. A consumer deriving a live-zone
+%% gauge from opened minus closed must key it on world_id and drop the world's
+%% counters when the world ends - see ADR 0005.
 -spec terminate(term(), map()) -> ok.
 terminate(_Reason, #{ets_tab := Tab}) ->
     ets:delete(Tab),

--- a/src/world/asobi_zone_manager.erl
+++ b/src/world/asobi_zone_manager.erl
@@ -315,7 +315,8 @@ start_zone(
         zone_monitors := Monitors,
         max_active_zones := MaxActive,
         zone_config := BaseConfig,
-        initial_zone_states := InitialStates
+        initial_zone_states := InitialStates,
+        world_id := WorldId
     } = State
 ) ->
     case ets:info(Tab, size) >= MaxActive of
@@ -332,6 +333,7 @@ start_zone(
             case asobi_zone_sup:start_zone(ZoneSup, Config) of
                 {ok, Pid} ->
                     ets:insert(Tab, {Coords, Pid}),
+                    asobi_telemetry:zone_opened(WorldId, Coords),
                     MonRef = monitor(process, Pid),
                     Now = erlang:monotonic_time(millisecond),
                     State1 = State#{
@@ -349,9 +351,18 @@ cleanup_zone(
     #{
         ets_tab := Tab,
         zone_last_active := Active,
-        zone_monitors := Monitors
+        zone_monitors := Monitors,
+        world_id := WorldId
     } = State
 ) ->
+    %% cleanup_zone/2 is reachable more than once for the same coords (a DOWN
+    %% racing await_zone_down/3, for one), so gate the close on the row still
+    %% being there - a live-zone gauge built from opened minus closed would go
+    %% negative otherwise.
+    case ets:member(Tab, Coords) of
+        true -> asobi_telemetry:zone_closed(WorldId, Coords);
+        false -> ok
+    end,
     ets:delete(Tab, Coords),
     Monitors1 =
         case maps:get(Coords, Monitors, undefined) of

--- a/test/asobi_iap_SUITE.erl
+++ b/test/asobi_iap_SUITE.erl
@@ -247,13 +247,18 @@ apple_valid_jws_wrong_bundle(Config) ->
     cleanup_apple_env(),
     Config.
 
+%% asobi#357: this used a fixed `txn-1`. iap_transactions is unique on
+%% (provider, transaction_id) and the suite never deleted the row, so the
+%% first run passed and every later run against the same database got a 409.
+%% A run-unique id is better than cleaning up afterwards: it also lets the
+%% suite run concurrently with itself.
 apple_valid_jws_correct_bundle(Config) ->
     configure_apple(Config, ~"com.test.app"),
     Chain = ?config(test_chain, Config),
     Jws = build_signed_jws(Chain, #{
         ~"bundleId" => ~"com.test.app",
         ~"productId" => ~"premium_pack",
-        ~"transactionId" => ~"txn-1",
+        ~"transactionId" => asobi_test_helpers:unique_id(~"txn"),
         ~"quantity" => 1,
         ~"type" => ~"Consumable"
     }),

--- a/test/asobi_leaderboard_SUITE.erl
+++ b/test/asobi_leaderboard_SUITE.erl
@@ -7,10 +7,20 @@
     submit_and_top/1,
     rank_query/1,
     around_query/1,
+    around_ranks_are_absolute/1,
+    around_at_board_edges/1,
     score_update/1
 ]).
 
-all() -> [submit_and_top, rank_query, around_query, score_update].
+all() ->
+    [
+        submit_and_top,
+        rank_query,
+        around_query,
+        around_ranks_are_absolute,
+        around_at_board_edges,
+        score_update
+    ].
 
 init_per_suite(Config) ->
     {ok, _} = application:ensure_all_started(asobi),
@@ -61,6 +71,65 @@ around_query(Config) ->
     Entries = asobi_leaderboard_server:around(BoardId, ~"player5", 2),
     ?assert(length(Entries) =:= 5),
     Config.
+
+%% #334: the rank around/3 attaches was derived from a player id fed to a
+%% function that walks ETS keys, so it always ran off the end of the table and
+%% numbered the window from BoardSize + 1. On a 10-entry board that put
+%% player5 at rank 16 while rank/2 and top/2 both said 6.
+around_ranks_are_absolute(Config) ->
+    {board_id, BoardId} = lists:keyfind(board_id, 1, Config),
+    true = is_binary(BoardId),
+    fill(BoardId, 10),
+    ?assertEqual(
+        [
+            {~"player7", 70, 4},
+            {~"player6", 60, 5},
+            {~"player5", 50, 6},
+            {~"player4", 40, 7},
+            {~"player3", 30, 8}
+        ],
+        asobi_leaderboard_server:around(BoardId, ~"player5", 2)
+    ),
+    %% around/3 and rank/2 must agree for every player on the board.
+    lists:foreach(
+        fun(I) when is_integer(I) ->
+            Name = list_to_binary("player" ++ integer_to_list(I)),
+            {ok, Rank} = asobi_leaderboard_server:rank(BoardId, Name),
+            [{Name, _, AroundRank}] = [
+                E
+             || {P, _, _} = E <- asobi_leaderboard_server:around(BoardId, Name, 2), P =:= Name
+            ],
+            ?assertEqual(Rank, AroundRank)
+        end,
+        lists:seq(1, 10)
+    ),
+    Config.
+
+%% The window is truncated at both ends of the board, so the start rank has to
+%% account for how many entries actually precede the queried player - not for
+%% how many were asked for.
+around_at_board_edges(Config) ->
+    {board_id, BoardId} = lists:keyfind(board_id, 1, Config),
+    true = is_binary(BoardId),
+    fill(BoardId, 10),
+    ?assertEqual(
+        [{~"player10", 100, 1}, {~"player9", 90, 2}, {~"player8", 80, 3}],
+        asobi_leaderboard_server:around(BoardId, ~"player10", 2)
+    ),
+    ?assertEqual(
+        [{~"player3", 30, 8}, {~"player2", 20, 9}, {~"player1", 10, 10}],
+        asobi_leaderboard_server:around(BoardId, ~"player1", 2)
+    ),
+    Config.
+
+fill(BoardId, N) ->
+    lists:foreach(
+        fun(I) when is_integer(I) ->
+            Name = list_to_binary("player" ++ integer_to_list(I)),
+            asobi_leaderboard_server:submit(BoardId, Name, I * 10)
+        end,
+        lists:seq(1, N)
+    ).
 
 score_update(Config) ->
     {board_id, BoardId} = lists:keyfind(board_id, 1, Config),

--- a/test/asobi_lua_bot_tests.erl
+++ b/test/asobi_lua_bot_tests.erl
@@ -56,17 +56,18 @@ think_raising_returns_error_test() ->
         file:delete(Path)
     end.
 
-think_infinite_loop_times_out_test() ->
-    %% asobi_bot uses a 50ms timeout for think. A while-true must hit
-    %% it and produce {error, timeout} so the bot falls back to
-    %% default_ai for that tick rather than hanging the gen_server.
+think_infinite_loop_is_terminated_test() ->
+    %% asobi_bot uses a 50ms budget for think. A while-true must hit one of
+    %% its bounds and produce an error so the bot falls back to default_ai
+    %% for that tick rather than hanging the gen_server. Which bound trips
+    %% first (deadline or #348's CPU budget) is machine-dependent.
     Path = bot_temp_script(~"function think(_, _) while true do end end\n"),
     try
         {ok, St} = asobi_lua_loader:new(Path),
         Start = erlang:monotonic_time(millisecond),
         Result = asobi_lua_loader:call(think, [~"bot1", #{}], St, 50),
         Elapsed = erlang:monotonic_time(millisecond) - Start,
-        ?assertEqual({error, timeout}, Result),
+        ?assert(lists:member(Result, [{error, timeout}, {error, reductions_exhausted}])),
         %% Wall-clock close to 50ms; never near a second.
         ?assert(Elapsed < 500)
     after

--- a/test/asobi_lua_loader_tests.erl
+++ b/test/asobi_lua_loader_tests.erl
@@ -79,10 +79,13 @@ call_with_timeout_ok() ->
     Cfg = encode_map(#{}, St),
     {ok, [_ | _], _} = asobi_lua_loader:call(init, [Cfg], St, 5000).
 
+%% slow_tick.lua spins for 100M iterations, so it trips whichever bound comes
+%% first on this machine: the 50ms deadline, or #348's CPU budget.
 call_with_timeout_slow() ->
     {ok, St} = asobi_lua_loader:new(fixture("slow_tick.lua")),
     Cfg = encode_map(#{}, St),
-    {error, timeout} = asobi_lua_loader:call(tick, [Cfg], St, 50).
+    Result = asobi_lua_loader:call(tick, [Cfg], St, 50),
+    true = lists:member(Result, [{error, timeout}, {error, reductions_exhausted}]).
 
 %% A tick that allocates an unbounded table must be killed by the per-eval
 %% heap cap and surface as `heap_exhausted`, not as a timeout. Use a

--- a/test/asobi_lua_resource_limits_tests.erl
+++ b/test/asobi_lua_resource_limits_tests.erl
@@ -22,19 +22,89 @@ safe_lib_dir() ->
 
 %% --- Loader-level timeout always enforced ---
 
-infinite_loop_call_returns_timeout_test() ->
-    %% asobi_lua_loader:call/4 must kill the child and return a
-    %% timeout result rather than blocking the parent. We give the
-    %% loop 100ms to be killed; if call/4 ever hangs the eunit timeout
-    %% catches it but the assertion below is what we want signalling.
+infinite_loop_call_is_terminated_test() ->
+    %% asobi_lua_loader:call/4 must kill the child and return an error
+    %% rather than blocking the parent. Which bound trips first depends on
+    %% how fast this machine interprets Lua - the CPU budget usually gets
+    %% there before the 100ms deadline - so assert the contract that
+    %% matters: killed, with a resource reason, inside the window.
     {ok, St} = asobi_lua_loader:new(temp_script(infinite_loop_script())),
     Cfg = encode_map(#{}, St),
     Start = erlang:monotonic_time(millisecond),
     Result = asobi_lua_loader:call(tick, [Cfg], St, 100),
     Elapsed = erlang:monotonic_time(millisecond) - Start,
-    ?assertEqual({error, timeout}, Result),
+    ?assert(lists:member(Result, [{error, timeout}, {error, reductions_exhausted}])),
     %% Wall-clock should be roughly the timeout; certainly under 1s.
     ?assert(Elapsed < 1000).
+
+%% --- #348: reduction budget ---
+
+%% The wall-clock timeout bounds latency, not work. Without a CPU bound a
+%% spinning callback is killed at its deadline and simply does it again on the
+%% next tick, holding a scheduler for its full budget forever.
+reduction_budget_kills_spin_before_deadline_test() ->
+    with_reductions_per_ms(1, fun() ->
+        {ok, St} = asobi_lua_loader:new(temp_script(infinite_loop_script())),
+        Cfg = encode_map(#{}, St),
+        Start = erlang:monotonic_time(millisecond),
+        %% Budget is 1 reduction per ms of the callback's own window, so a
+        %% 5s window buys 5000 reductions - gone almost immediately, while
+        %% the deadline is nowhere near.
+        Result = asobi_lua_loader:call(tick, [Cfg], St, 5000),
+        Elapsed = erlang:monotonic_time(millisecond) - Start,
+        ?assertEqual({error, reductions_exhausted}, Result),
+        ?assert(Elapsed < 1000)
+    end).
+
+%% Setting the rate to 0 restores the pre-#348 behaviour exactly: one receive
+%% for the whole window, and the deadline is the only thing that fires.
+reduction_budget_disabled_falls_back_to_timeout_test() ->
+    with_reductions_per_ms(0, fun() ->
+        {ok, St} = asobi_lua_loader:new(temp_script(infinite_loop_script())),
+        Cfg = encode_map(#{}, St),
+        Start = erlang:monotonic_time(millisecond),
+        Result = asobi_lua_loader:call(tick, [Cfg], St, 200),
+        Elapsed = erlang:monotonic_time(millisecond) - Start,
+        ?assertEqual({error, timeout}, Result),
+        %% Ran the full window rather than being cut short by a budget.
+        ?assert(Elapsed >= 200)
+    end).
+
+%% The budget must not fire on work a game legitimately does. A tick that
+%% builds and sums 200 entity tables costs ~24k reductions; the default rate
+%% gives a 500ms tick 25,000,000.
+reduction_budget_passes_normal_callback_test() ->
+    {ok, St} = asobi_lua_loader:new(temp_script(entity_tick_script())),
+    Cfg = encode_map(#{}, St),
+    ?assertMatch({ok, [_ | _], _}, asobi_lua_loader:call(tick, [Cfg], St, 500)).
+
+%% The three resource failures must be distinguishable in a log line, or an
+%% operator cannot tell a script that burned CPU from one that was merely slow.
+reduction_exhaustion_renders_distinctly_test() ->
+    ?assertEqual(
+        ~"callback exhausted its CPU budget",
+        asobi_lua_game_error:format_reason(reductions_exhausted)
+    ),
+    ?assertNotEqual(
+        asobi_lua_game_error:format_reason(timeout),
+        asobi_lua_game_error:format_reason(reductions_exhausted)
+    ),
+    ?assertNotEqual(
+        asobi_lua_game_error:format_reason(heap_exhausted),
+        asobi_lua_game_error:format_reason(reductions_exhausted)
+    ).
+
+with_reductions_per_ms(Rate, Fun) ->
+    Prev = application:get_env(asobi, max_reductions_per_ms),
+    application:set_env(asobi, max_reductions_per_ms, Rate),
+    try
+        Fun()
+    after
+        case Prev of
+            {ok, Old} -> application:set_env(asobi, max_reductions_per_ms, Old);
+            undefined -> application:unset_env(asobi, max_reductions_per_ms)
+        end
+    end.
 
 stack_overflow_does_not_crash_parent_test() ->
     %% Lua-level stack overflow must not propagate as an Erlang error
@@ -236,6 +306,23 @@ os_exit_does_not_halt_beam_test() ->
 infinite_loop_script() ->
     ~"""
     function tick(_) while true do end end
+    function init(_) return {} end
+    function join(id, s) return s end
+    function leave(id, s) return s end
+    function handle_input(_, _, s) return s end
+    function get_state(_, s) return s end
+    """.
+
+entity_tick_script() ->
+    ~"""
+    function tick(s)
+      local t = {}
+      for i = 1, 200 do t[i] = { x = i * 1.5, y = i * 2.5, hp = 100 } end
+      local sum = 0
+      for i = 1, 200 do sum = sum + t[i].x end
+      s.sum = sum
+      return s
+    end
     function init(_) return {} end
     function join(id, s) return s end
     function leave(id, s) return s end

--- a/test/asobi_lua_storage_SUITE.erl
+++ b/test/asobi_lua_storage_SUITE.erl
@@ -42,7 +42,7 @@ end_per_suite(_Config) ->
 
 set_then_get(Config) ->
     St = install_api(Config),
-    Collection = unique(~"settings"),
+    Collection = asobi_test_helpers:unique_id(~"settings"),
     {[true], _} = eval(
         [
             "local w = game.storage.set('",
@@ -62,7 +62,7 @@ set_then_get(Config) ->
 %% #296: the second write is the one that used to be silently dropped.
 set_twice_updates_the_row(Config) ->
     St = install_api(Config),
-    Collection = unique(~"saves"),
+    Collection = asobi_test_helpers:unique_id(~"saves"),
     {[true], St1} = eval(
         ["return game.storage.set('", Collection, "', 'slot1', { n = 1 }).ok ~= nil\n"], St
     ),
@@ -84,7 +84,7 @@ set_twice_updates_the_row(Config) ->
 
 player_set_then_player_get(Config) ->
     St = install_api(Config),
-    Collection = unique(~"inventory"),
+    Collection = asobi_test_helpers:unique_id(~"inventory"),
     PlayerId = create_player(),
     {[true], _} = eval(
         [
@@ -113,7 +113,7 @@ player_set_then_player_get(Config) ->
 %% below updates it instead of inserting its own.
 global_write_does_not_clobber_player_row(Config) ->
     St = install_api(Config),
-    Collection = unique(~"save"),
+    Collection = asobi_test_helpers:unique_id(~"save"),
     PlayerId = create_player(),
     {[true], St1} = eval(
         [
@@ -149,7 +149,7 @@ global_write_does_not_clobber_player_row(Config) ->
 %% update_all/2 #296 replaced) rewrites the global row too.
 player_write_does_not_clobber_global_row(Config) ->
     St = install_api(Config),
-    Collection = unique(~"save"),
+    Collection = asobi_test_helpers:unique_id(~"save"),
     PlayerId = create_player(),
     {[true], St1} = eval(
         [
@@ -205,14 +205,12 @@ storage_rows(Collection, Key) ->
 
 create_player() ->
     Now = calendar:universal_time(),
-    Params = #{username => unique(~"p"), inserted_at => Now, updated_at => Now},
+    Params = #{
+        username => asobi_test_helpers:unique_id(~"p"), inserted_at => Now, updated_at => Now
+    },
     CS = kura_changeset:cast(asobi_player, #{}, Params, maps:keys(Params)),
     {ok, #{id := Id}} = asobi_repo:insert(CS),
     Id.
-
-unique(Prefix) ->
-    Hex = binary:encode_hex(crypto:strong_rand_bytes(8), lowercase),
-    <<Prefix/binary, "_", Hex/binary>>.
 
 safe_lib_dir() ->
     case code:lib_dir(asobi) of

--- a/test/asobi_oauth_SUITE.erl
+++ b/test/asobi_oauth_SUITE.erl
@@ -172,9 +172,7 @@ unlink_last_auth_method(Config) ->
     IdentityCS = asobi_player_identity:changeset(#{}, #{
         player_id => NoPasswordId,
         provider => ~"google",
-        provider_uid => iolist_to_binary([
-            ~"google_", integer_to_binary(erlang:unique_integer([positive]))
-        ]),
+        provider_uid => asobi_test_helpers:unique_id(~"google"),
         provider_email => ~"test@example.com"
     }),
     {ok, _} = asobi_repo:insert(IdentityCS),
@@ -185,9 +183,7 @@ unlink_last_auth_method(Config) ->
 unlink_success(Config) ->
     {player1_id, PlayerId} = lists:keyfind(player1_id, 1, Config),
     true = is_binary(PlayerId),
-    ProviderUid = iolist_to_binary([
-        ~"discord_", integer_to_binary(erlang:unique_integer([positive]))
-    ]),
+    ProviderUid = asobi_test_helpers:unique_id(~"discord"),
     IdentityCS = asobi_player_identity:changeset(#{}, #{
         player_id => PlayerId,
         provider => ~"discord",
@@ -208,9 +204,7 @@ unlink_success(Config) ->
 identity_db_roundtrip(Config) ->
     {player1_id, PlayerId} = lists:keyfind(player1_id, 1, Config),
     true = is_binary(PlayerId),
-    ProviderUid = iolist_to_binary([
-        ~"test_uid_", integer_to_binary(erlang:unique_integer([positive]))
-    ]),
+    ProviderUid = asobi_test_helpers:unique_id(~"test_uid"),
     CS = asobi_player_identity:changeset(#{}, #{
         player_id => PlayerId,
         provider => ~"apple",
@@ -248,9 +242,7 @@ login_existing_identity(Config) ->
 %% first-sign-ins for the same provider_uid collided often) must retry with
 %% a fresh one instead of surfacing a 500 on the first collision.
 create_player_retries_on_username_collision(Config) ->
-    ProviderUid = iolist_to_binary([
-        ~"collide_uid_", integer_to_binary(erlang:unique_integer([positive]))
-    ]),
+    ProviderUid = asobi_test_helpers:unique_id(~"collide_uid"),
     Short = binary:part(ProviderUid, 0, min(8, byte_size(ProviderUid))),
     CollisionRand = asobi_id:rand_suffix(4),
     CollisionUsername = <<"discord_", Short/binary, "_", CollisionRand/binary>>,
@@ -329,9 +321,7 @@ create_player_deletes_orphan_on_identity_race_loss(Config) ->
             meck:passthrough([CS])
     end),
     try
-        ProviderUid = iolist_to_binary([
-            ~"race_uid_", integer_to_binary(erlang:unique_integer([positive]))
-        ]),
+        ProviderUid = asobi_test_helpers:unique_id(~"race_uid"),
         Claims = #{provider_uid => ProviderUid, provider_display_name => undefined},
         ?assertEqual(
             {asobi_error, ~"auth.already_registering"},
@@ -360,9 +350,7 @@ create_player_identity_insert_real_failure_returns_500(Config) ->
             meck:passthrough([CS])
     end),
     try
-        ProviderUid = iolist_to_binary([
-            ~"real_failure_uid_", integer_to_binary(erlang:unique_integer([positive]))
-        ]),
+        ProviderUid = asobi_test_helpers:unique_id(~"real_failure_uid"),
         Claims = #{
             provider_uid => ProviderUid,
             provider_display_name => undefined,

--- a/test/asobi_storage_SUITE.erl
+++ b/test/asobi_storage_SUITE.erl
@@ -216,10 +216,10 @@ list_storage(Config) ->
 list_storage_filters_owner_perm(Config) ->
     %% Unique collection/key per run so the asserts aren't polluted by
     %% leftover rows from previous test runs (the storage table persists
-    %% across runs).
-    Suffix = integer_to_binary(erlang:unique_integer([positive])),
-    Col = <<"private_listing_", Suffix/binary>>,
-    Key = <<"p1_secret_", Suffix/binary>>,
+    %% across runs). erlang:unique_integer/1 did not deliver that - it is
+    %% unique within a runtime instance, and each run is a new one (#357).
+    Col = asobi_test_helpers:unique_id(~"private_listing"),
+    Key = asobi_test_helpers:unique_id(~"p1_secret"),
     {ok, PutResp} = nova_test:put(
         binary_to_list(<<"/api/v1/storage/", Col/binary, "/", Key/binary>>),
         #{
@@ -308,9 +308,8 @@ storage_owner_permission(Config) ->
 %% schema directly via kura — that's the path `asobi_lua_api`'s
 %% `game.storage.player_set` follows for per-player rows.
 put_storage_per_player_keys_dont_collide(Config) ->
-    Suffix = integer_to_binary(erlang:unique_integer([positive])),
-    Col = <<"shared_", Suffix/binary>>,
-    Key = <<"counter_", Suffix/binary>>,
+    Col = asobi_test_helpers:unique_id(~"shared"),
+    Key = asobi_test_helpers:unique_id(~"counter"),
     {player1_id, P1} = lists:keyfind(player1_id, 1, Config),
     %% Register a fresh second player whose id we can capture here.
     U2 = asobi_test_helpers:unique_username(~"index_collide_p2"),
@@ -365,9 +364,10 @@ put_storage_per_player_keys_dont_collide(Config) ->
 %% DELETE through the controller and confirms each operates on
 %% player1's own row without crashing, leaving the global row alone.
 global_and_player_row_coexist_at_same_key(Config) ->
-    Suffix = integer_to_binary(erlang:unique_integer([positive])),
-    Col = <<"coexist_", Suffix/binary>>,
-    Key = <<"flag_", Suffix/binary>>,
+    %% The global row (player_id IS NULL) is unique on (collection, key) and
+    %% is never deleted, so both have to be unique across runs (asobi#357).
+    Col = asobi_test_helpers:unique_id(~"coexist"),
+    Key = asobi_test_helpers:unique_id(~"flag"),
     Path = binary_to_list(<<"/api/v1/storage/", Col/binary, "/", Key/binary>>),
 
     GlobalParams = #{

--- a/test/asobi_store_SUITE.erl
+++ b/test/asobi_store_SUITE.erl
@@ -60,9 +60,10 @@ init_per_suite(Config) ->
     B2 = nova_test:json(R2),
     #{~"player_id" := P1Id, ~"access_token" := P1Token} = B1,
     #{~"player_id" := P2Id, ~"access_token" := P2Token} = B2,
-    Suffix = integer_to_binary(erlang:unique_integer([positive])),
+    %% item_defs.slug is unique and this row is never deleted, so the id has
+    %% to be unique across runs, not just within one (asobi#357).
     ItemCS = asobi_item_def:changeset(#{}, #{
-        slug => iolist_to_binary([~"test_sword_", Suffix]),
+        slug => asobi_test_helpers:unique_id(~"test_sword"),
         name => ~"Test Sword",
         category => ~"weapon",
         rarity => ~"rare"

--- a/test/asobi_telemetry_tests.erl
+++ b/test/asobi_telemetry_tests.erl
@@ -2,6 +2,67 @@
 
 -include_lib("eunit/include/eunit.hrl").
 
+%% #312: setup/0's attach list was hand-maintained next to the emitters and
+%% had drifted to 24 of the 35 events - the missing eleven being, aside from
+%% auth_cache, exactly the failure and abuse signals someone turns the debug
+%% logger on to see. Derive the emitted set from the module's own abstract
+%% code so the list cannot silently fall behind an emitter again.
+attach_list_covers_every_emitted_event_test() ->
+    Declared = lists:sort(asobi_telemetry:events()),
+    Emitted = emitted_events(),
+    ?assertEqual([], Emitted -- Declared, "emitted but not attached by setup/0"),
+    ?assertEqual([], Declared -- Emitted, "attached by setup/0 but never emitted"),
+    ?assertEqual(Declared, lists:usort(asobi_telemetry:events())).
+
+setup_attaches_a_handler_to_every_event_test() ->
+    {ok, _} = application:ensure_all_started(telemetry),
+    _ = telemetry:detach(~"asobi-metrics-logger"),
+    ok = asobi_telemetry:setup(),
+    try
+        Attached = [Ev || #{event_name := Ev} <- telemetry:list_handlers([asobi])],
+        ?assertEqual([], asobi_telemetry:events() -- Attached)
+    after
+        telemetry:detach(~"asobi-metrics-logger")
+    end.
+
+%% Every event name passed as a literal to telemetry:execute/3 anywhere in
+%% asobi_telemetry. Reading the compiled abstract code rather than grepping
+%% means a new emitter is picked up the moment it compiles.
+%% get_object_code/1 rather than which/1: under cover the latter answers
+%% `cover_compiled`, and the instrumented forms are not the ones we want to
+%% read anyway.
+emitted_events() ->
+    {asobi_telemetry, Beam, _} = code:get_object_code(asobi_telemetry),
+    {ok, {_, [{abstract_code, {_, Forms}}]}} = beam_lib:chunks(Beam, [abstract_code]),
+    lists:usort(collect_execute_calls(Forms, [])).
+
+collect_execute_calls(
+    {call, _, {remote, _, {atom, _, telemetry}, {atom, _, execute}}, [EventArg | _]} = Node,
+    Acc
+) ->
+    Acc1 =
+        case literal_atom_list(EventArg) of
+            {ok, Name} -> [Name | Acc];
+            error -> Acc
+        end,
+    collect_execute_calls(tuple_to_list(Node), Acc1);
+collect_execute_calls(Node, Acc) when is_tuple(Node) ->
+    collect_execute_calls(tuple_to_list(Node), Acc);
+collect_execute_calls([H | T], Acc) ->
+    collect_execute_calls(T, collect_execute_calls(H, Acc));
+collect_execute_calls(_, Acc) ->
+    Acc.
+
+literal_atom_list({nil, _}) ->
+    {ok, []};
+literal_atom_list({cons, _, {atom, _, Atom}, Rest}) ->
+    case literal_atom_list(Rest) of
+        {ok, Tail} -> {ok, [Atom | Tail]};
+        error -> error
+    end;
+literal_atom_list(_) ->
+    error.
+
 game_error_emits_single_event_test() ->
     {ok, _} = application:ensure_all_started(telemetry),
     Self = self(),

--- a/test/asobi_test_helpers.erl
+++ b/test/asobi_test_helpers.erl
@@ -1,6 +1,6 @@
 -module(asobi_test_helpers).
 
--export([start/1, unique_username/1]).
+-export([start/1, unique_username/1, unique_id/1]).
 -export([http_routes/1, routes_missing_options/1, preflight_targets/1, sample_path/1]).
 
 -spec start(list()) -> list().
@@ -13,6 +13,24 @@ unique_username(_Prefix) ->
     Bytes = crypto:strong_rand_bytes(16),
     Hex = binary:encode_hex(Bytes, lowercase),
     binary:part(Hex, 0, 32).
+
+-doc """
+A value no other run will produce, for any column under a unique index.
+
+The local database persists between runs while CI gets a fresh one, so a
+suite that writes a uniquely-constrained fixture and does not delete it only
+ever breaks local developers - and looks like a regression in unrelated work
+when it does (asobi#357).
+
+`erlang:unique_integer/1` is not a substitute: it is unique within one
+runtime instance, and each `rebar3 ct` run is a new one, so two runs hand out
+the same low integers. Random bytes are unique across runs and let a suite
+run concurrently with itself.
+""".
+-spec unique_id(binary()) -> binary().
+unique_id(Prefix) ->
+    Hex = binary:encode_hex(crypto:strong_rand_bytes(8), lowercase),
+    <<Prefix/binary, "_", Hex/binary>>.
 
 %% --- Router enumeration ---
 %%

--- a/test/asobi_test_helpers_tests.erl
+++ b/test/asobi_test_helpers_tests.erl
@@ -1,0 +1,20 @@
+-module(asobi_test_helpers_tests).
+
+-include_lib("eunit/include/eunit.hrl").
+
+%% Shape only. The property that actually matters for asobi#357 - a fixture id
+%% no *other run* will produce - cannot be asserted from inside one run, and a
+%% test that spawns peer nodes to show erlang:unique_integer/1 colliding is
+%% flaky in both directions (fresh instances usually, not always, hand out the
+%% same counter values). The regression evidence is running a suite twice
+%% against the same database.
+unique_id_keeps_the_prefix_test() ->
+    ?assertMatch(<<"txn_", _/binary>>, asobi_test_helpers:unique_id(~"txn")).
+
+unique_id_draws_from_a_large_space_test() ->
+    Ids = [asobi_test_helpers:unique_id(~"x") || _ <- lists:seq(1, 1000)],
+    ?assertEqual(1000, length(lists:usort(Ids))),
+    %% 8 random bytes, hex-encoded: the suffix has to be wide enough that two
+    %% runs colliding is not a thing that happens.
+    [Suffix] = tl(binary:split(hd(Ids), ~"_")),
+    ?assertEqual(16, byte_size(Suffix)).

--- a/test/asobi_world_ticker_tests.erl
+++ b/test/asobi_world_ticker_tests.erl
@@ -25,7 +25,10 @@ ticker_test_() ->
         {"promote is idempotent", fun promote_idempotent/0},
         {"demote is idempotent", fun demote_idempotent/0},
         {"cold_tick_divisor defaults to 10", fun cold_divisor_default/0},
-        {"cold_tick_divisor is configurable", fun cold_divisor_configurable/0}
+        {"cold_tick_divisor is configurable", fun cold_divisor_configurable/0},
+        {"world tick emits telemetry", fun world_tick_emits_telemetry/0},
+        {"world tick telemetry is sampled", fun world_tick_telemetry_is_sampled/0},
+        {"sample interval defaults to ~1s", fun sample_every_defaults_to_one_second/0}
     ]}.
 
 get_tick_starts_at_zero() ->
@@ -132,3 +135,83 @@ cold_divisor_configurable() ->
     Pid = start_ticker(#{cold_tick_divisor => 5}),
     State = get_state_map(Pid),
     ?assertEqual(5, maps:get(cold_tick_divisor, State)).
+
+%% --- #313: world tick telemetry ---
+%%
+%% Before this, asobi_world_ticker emitted nothing at all, so there was no way
+%% for an operator to see how long a world tick takes - the signal that
+%% degrades first under entity load.
+
+world_tick_emits_telemetry() ->
+    Pid = start_ticker(#{
+        tick_rate => 10, tick_sample_interval_ms => 10, world_id => ~"w-tick-1"
+    }),
+    Events = with_subscription([asobi, world, tick], ~"w-tick-1", fun(Ref) ->
+        asobi_world_ticker:set_zones(Pid, [], self()),
+        collect_for(Ref, 200)
+    end),
+    ?assert(length(Events) >= 1),
+    [{Measurements, Metadata} | _] = Events,
+    ?assertEqual(~"w-tick-1", maps:get(world_id, Metadata)),
+    ?assertEqual(1, maps:get(count, Measurements)),
+    ?assertEqual(0, maps:get(zone_count, Measurements)),
+    ?assert(is_integer(maps:get(duration_ms, Measurements))),
+    ?assert(maps:get(max_duration_ms, Measurements) >= maps:get(duration_ms, Measurements)).
+
+%% One event per tick per world (20 Hz by default) is too hot for a raw sink,
+%% so the ticker samples. Compare events against ticks actually taken in the
+%% same window rather than against wall clock, which keeps this honest on a
+%% loaded machine.
+world_tick_telemetry_is_sampled() ->
+    Pid = start_ticker(#{
+        tick_rate => 10, tick_sample_interval_ms => 50, world_id => ~"w-tick-2"
+    }),
+    ?assertEqual(5, maps:get(sample_every, get_state_map(Pid))),
+    {Events, Ticks} = with_subscription([asobi, world, tick], ~"w-tick-2", fun(Ref) ->
+        asobi_world_ticker:set_zones(Pid, [], self()),
+        Before = asobi_world_ticker:get_tick(Pid),
+        Collected = collect_for(Ref, 300),
+        {Collected, asobi_world_ticker:get_tick(Pid) - Before}
+    end),
+    ?assert(Ticks >= 5),
+    ?assert(length(Events) >= 1),
+    ?assert(length(Events) * 2 =< Ticks).
+
+sample_every_defaults_to_one_second() ->
+    ?assertEqual(20, maps:get(sample_every, get_state_map(start_ticker(#{tick_rate => 50})))),
+    ?assertEqual(10, maps:get(sample_every, get_state_map(start_ticker(#{tick_rate => 100})))),
+    %% A tick slower than the sample interval still samples every tick.
+    ?assertEqual(1, maps:get(sample_every, get_state_map(start_ticker(#{tick_rate => 5000})))).
+
+%% Filter on world_id: a ticker start_link'ed by an earlier test outlives that
+%% test's process (a non-trapping process ignores a `normal` exit signal from
+%% its link) and keeps emitting, so an unfiltered subscription counts events
+%% from tickers this test never started.
+with_subscription(Event, WorldId, Fun) ->
+    {ok, _} = application:ensure_all_started(telemetry),
+    Self = self(),
+    Ref = make_ref(),
+    telemetry:attach(
+        Ref,
+        Event,
+        fun
+            (_E, M, #{world_id := W} = Meta, _) when W =:= WorldId -> Self ! {Ref, M, Meta};
+            (_E, _M, _Meta, _) -> ok
+        end,
+        []
+    ),
+    try
+        Fun(Ref)
+    after
+        telemetry:detach(Ref)
+    end.
+
+collect_for(Ref, WindowMs) ->
+    collect_until(Ref, erlang:monotonic_time(millisecond) + WindowMs, []).
+
+collect_until(Ref, Deadline, Acc) ->
+    Wait = max(0, Deadline - erlang:monotonic_time(millisecond)),
+    receive
+        {Ref, M, Meta} -> collect_until(Ref, Deadline, [{M, Meta} | Acc])
+    after Wait -> lists:reverse(Acc)
+    end.

--- a/test/asobi_zone_manager_tests.erl
+++ b/test/asobi_zone_manager_tests.erl
@@ -65,7 +65,8 @@ zone_manager_test_() ->
         {"per-coord initial zone_state reaches zone init", fun initial_zone_states_threaded/0},
         {"missing per-coord state leaves zone_state default", fun initial_zone_states_default/0},
         {"a zone start emits zone/opened", fun zone_open_emits_telemetry/0},
-        {"a zone death emits exactly one zone/closed", fun zone_close_emits_telemetry_once/0}
+        {"a zone death emits exactly one zone/closed", fun zone_close_emits_telemetry_once/0},
+        {"manager shutdown emits no zone/closed", fun manager_shutdown_emits_no_close/0}
     ]}.
 
 %% --- #313: zone lifecycle telemetry ---
@@ -98,6 +99,21 @@ zone_close_emits_telemetry_once() ->
     end),
     stop_manager(Ctx),
     ?assertEqual([#{world_id => ~"test-world", coords => {1, 2}}], Events).
+
+%% Pins the documented limitation rather than a wish: the manager does not trap
+%% exits, so a shutdown kills it without running terminate/2, and the instance
+%% supervisor stops it before the zone supervisor, so it never sees the zones'
+%% DOWNs either. A live-zone gauge therefore has to be keyed on world_id and
+%% dropped when the world ends; it cannot be a single global counter pair.
+%% If this ever starts emitting, ADR 0005 needs updating with it.
+manager_shutdown_emits_no_close() ->
+    Ctx = #{mgr := Mgr} = start_manager(),
+    Events = with_subscription([asobi, zone, closed], {2, 2}, fun(Ref) ->
+        {ok, _, created} = asobi_zone_manager:ensure_zone(Mgr, {2, 2}),
+        stop_manager(Ctx),
+        drain(Ref)
+    end),
+    ?assertEqual([], Events).
 
 %% Filter on coords: every manager in this module shares one world_id, and a
 %% manager started by an earlier test can still be reaping when this one

--- a/test/asobi_zone_manager_tests.erl
+++ b/test/asobi_zone_manager_tests.erl
@@ -63,8 +63,72 @@ zone_manager_test_() ->
         {"revive_zone declines while the named zone is still running",
             fun revive_zone_declines_live_zone/0},
         {"per-coord initial zone_state reaches zone init", fun initial_zone_states_threaded/0},
-        {"missing per-coord state leaves zone_state default", fun initial_zone_states_default/0}
+        {"missing per-coord state leaves zone_state default", fun initial_zone_states_default/0},
+        {"a zone start emits zone/opened", fun zone_open_emits_telemetry/0},
+        {"a zone death emits exactly one zone/closed", fun zone_close_emits_telemetry_once/0}
     ]}.
+
+%% --- #313: zone lifecycle telemetry ---
+%%
+%% Zones are lazy, so a live-zone count is not derivable from world count.
+%% opened/closed are a counter pair an operator can subtract into a gauge -
+%% which only works if closed fires exactly once per open.
+
+zone_open_emits_telemetry() ->
+    Ctx = #{mgr := Mgr} = start_manager(),
+    Events = with_subscription([asobi, zone, opened], {0, 2}, fun(Ref) ->
+        {ok, _, created} = asobi_zone_manager:ensure_zone(Mgr, {0, 2}),
+        %% ensure_zone is a call, so the emit has already happened.
+        drain(Ref)
+    end),
+    stop_manager(Ctx),
+    ?assertEqual([#{world_id => ~"test-world", coords => {0, 2}}], Events).
+
+zone_close_emits_telemetry_once() ->
+    Ctx = #{mgr := Mgr} = start_manager(),
+    Events = with_subscription([asobi, zone, closed], {1, 2}, fun(Ref) ->
+        {ok, ZonePid, created} = asobi_zone_manager:ensure_zone(Mgr, {1, 2}),
+        exit(ZonePid, kill),
+        timer:sleep(50),
+        %% The manager has already cleaned up; a further cleanup pass over the
+        %% same coords must not emit a second close, or a gauge built from
+        %% opened minus closed drifts negative.
+        not_loaded = asobi_zone_manager:get_zone(Mgr, {1, 2}),
+        drain(Ref)
+    end),
+    stop_manager(Ctx),
+    ?assertEqual([#{world_id => ~"test-world", coords => {1, 2}}], Events).
+
+%% Filter on coords: every manager in this module shares one world_id, and a
+%% manager started by an earlier test can still be reaping when this one
+%% subscribes.
+with_subscription(Event, Coords, Fun) ->
+    {ok, _} = application:ensure_all_started(telemetry),
+    Self = self(),
+    Ref = make_ref(),
+    telemetry:attach(
+        Ref,
+        Event,
+        fun
+            (_E, _M, #{coords := C} = Meta, _) when C =:= Coords -> Self ! {Ref, Meta};
+            (_E, _M, _Meta, _) -> ok
+        end,
+        []
+    ),
+    try
+        Fun(Ref)
+    after
+        telemetry:detach(Ref)
+    end.
+
+drain(Ref) ->
+    drain(Ref, []).
+
+drain(Ref, Acc) ->
+    receive
+        {Ref, Meta} -> drain(Ref, [Meta | Acc])
+    after 50 -> lists:reverse(Acc)
+    end.
 
 starts_ok() ->
     Ctx = start_manager(),


### PR DESCRIPTION
Five open defects, none related to each other in code. One PR because they are all small, they touch disjoint files, and splitting them into five would cost five review contexts for one afternoon's backlog. Each is its own commit, so they read independently and revert independently.

Closes #334
Closes #348
Closes #312
Closes #313
Closes #357

---

## #334 - `around/3` ranks were offset by the size of the board

`count_before/2` walks the `ordered_set` comparing ETS *keys* (`{-Score, PlayerId}`); `entries_around/3` handed it the first entry's *player id*. No key ever equals a player id, so the walk always ran to `'$end_of_table'` and returned the board size - every rank in the window was numbered from `BoardSize + 1`.

`GET /api/v1/leaderboards/:id/around/:player_id` served those ranks straight to clients, so an "around me" panel showed every player a rank worse than they are, disagreeing with the rank the same player got back from `submit`.

The fix derives the start rank from the queried player's own key and steps back by the number of entries that precede them in the window, which stays correct when the window is truncated at either end of the board.

**Tests**: 2 new cases (`around_ranks_are_absolute`, `around_at_board_edges`), both fail on the old code and pass on the new. The first also cross-checks `around/3` against `rank/2` for all 10 players. The pre-existing `around_query` passes either way - it only asserts `length(Entries) =:= 5`, which is why the defect survived.

## #348 - reduction budget on Lua callbacks

The wall-clock timeout bounds latency, not work: a spinning callback is killed at its deadline and then does it again on the next tick, holding a scheduler for its full budget forever. `luerl_sandbox:run/3` offers a reduction limit upstream, but only over `luerl:do/2`; asobi's hot path is `luerl:call_function/3` against an already-loaded state, so the poll went into `bounded_eval/2`, which already spawned and monitored the worker.

**What the budget is.** `asobi_lua.max_reductions_per_ms` (default 50,000) times that callback's own wall-clock budget. Per-ms rather than absolute because the surface spans 50 ms (`think`) to 5000 ms (`generate_world`) and scaling keeps their relative weights. The rate is measured, not guessed: a 200-entity tick costs ~24k reductions in total, a spin sustains ~284k reductions/ms, so the budget sits ~1000x above a normal tick and cuts a spin at roughly 18% of its wall-clock window. Setting it to `0` restores the previous single-`receive` behaviour exactly.

**What happens when it is exceeded.** The same thing that happens on a timeout: the result is discarded, the previous Luerl state is kept, the error is logged, and the tick is skipped. The callers already have a catch-all clause next to their `{error, timeout}` clause, so no match or zone is ever torn down for this - killing a match because one callback overran would be worse than the spin it prevents. `reductions_exhausted` is a distinct tag purely so an operator can tell "burned CPU" from "was slow" and from "allocated too much" in a log line.

Sampled every 10 ms, so overshoot is bounded by one interval - the budget bounds sustained CPU, not the instantaneous peak. `handle_input/3` is still unbounded by design (ADR 0002: it runs in the calling process, no child).

`guides/security-lua-known-limitations.md` changes again: the section is no longer "the reduction limit Luerl offers is not applied" but "the CPU bound is sampled, not exact", and now documents the knob, the failure mode, and the two remaining limits. `guides/self-hosting.md` gains the config row.

**Tests**: 4 new. `reduction_budget_kills_spin_before_deadline_test` is the one that fails on the old code (1 failure when the loader change is reverted). Stated plainly:
- `reduction_budget_disabled_falls_back_to_timeout_test` is a **negative control** and passes either way by design.
- `reduction_budget_passes_normal_callback_test` also passes either way - it is a regression guard that the default rate does not kill legitimate work, not coverage of the new bound.
- `reduction_exhaustion_renders_distinctly_test` covers the new `format_reason/1` clause and fails without it.

Three existing tests asserted `{error, timeout}` on a spinning callback and now accept either bound, because which one fires first is machine-dependent. Their intent (the parent is not wedged; the callback is killed) is unchanged.

## #312 - the debug logger attached 24 of 35 events

The attach list was hand-maintained beside the emitters and had drifted. The eleven it missed were - `auth_cache` aside - exactly the failure and abuse signals someone turns the debug logger on to find: rate limits, anticheat violations, rejected origins, `[asobi, error]` itself.

The list moves to an exported `asobi_telemetry:events/0`, so a consumer attaches to the whole surface without restating it. Restating it is how the drift happened, and how `opentelemetry_asobi` ended up with the same stale copy - that repo should now switch to `events/0` (out of scope here, noted in the ADR).

**Tests**: `attach_list_covers_every_emitted_event_test` derives the emitted set from the module's own compiled abstract code (every literal event name passed to `telemetry:execute/3`) and asserts set equality both ways, so a new emitter without a matching entry fails the build. Verified by deleting `[asobi, error]` from `events/0`: the test fails. Plus `setup_attaches_a_handler_to_every_event_test`.

## #313 - no world-loop telemetry

`asobi_world_ticker`, `asobi_zone_manager` and `asobi_zone_spawner` emitted nothing. Adds `[asobi, world, tick]` and the `[asobi, zone, opened | closed]` pair. `asobi_zone_spawner` is a pure entity-template registry, not a zone lifecycle owner, and still emits nothing by design.

Settling the shape the issue left open:

- **`world/tick`** measures the full fan-out/fan-in cycle (dispatch to every zone, then the last `tick_done`), which is the thing that degrades under entity load. Measurements `#{duration_ms, max_duration_ms, zone_count, count}`, metadata `#{world_id}`. **Sampled** - 20 events/s/world raw is too hot for a sink - roughly once a second (`tick_sample_interval_ms` / tick rate). It carries `max_duration_ms` for the sampled window because a sampled duration alone hides exactly the spikes worth paging on. `entity_count` from the issue's sketch is not available at the ticker; `zone_count` is what it actually fans out to. A tick that never fans in (a zone died mid-tick) is not sampled rather than reported with a fabricated duration.
- **`zone/opened` / `zone/closed`** are a counter pair, since zones are lazy and a live count is not derivable from world count. `closed` is gated on the zone still being in the manager's ETS table, because `cleanup_zone/2` is reachable more than once for the same coords - otherwise a gauge drifts negative.

**The gauge can still drift upward, and I could not honestly fix it here.** A world teardown emits no `closed` at all: `asobi_zone_manager` does not trap exits, so a supervisor shutdown kills it without running `terminate/2`, and `asobi_world_instance` stops the manager *before* the zone supervisor, so it never processes the zones' `DOWN`s either. My first attempt put the emit in `terminate/2`; the test I wrote for it failed, which is how I found this. Making the manager trap exits would close the gap but is a supervision-tree change with its own shutdown-latency cost, so it is documented instead: key the gauge on `world_id` and drop a world's counters on `[asobi, world, finished]`. Both the ADR and a test now pin that.

ADR 0005 is updated: new events documented, `coords` classified unbounded, the count moves 35 -> 38, the gauge caveat recorded, and the two "known gaps" entries struck through. Additive, so a minor bump under the ADR's stability rule.

**Tests**: 6 new (3 ticker, 3 zone manager). 5 fail when the emitters are reverted. The 6th, `manager_shutdown_emits_no_close`, **passes either way** - it pins the documented limitation above so the ADR and the code cannot disagree silently, and is not coverage of the new events.

Worth noting for anyone writing telemetry tests here: eunit's per-test process exiting `normal` does **not** kill a `start_link`ed gen_server, so a previous test's ticker keeps emitting into the next test's subscription. The subscriptions filter on `world_id` / `coords` for that reason; the sampling test was green, then red, until I found it.

## #357 - suites leaving uniquely-constrained rows behind

`asobi_iap_SUITE` inserted `iap_transactions` with a fixed `txn-1` and never deleted it. The table is unique on `(provider, transaction_id)`, so the first run passed and every later run against the same database got a 409. CI never saw it because CI gets a fresh database - which is why it survived three weeks costing only local developers, and looking like a regression in whatever unrelated work happened to be in flight.

**The sweep found a second, quieter cause.** `erlang:unique_integer([positive])` is unique within one *runtime instance*, and each `rebar3 ct` run is a new one, so two runs hand out the same low integers (measured: three fresh VMs, two produced the identical `2242, 2306, 2370`). Anything keyed on it was never run-unique despite comments in `asobi_storage_SUITE` claiming exactly that. Affected fixtures under a unique index:

- `asobi_oauth_SUITE` - `provider_uid`, unique on `(provider, provider_uid)`. **This suite was already failing on a first run here**, for this reason.
- `asobi_store_SUITE` - `item_defs.slug`.
- `asobi_storage_SUITE` - the global row (`player_id IS NULL`), unique on `(collection, key)`.

Also swept and cleared: `group_members`, `wallets`, `friendships`, `cloud_saves`, `leaderboard_entries`, `zone_snapshots`, `players.username` - all keyed on a per-run player id, uuid, or the existing random `unique_username/1`, so none can collide across runs.

Adds `asobi_test_helpers:unique_id/1` (random bytes, like the existing `unique_username/1`). Preferred over an `end_per_testcase` cleanup because it also lets a suite run concurrently with itself, which cleanup does not. `asobi_lua_storage_SUITE` had grown a private copy of the same helper; it now shares this one.

**Evidence**: before, the first run of `iap + storage + store + oauth` failed 2 tests on a database that already had leftovers. After, three consecutive runs pass 59/59. The two unit tests on `unique_id/1` are shape only, and say so in a comment - the cross-run property cannot be asserted from inside one run, and a peer-node test showing `unique_integer` colliding is flaky in both directions, so I dropped it rather than count it as coverage.

---

## Checks

All green on the final tree: `rebar3 fmt --check`, `xref`, `dialyzer`, `ex_doc` (zero warnings - it caught two bad references in this branch, both fixed), full `eunit` (1511 tests, 0 failures), and `ct` for every suite touched (65 tests, 0 failures).

One process note, since it produced a red herring mid-way: running `rebar3 ct` and `rebar3 eunit` concurrently in the same worktree corrupts `_build` and surfaces as an unrelated `undef` on `asobi_rate_limit_plugin`. All the numbers above come from serial runs.

## Not done

- #287 (CI stale-ebin cache) - needs a change to `Taure/erlang-ci`, out of scope.
- `opentelemetry_asobi` still carries its own copy of the stale 24-name list. Different repo; `events/0` now exists for it to use.
- The four events with no in-tree emitter (`session/disconnected`, `ws/message_out`, `store/purchase`, `anticheat/violation`) are now attached along with everything else. Still no emitters - ADR 0005 already warns not to read silence on `anticheat/violation` as "no cheating".
