### PR TITLE
feat: publish ghcr.io/widgrensit/asobi

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,12 +1,23 @@
 # The build needs rebar.config, rebar.lock, config/, include/, src/ and priv/.
-# Everything else is weight in the context, and _build is both large and
-# poisonous: host-built artefacts for a different glibc must never leak into
-# an image built on a different base.
+# Everything else is weight in the build context.
+#
+# Two of these are correctness, not size:
+#   _build/     host-built artefacts, linked against the host's glibc. Leaking
+#               them into an image on a different base is the "built last week,
+#               broken now" class of bug.
+#   _checkouts/ local dependency overrides. An image must be built from the
+#               locked deps, never from whatever someone happens to be editing.
 _build/
+_checkouts/
+.git/
+.github/
+test/
 doc/
 docs/
 guides/
 examples/
 scripts/
 console/node_modules/
-.git/
+*.md
+erl_crash.dump
+rebar3.crashdump

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,9 +1,12 @@
+# The build needs rebar.config, rebar.lock, config/, include/, src/ and priv/.
+# Everything else is weight in the context, and _build is both large and
+# poisonous: host-built artefacts for a different glibc must never leak into
+# an image built on a different base.
 _build/
-_checkouts/
-.git/
-.github/
-test/
+doc/
 docs/
