### PR TITLE
feat(extensions): ops/0 - operator actions on the ops plane

### DIFF
--- a/guides/extensions.md
+++ b/guides/extensions.md
@@ -53,16 +53,19 @@ Two consumption paths, and an extension wants both.
 |---|---|---|
 | Game logic, in-match, server-side | `game.quests.progress(player_id, 1)` | "player killed something, +1" |
 | Game client, over the network | `asobi.rpc("quests.claim", ...)` | "give me my reward" |
+| An operator, on the ops plane | `POST /api/v1/ops/ext/quests/define` | "add a daily quest" |
 
 An extension with only the wire cannot observe gameplay; one with only Lua
-cannot be triggered by a player action from the client.
+cannot be triggered by a player action from the client. The third is a
+different audience, not a third way to reach the same one: `rpc/0` is
+player-scoped, and no player ever holds an operator capability.
 
 ## What you declare
 
 ```erlang
 -module(asobi_quests_extension).
 -behaviour(asobi_extension).
--export([info/0, rpc/0, lua/0, sup/0, owns/0, codes/0, erase_player/1]).
+-export([info/0, rpc/0, lua/0, sup/0, owns/0, codes/0, ops/0, erase_player/1]).
 
 info() -> #{name => quests, extension_version => 1}.
 
@@ -90,6 +93,10 @@ owns() -> #{tables => [~"quests", ~"quest_progress"],
 codes() -> #{~"quests.already_claimed" =>
                #{status => 409, message => ~"This quest was already claimed."}}.
 
+ops()  -> #{~"define" => #{method => post,
+                           mfa    => {asobi_quests_ops, define, 2},
+                           class  => config}}.
+
 erase_player(PlayerId) ->
     {ok, _} = asobi_repo:delete_all(by_player(asobi_quest_progress, PlayerId)),
     ok.
@@ -110,6 +117,8 @@ Only `info/0` is required. The rest default to nothing.
   derivation rather than its source.
 - `codes/0` - the error codes this extension mints. Core's set is closed, so
   an undeclared code answers 500 and logs as a core defect.
+- `ops/0` - operator actions, reached on the ops plane rather than by a player.
+  See [Writing an operator action](#writing-an-operator-action).
 - `erase_player/1` - how to erase one player, when your rows do not cascade.
 - `info/0` - the contract version, distinct from the package version, because a
   minor release can change an experimental contract.
@@ -172,8 +181,8 @@ player on that socket; an unauthenticated socket is refused before the method
 is looked up. There is deliberately no per-method capability class:
 `read | player_data | config` (ADR 0007) is an operator vocabulary that a
 player never holds, so tagging a socket method with one would make it deniable
-for every caller the dispatcher has. An operator-only extension method needs
-the ops plane, which is read-only today.
+for every caller the dispatcher has. An operator-only method goes in `ops/0`
+instead - see [Writing an operator action](#writing-an-operator-action).
 
 ### Readiness
 
@@ -182,6 +191,63 @@ The route table compiles during Nova's boot; migrations run afterwards, from
 tables exist, so the dispatcher fails closed until migrations finish: every
 call answers `not_ready` (503) until then. You get this for free - there is
 nothing to call.
+
+## Writing an operator action
+
+`rpc/0` is player-scoped by construction, so an admin action - defining a
+quest, correcting a counter, anything a player must never call - has no home
+there. `ops/0` is that home, and it is reached on the ops plane by an operator
+credential:
+
+```erlang
+-spec ops() -> asobi_extension:ops().
+ops() ->
+    #{~"define" => #{method => post,
+                     mfa    => {asobi_quests_ops, define, 2},
+                     class  => config},
+      ~"summary" => #{method => get,
+                      mfa    => {asobi_quests_ops, summary, 2},
+                      class  => read}}.
+```
+
+```
+POST /api/v1/ops/ext/quests/define
+GET  /api/v1/ops/ext/quests/summary?filter=active
+```
+
+You still declare no routes. Core owns exactly one - `/ext/:extension/:action`
+- and dispatches every declared action behind it, the same way it owns one
+WebSocket frame type and dispatches `rpc/0` behind that (ADR 0003).
+
+A handler has the same shape as an RPC handler, because there is no reason for
+a second one:
+
+```erlang
+-spec define(map(), asobi_ops_extension:ctx()) -> asobi_rpc:reply().
+define(#{~"key" := Key}, #{actor := #{id := ActorId}}) ->
+    case asobi_quests:define(Key, ActorId) of
+        {ok, Quest}          -> {ok, #{quest => Quest}};
+        {error, name_taken}  -> {error, ~"quests.name_taken"}
+    end.
+```
+
+`Params` is the decoded JSON body for a write and the parsed query string for
+a `get`. `Ctx` carries the actor that was admitted, so recording who asked
+needs no second lookup.
+
+Three things are core's, not yours:
+
+- **`class` is the whole authorisation.** `read | player_data | config` is
+  ADR 0007's vocabulary, the same one core's own ops routes carry. An action
+  is admitted when its class is in the caller's capabilities and never
+  otherwise. There is nothing to check inside your handler.
+- **An undeclared action is denied, not 404.** It has no class, and a route
+  with no class is refused - so an unknown extension, an unknown action and a
+  method the action does not answer all answer 403. Which extensions are
+  installed is not something an unauthorised caller gets to enumerate.
+- **Every method but `get` is audited.** Core wraps the call in a durable
+  audit row naming the operator before your function runs. You cannot opt out,
+  and declaring a method other than `get` is what opts in.
 
 ## Writing a Lua binding
 

--- a/src/asobi_router.erl
+++ b/src/asobi_router.erl
@@ -254,6 +254,15 @@ ops_routes() ->
             }},
             {~"/notifications", fun asobi_ops_controller:notifications/1, #{
                 methods => [get, options]
+            }},
+            %% The one route core owns on behalf of extensions. Extensions
+            %% contribute no routes (ADR 0003); this dispatches every action an
+            %% installed manifest declares, exactly as one WebSocket frame type
+            %% dispatches `rpc/0`. Its class is per action and comes from that
+            %% manifest, so it is deliberately absent from
+            %% `asobi_ops_caps:classes/0` - see `m:asobi_ops_extension`.
+            {~"/ext/:extension/:action", fun asobi_ops_extension:handle/1, #{
+                methods => [get, post, put, delete, options]
             }}
         ]
     }.

--- a/src/extensions/asobi_extension.erl
+++ b/src/extensions/asobi_extension.erl
@@ -128,7 +128,10 @@ second consumer has said what it is missing.
     owns/0,
     token/0,
     code_spec/0,
-    codes/0
+    codes/0,
+    ops/0,
+    ops_action/0,
+    ops_entry/0
 ]).
 
 -doc "The extension's short name, and the root of everything it owns.".
@@ -265,11 +268,63 @@ operator-facing erasure calls the same function.
 """.
 -callback erase_player(PlayerId :: binary()) -> ok | {error, term()}.
 
+-doc "One operator action, the last segment of `/api/v1/ops/ext/<name>/<action>`.".
+-type ops_action() :: binary().
+
+-doc """
+One operator action: the method it answers, the target, and its capability
+class.
+
+`class` is `read | player_data | config` (ADR 0007), the same vocabulary core's
+own ops routes carry, and it is the only thing that authorises the call. An
+action with no class is not reachable, because `asobi_ops_caps` denies a route
+it cannot tag.
+
+`mfa` is applied as `Module:Function(Params, Ctx)` - the same shape as `rpc/0`,
+for the same reason - where `Params` is the decoded JSON body for a write and
+the query string for a read, and `Ctx` carries the `t:asobi_ops_auth:actor/0`
+that was admitted.
+
+Anything but `get` is audited: core wraps it in `asobi_ops_audit:mutation/4`
+before it runs, so an extension cannot write on the ops plane without a durable
+row naming the operator who asked. That is not something an extension can opt
+out of, which is why the method is declared here rather than inferred.
+""".
+-type ops_entry() :: #{
+    method := get | post | put | delete,
+    mfa := mfa(),
+    class := asobi_ops_caps:class()
+}.
+
+-doc """
+The operator actions this extension serves, as `Action => t:ops_entry/0`.
+
+`rpc/0` is player-scoped by construction: the caller is the authenticated
+player on that socket, and `read | player_data | config` is an operator
+vocabulary no player ever holds. So an extension with an admin surface - the
+first one hit it immediately with `quests.define` - had nowhere to put it.
+This is that home.
+
+Extensions still contribute **no routes** (ADR 0003). Core owns one route,
+`/api/v1/ops/ext/:extension/:action`, and dispatches it here exactly as it owns
+one WebSocket frame type and dispatches `rpc/0` behind it. An action is
+therefore reachable at:
+
+```
+POST /api/v1/ops/ext/quests/define
+```
+
+Actions cannot collide across extensions: they are keyed by the extension's
+own name, and two extensions cannot share a name.
+""".
+-type ops() :: #{ops_action() => ops_entry()}.
+
 -callback info() -> info().
 -callback rpc() -> rpc().
 -callback lua() -> lua().
 -callback sup() -> [supervisor:child_spec()].
 -callback owns() -> owns().
 -callback codes() -> codes().
+-callback ops() -> ops().
 
--optional_callbacks([rpc/0, lua/0, sup/0, owns/0, codes/0, erase_player/1]).
+-optional_callbacks([rpc/0, lua/0, sup/0, owns/0, codes/0, ops/0, erase_player/1]).

--- a/src/extensions/asobi_extensions.erl
+++ b/src/extensions/asobi_extensions.erl
@@ -44,7 +44,7 @@ surfaces with Nova's crash context rather than a legible asobi error.
 -include_lib("kernel/include/logger.hrl").
 
 -export([resolve/0, check/0, validate/1, describe/1, sup_specs/1, error_codes/0]).
--export([rpc_methods/0, lua_bindings/0]).
+-export([rpc_methods/0, lua_bindings/0, ops_action/2]).
 -ifdef(TEST).
 -export([reset/0]).
 -endif.
@@ -53,6 +53,7 @@ surfaces with Nova's crash context rather than a legible asobi error.
 -define(CODES_KEY, {?MODULE, error_codes}).
 -define(RPC_KEY, {?MODULE, rpc_methods}).
 -define(LUA_KEY, {?MODULE, lua_bindings}).
+-define(OPS_KEY, {?MODULE, ops_actions}).
 
 -doc "One resolved extension. `sup/0` is deliberately absent; see `sup_specs/1`.".
 -type extension() :: #{
@@ -61,6 +62,7 @@ surfaces with Nova's crash context rather than a legible asobi error.
     name := asobi_extension:name(),
     extension_version := pos_integer(),
     rpc := asobi_extension:rpc(),
+    ops := asobi_extension:ops(),
     lua := asobi_extension:lua(),
     owns := asobi_extension:owns(),
     codes := asobi_extension:codes()
@@ -100,6 +102,7 @@ resolve() ->
             persistent_term:put(?CODES_KEY, error_code_table(Extensions)),
             persistent_term:put(?RPC_KEY, rpc_table(Extensions)),
             persistent_term:put(?LUA_KEY, lua_table(Extensions)),
+            persistent_term:put(?OPS_KEY, ops_table(Extensions)),
             persistent_term:put(?KEY, Extensions),
             Extensions;
         Extensions ->
@@ -145,6 +148,19 @@ one pass over bindings, not a walk over namespaces.
 lua_bindings() ->
     persistent_term:get(?LUA_KEY, []).
 
+-doc """
+The operator action `Extension` declares as `Action`, or `undefined`.
+
+Read on two request paths - the capability check in `m:asobi_ops_caps` and the
+dispatch in `m:asobi_ops_extension` - so like `rpc_methods/0` it reads the
+memoised table and never triggers discovery. `undefined` for an extension that
+is not installed and for an action it does not declare, which is one answer
+because they are one outcome: nothing to route to, and nothing to authorise.
+""".
+-spec ops_action(binary(), binary()) -> asobi_extension:ops_entry() | undefined.
+ops_action(Extension, Action) ->
+    maps:get({Extension, Action}, persistent_term:get(?OPS_KEY, #{}), undefined).
+
 %% The codes term is written before the resolved term, so a concurrent second
 %% caller that sees ?KEY populated also sees the codes it implies.
 error_code_table(Extensions) ->
@@ -156,6 +172,12 @@ error_code_table(Extensions) ->
 
 rpc_table(Extensions) ->
     maps:from_list([{Method, Target} || #{rpc := Rpc} <- Extensions, Method := Target <- Rpc]).
+
+ops_table(Extensions) ->
+    maps:from_list([
+        {{atom_to_binary(Name, utf8), Action}, Entry}
+     || #{name := Name, ops := Ops} <- Extensions, Action := Entry <- Ops
+    ]).
 
 lua_table(Extensions) ->
     [
@@ -217,6 +239,7 @@ sup_specs(Module) ->
 -spec reset() -> ok.
 reset() ->
     _ = persistent_term:erase(?KEY),
+    _ = persistent_term:erase(?OPS_KEY),
     _ = persistent_term:erase(?CODES_KEY),
     _ = persistent_term:erase(?RPC_KEY),
     _ = persistent_term:erase(?LUA_KEY),
@@ -313,6 +336,7 @@ read_manifest(App, Module) ->
         {lua, call(Module, lua, #{})},
         {owns, call(Module, owns, #{})},
         {codes, call(Module, codes, #{})},
+        {ops, call(Module, ops, #{})},
         {sup, call(Module, sup, [])}
     ],
     case [{Key, Detail} || {Key, {error, Detail}} <- Reads] of
@@ -336,8 +360,16 @@ call(Module, Function, Default) ->
     end.
 
 build(App, Module, Values) ->
-    #{info := Info, rpc := Rpc, lua := Lua, owns := Owns, codes := Codes, sup := Sup} = Values,
-    case shape_problems(Info, Rpc, Lua, Owns, Codes, Sup) of
+    #{
+        info := Info,
+        rpc := Rpc,
+        lua := Lua,
+        owns := Owns,
+        codes := Codes,
+        ops := Ops,
+        sup := Sup
+    } = Values,
+    case shape_problems(Info, Rpc, Lua, Owns, Codes, Ops, Sup) of
         [] ->
             #{name := Name, extension_version := Version} = Info,
             {ok, #{
@@ -348,18 +380,20 @@ build(App, Module, Values) ->
                 rpc => Rpc,
                 lua => Lua,
                 owns => Owns,
-                codes => Codes
+                codes => Codes,
+                ops => Ops
             }};
         Details ->
             {error, [{bad_manifest, App, Module, Detail} || Detail <- Details]}
     end.
 
-shape_problems(Info, Rpc, Lua, Owns, Codes, Sup) ->
+shape_problems(Info, Rpc, Lua, Owns, Codes, Ops, Sup) ->
     info_problems(Info) ++
         rpc_problems(Rpc) ++
         lua_problems(Lua) ++
         owns_problems(Owns) ++
         codes_problems(Codes) ++
+        ops_problems(Ops) ++
         sup_problems(Sup).
 
 info_problems(#{name := Name, extension_version := Version}) when
@@ -384,6 +418,32 @@ rpc_problems(Rpc) ->
 is_rpc_entry(Method, {M, F, 2}) when is_atom(M), is_atom(F) ->
     is_dotted(Method);
 is_rpc_entry(_Method, _Target) ->
+    false.
+
+ops_problems(Ops) when is_map(Ops) ->
+    [
+        {ops, ~"action must map to #{method, mfa => {Module, Function, 2}, class}", Action}
+     || Action := Entry <- Ops, not is_ops_entry(Action, Entry)
+    ];
+ops_problems(Ops) ->
+    [{ops, ~"must be a map", Ops}].
+
+%% The action is one path segment, so it may not carry a slash or a dot: the
+%% router splits on the first and the console builds links from the second.
+%% Arity 2 for the same reason `rpc/0` insists on it - core applies every
+%% target as `Module:Function(Params, Ctx)`.
+is_ops_entry(Action, #{method := Method, mfa := {M, F, 2}, class := Class}) when
+    is_atom(M), is_atom(F)
+->
+    is_segment(Action) andalso
+        lists:member(Method, [get, post, put, delete]) andalso
+        lists:member(Class, asobi_ops_caps:class_names());
+is_ops_entry(_Action, _Entry) ->
+    false.
+
+is_segment(Action) when is_binary(Action), Action =/= ~"" ->
+    binary:match(Action, [~"/", ~".", ~"?", ~"#", ~"%"]) =:= nomatch;
+is_segment(_Action) ->
     false.
 
 is_dotted(Method) when is_binary(Method) ->

--- a/src/ops/asobi_ops_caps.erl
+++ b/src/ops/asobi_ops_caps.erl
@@ -17,7 +17,7 @@ A route with no entry in `classes/0` has no class and `authorised/2` denies
 it, so an untagged or mis-mounted route is closed rather than open.
 """.
 
--export([classes/0, class/2, authorised/2]).
+-export([classes/0, class/2, authorised/2, class_names/0]).
 
 -type class() :: read | player_data | config.
 -type segment() :: binary() | '_'.
@@ -73,9 +73,23 @@ class(Method, Path) ->
 authorised(undefined, _Caps) -> false;
 authorised(Class, Caps) -> lists:member(Class, Caps).
 
+-doc "Every class, for validating one declared in an extension manifest.".
+-spec class_names() -> [class()].
+class_names() ->
+    [read, player_data, config].
+
 -spec lookup(atom(), [binary()]) -> class() | undefined.
 lookup(undefined, _Segments) ->
     undefined;
+%% The one route core owns on behalf of extensions. Its class is not in
+%% classes/0 because it is per action, declared in the manifest that also
+%% declares the handler - so an action reaches its own class or nothing, and
+%% "untagged denies" holds unchanged for a method or extension nobody declared.
+lookup(Method, [~"ext", Extension, Action]) ->
+    case asobi_extensions:ops_action(Extension, Action) of
+        #{method := Method, class := Class} -> Class;
+        _ -> undefined
+    end;
 lookup(Method, Segments) ->
     case [Class || {M, S, Class} <- classes(), M =:= Method, matches(S, Segments)] of
         [Class] -> Class;

--- a/src/ops/asobi_ops_extension.erl
+++ b/src/ops/asobi_ops_extension.erl
@@ -1,0 +1,159 @@
+-module(asobi_ops_extension).
+-moduledoc """
+The ops plane's one extension seam: `/api/v1/ops/ext/:extension/:action`.
+
+`rpc/0` is player-scoped by construction, so an extension with an operator
+action - `quests.define` was the first - had nowhere to put it. `ops/0` is
+that home, and this module is what makes it reachable.
+
+Extensions contribute no routes (ADR 0003). Core owns this one and dispatches
+every declared action behind it, exactly as it owns one WebSocket frame type
+and dispatches `rpc/0` behind that. The route table stays core's.
+
+## What authorises
+
+Nothing here. `asobi_ops_auth:verify/1` has already resolved the actor and
+checked the action's declared class against its caps before this module runs,
+because `asobi_ops_caps:class/2` reads the same manifest entry this dispatch
+reads. An action nobody declared has no class, and a route with no class is
+denied - so an unknown extension, an unknown action and a method the action
+does not answer are all 403 from the security callback rather than 404 from
+here. That is the same answer the plane gives every other unauthorised call,
+and it is deliberate: enumerating which extensions are installed is not a
+capability an unauthorised caller should have.
+
+## What is audited
+
+Everything but `get`. Core wraps the call in `asobi_ops_audit:mutation/4`
+before it runs, so an extension cannot write on this plane without a durable
+row naming the operator. An extension opts into neither the audit nor its
+shape; declaring a method other than `get` is what opts in.
+
+## What a handler is given
+
+`Module:Function(Params, Ctx)`, the same shape as an RPC handler:
+
+* `Params` is the decoded JSON body for a write, and the parsed query string
+  for a `get`. Always a map with binary keys.
+* `Ctx` carries the actor, so a handler can record who asked without another
+  lookup, plus the extension and action it was reached as.
+
+and it returns an `t:asobi_rpc:reply/0`: `{ok, map()}`, `{error, Code}` or
+`{error, Code, Details}`. Codes come from the extension's own `codes/0` domain,
+so the answer is the shared error object every other route already returns.
+""".
+
+-include_lib("kernel/include/logger.hrl").
+
+-export([handle/1]).
+
+-doc "What an ops handler is told about its caller.".
+-type ctx() :: #{
+    actor := asobi_ops_auth:actor(),
+    extension := binary(),
+    action := binary()
+}.
+
+-export_type([ctx/0]).
+
+-spec handle(cowboy_req:req()) ->
+    {json, map()}
+    | {json, integer(), map(), map()}
+    | {asobi_error, asobi_error:code()}
+    | {asobi_error, asobi_error:code(), asobi_error:details()}.
+handle(
+    #{
+        bindings := #{~"extension" := Extension, ~"action" := Action},
+        auth_data := #{ops_actor := Actor}
+    } = Req
+) ->
+    case asobi_readiness:guard() of
+        ok -> dispatch(Extension, Action, Actor, Req);
+        {error, _Object} -> {asobi_error, ~"not_ready"}
+    end.
+
+%% The entry is re-read rather than threaded from the capability check: the
+%% check runs in the security callback and passing a term across that boundary
+%% would mean two sources for the same fact. The read is a persistent_term hit.
+dispatch(Extension, Action, Actor, Req) ->
+    case asobi_extensions:ops_action(Extension, Action) of
+        #{method := get, mfa := Mfa} ->
+            reply(call(Mfa, query_params(Req), ctx(Extension, Action, Actor)), Extension, Action);
+        #{mfa := Mfa} ->
+            Ctx = ctx(Extension, Action, Actor),
+            Params = body_params(Req),
+            Outcome = asobi_ops_audit:mutation(
+                Actor,
+                <<Extension/binary, ".", Action/binary>>,
+                {~"extension", Extension},
+                fun() -> call(Mfa, Params, Ctx) end
+            ),
+            reply(Outcome, Extension, Action);
+        undefined ->
+            %% Unreachable through the router: an undeclared action has no
+            %% class and the security callback already denied it. Answered
+            %% rather than crashed because a manifest could change under a live
+            %% request, and answered `forbidden` so this agrees with the gate
+            %% instead of confirming that the action does not exist.
+            {asobi_error, ~"forbidden"}
+    end.
+
+ctx(Extension, Action, Actor) ->
+    #{actor => Actor, extension => Extension, action => Action}.
+
+call({M, F, 2}, Params, Ctx) ->
+    try
+        M:F(Params, Ctx)
+    catch
+        Class:Reason:Stack -> {raised, Class, Reason, Stack}
+    end.
+
+reply({ok, Result}, _Extension, _Action) when is_map(Result) ->
+    {json, Result};
+reply({error, Code}, Extension, Action) ->
+    error_reply(Code, #{}, Extension, Action);
+reply({error, Code, Details}, Extension, Action) when is_map(Details) ->
+    error_reply(Code, Details, Extension, Action);
+reply({raised, Class, Reason, Stack}, Extension, Action) ->
+    ?LOG_ERROR(#{
+        msg => ~"ops_extension_handler_raised",
+        extension => Extension,
+        action => Action,
+        class => Class,
+        reason => Reason,
+        stacktrace => Stack
+    }),
+    {asobi_error, ~"internal"};
+reply(Other, Extension, Action) ->
+    ?LOG_ERROR(#{
+        msg => ~"ops_extension_handler_returned_outside_the_contract",
+        extension => Extension,
+        action => Action,
+        returned => Other
+    }),
+    {asobi_error, ~"internal"}.
+
+%% A code the extension never declared would let a handler mint an arbitrary
+%% status out of `params`, so it is a defect here exactly as it is on the RPC
+%% seam.
+error_reply(Code, Details, Extension, Action) when is_binary(Code) ->
+    case asobi_error:defined(Code) of
+        true ->
+            {asobi_error, Code, Details};
+        false ->
+            ?LOG_ERROR(#{
+                msg => ~"ops_extension_undeclared_code",
+                extension => Extension,
+                action => Action,
+                code => Code
+            }),
+            {asobi_error, ~"internal"}
+    end;
+error_reply(Code, _Details, Extension, Action) ->
+    reply({returned, Code}, Extension, Action).
+
+body_params(#{json := Params}) when is_map(Params) -> Params;
+body_params(_Req) -> #{}.
+
+query_params(Req) ->
+    maps:from_list(cowboy_req:parse_qs(Req)).

--- a/test/asobi_error_contract_tests.erl
+++ b/test/asobi_error_contract_tests.erl
@@ -207,6 +207,12 @@ code_violations(asobi_error, _Nodes) ->
 %% `asobi_rpc_tests:an_undeclared_code_does_not_reach_the_client/0`.
 code_violations(asobi_rpc, _Nodes) ->
     [];
+%% And the third, for the same reason on the ops plane: `asobi_ops_extension`
+%% maps an extension handler's *returned* code onto an object, gates it on the
+%% same `asobi_error:defined/1`, and answers `internal` for anything else.
+%% Pinned by `asobi_ops_extension_tests:an_undeclared_code_is_a_defect/0`.
+code_violations(asobi_ops_extension, _Nodes) ->
+    [];
 code_violations(_Module, Nodes) ->
     Codes = asobi_error:codes(),
     [V || Node <- Nodes, {violation, V} <- [code_violation(Node, Codes)]].

--- a/test/asobi_ops_tests.erl
+++ b/test/asobi_ops_tests.erl
@@ -294,15 +294,37 @@ ops_routes_are_mounted_behind_the_operator_check_test() ->
     #{security := Security, routes := Routes} = ops_group(),
     ?assertEqual(fun asobi_ops_auth:verify/1, Security),
     ?assert(Routes =/= []),
-    [?assertEqual([get, options], maps:get(methods, Opts)) || {_Path, _Handler, Opts} <- Routes].
+    [
+        ?assertEqual([get, options], maps:get(methods, Opts))
+     || {Path, _Handler, Opts} <- Routes, not extension_route(Path)
+    ].
 
-%% Read-only means read-only: the plane must not grow a write route by
-%% accident, and `asobi_ops_notifications:broadcast/5` is deliberately not one.
-ops_plane_serves_no_write_method_test() ->
+%% Core's own plane is read-only and must not grow a write route by accident,
+%% and `asobi_ops_notifications:broadcast/5` is deliberately not one. The
+%% extension dispatch route is the single exception, and it is not an exception
+%% to the audit: every method on it but `get` runs inside
+%% `asobi_ops_audit:mutation/4`.
+core_ops_routes_serve_no_write_method_test() ->
     #{routes := Routes} = ops_group(),
-    Methods = lists:usort([M || {_Path, _Handler, Opts} <- Routes, M <- maps:get(methods, Opts)]),
+    Methods = lists:usort([
+        M
+     || {Path, _Handler, Opts} <- Routes,
+        not extension_route(Path),
+        M <- maps:get(methods, Opts)
+    ]),
     ?assertEqual([get, options], Methods),
     ?assertEqual([], [Class || {_M, _S, Class} <- asobi_ops_caps:classes(), Class =/= read]).
+
+%% The exception, stated once so it cannot widen quietly: exactly one route
+%% carries a write method, and it is the extension dispatch.
+exactly_one_ops_route_carries_a_write_method_test() ->
+    #{routes := Routes} = ops_group(),
+    Writing = [
+        Path
+     || {Path, _Handler, Opts} <- Routes,
+        [] =/= [M || M <- maps:get(methods, Opts), M =/= get, M =/= options]
+    ],
+    ?assertEqual([~"/ext/:extension/:action"], Writing).
 
 ops_group() ->
     [Group] = [G || #{prefix := ~"/api/v1/ops"} = G <- asobi_router:routes(dev)],
@@ -313,6 +335,9 @@ no_ops_route_sits_in_the_player_scoped_group_test() ->
         ?assertEqual([], [Path || {Path, _Handler, _Opts} <- Routes, ops_path(Path)])
      || #{prefix := Prefix, routes := Routes} <- asobi_router:routes(dev), Prefix =/= ~"/api/v1/ops"
     ].
+
+extension_route(~"/ext/:extension/:action") -> true;
+extension_route(_Path) -> false.
 
 ops_path(<<"/ops", _/binary>>) -> true;
 ops_path(_Path) -> false.
@@ -325,11 +350,27 @@ ops_routes_and_capability_classes_agree_test() ->
         {Method, [binding_or_literal(S) || S <- binary:split(Path, ~"/", [global, trim_all])]}
      || #{prefix := ~"/api/v1/ops", routes := Routes} <- asobi_router:routes(dev),
         {Path, _Handler, Opts} <- Routes,
+        not extension_route(Path),
         Method <- maps:get(methods, Opts),
         Method =/= options
     ]),
     Tagged = lists:sort([{Method, Segments} || {Method, Segments, _} <- asobi_ops_caps:classes()]),
     ?assertEqual(Tagged, Routed).
+
+%% The extension dispatch is the one route with no entry in `classes/0`,
+%% because its class is per action and lives in the manifest that also declares
+%% the handler. Excluded above, so it is checked here instead: an action nobody
+%% declared has no class, which is what denies it.
+extension_route_is_classed_by_the_manifest_test() ->
+    asobi_extensions:reset(),
+    ?assertEqual(
+        undefined,
+        asobi_ops_caps:class(~"POST", ~"/api/v1/ops/ext/quests/define")
+    ),
+    ?assertEqual(
+        undefined,
+        asobi_ops_caps:class(~"GET", ~"/api/v1/ops/ext/nothing/at-all")
+    ).
 
 %% The router spells a bound segment `:id`; the class table spells it `'_'`,
 %% because it matches against a real request path where the binding is already

--- a/test/extensions/asobi_extensions_tests.erl
+++ b/test/extensions/asobi_extensions_tests.erl
@@ -40,6 +40,10 @@ extensions_test_() ->
         fun lua_args_must_match_the_mfa_arity/0,
         fun an_rpc_handler_must_have_arity_two/0,
         fun a_bot_binding_is_refused_not_ignored/0,
+        fun an_ops_handler_must_have_arity_two/0,
+        fun an_ops_action_must_carry_a_real_class/0,
+        fun an_ops_action_must_be_one_path_segment/0,
+        fun a_declared_ops_action_is_reachable_by_its_class/0,
         fun a_declared_code_carries_its_status_and_message/0,
         fun an_undeclared_code_is_still_a_server_bug/0,
         fun core_codes_stay_core_only/0,
@@ -344,6 +348,61 @@ a_bot_binding_is_refused_not_ignored() ->
 
 binding(Vms) ->
     #{mfa => {tunable_lua, status, 1}, args => [binary], effects => none, vms => Vms}.
+
+%% asobi#372. `ops/0` is dispatched by core as `Module:Function(Params, Ctx)`,
+%% exactly as `rpc/0` is, so the same arity rule holds for the same reason.
+an_ops_handler_must_have_arity_two() ->
+    tunable(#{ops => #{~"thing" => ops_entry(#{mfa => {tunable_ops, thing, 1}})}}),
+    ?assertMatch(
+        [{bad_manifest, ?TUNABLE, _, {ops, _, ~"thing"}}],
+        check_problems()
+    ),
+    retune(#{ops => #{~"thing" => ops_entry(#{})}}),
+    ?assertMatch({ok, [_]}, asobi_extensions:check()).
+
+%% The class is the only thing that authorises the call, so a class outside
+%% ADR 0007's vocabulary is a build failure rather than a route that resolves
+%% to a capability nobody can hold.
+an_ops_action_must_carry_a_real_class() ->
+    tunable(#{ops => #{~"thing" => ops_entry(#{class => superuser})}}),
+    ?assertMatch(
+        [{bad_manifest, ?TUNABLE, _, {ops, _, ~"thing"}}],
+        check_problems()
+    ).
+
+%% The action is one path segment under /api/v1/ops/ext/<name>/, so a slash
+%% would silently mount somewhere the capability check cannot tag.
+an_ops_action_must_be_one_path_segment() ->
+    tunable(#{ops => #{~"quests/define" => ops_entry(#{})}}),
+    ?assertMatch(
+        [{bad_manifest, ?TUNABLE, _, {ops, _, ~"quests/define"}}],
+        check_problems()
+    ).
+
+%% The end of the chain: a declared action resolves to its declared class on
+%% the path the router serves, and the same path with a method it does not
+%% answer resolves to nothing - which is what denies it.
+a_declared_ops_action_is_reachable_by_its_class() ->
+    tunable(#{ops => #{~"thing" => ops_entry(#{class => player_data})}}),
+    _ = asobi_extensions:resolve(),
+    ?assertEqual(
+        player_data,
+        asobi_ops_caps:class(~"POST", ~"/api/v1/ops/ext/tunable/thing")
+    ),
+    ?assertEqual(
+        undefined,
+        asobi_ops_caps:class(~"GET", ~"/api/v1/ops/ext/tunable/thing")
+    ),
+    ?assertEqual(
+        undefined,
+        asobi_ops_caps:class(~"POST", ~"/api/v1/ops/ext/tunable/other")
+    ).
+
+ops_entry(Overrides) ->
+    maps:merge(
+        #{method => post, mfa => {tunable_ops, thing, 2}, class => config},
+        Overrides
+    ).
 
 %% --- Error codes ---
 

--- a/test/extensions/asobi_fixture_quests_extension.erl
+++ b/test/extensions/asobi_fixture_quests_extension.erl
@@ -2,7 +2,7 @@
 -moduledoc "A complete extension manifest, shaped exactly like the design's worked example.".
 -behaviour(asobi_extension).
 
--export([info/0, rpc/0, lua/0, sup/0, owns/0, codes/0, erase_player/1]).
+-export([info/0, rpc/0, lua/0, sup/0, owns/0, codes/0, ops/0, erase_player/1]).
 
 -spec info() -> asobi_extension:info().
 info() ->
@@ -59,6 +59,21 @@ owns() ->
         rpc => [~"quests"],
         lua => [~"quests"],
         queues => [~"quests"]
+    }.
+
+-spec ops() -> asobi_extension:ops().
+ops() ->
+    #{
+        ~"define" => #{
+            method => post,
+            mfa => {asobi_fixture_quests_ops, define, 2},
+            class => config
+        },
+        ~"summary" => #{
+            method => get,
+            mfa => {asobi_fixture_quests_ops, summary, 2},
+            class => read
+        }
     }.
 
 -spec erase_player(binary()) -> ok | {error, term()}.

--- a/test/extensions/asobi_fixture_quests_ops.erl
+++ b/test/extensions/asobi_fixture_quests_ops.erl
@@ -1,0 +1,42 @@
+-module(asobi_fixture_quests_ops).
+-moduledoc "Operator actions for the quests fixture, plus a record of the calls.".
+
+-export([define/2, summary/2, raises/2, undeclared_code/2, off_contract/2]).
+-export([reset/0, calls/0]).
+
+-define(KEY, {?MODULE, calls}).
+
+-spec define(map(), asobi_ops_extension:ctx()) -> asobi_rpc:reply().
+define(#{~"key" := ~"taken"}, _Ctx) ->
+    {error, ~"quests.not_found"};
+define(Params, #{actor := #{id := ActorId}} = Ctx) ->
+    record({define, Params, Ctx}),
+    {ok, #{~"defined" => maps:get(~"key", Params, ~""), ~"by" => ActorId}}.
+
+-spec summary(map(), asobi_ops_extension:ctx()) -> asobi_rpc:reply().
+summary(Params, Ctx) ->
+    record({summary, Params, Ctx}),
+    {ok, #{~"count" => 2, ~"filter" => maps:get(~"filter", Params, ~"all")}}.
+
+-spec raises(map(), asobi_ops_extension:ctx()) -> no_return().
+raises(_Params, _Ctx) ->
+    error(deliberate).
+
+-spec undeclared_code(map(), asobi_ops_extension:ctx()) -> asobi_rpc:reply().
+undeclared_code(_Params, _Ctx) ->
+    {error, ~"quests.never_declared"}.
+
+-spec off_contract(map(), asobi_ops_extension:ctx()) -> term().
+off_contract(_Params, _Ctx) ->
+    surprise.
+
+-spec reset() -> ok.
+reset() ->
+    persistent_term:put(?KEY, []).
+
+-spec calls() -> [term()].
+calls() ->
+    lists:reverse(persistent_term:get(?KEY, [])).
+
+record(Call) ->
+    persistent_term:put(?KEY, [Call | persistent_term:get(?KEY, [])]).

--- a/test/extensions/asobi_fixture_tunable_extension.erl
+++ b/test/extensions/asobi_fixture_tunable_extension.erl
@@ -5,7 +5,7 @@ and colliding shape instead of a file per case.
 """.
 -behaviour(asobi_extension).
 
--export([info/0, rpc/0, lua/0, sup/0, owns/0, codes/0]).
+-export([info/0, rpc/0, lua/0, sup/0, owns/0, codes/0, ops/0]).
 -export([set/1, clear/0]).
 
 -define(KEY, {?MODULE, manifest}).
@@ -26,6 +26,10 @@ info() ->
 -spec rpc() -> asobi_extension:rpc().
 rpc() ->
     value(rpc, #{}).
+
+-spec ops() -> asobi_extension:ops().
+ops() ->
+    value(ops, #{}).
 
 -spec lua() -> asobi_extension:lua().
 lua() ->

--- a/test/extensions/asobi_ops_extension_tests.erl
+++ b/test/extensions/asobi_ops_extension_tests.erl
@@ -1,0 +1,156 @@
+-module(asobi_ops_extension_tests).
+
+-include_lib("eunit/include/eunit.hrl").
+
+-define(QUESTS, asobi_fixture_quests).
+-define(ACTOR, #{
+    id => ~"op-1",
+    display => ~"operator",
+    source => static_secret,
+    caps => [read, player_data, config],
+    attested => false
+}).
+
+%% `ops/0` was the answer to the one gap the first extension filed that #365
+%% deliberately left open: an extension had nowhere to put an operator action,
+%% because `rpc/0` is player-scoped and a player never holds an operator
+%% capability. These assertions are the difference between "the declaration is
+%% well-formed" and "an operator can call it".
+
+extension_ops_test_() ->
+    {foreach, fun setup/0, fun cleanup/1, [
+        fun a_declared_action_is_dispatched/0,
+        fun a_read_action_gets_the_query_string/0,
+        fun the_actor_reaches_the_handler/0,
+        fun a_declared_code_survives/0,
+        fun an_undeclared_code_is_a_defect/0,
+        fun a_raising_handler_is_a_defect/0,
+        fun an_off_contract_return_is_a_defect/0,
+        fun an_unknown_action_answers_as_the_gate_did/0,
+        fun a_write_is_audited/0,
+        fun a_read_is_not_audited/0,
+        fun nothing_is_served_before_migrations/0
+    ]}.
+
+setup() ->
+    asobi_extensions:reset(),
+    asobi_fixture_quests_ops:reset(),
+    ok = asobi_fixture_app:install(?QUESTS, asobi_fixture_quests_extension, []),
+    _ = asobi_extensions:resolve(),
+    asobi_readiness:mark_ready(),
+    meck:new(asobi_ops_audit, [passthrough, no_link]),
+    meck:expect(asobi_ops_audit, mutation, fun(_Actor, Action, Target, Fun) ->
+        persistent_term:put({?MODULE, audited}, {Action, Target}),
+        Fun()
+    end),
+    ok.
+
+cleanup(_) ->
+    meck:unload(asobi_ops_audit),
+    _ = persistent_term:erase({?MODULE, audited}),
+    asobi_fixture_app:uninstall(?QUESTS),
+    asobi_extensions:reset(),
+    asobi_fixture_quests_ops:reset(),
+    ok.
+
+%% --- Dispatch ---
+
+a_declared_action_is_dispatched() ->
+    ?assertEqual(
+        {json, #{~"defined" => ~"daily", ~"by" => ~"op-1"}},
+        post(~"quests", ~"define", #{~"key" => ~"daily"})
+    ).
+
+a_read_action_gets_the_query_string() ->
+    ?assertEqual(
+        {json, #{~"count" => 2, ~"filter" => ~"active"}},
+        get(~"quests", ~"summary", ~"filter=active")
+    ).
+
+the_actor_reaches_the_handler() ->
+    _ = post(~"quests", ~"define", #{~"key" => ~"daily"}),
+    [{define, _Params, Ctx}] = asobi_fixture_quests_ops:calls(),
+    ?assertMatch(#{actor := #{id := ~"op-1"}, extension := ~"quests", action := ~"define"}, Ctx).
+
+%% --- The error contract ---
+
+a_declared_code_survives() ->
+    ?assertEqual(
+        {asobi_error, ~"quests.not_found", #{}},
+        post(~"quests", ~"define", #{~"key" => ~"taken"})
+    ).
+
+%% A handler could build a code out of `params`, so a code nobody declared is
+%% the extension's defect and answers `internal` rather than minting a status.
+an_undeclared_code_is_a_defect() ->
+    ?assertEqual({asobi_error, ~"internal"}, dispatch_mfa(undeclared_code)).
+
+a_raising_handler_is_a_defect() ->
+    ?assertEqual({asobi_error, ~"internal"}, dispatch_mfa(raises)).
+
+an_off_contract_return_is_a_defect() ->
+    ?assertEqual({asobi_error, ~"internal"}, dispatch_mfa(off_contract)).
+
+%% Unreachable through the router - an undeclared action has no class and the
+%% security callback denied it - but answered rather than crashed, because a
+%% manifest can change under a live request. `forbidden` rather than a 404, so
+%% the dispatcher agrees with the gate instead of confirming what is installed.
+an_unknown_action_answers_as_the_gate_did() ->
+    ?assertEqual({asobi_error, ~"forbidden"}, post(~"quests", ~"nope", #{})),
+    ?assertEqual({asobi_error, ~"forbidden"}, post(~"nothing", ~"define", #{})).
+
+%% --- The audit ---
+
+a_write_is_audited() ->
+    _ = post(~"quests", ~"define", #{~"key" => ~"daily"}),
+    ?assertEqual(
+        {~"quests.define", {~"extension", ~"quests"}},
+        persistent_term:get({?MODULE, audited}, undefined)
+    ).
+
+a_read_is_not_audited() ->
+    _ = get(~"quests", ~"summary", ~""),
+    ?assertEqual(undefined, persistent_term:get({?MODULE, audited}, undefined)).
+
+%% --- Readiness ---
+
+%% The route table compiles before migrations run, so an action is reachable
+%% before its tables exist.
+nothing_is_served_before_migrations() ->
+    meck:new(asobi_readiness, [passthrough, no_link]),
+    meck:expect(asobi_readiness, guard, fun() -> {error, asobi_error:object(~"not_ready")} end),
+    try
+        ?assertEqual({asobi_error, ~"not_ready"}, post(~"quests", ~"define", #{~"key" => ~"d"}))
+    after
+        meck:unload(asobi_readiness)
+    end.
+
+%% --- Helpers ---
+
+post(Extension, Action, Params) ->
+    asobi_ops_extension:handle(req(Extension, Action, #{json => Params})).
+
+get(Extension, Action, Qs) ->
+    asobi_ops_extension:handle(req(Extension, Action, #{qs => Qs})).
+
+req(Extension, Action, Extra) ->
+    maps:merge(
+        #{
+            bindings => #{~"extension" => Extension, ~"action" => Action},
+            auth_data => #{ops_actor => ?ACTOR}
+        },
+        Extra
+    ).
+
+%% Re-point the declared action at another fixture function, so the handler
+%% contract is exercised through the same dispatch a real call takes.
+dispatch_mfa(Function) ->
+    meck:new(asobi_extensions, [passthrough, no_link]),
+    meck:expect(asobi_extensions, ops_action, fun(_Extension, _Action) ->
+        #{method => post, mfa => {asobi_fixture_quests_ops, Function, 2}, class => config}
+    end),
+    try
+        post(~"quests", ~"define", #{})
+    after
+        meck:unload(asobi_extensions)
+    end.


### PR DESCRIPTION
Closes gap 8, the last one from the `asobi_quests` report and the only one #365 left open.

## The gap

An extension with an admin action had nowhere to put it. `rpc/0` is player-scoped by construction: the caller is the authenticated player on that socket, and `read | player_data | config` (ADR 0007) is an **operator** vocabulary no player ever holds - so tagging a socket method with a capability class would have made it deniable for every caller that dispatcher has. `asobi_quests` exported `define/2` and deliberately left it out of its manifest, reachable only by a host that routed to it itself.

#365 named the reachable home - the ops plane - and left opening it as a decision about that plane. This is that decision.

## The shape

```erlang
ops() ->
    #{~"define"  => #{method => post, mfa => {asobi_quests_ops, define, 2},  class => config},
      ~"summary" => #{method => get,  mfa => {asobi_quests_ops, summary, 2}, class => read}}.
```

```
POST /api/v1/ops/ext/quests/define
GET  /api/v1/ops/ext/quests/summary?filter=active
```

**Extensions still contribute no routes (ADR 0003).** Core owns exactly one - `/api/v1/ops/ext/:extension/:action` - and dispatches every declared action behind it, the same shape as owning one WebSocket frame type and dispatching `rpc/0` behind that. The route table stays core's, and the router comment that says so stays true.

## Authorisation is still one decision

`asobi_ops_caps:class/2` resolves this route from the manifest entry that also declares the handler, on the same path it resolves its own table. So:

- An action nobody declared has **no class**, and a route with no class is denied. An unknown extension, an unknown action and a method the action does not answer are all **403 from the security callback**, never a 404 from the dispatcher - which extensions are installed is not something an unauthorised caller gets to enumerate.
- The dispatcher's own unreachable `undefined` branch answers `forbidden` for the same reason, so it agrees with the gate rather than confirming what exists.
- A class outside ADR 0007's vocabulary is a **build failure**, not a route resolving to a capability nobody can hold.

## Every write is audited

Everything but `get` runs inside `asobi_ops_audit:mutation/4`, so an extension cannot write on this plane without a durable row naming the operator. Declaring a method other than `get` is what opts in; there is no way to opt out.

## This is the plane's first non-GET route

Stated where it can be seen rather than left to be discovered:

- `ops_plane_serves_no_write_method_test` becomes `core_ops_routes_serve_no_write_method_test` - core's own routes still serve none, and every entry in `classes/0` is still `read`.
- A new `exactly_one_ops_route_carries_a_write_method_test` pins that the exception is one route and names it, so it cannot widen quietly.
- `extension_route_is_classed_by_the_manifest_test` covers what the agreement test now excludes.

## The handler contract

Unchanged from RPC - `(Params, Ctx)` returning `{ok, map()} | {error, Code} | {error, Code, Details}` - because a second shape is a second thing to learn for no reason. `Params` is the decoded body for a write and the parsed query string for a read; `Ctx` carries the admitted actor. A code the extension never declared is a defect here exactly as it is on the RPC seam, and `asobi_error_contract_tests` gains this module beside `asobi_rpc` for the same stated reason.

## Checks

`rebar3 fmt --check`, `xref` and `eunit` (1573 tests, 0 failures) clean. 11 new dispatch tests, 4 new manifest-validation tests, guide section added.