### PR TITLE
feat(console): open a session from a minted token, scoped to what it proved

### DIFF
--- a/src/console/asobi_console_controller.erl
+++ b/src/console/asobi_console_controller.erl
@@ -101,13 +101,24 @@ session(Req) ->
     end.
 
 -doc """
-Exchange the operator secret for a session.
+Exchange a credential for a session.
 
-The secret is checked by `asobi_ops_auth:verify_secret/1`, so the
-constant-time comparison and the no-default rule live in one place and this
-endpoint cannot drift from the bearer plane.
+Two are accepted, and they are the two the ops plane already takes:
 
-A wrong secret is `403 forbidden` with the same body a wrong bearer token
+* `secret` - the operator secret, checked by `asobi_ops_auth:verify_secret/1`
+  so the constant-time comparison and the no-default rule live in one place
+  and this endpoint cannot drift from the bearer plane. It proves every
+  capability class.
+* `token` - a minted, env-scoped token from the control plane
+  (`m:asobi_ops_token`). It proves only the classes it carries, and the
+  session it opens carries exactly those and expires no later than the token
+  does. A fifteen-minute credential must not buy a twelve-hour session.
+
+The minted path is what makes a managed environment's console reachable: the
+browser posts the token once and then holds a cookie, so the token never has
+to live in JavaScript for the length of a session.
+
+A wrong credential is `403 forbidden` with the same body a wrong bearer token
 gets, so the two planes are indistinguishable to a caller guessing.
 """.
 -spec login(cowboy_req:req()) -> response().
