### PR TITLE
feat(protocol): sync the fixture corpus into the SDKs, and fail on drift

### DIFF
--- a/.github/workflows/protocol-sync.yml
+++ b/.github/workflows/protocol-sync.yml
@@ -1,0 +1,103 @@
+name: Protocol sync
+
+# The fixture corpus is ground truth for every SDK's dispatch tests, and all
+# seven vendor a copy. Without this, a new event reaches the SDKs whenever
+# somebody remembers - which is how core got to 38 fixtures while the SDKs sat
+# between 28 and 35.
+#
+# On a corpus change this opens (or updates) one PR per SDK. It does not merge
+# them: an SDK may need a dispatch case for the new event, and that is a human
+# decision in that repo.
+#
+# Needs SDK_SYNC_TOKEN, a fine-grained PAT with contents:write and
+# pull-requests:write on the seven SDK repos. Without it the job says so and
+# stops, rather than failing a build nobody can fix.
+
+on:
+  push:
+    branches: [main]
+    paths: ['priv/protocol/**']
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - sdk: js
+            repo: widgrensit/asobi-js
+          - sdk: dart
+            repo: widgrensit/asobi-dart
+          - sdk: godot
+            repo: widgrensit/asobi-godot
+          - sdk: love2d
+            repo: widgrensit/asobi-love2d
+          - sdk: defold
+            repo: widgrensit/asobi-defold
+          - sdk: unity
+            repo: widgrensit/asobi-unity
+          - sdk: unreal
+            repo: widgrensit/asobi-unreal
+    steps:
+      - name: Check out asobi
+        uses: actions/checkout@v5
+
+      - name: Check for the sync token
+        id: token
+        env:
+          TOKEN: ${{ secrets.SDK_SYNC_TOKEN }}
+        run: |
+          if [ -z "$TOKEN" ]; then
+            echo "SDK_SYNC_TOKEN is not set - cannot open a PR in ${{ matrix.repo }}."
+            echo "Create a fine-grained PAT with contents:write and pull-requests:write"
+            echo "on the seven SDK repos and add it as a repository secret."
+            echo "present=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "present=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Check out ${{ matrix.repo }}
+        if: steps.token.outputs.present == 'true'
+        uses: actions/checkout@v5
+        with:
+          repository: ${{ matrix.repo }}
+          token: ${{ secrets.SDK_SYNC_TOKEN }}
+          path: sdk
+
+      - name: Sync the corpus
+        if: steps.token.outputs.present == 'true'
+        id: sync
+        run: |
+          scripts/protocol-sync.sh apply "${{ matrix.sdk }}" sdk
+          cd sdk
+          if git diff --quiet; then
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+            git diff --stat
+          fi
+
+      - name: Open a PR
+        if: steps.sync.outputs.changed == 'true'
+        uses: peter-evans/create-pull-request@v7
+        with:
+          path: sdk
+          token: ${{ secrets.SDK_SYNC_TOKEN }}
+          branch: chore/protocol-fixtures
+          base: main
+          commit-message: "chore: sync the protocol fixtures from asobi"
+          title: "chore: sync the protocol fixtures from asobi"
+          body: |
+            The fixture corpus in `widgrensit/asobi` changed, so this brings the
+            vendored copy back in line. Opened by asobi's `protocol-sync`
+            workflow from ${{ github.sha }}.
+
+            **A new fixture is not automatically dispatched.** If this adds an
+            event this SDK has no case for, the dispatch test will fail and the
+            case belongs in this PR before it merges.
+          delete-branch: true

--- a/priv/protocol/README.md
+++ b/priv/protocol/README.md
@@ -40,6 +40,26 @@ priv/protocol/
 
 One file per event. Filename is the `type` field plus `.json`.
 
