### PR TITLE
test: three real timeout and fixture-hygiene fixes (does not fix #376)

### DIFF
--- a/test/prop_chat_zone_routing.erl
+++ b/test/prop_chat_zone_routing.erl
@@ -51,6 +51,11 @@ setup() ->
         _ ->
             ok
     end,
+    %% `no_link` mocks outlive the process that created them, so one left
+    %% behind by an earlier module makes this meck:new/2 raise
+    %% `already_started` - a fixture that fails in milliseconds, which eunit
+    %% reports as a cancelled group with nothing named. Clear first.
+    unload_stale([asobi_repo, asobi_presence]),
     meck:new(asobi_repo, [no_link]),
     meck:expect(asobi_repo, insert, fun(_CS) -> {ok, #{}} end),
     ok.
@@ -250,3 +255,14 @@ cleanup_listeners(Listeners) ->
 
 -spec narrow_list(term()) -> [term()].
 narrow_list(L) when is_list(L) -> L.
+
+unload_stale(Modules) ->
+    [
+        try
+            meck:unload(M)
+        catch
+            _:_ -> ok
+        end
+     || M <- Modules
+    ],
+    ok.

--- a/test/prop_chat_zone_routing.erl
+++ b/test/prop_chat_zone_routing.erl
@@ -20,12 +20,15 @@
 chat_zone_routing_test_() ->
     %% Two timeouts, because there are two ways this cancels a group with
     %% zero failures and nothing named. The outer one covers setup/0 and
-    %% cleanup/1, which otherwise run under eunit's 5s default; the inner
-    %% one is the property's own, and its floor is 300s rather than 60s
-    %% because 60 is a performance budget, not a hang detector - a CI runner
-    %% managed 21 of 25 iterations of the reconnect property inside it
-    %% (asobi#376).
-    {timeout, 120,
+    %% cleanup/1, which otherwise run under eunit's 5s default; the inner one
+    %% is the property's own, and its floor is 300s rather than 60s because 60
+    %% is a performance budget, not a hang detector (asobi#376).
+    %%
+    %% The outer MUST outlast the inner. It covers the whole fixture, tests
+    %% included, so a shorter outer silently pre-empts the inner and cancels
+    %% the group - which is exactly what #374 did, moving the failure from one
+    %% property module to the next.
+    {timeout, 900,
         {setup, fun setup/0, fun cleanup/1, [
             {timeout, max(300, ?NUMTESTS div 2),
                 ?_assert(

--- a/test/prop_input_never_dropped.erl
+++ b/test/prop_input_never_dropped.erl
@@ -64,6 +64,11 @@ setup() ->
         _ ->
             ets:delete_all_objects(asobi_player_worlds)
     end,
+    %% `no_link` mocks outlive the process that created them, so one left
+    %% behind by an earlier module makes this meck:new/2 raise
+    %% `already_started` - a fixture that fails in milliseconds, which eunit
+    %% reports as a cancelled group with nothing named. Clear first.
+    unload_stale([asobi_repo, asobi_presence]),
     meck:new(asobi_repo, [no_link]),
     meck:expect(asobi_repo, insert, fun(_CS) -> {ok, #{}} end),
     meck:expect(asobi_repo, insert, fun(_CS, _Opts) -> {ok, #{}} end),
@@ -210,3 +215,14 @@ start_world() ->
     timer:sleep(40),
     ServerPid = asobi_world_instance:get_child(InstancePid, asobi_world_server),
     #{instance_pid => InstancePid, world_pid => ServerPid}.
+
+unload_stale(Modules) ->
+    [
+        try
+            meck:unload(M)
+        catch
+            _:_ -> ok
+        end
+     || M <- Modules
+    ],
+    ok.

--- a/test/prop_input_never_dropped.erl
+++ b/test/prop_input_never_dropped.erl
@@ -32,12 +32,15 @@
 input_never_dropped_test_() ->
     %% Two timeouts, because there are two ways this cancels a group with
     %% zero failures and nothing named. The outer one covers setup/0 and
-    %% cleanup/1, which otherwise run under eunit's 5s default; the inner
-    %% one is the property's own, and its floor is 300s rather than 60s
-    %% because 60 is a performance budget, not a hang detector - a CI runner
-    %% managed 21 of 25 iterations of the reconnect property inside it
-    %% (asobi#376).
-    {timeout, 120,
+    %% cleanup/1, which otherwise run under eunit's 5s default; the inner one
+    %% is the property's own, and its floor is 300s rather than 60s because 60
+    %% is a performance budget, not a hang detector (asobi#376).
+    %%
+    %% The outer MUST outlast the inner. It covers the whole fixture, tests
+    %% included, so a shorter outer silently pre-empts the inner and cancels
+    %% the group - which is exactly what #374 did, moving the failure from one
+    %% property module to the next.
+    {timeout, 900,
         {setup, fun setup/0, fun cleanup/1, fun(Ctx) ->
             [
                 {timeout, max(300, ?NUMTESTS div 2),

--- a/test/prop_reconnect_lifecycle.erl
+++ b/test/prop_reconnect_lifecycle.erl
@@ -66,6 +66,11 @@ setup() ->
         _ ->
             ets:delete_all_objects(asobi_player_worlds)
     end,
+    %% `no_link` mocks outlive the process that created them, so one left
+    %% behind by an earlier module makes this meck:new/2 raise
+    %% `already_started` - a fixture that fails in milliseconds, which eunit
+    %% reports as a cancelled group with nothing named. Clear first.
+    unload_stale([asobi_repo, asobi_presence]),
     meck:new(asobi_repo, [no_link]),
     meck:expect(asobi_repo, insert, fun(_CS) -> {ok, #{}} end),
     meck:expect(asobi_repo, insert, fun(_CS, _Opts) -> {ok, #{}} end),
@@ -212,3 +217,14 @@ fake_session(PlayerId) ->
 
 -spec narrow_list(term()) -> [term()].
 narrow_list(L) when is_list(L) -> L.
+
+unload_stale(Modules) ->
+    [
+        try
+            meck:unload(M)
+        catch
+            _:_ -> ok
+        end
+     || M <- Modules
+    ],
+    ok.

--- a/test/prop_reconnect_lifecycle.erl
+++ b/test/prop_reconnect_lifecycle.erl
@@ -34,12 +34,15 @@
 reconnect_lifecycle_test_() ->
     %% Two timeouts, because there are two ways this cancels a group with
     %% zero failures and nothing named. The outer one covers setup/0 and
-    %% cleanup/1, which otherwise run under eunit's 5s default; the inner
-    %% one is the property's own, and its floor is 300s rather than 60s
-    %% because 60 is a performance budget, not a hang detector - a CI runner
-    %% managed 21 of 25 iterations of the reconnect property inside it
-    %% (asobi#376).
-    {timeout, 120,
+    %% cleanup/1, which otherwise run under eunit's 5s default; the inner one
+    %% is the property's own, and its floor is 300s rather than 60s because 60
+    %% is a performance budget, not a hang detector (asobi#376).
+    %%
+    %% The outer MUST outlast the inner. It covers the whole fixture, tests
+    %% included, so a shorter outer silently pre-empts the inner and cancels
+    %% the group - which is exactly what #374 did, moving the failure from one
+    %% property module to the next.
+    {timeout, 900,
         {setup, fun setup/0, fun cleanup/1, fun(Ctx) ->
             [
                 {timeout, max(300, ?NUMTESTS div 2),

--- a/test/prop_zone_invariants.erl
+++ b/test/prop_zone_invariants.erl
@@ -34,12 +34,15 @@
 zone_invariants_test_() ->
     %% Two timeouts, because there are two ways this cancels a group with
     %% zero failures and nothing named. The outer one covers setup/0 and
-    %% cleanup/1, which otherwise run under eunit's 5s default; the inner
-    %% one is the property's own, and its floor is 300s rather than 60s
-    %% because 60 is a performance budget, not a hang detector - a CI runner
-    %% managed 21 of 25 iterations of the reconnect property inside it
-    %% (asobi#376).
-    {timeout, 120,
+    %% cleanup/1, which otherwise run under eunit's 5s default; the inner one
+    %% is the property's own, and its floor is 300s rather than 60s because 60
+    %% is a performance budget, not a hang detector (asobi#376).
+    %%
+    %% The outer MUST outlast the inner. It covers the whole fixture, tests
+    %% included, so a shorter outer silently pre-empts the inner and cancels
+    %% the group - which is exactly what #374 did, moving the failure from one
+    %% property module to the next.
+    {timeout, 900,
         {setup, fun setup/0, fun cleanup/1, fun(Ctx) ->
             [
                 {timeout, max(300, ?NUMTESTS div 2),

--- a/test/prop_zone_invariants.erl
+++ b/test/prop_zone_invariants.erl
@@ -69,6 +69,11 @@ setup() ->
         _ ->
             ets:delete_all_objects(asobi_player_worlds)
     end,
+    %% `no_link` mocks outlive the process that created them, so one left
+    %% behind by an earlier module makes this meck:new/2 raise
+    %% `already_started` - a fixture that fails in milliseconds, which eunit
+    %% reports as a cancelled group with nothing named. Clear first.
+    unload_stale([asobi_repo, asobi_presence]),
     meck:new(asobi_repo, [no_link]),
     meck:expect(asobi_repo, insert, fun(_CS) -> {ok, #{}} end),
     meck:expect(asobi_repo, insert, fun(_CS, _Opts) -> {ok, #{}} end),
@@ -203,3 +208,14 @@ start_world() ->
     timer:sleep(40),
     ServerPid = asobi_world_instance:get_child(InstancePid, asobi_world_server),
     #{instance_pid => InstancePid, world_pid => ServerPid}.
+
+unload_stale(Modules) ->
+    [
+        try
+            meck:unload(M)
+        catch
+            _:_ -> ok
+        end
+     || M <- Modules
+    ],
+    ok.


### PR DESCRIPTION
**This does not fix #376.** It fixes three real things found while chasing it, and I am flagging that up front rather than leaving the title to imply otherwise.

## What is real here

1. **The outer fixture timeout pre-empted the inner one.** #374 wrapped each property fixture in `{timeout, 120, {setup, ...}}` to cover `setup/0`, alongside a 300s allowance on the property. The outer covers the whole fixture *including its tests*, so 120 silently won and cancelled the group anyway. 900s now, and the rule is written where the next person will hit it.

2. **A leaked `no_link` meck.** Every property fixture creates its `asobi_repo` and `asobi_presence` mocks with `no_link`, so they outlive the process that made them. One left behind by an earlier module makes the next `meck:new/2` raise `already_started` - a fixture that fails in milliseconds. Unloading first is right regardless: a fixture that cannot run twice in one VM depends on every other module's cleanup having succeeded.

3. **(From #374, kept)** the property floor at 300s. A CI runner was managing 21 of 25 iterations of the reconnect property inside the old 60s.

Together these made `prop_reconnect_lifecycle` pass on CI in **1.23s** where it had never passed.

## What it does not fix

The run still ends `Failed: 0 ... one or more tests were cancelled`. See #376, which now carries the bisect: **`main` has failed EUnit on every commit since #372 and was green at #371**. That is where the next look should start, and it is not a timeout.

Merging this is a judgement call: the content is three improvements, and its own CI cannot go green until #376 is fixed.