### PR TITLE
feat(console): turn the console on from the environment, and fix the docs it needed

### DIFF
--- a/.github/workflows/docs-drift.yml
+++ b/.github/workflows/docs-drift.yml
@@ -17,6 +17,10 @@ on:
       - 'src/controllers/asobi_guest_controller.erl'
       - 'src/asobi_auth_error.erl'
       - 'scripts/check-error-drift.sh'
+      - 'scripts/check-archived-refs.sh'
+      - 'guides/**'
+      - 'README.md'
+      - 'docs/ARCHITECTURE.md'
       - '.github/workflows/docs-drift.yml'
   pull_request:
     branches: [main]
@@ -25,6 +29,10 @@ on:
       - 'src/controllers/asobi_guest_controller.erl'
       - 'src/asobi_auth_error.erl'
       - 'scripts/check-error-drift.sh'
+      - 'scripts/check-archived-refs.sh'
+      - 'guides/**'
+      - 'README.md'
+      - 'docs/ARCHITECTURE.md'
       - '.github/workflows/docs-drift.yml'
 
 concurrency:
@@ -40,3 +48,6 @@ jobs:
           persist-credentials: false
       - name: Check error-table-vs-controller drift
         run: scripts/check-error-drift.sh
+
+      - name: No user-facing doc points at an archived repository
+        run: scripts/check-archived-refs.sh

--- a/README.md
+++ b/README.md
@@ -134,8 +134,8 @@ UDP relay if you need sub-3ms physics.
 
 ## Related projects
 