+## Keeping the SDK copies in sync
+
+Every official SDK vendors a copy, and copies drift: when the automation below
+was written core had 38 fixtures and the SDKs had between 28 and 35, with
+nothing to notice.
+
+```sh
+scripts/protocol-sync.sh check <sdk> <path-to-sdk-repo>   # fails on drift, names each file
+scripts/protocol-sync.sh apply <sdk> <path-to-sdk-repo>   # copies in, removes stale
+scripts/protocol-sync.sh sdks                             # js dart godot love2d defold unity unreal
+```
+
+`.github/workflows/protocol-sync.yml` runs `apply` against all seven on any
+change under `priv/protocol/` on main and opens one PR per SDK. It does not
+merge them: a new event usually needs a dispatch case, and that is a decision
+in the SDK's own repo.
+
+An SDK's own CI should run `check` against a pinned asobi so drift fails there
+too, rather than waiting for the next corpus change to reveal it.
+
 ## Using the corpus from a client SDK
 
 A typical SDK dispatch test fetches `priv/protocol/fixtures/<type>.json` (vendored or pulled from a published asobi release artifact), feeds the raw bytes into the SDK's `_handle_message` (or equivalent), and asserts a callback fired:

--- a/scripts/protocol-sync.sh
+++ b/scripts/protocol-sync.sh
@@ -1,0 +1,100 @@
+#!/usr/bin/env bash
+# Sync priv/protocol/fixtures into a client SDK, or report the drift.
+#
+# The corpus is ground truth for every SDK's dispatch tests, and all seven
+# vendor a copy. Copies drift: at the time this was written core had 38
+# fixtures and the SDKs had between 28 and 35, with no automation to notice.
+# So this is the automation - `check` fails a build on drift, `apply` fixes it.
+#
+#   scripts/protocol-sync.sh check <sdk> <path-to-sdk-repo>
+#   scripts/protocol-sync.sh apply <sdk> <path-to-sdk-repo>
+#   scripts/protocol-sync.sh path  <sdk>        # where that SDK keeps them
+#   scripts/protocol-sync.sh sdks               # every SDK it knows
+#
+# `check` exits 1 on drift and prints one line per file, so CI output says
+# which fixture is missing rather than "tests failed".
+set -euo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+CORPUS="$HERE/priv/protocol/fixtures"
+
+# Each SDK's vendored copy. Paths differ because each ecosystem has its own
+# test layout, and none of them is wrong - so the map lives here rather than
+# every SDK growing a config file.
+sdk_path() {
+  case "$1" in
+    js)      echo "test/fixtures" ;;
+    dart)    echo "test/fixtures" ;;
+    godot)   echo "test/fixtures" ;;
+    love2d)  echo "test/fixtures" ;;
+    defold)  echo "tests/fixtures" ;;
+    unity)   echo "Tests/Runtime/Resources/Fixtures" ;;
+    unreal)  echo "Source/AsobiSDK/Tests/Fixtures" ;;
+    *)       return 1 ;;
+  esac
+}
+
+SDKS="js dart godot love2d defold unity unreal"
+
+# The Unity repo does not track a .meta per fixture - the editor generates
+# them and they are not committed - so this syncs the JSON and nothing else.
+
+usage() { sed -n '2,14p' "${BASH_SOURCE[0]}" | sed 's/^# \{0,1\}//'; exit 2; }
+
+cmd="${1:-}"; shift || usage
+
+case "$cmd" in
+  sdks) echo "$SDKS"; exit 0 ;;
+  path) sdk_path "${1:?usage: path <sdk>}" || { echo "unknown sdk: $1" >&2; exit 2; }; exit 0 ;;
+  check|apply) : ;;
+  *) usage ;;
+esac
+
+sdk="${1:?usage: $cmd <sdk> <path-to-sdk-repo>}"
+repo="${2:?usage: $cmd <sdk> <path-to-sdk-repo>}"
+rel="$(sdk_path "$sdk")" || { echo "unknown sdk: $sdk" >&2; exit 2; }
+dest="$repo/$rel"
+
+[ -d "$CORPUS" ] || { echo "no corpus at $CORPUS" >&2; exit 2; }
+[ -d "$repo" ] || { echo "no repo at $repo" >&2; exit 2; }
+
+drift=0
+report() { echo "  $1"; drift=$((drift + 1)); }
+
+mkdir -p "$dest"
+
+for src in "$CORPUS"/*.json; do
+  name="$(basename "$src")"
+  if [ ! -f "$dest/$name" ]; then
+    report "missing: $name"
+    [ "$cmd" = apply ] && cp "$src" "$dest/$name"
+  elif ! cmp -s "$src" "$dest/$name"; then
+    report "differs: $name"
+    [ "$cmd" = apply ] && cp "$src" "$dest/$name"
+  fi
+done
+
+for existing in "$dest"/*.json; do
+  [ -e "$existing" ] || continue
+  name="$(basename "$existing")"
+  if [ ! -f "$CORPUS/$name" ]; then
+    report "stale: $name (no such event in core)"
+    if [ "$cmd" = apply ]; then
+      rm -f "$existing"
+    fi
+  fi
+done
+
+if [ "$drift" -eq 0 ]; then
+  echo "$sdk: in sync ($(ls "$CORPUS"/*.json | wc -l | tr -d ' ') fixtures)"
+  exit 0
+fi
+
+if [ "$cmd" = apply ]; then
+  echo "$sdk: $drift change(s) applied to $rel"
+  exit 0
+fi
+
+echo "$sdk: $drift file(s) out of sync with asobi's corpus."
+echo "Run: scripts/protocol-sync.sh apply $sdk $repo"
+exit 1

--- a/scripts/test/protocol-sync-test.sh
+++ b/scripts/test/protocol-sync-test.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+# Exercises protocol-sync.sh against a throwaway SDK tree.
+#
+#   scripts/test/protocol-sync-test.sh
+set -euo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SYNC="$HERE/../protocol-sync.sh"
+CORPUS="$HERE/../../priv/protocol/fixtures"
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+fails=0
+check() {
+  local name="$1" got="$2" want="$3"
+  if [ "$got" = "$want" ]; then echo "ok   - $name"; else
+    echo "FAIL - $name: got [$got] want [$want]"; fails=$((fails + 1))
+  fi
+}
+has() {
+  local name="$1" out="$2" needle="$3"
+  if grep -qF -- "$needle" <<<"$out"; then echo "ok   - $name"; else
+    echo "FAIL - $name: expected to find: $needle"; fails=$((fails + 1))
+  fi
+}
+
+repo="$TMP/sdk"
+dest="$repo/test/fixtures"
+mkdir -p "$dest"
+
+# 1. An empty SDK is every fixture out of sync, and says so per file.
+set +e
+out="$("$SYNC" check js "$repo")"; rc=$?
+set -e
+check "an empty vendored copy fails the check" "$rc" "1"
+has "and names a missing fixture" "$out" "missing: session.connected.json"
+
+# 2. apply brings it into sync, and check then passes.
+"$SYNC" apply js "$repo" >/dev/null
+out="$("$SYNC" check js "$repo")"
+has "apply then check is in sync" "$out" "in sync"
+check "every fixture copied" \
+  "$(ls "$dest"/*.json | wc -l | tr -d ' ')" "$(ls "$CORPUS"/*.json | wc -l | tr -d ' ')"
+
+# 3. A fixture whose content moved is drift, not just a missing file.
+printf '{"type":"tampered"}' > "$dest/session.connected.json"
+set +e
+out="$("$SYNC" check js "$repo")"; rc=$?
+set -e
+check "an edited fixture fails" "$rc" "1"
+has "and is reported as differing" "$out" "differs: session.connected.json"
+"$SYNC" apply js "$repo" >/dev/null
+check "apply restores it" "$(cat "$dest/session.connected.json")" "$(cat "$CORPUS/session.connected.json")"
+
+# 4. A fixture for an event core no longer emits is stale, and apply removes
+#    it - otherwise an SDK keeps dispatch-testing a message that cannot arrive.
+printf '{"type":"gone.away"}' > "$dest/gone.away.json"
+set +e
+out="$("$SYNC" check js "$repo")"; rc=$?
+set -e
+check "a stale fixture fails" "$rc" "1"
+has "and is named" "$out" "stale: gone.away.json"
+"$SYNC" apply js "$repo" >/dev/null
+[ ! -f "$dest/gone.away.json" ] && echo "ok   - apply removes it" || {
+  echo "FAIL - apply left the stale fixture"; fails=$((fails + 1)); }
+
+# 5. Each SDK's path is its own; unknown ones are refused rather than guessed.
+check "unity path" "$("$SYNC" path unity)" "Tests/Runtime/Resources/Fixtures"
+check "defold path" "$("$SYNC" path defold)" "tests/fixtures"
+set +e
+"$SYNC" path bevy >/dev/null 2>&1; rc=$?
+set -e
+check "an unknown sdk is refused" "$rc" "2"
+check "seven sdks" "$("$SYNC" sdks | wc -w | tr -d ' ')" "7"
+
+if [ "$fails" -gt 0 ]; then echo "$fails check(s) failed"; exit 1; fi
+echo "all checks passed"


### PR DESCRIPTION
Wave 2b's prerequisite, and the reason it comes before the SDK work rather than after.

## The corpus has already drifted in all seven

The fixture corpus is ground truth for every SDK's dispatch tests, and all seven vendor a copy. Nothing keeps the copies honest, and they are not:

| SDK | Fixtures | Core has 38 |
|---|---|---|
| godot, defold | 35 | 3 missing, plus content drift |
| dart, love2d | 34 | 4 missing |
| unity | 34 | 11 files out of sync |
| js | 28 | 10 missing |
| unreal | vendored, differs | |

Several files that *exist* on both sides no longer match - `error.json`, `match.joined.json` and the `game.*` frames among them. So every SDK is dispatch-testing against a wire that moved, and passing.

Adding `rpc.ok`, `rpc.error`, `module.message` and `module.error` to that corpus without automation would repeat the problem at a larger size. Hence this first.

## What is here

```sh
scripts/protocol-sync.sh check <sdk> <path-to-sdk-repo>   # exits 1, names every file
scripts/protocol-sync.sh apply <sdk> <path-to-sdk-repo>   # copies in, deletes stale
scripts/protocol-sync.sh sdks                             # js dart godot love2d defold unity unreal
```

`check` names each missing, differing and stale file, so a red build says *which fixture* rather than "tests failed". `apply` fixes all three - including **deleting** a fixture for an event core no longer emits, because an SDK that keeps dispatch-testing a message that cannot arrive is worse off than one missing a case.

The per-SDK paths live in the script rather than in seven config files, since each ecosystem's test layout is its own and none of them is wrong.

`.github/workflows/protocol-sync.yml` runs `apply` against all seven on any change under `priv/protocol/` on main and opens one PR per SDK. It deliberately **does not merge them**: a new fixture usually needs a dispatch case, and that is a decision in that repo.

## What you need to do to switch it on

Create a fine-grained PAT with `contents:write` and `pull-requests:write` on the seven SDK repos, and add it as the `SDK_SYNC_TOKEN` repository secret. Without it the job prints exactly that and stops, rather than failing a build nobody can fix.

## Unity

JSON only. That repo tracks a `.meta` for directories and `.cs` files but not for the fixtures, so generating them would add files it deliberately does not carry.

## Tests

`scripts/test/protocol-sync-test.sh` - 14 checks against a throwaway SDK tree: empty copy fails, `apply` then `check` is in sync, an edited fixture is reported as differing and restored, a stale fixture is named and removed, each path resolves, an unknown SDK is refused rather than guessed.