### PR TITLE
feat(extensions): a player-erase hook, a readiness gate, and derived queue claims

### DIFF
--- a/guides/extensions.md
+++ b/guides/extensions.md
@@ -62,7 +62,7 @@ cannot be triggered by a player action from the client.
 ```erlang
 -module(asobi_quests_extension).
 -behaviour(asobi_extension).
--export([info/0, rpc/0, lua/0, sup/0, owns/0, codes/0]).
+-export([info/0, rpc/0, lua/0, sup/0, owns/0, codes/0, erase_player/1]).
 
 info() -> #{name => quests, extension_version => 1}.
 
@@ -77,7 +77,7 @@ lua()  -> #{~"quests" =>
                 ~"status"   => #{mfa     => {asobi_quests_lua, status, 1},
                                  args    => [binary],
                                  effects => none,
-                                 vms     => [match, world, bot]}}}.
+                                 vms     => [match, world, zone]}}}.
 
 sup()  -> [#{id    => asobi_quests_tracker,
              start => {asobi_quests_tracker, start_link, []}}].
@@ -89,22 +89,28 @@ owns() -> #{tables => [~"quests", ~"quest_progress"],
 
 codes() -> #{~"quests.already_claimed" =>
                #{status => 409, message => ~"This quest was already claimed."}}.
+
+erase_player(PlayerId) ->
+    {ok, _} = asobi_repo:delete_all(by_player(asobi_quest_progress, PlayerId)),
+    ok.
 ```
 