-*.md
-erl_crash.dump
-rebar3.crashdump
+guides/
+examples/
+scripts/
+console/node_modules/
+.git/

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,0 +1,72 @@
+name: Docker publish
+
+# Publishes ghcr.io/widgrensit/asobi - a ready-to-run node: the game backend,
+# the Lua runtime and the operator console in one image.
+#
+# This used to be published from widgrensit/asobi_lua, back when the Lua
+# runtime was a separate application. That repo has held no source of its own
+# since the merge; its image was an alias for a release built entirely out of
+# this one. Publishing it from here removes the indirection and names the image
+# after what is actually in it.
+#
+# The old name keeps being published from asobi_lua for now so nobody's compose
+# file breaks. See docs/adr for the deprecation window.
+#
+# No staleness gate. The alias needed one because it pinned asobi by git ref and
+# could silently republish an old commit; an image built from this repo's own
+# HEAD cannot be behind itself.
+
+on:
+  push:
+    branches: [main]
+    tags: ['v*.*.*']
+  workflow_dispatch:
+
+concurrency:
+  group: docker-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Set up Buildx
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
+
+      - name: Log in to GHCR
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Compute tags and labels
+        id: meta
+        uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302 # v6.2.0
+        with:
+          images: ghcr.io/${{ github.repository }}
+          tags: |
+            type=ref,event=branch
+            type=sha,format=long
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=raw,value=latest,enable={{is_default_branch}}
+
+      - name: Build and push
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
+        with:
+          context: .
+          file: Dockerfile
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          provenance: false

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,75 @@
+FROM erlang:29.0.4-slim AS builder
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    git ca-certificates curl && \
+    rm -rf /var/lib/apt/lists/*
+
+WORKDIR /build
+
+# Install rebar3
+RUN curl -fsSL https://github.com/erlang/rebar3/releases/download/3.27.0/rebar3 -o /usr/local/bin/rebar3 && \
+    chmod +x /usr/local/bin/rebar3
+
+# Copy dependency specs first for layer caching
+COPY rebar.config rebar.lock ./
+RUN rebar3 compile --deps_only
+
+# Build the release.
+COPY config/ config/
+COPY include/ include/
+COPY src/ src/
+COPY priv/ priv/
+RUN rebar3 as prod release
+
+# --- Runtime ---
+# Must match the builder's Debian release (erlang:28.4.2-slim is trixie-based)
+# so the linked-against GLIBC matches at runtime.
+FROM debian:trixie-slim
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    libncurses6 libssl3 libtinfo6 ca-certificates tini && \
+    rm -rf /var/lib/apt/lists/*
+
+RUN groupadd -r asobi && useradd -r -g asobi -d /app asobi
+
+WORKDIR /app
+COPY --from=builder /build/_build/prod/rel/asobi/ ./
+
+# Game scripts mount point
+RUN mkdir -p /app/game && chown -R asobi:asobi /app
+VOLUME ["/app/game"]
+
+USER asobi
+EXPOSE 8084
+
+ENV ASOBI_PORT=8084 \
+    ASOBI_NODE_HOST=127.0.0.1 \
+    ASOBI_DB_HOST=db \
+    ASOBI_DB_NAME=asobi \
+    ASOBI_DB_USER=postgres \
+    ASOBI_DB_PASSWORD=postgres
+
+# Anonymous guest auth (POST /api/v1/auth/guest) is off by default. The game
+# opts in with `guest_auth = true` in its Lua; the operator only supplies the
+# secret pepper (ADR 0004). Guest auth is on iff both are set. Use a base64/hex
+# pepper from >= 32 random bytes (NOT raw /dev/urandom bytes, whose quotes/
+# newlines would break the rendered config):  openssl rand -base64 48
+# A pepper under 32 bytes is treated as unconfigured, so guest auth fails closed.
+# The rendered sys.config holds the pepper in cleartext - treat it as
+# secret-bearing (the release already sets a small crash-dump policy).
+ENV ASOBI_GUEST_VERIFIER_PEPPER=""
+
+# Erlang term fragment spliced into kura's socket_options list.
+# Default forces IPv4; set to "inet6" for IPv6-only Postgres networks.
+ENV ASOBI_DB_SOCKET_OPTS=inet
+
+# vm.args has `-setcookie ${ERLANG_COOKIE}`. Left unset, relx renders an
+# EMPTY value and erlexec silently consumes the next flag (+pc) as the
+# cookie, so `+pc unicode` never applies and bin/asobi rpc/remote
+# can't attach. Distribution stays container-internal (-sname, no epmd
+# port exposed), so a static default is fine; override per deploy if you
+# expose distribution.
+ENV ERLANG_COOKIE=asobi
+
+ENTRYPOINT ["tini", "--"]
+CMD ["bin/asobi", "foreground"]


### PR DESCRIPTION
## The image is named after a component that no longer exists separately

`ghcr.io/widgrensit/asobi_lua` is published from a repo that has held **no source** since the Lua runtime merged into asobi. Its own Dockerfile says so:

```
# Build the release. There is no local src/ - asobi_lua is an alias image whose
# only application is the asobi dependency (widgrensit/asobi#339).
```

The image content is 100% asobi. The name is an artifact of a layout that no longer exists, and it names the whole node after one part of it.

This publishes `ghcr.io/widgrensit/asobi` from here: game backend, Lua runtime and operator console in one image, named after what is in it.

The staleness gate does not come across. The alias needed one because it pinned asobi by git ref and could silently republish an old commit; an image built from this repo's own HEAD cannot be behind itself.

## Verified by building and running, not by reading

- **The first port failed.** `undefined macro 'MAX_BOT_FILL'` — `include/` wasn't copied. Only a real build catches that.
- `bin/asobi` and `luerl-1.5.1` are both in the release.
- `ASOBI_CONSOLE=true` with no secret logs `console_disabled_without_secret` and the node carries on.
- `ASOBI_OPS_SECRET_FILE` mounted as a file logs `console_enabled`.

That last pair exercises the env plumbing from #394 end to end in a real image, which is how a self-hoster will actually meet it.

## .dockerignore

I overwrote the existing file instead of extending it, dropping `_checkouts/`, `.github/`, `test/`, `*.md` and the crashdumps; the second commit restores them. `_checkouts/` is the one that matters — it holds local dependency overrides, and an image must be built from the locked deps, not from whatever someone is editing.

## Follow-ups, not in this PR

`asobi_lua` keeps publishing the old name so no compose file breaks today. Retiring it is a separate decision with a deprecation window, and it is the last thing blocking that repo from being archived.

Docs still say `ghcr.io/widgrensit/asobi_lua` throughout — that's the Tier 3 sweep, which I'll run against this once merged.