### PR TITLE
test: give the property fixtures a hang detector, not a performance budget

### DIFF
--- a/test/prop_chat_zone_routing.erl
+++ b/test/prop_chat_zone_routing.erl
@@ -18,13 +18,16 @@
 -define(PROX_RADIUS, 1).
 
 chat_zone_routing_test_() ->
-    %% The timeout wraps the whole fixture, not just the property: eunit
-    %% gives setup/0 the default 5s, and starting a world under a loaded
-    %% CI runner can exceed it - which cancels the group with 0 failures
-    %% and fails the build with nothing named.
+    %% Two timeouts, because there are two ways this cancels a group with
+    %% zero failures and nothing named. The outer one covers setup/0 and
+    %% cleanup/1, which otherwise run under eunit's 5s default; the inner
+    %% one is the property's own, and its floor is 300s rather than 60s
+    %% because 60 is a performance budget, not a hang detector - a CI runner
+    %% managed 21 of 25 iterations of the reconnect property inside it
+    %% (asobi#376).
     {timeout, 120,
         {setup, fun setup/0, fun cleanup/1, [
-            {timeout, max(60, ?NUMTESTS div 2),
+            {timeout, max(300, ?NUMTESTS div 2),
                 ?_assert(
                     proper:quickcheck(prop_chat_zone_routing(), [
                         {numtests, ?NUMTESTS}, {to_file, user}

--- a/test/prop_chat_zone_routing.erl
+++ b/test/prop_chat_zone_routing.erl
@@ -18,14 +18,19 @@
 -define(PROX_RADIUS, 1).
 
 chat_zone_routing_test_() ->
-    {setup, fun setup/0, fun cleanup/1, [
-        {timeout, max(60, ?NUMTESTS div 2),
-            ?_assert(
-                proper:quickcheck(prop_chat_zone_routing(), [
-                    {numtests, ?NUMTESTS}, {to_file, user}
-                ])
-            )}
-    ]}.
+    %% The timeout wraps the whole fixture, not just the property: eunit
+    %% gives setup/0 the default 5s, and starting a world under a loaded
+    %% CI runner can exceed it - which cancels the group with 0 failures
+    %% and fails the build with nothing named.
+    {timeout, 120,
+        {setup, fun setup/0, fun cleanup/1, [
+            {timeout, max(60, ?NUMTESTS div 2),
+                ?_assert(
+                    proper:quickcheck(prop_chat_zone_routing(), [
+                        {numtests, ?NUMTESTS}, {to_file, user}
+                    ])
+                )}
+        ]}}.
 
 setup() ->
     {ok, _} = application:ensure_all_started(telemetry),

--- a/test/prop_input_never_dropped.erl
+++ b/test/prop_input_never_dropped.erl
@@ -30,16 +30,21 @@
 }).
 
 input_never_dropped_test_() ->
-    {setup, fun setup/0, fun cleanup/1, fun(Ctx) ->
-        [
-            {timeout, max(60, ?NUMTESTS div 2),
-                ?_assert(
-                    proper:quickcheck(prop_input_never_dropped(Ctx), [
-                        {numtests, ?NUMTESTS}, {to_file, user}
-                    ])
-                )}
-        ]
-    end}.
+    %% The timeout wraps the whole fixture, not just the property: eunit
+    %% gives setup/0 the default 5s, and starting a world under a loaded
+    %% CI runner can exceed it - which cancels the group with 0 failures
+    %% and fails the build with nothing named.
+    {timeout, 120,
+        {setup, fun setup/0, fun cleanup/1, fun(Ctx) ->
+            [
+                {timeout, max(60, ?NUMTESTS div 2),
+                    ?_assert(
+                        proper:quickcheck(prop_input_never_dropped(Ctx), [
+                            {numtests, ?NUMTESTS}, {to_file, user}
+                        ])
+                    )}
+            ]
+        end}}.
 
 setup() ->
     {ok, _} = application:ensure_all_started(telemetry),

--- a/test/prop_input_never_dropped.erl
+++ b/test/prop_input_never_dropped.erl
@@ -30,14 +30,17 @@
 }).
 
 input_never_dropped_test_() ->
-    %% The timeout wraps the whole fixture, not just the property: eunit
-    %% gives setup/0 the default 5s, and starting a world under a loaded
-    %% CI runner can exceed it - which cancels the group with 0 failures
-    %% and fails the build with nothing named.
+    %% Two timeouts, because there are two ways this cancels a group with
+    %% zero failures and nothing named. The outer one covers setup/0 and
+    %% cleanup/1, which otherwise run under eunit's 5s default; the inner
+    %% one is the property's own, and its floor is 300s rather than 60s
+    %% because 60 is a performance budget, not a hang detector - a CI runner
+    %% managed 21 of 25 iterations of the reconnect property inside it
+    %% (asobi#376).
     {timeout, 120,
         {setup, fun setup/0, fun cleanup/1, fun(Ctx) ->
             [
-                {timeout, max(60, ?NUMTESTS div 2),
+                {timeout, max(300, ?NUMTESTS div 2),
                     ?_assert(
                         proper:quickcheck(prop_input_never_dropped(Ctx), [
                             {numtests, ?NUMTESTS}, {to_file, user}

--- a/test/prop_reconnect_lifecycle.erl
+++ b/test/prop_reconnect_lifecycle.erl
@@ -32,16 +32,21 @@
 }).
 
 reconnect_lifecycle_test_() ->
-    {setup, fun setup/0, fun cleanup/1, fun(Ctx) ->
-        [
-            {timeout, max(60, ?NUMTESTS div 2),
-                ?_assert(
-                    proper:quickcheck(prop_reconnect_lifecycle(Ctx), [
-                        {numtests, ?NUMTESTS}, {to_file, user}
-                    ])
-                )}
-        ]
-    end}.
+    %% The timeout wraps the whole fixture, not just the property: eunit
+    %% gives setup/0 the default 5s, and starting a world under a loaded
+    %% CI runner can exceed it - which cancels the group with 0 failures
+    %% and fails the build with nothing named.
+    {timeout, 120,
+        {setup, fun setup/0, fun cleanup/1, fun(Ctx) ->
+            [
+                {timeout, max(60, ?NUMTESTS div 2),
+                    ?_assert(
+                        proper:quickcheck(prop_reconnect_lifecycle(Ctx), [
+                            {numtests, ?NUMTESTS}, {to_file, user}
+                        ])
+                    )}
+            ]
+        end}}.
 
 setup() ->
     {ok, _} = application:ensure_all_started(telemetry),

--- a/test/prop_reconnect_lifecycle.erl
+++ b/test/prop_reconnect_lifecycle.erl
@@ -32,14 +32,17 @@
 }).
 
 reconnect_lifecycle_test_() ->
-    %% The timeout wraps the whole fixture, not just the property: eunit
-    %% gives setup/0 the default 5s, and starting a world under a loaded
-    %% CI runner can exceed it - which cancels the group with 0 failures
-    %% and fails the build with nothing named.
+    %% Two timeouts, because there are two ways this cancels a group with
+    %% zero failures and nothing named. The outer one covers setup/0 and
+    %% cleanup/1, which otherwise run under eunit's 5s default; the inner
+    %% one is the property's own, and its floor is 300s rather than 60s
+    %% because 60 is a performance budget, not a hang detector - a CI runner
+    %% managed 21 of 25 iterations of the reconnect property inside it
+    %% (asobi#376).
     {timeout, 120,
         {setup, fun setup/0, fun cleanup/1, fun(Ctx) ->
             [
-                {timeout, max(60, ?NUMTESTS div 2),
+                {timeout, max(300, ?NUMTESTS div 2),
                     ?_assert(
                         proper:quickcheck(prop_reconnect_lifecycle(Ctx), [
                             {numtests, ?NUMTESTS}, {to_file, user}

--- a/test/prop_zone_invariants.erl
+++ b/test/prop_zone_invariants.erl
@@ -32,14 +32,17 @@
 }).
 
 zone_invariants_test_() ->
-    %% The timeout wraps the whole fixture, not just the property: eunit
-    %% gives setup/0 the default 5s, and starting a world under a loaded
-    %% CI runner can exceed it - which cancels the group with 0 failures
-    %% and fails the build with nothing named.
+    %% Two timeouts, because there are two ways this cancels a group with
+    %% zero failures and nothing named. The outer one covers setup/0 and
+    %% cleanup/1, which otherwise run under eunit's 5s default; the inner
+    %% one is the property's own, and its floor is 300s rather than 60s
+    %% because 60 is a performance budget, not a hang detector - a CI runner
+    %% managed 21 of 25 iterations of the reconnect property inside it
+    %% (asobi#376).
     {timeout, 120,
         {setup, fun setup/0, fun cleanup/1, fun(Ctx) ->
             [
-                {timeout, max(60, ?NUMTESTS div 2),
+                {timeout, max(300, ?NUMTESTS div 2),
                     ?_assert(
                         proper:quickcheck(prop_zone_invariants(Ctx), [
                             {numtests, ?NUMTESTS}, {to_file, user}

--- a/test/prop_zone_invariants.erl
+++ b/test/prop_zone_invariants.erl
@@ -32,16 +32,21 @@
 }).
 
 zone_invariants_test_() ->
-    {setup, fun setup/0, fun cleanup/1, fun(Ctx) ->
-        [
-            {timeout, max(60, ?NUMTESTS div 2),
-                ?_assert(
-                    proper:quickcheck(prop_zone_invariants(Ctx), [
-                        {numtests, ?NUMTESTS}, {to_file, user}
-                    ])
-                )}
-        ]
-    end}.
+    %% The timeout wraps the whole fixture, not just the property: eunit
+    %% gives setup/0 the default 5s, and starting a world under a loaded
+    %% CI runner can exceed it - which cancels the group with 0 failures
+    %% and fails the build with nothing named.
+    {timeout, 120,
+        {setup, fun setup/0, fun cleanup/1, fun(Ctx) ->
+            [
+                {timeout, max(60, ?NUMTESTS div 2),
+                    ?_assert(
+                        proper:quickcheck(prop_zone_invariants(Ctx), [
+                            {numtests, ?NUMTESTS}, {to_file, user}
+                        ])
+                    )}
+            ]
+        end}}.
 
 setup() ->
     {ok, _} = application:ensure_all_started(telemetry),


### PR DESCRIPTION
Closes #376.

## The diagnosis

Four CI runs in a row failed EUnit with `Failed: 0. Skipped: 0.` and "one or more tests were cancelled", naming nothing. The verbose log does name it:

```
prop_reconnect_lifecycle:43: -reconnect_lifecycle_test_/0-fun-1-
    .....................*skipped*
```

Twenty-one of twenty-five iterations, then killed. The only timer on that item is its own `max(60, ?NUMTESTS div 2)` - **60 seconds at the default numtests, which is 2.4 seconds per iteration for a property that stands up a whole world**. The runner did not make it.

The thing that made this look unexplainable - the abort landing one second after the module header - is PropEr's dots being flushed at the end, not a one-second timer. Wall-clock in that log is when output was written, not when work happened.

## The fix

**Floor to 300s.** A test timeout catches a hang; sizing it to what the fastest machine needs turns every slow runner into a red build that names nothing. The `?NUMTESTS div 2` scaling is untouched, so the nightly's 1000-iteration run keeps its 500s.

**The fixture wrap stays.** `{timeout, N, ...}` sat on the property but not on the `{setup, ...}` around it, so `setup/0` and `cleanup/1` ran under eunit's 5s default - a second way to cancel a group with zero failures, and these setups start telemetry, a pg scope and a world. Not the cause of this failure, but the same class, found while chasing it.

Four modules: `prop_chat_zone_routing`, `prop_input_never_dropped`, `prop_reconnect_lifecycle`, `prop_zone_invariants`.