### PR TITLE
fix(test): unlink match servers, so a 60s timeout cannot kill a later group

### DIFF
--- a/test/asobi_lua_SUITE.erl
+++ b/test/asobi_lua_SUITE.erl
@@ -122,7 +122,11 @@ start_lua_match(Config, Script, Extra) ->
         },
         Extra
     ),
+    %% Unlinked: a match left in `waiting` stops with {shutdown, timeout}
+    %% after ?WAITING_TIMEOUT, and a still-linked one takes the test process
+    %% with it long after the case that started it (asobi#376).
     {ok, Pid} = asobi_match_server:start_link(MatchConfig),
+    unlink(Pid),
     Pid.
 
 stop(Pid) ->

--- a/test/asobi_match_broadcast_tests.erl
+++ b/test/asobi_match_broadcast_tests.erl
@@ -122,7 +122,9 @@ start_match(GameModule) ->
         max_players => 4,
         tick_rate => 30
     },
+    %% Unlinked: see the note in asobi_match_server_tests (asobi#376).
     {ok, Pid} = asobi_match_server:start_link(Config),
+    unlink(Pid),
     Pid.
 
 stop(Pid) ->

--- a/test/asobi_match_lobby_tests.erl
+++ b/test/asobi_match_lobby_tests.erl
@@ -25,8 +25,10 @@ cleanup(_) ->
     meck:unload(asobi_repo),
     ok.
 
+%% Unlinked: see the note in asobi_match_server_tests (asobi#376).
 start_match(Overrides) ->
     {ok, Pid} = asobi_match_server:start_link(maps:merge(?BASE_CONFIG, Overrides)),
+    unlink(Pid),
     Pid.
 
 stop_match(Pid) ->

--- a/test/asobi_match_server_tests.erl
+++ b/test/asobi_match_server_tests.erl
@@ -43,9 +43,14 @@ cleanup(_) ->
 start_match() ->
     start_match(#{}).
 
+%% Unlinked deliberately. A match left in `waiting` stops with
+%% {shutdown, timeout} after ?WAITING_TIMEOUT, and a still-linked one takes
+%% the eunit process with it - sixty seconds later, in whatever unrelated
+%% group happens to be running by then (asobi#376).
 start_match(Overrides) ->
     Config = maps:merge(?BASE_CONFIG, Overrides),
     {ok, Pid} = asobi_match_server:start_link(Config),
+    unlink(Pid),
     Pid.
 
 %% --- Test generators ---


### PR DESCRIPTION
Closes #376.

## The bug

`asobi_match_server:waiting/3` stops with `{shutdown, timeout}` after `?WAITING_TIMEOUT` - **sixty seconds**:

```erlang
waiting(state_timeout, waiting_timeout, State) ->
    {stop, {shutdown, timeout}, State};
```

Five test modules start one with `start_link` and never unlink it. `asobi_match_server_tests` starts **49** and stops **36**, so thirteen linked match servers are left sitting in `waiting` on every run.

A minute later each one exits `{shutdown, timeout}`, and **the link carries that into whatever eunit process is running at that moment** - some unrelated group, usually a property module, because those run last.

eunit reports it exactly as #376 describes:

```
*unexpected termination of test process*
::{shutdown,timeout}
  Failed: 0.  Skipped: 0.  Passed: 1580.
```

Zero failures, because nothing failed. A group was killed from outside.

## It accounts for every symptom

- **The exact reason.** `{shutdown, timeout}` is this codebase's own, not eunit's.
- **The alternating victim** - `prop_reconnect_lifecycle` one run, `prop_zone_invariants` the next. Whichever group is running when a stray timer lands.
- **The sub-second gap** between a module header and the kill, which no timeout in the tree could explain: the timer that fired belonged to a process nobody was looking at.
- **`undefined` for a name.** eunit does not know which test, because none of them did anything.
- **CI-only.** It is a race against total run time: the leak has to still be linked sixty seconds later. A slower runner keeps the suite alive long enough for the timer to land inside a later module.

## On the bisect

The table in #376 - green at #371, red from #372 - was a false lead, and I have posted the correction there. A probe branch at #371 fails too. #372 did not cause this; it added enough test time to make the landing more likely.

## The fix

`unlink(Pid)` at every `asobi_match_server:start_link` site in tests, which is what `asobi_bot_presence_tests` already did and the reason it was never a suspect. Five modules: `asobi_match_server_tests`, `asobi_match_lobby_tests`, `asobi_match_broadcast_tests`, `asobi_lua_SUITE`.

Local: 1583 tests, 0 failures. The real proof is CI staying green across several runs, since this was never deterministic.

## Relationship to #378

The three fixes there were all real - a property genuinely exceeding 60s, an outer fixture timeout pre-empting the inner one, and a leaked `no_link` meck. **None of them was this.** They can merge or not on their own merits.