### PR TITLE
fix(console): use the redirect shape that carries the Req

### DIFF
--- a/src/console/asobi_console_controller.erl
+++ b/src/console/asobi_console_controller.erl
@@ -190,9 +190,13 @@ granted(#{id := Id, csrf := Csrf, expires_at := ExpiresAt} = Session, Req, Reply
     Req2 = cowboy_req:set_resp_cookie(?CSRF_COOKIE, Csrf, Req1, Options#{http_only => false}),
     reply(Reply, Session, Csrf, ExpiresAt, Req2).
 
-%% 303, not 302: the browser must follow with GET whatever it posted with.
+%% `{redirect, Route, Req}` rather than a hand-rolled status tuple: it is the
+%% only redirect shape that carries a Req, and the Req is what holds the two
+%% cookies just set. Nova's `{status, Code, Headers, Body}` takes a *body* in
+%% that position, so passing a Req there matches the `is_map(Body)` clause and
+%% crashes trying to encode the request as JSON.
 reply(redirect, _Session, _Csrf, _ExpiresAt, Req) ->
-    {status, 303, #{~"location" => ~"/console", ~"cache-control" => ~"no-store"}, Req};
+    {redirect, ~"/console", Req};
 reply(json, Session, Csrf, ExpiresAt, Req) ->
     {json, 200, #{~"cache-control" => ~"no-store"}, Req, #{
         data => #{

--- a/test/asobi_console_SUITE.erl
+++ b/test/asobi_console_SUITE.erl
@@ -32,7 +32,8 @@
     a_minted_token_opens_a_session/1,
     a_minted_session_carries_only_the_token_s_caps/1,
     a_minted_session_does_not_outlive_its_token/1,
-    a_bad_minted_token_is_refused_like_a_bad_secret/1
+    a_bad_minted_token_is_refused_like_a_bad_secret/1,
+    a_form_post_redirects_into_the_console/1
 ]).
 
 all() ->
@@ -57,6 +58,7 @@ groups() ->
             a_minted_session_carries_only_the_token_s_caps,
             a_minted_session_does_not_outlive_its_token,
             a_bad_minted_token_is_refused_like_a_bad_secret,
+            a_form_post_redirects_into_the_console,
             session_cookie_opens_the_ops_plane,
             cookie_without_csrf_is_refused,
             whoami_reports_the_actor,
@@ -282,6 +284,24 @@ a_bad_minted_token_is_refused_like_a_bad_secret(Config) ->
         "/console/session", #{json => #{~"token" => ~"v1.not.valid"}}, Config
     ),
     ?assertStatus(403, Resp),
+    Config.
+
+%% The shape the control plane actually sends: a urlencoded body, answered with
+%% a redirect rather than JSON because the caller is a navigating browser. The
+%% JSON cases above all passed while this crashed with a function_clause in
+%% nova_handler, because none of them posted a form.
+a_form_post_redirects_into_the_console(Config) ->
+    {ok, Resp} = nova_test:post(
+        "/console/session",
+        #{
+            headers => [{~"content-type", ~"application/x-www-form-urlencoded"}],
+            body => <<"token=", (minted([read]))/binary>>
+        },
+        Config
+    ),
+    ?assertStatus(302, Resp),
+    Cookies = set_cookies(Resp),
+    ?assertNotEqual(nomatch, binary:match(find(~"asobi_console=", Cookies), ~"asobi_console=")),
     Config.
 
 session_cookie_opens_the_ops_plane(Config) ->


### PR DESCRIPTION
The form hand-off answered `{status, 303, Headers, Req}`. **Nova has no such clause.** `{status, Code, Headers, Body}` takes a *body* in that position; a Req is a map, so it matched the `is_map(Body)` clause and crashed trying to encode the request as JSON.

Every form POST to `/console/session` returned **500**. Found by curling a hand-minted token at the live `demo-live3` environment:

```
HTTP/2 500
server: Cowboy/Nova
```

and in the engine log: `function_clause` in `nova_handler:execute/2`.

`{redirect, Route, Req}` is the only redirect shape that carries a Req, and the Req is what holds the two cookies just set.

## Why the tests did not catch it

Four CT cases cover this endpoint and **all four post JSON**. The shape the control plane actually sends - a urlencoded body - was never exercised. The new case posts one.

## Pairs with

widgrensit/asobi_saas#268. The control plane's Traefik CSP had `form-action 'self'`, so the browser blocked the submit before it ever reached this bug. Both are needed; either alone leaves the button broken.