### PR TITLE
feat(ops): sign minted tokens with a dedicated per-env secret

### DIFF
--- a/guides/configuration.md
+++ b/guides/configuration.md
@@ -387,14 +387,22 @@ tenant and checked they own this environment. Self-hosting needs none of this
 and can skip it.
 
 ```erlang
-{ops_token_secret, ~"${ENGINE_API_KEY}"},
+{ops_token_secret, ~"${ASOBI_OPS_TOKEN_SECRET}"},
 {env_id, ~"${GAME_ID}"}
 ```
 
 | Key | Default | Description |
 |-----|---------|-------------|
-| `ops_token_secret` | none | The value the control plane also holds. The signing key is **derived** from it, never used directly |
+| `ops_token_secret` | none | A per-environment secret that signs ops tokens and nothing else. At least 32 bytes; shorter is treated as unset |
 | `env_id` | none | This environment's id. A token minted for another one is refused |
+
+It is deliberately **not** the credential the engine authenticates with. A
+value that both proves who the engine is and signs the operator credentials it
+accepts is one leak away from doing both for an attacker, and deriving one
+from the other prevents confusion but not shared compromise.
+
+Rotating it revokes every ops token outstanding for the environment at once,
+which is the only revocation there is.
 
 Both or neither: a node that knows the secret but not which environment it is
 cannot check a token's `env` claim, so it refuses every minted token rather

--- a/src/ops/asobi_ops_token.erl
+++ b/src/ops/asobi_ops_token.erl
@@ -21,19 +21,22 @@ stripped down to this one.
 
 ## The key
 
-Not `ops_secret`, and not the credential it is derived from either:
+`ops_token_secret`, from `ASOBI_OPS_TOKEN_SECRET` - a per-environment secret
+that signs ops tokens and does nothing else.
 
-```erlang
-Key = crypto:mac(hmac, sha256, EngineApiKey, <<"asobi.ops.token.v1">>)
-```
+It was briefly derived from `ENGINE_API_KEY`, because both sides already held
+that value. Deriving through a label stops two keys being *confused*; it does
+not stop them being *compromised together*, and a value that both
+authenticates this engine to the control plane and signs the operator
+credentials it accepts is one leak away from doing both for an attacker. So
+it is its own secret, generated per environment by the provisioner and held
+nowhere else - not even in the control plane's database.
 
-`ENGINE_API_KEY` is the one value the control plane and this environment
-already both hold, so signing needs no new plumbing - but a credential used
-to authenticate must not double as a signing key, so it is separated by
-label first. The same construction the console's CSRF token uses.
+Being per environment, a token minted for one env cannot validate at another
+even before `env` is checked. `env` is checked anyway.
 
-It is **per environment**, so a token minted for one env cannot validate at
-another even before `env` is checked. `env` is checked anyway.
+Rotating it revokes every token outstanding for this environment at once,
+which is the only revocation there is.
 
 ## What a signature does not buy
 
@@ -47,10 +50,9 @@ Nothing here is stateful: there is no revocation list, which is exactly why
 the lifetime is capped rather than merely checked.
 """.
 
--export([verify/1, key/1, sign/2, max_ttl/0]).
+-export([verify/1, sign/2, max_ttl/0]).
 
 -define(VERSION, ~"v1").
--define(LABEL, ~"asobi.ops.token.v1").
 %% Fifteen minutes. Long enough that an operator is not re-minting mid-task,
 %% short enough that a leaked token is a nuisance rather than an incident -
 %% and there is nothing to revoke it with.
@@ -72,16 +74,6 @@ the lifetime is capped rather than merely checked.
 -doc "The longest lifetime this node will honour, in seconds.".
 -spec max_ttl() -> pos_integer().
 max_ttl() -> ?MAX_TTL_SECONDS.
-
--doc """
-The signing key for `EngineApiKey`.
-
-Exported because the control plane derives the same key from the same value,
-and the derivation is the contract between them.
-""".
--spec key(binary()) -> binary().
-key(EngineApiKey) when is_binary(EngineApiKey), EngineApiKey =/= ~"" ->
-    crypto:mac(hmac, sha256, EngineApiKey, ?LABEL).
 
 -doc """
 Mint a token for `Claims`.