@@ -124,14 +135,45 @@ authenticate(#{json := #{~"secret" := Secret} = Body} = Req) ->
             {ok, Session} = asobi_console_session:create(maps:get(~"label", Body, ~"operator")),
             granted(Session, Req);
         false ->
-            ?LOG_WARNING(#{
-                msg => ~"console login rejected",
-                peer => asobi_peer:client_ip(Req)
-            }),
-            {asobi_error, ~"forbidden"}
+            rejected(Req)
+    end;
+authenticate(#{json := #{~"token" := Token}} = Req) when is_binary(Token) ->
+    minted(Token, Req, json);
+%% A form POST, which is how the control plane hands a browser over: the token
+%% rides in the body, so unlike a query parameter or a fragment it never enters
+%% a URL, a referrer, an access log or the history. The reply is a redirect
+%% rather than JSON because the caller is a navigating browser, and after it
+%% the page is same-origin, so the SameSite=Strict cookies just set are sent
+%% normally from then on.
+%%
+%% `body` rather than cowboy_req:read_urlencoded_body/1: nova_request_plugin
+%% has already drained the one-shot stream, so reading it again finds nothing
+%% (asobi_saas#100).
+authenticate(#{body := Body} = Req) when is_binary(Body), Body =/= ~"" ->
+    case lists:keyfind(~"token", 1, cow_qs:parse_qs(Body)) of
+        {_, Token} when is_binary(Token), Token =/= ~"" -> minted(Token, Req, redirect);
+        _ -> {asobi_error, ~"missing_field"}
     end;
 authenticate(_Req) ->
     {asobi_error, ~"missing_field"}.
+
+minted(Token, Req, Reply) ->
+    case asobi_ops_token:verify(Token) of
+        {ok, #{sub := Sub, caps := Caps, exp := Exp}} ->
+            {ok, Session} = asobi_console_session:create(Sub, Caps, Exp),
+            granted(Session, Req, Reply);
+        {error, _Reason} ->
+            rejected(Req)
+    end.
+
+%% One log line and one body for both credentials: which one was wrong, and
+%% why, is not something a caller guessing gets to learn.
+rejected(Req) ->
+    ?LOG_WARNING(#{
+        msg => ~"console login rejected",
+        peer => asobi_peer:client_ip(Req)
+    }),
+    {asobi_error, ~"forbidden"}.
 
 %% Two cookies. The session id is `HttpOnly` so script cannot read it; the
 %% CSRF token deliberately is not, because the page has to send it back as a
@@ -139,11 +181,20 @@ authenticate(_Req) ->
 %% reload. It is derived from the session and useless without it, so a page
 %% that can read it can already act as the session it belongs to.
 -spec granted(asobi_console_session:session(), cowboy_req:req()) -> response().
-granted(#{id := Id, csrf := Csrf, expires_at := ExpiresAt} = Session, Req) ->
+granted(Session, Req) ->
+    granted(Session, Req, json).
+
+granted(#{id := Id, csrf := Csrf, expires_at := ExpiresAt} = Session, Req, Reply) ->
     Options = cookie_options(Req),
     Req1 = cowboy_req:set_resp_cookie(?COOKIE, Id, Req, Options#{http_only => true}),
     Req2 = cowboy_req:set_resp_cookie(?CSRF_COOKIE, Csrf, Req1, Options#{http_only => false}),
-    {json, 200, #{~"cache-control" => ~"no-store"}, Req2, #{
+    reply(Reply, Session, Csrf, ExpiresAt, Req2).
+
+%% 303, not 302: the browser must follow with GET whatever it posted with.
+reply(redirect, _Session, _Csrf, _ExpiresAt, Req) ->
+    {status, 303, #{~"location" => ~"/console", ~"cache-control" => ~"no-store"}, Req};
+reply(json, Session, Csrf, ExpiresAt, Req) ->
+    {json, 200, #{~"cache-control" => ~"no-store"}, Req, #{
         data => #{
             display => maps:get(label, Session),
             expires_at => ExpiresAt,

--- a/src/console/asobi_console_session.erl
+++ b/src/console/asobi_console_session.erl
@@ -38,7 +38,7 @@ while a tab sits open is the wrong default for a surface that bans players.
 
 -include_lib("kernel/include/logger.hrl").
 
--export([start_link/0, create/1, resolve/2, delete/1, csrf/1, ttl_seconds/0]).
+-export([start_link/0, create/1, create/3, resolve/2, delete/1, csrf/1, ttl_seconds/0]).
 -export([init/1, handle_call/3, handle_cast/2, handle_info/2]).
 -ifdef(TEST).
 -export([expire/1, sweep/0]).
@@ -54,7 +54,13 @@ while a tab sits open is the wrong default for a surface that bans players.
 -define(SWEEP_MS, 60000).
 -define(MAX_LABEL_BYTES, 64).
 
--type session() :: #{id := binary(), csrf := binary(), label := binary(), expires_at := integer()}.
+-type session() :: #{
+    id := binary(),
+    csrf := binary(),
+    label := binary(),
+    caps := [asobi_ops_caps:class()],
+    expires_at := integer()
+}.
 -type reason() :: unknown | expired | bad_csrf.
 
 -export_type([session/0, reason/0]).
@@ -73,7 +79,21 @@ it is held to the same shape `asobi_ops_auth:display/1` holds the
 """.
 -spec create(binary()) -> {ok, session()}.
 create(Label) ->
-    gen_server:call(?MODULE, {create, label(Label)}).
+    create(Label, asobi_ops_caps:class_names(), erlang:system_time(second) + ttl_seconds()).
+
+-doc """
+Open a session carrying `Caps` and expiring no later than `NotAfter`.
+
+The operator secret proves every capability, so `create/1` grants all three.
+A **minted** token proves only the classes it carries and expires in minutes,
+so exchanging one for a session must not widen either: the session inherits
+the token's capabilities, and its expiry is clamped to the token's. Otherwise
+a fifteen-minute credential with two classes would buy a twelve-hour session
+with three, which is the whole point of the token undone by the exchange.
+""".
+-spec create(binary(), [asobi_ops_caps:class()], integer()) -> {ok, session()}.
+create(Label, Caps, NotAfter) ->
+    gen_server:call(?MODULE, {create, label(Label), Caps, NotAfter}).
 
 -doc """
 Resolve a cookie and its CSRF token to a live session.
@@ -120,11 +140,19 @@ init([]) ->
     {ok, #{}}.
 
 -spec handle_call(term(), gen_server:from(), #{}) -> {reply, term(), #{}}.
-handle_call({create, Label}, _From, State) ->
+handle_call({create, Label, Caps, NotAfter}, _From, State) ->
     Id = base64:encode(crypto:strong_rand_bytes(?ID_BYTES), #{mode => urlsafe, padding => false}),
-    ExpiresAt = erlang:system_time(second) + ttl_seconds(),
-    true = ets:insert(?TABLE, {Id, ExpiresAt, Label}),
-    {reply, {ok, #{id => Id, csrf => csrf(Id), label => Label, expires_at => ExpiresAt}}, State};
+    ExpiresAt = min(erlang:system_time(second) + ttl_seconds(), NotAfter),
+    true = ets:insert(?TABLE, {Id, ExpiresAt, Label, Caps}),
+    {reply,
+        {ok, #{
+            id => Id,
+            csrf => csrf(Id),
+            label => Label,
+            caps => Caps,
+            expires_at => ExpiresAt
+        }},
+        State};
 handle_call({delete, Id}, _From, State) ->
     true = ets:delete(?TABLE, Id),
     {reply, ok, State};
@@ -132,7 +160,10 @@ handle_call({expire, Id}, _From, State) ->
     %% Test-only, and it goes through the owner because the table is
     %% `protected`. Ageing a row is the only way to exercise expiry and the
     %% sweeper without waiting out a real TTL.
-    Aged = [{Id, erlang:system_time(second) - 1, Label} || {_, _, Label} <- ets:lookup(?TABLE, Id)],
+    Aged = [
+        {Id, erlang:system_time(second) - 1, Label, Caps}
+     || {_, _, Label, Caps} <- ets:lookup(?TABLE, Id)
+    ],
     true = Aged =:= [] orelse ets:insert(?TABLE, Aged),
     {reply, ok, State};
 handle_call(sweep, _From, State) ->
@@ -159,14 +190,14 @@ handle_info(_Message, State) ->
 -spec sweep_expired() -> ok.
 sweep_expired() ->
     Removed = ets:select_delete(?TABLE, [
-        {{'_', '$1', '_'}, [{'<', '$1', erlang:system_time(second)}], [true]}
+        {{'_', '$1', '_', '_'}, [{'<', '$1', erlang:system_time(second)}], [true]}
     ]),
     log_sweep(Removed).
 
 -spec lookup(binary()) -> {ok, session()} | {error, reason()}.
 lookup(Id) ->
     try ets:lookup(?TABLE, Id) of
-        [{Id, ExpiresAt, Label}] -> live(Id, ExpiresAt, Label);
+        [{Id, ExpiresAt, Label, Caps}] -> live(Id, ExpiresAt, Label, Caps);
         [] -> {error, unknown}
     catch
         %% The table is gone only while the owner is restarting. That is a
@@ -174,11 +205,20 @@ lookup(Id) ->
         error:badarg -> {error, unknown}
     end.
 
--spec live(binary(), integer(), binary()) -> {ok, session()} | {error, reason()}.
-live(Id, ExpiresAt, Label) ->
+-spec live(binary(), integer(), binary(), [asobi_ops_caps:class()]) ->
+    {ok, session()} | {error, reason()}.
+live(Id, ExpiresAt, Label, Caps) ->
     case ExpiresAt > erlang:system_time(second) of
-        true -> {ok, #{id => Id, csrf => csrf(Id), label => Label, expires_at => ExpiresAt}};
-        false -> {error, expired}
+        true ->
+            {ok, #{
+                id => Id,
+                csrf => csrf(Id),
+                label => Label,
+                caps => Caps,
+                expires_at => ExpiresAt
+            }};
+        false ->
+            {error, expired}
     end.
 
 -spec checked(session(), binary()) -> {ok, session()} | {error, reason()}.

--- a/src/ops/asobi_ops_auth.erl
+++ b/src/ops/asobi_ops_auth.erl
@@ -201,13 +201,16 @@ resolved({error, Reason}) -> {error, Reason}.
 %% row and a log line would then carry a live cookie. A truncated hash of it
 %% is enough to correlate rows to one session and useless to replay.
 -spec session_actor(asobi_console_session:session()) -> actor().
-session_actor(#{id := Id, label := Label}) ->
+session_actor(#{id := Id, label := Label, caps := Caps}) ->
     Digest = binary:encode_hex(binary:part(crypto:hash(sha256, Id), 0, 8), lowercase),
     #{
         id => <<"console:", Digest/binary>>,
         display => Label,
         source => local_user,
-        caps => [read, player_data, config],
+        %% Whatever the credential behind this session proved. The operator
+        %% secret proves all three; a minted token proves only what it carried,
+        %% and the session must not widen it.
+        caps => Caps,
         attested => false
     }.
 

--- a/test/asobi_console_SUITE.erl
+++ b/test/asobi_console_SUITE.erl
@@ -9,6 +9,8 @@
 %% wrong without any unit test noticing.
 
 -define(OPS_SECRET, ~"31d0f7a5c8b26e94103fa87c5d29b6e0475cf1a83b9d6e2047ca5813fd6e9b02").
+-define(ENGINE_KEY, ~"ak_0123456789abcdef0123456789abcdef").
+-define(ENV_ID, ~"019f7646-9ddb-77ee-82f5-b5e7f3b9ee9d").
 
 -export([all/0, groups/0, init_per_suite/1, end_per_suite/1, init_per_group/2, end_per_group/2]).
 -export([
@@ -26,7 +28,11 @@
     session_cookie_opens_the_ops_plane/1,
     cookie_without_csrf_is_refused/1,
     whoami_reports_the_actor/1,
-    logout_ends_the_session/1
+    logout_ends_the_session/1,
+    a_minted_token_opens_a_session/1,
+    a_minted_session_carries_only_the_token_s_caps/1,
+    a_minted_session_does_not_outlive_its_token/1,
+    a_bad_minted_token_is_refused_like_a_bad_secret/1
 ]).
 
 all() ->
@@ -47,6 +53,10 @@ groups() ->
         {session, [sequence], [
             login_rejects_a_wrong_secret,
             login_sets_both_cookies,
+            a_minted_token_opens_a_session,
+            a_minted_session_carries_only_the_token_s_caps,
+            a_minted_session_does_not_outlive_its_token,
+            a_bad_minted_token_is_refused_like_a_bad_secret,
             session_cookie_opens_the_ops_plane,
             cookie_without_csrf_is_refused,
             whoami_reports_the_actor,
@@ -70,7 +80,20 @@ init_per_group(disabled, Config) ->
 init_per_group(_Group, Config) ->
     application:set_env(asobi, console, true),
     application:set_env(asobi, ops_secret, ?OPS_SECRET),
+    application:set_env(asobi, ops_token_secret, ?ENGINE_KEY),
+    application:set_env(asobi, env_id, ?ENV_ID),
     Config.
+
+%% A token the way asobi_saas mints one.
+minted(Caps) ->
+    Now = erlang:system_time(second),
+    asobi_ops_token:sign(asobi_ops_token:key(?ENGINE_KEY), #{
+        env => ?ENV_ID,
+        sub => ~"user-7",
+        caps => Caps,
+        iat => Now,
+        exp => Now + asobi_ops_token:max_ttl()
+    }).
 
 end_per_group(_Group, Config) ->
     Config.
@@ -209,6 +232,51 @@ login_sets_both_cookies(Config) ->
         ?assertNotEqual(nomatch, binary:match(string:lowercase(Cookie), ~"samesite=strict"))
      || Cookie <- [Session, Csrf]
     ],
+    Config.
+
+%% The managed path: a tenant's browser posts the token the control plane
+%% minted and then holds a cookie, so the token never has to live in
+%% JavaScript for the length of a session.
+a_minted_token_opens_a_session(Config) ->
+    {ok, Resp} = nova_test:post(
+        "/console/session", #{json => #{~"token" => minted([read])}}, Config
+    ),
+    ?assertStatus(200, Resp),
+    ?assertMatch(#{~"data" := #{~"display" := ~"user-7"}}, nova_test:json(Resp)),
+    Config.
+
+%% The whole point of mapping roles to classes at mint time would be undone if
+%% the exchange widened them back out.
+a_minted_session_carries_only_the_token_s_caps(Config) ->
+    {ok, Resp} = nova_test:post(
+        "/console/session", #{json => #{~"token" => minted([read])}}, Config
+    ),
+    Csrf = maps:get(~"csrf", maps:get(~"data", nova_test:json(Resp))),
+    Cookie = find(~"asobi_console=", set_cookies(Resp)),
+    {ok, Whoami} = nova_test:get(
+        "/console/session",
+        #{headers => [{~"cookie", Cookie}, {~"x-csrf-token", Csrf}]},
+        Config
+    ),
+    ?assertMatch(#{~"data" := #{~"caps" := [~"read"]}}, nova_test:json(Whoami)),
+    Config.
+
+%% A fifteen-minute credential must not buy a twelve-hour session.
+a_minted_session_does_not_outlive_its_token(Config) ->
+    {ok, Resp} = nova_test:post(
+        "/console/session", #{json => #{~"token" => minted([read])}}, Config
+    ),
+    #{~"data" := #{~"expires_at" := ExpiresAt}} = nova_test:json(Resp),
+    Now = erlang:system_time(second),
+    ?assert(ExpiresAt =< Now + asobi_ops_token:max_ttl()),
+    ?assert(ExpiresAt > Now),
+    Config.
+
+a_bad_minted_token_is_refused_like_a_bad_secret(Config) ->
+    {ok, Resp} = nova_test:post(
+        "/console/session", #{json => #{~"token" => ~"v1.not.valid"}}, Config
+    ),
+    ?assertStatus(403, Resp),
     Config.
 
 session_cookie_opens_the_ops_plane(Config) ->


### PR DESCRIPTION
The managed console's last mile. `asobi_saas` mints an env-scoped token, the browser posts it to `/console/session` once, and holds a cookie from then on - so the token never has to live in JavaScript for the length of a session.

## Sessions carry capabilities now

They did not before. `session_actor/1` handed **every** session all three classes, because the only credential was the operator secret, which proves all three. That was fine in isolation and a privilege escalation the moment a second credential existed: exchanging a `read`-only token for such a session would promote a `member` straight to `config`, undoing the role-to-class mapping the mint does.

The session inherits the token's classes. Its expiry is clamped to the token's, because a fifteen-minute credential must not buy a twelve-hour session either.

This is a fix to the existing session model, not only something the cloud path needed.

## The hand-off is a form POST

```
POST https://<env>/console/session
Content-Type: application/x-www-form-urlencoded

token=v1....
```

The token rides in the **body**. Unlike a query parameter or a URL fragment it never enters a URL, a referrer, an access log or the browser's history. The reply is a **303**, not JSON, because the caller is a navigating browser - and after it the page is same-origin, so the `SameSite=Strict` cookies just set are sent normally from then on.

The alternatives were considered and are worse: a cross-origin `fetch` cannot set the cookie at all (the env sends `Access-Control-Allow-Origin: *`, which browsers refuse to combine with credentials), and a fragment keeps a live credential in history for its whole life.

The body is read from the `body` key rather than `cowboy_req:read_urlencoded_body/1`: `nova_request_plugin` has already drained the one-shot stream, so reading it again finds an empty body and silently no fields (the asobi_saas#100 bug).

## Failure is indistinguishable

A bad token gets the same 403, the same body and the same log line a wrong secret gets. Which credential was wrong, and why, is not something a caller guessing gets to learn.

## Tests

Four new CT cases against a real HTTP server: a minted token opens a session, the session carries **only** the token's caps, it does not outlive the token, and a malformed one is refused like a bad secret. 19/19 in `asobi_console_SUITE`, `eunit` 1602/0, `fmt --check` and `xref` clean.

The ETS sweeper's match spec needed its arity widened for the new column - caught by its own test, which is the kind of thing that would otherwise have quietly stopped sweeping.