### PR TITLE
fix(console): Lax cookies, so the managed hand-off does not land on a login

### DIFF
--- a/src/console/asobi_console_controller.erl
+++ b/src/console/asobi_console_controller.erl
@@ -235,11 +235,22 @@ clear(Req) ->
 %% `Secure` is set whenever the request looks like TLS, directly or through a
 %% proxy that says so. A forwarded header can only *add* the flag here, so
 %% believing an unverified one can make a cookie stricter and never weaker.
+%%
+%% `Lax`, not `Strict`. The managed hand-off arrives as a cross-site form POST
+%% from the control plane, and a browser treats every hop of that redirect
+%% chain as cross-site - so a `Strict` cookie is set and then not sent on the
+%% redirect to `/console`, landing the operator on a login page holding a
+%% session they cannot use until they reload.
+%%
+%% `Lax` still refuses to send these on a cross-site POST or an XHR, which is
+%% the case that matters: every state-changing request also needs the
+%% `x-csrf-token` header, and that is the defence doing the work. What `Lax`
+%% adds is the top-level GET navigation, which is exactly the hop being fixed.
 -spec cookie_options(cowboy_req:req()) -> map().
 cookie_options(Req) ->
     #{
         path => ~"/",
-        same_site => strict,
+        same_site => lax,
         secure => secure(Req),
         max_age => asobi_console_session:ttl_seconds()
     }.

--- a/test/asobi_console_SUITE.erl
+++ b/test/asobi_console_SUITE.erl
@@ -228,8 +228,13 @@ login_sets_both_cookies(Config) ->
     %% not be, because the page has to send it back as a header after reload.
     ?assertNotEqual(nomatch, binary:match(string:lowercase(Session), ~"httponly")),
     ?assertEqual(nomatch, binary:match(string:lowercase(Csrf), ~"httponly")),
+    %% Lax, not Strict: the managed hand-off is a cross-site form POST, and a
+    %% browser treats the redirect after one as cross-site too - a Strict
+    %% cookie would be set and then withheld on the very next hop. Lax still
+    %% withholds it from a cross-site POST or XHR, which is the case the CSRF
+    %% header exists to cover.
     [
-        ?assertNotEqual(nomatch, binary:match(string:lowercase(Cookie), ~"samesite=strict"))
+        ?assertNotEqual(nomatch, binary:match(string:lowercase(Cookie), ~"samesite=lax"))
      || Cookie <- [Session, Csrf]
     ],
     Config.


### PR DESCRIPTION
Pairs with the control-plane page in widgrensit/asobi_saas#264.

## The bug

The hand-off arrives as a **cross-site form POST** from console.asobi.dev, and browsers treat every hop of the redirect chain following one as cross-site.

So `/console/session` sets a `SameSite=Strict` cookie, 303s to `/console`, and the browser **withholds the cookie it just set** on that very next hop. The operator lands on a login page holding a session they cannot use until they manually reload - indistinguishable, from where they are standing, from the hand-off simply being broken.

I picked `Strict` without thinking about the redirect, then designed the hand-off against it.

## Why `Lax` is the right setting, not a concession

`Lax` still refuses to send these cookies on a **cross-site POST or XHR**, which is the case that matters for an ops console. And every state-changing request on this plane already requires the `x-csrf-token` header - derived, not stored, and verifiable only with the node secret. That is the defence doing the work; `SameSite` is the belt rather than the braces.

What `Lax` adds is the top-level GET navigation. That is precisely the hop being fixed and nothing else.

## Tests

`asobi_console_SUITE`'s cookie assertion now pins `samesite=lax` on both cookies, with the reasoning next to it so the next person does not "tighten" it back and break the hand-off silently. 19/19, `eunit` 1602/0.