-Only `info/0` is required. The rest default to empty.
+Only `info/0` is required. The rest default to nothing.
 
 - `rpc/0` - core cannot guess that `quests.claim` is `{asobi_quests_rpc, claim, 2}`.
   The arity is always 2; see [Writing an RPC handler](#writing-an-rpc-handler).
 - `lua/0` - the `game.<ns>.*` surface a Lua game calls. `effects` is not
   decoration: probe VMs re-run the whole script body to ask `phases()` and swap
   every `write` function for an inert stub, so a `write` declared `none` fires
-  twice on every match creation. See
-  [Writing a Lua binding](#writing-a-lua-binding).
+  twice on every match creation. `vms` may name `match`, `world` or `zone`;
+  `bot` is refused. See [Writing a Lua binding](#writing-a-lua-binding).
 - `sup/0` - child specs, if you want asobi supervising them.
-- `owns/0` - the tokens this extension claims. It earns nothing with one
-  extension installed; it is the N >= 2 key.
+- `owns/0` - the closed statement of what this extension claims. Every kind is
+  derived from your own code as well, so `owns/0` is an assertion over the
+  derivation rather than its source.
 - `codes/0` - the error codes this extension mints. Core's set is closed, so
   an undeclared code answers 500 and logs as a core defect.
+- `erase_player/1` - how to erase one player, when your rows do not cascade.
 - `info/0` - the contract version, distinct from the package version, because a
   minor release can change an experimental contract.
 
@@ -279,15 +285,48 @@ Per-extension restart limits default to 5 in 60 and are settable:
 Lua namespace or job queue is a build failure naming both claimants, and so is
 claiming a name core reserves.
 
-The claim set is `owns/0` plus what the manifest already implies: the prefixes
-in `rpc/0` and the namespaces in `lua/0`. So a collision is caught even before
-either extension has bothered with `owns/0`.
+The claim set is `owns/0` plus what your own code already implies, and every
+kind derives:
 
-Core's reserved names are derived from core itself: Lua namespaces from
+| Kind | Derived from |
+|---|---|
+| `rpc` | the prefixes in `rpc/0` and the domains in `codes/0` |
+| `lua` | the namespaces in `lua/0` |
+| `tables` | `table/0` on your `kura_schema` modules |
+| `queues` | `queue/0` on your `shigoto_worker` modules |
+
+So a collision is caught even before either extension has bothered with
+`owns/0`, and a queue you actually run is claimed whether or not you remembered
+to say so.
+
+That leaves `owns/0` one job: it is the **closed-set assertion**. Naming a kind
+at all says "this is the whole set", so anything derived outside it is a build
+failure. That is what catches the typo - a worker on `quests`, an `owns/0`
+saying `quest` - which used to be invisible, because nothing read `owns.queues`
+at runtime.
+
+Core's reserved names are derived from core itself, by the same two rules: Lua
+namespaces from
 `asobi_lua_surface`, tables from core's schemas, queues from core's shigoto
 workers, and RPC prefixes from the domains of `asobi_error:core_codes/0` - an
 RPC prefix and an error-code domain are the same token, so owning `storage`
 would mint codes inside core's closed code set.
+
+## Bots are not a target
+
+`vms` may name `match`, `world` or `zone`. `bot` is **refused at
+`rebar3 asobi check`**, not ignored.
+
+A bot script is loaded without any `game` table at all - see
+[Bots](lua-bots.md) - so a binding declaring `bot` would install nothing, and a
+declaration that silently does nothing is a defect. Making it work was the
+alternative and was rejected: `game.quests` in a bot VM would be one extension
+namespace floating in a `game` table with no `game.log`, `game.economy` or
+`game.storage` under it, and a bot has no `players.id` - `bot_Spark` is not a
+player row - so the argument every extension binding takes cannot be supplied.
+
+A bot decides from the state the match broadcasts and nothing more. Put what it
+needs in that state.
 
 ## Error codes
 
@@ -333,8 +372,62 @@ Rules:
 
 Your migrations run from your own application: kura discovers them through
 `asobi_repo:migration_apps/0`, inside core's transaction and under one
-advisory lock. Declare `on_delete = cascade` on the `#kura_assoc` into
-`players.id` and the generated migration carries it.
+advisory lock.
+
+## Deleting a player
+
+Cascade or declare an erase path - and an undeclared `on_delete` lowers to
+`no_action`, so the foreign key `rebar3 kura compile` generates refuses the
+delete until you have picked one. The first row your extension writes for a
+player makes that player undeletable otherwise.
+
+Cascade is one line on the association:
+
+```erlang
+#kura_assoc{
+    name = player, type = belongs_to, schema = asobi_player,
+    foreign_key = player_id, on_delete = cascade
+}
+```
+
+`rebar3 kura compile` carries that into the generated migration as
+`ON DELETE CASCADE`, and there is nothing else to write. The symptom of
+declaring neither is guests quietly ceasing to be reaped.
+
+Cascade is right for progress rows and wrong for a financial or audit row -
+the case that rejected a blanket cascade in the first place. Implement
+`erase_player/1` instead:
+
+```erlang
+-spec erase_player(binary()) -> ok | {error, term()}.
+erase_player(PlayerId) ->
+    {ok, _} = asobi_repo:delete_all(by_player(asobi_quest_progress, PlayerId)),
+    ok.
+```
+
+Core calls it inside its own transaction, before deleting any of its own rows,
+once per installed extension in dependency order. Do not open a transaction of
+your own. Extensions run before core so an erase path can still read the
+player's core rows.
+
+**Erasure is atomic across every extension.** Returning `{error, Reason}` or
+raising aborts the whole deletion - no extension's rows go, core's rows stay,
+the player survives, and one logged line names the extension and the reason.
+Best-effort was rejected: an erasure that half-succeeds and reports success
+leaves an account gone with some extension's rows orphaned and nothing durable
+saying which, which is a worse answer to a data-subject request than one that
+fails loudly and can be retried.
+
+The corollary: an erase path doing work the transaction cannot undo - deleting
+a remote object, calling a third party - must be idempotent, because a later
+extension's failure rolls back everything around it and the deletion is retried.
+
+Omit `erase_player/1` when your rows cascade: it is the alternative to that
+declaration, not a second copy of it. Cascade lives on the column because the
+database is what enforces it, and a manifest key saying the same thing could
+disagree with the schema that actually decides - which is why this is a
+callback and not an `owns/0` key. Delete the rows or null the player reference
+and keep the ledger; core only needs the player row to be able to go.
 
 ## Counters
 
@@ -357,6 +450,36 @@ The conflict target must be a primary key or covered by a unique index.
 There is no general `query/2`. Every identifier `increment/3` interpolates is
 a field of the schema you pass and every value is a bound parameter, which is
 a promise raw SQL through the seam could not make.
+
+## Readiness
+
+The route table compiles during Nova's boot; migrations run afterwards, from
+`asobi_app:start/2`. An extension endpoint is therefore reachable before its
+tables exist, so core fails closed until migrations finish:
+
+```erlang
+case asobi_readiness:guard() of
+    ok -> dispatch(Method, Params);
+    {error, Object} -> {asobi_error, 503, Object}
+end.
+```
+
+The `not_ready` code is 503, because retrying works.
+
+Your `sup/0` children are on the other side of that seam and get two guarantees,
+so none of them needs a retry path:
+
+- **They start in the order `sup/0` returns them**, and after the children of
+  every extension your application depends on. That is OTP's own child order and
+  `asobi_extensions:resolve/0`'s dependency order; nothing sorts either.
+- **`init/1` may query.** Extension children start after migrations have run to
+  completion, so the pool is up and every table - core's and yours - exists.
+
+If migrations did not complete, `asobi_extension_sup` starts **no extension at
+all** and logs which ones it did not start. The alternative is every extension
+crash-looping into its own restart budget and going dark anyway, with an OTP
+crash report as the only explanation. The marker is written once, before this
+supervisor exists, so it cannot flip later and there is nothing to retry.
 
 ## Where the logic goes
 

--- a/guides/lua-bots.md
+++ b/guides/lua-bots.md
@@ -97,6 +97,10 @@ only for match and world scripts; inside a bot's `think`, `game` is `nil`.
 There is no `game.economy`, `game.log`, `game.storage` or `game.leaderboard`
 for a bot.
 
+An installed [extension](extensions.md) cannot add one either. `bot` is not a
+VM kind an extension's `lua/0` may name, and declaring it is a build failure
+rather than a binding that quietly installs nothing.
+
 What is available:
 
 - The Lua standard library, minus what the sandbox clears. `io`, `package`,

--- a/src/asobi_guest_reaper.erl
+++ b/src/asobi_guest_reaper.erl
@@ -183,6 +183,12 @@ reap_one(Identity) ->
 %% Delete the player and its FK children (which are ON DELETE NO ACTION, so the
 %% player row can't go first) atomically, children before the player. Only count
 %% a genuine deletion; a rolled-back/failed sweep reports skipped, not reaped.
+%%
+%% Installed extensions erase first, in the same transaction: an extension row
+%% that does not cascade holds the player row down exactly as core's own
+%% children do, so without this every such extension makes guests unreapable.
+%% Extensions before core so an erase path can still read the player's core
+%% rows.
 -spec delete_guest_cascade(binary()) -> reaped | skipped.
 delete_guest_cascade(PlayerId) ->
     Fun = fun() ->
@@ -197,7 +203,9 @@ delete_guest_cascade(PlayerId) ->
                 %% Assert each delete: a bare `{error,_}` return (not a raise)
                 %% would otherwise let pgo commit a partial cascade (children
                 %% gone, player left). Matching {ok,_} turns that into a badmatch
-                %% that raises, rolling the whole transaction back.
+                %% that raises, rolling the whole transaction back. Same reason
+                %% the extension erase path is asserted rather than inspected.
+                ok = asobi_extension_erase:run(PlayerId),
                 {ok, _} = asobi_repo:delete_all(by_player(asobi_player_stats, PlayerId)),
                 %% player_tokens keys players by `user_id`, not `player_id`.
                 {ok, _} = asobi_repo:delete_all(by_user(asobi_player_token, PlayerId)),

--- a/src/asobi_readiness.erl
+++ b/src/asobi_readiness.erl
@@ -27,6 +27,13 @@ readiness contract rather than inventing one.
 
 `persistent_term` rather than a process: the read is on the dispatch path,
 it happens once per call, and the value is written exactly once at boot.
+
+## The other reader
+
+`asobi_extension_sup` reads `ready/0` at `init/1`. Migrations run before
+`asobi_sup:start_link/0`, so the answer is already final by then, which is what
+lets an extension's own `sup/0` children query at `init/1` without a retry
+path: either the database is there, or no extension started at all.
 """.
 
 -export([guard/0, ready/0, mark_ready/0]).

--- a/src/extensions/asobi_extension.erl
+++ b/src/extensions/asobi_extension.erl
@@ -16,7 +16,7 @@ behaviour covers only what core cannot infer.
 ```erlang
 -module(asobi_quests_extension).
 -behaviour(asobi_extension).
--export([info/0, rpc/0, lua/0, sup/0, owns/0, codes/0]).
+-export([info/0, rpc/0, lua/0, sup/0, owns/0, codes/0, erase_player/1]).
 
 info() -> #{name => quests, extension_version => 1}.
 
@@ -36,12 +36,16 @@ sup()  -> [#{id => asobi_quests_tracker,
 
 owns() -> #{tables => [~"quests"], rpc => [~"quests"],
             lua => [~"quests"], queues => [~"quests"]}.
+
+erase_player(PlayerId) ->
+    {ok, _} = asobi_repo:delete_all(by_player(asobi_quest_progress, PlayerId)),
+    ok.
 ```
 
-Only `info/0` is required. `rpc/0`, `lua/0`, `sup/0`, `owns/0` and `codes/0`
-default to empty, because several are frequently empty: an extension with no
-processes has no `sup/0`, and `owns/0` earns nothing until a second extension
-exists to collide with.
+Only `info/0` is required. `rpc/0`, `lua/0`, `sup/0`, `owns/0`, `codes/0` and
+`erase_player/1` default to nothing, because several are frequently empty: an
+extension with no processes has no `sup/0`, and one whose rows cascade needs no
+`erase_player/1`.
 
 An extension declaring neither `rpc/0` nor `lua/0` is reachable by nobody:
 game logic calls `game.<ns>.*` from Lua, and clients call
@@ -92,6 +96,20 @@ function - a game developer must never see a silent nil.
 in its `.app.src`. Applications in a release are permanent by default and a
 permanent application terminating takes the whole runtime with it, so an
 extension supervising itself can kill the node. See `m:asobi_extension_sup`.
+
+Two guarantees a `sup/0` child may rely on, so no extension has to reinvent a
+retry path around them:
+
+- **Children start in the order `sup/0` returns them**, and one extension's
+  children start after every extension its application depends on. That is
+  OTP's own child order and `asobi_extensions:resolve/0`'s dependency order;
+  nothing sorts either.
+- **`init/1` may query.** Extension children start after
+  `kura_migrator:migrate/1` has run to completion, so the pool is up and every
+  table - core's and the extension's own - exists. If migrations did not
+  complete, `asobi_extension_sup` starts no extension at all rather than
+  letting each one crash-loop into its restart budget and go dark with an OTP
+  crash report as the only explanation.
 
 This contract is experimental and deliberately unfrozen. The wire freezes,
 because SDK users vendor by copying source; this module freezes when a real
@@ -149,6 +167,10 @@ creation.
 
 `mfa` is called fully qualified rather than stored as a fun, so a code upgrade
 takes effect without waiting for every live match VM to end.
+
+`vms` may name any of `asobi_lua_surface:extension_vm_kinds/0`. `bot` is not
+one of them and is refused rather than ignored: a bot script has no `game`
+table at all, so the binding would install nothing.
 """.
 -type lua_function() :: #{
     mfa := mfa(),
@@ -186,6 +208,63 @@ per deployment and nothing reachable from a request can widen it.
 """.
 -type codes() :: #{asobi_error:code() => code_spec()}.
 
+-doc """
+Erase everything this extension holds about one player.
+
+An extension foreign-keying into `players.id` must **cascade or declare an
+erase path**, and this is the erase path. Declare neither and installing the
+extension makes players undeletable: an undeclared `on_delete` lowers to
+`no_action`, so the first extension row for a player turns core's delete into a
+constraint violation.
+
+Cascade is right for progress rows and wrong for a financial or audit row - the
+case that rejected a blanket cascade in the first place. An extension holding
+one exports this instead, and answers erasure in whatever way its own law
+requires: delete the rows, or null the player reference and keep the ledger.
+Core does not care which, only that the player row can then go.
+
+Not an `owns/0` key. `owns/0` is a set of names, validated at build time and
+read by nothing at runtime; it reserves, it does not execute. Cascade is
+already declared where the database can enforce it - `on_delete = cascade` on
+the `#kura_assoc`, carried into the generated migration - and a second
+declaration of the same fact in the manifest could disagree with the schema
+that actually decides. So the two alternatives stay in the two places that
+enforce them: cascade on the column, erase here.
+
+## When it runs, and what a failure does
+
+Core calls it **inside its own transaction**, before deleting any of its own
+rows, once per installed extension in dependency order. Do not open a
+transaction of your own.
+
+Extensions before core, because an erase path may want to read what core still
+has (a player's stats, its identities) while writing its own summary row. Order
+*between* extensions is not load-bearing and is not promised beyond dependency
+order: extensions never foreign-key each other, only core.
+
+**Erasure is atomic across every extension, not best-effort with a report.**
+Returning `{error, Reason}` or raising aborts the whole deletion: no extension's
+rows go, core's rows stay, the player survives, and one logged line names the
+extension and the reason. The alternative was considered and rejected. A
+best-effort erasure ends with the account gone and some extension's rows
+orphaned, or the reverse, and nothing durable saying which - a half-finished
+erasure that reports success is a worse answer to a data-subject request than
+one that fails loudly and can be retried. Every extension shares `asobi_repo`,
+so the single transaction that makes this true costs nothing to arrange.
+
+The corollary is that an erase path doing work the transaction cannot undo -
+deleting a remote object, calling a third party - must be idempotent, because a
+later extension's failure will roll back everything around it and the whole
+deletion will be retried.
+
+Core deletes a player in one place today, `asobi_guest_reaper`, so that is
+where this runs. (`asobi_guest_controller` also deletes, but only a player row
+it inserted microseconds earlier and lost a race on, which no extension has
+been told about yet.) `m:asobi_extension_erase` is the seam, and a future
+operator-facing erasure calls the same function.
+""".
+-callback erase_player(PlayerId :: binary()) -> ok | {error, term()}.
+
 -callback info() -> info().
 -callback rpc() -> rpc().
 -callback lua() -> lua().
@@ -193,4 +272,4 @@ per deployment and nothing reachable from a request can widen it.
 -callback owns() -> owns().
 -callback codes() -> codes().
 
--optional_callbacks([rpc/0, lua/0, sup/0, owns/0, codes/0]).
+-optional_callbacks([rpc/0, lua/0, sup/0, owns/0, codes/0, erase_player/1]).

--- a/src/extensions/asobi_extension_erase.erl
+++ b/src/extensions/asobi_extension_erase.erl
@@ -1,0 +1,72 @@
+-module(asobi_extension_erase).
+-moduledoc """
+Runs every installed extension's erase path for one player.
+
+Core's caller holds the transaction; this walks the installed set inside it,
+calls `erase_player/1` on each extension that exports one, and stops at the
+first failure. See `c:asobi_extension:erase_player/1` for why erasure is atomic
+across extensions rather than best-effort, and why the alternative to this
+callback is a cascade in the migration rather than a key in `owns/0`.
+
+A caller must **assert the result**, because a bare `{error, _}` returned from
+inside `asobi_repo:transaction/1` still commits:
+
+```erlang
+asobi_repo:transaction(fun() ->
+    ok = asobi_extension_erase:run(PlayerId),
+    {ok, _} = asobi_repo:delete_all(...),
+    ...
+end).
+```
+
+The badmatch is what rolls the transaction back; the line naming the extension
+is logged here, before the reason is flattened into a badmatch term.
+
+An extension that raises is caught rather than allowed to propagate, so the
+failure is attributed to a name before it becomes the caller's problem. Nothing
+runs after a catch: the Postgres transaction is already aborted at that point,
+and the only correct next statement is the caller's rollback.
+""".
+
+-include_lib("kernel/include/logger.hrl").
+
+-export([run/1]).
+
+-doc """
+`ok`, or the first extension to fail and why. Nothing is retried and nothing
+after it is attempted.
+""".
+-spec run(binary()) -> ok | {error, {asobi_extension:name(), term()}}.
+run(PlayerId) ->
+    erase_each(asobi_extensions:resolve(), PlayerId).
+
+erase_each([], _PlayerId) ->
+    ok;
+erase_each([#{name := Name, module := Module} | Rest], PlayerId) ->
+    case erase_one(Module, PlayerId) of
+        ok ->
+            erase_each(Rest, PlayerId);
+        {error, Reason} ->
+            ?LOG_ERROR(#{
+                msg => ~"extension_erase_failed",
+                extension => Name,
+                player_id => PlayerId,
+                reason => Reason,
+                detail => ~"this player was not deleted; nothing was erased"
+            }),
+            {error, {Name, Reason}}
+    end.
+
+erase_one(Module, PlayerId) ->
+    case erlang:function_exported(Module, erase_player, 1) of
+        false ->
+            ok;
+        true ->
+            try Module:erase_player(PlayerId) of
+                ok -> ok;
+                {error, Reason} -> {error, Reason};
+                Other -> {error, {bad_return, Other}}
+            catch
+                Class:Reason:Stacktrace -> {error, {raised, Class, Reason, Stacktrace}}
+            end
+    end.

--- a/src/extensions/asobi_extension_reserved.erl
+++ b/src/extensions/asobi_extension_reserved.erl
@@ -26,9 +26,15 @@ cannot drift:
 Deriving from modules costs one `code:ensure_loaded/1` sweep over core's
 module list. `asobi_extensions` only asks for it when at least one extension
 is installed, so a node with none pays nothing.
+
+`schema_tables/1` and `worker_queues/1` are the two derivation rules
+themselves, exported over an arbitrary module list. `asobi_extensions` runs
+them over an **extension's** modules to derive that extension's table and queue
+claims, so core's names and an extension's names are found by the same rule
+rather than by two that can disagree.
 """.
 
--export([namespaces/0, kinds/0]).
+-export([namespaces/0, kinds/0, schema_tables/1, worker_queues/1]).
 
 -type kind() :: tables | rpc | lua | queues.
 -export_type([kind/0]).
@@ -44,11 +50,21 @@ namespaces() ->
     Modules = core_modules(),
     Lua = lua(),
     #{
-        tables => exported_values(Modules, table, {fields, 0}),
-        queues => exported_values(Modules, queue, {perform, 1}),
+        tables => schema_tables(Modules),
+        queues => worker_queues(Modules),
         lua => Lua,
         rpc => lists:usort(error_domains() ++ Lua)
     }.
+
+-doc "Every table declared by a `kura_schema` module in this list.".
+-spec schema_tables([module()]) -> [asobi_extension:token()].
+schema_tables(Modules) ->
+    exported_values(Modules, table, {fields, 0}).
+
+-doc "Every queue declared by a `shigoto_worker` module in this list.".
+-spec worker_queues([module()]) -> [asobi_extension:token()].
+worker_queues(Modules) ->
+    exported_values(Modules, queue, {perform, 1}).
 
 lua() ->
     lists:usort([

--- a/src/extensions/asobi_extension_sup.erl
+++ b/src/extensions/asobi_extension_sup.erl
@@ -39,9 +39,30 @@ Three deliberate choices:
 
 Per-extension intensity defaults to 5 in 60 and is settable with
 `{extension_restart, #{intensity => I, period => P}}` in asobi's app env.
+
+## Readiness is a precondition, not a race
+
+An extension child that queries at `init/1` needs the pool up and its own
+tables created, and must not crash if they are not - a crash loop here ends
+with the extension dark and staying dark, which is exactly the outcome the
+transient sub-supervisor is for. Rather than making every extension carry a
+retry path, a loaded-marker and a fallback, core makes the precondition hold.
+
+`asobi_app:start/2` runs `kura_migrator:migrate/1` and then
+`asobi_readiness:mark_ready/0` **before** `asobi_sup:start_link/0`, so by the
+time this supervisor initialises the answer is already final and cannot flip
+later. If it is `false`, migrations did not complete: no extension starts and
+one line says which ones. `asobi_readiness:guard/0` is the other half of the
+same marker, and answers 503 on the dispatch path for the same reason.
+
+The extension is dark either way. The difference is that it is dark for a
+stated reason instead of after burning its restart budget, and that `init/1`
+gets to assume a working database.
 """.
 
 -behaviour(supervisor).
+
+-include_lib("kernel/include/logger.hrl").
 
 -export([start_link/0, running/0]).
 -export([init/1]).
@@ -70,7 +91,20 @@ init([]) ->
 children([]) ->
     [];
 children(Extensions) ->
-    [sub_sup(Extension) || Extension <- Extensions] ++ [watch(Extensions)].
+    case asobi_readiness:ready() of
+        true -> [sub_sup(Extension) || Extension <- Extensions] ++ [watch(Extensions)];
+        false -> none_started(Extensions)
+    end.
+
+%% No watch child either: it exists to say which extension went dark, and
+%% saying it twice about the same set is noise.
+none_started(Extensions) ->
+    ?LOG_ERROR(#{
+        msg => ~"extensions_not_started",
+        extensions => [Name || #{name := Name} <- Extensions],
+        detail => ~"migrations did not complete; extensions answer 503, core is unaffected"
+    }),
+    [].
 
 sub_sup(#{name := Name, module := Module}) ->
     #{

--- a/src/extensions/asobi_extensions.erl
+++ b/src/extensions/asobi_extensions.erl
@@ -421,7 +421,7 @@ is_lua_binding(Name, #{mfa := {M, F, A}, args := Args, effects := Effects, vms :
     length(Args) =:= A andalso
         lists:member(Effects, asobi_lua_surface:effects()) andalso
         Vms =/= [] andalso
-        lists:all(fun(Vm) -> lists:member(Vm, asobi_lua_surface:vm_kinds()) end, Vms);
+        lists:all(fun(Vm) -> lists:member(Vm, asobi_lua_surface:extension_vm_kinds()) end, Vms);
 is_lua_binding(_Name, _Binding) ->
     false.
 
@@ -429,6 +429,14 @@ binding_problem(#{mfa := {_, _, A}, args := Args}) when
     is_integer(A), is_list(Args), length(Args) =/= A
 ->
     ~"args must declare one type per mfa argument";
+%% `bot` is a VM kind core has and not one an extension may bind into: a bot
+%% script is loaded with no `game` table at all, so the binding would install
+%% nothing. See `asobi_lua_surface:extension_vm_kinds/0`.
+binding_problem(#{vms := Vms}) when is_list(Vms) ->
+    case lists:member(bot, Vms) of
+        true -> ~"vms cannot include bot: a bot VM has no game.* table to install into";
+        false -> ~"binding must be #{mfa, args, effects, vms}"
+    end;
 binding_problem(_Binding) ->
     ~"binding must be #{mfa, args, effects, vms}".
 
@@ -488,11 +496,29 @@ sup_problems(Specs) ->
 Namespace disjointness across the declared set, and against core's reserved
 names.
 
-The claim set per namespace is `owns/0` **plus** what the manifest already
-implies: the prefixes in `rpc/0`, the domains in `codes/0` and the namespaces
-in `lua/0`. So two extensions installing the same `game.quests` collide even
-before either has bothered with `owns/0`, which earns nothing until there is a
-second extension.
+The claim set per namespace is `owns/0` **plus** what the extension's own code
+already implies, and every kind derives:
+
+| Kind | Derived from |
+|---|---|
+| `rpc` | the prefixes in `rpc/0` and the domains in `codes/0` |
+| `lua` | the namespaces in `lua/0` |
+| `tables` | `table/0` on the extension's `kura_schema` modules |
+| `queues` | `queue/0` on the extension's `shigoto_worker` modules |
+
+So two extensions installing the same `game.quests`, or the same job queue,
+collide before either has bothered with `owns/0`.
+
+The last two derive through `asobi_extension_reserved`, the same rule that
+finds core's own tables and queues, so a name core reserves and a name an
+extension claims can never be found two different ways.
+
+That leaves `owns/0` doing one job, and it is worth stating because it is no
+longer the source of anything: it is the **closed-set assertion** over what was
+derived. Naming a kind at all says "this is the complete set", and anything
+derived outside it is `undeclared_claim` - which is what turns a typo in
+`owns.queues` from an invisible no-op into a build failure. Nothing in
+`owns/0` is load-bearing for collision detection any more.
 """.
 -spec validate([extension()]) -> ok | {error, [problem(), ...]}.
 validate([]) ->
@@ -553,8 +579,13 @@ derived(#{rpc := Rpc, codes := Codes}, rpc) ->
     );
 derived(#{lua := Lua}, lua) ->
     lists:usort(maps:keys(Lua));
-derived(_Extension, _Kind) ->
-    [].
+%% A shigoto queue is only ever what the worker's own `queue/0` returns -
+%% nothing reads `owns.queues` at runtime - so deriving it here is what makes
+%% the claim enforceable at all. Same for a table and its schema.
+derived(#{app := App}, tables) ->
+    asobi_extension_reserved:schema_tables(modules(App));
+derived(#{app := App}, queues) ->
+    asobi_extension_reserved:worker_queues(modules(App)).
 
 prefix(Method) when is_binary(Method) ->
     case binary:split(Method, ~".") of

--- a/src/lua/asobi_lua_surface.erl
+++ b/src/lua/asobi_lua_surface.erl
@@ -15,12 +15,13 @@ Three things live here, and only here:
   means it mutates durable state, fans an event out to players, or moves
   a resource; `none` means it only reads or computes. Probe VMs
   (`asobi_lua_api:install/2`) suppress every `write`.
-- `t:vm_kind/0` - the kinds of VM a Lua chunk runs in.
+- `t:vm_kind/0` - the kinds of VM a Lua chunk runs in, and
+  `extension_vm_kinds/0`, the subset an extension may bind into.
 """.
 
 -export([reserved_namespaces/0, is_reserved/1, name/1]).
 -export([effects/0]).
--export([vm_kinds/0]).
+-export([vm_kinds/0, extension_vm_kinds/0]).
 
 -export_type([namespace/0, effect/0, vm_kind/0]).
 
@@ -61,3 +62,26 @@ effects() ->
 -spec vm_kinds() -> [vm_kind(), ...].
 vm_kinds() ->
     [match, world, zone, bot].
+
+-doc """
+The VM kinds an extension's `lua/0` binding may name.
+
+`bot` is absent, and its absence is enforced rather than documented. A bot
+script is loaded by `asobi_lua_loader:new/1`, whose PreInstall is the identity,
+so it never reaches `asobi_lua_api:install/2` and has no `game` table at all -
+see `guides/lua-bots.md`. A binding declaring `bot` would therefore install
+nothing, and a declaration that silently does nothing is the failure mode this
+list exists to prevent: `asobi_extensions` refuses it at
+`rebar3 asobi check`.
+
+Making it work instead was the alternative, and it was rejected. A bot decides
+from the state the match broadcasts and nothing more, so `game.<ns>` in a bot
+VM would be one extension namespace floating in a `game` table with no
+`game.log`, no `game.economy` and no `game.storage` under it. A bot also has no
+`players.id` - `bot_Spark` is not a player row - so the one argument every
+extension binding takes cannot be supplied. The documented route stands: put
+the value in the state the match broadcasts.
+""".
+-spec extension_vm_kinds() -> [vm_kind(), ...].
+extension_vm_kinds() ->
+    [match, world, zone].

--- a/test/asobi_guest_reaper_tests.erl
+++ b/test/asobi_guest_reaper_tests.erl
@@ -12,12 +12,16 @@ reaper_test_() ->
         {"starts even with guest_auth unset", fun starts_without_guest_auth/0},
         {"sweep is a no-op while guest auth is off", fun sweep_skipped_when_disabled/0},
         {"guest_auth set after start: a sweep queries", fun sweep_runs_when_enabled_later/0},
-        {"timer tick picks up a flag set after boot", fun timer_sweep_self_corrects/0}
+        {"timer tick picks up a flag set after boot", fun timer_sweep_self_corrects/0},
+        {"an installed extension erases before core deletes", fun extension_erases_first/0},
+        {"a refusing extension leaves the player alone", fun refusing_extension_aborts_reap/0}
     ]}.
 
 setup() ->
     application:unset_env(asobi, guest_auth),
     application:set_env(asobi, guest_reap_after, 60),
+    asobi_extensions:reset(),
+    asobi_fixture_erase:reset(),
     meck:new(asobi_repo, [no_link]),
     meck:expect(asobi_repo, all, fun(_Q) -> {ok, []} end),
     ok.
@@ -28,6 +32,9 @@ cleanup(_) ->
         Pid -> gen_server:stop(Pid)
     end,
     meck:unload(asobi_repo),
+    _ = asobi_fixture_app:uninstall(asobi_fixture_quests),
+    asobi_fixture_erase:reset(),
+    asobi_extensions:reset(),
     application:unset_env(asobi, guest_auth),
     application:unset_env(asobi, guest_reap_after),
     application:unset_env(asobi, guest_reap_interval_ms),
@@ -53,6 +60,51 @@ timer_sweep_self_corrects() ->
     {ok, _} = asobi_guest_reaper:start_link(),
     application:set_env(asobi, guest_auth, true),
     ?assert(wait_for_sweep(200)).
+
+%% asobi#369. An extension row foreign-keying into players.id is ON DELETE NO
+%% ACTION, exactly like core's own children, so without running the extension's
+%% erase path first the delete is a constraint violation and every guest quietly
+%% stops being reaped. Extensions run before core deletes anything, so an erase
+%% path can still read the player's core rows.
+extension_erases_first() ->
+    install_quests(),
+    expect_one_reapable_guest(),
+    {ok, _} = asobi_guest_reaper:start_link(),
+    application:set_env(asobi, guest_auth, true),
+    ?assertEqual({ok, 1}, asobi_guest_reaper:sweep_now()),
+    ?assertEqual([{quests, ~"p-1"}], asobi_fixture_erase:calls()),
+    ?assertEqual(1, meck:num_calls(asobi_repo, delete, '_')).
+
+%% Atomic. The extension refuses, the assertion inside the transaction raises,
+%% and core never deletes a row - so the player survives intact rather than
+%% half-erased, and the sweep reports skipped rather than reaped.
+refusing_extension_aborts_reap() ->
+    install_quests(),
+    ok = asobi_fixture_erase:outcome(quests, {error, ledger_is_immutable}),
+    expect_one_reapable_guest(),
+    {ok, _} = asobi_guest_reaper:start_link(),
+    application:set_env(asobi, guest_auth, true),
+    ?assertEqual({ok, 0}, asobi_guest_reaper:sweep_now()),
+    ?assertEqual(0, meck:num_calls(asobi_repo, delete, '_')),
+    ?assertEqual(0, meck:num_calls(asobi_repo, delete_all, '_')).
+
+install_quests() ->
+    ok = asobi_fixture_app:install(
+        asobi_fixture_quests, asobi_fixture_quests_extension, []
+    ).
+
+%% One unclaimed guest identity, and a transaction that runs its fun inline so
+%% the assertion inside it is the thing under test.
+expect_one_reapable_guest() ->
+    meck:expect(asobi_repo, all, fun(_Q) ->
+        {ok, [#{player_id => ~"p-1", provider => ~"guest"}]}
+    end),
+    meck:expect(asobi_repo, get, fun(asobi_player, ~"p-1") ->
+        {ok, #{id => ~"p-1", hashed_password => undefined}}
+    end),
+    meck:expect(asobi_repo, delete_all, fun(_Q) -> {ok, 1} end),
+    meck:expect(asobi_repo, delete, fun(asobi_player, _Player) -> {ok, #{}} end),
+    meck:expect(asobi_repo, transaction, fun(Fun) -> Fun() end).
 
 wait_for_sweep(0) ->
     meck:num_calls(asobi_repo, all, '_') > 0;

--- a/test/extensions/asobi_extension_erase_tests.erl
+++ b/test/extensions/asobi_extension_erase_tests.erl
@@ -1,0 +1,77 @@
+-module(asobi_extension_erase_tests).
+
+-include_lib("eunit/include/eunit.hrl").
+
+-define(QUESTS, asobi_fixture_quests).
+-define(CLANS, asobi_fixture_clans).
+-define(MINIMAL, asobi_fixture_minimal).
+-define(PLAYER, ~"01960000-0000-7000-8000-000000000001").
+
+erase_test_() ->
+    {foreach, fun setup/0, fun cleanup/1, [
+        fun nothing_installed_is_nothing_to_run/0,
+        fun an_extension_without_an_erase_path_is_skipped/0,
+        fun every_extension_erases_in_dependency_order/0,
+        fun a_refusing_extension_stops_the_whole_deletion/0,
+        fun a_raising_extension_is_attributed_not_propagated/0,
+        fun a_return_outside_the_contract_is_a_failure/0
+    ]}.
+
+setup() ->
+    asobi_extensions:reset(),
+    asobi_fixture_erase:reset(),
+    ok.
+
+cleanup(_) ->
+    _ = [asobi_fixture_app:uninstall(A) || A <- [?QUESTS, ?CLANS, ?MINIMAL]],
+    asobi_fixture_erase:reset(),
+    asobi_extensions:reset(),
+    ok.
+
+nothing_installed_is_nothing_to_run() ->
+    ?assertEqual(ok, asobi_extension_erase:run(?PLAYER)),
+    ?assertEqual([], asobi_fixture_erase:calls()).
+
+%% The callback is optional: an extension whose rows cascade declares nothing
+%% and must not become a deletion failure.
+an_extension_without_an_erase_path_is_skipped() ->
+    ok = asobi_fixture_app:install(?MINIMAL, asobi_fixture_minimal_extension, []),
+    ?assertEqual(ok, asobi_extension_erase:run(?PLAYER)),
+    ?assertEqual([], asobi_fixture_erase:calls()).
+
+%% clans sorts first alphabetically and depends on quests, so this order can
+%% only come from the resolved dependency order.
+every_extension_erases_in_dependency_order() ->
+    install_both(),
+    ?assertEqual(ok, asobi_extension_erase:run(?PLAYER)),
+    ?assertEqual([{quests, ?PLAYER}, {clans, ?PLAYER}], asobi_fixture_erase:calls()).
+
+%% Atomic, not best-effort: the first refusal names itself and nothing after it
+%% is attempted, so the caller's assertion rolls the transaction back with every
+%% extension's rows still in place.
+a_refusing_extension_stops_the_whole_deletion() ->
+    install_both(),
+    ok = asobi_fixture_erase:outcome(quests, {error, ledger_is_immutable}),
+    ?assertEqual(
+        {error, {quests, ledger_is_immutable}}, asobi_extension_erase:run(?PLAYER)
+    ),
+    ?assertEqual([{quests, ?PLAYER}], asobi_fixture_erase:calls()).
+
+a_raising_extension_is_attributed_not_propagated() ->
+    install_both(),
+    ok = asobi_fixture_erase:outcome(quests, {raise, boom}),
+    ?assertMatch(
+        {error, {quests, {raised, error, boom, _}}}, asobi_extension_erase:run(?PLAYER)
+    ),
+    ?assertEqual([{quests, ?PLAYER}], asobi_fixture_erase:calls()).
+
+a_return_outside_the_contract_is_a_failure() ->
+    install_both(),
+    ok = asobi_fixture_erase:outcome(quests, deleted_i_think),
+    ?assertEqual(
+        {error, {quests, {bad_return, deleted_i_think}}}, asobi_extension_erase:run(?PLAYER)
+    ).
+
+install_both() ->
+    ok = asobi_fixture_app:install(?QUESTS, asobi_fixture_quests_extension, []),
+    ok = asobi_fixture_app:install(?CLANS, asobi_fixture_clans_extension, [?QUESTS]).

--- a/test/extensions/asobi_extension_sup_tests.erl
+++ b/test/extensions/asobi_extension_sup_tests.erl
@@ -9,11 +9,16 @@ extension_sup_test_() ->
     {foreach, fun setup/0, fun cleanup/1, [
         fun no_extensions_means_no_children/0,
         fun each_extension_gets_its_own_sub_supervisor/0,
-        fun a_spent_extension_goes_dark_alone/0
+        fun a_spent_extension_goes_dark_alone/0,
+        fun nothing_starts_when_migrations_did_not_complete/0
     ]}.
 
+%% Extension children start after migrations, so the ready marker is the
+%% precondition every case here but the last one runs under.
 setup() ->
     asobi_extensions:reset(),
+    asobi_readiness:reset(),
+    ok = asobi_readiness:mark_ready(),
     ok.
 
 cleanup(_) ->
@@ -21,6 +26,7 @@ cleanup(_) ->
     _ = [asobi_fixture_app:uninstall(A) || A <- [?QUESTS, ?CLANS]],
     application:unset_env(asobi, extension_restart),
     _ = logger:remove_handler(asobi_fixture_log),
+    asobi_readiness:reset(),
     asobi_extensions:reset(),
     ok.
 
@@ -64,6 +70,24 @@ a_spent_extension_goes_dark_alone() ->
     ?assertEqual([clans], asobi_extension_sup:running()),
     ?assert(is_pid(whereis(asobi_fixture_clans_worker))).
 
+%% asobi#369. An extension child that queries at init/1 must not have to carry a
+%% retry path around a database that is not there. Migrations run to completion
+%% before asobi_sup starts, so if the marker is false they failed: start nothing,
+%% say which extensions did not start, and leave a crash loop unwritten. The
+%% answer cannot flip afterwards - mark_ready/0 is called once, before this
+%% supervisor exists - so there is nothing to retry.
+nothing_starts_when_migrations_did_not_complete() ->
+    install_both(),
+    asobi_readiness:reset(),
+    ok = logger:add_handler(asobi_fixture_log, asobi_fixture_log_handler, #{
+        level => all, config => #{pid => self()}
+    }),
+    {ok, Pid} = asobi_extension_sup:start_link(),
+    ?assertEqual([], supervisor:which_children(Pid)),
+    ?assertEqual([], asobi_extension_sup:running()),
+    ?assertEqual(undefined, whereis(asobi_fixture_quests_worker)),
+    ?assertEqual([quests, clans], await_not_started_log()).
+
 %% --- Helpers ---
 
 install_both() ->
@@ -82,6 +106,15 @@ await_down_log() ->
             [Name];
         {log_event, _Other} ->
             await_down_log()
+    after 5000 -> []
+    end.
+
+await_not_started_log() ->
+    receive
+        {log_event, #{msg := {report, #{msg := ~"extensions_not_started", extensions := Names}}}} ->
+            Names;
+        {log_event, _Other} ->
+            await_not_started_log()
     after 5000 -> []
     end.
 

--- a/test/extensions/asobi_extensions_tests.erl
+++ b/test/extensions/asobi_extensions_tests.erl
@@ -27,6 +27,10 @@ extensions_test_() ->
         fun reserved_core_queue_refused/0,
         fun reserved_rpc_prefix_refused/0,
         fun claiming_outside_the_owned_set_refused/0,
+        fun a_queue_is_derived_from_the_worker_that_declares_it/0,
+        fun a_table_is_derived_from_the_schema_that_declares_it/0,
+        fun a_typo_in_owns_queues_is_caught/0,
+        fun a_derived_queue_matches_its_own_owns/0,
         fun duplicate_extension_names_refused/0,
         fun malformed_info_refused/0,
         fun a_raising_manifest_is_reported_not_propagated/0,
@@ -35,6 +39,7 @@ extensions_test_() ->
         fun resolve_raises_on_an_invalid_set/0,
         fun lua_args_must_match_the_mfa_arity/0,
         fun an_rpc_handler_must_have_arity_two/0,
+        fun a_bot_binding_is_refused_not_ignored/0,
         fun a_declared_code_carries_its_status_and_message/0,
         fun an_undeclared_code_is_still_a_server_bug/0,
         fun core_codes_stay_core_only/0,
@@ -185,6 +190,47 @@ claiming_outside_the_owned_set_refused() ->
     }),
     ?assert(lists:member({undeclared_claim, rpc, ~"gold", ?TUNABLE}, check_problems())).
 
+%% asobi#369. `rpc` and `lua` claims are derived from the manifest, so a
+%% collision is caught even with no `owns/0` at all. A queue was only ever what
+%% `owns/0` said, which made the claim unenforceable: nothing read it, so a typo
+%% was invisible. It now derives from `queue/0` + `perform/1` on the extension's
+%% own modules - core's own rule, applied to an extension's module list. The
+%% minimal fixture declares no `owns/0` whatsoever, so only the derivation can
+%% produce this collision.
+a_queue_is_derived_from_the_worker_that_declares_it() ->
+    ok = asobi_fixture_app:install(
+        ?MINIMAL, [asobi_fixture_minimal_extension, asobi_fixture_quests_job], []
+    ),
+    tunable(#{owns => #{queues => [~"quests"]}}),
+    ?assert(
+        lists:member({namespace_conflict, queues, ~"quests", ?MINIMAL, ?TUNABLE}, check_problems())
+    ).
+
+a_table_is_derived_from_the_schema_that_declares_it() ->
+    ok = asobi_fixture_app:install(
+        ?MINIMAL, [asobi_fixture_minimal_extension, asobi_fixture_quests_schema], []
+    ),
+    tunable(#{owns => #{tables => [~"quest_progress"]}}),
+    ?assert(
+        lists:member(
+            {namespace_conflict, tables, ~"quest_progress", ?MINIMAL, ?TUNABLE}, check_problems()
+        )
+    ).
+
+%% The typo that used to be invisible. The worker says `quests`; `owns/0` says
+%% `quest`. Deriving the real queue is what turns that into a build failure -
+%% `owns/0` is now the closed-set assertion over what was derived, not its
+%% source.
+a_typo_in_owns_queues_is_caught() ->
+    tunable(#{owns => #{queues => [~"quest"]}}, [asobi_fixture_quests_job]),
+    ?assert(lists:member({undeclared_claim, queues, ~"quests", ?TUNABLE}, check_problems())).
+
+%% An extension does not collide with itself: the queue it derives is the queue
+%% it owns.
+a_derived_queue_matches_its_own_owns() ->
+    tunable(#{owns => #{queues => [~"quests"]}}, [asobi_fixture_quests_job]),
+    ?assertMatch({ok, [_]}, asobi_extensions:check()).
+
 duplicate_extension_names_refused() ->
     install(?QUESTS),
     tunable(#{info => #{name => quests, extension_version => 1}}),
@@ -280,6 +326,25 @@ an_rpc_handler_must_have_arity_two() ->
     retune(#{rpc => #{~"tunable.thing" => {tunable_rpc, thing, 2}}}),
     ?assertMatch({ok, [_]}, asobi_extensions:check()).
 
+%% asobi#369. A bot script is loaded through asobi_lua_loader:new/1, whose
+%% PreInstall is the identity, so it never reaches asobi_lua_api:install/2 and
+%% has no `game` table at all - `vms => [bot]` used to be a declaration that
+%% silently installed nothing. Refused at build time instead.
+a_bot_binding_is_refused_not_ignored() ->
+    tunable(#{lua => #{~"tunable" => #{~"status" => binding([match, bot])}}}),
+    ?assertMatch(
+        [
+            {bad_manifest, ?TUNABLE, _,
+                {lua, ~"vms cannot include bot: a bot VM has no game.* table to install into", _}}
+        ],
+        check_problems()
+    ),
+    retune(#{lua => #{~"tunable" => #{~"status" => binding([match, world, zone])}}}),
+    ?assertMatch({ok, [_]}, asobi_extensions:check()).
+
+binding(Vms) ->
+    #{mfa => {tunable_lua, status, 1}, args => [binary], effects => none, vms => Vms}.
+
 %% --- Error codes ---
 
 %% asobi#360. An extension reporting an ordinary domain condition must not
@@ -353,14 +418,25 @@ a_malformed_code_spec_refused() ->
 
 %% --- Helpers ---
 
+%% The schema and the worker are part of the fixture because table and queue
+%% claims are derived from them, exactly as a real extension's are.
 install(?QUESTS) ->
-    ok = asobi_fixture_app:install(?QUESTS, asobi_fixture_quests_extension, []);
+    ok = asobi_fixture_app:install(
+        ?QUESTS,
+        [asobi_fixture_quests_extension, asobi_fixture_quests_schema, asobi_fixture_quests_job],
+        []
+    );
 install(?MINIMAL) ->
     ok = asobi_fixture_app:install(?MINIMAL, asobi_fixture_minimal_extension, []).
 
 tunable(Manifest) ->
+    tunable(Manifest, []).
+
+tunable(Manifest, ExtraModules) ->
     ok = asobi_fixture_tunable_extension:set(Manifest),
-    ok = asobi_fixture_app:install(?TUNABLE, asobi_fixture_tunable_extension, []).
+    ok = asobi_fixture_app:install(
+        ?TUNABLE, [asobi_fixture_tunable_extension | ExtraModules], []
+    ).
 
 %% The application is already loaded; only the manifest changes.
 retune(Manifest) ->

--- a/test/extensions/asobi_fixture_app.erl
+++ b/test/extensions/asobi_fixture_app.erl
@@ -10,11 +10,15 @@ exactly how it works for a real dependency.
 
 -export([install/3, uninstall/1]).
 
--spec install(atom(), module() | none, [atom()]) -> ok | {error, term()}.
+%% A list, not just the manifest module, because table and queue claims are
+%% derived from the application's own schema and worker modules - the same rule
+%% core's reserved set uses - so a fixture needs to be able to carry them.
+-spec install(atom(), module() | [module()] | none, [atom()]) -> ok | {error, term()}.
 install(App, Module, ExtraDeps) ->
     Modules =
         case Module of
             none -> [];
+            List when is_list(List) -> List;
             _ -> [Module]
         end,
     application:load(

--- a/test/extensions/asobi_fixture_clans_extension.erl
+++ b/test/extensions/asobi_fixture_clans_extension.erl
@@ -2,7 +2,7 @@
 -moduledoc "A second extension, whose application depends on the first, so ordering is observable.".
 -behaviour(asobi_extension).
 
--export([info/0, rpc/0, lua/0, sup/0, owns/0]).
+-export([info/0, rpc/0, lua/0, sup/0, owns/0, erase_player/1]).
 
 -spec info() -> asobi_extension:info().
 info() ->
@@ -20,7 +20,7 @@ lua() ->
                 mfa => {asobi_fixture_clans_lua, of_player, 1},
                 args => [binary],
                 effects => none,
-                vms => [match, world, zone, bot]
+                vms => [match, world, zone]
             }
         }
     }.
@@ -42,3 +42,7 @@ owns() ->
         lua => [~"clans"],
         queues => [~"clans"]
     }.
+
+-spec erase_player(binary()) -> ok | {error, term()}.
+erase_player(PlayerId) ->
+    asobi_fixture_erase:run(clans, PlayerId).

--- a/test/extensions/asobi_fixture_erase.erl
+++ b/test/extensions/asobi_fixture_erase.erl
@@ -1,0 +1,37 @@
+-module(asobi_fixture_erase).
+-moduledoc """
+The erase paths of the fixture extensions, and a record of what was called.
+
+Two extensions must be observable in one run to pin ordering, and a manifest
+module has to be named after its own application, so the recording lives here
+and each fixture's `erase_player/1` delegates to it.
+""".
+
+-export([reset/0, calls/0, outcome/2, run/2]).
+
+-define(CALLS, {?MODULE, calls}).
+-define(OUTCOMES, {?MODULE, outcomes}).
+
+-spec reset() -> ok.
+reset() ->
+    _ = persistent_term:erase(?CALLS),
+    _ = persistent_term:erase(?OUTCOMES),
+    ok.
+
+-doc "Every `erase_player/1` call, in the order core made them.".
+-spec calls() -> [{atom(), binary()}].
+calls() ->
+    lists:reverse(persistent_term:get(?CALLS, [])).
+
+-doc "What this extension's erase path does: `ok`, `{error, R}` or `{raise, R}`.".
+-spec outcome(atom(), term()) -> ok.
+outcome(Name, Outcome) ->
+    persistent_term:put(?OUTCOMES, maps:put(Name, Outcome, persistent_term:get(?OUTCOMES, #{}))).
+
+-spec run(atom(), binary()) -> ok | {error, term()}.
+run(Name, PlayerId) ->
+    persistent_term:put(?CALLS, [{Name, PlayerId} | persistent_term:get(?CALLS, [])]),
+    case maps:get(Name, persistent_term:get(?OUTCOMES, #{}), ok) of
+        {raise, Reason} -> error(Reason);
+        Outcome -> Outcome
+    end.

--- a/test/extensions/asobi_fixture_quests_extension.erl
+++ b/test/extensions/asobi_fixture_quests_extension.erl
@@ -2,7 +2,7 @@
 -moduledoc "A complete extension manifest, shaped exactly like the design's worked example.".
 -behaviour(asobi_extension).
 
--export([info/0, rpc/0, lua/0, sup/0, owns/0, codes/0]).
+-export([info/0, rpc/0, lua/0, sup/0, owns/0, codes/0, erase_player/1]).
 
 -spec info() -> asobi_extension:info().
 info() ->
@@ -29,7 +29,7 @@ lua() ->
                 mfa => {asobi_fixture_quests_lua, status, 1},
                 args => [binary],
                 effects => none,
-                vms => [match, world, bot]
+                vms => [match, world]
             }
         }
     }.
@@ -60,3 +60,7 @@ owns() ->
         lua => [~"quests"],
         queues => [~"quests"]
     }.
+
+-spec erase_player(binary()) -> ok | {error, term()}.
+erase_player(PlayerId) ->
+    asobi_fixture_erase:run(quests, PlayerId).

--- a/test/extensions/asobi_fixture_quests_job.erl
+++ b/test/extensions/asobi_fixture_quests_job.erl
@@ -1,0 +1,12 @@
+-module(asobi_fixture_quests_job).
+-moduledoc "A shigoto worker belonging to an extension, so its queue claim is derivable.".
+
+-export([queue/0, perform/1]).
+
+-spec queue() -> binary().
+queue() ->
+    ~"quests".
+
+-spec perform(map()) -> ok.
+perform(_Args) ->
+    ok.

--- a/test/extensions/asobi_fixture_quests_schema.erl
+++ b/test/extensions/asobi_fixture_quests_schema.erl
@@ -1,0 +1,12 @@
+-module(asobi_fixture_quests_schema).
+-moduledoc "A kura schema belonging to an extension, so its table claim is derivable.".
+
+-export([table/0, fields/0]).
+
+-spec table() -> binary().
+table() ->
+    ~"quest_progress".
+
+-spec fields() -> [].
+fields() ->
+    [].


### PR DESCRIPTION
Four gaps the first real extension (widgrensit/asobi_quests) filed and #364 did not close: 6, 7 and 9 from its report, plus a bot-VM declaration that silently installed nothing.

## Gap 6 - `erase_player/1`

An extension holding rows for a player could make that player undeletable and had no way to say otherwise. `cascade` is declarable on a `#kura_assoc` and carried into the generated migration, but it is wrong for anything holding a financial or audit row - the exact case that rejected a blanket cascade - and such an extension had no alternative to register. The delete became a constraint violation the guest reaper swallowed as `skipped`.

New optional callback `erase_player/1`, run by `asobi_extension_erase` from inside core's own transaction, extensions before core, in dependency order.

Not an `owns/0` key: `owns/0` reserves names and executes nothing, and cascade is already declared where the database enforces it, so a second declaration of the same fact in the manifest could disagree with the schema that decides. Erasure is atomic across extensions rather than best-effort - a half-finished erasure reporting success is a worse answer to a data-subject request than one that fails loudly and can be retried - and every extension shares `asobi_repo`, so the single transaction costs nothing to arrange.

## Gap 7 - the readiness gate

A `sup/0` child could not assume the pool was usable at `init/1`, and a crash loop there ends with the extension dark and staying dark. `asobi_sup` starts after migrations, so the readiness answer is already final when extension children start: they now get two guarantees - they start in the order `sup/0` returns them, after the children of every extension they depend on, and `init/1` may query. If migrations did not complete, `asobi_extension_sup` starts no extension at all and logs which ones it did not start.

## Gap 9 - queues derived

`owns.queues` was the one claim derived from nothing, so a typo was invisible and a queue claimed by nobody was unenforceable. Queues are now derived from `queue/0` + `perform/1` on the extension's own modules, exactly as core's are.

## The bot VM

`vms => [bot]` was a declaration that installed nothing: a bot script loads through `asobi_lua_loader:new/1`, whose PreInstall is the identity, so it never reaches `asobi_lua_api:install/2` and has no `game` table at all. Refused at build time now, and `guides/lua-bots.md` says so.

## Checks

`rebar3 fmt --check`, `xref` and `eunit` (1556 tests, 0 failures) clean. Rebased onto main after #365, #369 and #370; the one substantive conflict was the quests fixture, whose `status` binding declared `bot` - it declares `[match, world]` now, which is what `asobi_extension_lua_tests` was written against.