### PR TITLE
fix(ci): fail the protocol sync when it cannot sync

### DIFF
--- a/.github/workflows/protocol-sync.yml
+++ b/.github/workflows/protocol-sync.yml
@@ -10,8 +10,17 @@ name: Protocol sync
 # decision in that repo.
 #
 # Needs SDK_SYNC_TOKEN, a fine-grained PAT with contents:write and
-# pull-requests:write on the seven SDK repos. Without it the job says so and
-# stops, rather than failing a build nobody can fix.
+# pull-requests:write on the seven SDK repos.
+#
+# Without it this FAILS. It used to log the reason and pass, on the reasoning
+# that a build nobody can fix should not go red - but the token was never set,
+# so every run since has reported success while syncing nothing, and the drift
+# this workflow exists to prevent happened anyway: the defold corpus went stale
+# enough to hide a real entity-sync bug for weeks, and unity's fixtures had to
+# be copied across by hand on 2026-08-05.
+#
+# A green run that did nothing is worse than a red one. This repo's owner is
+# the person who can add the secret, so red is the signal that gets it fixed.
 
 on:
   push:
@@ -48,21 +57,18 @@ jobs:
         uses: actions/checkout@v5
 
       - name: Check for the sync token
-        id: token
         env:
           TOKEN: ${{ secrets.SDK_SYNC_TOKEN }}
         run: |
           if [ -z "$TOKEN" ]; then
-            echo "SDK_SYNC_TOKEN is not set - cannot open a PR in ${{ matrix.repo }}."
+            echo "::error::SDK_SYNC_TOKEN is not set, so ${{ matrix.repo }} was NOT synced."
+            echo "The corpus changed and this SDK's vendored copy is now behind."
             echo "Create a fine-grained PAT with contents:write and pull-requests:write"
-            echo "on the seven SDK repos and add it as a repository secret."
-            echo "present=false" >> "$GITHUB_OUTPUT"
-          else
-            echo "present=true" >> "$GITHUB_OUTPUT"
+            echo "on the seven SDK repos and add it as the SDK_SYNC_TOKEN secret."
+            exit 1
           fi
 
       - name: Check out ${{ matrix.repo }}
-        if: steps.token.outputs.present == 'true'
         uses: actions/checkout@v5
         with:
           repository: ${{ matrix.repo }}
@@ -70,7 +76,6 @@ jobs:
           path: sdk
 
       - name: Sync the corpus
-        if: steps.token.outputs.present == 'true'
         id: sync
         run: |
           scripts/protocol-sync.sh apply "${{ matrix.sdk }}" sdk


### PR DESCRIPTION
## What is wrong

`SDK_SYNC_TOKEN` has never been set. Every run of this workflow skips all seven SDKs and reports **success**:

```
sync (dart, widgrensit/asobi-dart)   SDK_SYNC_TOKEN is not set - cannot open a PR
sync (godot, widgrensit/asobi-godot) SDK_SYNC_TOKEN is not set - cannot open a PR
...                                  (all seven, run concluded: success)
```

So the drift it exists to prevent happened anyway. Checked against current `main` in each repo:

| SDK | state |
|---|---|
| js, godot, love2d, defold | in sync |
| dart | 6 files behind |
| unity | 7 files behind |
| unreal | 10 files behind |

And it is not cosmetic. Defold's copy was stale enough to hide a real entity-sync bug — the SDK understood only the binary delta shape and dropped every JSON delta — which surfaced only when the fixtures were finally synced by hand today.

## The change

The token check now fails the job instead of logging and passing.

The graceful skip was deliberate; the header comment gives the reasoning — "rather than failing a build nobody can fix". That reasoning does not survive contact with the outcome: the workflow only runs when the corpus actually changed, so a run that cannot sync means the SDKs are drifting *right now*, and red is the correct signal. The person who can add the secret is the person who owns this repo. The comment is updated to say all of this, so the next person does not re-soften it.

Follow-up PRs bring dart, unity and unreal back in line.