-- [**asobi_lua**](https://github.com/widgrensit/asobi_lua) — Lua scripting runtime + Docker image (`ghcr.io/widgrensit/asobi_lua`)
-- [**asobi_admin**](https://github.com/widgrensit/asobi_admin) — admin dashboard
+- Lua scripting and the operator console ship in asobi itself — see [Self-hosting](guides/self-hosting.md)
+- Docker image: `ghcr.io/widgrensit/asobi_lua`
 - Client SDKs: [asobi-godot](https://github.com/widgrensit/asobi-godot) · [asobi-defold](https://github.com/widgrensit/asobi-defold) · [asobi-love2d](https://github.com/widgrensit/asobi-love2d) · [asobi-unity](https://github.com/widgrensit/asobi-unity) · [asobi-unreal](https://github.com/widgrensit/asobi-unreal) · [asobi-js](https://github.com/widgrensit/asobi-js) · [asobi-dart](https://github.com/widgrensit/asobi-dart) · [flame_asobi](https://github.com/widgrensit/flame_asobi)
 
 ## Stability

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -491,10 +491,15 @@ persists and broadcasts the result.
 
 ## Admin
 
-This node ships no admin console. The dashboard is a separate project,
-[asobi_admin](https://github.com/widgrensit/asobi_admin), which reads the same
-database. There is no `/admin` route in `asobi_router.erl`, and asobi no longer
-depends on Arizona.
+This node serves its own operator console at `/console`, off unless
+`{console, true}` and an `ops_secret` are configured. It reads the ops plane at
+`/api/v1/ops` over HTTP like any other client - it holds no privileged path
+into the database of its own.
+
+The console was previously a separate project, `asobi_admin`, which read the
+same database directly. That is archived: a second deployment to run, secure
+and keep in step was the wrong shape for something an operator opens during an
+incident.
 
 ## Background Jobs (Shigoto)
 

--- a/guides/configuration.md
+++ b/guides/configuration.md
@@ -435,6 +435,38 @@ port; an operator surface on a public port has to be asked for.
 | `console_session_ttl` | `43200` | Session lifetime in seconds, clamped to 60-86400. Absolute: it is not extended by use |
 | `console_secure_cookie` | `false` | Force `Secure` on the session cookies. Set it behind a TLS terminator that does not send `x-forwarded-proto` |
 | `console_api_base` | none | Absolute `https://host[:port]` origin the console should call instead of this one. Also widens `connect-src`. Anything that is not a bare origin is ignored |
+| `console_label` | none | Names this deployment in the tab title and the console header, so several open consoles are distinguishable |
+| `console_production` | `false` | Marks a deployment to be careful in. The console colours its label |
+
+### From the environment
+
+Running a release rather than writing a `sys.config`? Every key above has an
+environment variable, read at boot. A variable overrides `sys.config` only when
+it is set, so the two can coexist.
+
+| Variable | Sets |
+|----------|------|
+| `ASOBI_CONSOLE` | `console`. `1`, `true`, `yes` or `on` enable it; anything else, including a typo, leaves it off |
+| `ASOBI_OPS_SECRET_FILE` | `ops_secret`, read from a file. **Preferred** |
+| `ASOBI_OPS_SECRET` | `ops_secret`, read from the variable itself |
+| `ASOBI_CONSOLE_LABEL` | `console_label` |
+| `ASOBI_CONSOLE_PRODUCTION` | `console_production` |
+
+Prefer the file: it keeps the secret out of `docker inspect`, out of the
+process environment, and out of a compose file that tends to end up in git. A
+trailing newline is stripped, so the usual `openssl rand -hex 32 > secret`
+works. If the file is named but unreadable or empty, the console stays off and
+says so - it does **not** fall back to `ASOBI_OPS_SECRET`, because a deployment
+that mounted a secret and got the path wrong must not come up quietly using
+something else.
+
+Enabling the console without a secret leaves it off and logs an error. The node
+still starts: the game is the product and the console is an accessory, so an
+operator surface that is misconfigured must not take players offline.
+
+There is no `ASOBI_DB_PASSWORD_FILE`. The database password is substituted into
+`sys.config` before any Erlang runs, so it cannot be read from a file the way
+these can.
 
 The console does not hold `ops_secret`. It posts it once to
 `/console/session`, gets back an `HttpOnly` cookie plus a derived CSRF token,

--- a/guides/extensions.md
+++ b/guides/extensions.md
@@ -305,8 +305,8 @@ upgrade takes effect without waiting for every live match VM to end.
 | Namespace ownership | Cannot be inferred | `owns/0` |
 
 Discovery walks the OTP application graph, filtering on "exports
-`<app>_extension`". Depending on asobi is not the filter: `asobi_lua`,
-`asobi_engine` and `asobi_admin` all have asobi in their closure and none is an
+`<app>_extension`". Depending on asobi is not the filter: `asobi_engine` and
+every game that embeds asobi have it in their closure and none is an
 extension.
 
 ## Prefer a library application

--- a/guides/migrate-from-hathora.md
+++ b/guides/migrate-from-hathora.md
@@ -129,7 +129,7 @@ that to be you again.
 | `getConnectionInfo(roomId)` | WebSocket upgrade on `GET /ws` | See [§ WebSocket handshake](#websocket-handshake) — first frame must authenticate. |
 | `ping` region API | *(none)* | If you need client-side region selection, probe each deployment endpoint yourself. |
 | Hathora SDK | asobi SDKs | [asobi-unity](https://github.com/widgrensit/asobi-unity), [asobi-unreal](https://github.com/widgrensit/asobi-unreal), [asobi-js](https://github.com/widgrensit/asobi-js), [asobi-godot](https://github.com/widgrensit/asobi-godot), [asobi-defold](https://github.com/widgrensit/asobi-defold), [asobi-dart](https://github.com/widgrensit/asobi-dart), [flame_asobi](https://github.com/widgrensit/flame_asobi). |
-| Hathora Console | [asobi-admin](https://github.com/widgrensit/asobi_admin) | Tenants, games, API keys, match inspection. Pre-1.0. |
+| Hathora Console | Built-in operator console at `/console` | Match and player inspection. Tenants, games and API keys are an [asobi cloud](https://asobi.dev) concern, not a self-hosted one. |
 | `hathora.yml` | `docker-compose.yml` | Plain Compose, no proprietary spec. |
 | Process-hour billing | Flat per-container | No surprise invoices. |
 

--- a/guides/migrate-from-nakama.md
+++ b/guides/migrate-from-nakama.md
@@ -71,7 +71,7 @@ Nakama and asobi agree on most of the vocabulary:
 | **RPC endpoints** | Nova controllers (Erlang) or Lua callbacks | For per-match logic, use Lua in `match.lua`. For cross-match workflows, write a Nova controller. |
 | **Hooks (`before_authenticate`, `after_friendAdd`)** | Nova plugins + match lifecycle callbacks | Pre- and post-request middleware in Nova. |
 | **Runtime Lua / TS / Go** | Luerl Lua (for match logic), Erlang/OTP (for the engine) | One scripting language (Lua); the engine is all OTP. |
-| **Nakama Console** | [asobi_admin](https://github.com/widgrensit/asobi_admin) | Pre-1.0 admin surface. |
+| **Nakama Console** | Built-in operator console at `/console` | Ships in asobi. Set `{console, true}` and an `ops_secret`. |
 | **`sessiontoken`** | `session_token` | Same concept, returned from `/register` or `/login`. |
 | **WebSocket** | `/ws` with `session.connect` first frame | See the Hathora guide's [WebSocket handshake](migrate-from-hathora.md#websocket-handshake) section for the protocol. |
 
@@ -211,7 +211,9 @@ down the Nakama server.
   seasons and quests as extensions, but nothing as opinionated as Hiro.
 - **Go and TypeScript runtimes** as alternatives to Lua. asobi is Lua or
   Erlang — no JS/TS runtime.
-- **Nakama Console** is further along than asobi_admin today.
+- **Nakama Console** is further along than asobi's console today: asobi's ops
+  plane is read-only, so moderation still means a database write or a Lua
+  handler, not a button.
 - **Published case studies from AAA studios.** asobi is newer.
 
 If you're deeply reliant on Satori, you'll need to build the equivalent

--- a/guides/migrate-from-playfab.md
+++ b/guides/migrate-from-playfab.md
@@ -74,7 +74,7 @@ This guide walks you from "my PlayFab stack is working but brittle" to
 | **Receipt validation (IAP)** | `/api/v1/iap/apple`, `/api/v1/iap/google` | Verifies Apple App Store and Google Play receipts. |
 | **Automation rules / webhooks** | Shigoto jobs | Write the rule as an Erlang callback or Lua handler. |
 | **Insights / Analytics** | `asobi_telemetry` + your pipeline | We emit telemetry; pipe to Prometheus / Grafana / ClickHouse. No hosted analytics yet. |
-| **Game Manager (web console)** | [asobi_admin](https://github.com/widgrensit/asobi_admin) | Players, leaderboards, economy, chat. Pre-1.0. |
+| **Game Manager (web console)** | Built-in operator console at `/console` | Players, matches, leaderboards, economy, chat. Read-only today. |
 
 ## Migration path
 

--- a/guides/self-hosting.md
+++ b/guides/self-hosting.md
@@ -128,17 +128,30 @@ and writes to `/app/game/` using pattern 2. Tracked in [#TBD].
 
 ## A minimal production compose
 
+Two files sit next to it, neither of which belongs in git:
+
+```bash
+echo "ASOBI_DB_PASSWORD=$(openssl rand -hex 24)" > .env
+openssl rand -hex 32 > ops_secret.txt
+printf '.env\nops_secret.txt\n' >> .gitignore
+```
+
+`.env` is read by compose automatically and is the single source for the
+database password - Postgres and asobi both take it from there, so it cannot
+drift between them. `ops_secret.txt` is mounted as a file rather than passed as
+a variable, which keeps it out of `docker inspect` and out of the process
+environment.
+
 ```yaml
 services:
   postgres:
     image: postgres:17
     environment:
       POSTGRES_USER: asobi
-      POSTGRES_PASSWORD_FILE: /run/secrets/db_password
+      POSTGRES_PASSWORD: ${ASOBI_DB_PASSWORD:?set ASOBI_DB_PASSWORD in .env}
       POSTGRES_DB: asobi
     volumes:
       - pgdata:/var/lib/postgresql/data
-    secrets: [db_password]
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U asobi"]
       interval: 5s
@@ -155,26 +168,60 @@ services:
       ASOBI_DB_HOST: postgres
       ASOBI_DB_NAME: asobi
       ASOBI_DB_USER: asobi
-      ASOBI_DB_PASSWORD_FILE: /run/secrets/db_password
+      # Compose reads a sibling `.env` automatically, so the password lives
+      # there rather than in this file. There is no ASOBI_DB_PASSWORD_FILE:
+      # the password is substituted into sys.config before the VM starts, so
+      # unlike the ops secret below it cannot be read from a file.
+      ASOBI_DB_PASSWORD: ${ASOBI_DB_PASSWORD:?set ASOBI_DB_PASSWORD in .env}
       ASOBI_NODE_HOST: 0.0.0.0
+      # The operator console, on the game port. Drop these two lines to run
+      # without it.
+      ASOBI_CONSOLE: "true"
+      ASOBI_OPS_SECRET_FILE: /run/secrets/ops_secret
     volumes:
       - /srv/asobi/game:/app/game:ro
-    secrets: [db_password]
+    secrets: [ops_secret]
     ports:
       - "8084:8084"
     restart: unless-stopped
 
 secrets:
-  db_password:
-    file: ./db_password.txt
+  ops_secret:
+    file: ./ops_secret.txt
 
 volumes:
   pgdata:
 ```
 
 Put this behind a TLS-terminating reverse proxy (Caddy, nginx,
-Traefik) — asobi_lua speaks plain HTTP/WebSocket and expects the proxy
+Traefik) — asobi speaks plain HTTP/WebSocket and expects the proxy
 to handle certificates.
+
+### Opening the console
+
+Browse to `/console` on the same host and port your game uses, and paste the
+contents of `ops_secret.txt`. That is the whole sign-in: the secret is
+exchanged once for an `HttpOnly` cookie plus a CSRF token, and the browser
+never holds it again.
+
+You get players, matches, the matchmaker, leaderboards, economy, chat,
+tournaments, notifications, and live runtime stats — the same console the
+managed cloud uses, because it ships in asobi itself.
+
+The console is on the **game port**, so anyone who can reach your game can
+reach `/console`. Restrict it at the proxy: allowlist your own address, or
+require an extra layer in front of `/console` and `/api/v1/ops`. If it did not
+come up, the node logs why at boot — `console_disabled_without_secret` means
+the secret file was missing, unreadable or empty.
+
+Name it if you run more than one:
+
+```yaml
+      ASOBI_CONSOLE_LABEL: prod
+      ASOBI_CONSOLE_PRODUCTION: "true"
+```
+
+The label shows in the tab title, which is what tells two open consoles apart.
 
 ## Tuning knobs
 

--- a/scripts/check-archived-refs.sh
+++ b/scripts/check-archived-refs.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+# Fails if user-facing docs send a reader to a repository that is archived.
+#
+#   scripts/check-archived-refs.sh
+#
+# asobi_admin was archived on 2026-08-06 after its console moved into asobi,
+# and seven guides were still telling people to install it - including three
+# migration guides, which are the first thing someone arriving from Nakama or
+# PlayFab reads. An archived repo is read-only and stays public and indexed, so
+# nothing 404s and nothing complains; the docs are simply wrong and quietly
+# stay that way.
+#
+# Deliberately not a link checker. The links resolve fine. What is broken is
+# the advice.
+set -euo pipefail
+
+# Repositories that are archived, and what to say instead. Add a row when you
+# archive something, in the same PR.
+ARCHIVED=(
+  "asobi_admin|the operator console ships in asobi - see guides/self-hosting.md"
+)
+
+# Docs a reader follows. Deliberately excludes docs/adr/: an ADR records a
+# decision as it stood, and rewriting that history to keep a linter quiet is
+# worse than the stale name.
+PATHS=(guides README.md docs/ARCHITECTURE.md)
+
+fails=0
+for entry in "${ARCHIVED[@]}"; do
+  repo="${entry%%|*}"
+  advice="${entry#*|}"
+
+  # Links only. Naming a repository in prose - "this used to live in X" - is
+  # exactly how you explain a move, and flagging it would push writers into
+  # deleting the history rather than the bad advice.
+  hits="$(grep -rniE "github\.com/[a-z-]+/${repo}\b" "${PATHS[@]}" 2>/dev/null || true)"
+
+  if [ -n "$hits" ]; then
+    printf '\n%s is archived, but is still referenced as somewhere to go:\n\n' "$repo"
+    printf '%s\n' "$hits" | sed 's/^/  /'
+    printf '\n  Say instead: %s\n' "$advice"
+    fails=$((fails + 1))
+  fi
+done
+
+if [ "$fails" -gt 0 ]; then
+  printf '\n%d archived repository reference(s) in user-facing docs.\n' "$fails" >&2
+  exit 1
+fi
+
+echo "no user-facing docs point at an archived repository"

--- a/src/asobi_app.erl
+++ b/src/asobi_app.erl
@@ -5,6 +5,10 @@
 
 -spec start(application:start_type(), term()) -> {ok, pid()} | {error, term()}.
 start(_StartType, _StartArgs) ->
+    %% Before the router compiles: whether the console routes exist at all is
+    %% read from the `console` key, so the environment has to have been folded
+    %% in by now.
+    asobi_console_env:apply(),
     setup_telemetry(),
     asobi_error:register_handler(),
     register_lua_game_modes(),

--- a/src/console/asobi_console_env.erl
+++ b/src/console/asobi_console_env.erl
@@ -1,0 +1,134 @@
+-module(asobi_console_env).
+-moduledoc """
+Turns the console on from the environment, for deployments that run a release
+rather than write a `sys.config`.
+
+## Why this is Erlang and not `sys.config.src`
+
+relx substitutes `${VAR}` into `sys.config` before the VM starts, which is fine
+for a value that is always set and fatal for one that is not: an unset
+`${ASOBI_CONSOLE}` renders `{console, }` and the node will not boot. The
+existing keys get away with it only because the image declares `ENV` defaults
+for every one of them, and asobi itself ships no image.
+
+Reading the environment here instead means a missing variable is simply a
+missing variable, the keys stay optional, and a self-hoster who does write a
+`sys.config` is unaffected - an OS variable overrides it only when set.
+
+## Precedence
+
+`ASOBI_OPS_SECRET_FILE` beats `ASOBI_OPS_SECRET`. Reading a secret from a file
+keeps it out of `docker inspect`, out of the process environment, and out of a
+compose file that tends to end up in git, which is why Docker and Kubernetes
+both hand secrets over as files.
+
+The database password cannot work this way - it is substituted into
+`sys.config` before any of this runs - so `ASOBI_DB_PASSWORD_FILE` is not a
+thing, whatever the deployment guide used to imply.
+
+## Enabled without a secret
+
+The console stays off and says so at error level. It does not stop the node:
+the game is the product and the console is an accessory, so taking players
+offline because an operator surface is misconfigured is the wrong trade. A
+console that renders a sign-in nothing can pass is the worse failure, because
+it looks like it works.
+""".
+
+-export([apply/0]).
+
+-include_lib("kernel/include/logger.hrl").
+
+-spec apply() -> ok.
+apply() ->
+    ok = set_binary(console_label, "ASOBI_CONSOLE_LABEL"),
+    ok = set_boolean(console_production, "ASOBI_CONSOLE_PRODUCTION"),
+    ok = set_secret(),
+    ok = set_boolean(console, "ASOBI_CONSOLE"),
+    ok = resolve().
+
+%% The two keys have to agree, and only one of the four combinations is a
+%% problem: asked for, with nothing to authenticate against.
+-spec resolve() -> ok.
+resolve() ->
+    case {application:get_env(asobi, console, false), secret_configured()} of
+        {true, false} ->
+            application:set_env(asobi, console, false),
+            ?LOG_ERROR(#{
+                msg => ~"console_disabled_without_secret",
+                detail =>
+                    ~"enabled but no ops_secret is set, so nothing could sign in - set ASOBI_OPS_SECRET_FILE (preferred) or ASOBI_OPS_SECRET",
+                effect => ~"the console stays off; the node is unaffected"
+            });
+        {true, true} ->
+            ?LOG_NOTICE(#{
+                msg => ~"console_enabled",
+                path => ~"/console",
+                detail => ~"Shares the game port. Put it behind TLS and restrict who can reach it."
+            });
+        _ ->
+            ok
+    end.
+
+-spec secret_configured() -> boolean().
+secret_configured() ->
+    case application:get_env(asobi, ops_secret) of
+        {ok, S} when is_binary(S), S =/= ~"" -> true;
+        _ -> false
+    end.
+
+%% A file beats a plain variable, and an unreadable file is an error rather
+%% than a silent fallback - a deployment that mounted a secret and got the path
+%% wrong must not come up quietly using something else.
+-spec set_secret() -> ok.
+set_secret() ->
+    case os:getenv("ASOBI_OPS_SECRET_FILE") of
+        false ->
+            set_binary(ops_secret, "ASOBI_OPS_SECRET");
+        "" ->
+            set_binary(ops_secret, "ASOBI_OPS_SECRET");
+        Path ->
+            case file:read_file(Path) of
+                {ok, Contents} ->
+                    case string:trim(Contents) of
+                        ~"" ->
+                            ?LOG_ERROR(#{
+                                msg => ~"ops_secret_file_empty", path => list_to_binary(Path)
+                            });
+                        Secret ->
+                            application:set_env(asobi, ops_secret, Secret)
+                    end,
+                    ok;
+                {error, Reason} ->
+                    ?LOG_ERROR(#{
+                        msg => ~"ops_secret_file_unreadable",
+                        path => list_to_binary(Path),
+                        reason => Reason
+                    }),
+                    ok
+            end
+    end.
+
+-spec set_binary(atom(), string()) -> ok.
+set_binary(Key, Var) ->
+    case os:getenv(Var) of
+        false -> ok;
+        "" -> ok;
+        Value -> application:set_env(asobi, Key, list_to_binary(Value))
+    end.
+
+%% Only the words a person would write meaning yes. Anything else is false, so
+%% a typo closes the surface rather than opening it.
+-spec set_boolean(atom(), string()) -> ok.
+set_boolean(Key, Var) ->
+    case os:getenv(Var) of
+        false ->
+            ok;
+        "" ->
+            ok;
+        Value ->
+            application:set_env(asobi, Key, lists:member(string:lowercase(Value), truthy()))
+    end.
+
+-spec truthy() -> [string()].
+truthy() -> ["1", "true", "yes", "on"].

--- a/test/asobi_console_env_tests.erl
+++ b/test/asobi_console_env_tests.erl
@@ -1,0 +1,147 @@
+-module(asobi_console_env_tests).
+
+-include_lib("eunit/include/eunit.hrl").
+
+%% The console is off unless a deployment asked for it AND gave it something to
+%% authenticate against. Everything here is about that pair, because the shape
+%% that actually hurts is "enabled, no secret": a sign-in screen nothing can
+%% pass looks like it works.
+
+setup() ->
+    Keys = [console, ops_secret, console_label, console_production],
+    Saved = [{K, application:get_env(asobi, K)} || K <- Keys],
+    Vars = [
+        "ASOBI_CONSOLE",
+        "ASOBI_OPS_SECRET",
+        "ASOBI_OPS_SECRET_FILE",
+        "ASOBI_CONSOLE_LABEL",
+        "ASOBI_CONSOLE_PRODUCTION"
+    ],
+    [os:unsetenv(V) || V <- Vars],
+    [application:unset_env(asobi, K) || K <- Keys],
+    {Saved, Vars}.
+
+cleanup({Saved, Vars}) ->
+    [os:unsetenv(V) || V <- Vars],
+    [
+        case Prev of
+            {ok, Value} -> application:set_env(asobi, K, Value);
+            undefined -> application:unset_env(asobi, K)
+        end
+     || {K, Prev} <- Saved
+    ],
+    ok.
+
+with_env(Fun) ->
+    {setup, fun setup/0, fun cleanup/1, [Fun]}.
+
+env(Key) -> application:get_env(asobi, Key, undefined).
+
+%%--------------------------------------------------------------------
+
+an_absent_environment_changes_nothing_test_() ->
+    with_env(fun() ->
+        application:set_env(asobi, console, true),
+        application:set_env(asobi, ops_secret, ~"from-sys-config"),
+        asobi_console_env:apply(),
+        %% A self-hoster who wrote a sys.config keeps it: OS variables override
+        %% only when they are actually set.
+        ?assertEqual(true, env(console)),
+        ?assertEqual(~"from-sys-config", env(ops_secret))
+    end).
+
+enabling_without_a_secret_leaves_the_console_off_test_() ->
+    with_env(fun() ->
+        os:putenv("ASOBI_CONSOLE", "true"),
+        asobi_console_env:apply(),
+        ?assertEqual(false, env(console))
+    end).
+
+enabling_with_a_secret_turns_it_on_test_() ->
+    with_env(fun() ->
+        os:putenv("ASOBI_CONSOLE", "true"),
+        os:putenv("ASOBI_OPS_SECRET", "a-secret-long-enough-to-be-real"),
+        asobi_console_env:apply(),
+        ?assertEqual(true, env(console)),
+        ?assertEqual(~"a-secret-long-enough-to-be-real", env(ops_secret))
+    end).
+
+%% A typo must close the surface, not open it.
+only_the_words_meaning_yes_enable_it_test_() ->
+    with_env(fun() ->
+        os:putenv("ASOBI_OPS_SECRET", "s3cret"),
+        [
+            begin
+                os:putenv("ASOBI_CONSOLE", V),
+                application:unset_env(asobi, console),
+                asobi_console_env:apply(),
+                ?assertEqual(true, env(console))
+            end
+         || V <- ["1", "true", "TRUE", "yes", "on"]
+        ],
+        [
+            begin
+                os:putenv("ASOBI_CONSOLE", V),
+                application:unset_env(asobi, console),
+                asobi_console_env:apply(),
+                ?assertEqual(false, env(console))
+            end
+         || V <- ["0", "false", "no", "off", "ture", "please"]
+        ]
+    end).
+
+%% Secrets belong in files: a file keeps them out of `docker inspect`, out of
+%% the process environment, and out of a compose file that ends up in git.
+a_secret_file_beats_the_plain_variable_test_() ->
+    with_env(fun() ->
+        Path = write_temp(~"secret-from-a-file\n"),
+        os:putenv("ASOBI_OPS_SECRET", "secret-from-the-environment"),
+        os:putenv("ASOBI_OPS_SECRET_FILE", Path),
+        os:putenv("ASOBI_CONSOLE", "true"),
+        asobi_console_env:apply(),
+        %% Trailing newline stripped: every tool that writes a secret file adds
+        %% one, and a secret that fails to compare is indistinguishable from a
+        %% wrong secret.
+        ?assertEqual(~"secret-from-a-file", env(ops_secret)),
+        ?assertEqual(true, env(console)),
+        file:delete(Path)
+    end).
+
+%% A deployment that mounted a secret and got the path wrong must not come up
+%% quietly using something else.
+an_unreadable_secret_file_does_not_fall_back_test_() ->
+    with_env(fun() ->
+        os:putenv("ASOBI_OPS_SECRET", "secret-from-the-environment"),
+        os:putenv("ASOBI_OPS_SECRET_FILE", "/nonexistent/ops_secret"),
+        os:putenv("ASOBI_CONSOLE", "true"),
+        asobi_console_env:apply(),
+        ?assertEqual(undefined, env(ops_secret)),
+        ?assertEqual(false, env(console))
+    end).
+
+an_empty_secret_file_does_not_enable_the_console_test_() ->
+    with_env(fun() ->
+        Path = write_temp(~"   \n"),
+        os:putenv("ASOBI_OPS_SECRET_FILE", Path),
+        os:putenv("ASOBI_CONSOLE", "true"),
+        asobi_console_env:apply(),
+        ?assertEqual(false, env(console)),
+        file:delete(Path)
+    end).
+
+the_target_label_and_production_flag_come_from_the_environment_test_() ->
+    with_env(fun() ->
+        os:putenv("ASOBI_CONSOLE_LABEL", "prod-eu"),
+        os:putenv("ASOBI_CONSOLE_PRODUCTION", "true"),
+        asobi_console_env:apply(),
+        ?assertEqual(~"prod-eu", env(console_label)),
+        ?assertEqual(true, env(console_production))
+    end).
+
+write_temp(Contents) ->
+    Path =
+        lists:flatten(
+            io_lib:format("/tmp/asobi_ops_secret_~p_~p", [erlang:unique_integer([positive]), self()])
+        ),
+    ok = file:write_file(Path, Contents),
+    Path.


### PR DESCRIPTION
## A self-hoster could not turn the console on

`console` and `ops_secret` existed only as `sys.config` keys — **no environment variable behind either**. Anyone running the release had to fork the repo to get a console, which is exactly the tooling they were pointed at when `asobi_admin` was archived this morning.

`asobi_console_env` folds the environment in at boot:

| Variable | Sets |
|---|---|
| `ASOBI_CONSOLE` | `console` — `1`/`true`/`yes`/`on`; a typo leaves it **off** |
| `ASOBI_OPS_SECRET_FILE` | `ops_secret` from a file — **preferred** |
| `ASOBI_OPS_SECRET` | `ops_secret` from the variable |
| `ASOBI_CONSOLE_LABEL` / `ASOBI_CONSOLE_PRODUCTION` | the target markers |

**Erlang, not `sys.config.src` substitution.** An unset `${ASOBI_CONSOLE}` renders `{console, }` and the node won't boot. The existing keys survive that only because the image declares `ENV` defaults for every one of them — and asobi ships no image of its own. Reading the environment in Erlang makes a missing variable just a missing variable, and a variable overrides `sys.config` only when set, so anyone who wrote one is unaffected.

**A file beats a variable, and never falls back.** An unreadable or empty secret file leaves the console off rather than quietly using `ASOBI_OPS_SECRET` — a deployment that mounted a secret and got the path wrong must not come up on something else.

**Enabled without a secret disables the console, not the node.** A sign-in nothing can pass looks like it works, which is the worse failure; and taking players offline because an *operator* surface is misconfigured is the wrong trade.

## The documented compose gave asobi an empty database password

`guides/self-hosting.md` told self-hosters to set `ASOBI_DB_PASSWORD_FILE`. **Nothing has ever read it** — not the Dockerfile, not an entrypoint (there isn't one), not the config. The release reads `ASOBI_DB_PASSWORD`. `POSTGRES_PASSWORD_FILE` on the line above *is* real, which is why it reads plausibly and nobody caught it.

The password now comes from `.env` — single-source for Postgres and asobi so it cannot drift between them — and the guide states outright that no `ASOBI_DB_PASSWORD_FILE` exists and why (it's substituted before any Erlang runs, unlike the ops secret).

The compose now also enables the console in two lines, and there's an **Opening the console** section: where to browse, what to paste, that it's on the game port so restrict it at the proxy, and what the boot log says when it didn't come up.

## Five docs pointed at an archived repo

`README.md`, `docs/ARCHITECTURE.md`, and the Nakama, PlayFab and Hathora migration guides all sent readers to `asobi_admin` for ops tooling — the migration guides being the first thing someone arriving from a competitor reads.

`scripts/check-archived-refs.sh` now fails CI on that. **Links only**: naming a repo in prose is how you explain a move, and flagging that would push writers into deleting the history rather than the bad advice. Verified it fails on the pre-fix tree (catches all five) and passes on this one.

`docs/adr/0007` still names `asobi_admin` and is deliberately untouched — an ADR records a decision as it stood, and rewriting that to keep a linter quiet is worse than a stale name. The checker excludes `docs/adr/` for that reason.

## Tests

`asobi_console_env_tests`: absent environment changes nothing, enabled-without-secret stays off, only the words meaning yes enable it (`ture` and `please` do not), a file beats the variable, trailing newline stripped, unreadable and empty files don't fall back. Full suite **1621 EUnit** passing, dialyzer clean, `fmt --check` and `xref` clean.