@@ -200,10 +192,12 @@ claims_json(#{env := Env, sub := Sub, caps := Caps, iat := Iat, exp := Exp}) ->
 %% for one tenant's environment gets honoured by another's.
 config() ->
     case {application:get_env(asobi, ops_token_secret), application:get_env(asobi, env_id)} of
+        %% A short secret is how a placeholder becomes a signing key. 32 bytes
+        %% is what the provisioner generates; anything less is unconfigured.
         {{ok, Secret}, {ok, EnvId}} when
-            is_binary(Secret), Secret =/= ~"", is_binary(EnvId), EnvId =/= ~""
+            is_binary(Secret), byte_size(Secret) >= 32, is_binary(EnvId), EnvId =/= ~""
         ->
-            {ok, key(Secret), EnvId};
+            {ok, Secret, EnvId};
         _ ->
             error
     end.

--- a/test/asobi_console_SUITE.erl
+++ b/test/asobi_console_SUITE.erl
@@ -9,7 +9,7 @@
 %% wrong without any unit test noticing.
 
 -define(OPS_SECRET, ~"31d0f7a5c8b26e94103fa87c5d29b6e0475cf1a83b9d6e2047ca5813fd6e9b02").
--define(ENGINE_KEY, ~"ak_0123456789abcdef0123456789abcdef").
+-define(SIGNING_SECRET, ~"a-per-env-ops-signing-secret-32b!").
 -define(ENV_ID, ~"019f7646-9ddb-77ee-82f5-b5e7f3b9ee9d").
 
 -export([all/0, groups/0, init_per_suite/1, end_per_suite/1, init_per_group/2, end_per_group/2]).
@@ -80,14 +80,14 @@ init_per_group(disabled, Config) ->
 init_per_group(_Group, Config) ->
     application:set_env(asobi, console, true),
     application:set_env(asobi, ops_secret, ?OPS_SECRET),
-    application:set_env(asobi, ops_token_secret, ?ENGINE_KEY),
+    application:set_env(asobi, ops_token_secret, ?SIGNING_SECRET),
     application:set_env(asobi, env_id, ?ENV_ID),
     Config.
 
 %% A token the way asobi_saas mints one.
 minted(Caps) ->
     Now = erlang:system_time(second),
-    asobi_ops_token:sign(asobi_ops_token:key(?ENGINE_KEY), #{
+    asobi_ops_token:sign(?SIGNING_SECRET, #{
         env => ?ENV_ID,
         sub => ~"user-7",
         caps => Caps,

--- a/test/asobi_ops_auth_tests.erl
+++ b/test/asobi_ops_auth_tests.erl
@@ -9,7 +9,7 @@
 %% here, and an unconfigured deployment admits nobody.
 
 -define(SECRET, ~"7f4c1b9a2e6d8053f1a4c7b0e9d2635847ac1fbe2093d75641c8ba0fe3729d15").
--define(ENGINE_KEY, ~"engine-api-key-not-a-real-one").
+-define(SIGNING_SECRET, ~"a-per-env-ops-signing-secret-32b!").
 -define(ENV_ID, ~"019f7646-9ddb-77ee-82f5-b5e7f3b9ee9d").
 
 %%--------------------------------------------------------------------
@@ -123,7 +123,7 @@ cloud_test_() ->
 
 cloud_setup() ->
     Original = setup(),
-    application:set_env(asobi, ops_token_secret, ?ENGINE_KEY),
+    application:set_env(asobi, ops_token_secret, ?SIGNING_SECRET),
     application:set_env(asobi, env_id, ?ENV_ID),
     Original.
 
@@ -136,7 +136,7 @@ minted(Caps) -> minted(Caps, ?ENV_ID).
 
 minted(Caps, EnvId) ->
     Now = erlang:system_time(second),
-    asobi_ops_token:sign(asobi_ops_token:key(?ENGINE_KEY), #{
+    asobi_ops_token:sign(?SIGNING_SECRET, #{
         env => EnvId,
         sub => ~"user-7",
         caps => Caps,

--- a/test/asobi_ops_token_tests.erl
+++ b/test/asobi_ops_token_tests.erl
@@ -3,7 +3,7 @@
 -include_lib("eunit/include/eunit.hrl").
 
 -define(ENV, ~"019f7646-9ddb-77ee-82f5-b5e7f3b9ee9d").
--define(ENGINE_KEY, ~"engine-api-key-not-a-real-one").
+-define(SIGNING_SECRET, ~"a-per-env-ops-signing-secret-32b!").
 
 %% The cloud credential. A valid MAC is necessary and not sufficient, and most
 %% of what is asserted here is the "not sufficient" half: a signature the
@@ -25,11 +25,11 @@ token_test_() ->
         fun a_malformed_token_is_refused/0,
         fun a_version_that_is_not_ours_is_refused/0,
         fun nothing_verifies_without_both_halves_of_the_config/0,
-        fun the_key_is_derived_not_the_credential/0
+        fun a_short_secret_is_not_a_configuration/0
     ]}.
 
 setup() ->
-    application:set_env(asobi, ops_token_secret, ?ENGINE_KEY),
+    application:set_env(asobi, ops_token_secret, ?SIGNING_SECRET),
     application:set_env(asobi, env_id, ?ENV),
     ok.
 
@@ -55,7 +55,7 @@ a_token_for_another_environment_is_refused() ->
     ?assertEqual({error, wrong_environment}, asobi_ops_token:verify(Token)).
 
 a_token_signed_with_another_key_is_refused() ->
-    Token = asobi_ops_token:sign(asobi_ops_token:key(~"a-different-engine-key"), claims(#{})),
+    Token = asobi_ops_token:sign(~"a-different-per-env-signing-secret", claims(#{})),
     ?assertEqual({error, bad_signature}, asobi_ops_token:verify(Token)).
 
 a_tampered_payload_is_refused() ->
@@ -124,18 +124,15 @@ nothing_verifies_without_both_halves_of_the_config() ->
     application:unset_env(asobi, ops_token_secret),
     ?assertEqual({error, not_configured}, asobi_ops_token:verify(Token)).
 
-%% A credential used to authenticate must not double as a signing key.
-the_key_is_derived_not_the_credential() ->
-    ?assertNotEqual(?ENGINE_KEY, asobi_ops_token:key(?ENGINE_KEY)),
-    ?assertEqual(32, byte_size(asobi_ops_token:key(?ENGINE_KEY))),
-    ?assertNotEqual(
-        asobi_ops_token:key(?ENGINE_KEY),
-        asobi_ops_token:key(<<?ENGINE_KEY/binary, "x">>)
-    ).
+%% A short secret is how a placeholder becomes a signing key, so it is treated
+%% as no configuration at all rather than as a weak one.
+a_short_secret_is_not_a_configuration() ->
+    application:set_env(asobi, ops_token_secret, ~"too-short"),
+    ?assertEqual({error, not_configured}, asobi_ops_token:verify(mint())).
 
 %%--------------------------------------------------------------------
 
-key() -> asobi_ops_token:key(?ENGINE_KEY).
+key() -> ?SIGNING_SECRET.
 
 mint() -> mint(#{}).
 


### PR DESCRIPTION
Closes the one residual risk worth acting on from the security review.

## What was wrong

`ops_token_secret` was `ENGINE_API_KEY`, with the signing key derived from it through a label:

```erlang
Key = crypto:mac(hmac, sha256, EngineApiKey, <<"asobi.ops.token.v1">>)
```

Deriving stops two keys being **confused**. It does not stop them being **compromised together**. A value that both authenticates this engine to the control plane *and* signs the operator credentials it accepts is one leak away from doing both for an attacker.

The original justification was that it needed no new plumbing. That was true and it is not a good enough reason.

## What it is now

`ASOBI_OPS_TOKEN_SECRET`, generated per environment by the provisioner (widgrensit/asobi_saas#262), held in that environment's Kubernetes Secret and **nowhere else** - not even in the control plane's database, so a database compromise does not hand over the ability to mint.

With a single-purpose key there is nothing left to derive, so `key/1` is gone and the secret is the HMAC key directly.

**A secret shorter than 32 bytes is treated as no configuration at all**, not as a weak one - a short value is how a placeholder becomes a signing key.

## Migration

An environment provisioned before this key existed does not have it, and refuses every minted token until it is re-provisioned. Failing closed is the point: falling back to the engine key is exactly the coupling being removed.

Order: merge widgrensit/asobi_saas#262 and widgrensit/asobi_engine#94 with this, roll, then re-provision each env so the Secret gains the key. Until then the cloud console is off, which is the correct state for a feature whose credential does not exist yet.

## Tests

`eunit` and the console CT suite unchanged in shape - the fixtures now use a per-env signing secret rather than a derived one. The test that asserted the key was derived rather than the credential is replaced by one asserting a short secret is refused, which is the property that matters now.

`fmt --check`, `xref`, `eunit` and `asobi_console_SUITE` (19/19) clean.