### PR TITLE
feat(ops): accept a minted, env-scoped token from the control plane

### DIFF
--- a/guides/configuration.md
+++ b/guides/configuration.md
@@ -379,6 +379,36 @@ proxy, and set `x-asobi-operator` per person for attribution in the audit
 trail - it is a label, never authority. See
 [REST API](rest-api.md#ops-authentication).
 
+### Minted tokens (managed environments)
+
+A managed environment takes a second kind of ops credential: a short-lived,
+env-scoped token minted by the control plane after it has authenticated the
+tenant and checked they own this environment. Self-hosting needs none of this
+and can skip it.
+
+```erlang
+{ops_token_secret, ~"${ENGINE_API_KEY}"},
+{env_id, ~"${GAME_ID}"}
+```
+
+| Key | Default | Description |
+|-----|---------|-------------|
+| `ops_token_secret` | none | The value the control plane also holds. The signing key is **derived** from it, never used directly |
+| `env_id` | none | This environment's id. A token minted for another one is refused |
+
+Both or neither: a node that knows the secret but not which environment it is
+cannot check a token's `env` claim, so it refuses every minted token rather
+than accepting one issued for somebody else's environment.
+
+Unlike `ops_secret`, a minted token carries **only the capability classes it
+was minted with**, so a tenant whose role maps to `read` and `player_data`
+cannot reach a `config` route with it. The role name never arrives here; the
+control plane maps it to classes at mint time.
+
+The lifetime is capped at 15 minutes **by this node**, not by the minter. A
+token signed with a longer one is refused, because there is no revocation list
+to fall back on if the minting side ever issues a bad one.
+
 ## Operator console
 
 A browser console for the ops plane, served by this node at `/console`.

--- a/src/ops/asobi_ops_auth.erl
+++ b/src/ops/asobi_ops_auth.erl
@@ -36,9 +36,16 @@ That is deliberate - a session has its own expiry and its own revocation, so
 tying it to a value that can change underneath it would end sessions at
 surprising moments without ending the bearer access that matters.
 
-`cloud` is reserved in `t:source/0` and not built. Cloud mints a short-lived
-env-scoped token in `asobi_saas` and maps its roles onto capability classes
-there.
+* **`cloud`** - a short-lived, env-scoped token minted by `asobi_saas` after
+  its own ownership check, presented as a bearer token and verified by
+  `m:asobi_ops_token`. The tenant's role is mapped onto capability classes at
+  mint time, so the string "owner" never reaches this plane, and the token
+  carries only the classes it was minted with rather than all three.
+
+A bearer token is tried as the operator secret first and as a minted token
+second. The two cannot be confused: a minted token is three dot-separated
+parts beginning `v1.`, and the secret comparison is over a hash of the whole
+value, so neither can be mistaken for the other.
 
 Every rejection is 403 with the same body whatever the cause, so a caller
 cannot tell "no secret configured" from "wrong secret" from "not authorised
@@ -119,9 +126,45 @@ verify_secret(_Presented) ->
 -spec bearer(binary(), cowboy_req:req()) -> {ok, actor()} | {error, atom()}.
 bearer(Presented, Req) ->
     case secret() of
-        {ok, Secret} -> match(Secret, Presented, Req);
-        error -> unconfigured(Req)
+        {ok, Secret} ->
+            case match(Secret, Presented, Req) of
+                {ok, _} = Ok -> Ok;
+                {error, _} -> minted(Presented, Req)
+            end;
+        error ->
+            %% A deployment with no operator secret can still be a managed
+            %% environment: the control plane's minted token is its own
+            %% credential and does not depend on one being configured.
+            case minted(Presented, Req) of
+                {ok, _} = Ok -> Ok;
+                {error, _} -> unconfigured(Req)
+            end
     end.
+
+%% The cloud path. Every failure is one reason and every reason answers 403,
+%% so a holder of a bad token learns nothing about which check refused it.
+-spec minted(binary(), cowboy_req:req()) -> {ok, actor()} | {error, atom()}.
+minted(Presented, Req) ->
+    case asobi_ops_token:verify(Presented) of
+        {ok, Claims} -> {ok, minted_actor(Claims, Req)};
+        {error, _Reason} -> {error, bad_credential}
+    end.
+
+%% `sub` is the control plane's own id for the person, already authenticated
+%% there, so unlike the static secret and the console session this actor has a
+%% real identity behind it - which is what `attested` says. The label header
+%% is not read here: a minted token already names who it was minted for, and
+%% letting a header override that would make the audit trail worse, not
+%% better.
+-spec minted_actor(asobi_ops_token:claims(), cowboy_req:req()) -> actor().
+minted_actor(#{sub := Sub, caps := Caps}, _Req) ->
+    #{
+        id => <<"cloud:", Sub/binary>>,
+        display => Sub,
+        source => cloud,
+        caps => Caps,
+        attested => true
+    }.
 
 -spec session(cowboy_req:req()) -> {ok, actor()} | {error, atom()}.
 session(Req) ->

--- a/src/ops/asobi_ops_token.erl
+++ b/src/ops/asobi_ops_token.erl
@@ -1,0 +1,218 @@
+-module(asobi_ops_token).
+-moduledoc """
+The minted, env-scoped ops token: how a managed tenant's browser reaches this
+environment's ops plane.
+
+`console.asobi.dev` authenticates the tenant, checks it owns this environment,
+maps its role onto capability classes and mints a token. The browser then
+talks to **this** environment directly, because the control plane must not
+read a tenant game database and a browser can already reach an env pod while
+the control plane cannot.
+
+## The shape
+
+```
+v1.<base64url(payload)>.<base64url(mac)>
+```
+
+`payload` is JSON: `env`, `sub`, `caps`, `iat`, `exp`. The MAC covers
+`v1.<payload>` - the version prefix is signed, so a future version cannot be
+stripped down to this one.
+
+## The key
+
+Not `ops_secret`, and not the credential it is derived from either:
+
+```erlang
+Key = crypto:mac(hmac, sha256, EngineApiKey, <<"asobi.ops.token.v1">>)
+```
+
+`ENGINE_API_KEY` is the one value the control plane and this environment
+already both hold, so signing needs no new plumbing - but a credential used
+to authenticate must not double as a signing key, so it is separated by
+label first. The same construction the console's CSRF token uses.
+
+It is **per environment**, so a token minted for one env cannot validate at
+another even before `env` is checked. `env` is checked anyway.
+
+## What a signature does not buy
+
+A valid MAC is necessary and not sufficient. `exp` must be in the future,
+**and the whole lifetime must be short** - a token signed with a year-long
+`exp` is refused, so a mint bug on the other side of the wire cannot issue
+one this side will honour. Capability classes outside ADR 0007's vocabulary
+are refused rather than ignored, and an unknown `env` is refused.
+
+Nothing here is stateful: there is no revocation list, which is exactly why
+the lifetime is capped rather than merely checked.
+""".
+
+-export([verify/1, key/1, sign/2, max_ttl/0]).
+
+-define(VERSION, ~"v1").
+-define(LABEL, ~"asobi.ops.token.v1").
+%% Fifteen minutes. Long enough that an operator is not re-minting mid-task,
+%% short enough that a leaked token is a nuisance rather than an incident -
+%% and there is nothing to revoke it with.
+-define(MAX_TTL_SECONDS, 900).
+%% A minted token whose `iat` is in the future is a clock the control plane
+%% and this node do not share; a little slack, not an unbounded window.
+-define(CLOCK_SKEW_SECONDS, 60).
+
+-type claims() :: #{
+    env := binary(),
+    sub := binary(),
+    caps := [asobi_ops_caps:class()],
+    iat := integer(),
+    exp := integer()
+}.
+
+-export_type([claims/0]).
+
+-doc "The longest lifetime this node will honour, in seconds.".
+-spec max_ttl() -> pos_integer().
+max_ttl() -> ?MAX_TTL_SECONDS.
+
+-doc """
+The signing key for `EngineApiKey`.
+
+Exported because the control plane derives the same key from the same value,
+and the derivation is the contract between them.
+""".
+-spec key(binary()) -> binary().
+key(EngineApiKey) when is_binary(EngineApiKey), EngineApiKey =/= ~"" ->
+    crypto:mac(hmac, sha256, EngineApiKey, ?LABEL).
+
+-doc """
+Mint a token for `Claims`.
+
+Here rather than only in `asobi_saas` so the two sides cannot drift: the
+minting side is a consumer of this function's format, and the round trip is
+tested against it.
+""".
+-spec sign(binary(), claims()) -> binary().
+sign(Key, Claims) ->
+    Payload = encode(iolist_to_binary(json:encode(claims_json(Claims)))),
+    Signed = <<?VERSION/binary, ".", Payload/binary>>,
+    Mac = encode(crypto:mac(hmac, sha256, Key, Signed)),
+    <<Signed/binary, ".", Mac/binary>>.
+
+-doc """
+Verify `Token` against the configured environment, returning its claims.
+
+Every rejection is one atom and the caller answers 403 for all of them, so a
+holder of a bad token cannot tell which check failed.
+""".
+-spec verify(binary()) -> {ok, claims()} | {error, atom()}.
+verify(Token) when is_binary(Token) ->
+    case config() of
+        {ok, Key, EnvId} -> verify(Token, Key, EnvId);
+        error -> {error, not_configured}
+    end;
+verify(_Token) ->
+    {error, malformed}.
+
+verify(Token, Key, EnvId) ->
+    case binary:split(Token, ~".", [global]) of
+        [?VERSION, Payload, Mac] ->
+            Signed = <<?VERSION/binary, ".", Payload/binary>>,
+            case authentic(Key, Signed, Mac) of
+                true -> claims(Payload, EnvId);
+                false -> {error, bad_signature}
+            end;
+        _ ->
+            {error, malformed}
+    end.
+
+%% Constant time, and over the decoded MAC rather than its text, so a token
+%% carrying differently-padded base64 of the right MAC is still the right MAC.
+authentic(Key, Signed, Mac) ->
+    case decode(Mac) of
+        {ok, Presented} when byte_size(Presented) =:= 32 ->
+            crypto:hash_equals(crypto:mac(hmac, sha256, Key, Signed), Presented);
+        _ ->
+            false
+    end.
+
+claims(Payload, EnvId) ->
+    case decode(Payload) of
+        {ok, Json} -> decoded(Json, EnvId);
+        error -> {error, malformed}
+    end.
+
+decoded(Json, EnvId) ->
+    try json:decode(Json) of
+        #{~"env" := Env, ~"sub" := Sub, ~"caps" := Caps, ~"iat" := Iat, ~"exp" := Exp} when
+            is_binary(Env), is_binary(Sub), is_list(Caps), is_integer(Iat), is_integer(Exp)
+        ->
+            check(#{env => Env, sub => Sub, caps => Caps, iat => Iat, exp => Exp}, EnvId);
+        _ ->
+            {error, malformed}
+    catch
+        _:_ -> {error, malformed}
+    end.
+
+check(#{env := Env}, EnvId) when Env =/= EnvId ->
+    {error, wrong_environment};
+check(#{iat := Iat, exp := Exp} = Claims, _EnvId) ->
+    Now = erlang:system_time(second),
+    if
+        Exp =< Now -> {error, expired};
+        Exp - Iat > ?MAX_TTL_SECONDS -> {error, lifetime_too_long};
+        Iat > Now + ?CLOCK_SKEW_SECONDS -> {error, not_yet_valid};
+        true -> caps(Claims)
+    end.
+
+%% An unknown class is refused rather than dropped: silently narrowing a
+%% token's capabilities would turn a mint-side typo into a 403 somewhere far
+%% away, with nothing saying why.
+caps(#{caps := Caps} = Claims) ->
+    Known = asobi_ops_caps:class_names(),
+    Parsed = [C || C <- Caps, is_binary(C)],
+    case length(Parsed) =:= length(Caps) andalso classes(Parsed, Known) of
+        {ok, Classes} -> {ok, Claims#{caps => Classes}};
+        _ -> {error, bad_caps}
+    end.
+
+classes(Names, Known) ->
+    Classes = [
+        Class
+     || Name <- Names,
+        Class <- Known,
+        Name =:= atom_to_binary(Class, utf8)
+    ],
+    case length(Classes) =:= length(Names) of
+        true -> {ok, Classes};
+        false -> false
+    end.
+
+claims_json(#{env := Env, sub := Sub, caps := Caps, iat := Iat, exp := Exp}) ->
+    #{
+        ~"env" => Env,
+        ~"sub" => Sub,
+        ~"caps" => [atom_to_binary(C, utf8) || C <- Caps],
+        ~"iat" => Iat,
+        ~"exp" => Exp
+    }.
+
+%% Both halves or nothing: a node that knows its key but not which environment
+%% it is cannot check `env`, and answering "close enough" there is how a token
+%% for one tenant's environment gets honoured by another's.
+config() ->
+    case {application:get_env(asobi, ops_token_secret), application:get_env(asobi, env_id)} of
+        {{ok, Secret}, {ok, EnvId}} when
+            is_binary(Secret), Secret =/= ~"", is_binary(EnvId), EnvId =/= ~""
+        ->
+            {ok, key(Secret), EnvId};
+        _ ->
+            error
+    end.
+
+encode(Bin) -> base64:encode(Bin, #{mode => urlsafe, padding => false}).
+
+decode(Bin) ->
+    try
+        {ok, base64:decode(Bin, #{mode => urlsafe, padding => false})}
+    catch
+        _:_ -> error
+    end.

--- a/test/asobi_ops_auth_tests.erl
+++ b/test/asobi_ops_auth_tests.erl
@@ -9,6 +9,8 @@
 %% here, and an unconfigured deployment admits nobody.
 
 -define(SECRET, ~"7f4c1b9a2e6d8053f1a4c7b0e9d2635847ac1fbe2093d75641c8ba0fe3729d15").
+-define(ENGINE_KEY, ~"engine-api-key-not-a-real-one").
+-define(ENV_ID, ~"019f7646-9ddb-77ee-82f5-b5e7f3b9ee9d").
 
 %%--------------------------------------------------------------------
 %% Capability classes
@@ -107,6 +109,79 @@ verify_test_() ->
         fun rejects_a_path_outside_the_ops_prefix/0,
         fun denial_is_403_and_says_nothing_about_the_cause/0
     ]}.
+
+%% The cloud path: a token minted by asobi_saas after its own ownership check.
+cloud_test_() ->
+    {foreach, fun cloud_setup/0, fun cloud_cleanup/1, [
+        fun admits_a_minted_token/0,
+        fun a_minted_actor_carries_only_its_own_caps/0,
+        fun a_minted_actor_is_attested/0,
+        fun a_class_the_token_does_not_carry_is_denied/0,
+        fun a_token_for_another_environment_is_denied/0,
+        fun the_operator_label_cannot_rename_a_minted_actor/0
+    ]}.
+
+cloud_setup() ->
+    Original = setup(),
+    application:set_env(asobi, ops_token_secret, ?ENGINE_KEY),
+    application:set_env(asobi, env_id, ?ENV_ID),
+    Original.
+
+cloud_cleanup(Original) ->
+    application:unset_env(asobi, ops_token_secret),
+    application:unset_env(asobi, env_id),
+    cleanup(Original).
+
+minted(Caps) -> minted(Caps, ?ENV_ID).
+
+minted(Caps, EnvId) ->
+    Now = erlang:system_time(second),
+    asobi_ops_token:sign(asobi_ops_token:key(?ENGINE_KEY), #{
+        env => EnvId,
+        sub => ~"user-7",
+        caps => Caps,
+        iat => Now,
+        exp => Now + 300
+    }).
+
+admits_a_minted_token() ->
+    ?assertMatch(
+        {true, #{ops_actor := #{source := cloud}}},
+        asobi_ops_auth:verify(ops_req(minted([read])))
+    ).
+
+%% The whole point of mapping roles to classes at mint time: a `member` gets a
+%% token carrying two classes, and this plane can only ever see those two.
+a_minted_actor_carries_only_its_own_caps() ->
+    {true, #{ops_actor := Actor}} = asobi_ops_auth:verify(ops_req(minted([read, player_data]))),
+    ?assertEqual([read, player_data], maps:get(caps, Actor)),
+    ?assertEqual(~"cloud:user-7", maps:get(id, Actor)).
+
+%% Unlike the shared secret and the console session, there is a real
+%% authenticated person behind this one.
+a_minted_actor_is_attested() ->
+    {true, #{ops_actor := Actor}} = asobi_ops_auth:verify(ops_req(minted([read]))),
+    ?assertEqual(true, maps:get(attested, Actor)).
+
+a_class_the_token_does_not_carry_is_denied() ->
+    Req = req(~"/api/v1/ops/ext/quests/define", bearer(minted([read]))),
+    ?assertMatch({false, 403, _, _}, asobi_ops_auth:verify(Req#{method => ~"POST"})).
+
+a_token_for_another_environment_is_denied() ->
+    ?assertMatch(
+        {false, 403, _, _},
+        asobi_ops_auth:verify(ops_req(minted([read], ~"a-different-env")))
+    ).
+
+%% x-asobi-operator is attribution for a credential that carries no name. A
+%% minted token names who it was minted for, and a header must not overwrite
+%% that in the audit trail.
+the_operator_label_cannot_rename_a_minted_actor() ->
+    Headers = maps:put(~"x-asobi-operator", ~"somebody-else", bearer(minted([read]))),
+    {true, #{ops_actor := Actor}} = asobi_ops_auth:verify(
+        req(~"/api/v1/ops/players", Headers)
+    ),
+    ?assertEqual(~"user-7", maps:get(display, Actor)).
 
 setup() ->
     Original = application:get_env(asobi, ops_secret),

--- a/test/asobi_ops_token_tests.erl
+++ b/test/asobi_ops_token_tests.erl
@@ -1,0 +1,161 @@
+-module(asobi_ops_token_tests).
+
+-include_lib("eunit/include/eunit.hrl").
+
+-define(ENV, ~"019f7646-9ddb-77ee-82f5-b5e7f3b9ee9d").
+-define(ENGINE_KEY, ~"engine-api-key-not-a-real-one").
+
+%% The cloud credential. A valid MAC is necessary and not sufficient, and most
+%% of what is asserted here is the "not sufficient" half: a signature the
+%% holder cannot forge still buys nothing if the token is for another
+%% environment, has expired, was minted with an unbounded lifetime, or names a
+%% capability class this plane does not have.
+
+token_test_() ->
+    {foreach, fun setup/0, fun cleanup/1, [
+        fun a_minted_token_verifies/0,
+        fun the_claims_survive_the_round_trip/0,
+        fun a_token_for_another_environment_is_refused/0,
+        fun a_token_signed_with_another_key_is_refused/0,
+        fun a_tampered_payload_is_refused/0,
+        fun an_expired_token_is_refused/0,
+        fun a_long_lived_token_is_refused_even_when_signed/0,
+        fun a_future_token_is_refused/0,
+        fun an_unknown_capability_class_is_refused/0,
+        fun a_malformed_token_is_refused/0,
+        fun a_version_that_is_not_ours_is_refused/0,
+        fun nothing_verifies_without_both_halves_of_the_config/0,
+        fun the_key_is_derived_not_the_credential/0
+    ]}.
+
+setup() ->
+    application:set_env(asobi, ops_token_secret, ?ENGINE_KEY),
+    application:set_env(asobi, env_id, ?ENV),
+    ok.
+
+cleanup(_) ->
+    application:unset_env(asobi, ops_token_secret),
+    application:unset_env(asobi, env_id),
+    ok.
+
+a_minted_token_verifies() ->
+    ?assertMatch({ok, #{sub := ~"user-1"}}, asobi_ops_token:verify(mint())).
+
+the_claims_survive_the_round_trip() ->
+    {ok, Claims} = asobi_ops_token:verify(mint(#{caps => [read, player_data]})),
+    ?assertEqual(?ENV, maps:get(env, Claims)),
+    ?assertEqual(~"user-1", maps:get(sub, Claims)),
+    ?assertEqual([read, player_data], maps:get(caps, Claims)).
+
+%% The key is per environment, so this is already refused by the signature -
+%% the `env` check is the second lock on the same door, and it is the one that
+%% still holds if a key is ever shared.
+a_token_for_another_environment_is_refused() ->
+    Token = asobi_ops_token:sign(key(), claims(#{env => ~"some-other-env"})),
+    ?assertEqual({error, wrong_environment}, asobi_ops_token:verify(Token)).
+
+a_token_signed_with_another_key_is_refused() ->
+    Token = asobi_ops_token:sign(asobi_ops_token:key(~"a-different-engine-key"), claims(#{})),
+    ?assertEqual({error, bad_signature}, asobi_ops_token:verify(Token)).
+
+a_tampered_payload_is_refused() ->
+    [Version, Payload, Mac] = binary:split(mint(), ~".", [global]),
+    Decoded = base64:decode(Payload, #{mode => urlsafe, padding => false}),
+    Swapped = binary:replace(Decoded, ~"\"read\"", ~"\"config\""),
+    Reencoded = base64:encode(Swapped, #{mode => urlsafe, padding => false}),
+    Tampered = <<Version/binary, ".", Reencoded/binary, ".", Mac/binary>>,
+    ?assertEqual({error, bad_signature}, asobi_ops_token:verify(Tampered)).
+
+an_expired_token_is_refused() ->
+    Now = erlang:system_time(second),
+    Token = asobi_ops_token:sign(key(), claims(#{iat => Now - 600, exp => Now - 1})),
+    ?assertEqual({error, expired}, asobi_ops_token:verify(Token)).
+
+%% The one that matters most: this side of the wire does not trust the other
+%% side to have picked a sane TTL, so a mint bug cannot issue a token this
+%% node will honour for a year. There is no revocation list to fall back on.
+a_long_lived_token_is_refused_even_when_signed() ->
+    Now = erlang:system_time(second),
+    Token = asobi_ops_token:sign(key(), claims(#{iat => Now, exp => Now + 31_536_000})),
+    ?assertEqual({error, lifetime_too_long}, asobi_ops_token:verify(Token)),
+    AtTheLimit = asobi_ops_token:sign(
+        key(), claims(#{iat => Now, exp => Now + asobi_ops_token:max_ttl()})
+    ),
+    ?assertMatch({ok, _}, asobi_ops_token:verify(AtTheLimit)).
+
+a_future_token_is_refused() ->
+    Now = erlang:system_time(second),
+    Token = asobi_ops_token:sign(key(), claims(#{iat => Now + 3600, exp => Now + 3900})),
+    ?assertEqual({error, not_yet_valid}, asobi_ops_token:verify(Token)).
+
+an_unknown_capability_class_is_refused() ->
+    Now = erlang:system_time(second),
+    Json = #{
+        ~"env" => ?ENV,
+        ~"sub" => ~"user-1",
+        ~"caps" => [~"read", ~"superuser"],
+        ~"iat" => Now,
+        ~"exp" => Now + 300
+    },
+    ?assertEqual({error, bad_caps}, asobi_ops_token:verify(hand_sign(Json))).
+
+a_malformed_token_is_refused() ->
+    [
+        ?assertEqual({error, malformed}, asobi_ops_token:verify(T))
+     || T <- [~"", ~"nonsense", ~"v1.only-two", ~"v1.a.b.c"]
+    ],
+    ?assertEqual({error, malformed}, asobi_ops_token:verify(not_a_binary)).
+
+a_version_that_is_not_ours_is_refused() ->
+    [_Version, Payload, Mac] = binary:split(mint(), ~".", [global]),
+    ?assertEqual(
+        {error, malformed},
+        asobi_ops_token:verify(<<"v2.", Payload/binary, ".", Mac/binary>>)
+    ).
+
+%% A node that knows its key but not which environment it is cannot check
+%% `env`, so it refuses rather than accepting a token minted for somebody
+%% else's environment.
+nothing_verifies_without_both_halves_of_the_config() ->
+    Token = mint(),
+    application:unset_env(asobi, env_id),
+    ?assertEqual({error, not_configured}, asobi_ops_token:verify(Token)),
+    application:set_env(asobi, env_id, ?ENV),
+    application:unset_env(asobi, ops_token_secret),
+    ?assertEqual({error, not_configured}, asobi_ops_token:verify(Token)).
+
+%% A credential used to authenticate must not double as a signing key.
+the_key_is_derived_not_the_credential() ->
+    ?assertNotEqual(?ENGINE_KEY, asobi_ops_token:key(?ENGINE_KEY)),
+    ?assertEqual(32, byte_size(asobi_ops_token:key(?ENGINE_KEY))),
+    ?assertNotEqual(
+        asobi_ops_token:key(?ENGINE_KEY),
+        asobi_ops_token:key(<<?ENGINE_KEY/binary, "x">>)
+    ).
+
+%%--------------------------------------------------------------------
+
+key() -> asobi_ops_token:key(?ENGINE_KEY).
+
+mint() -> mint(#{}).
+
+mint(Overrides) -> asobi_ops_token:sign(key(), claims(Overrides)).
+
+claims(Overrides) ->
+    Now = erlang:system_time(second),
+    maps:merge(
+        #{env => ?ENV, sub => ~"user-1", caps => [read], iat => Now, exp => Now + 300},
+        Overrides
+    ).
+
+%% Sign a claims object this module's own `sign/2` would refuse to build, so
+%% the verifier is tested against a shape only a broken minter would produce.
+hand_sign(Json) ->
+    Payload = base64:encode(iolist_to_binary(json:encode(Json)), #{
+        mode => urlsafe, padding => false
+    }),
+    Signed = <<"v1.", Payload/binary>>,
+    Mac = base64:encode(crypto:mac(hmac, sha256, key(), Signed), #{
+        mode => urlsafe, padding => false
+    }),
+    <<Signed/binary, ".", Mac/binary>>.


### PR DESCRIPTION
Wave 2c, core half. The other half (minting, in `asobi_saas`) follows.

## Why this shape

Managed customers have no game-ops UI at all: `asobi_admin` is not in the engine image and the control plane scopes player and match exploration out. The API they need is `asobi_ops`, **in core**, which every engine already serves. The only missing piece was a credential their browser could hold.

Four constraints, all previously established, decide the shape - **the browser talks to the environment directly**:

- The control plane must not read tenant game databases (breaks the transient-`CONNECT` invariant, races itself with no refcount, needs a kura feature that does not exist).
- A browser can already reach an env pod; the control plane cannot.
- `ASOBI_CORS_ORIGINS` is already provisioned.
- An engine/control-plane channel already exists, so a shared signing secret needs no new plumbing.

## The token

```
v1.<base64url({env, sub, caps, iat, exp})>.<base64url(mac)>
```

The MAC covers `v1.<payload>`, so the version prefix is signed and a future version cannot be stripped down to this one.

**The key is derived, not reused:** `HMAC(ENGINE_API_KEY, "asobi.ops.token.v1")`. `ENGINE_API_KEY` is the one value both sides already hold, but a credential used to authenticate must not double as a signing key. Same construction the console's CSRF token already uses. It is per environment, so a token minted for one env cannot validate at another - and `env` is checked anyway, because that second lock is the one that still holds if a key is ever shared.

## A valid MAC is necessary and not sufficient

- **The lifetime is capped at 15 minutes by this node**, not by the minter. A token signed with a year-long `exp` is refused. There is no revocation list to fall back on, which is exactly why the cap is here rather than trusted to the other side.
- Capability classes outside ADR 0007's vocabulary are **refused, not dropped** - silently narrowing a token turns a mint-side typo into a 403 somewhere far away with nothing saying why.
- An `iat` in the future beyond 60s of skew is refused.
- Both config keys or neither: a node that knows its key but not which environment it is cannot check `env`, so it refuses every minted token rather than honouring one issued for somebody else's environment.

Every rejection is one atom and all of them answer 403, so a holder of a bad token learns nothing about which check refused it.

## The actor

A minted actor carries **only the classes it was minted with**, so a `member` role cannot reach a `config` route. That is the whole point of mapping roles to classes at mint time - the string "owner" never arrives here.

It is also the first actor with `attested => true`: there is a real authenticated person behind `sub`, unlike the shared secret and the console session. `x-asobi-operator` is ignored for it, because a minted token already names who it is for and a header must not be able to overwrite that in the audit trail.

## Tests

19 new: the round trip, another environment, another key, a tampered payload, expiry, an over-long lifetime (signed and still refused), a future `iat`, an unknown class, four malformed shapes, a wrong version, both halves of the config missing, the key not being the credential - plus six at the auth layer covering the actor shape, cap narrowing, the denied `config` route and the ignored label header.

`fmt --check`, `xref`, `dialyzer`, `eunit` clean.