### PR TITLE
chore: ignore agent-created git worktrees

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,7 @@ doc/
 # Console toolchain. `console/` holds the source; the built bundle in
 # priv/console IS committed - see console/README.md.
 console/node_modules/
+
+# Agent-created git worktrees. Each is its own repository, so a bare
+# `git add -A` records it as a gitlink to a path that exists on one machine.
+.claude/worktrees/


### PR DESCRIPTION
Each `.claude/worktrees/*` is its own git repository, so a bare `git add -A` stages it as a **gitlink** pointing at a path that exists on exactly one machine. Git warns about it, and that warning is easy to lose in a long push.

It happened twice in `asobi_saas` during the Wave 2c work. Both were caught and amended before the PR existed, but only because the warning was read - which is not a control.

`.claude/` itself stays visible on purpose: `CLAUDE.md` and `AGENTS.md` are committed. Only the worktrees directory is scratch.