### PR TITLE
docs: rewrite the guides for Lua-in-core, extensions and the operator console

### DIFF
--- a/.github/workflows/docs-drift.yml
+++ b/.github/workflows/docs-drift.yml
@@ -21,6 +21,8 @@ on:
       - 'guides/**'
       - 'README.md'
       - 'docs/ARCHITECTURE.md'
+      - 'examples/**'
+      - 'CONTRIBUTING.md'
       - '.github/workflows/docs-drift.yml'
   pull_request:
     branches: [main]
@@ -33,6 +35,8 @@ on:
       - 'guides/**'
       - 'README.md'
       - 'docs/ARCHITECTURE.md'
+      - 'examples/**'
+      - 'CONTRIBUTING.md'
       - '.github/workflows/docs-drift.yml'
 
 concurrency:

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@
 </p>
 
 <p align="center">
-  <img src="docs/media/hotreload-demo.gif" alt="asobi hot-reload: edit a Lua file, save, live match updates — no restart" width="800">
+  <img src="docs/media/hotreload-demo.gif" alt="asobi hot-reload: edit a Lua file, save, the live match updates without a restart" width="800">
   <br>
   <em>Edit a Lua file. Save. Live match updates. No restart. <a href="examples/hotreload-demo/">Try it.</a></em>
 </p>
@@ -40,7 +40,7 @@ Godot, Defold, LÖVE, Phaser, or Flame+Flutter, asobi ships the backend
 pieces you'd otherwise rebuild from scratch: matches, matchmaker, chat,
 leaderboards, economy, voting, phases, worlds, presence, inventory.
 
-Not the right fit for twitch-latency AAA shooters — WebSocket/TCP has a
+Not the right fit for twitch-latency AAA shooters - WebSocket/TCP has a
 floor around 4ms. Great for turn-based, casual, MMO zone, roguelike,
 co-op, party, and social games.
 
@@ -51,38 +51,46 @@ git clone https://github.com/widgrensit/asobi
 cd asobi/examples/hotreload-demo && docker compose up
 ```
 
-Open <http://localhost:3000>, then edit `lua/match.lua` and save — the
-running match updates live. No restart, no reconnect, no kicked players.
+Open <http://localhost:3000>, then edit `lua/match.lua` and save. The
+running match picks the new code up on its next tick. No restart, no
+reconnect, no kicked players.
 
-## Two ways to use asobi
+## One product, two front doors
 
-**Write your game in Lua** — use the [**asobi_lua**](https://github.com/widgrensit/asobi_lua)
-Docker runtime. One container, hot-reloadable Lua match scripts, batteries
-included. No Erlang required. **This is what most people want.**
+asobi is a single Erlang/OTP node holding the game backend, the Lua
+runtime, and the operator console. Pick the surface you want to write
+against; it is the same node either way.
 
-**Write your game in Erlang** — depend on this library directly. You get the
-same match supervisor, matchmaker, leaderboards, economy, world server, and
-voting primitives, implemented as OTP behaviours you compose with the rest of
-your release.
+**Write your game in Lua.** Run `ghcr.io/widgrensit/asobi` and mount a
+directory of Lua scripts over `/app/game`. This is the default path and
+what most people want.
+
+**Write your game in Erlang.** Depend on the Hex package and implement
+the `asobi_match` behaviour. Same match supervisor, matchmaker,
+leaderboards, economy, world server, and voting primitives, composed into
+your own release.
 
 ```erlang
 %% rebar.config
 {deps, [
-    {asobi, "~> 0.1"}
+    {asobi, "~> 0.68"}
 ]}.
 ```
 
+[Getting started](guides/getting-started.md) covers both.
+
 ## Features
 
-- **`asobi_match`** — behaviour for per-match logic, backed by a supervised `gen_server` with ETS state backup on crash.
-- **`asobi_matchmaker`** — pluggable strategies (`fill`, `skill_based`); your own via the `asobi_matchmaker_strategy` behaviour.
-- **`asobi_world_server`** — persistent worlds with lazy zones, spatial grid indexing, terrain chunk serving, adaptive tick rates.
-- **`asobi_vote_server`** — plurality, ranked choice, approval, weighted. Fixed / ready-up / hybrid / adaptive windows. Spectator voting, veto tokens, majority-tyranny mitigations.
-- **`asobi_phase`, `asobi_timer`** — phase engine, five timer primitives. Seasons moved out to [`asobi_seasons`](https://github.com/widgrensit/asobi_seasons), an extension.
-- **Auth** — email/password, Google / Apple / Steam sign-in, and **guest (anonymous) play** with device-based create-or-resume and upgrade-to-account (game-declared, operator-peppered).
+- **`asobi_match`** - behaviour for per-match logic, backed by a supervised `gen_server` with ETS state backup on crash.
+- **`asobi_matchmaker`** - pluggable strategies (`fill`, `skill_based`); your own via the `asobi_matchmaker_strategy` behaviour.
+- **`asobi_world_server`** - zoned worlds with lazy zone loading, spatial grid indexing, terrain chunk serving, and cold-zone tick throttling.
+- **`asobi_vote_server`** - plurality, ranked choice, approval, weighted. Fixed / ready-up / hybrid / adaptive windows. Spectator voting, veto tokens, majority-tyranny mitigations.
+- **`asobi_phase`, `asobi_timer`** - phase engine, plus `countdown` / `conditional` / `cycle` / `scheduled` timer primitives. Seasons moved out to [`asobi_seasons`](https://github.com/widgrensit/asobi_seasons), an extension.
+- **Auth** - email/password, Google / Apple / Steam sign-in, and **guest (anonymous) play** with device-based create-or-resume and upgrade-to-account (game-declared, operator-peppered).
 - **Rate limiting** via `seki` (sliding window, per route group), **sessions** cached in ETS, **presence** via `pg`, **chat / social / economy / inventory / storage / tournaments / notifications** as Nova controllers.
-- **Client SDKs** for Godot, Defold, Unity, Unreal, JS/TS, Dart, Flame — [see below](#client-sdks).
-- **Operator console** — a browser UI over the ops read plane: players, matches, matchmaker queue, leaderboards, economy, chat, tournaments, notifications. Served by the node itself at `/console`, off until you turn it on.
+- **Extensions** - game-specific methods, callable as an `rpc.call` WebSocket frame and over `/api/v1/ops/ext/:extension/:action`. See [Extensions](guides/extensions.md).
+- **Client SDKs** for Godot, Defold, Unity, Unreal, JS/TS, Dart, Flame - [see below](#client-sdks).
+- **Operator console** - a browser UI over the ops plane, read-only today: players, matches, matchmaker queue, leaderboards, economy, chat, tournaments, notifications. Served by the node itself at `/console`, off until you turn it on.
 
 ## Benchmarks
 
@@ -92,10 +100,10 @@ Single node, 8 cores, same-machine client. See [guides/benchmarks.md](guides/ben
 |---|---|
 | WebSocket throughput | **83,000 msg/sec** @ 3,500 concurrent connections |
 | RTT p50 / p99 | 4.4 ms / 6.5 ms |
-| REST reads (matches / friends / wallets) | 7–14 ms p50 |
+| REST reads (matches / friends / wallets) | 7-14 ms p50 |
 | Memory per connection | ~15 KB |
 
-Not a twitch-FPS backend — WebSocket/TCP has a latency floor. Excellent for
+Not a twitch-FPS backend; WebSocket/TCP has a latency floor. Excellent for
 turn-based, casual, MMO zone, roguelike, co-op, and party games. Pair with a
 UDP relay if you need sub-3ms physics.
 
@@ -105,71 +113,76 @@ UDP relay if you need sub-3ms physics.
 |---|---|---|---|
 | **Godot 4.x** (GDScript) | [asobi-godot](https://github.com/widgrensit/asobi-godot) | [Guide](https://asobi.dev/godot) | [Demo](https://github.com/widgrensit/asobi-godot-demo) |
 | **Defold** (Lua) | [asobi-defold](https://github.com/widgrensit/asobi-defold) | [Guide](https://asobi.dev/defold) | [Demo](https://github.com/widgrensit/asobi-defold-demo) |
-| **LÖVE** (Lua) | [asobi-love2d](https://github.com/widgrensit/asobi-love2d) | — | _demo planned_ |
-| **Phaser** (TypeScript) | [asobi-js](https://github.com/widgrensit/asobi-js) (browser) | — | _example planned — [#103](https://github.com/widgrensit/asobi/issues/103)_ |
+| **LÖVE** (Lua) | [asobi-love2d](https://github.com/widgrensit/asobi-love2d) | - | _demo planned_ |
+| **Phaser** (TypeScript) | [asobi-js](https://github.com/widgrensit/asobi-js) (browser) | - | _example planned, [#103](https://github.com/widgrensit/asobi/issues/103)_ |
 | **Unity 2021.3+** (C#) | [asobi-unity](https://github.com/widgrensit/asobi-unity) | [Guide](https://asobi.dev/unity) | [Demo](https://github.com/widgrensit/asobi-unity-demo) |
-| **Unreal Engine 5** (C++) | [asobi-unreal](https://github.com/widgrensit/asobi-unreal) | — | — |
-| **TypeScript / JS** (Browser + Node) | [asobi-js](https://github.com/widgrensit/asobi-js) | — | — |
-| **Dart / Flutter** | [asobi-dart](https://github.com/widgrensit/asobi-dart) | [Guide](https://asobi.dev/dart) | — |
-| **Flame** (Flutter) | [flame_asobi](https://github.com/widgrensit/flame_asobi) | — | [Demo](https://github.com/widgrensit/asobi-flame-demo) |
+| **Unreal Engine 5** (C++) | [asobi-unreal](https://github.com/widgrensit/asobi-unreal) | - | - |
+| **TypeScript / JS** (Browser + Node) | [asobi-js](https://github.com/widgrensit/asobi-js) | - | - |
+| **Dart / Flutter** | [asobi-dart](https://github.com/widgrensit/asobi-dart) | [Guide](https://asobi.dev/dart) | - |
+| **Flame** (Flutter) | [flame_asobi](https://github.com/widgrensit/flame_asobi) | - | [Demo](https://github.com/widgrensit/asobi-flame-demo) |
 
 ## Documentation
 
-- [**Glossary**](guides/glossary.md) — asobi vs asobi_lua vs asobi.dev Cloud. Start here if the names blur.
-- [**Getting started**](guides/getting-started.md) — stand up a local asobi node from Erlang
-- [**Architecture**](guides/architecture.md) — supervision tree, modules, design
+- [**Glossary**](guides/glossary.md) - the self-hosted node vs asobi.dev Cloud. Start here if the names blur.
+- [**Getting started**](guides/getting-started.md) - stand up a local node, in Lua or in Erlang
+- [**Self-hosting**](guides/self-hosting.md) - requirements, production compose, operating notes
+- [**Architecture**](guides/architecture.md) - supervision tree, modules, design
 - [**REST API**](guides/rest-api.md) · [**WebSocket protocol**](guides/websocket-protocol.md)
-- [**Matchmaking**](guides/matchmaking.md) · [**Voting**](guides/voting.md) · [**World server**](guides/world-server.md) · [**Large worlds**](guides/large-worlds.md)
+- [**Matchmaking**](guides/matchmaking.md) · [**Lobbies**](guides/lobbies.md) · [**Voting**](guides/voting.md) · [**Phases**](guides/phases.md)
+- [**World server**](guides/world-server.md) · [**Large worlds**](guides/large-worlds.md)
 - [**Economy**](guides/economy.md) · [**Authentication**](guides/authentication.md) · [**IAP**](guides/iap.md)
-- [**Lua scripting**](guides/lua-scripting.md) · [**Lua bots**](guides/lua-bots.md)
-- [**Configuration**](guides/configuration.md) · [**Operator console**](console/README.md) · [**Clustering**](guides/clustering.md) · [**Performance tuning**](guides/performance-tuning.md)
+- [**Lua scripting**](guides/lua-scripting.md) · [**Lua API reference**](guides/lua-api.md) · [**Lua bots**](guides/lua-bots.md)
+- [**Extensions**](guides/extensions.md) - add your own RPC methods and ops actions
+- [**Configuration**](guides/configuration.md) · [**Operator console**](guides/console.md) · [**Clustering**](guides/clustering.md) · [**Performance tuning**](guides/performance-tuning.md)
 - [**Benchmarks**](guides/benchmarks.md) · [**Comparison vs Nakama / Colyseus / SpacetimeDB**](guides/comparison.md)
-- [**HexDocs**](https://hexdocs.pm/asobi) — full API reference
+- [**HexDocs**](https://hexdocs.pm/asobi) - full API reference
 
 ## Migrating?
 
-- [**from Hathora**](guides/migrate-from-hathora.md) — Hathora shuts down 2026-05-05.
+- [**from Hathora**](guides/migrate-from-hathora.md) - Hathora shuts down 2026-05-05.
 - [**from PlayFab**](guides/migrate-from-playfab.md)
 - [**from Nakama self-host**](guides/migrate-from-nakama.md)
 
 ## Related projects
 
-- Lua scripting and the operator console ship in asobi itself — see [Self-hosting](guides/self-hosting.md)
-- Docker image: `ghcr.io/widgrensit/asobi_lua`
+- Lua scripting and the operator console ship in asobi itself - see [Self-hosting](guides/self-hosting.md)
+- Docker image: `ghcr.io/widgrensit/asobi`, release binary `bin/asobi`
 - Client SDKs: [asobi-godot](https://github.com/widgrensit/asobi-godot) · [asobi-defold](https://github.com/widgrensit/asobi-defold) · [asobi-love2d](https://github.com/widgrensit/asobi-love2d) · [asobi-unity](https://github.com/widgrensit/asobi-unity) · [asobi-unreal](https://github.com/widgrensit/asobi-unreal) · [asobi-js](https://github.com/widgrensit/asobi-js) · [asobi-dart](https://github.com/widgrensit/asobi-dart) · [flame_asobi](https://github.com/widgrensit/flame_asobi)
 
 ## Stability
 
-> [!NOTE]
-> asobi is pre-1.0. The API is stabilising; expect minor breaking changes
-> until 1.0. We will never relicense — see [guides/exit.md](guides/exit.md)
-> for the "if asobi disappears tomorrow" runbook.
+asobi is pre-1.0. The API is stabilising; expect minor breaking changes
+until 1.0. We will never relicense - see [guides/exit.md](guides/exit.md)
+for the "if asobi disappears tomorrow" runbook.
 
 ## Run it yourself, or use the cloud
 
 asobi is Apache-2 and self-hostable. One Docker container runs the full
-stack — see [`docker-compose.example.yml`](docker-compose.example.yml) for
+stack; see [`docker-compose.example.yml`](docker-compose.example.yml) for
 a production-shaped setup with Postgres.
 
 Don't want to operate it? [**asobi.dev/cloud**](https://asobi.dev/cloud)
-is the managed version — €9/mo Indie tier, EU-sovereign, same open-source
-core. If we ever pivot, you still have the code — see
-[guides/exit.md](guides/exit.md).
+is the managed version, EU-sovereign, same open-source core. If we ever
+pivot, you still have the code - see [guides/exit.md](guides/exit.md).
 
 ## FAQ
 
 **Does asobi replace Nakama / Colyseus / PlayFab?**
 For the indie-2D multiplayer slot, yes. For AAA shooters needing
-per-match dedicated UDP servers, no — pair asobi with a UDP relay.
+per-match dedicated UDP servers, no; pair asobi with a UDP relay.
 
 **Can I write my game logic in something other than Lua?**
 Yes. Depend on asobi as an Erlang library and write match code in Erlang,
 or call the REST/WebSocket API from any language. Lua is the easy mode.
 
 **Does it scale across machines?**
-asobi is single-node by design — one BEAM node handles tens of thousands
-of connections. Shard at the app level (game-per-node, region-per-node),
-don't try to cluster a single match across hosts.
+asobi is single-node by design, and several subsystems are node-local:
+the matchmaker queue and its tickets, rate-limit buckets, and console
+sessions all live in the node that served the request, so players queuing
+against different nodes never match each other. Matches and worlds do not
+migrate. Shard at the app level (game-per-node, region-per-node) rather
+than clustering a single match across hosts. The full list of what is
+per-node is in [Clustering](guides/clustering.md).
 
 **What happens if asobi disappears?**
 Apache-2, single-binary deploy, Postgres backing store. Nothing in your

--- a/docker-compose.example.yml
+++ b/docker-compose.example.yml
@@ -1,4 +1,4 @@
-## Example docker-compose for running Asobi with Lua game scripts.
+## Example docker-compose for running asobi with Lua game scripts.
 ## Copy this file to your project and customize.
 ##
 ##   cp docker-compose.example.yml docker-compose.yml
@@ -8,7 +8,7 @@
 
 services:
   asobi:
-    image: ghcr.io/widgrensit/asobi_lua:latest
+    image: ghcr.io/widgrensit/asobi:latest
     ports:
       - "8084:8084"
     volumes:

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,14 +1,14 @@
 # Architecture
 
-This document describes Asobi's internal architecture, supervision trees,
-data model, and protocol design.
+An internal design note. It is not published to HexDocs and it is not the API
+reference.
 
-> This is an internal design document. It is not published to HexDocs and is not
-> the API reference. For the canonical, maintained references see the
-> [Architecture guide](../guides/architecture.md) (supervision, lifecycles,
-> deployment models), the [REST API guide](../guides/rest-api.md) (every HTTP
-> endpoint and status code), and the
-> [WebSocket protocol guide](../guides/websocket-protocol.md) (the message catalogue).
+The maintained references are the [Architecture guide](../guides/architecture.md)
+(what a node is, the supervision tree, lifecycles, per-subsystem detail), the
+[REST API guide](../guides/rest-api.md) (every HTTP endpoint and status code),
+the [WebSocket protocol guide](../guides/websocket-protocol.md) (the message
+catalogue) and [Clustering](../guides/clustering.md) (what is and is not
+cluster-safe). Where this file and a guide disagree, the guide wins.
 
 ## Stack
 
@@ -16,347 +16,167 @@ data model, and protocol design.
 |-------|-----------|
 | HTTP / REST | Nova (Cowboy) |
 | WebSocket | Nova WebSocket (Cowboy) |
-| Database / ORM | Kura (PostgreSQL via pgo) |
-| Authentication | nova_auth |
-| Background Jobs | Shigoto |
-| Pub/Sub / Presence | `pg` module + Nova PubSub |
-| Telemetry | OpenTelemetry (opentelemetry_kura) |
+| Database | Kura with `kura_backend_postgres`, over pgo |
+| Authentication | nova_auth, nova_auth_oidc |
+| Rate limiting / resilience | seki, nova_resilience |
+| Lua runtime | Luerl |
+| Background jobs | Shigoto |
+| Pub/sub and presence | `pg` plus Nova PubSub |
+| Telemetry | plain `telemetry` events |
 | JSON | OTP `json` module |
 
-## Architecture Overview
+Telemetry is `telemetry:execute/3` and nothing else. asobi attaches no
+exporter, depends on no OpenTelemetry package, and holds the event surface in
+one list in `asobi_telemetry:events/0`, asserted against the module's own
+`execute` calls by `asobi_telemetry_tests`. Consumers - an OpenTelemetry
+bridge, a Prometheus scraper, your own handler - attach out of tree. See
+`docs/adr/0005-telemetry-event-surface.md`.
+
+## Overview
 
 ```
 ┌─────────────────────────────────────────────────────────┐
-│                    Mobile Game Clients                    │
-│              (Unity, Unreal, Godot, Native)              │
+│                     Game clients                        │
+│    (Godot, Defold, LÖVE, Unity, Unreal, JS, Dart)       │
 └────────────┬──────────────────────┬─────────────────────┘
              │ REST (JSON)          │ WebSocket (JSON)
              ▼                      ▼
 ┌────────────────────────────────────────────────────────┐
-│                      Nova Router                        │
-│  ┌──────────────┐  ┌──────────────┐  ┌──────────────┐ │
-│  │ REST API     │  │ WebSocket    │  │ Admin        │ │
-│  │ Controllers  │  │ Handler      │  │ (ext. repo)  │ │
-│  └──────┬───────┘  └──────┬───────┘  └──────┬───────┘ │
+│                      Nova router                       │
+│  ┌──────────────┐  ┌──────────────┐  ┌──────────────┐  │
+│  │ REST         │  │ WebSocket    │  │ Console +    │  │
+│  │ controllers  │  │ handler      │  │ ops plane    │  │
+│  └──────┬───────┘  └──────┬───────┘  └──────┬───────┘  │
 └─────────┼─────────────────┼─────────────────┼──────────┘
-          │                 │                 │
           ▼                 ▼                 ▼
 ┌────────────────────────────────────────────────────────┐
-│                   Asobi Core Services                   │
-│                                                         │
-│  ┌─────────┐ ┌──────────┐ ┌────────┐ ┌─────────────┐  │
-│  │ Players │ │ Matches  │ │ Social │ │ Economy     │  │
-│  │         │ │          │ │        │ │             │  │
-│  │ Session │ │ Match    │ │ Chat   │ │ Wallet      │  │
-│  │ Profile │ │ Maker    │ │ Groups │ │ Inventory   │  │
-│  │ Stats   │ │ Boards   │ │ Friends│ │ Store       │  │
-│  └────┬────┘ └────┬─────┘ └───┬────┘ └──────┬──────┘  │
-│       │           │           │              │          │
-│       ▼           ▼           ▼              ▼          │
-│  ┌──────────────────────────────────────────────────┐   │
-│  │           pg (Pub/Sub + Presence)                │   │
-│  │           ETS (Hot State + Leaderboards)         │   │
-│  │           Shigoto (Background Jobs)              │   │
-│  └──────────────────────────────────────────────────┘   │
-└─────────────────────────┬───────────────────────────────┘
-                          │
+│                     Core services                      │
+│                                                        │
+│  ┌─────────┐ ┌──────────┐ ┌────────┐ ┌─────────────┐   │
+│  │ Players │ │ Matches  │ │ Social │ │ Economy     │   │
+│  │ Session │ │ Worlds   │ │ Chat   │ │ Wallet      │   │
+│  │ Profile │ │ Maker    │ │ Groups │ │ Inventory   │   │
+│  │ Stats   │ │ Boards   │ │ Friends│ │ Store       │   │
+│  └────┬────┘ └────┬─────┘ └───┬────┘ └──────┬──────┘   │
+│       ▼           ▼           ▼             ▼          │
+│  ┌──────────────────────────────────────────────────┐  │
+│  │  pg (pub/sub + presence)                         │  │
+│  │  ETS (match backup, boards, caches, registries)  │  │
+│  │  Luerl (game scripts)                            │  │
+│  │  Shigoto (the broadcast fanout queue)            │  │
+│  └──────────────────────────────────────────────────┘  │
+└─────────────────────────┬──────────────────────────────┘
                           ▼
               ┌───────────────────────┐
               │   PostgreSQL (Kura)   │
               └───────────────────────┘
 ```
 
-## Supervision Tree
+The console and the ops plane are part of this node, not a second deployment.
 
-```
-asobi_sup (one_for_one)
-├── asobi_repo                          # Kura repo worker (pgo pool)
-├── asobi_registry                      # global process registry (via pg)
-├── asobi_presence                      # gen_server — online status via pg
-│
-├── asobi_player_sup (simple_one_for_one)
-│   └── asobi_player_session            # gen_server per connected player
-│
-├── asobi_match_sup (one_for_one)
-│   ├── asobi_matchmaker                # gen_server — periodic tick via Shigoto
-│   └── asobi_match_runner_sup (simple_one_for_one)
-│       └── asobi_match_server          # gen_statem per active match
-│
-├── asobi_leaderboard_sup (simple_one_for_one)
-│   └── asobi_leaderboard_server        # gen_server per leaderboard (ETS-backed)
-│
-├── asobi_chat_sup (simple_one_for_one)
-│   └── asobi_chat_channel              # gen_server per active channel
-│
-└── asobi_tournament_sup (simple_one_for_one)
-    └── asobi_tournament_server         # gen_server per active tournament
-```
+## Supervision tree
 
-### Key Design Decisions
+Regenerated from `src/asobi_sup.erl` in the
+[Architecture guide](../guides/architecture.md#supervision-tree), including the
+boot order the merge made load-bearing. It is not duplicated here; two copies
+is how the last one drifted.
 
-- **simple_one_for_one** for dynamic processes (players, matches, channels) — efficient for thousands of children
-- **one_for_one** at the top level — services are independent, one crash doesn't take down others
-- **gen_statem for matches** — match lifecycle is inherently a state machine (waiting → running → paused → finished)
-- **gen_server for everything else** — player sessions, leaderboards, chat channels are simpler request/response
+Design decisions worth stating once:
 
-## Data Model (Kura Schemas)
+- `simple_one_for_one` for dynamic children - sessions, matches, world
+  instances, boards, chat channels, votes, tournaments.
+- `one_for_one` at the top: services are independent and one crash does not
+  take the others down.
+- `gen_statem` for matches, because a match is a state machine.
+- `one_for_all` inside a world instance, because its zone supervisor, zone
+  manager, ticker and world server are meaningless without each other.
 
-### Players
+## Data model
 
-```
-┌─────────────────────┐     ┌──────────────────────────┐
-│ asobi_player        │     │ asobi_player_auth        │
-├─────────────────────┤     ├──────────────────────────┤
-│ id         uuid PK  │◄────│ player_id  uuid FK       │
-│ username   string   │     │ id         uuid PK       │
-│ display_name string │     │ provider   enum          │
-│ avatar_url string   │     │ provider_id string       │
-│ metadata   jsonb    │     │ credentials_hash string  │
-│ banned_at  datetime │     │ inserted_at datetime     │
-│ inserted_at datetime│     │ updated_at  datetime     │
-│ updated_at datetime │     └──────────────────────────┘
-└─────────────────────┘
-         │
-         │ has_one
-         ▼
-┌─────────────────────┐
-│ asobi_player_stats  │
-├─────────────────────┤
-│ player_id  uuid FK  │
-│ games_played integer│
-│ wins       integer  │
-│ losses     integer  │
-│ rating     float    │
-│ rating_dev float    │
-│ metadata   jsonb    │
-│ updated_at datetime │
-└─────────────────────┘
-```
+23 Kura schemas. Each module carries its own `table/0` and `fields/0`; read
+those rather than a diagram, which is what went stale here before.
 
-### Economy
+| Area | Schema module | Table |
+|---|---|---|
+| Players | `asobi_player` | `players` |
+| | `asobi_player_stats` | `player_stats` |
+| | `asobi_player_identity` | `player_identities` |
+| | `asobi_player_token` | `player_tokens` |
+| Matches | `asobi_match_record` | `match_records` |
+| | `asobi_vote` | `votes` |
+| Worlds | `asobi_zone_snapshot` | `zone_snapshots` |
+| Leaderboards | `asobi_leaderboard_entry` | `leaderboard_entries` |
+| Tournaments | `asobi_tournament` | `tournaments` |
+| Economy | `asobi_wallet` | `wallets` |
+| | `asobi_transaction` | `transactions` |
+| | `asobi_item_def` | `item_defs` |
+| | `asobi_player_item` | `player_items` |
+| | `asobi_store_listing` | `store_listings` |
+| | `asobi_iap_transaction` | `iap_transactions` |
+| Social | `asobi_friendship` | `friendships` |
+| | `asobi_group` | `groups` |
+| | `asobi_group_member` | `group_members` |
+| | `asobi_chat_message` | `chat_messages` |
+| | `asobi_notification` | `notifications` |
+| Storage | `asobi_cloud_save` | `cloud_saves` |
+| | `asobi_storage` | `storage` |
+| Ops | `asobi_ops_audit_entry` | `ops_audit_entries` |
 
-```
-┌─────────────────────┐     ┌──────────────────────────┐
-│ asobi_wallet        │     │ asobi_transaction        │
-├─────────────────────┤     ├──────────────────────────┤
-│ id         uuid PK  │     │ id           uuid PK     │
-│ player_id  uuid FK  │     │ wallet_id    uuid FK     │
-│ currency   enum     │     │ amount       integer     │
-│ balance    integer  │     │ balance_after integer    │
-│ inserted_at datetime│     │ reason       enum        │
-│ updated_at datetime │     │ reference_type string    │
-└─────────────────────┘     │ reference_id   string    │
-                            │ metadata     jsonb       │
-                            │ inserted_at  datetime    │
-                            └──────────────────────────┘
+Enum-looking columns (`provider`, `currency`, `reason`, `category`, `rarity`,
+`status`, `channel_type`, read and write permissions) are `string` in Kura, not
+PostgreSQL enums. Validation is in the changeset, not the column type.
 
-┌─────────────────────┐     ┌──────────────────────────┐
-│ asobi_item_def      │     │ asobi_player_item        │
-├─────────────────────┤     ├──────────────────────────┤
-│ id         uuid PK  │     │ id           uuid PK     │
-│ slug       string   │◄────│ item_def_id  uuid FK     │
-│ name       string   │     │ player_id    uuid FK     │
-│ category   enum     │     │ quantity     integer     │
-│ rarity     enum     │     │ metadata     jsonb       │
-│ stackable  boolean  │     │ acquired_at  datetime    │
-│ metadata   jsonb    │     │ updated_at   datetime    │
-│ inserted_at datetime│     └──────────────────────────┘
-└─────────────────────┘
+## Process architecture
 
-┌─────────────────────┐
-│ asobi_store_listing │
-├─────────────────────┤
-│ id         uuid PK  │
-│ item_def_id uuid FK │
-│ currency   enum     │
-│ price      integer  │
-│ active     boolean  │
-│ valid_from datetime │
-│ valid_until datetime│
-│ metadata   jsonb    │
-└─────────────────────┘
-```
+### Player session (`asobi_player_session`, gen_server)
 
-### Social
+One process per connection. It holds the authenticated `player_id`, monitors
+the WebSocket process, tracks the player's current match, world, zone and chat
+channels, and routes to them.
 
-```
-┌─────────────────────┐     ┌──────────────────────────┐
-│ asobi_friendship    │     │ asobi_group              │
-├─────────────────────┤     ├──────────────────────────┤
-│ id         uuid PK  │     │ id           uuid PK     │
-│ player_id  uuid FK  │     │ name         string      │
-│ friend_id  uuid FK  │     │ description  string      │
-│ status     enum     │     │ max_members  integer     │
-│ inserted_at datetime│     │ open         boolean     │
-│ updated_at datetime │     │ metadata     jsonb       │
-└─────────────────────┘     │ creator_id   uuid FK     │
- (pending/accepted/blocked) │ inserted_at  datetime    │
-                            │ updated_at   datetime    │
-                            └──────────────────────────┘
-                                       │
-                            ┌──────────┴───────────────┐
-                            │ asobi_group_member       │
-                            ├──────────────────────────┤
-                            │ group_id   uuid FK       │
-                            │ player_id  uuid FK       │
-                            │ role       enum          │
-                            │ joined_at  datetime      │
-                            └──────────────────────────┘
-                             (owner/admin/member)
-```
-
-### Chat & Notifications
-
-```
-┌─────────────────────┐     ┌──────────────────────────┐
-│ asobi_chat_message  │     │ asobi_notification       │
-├─────────────────────┤     ├──────────────────────────┤
-│ id         uuid PK  │     │ id           uuid PK     │
-│ channel_type enum   │     │ player_id    uuid FK     │
-│ channel_id string   │     │ type         enum        │
-│ sender_id  uuid FK  │     │ subject      string      │
-│ content    string   │     │ content      jsonb       │
-│ metadata   jsonb    │     │ read         boolean     │
-│ sent_at    datetime │     │ sent_at      datetime    │
-└─────────────────────┘     └──────────────────────────┘
- (room/group/direct)
-```
-
-### Matches, Leaderboards & Tournaments
-
-```
-┌─────────────────────┐     ┌──────────────────────────┐
-│ asobi_match_record  │     │ asobi_leaderboard_entry  │
-├─────────────────────┤     ├──────────────────────────┤
-│ id         uuid PK  │     │ leaderboard_id string    │
-│ mode       string   │     │ player_id    uuid FK     │
-│ status     enum     │     │ score        bigint      │
-│ players    jsonb    │     │ sub_score    bigint      │
-│ result     jsonb    │     │ metadata     jsonb       │
-│ metadata   jsonb    │     │ updated_at   datetime    │
-│ started_at datetime │     └──────────────────────────┘
-│ finished_at datetime│
-│ inserted_at datetime│     ┌──────────────────────────┐
-└─────────────────────┘     │ asobi_tournament         │
-                            ├──────────────────────────┤
-┌─────────────────────┐     │ id           uuid PK     │
-│ asobi_cloud_save    │     │ name         string      │
-├─────────────────────┤     │ leaderboard_id string    │
-│ player_id  uuid FK  │     │ max_entries   integer    │
-│ slot       string   │     │ entry_fee    jsonb       │
-│ data       jsonb    │     │ rewards      jsonb       │
-│ version    integer  │     │ start_at     datetime    │
-│ updated_at datetime │     │ end_at       datetime    │
-└─────────────────────┘     │ metadata     jsonb       │
-                            │ inserted_at  datetime    │
-                            └──────────────────────────┘
-
-┌─────────────────────┐
-│ asobi_storage       │
-├─────────────────────┤
-│ collection string   │
-│ key        string   │
-│ player_id  uuid FK  │  (nullable — global objects have no owner)
-│ value      jsonb    │
-│ version    integer  │
-│ read_perm  enum     │
-│ write_perm enum     │
-│ updated_at datetime │
-└─────────────────────┘
- (public/owner/none)
-```
-
-## Process Architecture
-
-### Player Session (`asobi_player_session` — gen_server)
-
-One process per connected player. Manages WebSocket state, presence, and acts as a message router.
-
-```
-Client ←→ WebSocket Handler ←→ Player Session Process
-                                    │
-                                    ├── pg groups: presence, player-specific topics
-                                    ├── Tracks: current match, world, chat channels
-                                    └── Handles: heartbeat, disconnect cleanup
-```
-
-**State:**
 ```erlang
 #{
-    player_id => uuid(),
-    ws_pid => pid(),                    %% WebSocket handler process
-    match_pid => pid() | undefined,     %% current match process
-    channels => [binary()],             %% joined chat channels
-    presence => #{status => binary(), metadata => map()},
+    player_id => binary(),
+    ws_pid => pid(),
+    match_pid => pid() | undefined,
+    channels => [binary()],
+    presence => #{status := binary()},
     connected_at => integer()
+    %% world_pid and zone_pid are added by set_zone/3 on a world join
 }
 ```
 
-**Lifecycle:**
-1. WebSocket connects → auth validated → `asobi_player_session:start_link/2`
-2. Joins `pg` groups for presence tracking
-3. Routes incoming WebSocket messages to appropriate service
-4. On disconnect → leaves all groups, notifies match/chat, cleans up
+It dies with the socket. Reconnection presents the same token and produces a
+new process.
 
-### Match Server (`asobi_match_server` — gen_statem)
+### Match server (`asobi_match_server`, gen_statem)
 
-One process per active match. Runs the game loop with configurable tick rate.
+One process per match.
 
 ```
-State Machine:
-  waiting ──[enough players]──→ running ──[game over]──→ finished
-     │                            │                         │
-     │ ←──[player leaves]        │ ←──[pause]──→ paused   │
-     │                            │                         │
-     └──[timeout]──→ cancelled   └──[error]──→ crashed    done
+waiting ──[min players]──► running ──[game over]──► finished
+   │                          │  ▲                     ▲
+   │                          ▼  │                     │
+   │                        paused                     │
+   └────────────────[cancel or timeout]────────────────┘
 ```
 
-**States:**
-- `waiting` — accepting players, waiting for minimum count
-- `running` — game loop active, ticking at configured rate
-- `paused` — game loop suspended (all players disconnected, admin pause)
-- `finished` — game over, results calculated, persisting to DB
-- `cancelled` — not enough players, timeout
+`cancelled` is a result value on the `finished` state, not a state.
 
-**Game Logic Behaviour:**
+The game module implements the `asobi_match` behaviour. `init/1` plus exactly
+one of `get_state/2` or `get_state/1` is the required minimum; the rest -
+`join/2`, `join/3`, `leave/2`, `handle_input/3`, `tick/1`, `vote_requested/1`,
+`vote_resolved/3`, `phases/1`, `on_phase_started/2`, `on_phase_ended/2` - are
+optional. Each tick drains queued inputs, calls `tick/1`, then broadcasts
+either one shared payload or one payload per player. Default tick is 100 ms.
 
-Game developers implement the `asobi_match` behaviour to define their game:
+### Matchmaker (`asobi_matchmaker`, gen_server)
 
-```erlang
--module(asobi_match).
+One per node. It schedules its own tick with `erlang:send_after/3`; nothing
+external drives it and no job queue is involved.
 
--callback init(Config :: map()) ->
-    {ok, GameState :: term()}.
+Tickets are entries in a map in the process's own state:
 
--callback join(PlayerId :: binary(), GameState :: term()) ->
-    {ok, GameState1 :: term()} | {error, Reason :: term()}.
-
--callback leave(PlayerId :: binary(), GameState :: term()) ->
-    {ok, GameState1 :: term()}.
-
--callback handle_input(PlayerId :: binary(), Input :: map(), GameState :: term()) ->
-    {ok, GameState1 :: term()}.
-
--callback tick(GameState :: term()) ->
-    {ok, GameState1 :: term()} |
-    {finished, Result :: map(), GameState1 :: term()}.
-
--callback get_state(PlayerId :: binary(), GameState :: term()) ->
-    StateForPlayer :: map().
-```
-
-**Tick loop** runs at a configurable rate (default 10/sec). Each tick:
-1. Collect queued player inputs
-2. Call `Mod:tick(GameState)` with accumulated inputs
-3. Compute state diff per player via `Mod:get_state/2`
-4. Broadcast diffs over WebSocket
-
-### Matchmaker (`asobi_matchmaker` — gen_server)
-
-Runs periodic matching ticks. Strategy modules group tickets; the shipped
-strategies are `fill` (FCFS) and `skill_based` (expanding window).
-
-**Ticket** (`asobi_matchmaker:add/2`):
 ```erlang
 #{
     id => binary(),
@@ -364,426 +184,300 @@ strategies are `fill` (FCFS) and `skill_based` (expanding window).
     mode => binary(),
     properties => map(),        %% game-defined, read by your strategy
     submitted_at => integer(),
-    status => pending
+    status => pending,
+    attempts => 0
 }
 ```
 
-There is no query expression and no party field. Ticket filtering beyond
-`mode` happens inside your strategy module against `properties`. See
-[Matchmaking](../guides/matchmaking.md).
+There is no ticket table and no ticket schema. The queue dies with the node.
 
-**Algorithm (each tick):**
-1. Load all active tickets from ETS
-2. Group by mode/region
-3. Within each group, find mutually compatible tickets (both match each other's query)
-4. Form matches from compatible pools (fill to min/max player count)
-5. For unfilled tickets, increment `expansion_level` (widens skill range)
-6. Tickets past max wait time → return error to player
-7. Matched tickets → spawn `asobi_match_server`, notify players
+One live ticket per player *per mode*: re-adding while already queued for the
+same mode returns the existing ticket. A player may hold tickets in different
+modes at the same time.
 
-**Query language:**
-```
-+region:eu-west mode:ranked skill:>=800 skill:<=1200
-```
+Each tick: group the tickets by mode, hand each group to the configured
+strategy (`fill` or `skill_based`), start a match through `asobi_match_sup` for
+each filled group on this node, expire anything past `max_wait_seconds`, keep
+the rest. There is no query parser, no party field and no region concept.
+Filtering beyond `mode` belongs in your strategy module, against `properties`.
+See [Matchmaking](../guides/matchmaking.md).
 
-### Leaderboard Server (`asobi_leaderboard_server` — gen_server)
+### Leaderboard server (`asobi_leaderboard_server`, gen_server)
 
-Hybrid ETS + PostgreSQL. ETS for hot reads, Kura for persistence.
+One per board. ETS for reads, PostgreSQL for the truth.
 
-**ETS table** per leaderboard: `ordered_set` keyed by `{-Score, -SubScore, PlayerId}` for automatic ordering.
+The table is an `ordered_set` keyed `{-Score, PlayerId}`, so iteration is rank
+order. `sub_score` is persisted as 0 and plays no part in ordering.
 
-**Operations:**
-- `submit(BoardId, PlayerId, Score)` — insert/update in ETS, async persist via Shigoto
-- `top(BoardId, N)` — read top N from ETS (microsecond response)
-- `around(BoardId, PlayerId, N)` — player's rank ± N entries from ETS
-- `rank(BoardId, PlayerId)` — player's rank via ETS position
-- `reset(BoardId)` — snapshot to archive table, clear ETS, Shigoto job
+- `submit/3` - update ETS, mark the player dirty
+- `top/2`, `around/3`, `rank/2` - read from ETS
+- `live_boards/0` - the boards with scores in memory
 
-**Lifecycle:** a board hydrates its ETS tables from `leaderboard_entries` before it accepts reads, and flushes pending scores on shutdown, so a restart does not reset the board. Each flush writes only the players that changed since the previous flush; a player whose write fails stays pending and is retried on the next tick.
+A 30 second timer in the board process flushes dirty players, upserting only
+what changed; a failed write stays pending for the next flush. `terminate/2`
+flushes. A board hydrates from `leaderboard_entries` before serving reads.
 
-**Time-scoped boards:** Shigoto schedules resets (daily/weekly/monthly). On reset, current entries archived to `asobi_leaderboard_archive` with period metadata.
+There is no `reset/0`, no archive table and no scheduled reset. A "weekly
+board" is a separate board id.
 
-### Chat Channel (`asobi_chat_channel` — gen_server)
+### Chat channel (`asobi_chat_channel`, gen_server)
 
-One process per active channel. Uses `pg` for member management.
+One per live channel. Members are a `pg` group `{chat, ChannelId}`. A send
+fans out to the group, then inserts the `chat_messages` row inline in the same
+callback - there is no batching worker. A bounded in-process buffer keeps
+recent messages for a fast history read; older history comes from Postgres.
 
-**Channel types:**
-- `room` — named persistent channel (e.g., `~"chat:lobby"`)
-- `group` — tied to a group/guild
-- `direct` — between two players
-- `match` — ephemeral, tied to a match lifetime
+Channel naming and who may reach which channel are in `asobi_chat_acl`.
 
-**Flow:**
-1. Player joins channel → process joins `pg` group `{chat, ChannelId}`
-2. Send message → broadcast to all members via `pg`
-3. Messages persisted to `asobi_chat_message` via Shigoto (async)
-4. History loaded from Kura on join (paginated)
+### Presence (`asobi_presence`, gen_server)
 
-### Presence (`asobi_presence` — gen_server)
+Delivery target and online-set membership are recorded separately: `track/2`
+records both, `track_bot/2` records only the delivery target, so bots receive
+broadcasts without inflating `online_count/0`. `pg` cleans up when a process
+dies, so there is no stale presence to sweep. Status changes broadcast over
+Nova PubSub.
 
-Tracks online players and their status using `pg`.
+## WebSocket protocol
 
-**Design:**
-- Player session joins `pg` group `{presence, PlayerId}` on connect
-- Status updates broadcast via Nova PubSub on channel `presence`
-- Friends receive presence updates by subscribing to their friends' presence topics
-- `pg` automatically cleans up when processes die — no stale presence
-
-## WebSocket Protocol
-
-Single WebSocket connection per client. JSON message envelope:
-
-### Client → Server
+One connection per client, JSON envelope both ways:
 
 ```json
-{
-    "cid": "optional-correlation-id",
-    "type": "message.type",
-    "payload": {}
-}
+{"cid": "optional-correlation-id", "type": "message.type", "payload": {}}
 ```
 
-### Server → Client
+`cid` is echoed on a reply to a request. It is optional everywhere except
+`rpc.call`, where it is required and validated.
+
+The message catalogue is the
+[WebSocket protocol guide](../guides/websocket-protocol.md). `asobi_ws_handler`
+routes each `type` to the owning service; the client sends input, the server
+decides and broadcasts.
+
+Errors are always the wire object, never an internal reason atom:
 
 ```json
-{
-    "cid": "correlation-id-if-request-response",
-    "type": "message.type",
-    "payload": {}
-}
+{"error": {"code": "matchmaker.unknown_mode", "message": "...", "details": {}}}
 ```
 
-### Message Types
-
-The authoritative message catalogue is the
-[WebSocket protocol guide](../guides/websocket-protocol.md). The handler
-(`asobi_ws_handler`) routes each `type` to the owning service; the client sends
-input, the server decides and broadcasts state deltas.
-
-### WebSocket Handler (`asobi_ws_handler`)
-
-Implements `nova_websocket` behaviour. Routes messages to the appropriate service:
-
-```erlang
-websocket_handle({text, Raw}, State) ->
-    #{~"type" := Type, ~"payload" := Payload} = json:decode(Raw),
-    Cid = maps:get(~"cid", json:decode(Raw), undefined),
-    Result = route_message(Type, Payload, State),
-    reply_if_needed(Cid, Result, State).
-
-route_message(~"match.input", Payload, #{match_pid := Pid} = _State) ->
-    asobi_match_server:handle_input(Pid, Payload);
-route_message(~"chat.send", Payload, State) ->
-    asobi_chat:send_message(Payload, State);
-%% ...etc
-```
+Codes and their HTTP statuses live in one list in `src/asobi_error.erl`.
 
 ## REST API
 
-The HTTP endpoint reference is the [REST API guide](../guides/rest-api.md). It is
-the single source of truth for paths, methods, and status codes; this document does
-not repeat it. All endpoints sit under `/api/v1` and exchange JSON. Routing lives in
-`asobi_router.erl`; the controllers are the `*_controller` modules under
-[Project Structure](#project-structure).
+Paths, methods and status codes are the
+[REST API guide](../guides/rest-api.md). Routing is `src/asobi_router.erl`;
+controllers are the `*_controller` modules under `src/controllers/`.
 
-The client sends intent over these endpoints, the server decides, and the server
-persists and broadcasts the result.
+## Console and ops plane
 
-## Admin
+The node serves an operator console at `/console` and an ops HTTP API at
+`/api/v1/ops/*`, on the same listener as the game.
 
-This node serves its own operator console at `/console`, off unless
-`{console, true}` and an `ops_secret` are configured. It reads the ops plane at
-`/api/v1/ops` over HTTP like any other client - it holds no privileged path
-into the database of its own.
+The two are gated separately. `/console` needs `console` to be true; the ops
+routes are always mounted and reject everything until an `ops_secret` is
+configured, so a stock node serves neither.
+[Operator console](../guides/console.md) owns the detail.
 
-The console was previously a separate project, `asobi_admin`, which read the
-same database directly. That is archived: a second deployment to run, secure
-and keep in step was the wrong shape for something an operator opens during an
-incident.
+Core's ops routes are all reads. Every core route carries a capability class -
+`read`, `player_data` or `config` (`src/ops/asobi_ops_caps.erl`) - and the only
+route that mutates is `/api/v1/ops/ext/:extension/:action`, whose behaviour
+comes from an installed extension.
 
-## Background Jobs (Shigoto)
+The console holds no privileged path into the database; it reads the ops plane
+over HTTP like any other client. It used to be a separate project,
+`asobi_admin`, reading the same database directly. That is archived: a second
+deployment to run, secure and keep in step was the wrong shape for something an
+operator opens during an incident.
 
-| Job | Schedule | Description |
-|-----|----------|-------------|
-| `matchmaker_tick` | Every 1s | Run matchmaking algorithm |
-| `leaderboard_persist` | Every 30s | Flush ETS leaderboard changes to PostgreSQL |
-| `leaderboard_reset` | Cron-based | Reset time-scoped leaderboards, archive entries |
-| `tournament_lifecycle` | Every 1m | Start/end tournaments based on schedule |
-| `chat_persist` | Every 5s | Batch-persist chat messages from memory to DB |
-| `notification_push` | On-demand | Send push notifications via APNs/FCM |
-| `iap_reconcile` | Every 1h | Reconcile IAP receipts with store APIs |
-| `presence_cleanup` | Every 5m | Safety net for stale presence (pg handles most) |
-| `analytics_flush` | Every 1m | Flush telemetry events to analytics pipeline |
+## Background jobs
 
-Player stats are not a background job: `asobi_match_server` folds a finished
-match into `player_stats` in the same transaction that writes the match
-record, so the counters and the match history can never disagree.
+One worker: `asobi_broadcast_worker`, on the `broadcast` fanout queue. Every
+node consumes the queue, so every node sees every job. Three job types:
+
+| Type | Effect on each node |
+|---|---|
+| `session_revoked` | `asobi_presence:disconnect/2` for the player, locally |
+| `notification` | push to the player's local session if connected |
+| `chat` | deliver to local members of the channel |
+
+Anything else logs `unknown_broadcast_type`. `max_attempts` is 1 and jobs are
+pruned after their window, so the queue is a best-effort push and the database
+is the source of truth.
+
+Everything else that could look like a job is not one. The matchmaker ticks
+itself. Leaderboards flush on their own 30 second timer. Chat rows are inserted
+inline by the channel process. Player stats are folded into `player_stats` by
+`asobi_match_server` inside the same transaction that writes the match record,
+so the counters and the match history cannot disagree.
 
 ## Security
 
-### Authentication Flow
+### Authentication
 
-1. Client authenticates via REST (email/password, device ID, or platform provider)
-2. Server returns JWT session token (short-lived, 15min) + refresh token (long-lived, 30 days)
-3. REST requests include token in `Authorization: Bearer <token>` header
-4. WebSocket authenticates via `session.connect` message with token
-5. Server validates token, starts player session process
+1. The client registers or logs in over REST (password, device, guest, or an
+   OAuth/OIDC provider).
+2. The server returns `player_id`, `access_token`, `refresh_token` and
+   `username`. Both tokens are opaque 32 random bytes issued by `nova_auth` and
+   stored in `player_tokens`. They are not JWTs and carry no claims. Access is
+   valid 60 minutes, refresh 30 days.
+3. REST requests carry `Authorization: Bearer <access_token>`.
+4. The WebSocket authenticates with `session.connect` carrying the same token.
+5. Both paths resolve the token through `asobi_auth_cache`, a per-node ETS
+   cache with a 60 second TTL (5 seconds for negatives). That TTL bounds
+   revocation latency across a cluster.
 
-### Server-Authoritative Design
+`asobi_auth_plugin` is the Nova plugin that does step 3. It resolves a bearer
+token; it does not validate a JWT.
 
-- All game state mutations go through `asobi_match_server`
-- Economy operations are ACID transactions via Kura Multi
-- Client never directly modifies server state
-- Leaderboard submissions validated against match results
-- Purchase receipts validated server-side with Apple/Google APIs
+### Server-authoritative design
 
-### Rate Limiting
+- All match state mutations go through `asobi_match_server`.
+- Each economy operation is one `asobi_repo:transaction/1`, serialised by a
+  Postgres advisory transaction lock on `(player_id, currency)`. That is what
+  makes concurrent debits on the same wallet safe; it is not Kura `Multi`.
+- Client score submission is refused by default. `POST /leaderboards/:id`
+  answers `leaderboard.client_submit_disabled` unless the board id is listed in
+  `leaderboard_client_submit`; the intended path is server code calling
+  `asobi_leaderboard_server:submit/3` from a finished match.
+- IAP receipts are verified server-side: Apple's signed transaction against
+  Apple's root certificates locally, Google's purchase token against the Play
+  Android Publisher API. Both refuse with `*_iap_not_configured` until the
+  bundle id or package name is set.
 
-Nova plugin for per-player rate limiting:
-- REST: token bucket per endpoint per player
-- WebSocket: message rate limit per type
-- Matchmaking: one active ticket per player
+### Rate limiting
 
-## Scaling Strategy
+`asobi_rate_limit_plugin` selects a bucket per path (auth, register, iap, api)
+and `asobi_ws_handler` gates the socket upgrade. Buckets are seki limiters
+registered at boot and held in memory, per node - a 5/s bucket in a
+three-node cluster is 15/s in aggregate. Matchmaking allows one active ticket
+per player per mode.
 
-### Single Node (Phase 1)
+## Scaling
 
-One BEAM node handles everything. Target: 50K concurrent players.
+One node is the design point: a match lives on one node, a world lives on one
+node, and neither migrates. [Clustering](../guides/clustering.md) is the single
+source of truth for what a second node does and does not buy you, and holds the
+complete list of per-node state. Measured numbers are in
+[Benchmarks](../guides/benchmarks.md); do not put a target here.
 
-```
-Single Node
-├── Nova (HTTP + WS)
-├── All game processes
-├── ETS tables
-└── PostgreSQL connection pool
-```
+Migrations run under a Kura advisory lock, so a rolling deploy is safe: the
+first node to start applies them and the rest wait, then see the version
+already recorded.
 
-### Clustered (Phase 2)
+## Project layout
 
-Multiple BEAM nodes with distributed Erlang. `pg` handles cross-node pub/sub.
+`src/` is one directory per subsystem, compiled recursively
+(`{src_dirs, [{"src", [{recursive, true}]}]}`).
 
-```
-                    Load Balancer (sticky sessions for WS)
-                    ┌───────────┬───────────┐
-                    ▼           ▼           ▼
-                 Node A      Node B      Node C
-                    │           │           │
-                    └─────── pg ────────────┘  (cluster-wide pub/sub)
-                              │
-                         PostgreSQL
-```
+| Directory | Holds |
+|---|---|
+| `src/` (top level) | application, supervisor, router, repo, error codes, telemetry, game-mode registry, cluster discovery |
+| `src/auth/` | token issue and cache, OIDC config, Steam, IAP verification |
+| `src/console/` | the operator console: shell, assets, session, CSP, environment |
+| `src/controllers/` | REST controllers |
+| `src/economy/` | wallets, transactions, items, listings |
+| `src/extensions/` | extension resolution, supervision, the RPC dispatcher, `rebar3 asobi check` |
+| `src/iap/` | IAP transaction schema |
+| `src/leaderboards/` | board processes and entries |
+| `src/lua/` | the Lua runtime: loader, sandbox, bridges, config, reload |
+| `src/matches/` | match behaviour, match server, matchmaker and strategies |
+| `src/migrations/` | Erlang migration modules |
+| `src/notifications/` | notification schema and delivery |
+| `src/ops/` | the ops plane: auth, capabilities, per-area readers, audit |
+| `src/players/` | player, stats, identity, token, session |
+| `src/plugins/` | Nova plugins: auth, rate limit, body cap, client gate, security headers |
+| `src/social/` | presence, chat, DMs, friends, groups |
+| `src/storage/` | cloud saves and generic key-value storage |
+| `src/timers/` | phases, entity timers, reconnect windows |
+| `src/tournaments/` | tournament server and schema |
+| `src/votes/` | vote server and schema |
+| `src/workers/` | `asobi_broadcast_worker` |
+| `src/world/` | world instances, zones, terrain, spatial index, lobby |
+| `src/ws/` | WebSocket handler and binary framing |
 
-- Player session lives on the node the WebSocket connected to
-- Match processes can spawn on any node (least-loaded selection)
-- Leaderboard ETS replicated across nodes or centralized on dedicated node
-- Matchmaker runs on one node (elected leader) or partitioned by mode/region
-- `pg` handles all cross-node messaging transparently
-
-### Database Scaling (Phase 3)
-
-- Read replicas for leaderboard persistence and analytics queries
-- Connection pooling per node via pgo
-- Table partitioning for high-volume tables (transactions, chat messages, analytics)
-
-## Project Structure
-
-```
-asobi/
-├── src/
-│   ├── asobi_app.erl                    # OTP application
-│   ├── asobi_sup.erl                    # Top-level supervisor
-│   ├── asobi_router.erl                 # Nova router
-│   ├── asobi_repo.erl                   # Kura repo
-│   │
-│   ├── asobi_ws_handler.erl             # WebSocket handler + message routing
-│   │
-│   ├── asobi_player.erl                 # Player schema
-│   ├── asobi_player_auth.erl            # Player auth schema
-│   ├── asobi_player_stats.erl           # Player stats schema
-│   ├── asobi_player_session.erl         # gen_server per player
-│   ├── asobi_player_controller.erl      # REST controller
-│   │
-│   ├── asobi_match.erl                  # Match behaviour (game devs implement)
-│   ├── asobi_match_server.erl           # gen_statem per match
-│   ├── asobi_match_record.erl           # Match record schema
-│   ├── asobi_match_controller.erl       # REST controller
-│   │
-│   ├── asobi_matchmaker.erl             # Matchmaking gen_server
-│   ├── asobi_matchmaker_query.erl       # Query parser/evaluator
-│   ├── asobi_matchmaker_controller.erl  # REST controller
-│   │
-│   ├── asobi_leaderboard_server.erl     # gen_server per board (ETS)
-│   ├── asobi_leaderboard_entry.erl      # Leaderboard entry schema
-│   ├── asobi_leaderboard_controller.erl # REST controller
-│   │
-│   ├── asobi_wallet.erl                 # Wallet schema
-│   ├── asobi_transaction.erl            # Transaction ledger schema
-│   ├── asobi_item_def.erl               # Item definition schema
-│   ├── asobi_player_item.erl            # Player item instance schema
-│   ├── asobi_store_listing.erl          # Store listing schema
-│   ├── asobi_economy.erl               # Economy operations (Multi transactions)
-│   ├── asobi_iap.erl                    # IAP receipt validation
-│   ├── asobi_economy_controller.erl     # REST controller
-│   ├── asobi_inventory_controller.erl   # REST controller
-│   │
-│   ├── asobi_friendship.erl             # Friendship schema
-│   ├── asobi_group.erl                  # Group schema
-│   ├── asobi_group_member.erl           # Group member schema
-│   ├── asobi_social_controller.erl      # REST controller
-│   │
-│   ├── asobi_chat_channel.erl           # gen_server per channel
-│   ├── asobi_chat_message.erl           # Chat message schema
-│   ├── asobi_chat_controller.erl        # REST (history endpoint)
-│   │
-│   ├── asobi_tournament.erl             # Tournament schema
-│   ├── asobi_tournament_server.erl      # gen_server per tournament
-│   ├── asobi_tournament_controller.erl  # REST controller
-│   │
-│   ├── asobi_notification.erl           # Notification schema
-│   ├── asobi_notification_controller.erl # REST controller
-│   │
-│   ├── asobi_cloud_save.erl             # Cloud save schema
-│   ├── asobi_storage.erl                # Generic storage schema
-│   ├── asobi_storage_controller.erl     # REST controller
-│   │
-│   ├── asobi_presence.erl               # Presence tracking via pg
-│   ├── asobi_auth_plugin.erl            # Nova plugin — JWT validation
-│   ├── asobi_rate_limit_plugin.erl      # Nova plugin — rate limiting
-│   └── asobi_telemetry.erl              # Telemetry setup
-│
-├── include/
-│   └── asobi.hrl                        # Shared records/macros
-│
-├── priv/
-│   ├── migrations/                      # Kura migrations
-│   └── static/                          # Admin dashboard assets
-│
-├── test/
-│   ├── asobi_match_SUITE.erl
-│   ├── asobi_matchmaker_SUITE.erl
-│   ├── asobi_leaderboard_SUITE.erl
-│   ├── asobi_economy_SUITE.erl
-│   ├── asobi_social_SUITE.erl
-│   ├── asobi_chat_SUITE.erl
-│   ├── asobi_ws_SUITE.erl
-│   └── asobi_api_SUITE.erl
-│
-├── docs/
-│   └── ARCHITECTURE.md                  # This file
-│
-├── config/
-│   ├── sys.config
-│   └── vm.args
-│
-├── docker-compose.yml                   # PostgreSQL
-├── rebar.config
-├── rebar.lock
-└── .github/
-    └── workflows/
-        └── ci.yml                       # erlang-ci
-```
+`priv/` holds two things: `priv/console/` (the built console bundle and its
+manifest) and `priv/protocol/` (protocol fixtures and their README).
 
 ## Configuration
 
-### sys.config
+`config/dev_sys.config.src` is the worked example. Abridged:
 
 ```erlang
 [
     {nova, [
-        {bootstrap_application, asobi_arena},
+        {bootstrap_application, asobi},
         {environment, dev},
-        {cowboy_configuration, #{
-            port => 8084
-        }},
-        {json_lib, json}
+        {cowboy_configuration, #{port => 8082}},
+        {json_lib, json},
+        {plugins, [
+            {pre_request, asobi_body_cap_plugin, #{
+                max_body => 1048576,
+                require_content_length => true
+            }},
+            {pre_request, nova_request_plugin, #{
+                decode_json_body => true,
+                parse_qs => true
+            }},
+            {pre_request, nova_cors_plugin, #{allow_origins => ~"*"}},
+            {pre_request, nova_correlation_plugin, #{}},
+            {pre_request, asobi_rate_limit_plugin, #{}},
+            {pre_request, asobi_client_gate_plugin, #{}},
+            {post_request, asobi_security_headers_plugin, #{}}
+        ]}
     ]},
     {kura, [
         {repo, asobi_repo},
+        {backend, kura_backend_postgres},
         {host, "localhost"},
         {port, 5432},
         {database, "asobi_dev"},
         {user, "postgres"},
         {password, "postgres"},
-        {pool_size, 10}
+        {pool_size, 200}
     ]},
     {shigoto, [
-        {pool, asobi_repo}
+        {pool, asobi_repo},
+        {poll_interval, 500},
+        {queues, [{~"default", 10}]},
+        {fanout_queues, [{~"broadcast", 5, #{window => 120}}]}
     ]},
     {asobi, [
-        {plugins, [
-            {pre_request, nova_request_plugin, #{
-                decode_json_body => true,
-                parse_qs => true
-            }},
-            {pre_request, nova_cors_plugin, #{
-                allow_origins => <<"*">>
-            }},
-            {pre_request, nova_correlation_plugin, #{}}
-        ]},
-        {game_modes, #{
-            ~"arena" => asobi_arena_game
-        }},
-        {matchmaker, #{
-            tick_interval => 1000,
-            max_wait_seconds => 60
-        }},
-        {session, #{
-            token_ttl => 900,
-            refresh_ttl => 2592000
-        }}
+        {game_modes, #{~"arena" => my_arena_game}},
+        {matchmaker, #{tick_interval => 1000, max_wait_seconds => 60}}
     ]},
-    {pg, [{scope, [nova_scope, arizona_pubsub]}]}
+    {pg, [{scope, [nova_scope, asobi_presence, asobi_chat]}]}
 ].
 ```
 
+Notes that bite people:
+
+- The plugin chain belongs under `{nova, [...]}`, not `{asobi, [...]}`, and the
+  listed order is the order they run in. The body cap has to precede
+  `nova_request_plugin`, which is what buffers the body into the heap, and the
+  rate limiter has to precede `asobi_client_gate_plugin` so the cheap in-memory
+  check sheds a flood before any external verification. `asobi_client_gate_plugin`
+  is a no-op until `client_gate` is configured.
+- `{backend, kura_backend_postgres}` is required in the `kura` block. Without
+  it Kura has no dialect.
+- `nova_scope` is the only scope asobi joins - matches, worlds, zones, chat
+  channels, boards, presence and per-player groups all live in it. The
+  `asobi_presence` and `asobi_chat` scopes in both shipped configs are started
+  by the `pg` application and nothing joins them; they are inert. Left in the
+  snippet because that is what the shipped config says.
+- Access and refresh token lifetimes are not configurable here. They are
+  `nova_auth` defaults, 60 minutes and 30 days.
+
+Full reference: [Configuration](../guides/configuration.md).
+
 ## Dependencies
 
-`rebar.config` is the authoritative list. asobi builds on Nova, Kura (with
-kura_postgres), nova_auth, nova_auth_oidc, nova_resilience, seki, and Shigoto. It
-does not depend on Arizona.
+`rebar.config` is the authoritative list. asobi builds on Nova, Kura with
+`kura_postgres`, nova_auth, nova_auth_oidc, nova_resilience, seki, luerl and
+Shigoto. It does not depend on Arizona and it does not depend on any
+OpenTelemetry package.
 
-## Build Phases
-
-### Phase 1 — Foundation
-- Project scaffold (rebar3 nova)
-- PostgreSQL + Docker Compose
-- Kura repo + initial migrations
-- Player schema + CRUD
-- nova_auth integration (register, login, JWT)
-- REST API skeleton with auth plugin
-- CI setup (erlang-ci)
-
-### Phase 2 — Real-Time
-- WebSocket handler with message routing
-- Player session process (gen_server)
-- Presence tracking via pg
-- Chat system (channels, messaging, persistence)
-
-### Phase 3 — Game Infrastructure
-- Match behaviour definition
-- Match server (gen_statem) with tick loop
-- Matchmaker with query-based matching
-- Leaderboard server (ETS + Kura hybrid)
-- Example game implementation (simple card game or trivia)
-
-### Phase 4 — Economy
-- Wallet + transaction ledger
-- Item definitions + player inventory
-- Store catalog + purchase flow
-- IAP receipt validation (Apple + Google)
-
-### Phase 5 — Social & Live Ops
-- Friends system
-- Groups/guilds
-- Tournaments
-- Cloud saves
-- Push notifications (via Hikyaku)
-- Generic key-value storage
-
-### Phase 6 — Admin & Polish
-- Arizona admin dashboard
-- Telemetry + observability
-- Rate limiting plugin
-- Security hardening
-- Documentation + guides
-
+Two pins are deliberate. `cowboy` is pinned to `~> 2.16` to force the patched
+release (CVE-2026-43966 / GHSA-w4f7-4cxr-rv3c, which affects versions below
+2.16.0). `nova` is on a git ref rather than Hex until the fix for
+novaframework/nova#400 releases - a websocket controller replying with a list
+of frames crashes the connection process on Hex nova 0.15.1, which is why
+`asobi_ws_handler` emits exactly one frame per `websocket_info/2` return.

--- a/docs/adr/0003-docs-single-sourced-by-truth-holder.md
+++ b/docs/adr/0003-docs-single-sourced-by-truth-holder.md
@@ -4,7 +4,16 @@ Date: 2026-07-17
 
 ## Status
 
-Accepted.
+Accepted, and partly overtaken by events. The principle stands; two rows of the
+ownership table no longer name repositories that exist.
+
+`asobi_lua` was merged into this repository (`src/lua/`) and retired, and
+`asobi_admin` was archived on 2026-08-06 when its console moved here. asobi is
+now the truth-holder for the Lua and console pages it once delegated, so the
+corollary below that says "asobi drops its Lua guides" is inverted: those guides
+live here, alongside the code whose CI can verify them. The decision that
+located them - ownership follows the code that can be wrong - is what put them
+here. A superseding ADR should restate the table against today's repositories.
 
 ## Context
 

--- a/docs/adr/0008-published-image-renamed-to-asobi.md
+++ b/docs/adr/0008-published-image-renamed-to-asobi.md
@@ -1,0 +1,75 @@
+# ADR 0008: The published image is ghcr.io/widgrensit/asobi
+
+Date: 2026-08-06
+
+## Status
+
+Accepted. The old name stops publishing on 2027-02-01.
+
+## Context
+
+The runnable image used to be published from `widgrensit/asobi_lua`, back when
+the Lua runtime was a separate OTP application in a separate repository. That
+repository has held no source of its own since the merge: its workflow pinned
+asobi by git ref, built a release entirely out of this repository, and pushed
+the result under its own name. The image was an alias.
+
+An alias needs a staleness gate, because it can silently republish an old
+commit when the pin is not moved. It also names the image after the smaller
+half of what is inside it. What ships is one node containing the game backend,
+the Lua runtime and the operator console - `asobi_lua` names one of the three.
+
+The name is also load-bearing in a way a repository name is not. It is pasted
+into every compose file, Dockerfile and Kubernetes manifest that runs asobi, so
+changing it breaks running deployments unless the old one keeps resolving for
+long enough for people to notice on their own schedule.
+
+## Decision
+
+Publish `ghcr.io/widgrensit/asobi` from this repository
+(`.github/workflows/docker-publish.yml`), tagged `latest` on the default branch
+alongside the branch, long-SHA and semver tags. The release binary inside it is
+`bin/asobi`.
+
+Keep publishing `ghcr.io/widgrensit/asobi_lua` in parallel until **2027-02-01**,
+after which that name stops receiving new tags. Images already pushed under it
+stay pullable; they simply stop moving. Six months is long enough to cover a
+studio that ships on a quarterly cadence and short enough that the alias does
+not become permanent.
+
+Documentation uses the new name only. The rename is noted as one sentence in
+exactly two places: beside the quickstart compose in
+`guides/getting-started.md`, and beside the production compose in
+`guides/self-hosting.md`. A one-word change does not get a migration section.
+
+Add an `asobi_lua` row to `scripts/check-archived-refs.sh` so CI fails if a
+guide sends a reader to the retired repository.
+
+## Consequences
+
+- Compose files, Dockerfiles and manifests naming `asobi_lua` keep working
+  until 2027-02-01 and then stop receiving updates. They do not break at that
+  moment; they freeze, which is the failure mode that gets noticed slowly. The
+  two doc notes are what make it get noticed sooner.
+- `bin/asobi_lua` no longer exists in the image. Anything that shells into the
+  container to run `bin/asobi_lua rpc` or `remote_console` has to change, and
+  unlike the image name this one fails loudly.
+- The staleness gate is gone with the alias. An image built from this
+  repository's own `HEAD` cannot be behind itself.
+- `asobi_lua` remains correct as a *module and configuration* prefix -
+  `asobi_lua_config`, `asobi_lua_api`, `ASOBI_LUA_RELOAD`, and the
+  `{asobi_lua, [...]}` application key that `asobi_lua_env:get_env/2` still
+  reads first. This ADR renames an image and a repository reference, nothing
+  else. Renaming those would break every reader's configuration.
+
+## Alternatives considered
+
+- **Cut over with no window.** Rejected: every deployment pinning the old name
+  breaks on its next pull, and the people it breaks are self-hosters who did
+  nothing wrong.
+- **Keep the alias indefinitely.** Rejected: an alias with no end date is two
+  names for one artefact forever, and the second one is the one that goes
+  stale without saying so. A deprecation without an end is not a decision.
+- **Publish under both names permanently and treat `asobi_lua` as the
+  Lua-flavoured variant.** Rejected: there is one image and one product. Two
+  names would imply a choice that does not exist.

--- a/examples/hotreload-demo/README.md
+++ b/examples/hotreload-demo/README.md
@@ -13,8 +13,8 @@ docker compose up -d
 
 Open <http://localhost:3000> in a browser.
 
-That's it. Compose brings up three containers — Postgres, asobi_lua, and
-an nginx proxy — so the browser hits everything on `localhost:3000` with
+That's it. Compose brings up three containers - Postgres, asobi, and
+an nginx proxy - so the browser hits everything on `localhost:3000` with
 no CORS to worry about. nginx proxies `/api/*` and `/ws` to asobi; the
 client HTML is served from `./client/`.
 
@@ -45,8 +45,8 @@ no reconnect, no reload, no message loss. Try:
 
 ## How it works
 
-asobi_lua runs your `match.lua` inside [Luerl](https://github.com/rvirding/luerl)
-— a pure-Erlang Lua 5.3 interpreter. When the mounted `.lua` file changes,
+asobi runs your `match.lua` inside [Luerl](https://github.com/rvirding/luerl) -
+a pure-Erlang Lua 5.3 interpreter. When the mounted `.lua` file changes,
 the Luerl VM re-loads the module. In-flight match state is kept in the
 BEAM process heap, so reloading the script doesn't reset the game.
 

--- a/examples/hotreload-demo/docker-compose.yml
+++ b/examples/hotreload-demo/docker-compose.yml
@@ -12,7 +12,7 @@ services:
       retries: 5
 
   asobi:
-    image: ghcr.io/widgrensit/asobi_lua:latest
+    image: ghcr.io/widgrensit/asobi:latest
     depends_on:
       postgres: { condition: service_healthy }
     volumes:

--- a/examples/world-spawns/docker-compose.yml
+++ b/examples/world-spawns/docker-compose.yml
@@ -12,7 +12,7 @@ services:
       retries: 5
 
   asobi:
-    image: ghcr.io/widgrensit/asobi_lua:latest
+    image: ghcr.io/widgrensit/asobi:latest
     depends_on:
       postgres:
         condition: service_healthy

--- a/examples/world-terrain/README.md
+++ b/examples/world-terrain/README.md
@@ -69,7 +69,7 @@ function terrain_provider(config)
 end
 ```
 
-The module must be listed in `asobi_lua`'s `terrain_providers` env, or it is
+The module must be listed in the `terrain_providers` application env, or it is
 rejected with `terrain_provider_not_allowed`.
 
 ## Run it

--- a/examples/world-walkers/README.md
+++ b/examples/world-walkers/README.md
@@ -13,7 +13,7 @@ see "two avatars on a screen", **start here**.
 docker compose up
 ```
 
-That brings up Postgres + asobi_lua. Asobi reads `lua/config.lua`,
+That brings up Postgres + asobi. Asobi reads `lua/config.lua`,
 sees `walkers = "world.lua"`, and registers `walkers` as a world mode.
 
 ## Connect two clients

--- a/examples/world-walkers/docker-compose.yml
+++ b/examples/world-walkers/docker-compose.yml
@@ -12,7 +12,7 @@ services:
       retries: 5
 
   asobi:
-    image: ghcr.io/widgrensit/asobi_lua:latest
+    image: ghcr.io/widgrensit/asobi:latest
     depends_on:
       postgres:
         condition: service_healthy

--- a/guides/architecture.md
+++ b/guides/architecture.md
@@ -1,341 +1,432 @@
 # Architecture
 
-## Overview
+## What a node is
 
-Asobi is an Erlang/OTP game backend built on Nova. This document covers the
-runtime architecture, session lifecycle, how services communicate, and the
-trade-offs for single-node, distributed Erlang, and cloud-native deployments.
+An asobi node is a single Erlang/OTP release holding the game backend, the Lua
+runtime and the operator console. There is no separate scripting service and no
+separate admin service. The image is `ghcr.io/widgrensit/asobi` and the release
+binary inside it is `bin/asobi` (`Dockerfile:75`).
 
-## Supervision Tree
+Two front doors onto the same node:
+
+- Run the image and write Lua. `match.lua` or a `config.lua` manifest is loaded
+  at boot and drives matches, worlds and bots.
+- Depend on the Hex package and write Erlang. Implement the `asobi_match`
+  behaviour and register the module under `game_modes`.
+
+Both reach the same processes, the same database and the same console.
+
+## Supervision tree
+
+`asobi_sup` is `one_for_one`, 10 restarts in 60 seconds
+(`src/asobi_sup.erl:16-20`). Nineteen children, in this order
+(`src/asobi_sup.erl:21-41`):
 
 ```
 asobi_sup (one_for_one)
-├── asobi_rate_limit_server     — per-node ETS rate limiter
-├── asobi_cluster               — node discovery (DNS/EPMD)
-├── asobi_player_session_sup    — dynamic simple_one_for_one
-│   └── asobi_player_session    — one per connected player
-├── asobi_match_sup             — dynamic simple_one_for_one
-│   └── asobi_match_server      — one per active match (gen_statem)
-├── asobi_matchmaker            — matching algorithm, tick-based
-├── asobi_leaderboard_sup       — one child per leaderboard
-│   └── asobi_leaderboard_server — in-memory buffer, periodic DB flush
-├── asobi_chat_sup              — chat channel processes
-├── asobi_tournament_sup        — tournament processes
-└── asobi_presence              — tracks online players via pg
+├── asobi_rate_limits             temporary; registers the seki limiter buckets
+├── asobi_oidc_providers          temporary; starts OIDC workers only if providers are configured
+├── asobi_auth_cache              per-node bearer-token cache
+├── asobi_cluster                 node discovery; returns `ignore` unless `cluster` is set
+├── asobi_player_session_sup      simple_one_for_one
+│   └── asobi_player_session      one per connected socket
+├── asobi_match_sup               simple_one_for_one; owns the asobi_match_state table
+│   └── asobi_match_server        one per match (gen_statem)
+├── asobi_world_sup               owns asobi_world_state and asobi_player_worlds
+│   ├── asobi_zone_snapshotter
+│   ├── asobi_world_registry
+│   └── asobi_world_instance_sup  simple_one_for_one
+│       └── asobi_world_instance  one_for_all: zone sup, zone manager, ticker, world server
+├── asobi_world_lobby_server      serialises asobi_world_lobby:find_or_create/1
+├── asobi_vote_sup                simple_one_for_one
+│   └── asobi_vote_server         one per open vote
+├── asobi_matchmaker              the queue; ticks itself
+├── asobi_leaderboard_sup         simple_one_for_one
+│   └── asobi_leaderboard_server  one per board
+├── asobi_chat_sup                simple_one_for_one; owns the channel registry table
+│   └── asobi_chat_channel        one per live channel
+├── asobi_tournament_sup          simple_one_for_one
+│   └── asobi_tournament_server   registered under `global`
+├── asobi_presence                online set and delivery targets, over pg
+├── asobi_guest_reaper            opt-in sweep of unclaimed guest accounts
+├── asobi_console_session         console session table; started whether or not the console is on
+├── asobi_lua_config              temporary; loads the game config
+├── asobi_lua_sup
+│   ├── asobi_lua_rate_limits     temporary; `game.log` budgets
+│   ├── asobi_bot_sup
+│   ├── asobi_bot_spawner
+│   └── asobi_lua_config_watcher
+└── asobi_extension_sup           one child group per installed extension
 ```
 
-## Session Lifecycle
+The last three entries are ordered deliberately and the order is load-bearing:
+core children, then the Lua config load, then the Lua children, then extensions
+(`src/asobi_sup.erl:44-52`). The Lua runtime used to be its own OTP
+application, which started after `asobi` and therefore loaded the game config
+after every `asobi_sup` child was already up. Moving the load earlier changes
+what a core child that reads configuration at `start_link/0` sees at boot, so
+it stays here and the old order is preserved exactly.
+
+A game config that fails to load aborts the boot. `load_lua_game_config/0`
+raises, which arrives as a supervisor `failed_to_start_child` and takes the
+already-started core children down with it (`src/asobi_sup.erl:60-72`). A node
+with an unloadable game config has nothing useful to serve.
+
+`asobi_extension_sup` is last so an extension's processes start after every
+core service they might call. With no extensions installed it is one idle
+supervisor with no children (`src/asobi_sup.erl:81-89`).
+
+`asobi_rate_limits` is a temporary registration child, not a server: it calls
+`seki:new_limiter/2` once per bucket and returns `ignore`
+(`src/asobi_sup.erl:217-305`). The buckets themselves live in seki, in memory,
+per node - ten of them, covering auth, register, iap, api, ws_connect, join,
+guest_global, script_log, rehome and rehome_global.
+
+## Session lifecycle
+
+One `asobi_player_session` process per connection, started when the socket
+sends `session.connect` and stopped when the socket closes
+(`src/ws/asobi_ws_handler.erl:356-370`). A session does not survive the
+connection. A client that reconnects presents the same token and gets a new
+session process.
 
 ```
-Client                    WS Handler              Session              Presence (pg)
-  │                          │                       │                      │
-  │── WS connect ───────────►│                       │                      │
-  │── session.connect ──────►│                       │                      │
-  │                          │── authenticate(token) │                      │
-  │                          │   (DB lookup)         │                      │
-  │                          │── start_session ─────►│                      │
-  │                          │                       │── track(id, self) ──►│
-  │                          │                       │   pg:join(player,id) │
-  │◄── session.connected ───│                       │                      │
-  │                          │                       │                      │
-  │   ... gameplay ...       │                       │                      │
-  │                          │                       │                      │
-  │── disconnect ───────────►│                       │                      │
-  │                          │── stop(session) ─────►│                      │
-  │                          │                       │── untrack(id) ──────►│
-  │                          │                       │   pg:leave           │
+Client              WS handler           Session              pg
+  │                     │                   │                  │
+  │─ WS connect ───────►│                   │                  │
+  │─ session.connect ──►│                   │                  │
+  │                     │ resolve_token     │                  │
+  │                     │─ start_session ──►│                  │
+  │                     │                   │─ join {player,Id}►│
+  │◄ session.connected ─│                   │                  │
+  │     ... play ...    │                   │                  │
+  │─ disconnect ───────►│                   │                  │
+  │                     │─ stop ───────────►│                  │
+  │                     │                   │─ leave ─────────►│
 ```
 
-**Key points:**
-- Token is validated **once** at `session.connect` via DB lookup
-- After authentication, `player_id` lives in process state — no further DB checks
-- The session process monitors the WS process; if WS dies, session cleans up
-- WS terminate calls `session:stop/1` for the reverse direction
+The token is resolved once, at `session.connect`. After that the `player_id`
+lives in process state and no further lookup happens on the hot path. The
+session monitors the WebSocket process, and `terminate/3` calls
+`asobi_player_session:stop/1` for the other direction.
 
-## Session Revocation
+### The auth cache
 
-When a player is banned, deleted, or their token is revoked:
+Bearer tokens are opaque 32 random bytes issued by `nova_auth` and stored in
+`player_tokens` (`src/asobi_auth.erl:6-18`,
+`src/migrations/m20260329095708_update_schema.erl:185`). They are not JWTs, so
+resolving one is a database read, and both the HTTP plugin and the WebSocket
+handler go through a per-node ETS cache to avoid doing it per request
+(`src/plugins/asobi_auth_plugin.erl:11`, `src/ws/asobi_ws_handler.erl:914`).
+
+Entries expire after `auth_cache_ttl_ms`, default 60000 ms; negative results
+expire after `auth_cache_negative_ttl_ms`, default 5000 ms
+(`src/auth/asobi_auth_cache.erl:94-95`). That TTL is the bound on revocation
+latency: a token revoked through `asobi_auth_tokens` or
+`asobi_auth_cache:revoke_player/1` is invalidated immediately on the node that
+did it, and everywhere else within the TTL. Access tokens are valid for 60
+minutes and refresh tokens for 30 days, both `nova_auth` defaults
+(`src/asobi_auth.erl:15`).
+
+The cache is per node. Nothing replicates it.
+
+## Session revocation
 
 ```erlang
 asobi_presence:revoke_session(PlayerId, ~"banned").
 ```
 
-**Flow:**
-1. `revoke_session/2` enqueues a job on the `broadcast` fanout queue via Shigoto
-2. All nodes poll the fanout queue and pick up the job
-3. Each node calls `asobi_presence:disconnect/2` locally
-4. `disconnect/2` looks up session processes in the local `pg` group
-5. Sends `{session_revoked, Reason}` to each session process
-6. Session forwards to WS process, then stops
-7. WS handler logs and returns `{stop, State}`
+`revoke_session/2` enqueues a job on the `broadcast` fanout queue
+(`src/social/asobi_presence.erl:121-123`). Every node consumes the fanout
+queue, and `asobi_broadcast_worker:perform/1` calls
+`asobi_presence:disconnect/2` locally, which looks the player up in the local
+`pg` group and sends `{session_revoked, Reason}` to each session process
+(`src/workers/asobi_broadcast_worker.erl:24-25`).
 
-This uses Shigoto's fanout queue mode — every node processes every broadcast
-job. Jobs are ephemeral (120s window, auto-pruned). Workers are idempotent.
-The source of truth is always the database.
+`asobi_broadcast_worker` is the only worker asobi ships, and it handles exactly
+three job types: `session_revoked`, `notification` and `chat`. Anything else
+logs `unknown_broadcast_type` and returns ok.
 
-**Two-layer API:**
-- `asobi_presence:revoke_session/2` — public API, enqueues broadcast job (cross-node)
-- `asobi_presence:disconnect/2` — local delivery mechanism, called by the broadcast worker
+Fanout jobs are ephemeral - a 120 second window in the dev config
+(`config/dev_sys.config.src`), auto-pruned. The database is the source of
+truth; the fanout is a best-effort push.
 
-## Match Lifecycle
+## Match lifecycle
 
-```
-Matchmaker              Match Sup            Match Server          Players (via pg)
-  │                        │                      │                     │
-  │── start_match(Config)─►│                      │                     │
-  │                        │── start_link ────────►│ (waiting state)     │
-  │                        │                      │                     │
-  │── join(Pid, Player1) ─────────────────────────►│                     │
-  │── join(Pid, Player2) ─────────────────────────►│ (min_players met)   │
-  │                        │                      │── enter running ───►│
-  │                        │                      │                     │
-  │                        │                      │◄── {input, ...} ────│
-  │                        │                      │── tick ──────────── │
-  │                        │                      │── broadcast_state ─►│
-  │                        │                      │   (10 Hz loop)      │
-  │                        │                      │                     │
-  │                        │                      │── enter finished    │
-  │                        │                      │── persist_result ──►DB
-  │                        │                      │── notify_players ──►│
-  │                        │                      │── cleanup (5s) ────►stop
-```
-
-**Match states:** `waiting → running → finished` (also `paused`)
-
-**Server-authoritative:** The match process owns all game state. Clients send
-inputs, the server applies them each tick, and broadcasts the resulting state.
-The game module (`asobi_match` behaviour) provides `init/1`, `join/2`,
-`handle_input/3`, `tick/1`, and either `get_state/2` (per-player) or
-`get_state/1` (shared, broadcast-once — see [Performance Tuning](performance-tuning.md)).
-
-## Database & Migrations
-
-Each node runs its own PGO connection pool. Migrations run automatically at
-application startup via `kura_migrator:migrate(asobi_repo)`.
-
-**Migration rules:**
-- The initial schema uses `create_table` operations
-- Kura topologically sorts tables by FK dependencies — order in the migration
-  file doesn't matter
-- All operations run in a single PostgreSQL transaction with an advisory lock
-- **Never delete or modify an applied migration** — add new `alter_table`
-  migrations instead
-- If migration fails, the app logs the error and continues starting (by design,
-  to allow the app to serve health checks even with a stale schema)
-
-**Multi-node consideration:** The advisory lock ensures only one node runs
-migrations at a time. Other nodes wait. This is safe for rolling deploys.
-
-## Deployment Models
-
-### Single Node (Current)
-
-Everything runs on one BEAM node. All process communication is local.
-This is the simplest model and works for small-to-medium scale.
+`asobi_match_server` is a `gen_statem` under `asobi_match_sup`
+(`src/matches/asobi_match_server.erl:60-62`,
+`src/matches/asobi_match_sup.erl:22-33`). States are `waiting`, `running`,
+`paused` and `finished`; a cancellation is a transition to `finished` with a
+`cancelled` result, not a state of its own.
 
 ```
-┌─────────────────────────────────┐
-│           BEAM Node             │
-│  ┌──────────┐  ┌─────────────┐ │
-│  │ WS/HTTP  │  │ Matchmaker  │ │
-│  │ Handlers │  │ (local)     │ │
-│  └──────────┘  └─────────────┘ │
-│  ┌──────────┐  ┌─────────────┐ │
-│  │ Sessions │  │ Matches     │ │
-│  │ (local)  │  │ (local)     │ │
-│  └──────────┘  └─────────────┘ │
-│  ┌──────────────────────────┐  │
-│  │ pg (presence, chat)      │  │
-│  └──────────────────────────┘  │
-└──────────────┬──────────────────┘
-               │
-         ┌─────▼─────┐
-         │ PostgreSQL │
-         └───────────┘
+Matchmaker           Match sup         Match server        Players (pg)
+  │                     │                   │                   │
+  │─ start_match(Cfg)──►│                   │                   │
+  │                     │─ start_link ─────►│ waiting           │
+  │─ join(Pid, P1) ────────────────────────►│                   │
+  │─ join(Pid, P2) ────────────────────────►│ running           │
+  │                     │                   │◄─ {input, ...} ───│
+  │                     │                   │── tick ───────────│
+  │                     │                   │── broadcast ─────►│
+  │                     │                   │ finished          │
+  │                     │                   │── persist ───────►DB
 ```
 
-**Migrations:** Always run at startup. One node, no contention.
+Server-authoritative: the match process owns all game state, clients send
+inputs, the server applies them on the tick and broadcasts the result. The tick
+is a `state_timeout`, default 100 ms
+(`src/matches/asobi_match_server.erl:47,200`).
 
-**Scale limit:** A single BEAM node can handle tens of thousands of concurrent
-WebSocket connections and hundreds of active matches. The bottleneck is usually
-the game tick loop CPU cost, not connection count.
+The game module implements the `asobi_match` behaviour. Only `init/1` and
+exactly one of `get_state/2` (per player) or `get_state/1` (shared,
+broadcast-once) are required; everything else is optional, including
+`join/2`, `join/3`, `leave/2`, `handle_input/3`, `tick/1`, `vote_requested/1`,
+`vote_resolved/3`, `phases/1`, `on_phase_started/2` and `on_phase_ended/2`
+(`src/matches/asobi_match.erl:30-128`). See
+[Performance tuning](performance-tuning.md) for when the shared form pays.
 
-### Distributed Erlang (Multi-Node)
+### Finding a match
 
-Multiple BEAM nodes connected via distributed Erlang. The `pg` module
-automatically replicates group membership across all connected nodes.
+A match joins the `pg` group `{asobi_match_server, MatchId}` in `nova_scope`
+when it starts, and `asobi_match_server:whereis/1` resolves through that group
+(`src/matches/asobi_match_server.erl:152-156,167`). Because `pg` replicates
+within a scope across connected nodes, a match pid is resolvable from any node
+in the cluster. The process itself does not move, and its 10 Hz broadcast stays
+where it is. Nothing registers matches under `global`. Tournament
+servers do: `asobi_tournament_server` starts as
+`{global, {asobi_tournament_server, TournamentId}}`
+(`src/tournaments/asobi_tournament_server.erl:10`).
 
+`asobi_match_state` is a separate thing and is often misread as the registry.
+It is a node-local public ETS table owned by `asobi_match_sup`
+(`src/matches/asobi_match_sup.erl:12`) into which a match writes a
+pid-stripped snapshot of its state, so a crashed match restarted by its
+supervisor on the same node resumes rather than starting empty
+(`src/matches/asobi_match_server.erl:948-968`). It is a crash-recovery buffer,
+it is per node, and it does not survive the node.
+
+## Matchmaker
+
+One `asobi_matchmaker` gen_server per node. It ticks itself with
+`erlang:send_after/3` - once in `init/1` and once at the end of every tick
+handler (`src/matches/asobi_matchmaker.erl:217,342`). The default interval is
+1000 ms and the default wait before a ticket expires is 60 seconds, both under
+the `matchmaker` key as `tick_interval` and `max_wait_seconds`.
+
+Tickets are a plain map in the gen_server's own state
+(`src/matches/asobi_matchmaker.erl:229,236-270`). There is no ticket table, no
+ticket schema and nothing persisted: the queue dies with the node, and a
+player queued against one node can never be matched with a player queued
+against another. Plan for that before you run more than one node - see
+[Clustering](clustering.md).
+
+One live ticket per player *per mode*. Re-adding while already queued for the
+same mode returns the existing ticket rather than minting a second, so a
+double-tapped "find match" cannot fill one player into a self-match
+(`src/matches/asobi_matchmaker.erl:246-252`). A player may hold tickets in two
+different modes at once.
+
+Grouping is a strategy module - `fill` (first-come, first-served) and
+`skill_based` (expanding window) ship. There is no query language and no region
+concept; filtering beyond `mode` happens inside your strategy against the
+ticket's `properties` map. When a group fills, the matchmaker starts the match
+through `asobi_match_sup` on its own node.
+
+## Lua subsystem
+
+The Lua runtime is fifteen modules under `src/lua/` plus the bot modules. It is
+not a wrapper around asobi; it is part of it.
+
+**Registration.** `asobi_app:start/2` calls
+`asobi_lua_sup:register_game_modes/0` before the supervision tree comes up,
+which registers `asobi_lua_match`, `asobi_lua_match_shared` and
+`asobi_lua_world` as the providers for the three Lua mode kinds
+(`src/asobi_app.erl:14,41-42`, `src/lua/asobi_lua_sup.erl:16-20`). Without that
+registration every `{lua, Script}` mode resolves to
+`{error, lua_runtime_unavailable}` (`src/asobi_game_modes.erl:92-100`). This is
+what makes a Lua mode resolvable at all, and it happens ahead of every
+`asobi_sup` child including the matchmaker.
+
+**Config load.** `asobi_lua_config:maybe_load_game_config/0` reads either a
+single `match.lua` or a `config.lua` manifest mapping mode names to script
+paths (`src/lua/asobi_lua_config.erl:5-20`). If neither file exists it is a
+no-op, so an Erlang project that configures modes in `sys.config` is
+unaffected. If a file exists and is broken, the boot fails - fail-closed, as
+described under the supervision tree above.
+
+**Loader and sandbox.** `asobi_lua_loader` builds the Luerl state and clears
+every dangerous standard-library entry point: `os.execute`, `os.exit`,
+`os.getenv`, `os.remove`, `os.rename`, `os.tmpname`, the whole of `io`,
+`dofile`, `loadfile`, `load`, `loadstring`, and the whole of `package`
+(`src/lua/asobi_lua_loader.erl:1-31`). `package` is replaced by a controlled
+`require/1` that resolves names relative to the loaded script's directory and
+rejects parent traversal and absolute paths. `init_sandboxed/0` gives a
+hardened state with no script attached, used for evaluating a `config.lua`
+manifest; `new/1` loads a script and pins its base directory. The API surface a
+script sees is `asobi_lua_api` and `asobi_lua_surface`; see
+[Lua API](lua-api.md).
+
+**Configuration keys.** The runtime's own keys go through
+`asobi_lua_env:get_env/2` (`src/lua/asobi_lua_env.erl:22-32`), which reads
+`asobi_lua` before `asobi` so a `sys.config` written against the old separate
+application did not become dead config at the merge. See
+[Which application key](configuration.md#which-application-key).
+
+## World and zone subsystem
+
+Twenty-two modules under `src/world/`. A world is long-lived, partitioned into
+zones on a grid, and ticked by its own process.
+
+`asobi_world_instance` is a `one_for_all` supervisor per world holding a zone
+supervisor, a zone manager, a ticker and the world server, started in that
+order because the world server discovers the others through the supervisor
+(`src/world/asobi_world_instance.erl:30-78`). One world therefore lives entirely
+on one node: its server, its ticker and every one of its zone processes are
+children of one supervisor tree on one BEAM. Worlds do not migrate.
+
+The world server joins the `pg` group `{asobi_world_server, WorldId}` so a
+world is discoverable from any connected node
+(`src/world/asobi_world_server.erl:174,187`). Two node-local public ETS tables
+back it: `asobi_world_state`, holding zone entity snapshots, and
+`asobi_player_worlds`, mapping a player to the world they are in
+(`src/world/asobi_world_sup.erl:26-36`). Both are node-local, and both are
+`public`, which is an explicit trust boundary - anything running in the same
+BEAM can read and write them, and a sandboxed runtime layered on top must keep
+its sandbox out of them.
+
+See [World server](world-server.md) and [Large worlds](large-worlds.md).
+
+## Leaderboards
+
+One `asobi_leaderboard_server` per board, hydrating its ETS tables from
+`leaderboard_entries` before it accepts reads
+(`src/leaderboards/asobi_leaderboard_server.erl:120-122`).
+
+The ETS table is an `ordered_set` keyed on `{-Score, PlayerId}`, so iteration
+order is rank order (`src/leaderboards/asobi_leaderboard_server.erl:138-168`).
+`sub_score` is written to the database as 0 and takes no part in ordering
+(`src/leaderboards/asobi_leaderboard_server.erl:362`); it exists as a column,
+not as a tiebreak.
+
+A 30 second timer inside the board process flushes dirty players to Postgres
+(`src/leaderboards/asobi_leaderboard_server.erl:123,177,180`). Each flush
+upserts only the players that changed since the last one; a player whose write
+fails stays pending and is retried. `terminate/2` flushes, so a clean restart
+does not lose scores.
+
+The exported API is `submit/3`, `top/2`, `rank/2`, `around/3` and
+`live_boards/0` (`src/leaderboards/asobi_leaderboard_server.erl:6`). There is
+no `reset/0`, no archive table and no scheduled reset. Time-scoped boards are
+something you build with separate board ids.
+
+## Chat
+
+One `asobi_chat_channel` process per live channel, members tracked in the `pg`
+group `{chat, ChannelId}`. A send fans out to the group's members and then
+inserts the row inline, in the same `handle_cast`
+(`src/social/asobi_chat_channel.erl:131-137,204-219`). There is no batching job
+and no async persist queue. Channel types and who may reach them are in
+`asobi_chat_acl`.
+
+## Presence
+
+`asobi_presence` records two separate things: the delivery target for a player
+and membership of the online set. `track/2` records both; `track_bot/2` records
+only the delivery target, so bots receive broadcasts without counting toward
+`online_count/0` (`src/social/asobi_presence.erl:15`). Status changes go out
+over `nova_pubsub`, not the fanout queue.
+
+Everything `asobi_presence:send/2` delivers is one of the shapes in
+`t:asobi_presence:message/0`.
+
+## Extensions and the RPC seam
+
+An extension is an OTP application listed in the release that declares a
+manifest. `asobi_extension_sup` starts one child group per installed extension,
+last in the tree. Extensions contribute no routes.
+
+Clients reach an extension over the WebSocket, through one frame type:
+
+```json
+{"type": "rpc.call", "cid": "c-1",
+ "payload": {"protocol": 1, "method": "shop.buy", "params": {"sku": "hat"}}}
 ```
-┌──────────────┐    ┌──────────────┐    ┌──────────────┐
-│    Node A     │    │    Node B     │    │    Node C     │
-│  WS/HTTP     │    │  WS/HTTP     │    │  WS/HTTP     │
-│  Sessions    │◄──►│  Sessions    │◄──►│  Sessions    │
-│  Matches     │    │  Matches     │    │  Matches     │
-│  Matchmaker  │    │  Matchmaker  │    │  Matchmaker  │
-│  pg (shared) │    │  pg (shared) │    │  pg (shared) │
-└──────┬───────┘    └──────┬───────┘    └──────┬───────┘
-       │                   │                   │
-       └───────────────────┼───────────────────┘
-                     ┌─────▼─────┐
-                     │ PostgreSQL │
-                     └───────────┘
+
+The reply is `rpc.ok` with a `result`, or `rpc.error` with the standard error
+object:
+
+```json
+{"type": "rpc.ok",    "cid": "c-1", "payload": {"result": {"reward": 100}}}
+{"type": "rpc.error", "cid": "c-1", "payload": {"error": {"code": "...", "message": "...", "details": {}}}}
 ```
 
-**What works across nodes today:**
-- **Presence** — `pg:get_members(nova_scope, {player, Id})` returns pids on all
-  nodes. Sending messages to those pids works transparently. Delivery targets
-  and the online set are separate: `asobi_presence:track/2` records both,
-  `track_bot/2` records only the delivery target, so bots receive broadcasts
-  without ever counting toward `online_count/0`. Everything `send/2` delivers
-  is one of the shapes in `t:asobi_presence:message/0`.
-- **Session revocation** — `asobi_presence:disconnect/2` reaches sessions on any
-  node.
-- **Chat** — `nova_pubsub` uses `pg` underneath, so chat messages cross nodes.
-- **Match state broadcasts** — `broadcast_state` uses `asobi_presence:send/2`
-  which goes through `pg`, so a match process on Node A can send state to a
-  player session on Node B.
+`cid` is required on `rpc.call` and validated, unlike the rest of the socket
+where it is optional - it is the only way a client pairs a reply with the call
+it made, and it is bounded and checked rather than reflected unchanged. A
+rejected `cid` is not echoed back (`src/extensions/asobi_rpc.erl:12-25,118-128`).
+Every client SDK speaks this. See [Extensions](extensions.md).
 
-**What does NOT work today:**
-- **Matchmaker** — Each node runs its own `asobi_matchmaker` (local registration).
-  A player on Node A and a player on Node B won't be matched together.
-- **Match lookup by ID** — `global:whereis_name({asobi_match_server, MatchId})`
-  fails because matches don't register globally.
-- **Rate limiting** — Per-node ETS, not shared.
+## Ops plane and console
 
-**Migrations:** The Kura advisory lock ensures only one node migrates at a
-time. Safe for rolling deploys, but you should NOT run migrations on every node
-simultaneously — let the first node apply, others will see the version already
-recorded and skip.
+The node serves an operator console at `/console` and an ops HTTP API at
+`/api/v1/ops/*`, on the same listener as the game
+(`src/asobi_router.erl:25-26,214,282`).
 
-**When to use:** Small clusters (2-5 nodes) on the same network. Full mesh
-topology. Good for HA and moderate scale. Not suitable for large clusters or
-multi-region.
+The two are gated separately. `/console` needs `console` to be true; the ops
+routes are always mounted and reject everything until an `ops_secret` is
+configured, so a stock node serves neither. [Operator console](console.md) owns
+the detail.
 
-### Cloud-Native (No Distributed Erlang)
+Core's ops routes are all reads. Every route carries a capability class -
+`read`, `player_data` or `config` (`src/ops/asobi_ops_caps.erl:22`) - and the
+only route that mutates is `/api/v1/ops/ext/:extension/:action`, whose
+behaviour comes from an installed extension.
 
-In Kubernetes, Fly.io, or similar platforms, distributed Erlang is often
-impractical:
-- Dynamic IPs and pod churn make node discovery fragile
-- Full mesh doesn't scale beyond ~50 nodes
-- The distribution protocol has a large security surface
-- Stateless horizontal scaling is the expected model
+The console holds no privileged path into the database. It reads the ops plane
+over HTTP like any other client. It was previously a separate project,
+`asobi_admin`, which read the same database directly; that is archived, because
+a second deployment to secure and keep in step was the wrong shape for
+something an operator opens during an incident.
 
-In this model, each BEAM node is independent. Cross-node communication goes
-through PostgreSQL (which you already have) and Shigoto (which you already have).
-No Redis, no NATS, no additional infrastructure.
+## Database and migrations
 
-#### The Shigoto Broadcast Pattern
+Each node runs its own pgo pool through Kura. Migrations are Erlang modules in
+`src/migrations/` and run at application start, before the supervision tree,
+via `kura_migrator:migrate(asobi_repo)` (`src/asobi_app.erl:16-22`).
 
-The core idea: **every cross-node event is a Shigoto fanout job**. All nodes
-consume the fanout queue. When a node picks up a job, it broadcasts locally
-via `pg` to the affected sessions, which push to clients via WebSocket.
+- All operations in one migration run in a single PostgreSQL transaction under
+  an advisory lock, so only one node migrates at a time and the rest wait. Safe
+  for a rolling deploy.
+- Kura topologically sorts `create_table` operations by foreign-key dependency,
+  so ordering within a migration file does not matter.
+- Never edit or delete an applied migration. Add an `alter_table` migration.
+- A failed migration logs `migration_failed` and the node carries on starting,
+  but `asobi_readiness:mark_ready/0` is not called - the node comes up and
+  reports itself unready rather than dying.
 
-```
-Producer Node                 PostgreSQL              All Consumer Nodes
-     │                            │                         │
-     │── shigoto:insert(...)────►│                         │
-     │   (broadcast queue)        │                         │
-     │                            │── fanout poll ─────────►│
-     │                            │   (no locking,          │── local pg lookup
-     │                            │    time-window)         │── broadcast to sessions
-     │                            │                         │── WS push to clients
-```
+## Running more than one node
 
-Fanout jobs are ephemeral — they live in the database for a configurable
-window (default 120s), then are automatically pruned. Workers must be
-idempotent. If a node misses a broadcast (e.g. during restart), the client
-catches up from the database on reconnect. The database is always the
-source of truth; fanout is best-effort push.
+Everything above describes one node, which is the shape asobi is designed
+around: a match lives on one node, a world lives on one node, and neither
+migrates.
 
-#### Architecture Diagram
+[Clustering](clustering.md) is the single source of truth for what is and is
+not cluster-safe, and holds the complete list of per-node state. Do not infer
+it from this page. Before you go further, four facts about a node that shape
+every clustering decision:
 
-```
-┌──────────────────┐  ┌──────────────────┐  ┌──────────────────┐
-│      Pod A       │  │      Pod B       │  │      Pod C       │
-│  WS/HTTP         │  │  WS/HTTP         │  │  WS/HTTP         │
-│  Sessions (pg)   │  │  Sessions (pg)   │  │  Sessions (pg)   │
-│  Matches (local) │  │  Matches (local) │  │  Matches (local) │
-│  Shigoto worker  │  │  Shigoto worker  │  │  Shigoto worker  │
-└────────┬─────────┘  └────────┬─────────┘  └────────┬─────────┘
-         │                     │                     │
-         └─────────────────────┼─────────────────────┘
-                               │
-                    ┌──────────▼──────────┐
-                    │     PostgreSQL      │
-                    │  ┌───────────────┐  │
-                    │  │ shigoto_jobs  │  │  ← shared job queue
-                    │  │ asobi tables  │  │  ← application state
-                    │  └───────────────┘  │
-                    └─────────────────────┘
-```
+- The matchmaker queue and its tickets are in one gen_server's state, per node,
+  never persisted.
+- The console session store and its CSRF secret are per node and per boot.
+- Rate-limit buckets and the auth cache are per node.
+- Matches and worlds are pinned to the node that started them.
 
-No Redis. No NATS. No distributed Erlang. Just PostgreSQL.
+Postgres is shared, so everything persistent is consistent across nodes.
+`pg`-scoped lookups - presence, chat, match and world `whereis` - resolve
+across connected nodes.
 
-#### What Goes Through the Fanout Queue
-
-| Event | Producer | Consumer Behavior |
-|-------|----------|-------------------|
-| Session revocation (ban/delete) | Admin action | All nodes: `asobi_presence:disconnect/2` locally |
-| Chat message (cross-pod) | Sender's pod | All nodes: deliver to local `pg` chat group members |
-| Notification | Any service | All nodes: push to player's local session if connected |
-| Presence update | Any pod | All nodes: update local presence state |
-| Matchmaker ticket | Player's pod | One node (matchmaker leader): process ticket |
-
-#### What Does NOT Go Through the Fanout Queue
-
-| Event | Why | Mechanism |
-|-------|-----|-----------|
-| Match state (10 Hz) | Too fast, must be local | Local `pg` on same pod (sticky placement) |
-| Match input | Same pod as match | Direct `gen_statem:cast` |
-| Leaderboard flush | Already DB-backed | Local buffer → periodic `asobi_repo:insert` |
-
-#### Sticky Match Placement
-
-The matchmaker assigns a pod for each match. All matched players connect (or
-get routed) to that pod. The match process, player sessions, and game tick
-loop stay local — no cross-pod communication at 10 Hz.
-
-The load balancer routes by match ID or a session cookie set during the
-matchmaker flow.
-
-#### Migrations
-
-Run as a separate Kubernetes Job or init container before the deployment rolls
-out. Do not race migrations across pods — use a single job with Kura's
-advisory lock as a safety net.
-
-## Match Placement: Same Node vs Distributed
-
-**Should all players in a match be on the same node?**
-
-Yes, for real-time games. The match server ticks at 10 Hz and broadcasts state
-to all players. If players are on different nodes:
-
-- **Distributed Erlang:** Works, but adds ~0.1-1ms per message hop. At 10 Hz
-  with 10 players on 3 nodes, that's 100 cross-node messages/second. Tolerable
-  for small clusters, but adds jitter.
-- **Cloud-native:** Unacceptable without distributed Erlang. You'd need to
-  serialize state to Redis/NATS per tick, which adds latency and complexity.
-
-**Recommendation:** Use sticky match placement. The matchmaker assigns a node,
-all matched players connect (or get routed) to that node for the duration of the
-match. This keeps the tight game loop local.
-
-**For non-real-time features** (leaderboards, chat, social, inventory): these
-are request/response or low-frequency pub/sub. Cross-node or cross-pod
-communication via the Shigoto fanout queue is fine.
-
-## Summary: Which Model When
-
-| Scale | Model | Notes |
-|-------|-------|-------|
-| Dev / small prod | Single node | Simplest. Up to ~10K concurrent connections. |
-| Medium (HA needed) | Distributed Erlang, 2-5 nodes | Add global matchmaker, global match registration. Sticky match placement. |
-| Large / cloud-native | Independent pods + Shigoto/PG | Cross-pod events via Shigoto fanout queue. Sticky match placement. No Redis/NATS needed. Migration via job. |
-
-The current codebase is designed for single-node. Moving to distributed Erlang
-requires making the matchmaker cluster-aware (global registration or a shared
-queue via `pg`). Moving to cloud-native requires only PostgreSQL — Shigoto
-provides the durable fanout queue for cross-pod broadcast, and `pg` handles
-local-node session routing. No additional infrastructure beyond what you
-already have.
+Sticky routing, where you need it, is a load-balancer configuration you own.
+asobi does not implement placement, does not assign nodes, and sets no cookie
+for it; the only cookies in the codebase are the console's
+(`src/console/asobi_console_session.erl`).

--- a/guides/authentication.md
+++ b/guides/authentication.md
@@ -1,24 +1,22 @@
 # Authentication
 
-Asobi supports multiple authentication methods: username/password, OAuth/OIDC
-social login (Google, Apple, Microsoft, Discord), Steam, and anonymous
-[guest](#guest-anonymous) accounts that a player can later upgrade to a real one.
+asobi supports username/password, OAuth/OIDC social login (Google, Apple,
+Microsoft, Discord), Steam, and anonymous [guest](#guest-anonymous) accounts a
+player can later upgrade to a real one. A player can link several providers to
+one account.
 
-Players can link multiple providers to a single account.
+Every auth endpoint returns the same four fields: `player_id`, `access_token`
+(short-lived), `refresh_token` (used against `/auth/refresh`) and `username`.
+Use `access_token` as the `Bearer` credential. There is no `session_token`
+field anywhere in asobi.
 
-> Auth endpoints return an `access_token` (short-lived) and a `refresh_token`
-> (used against `/auth/refresh`). Use the `access_token` as the `Bearer`
-> credential.
+Run the `curl` examples in Git Bash or WSL on Windows, or use PowerShell's
+`Invoke-RestMethod` with the same URL and a JSON `-Body`. Authenticated calls
+add `-Headers @{ Authorization = 'Bearer <token>' }`.
 
-> #### Windows {: .info}
->
-> Run the `curl` examples in Git Bash or WSL, or use PowerShell's
-> `Invoke-RestMethod` with the same URL and a JSON `-Body`. Authenticated calls
-> add `-Headers @{ Authorization = 'Bearer <token>' }`.
+## Username and password
 
-## Username & Password
-
-The simplest method. Register and login to receive a token pair:
+Register to create an account and receive a token pair:
 
 ```bash
 curl -X POST http://localhost:8084/api/v1/auth/register \
@@ -30,17 +28,28 @@ curl -X POST http://localhost:8084/api/v1/auth/register \
 {"player_id": "...", "access_token": "...", "refresh_token": "...", "username": "player1"}
 ```
 
+Log in to get a fresh pair for an existing account:
+
+```bash
+curl -X POST http://localhost:8084/api/v1/auth/login \
+  -H 'Content-Type: application/json' \
+  -d '{"username": "player1", "password": "secret123"}'
+```
+
+The response is identical. A wrong username or password answers
+`401 auth.invalid_credentials`; a missing field answers `400 missing_field`.
+
 Use the access token in subsequent requests:
 
 ```
 Authorization: Bearer <access_token>
 ```
 
-## Refresh & Rotation
+## Refresh and rotation
 
 Access tokens are short-lived. When one expires (a `401`), exchange the refresh
 token for a fresh pair at `/api/v1/auth/refresh`. Rotation is single-use: the
-server burns the presented refresh token and returns a new access token _and_ a
+server burns the presented refresh token and returns a new access token and a
 new refresh token, so always store both from the response.
 
 ```bash
@@ -53,11 +62,31 @@ curl -X POST http://localhost:8084/api/v1/auth/refresh \
 The official SDKs persist the refresh token, attach the access token to every
 call, and refresh-and-retry on a 401 automatically.
 
-## OAuth / Social Login
+## Logout
 
-For game clients, Asobi uses server-side token validation. The game client
-authenticates with the platform SDK (Google Sign-In, Apple Sign-In, etc.)
-to obtain an ID token, then sends it to Asobi for validation.
+```bash
+curl -X POST http://localhost:8084/api/v1/auth/logout \
+  -H 'Content-Type: application/json' \
+  -d '{"refresh_token": "<refresh_token>"}'
+```
+
+```json
+{"success": true}
+```
+
+Passing the refresh token revokes the whole **refresh family** - the chain of
+tokens that rotation minted from the original login, not just the one presented
+- so a stolen older token in that chain is dead too. The access token on the
+request is revoked as well.
+
+Calling it with no body still revokes the access token on the request and
+answers `200`. Logging out twice is not an error.
+
+## OAuth and social login
+
+The game client authenticates with the platform SDK (Google Sign-In, Apple
+Sign-In and so on) to obtain an ID token, then sends it to asobi for
+server-side validation.
 
 ```
 POST /api/v1/auth/oauth
@@ -67,8 +96,8 @@ POST /api/v1/auth/oauth
 
 1. Player taps "Sign in with Google" in your game
 2. Platform SDK returns an ID token (JWT)
-3. Game client sends the token to Asobi
-4. Asobi validates the JWT against the provider's JWKS
+3. The game client sends the token to asobi
+4. asobi validates the JWT against the provider's JWKS
 5. If the identity exists, the player is logged in
 6. If not, a new player account is created and linked
 
@@ -103,26 +132,53 @@ Returning player response:
 }
 ```
 
-### Error Responses
+### Error responses
 
-| Status | `error`                | Cause |
-|--------|------------------------|-------|
-| `400`  | `missing_required_fields` | `provider` or `token` missing |
-| `401`  | `invalid_token`        | Token failed provider validation |
-| `401`  | `unsupported_provider` | `provider` isn't one of the values below |
-| `403`  | *(registration reason)* | New-account registration is closed for this provider (`asobi_registration:check/1`) |
-| `409`  | `already_registering`  | Two first-sign-ins for the same provider identity raced; retry - the retry logs in to the account the other request created |
-| `500`  | `registration_failed`  | Account creation failed for a reason other than the race above (logged server-side) |
+| Status | `error.code` | Cause |
+|---|---|---|
+| `400` | `missing_field` | `provider` or `token` absent, or not a string |
+| `401` | `auth.provider_rejected` | The provider rejected the token. The specific reason is in `details.reason` |
+| `401` | `auth.unsupported_provider` | `provider` is not one of the values below, or the deployment configured no provider under that name |
+| `403` | `auth.registration_closed` | New-account registration is closed for this deployment |
+| `409` | `auth.already_registering` | Two first-sign-ins for the same provider identity raced; retry, and the retry logs in to the account the other request created |
+| `409` | `auth.provider_already_linked` | On `/auth/link`: that provider account already belongs to another player |
+| `500` | `auth.registration_failed` | Account creation failed for a reason other than the race above (logged server-side) |
 
-### Supported Providers
+Every provider-side rejection collapses to `auth.provider_rejected`, whatever
+went wrong. A bad signature, an expired token, a wrong audience, an unreachable
+JWKS and a Steam ticket the Steam Web API refused all produce that one code,
+with the distinguishing reason in `details.reason`:
 
-| Provider  | `provider` value | Issuer |
-|-----------|-----------------|--------|
-| Google    | `"google"`      | `https://accounts.google.com` |
-| Apple     | `"apple"`       | `https://appleid.apple.com` |
-| Microsoft | `"microsoft"`   | `https://login.microsoftonline.com/common/v2.0` |
-| Discord   | `"discord"`     | `https://discord.com` |
-| Steam     | `"steam"`       | N/A (custom, see below) |
+```json
+{"error": {"code": "auth.provider_rejected", "message": "...", "details": {"reason": "invalid_token"}}}
+```
+
+Branch on the code, log the reason. The reason is a server-side label - for
+Steam it is lifted from Steam's own error response - so it is not part of
+asobi's contract and can be reworded.
+
+### Supported providers
+
+The issuer column is the value **you configure**, not a default: asobi ships no
+OIDC provider configuration at all, so social login is entirely off until you
+add `oidc_providers`. These are the well-known issuers for each provider.
+
+| Provider | `provider` value | Issuer to configure |
+|---|---|---|
+| Google | `"google"` | `https://accounts.google.com` |
+| Apple | `"apple"` | `https://appleid.apple.com` |
+| Microsoft | `"microsoft"` | `https://login.microsoftonline.com/common/v2.0` |
+| Discord | `"discord"` | `https://discord.com` |
+| Steam | `"steam"` | not OIDC, see [Steam](#steam) below |
+
+A provider entry with no `issuer`, or with an issuer that is not `https://`,
+is **disabled at boot**. The node logs `oidc provider is missing issuer` or
+`oidc provider has a non-https issuer` naming the provider, then starts
+normally with that one provider dropped. You do not get an error at request
+time; you get `401 auth.unsupported_provider` for a provider you believe you
+configured, and the reason is in the boot log. The https rule is not optional:
+asobi pins the TLS trust anchor for the discovery and JWKS fetch, and a
+plaintext issuer bypasses that pin entirely.
 
 ### Configuration
 
@@ -132,25 +188,26 @@ Add provider credentials to your `sys.config`:
 {asobi, [
     {oidc_providers, #{
         google => #{
-            issuer => <<"https://accounts.google.com">>,
-            client_id => <<"YOUR_CLIENT_ID">>,
-            client_secret => <<"YOUR_CLIENT_SECRET">>
+            issuer => ~"https://accounts.google.com",
+            client_id => ~"YOUR_CLIENT_ID",
+            client_secret => ~"YOUR_CLIENT_SECRET"
         },
         apple => #{
-            issuer => <<"https://appleid.apple.com">>,
-            client_id => <<"YOUR_CLIENT_ID">>,
-            client_secret => <<"YOUR_CLIENT_SECRET">>
+            issuer => ~"https://appleid.apple.com",
+            client_id => ~"YOUR_CLIENT_ID",
+            client_secret => ~"YOUR_CLIENT_SECRET"
         }
     }}
 ]}
 ```
 
-Each provider needs a client ID and secret from the respective developer console:
+The map key is an atom and the value a map; anything else is logged and
+dropped. Each provider needs a client id and secret from its developer console:
 
-- **Google**: [Google Cloud Console](https://console.cloud.google.com/) → APIs & Services → Credentials
-- **Apple**: [Apple Developer](https://developer.apple.com/) → Certificates, Identifiers & Profiles → Service IDs
-- **Microsoft**: [Azure Portal](https://portal.azure.com/) → App registrations
-- **Discord**: [Discord Developer Portal](https://discord.com/developers/applications) → OAuth2
+- Google: [Google Cloud Console](https://console.cloud.google.com/), APIs and Services, Credentials
+- Apple: [Apple Developer](https://developer.apple.com/), Certificates Identifiers and Profiles, Service IDs
+- Microsoft: [Azure Portal](https://portal.azure.com/), App registrations
+- Discord: [Discord Developer Portal](https://discord.com/developers/applications), OAuth2
 
 ## Steam
 
@@ -163,15 +220,15 @@ curl -X POST http://localhost:8084/api/v1/auth/oauth \
   -d '{"provider": "steam", "token": "14000000..."}'
 ```
 
-Asobi validates the ticket via the Steam Web API and fetches the player's
+asobi validates the ticket via the Steam Web API and fetches the player's
 display name from their Steam profile.
 
 ### Configuration
 
 ```erlang
 {asobi, [
-    {steam_api_key, <<"YOUR_STEAM_WEB_API_KEY">>},
-    {steam_app_id, <<"YOUR_STEAM_APP_ID">>}
+    {steam_api_key, ~"YOUR_STEAM_WEB_API_KEY"},
+    {steam_app_id, ~"YOUR_STEAM_APP_ID"}
 ]}
 ```
 
@@ -187,18 +244,19 @@ the device, and presents it to resume the same account on every launch.
 Guest auth is **opt-in** and disabled by default. It turns on only when two
 independent parties agree (see [Configuration](#configuration-2)): the **game**
 declares `guest_auth = true` in its Lua config, and the **operator** supplies a
-verifier pepper. Either one alone leaves the endpoints returning `403`.
+verifier pepper. Either one alone leaves the endpoints returning
+`403 guest.disabled`.
 
 ### How it works
 
 1. On first launch the client generates a random `device_secret` (>= 32 bytes
    from a CSPRNG) and a stable `device_id`, and stores both on the device
    (Keychain on iOS, Keystore on Android, etc.).
-2. The client posts them to `POST /api/v1/auth/guest`. Asobi creates a player
+2. The client posts them to `POST /api/v1/auth/guest`. asobi creates a player
    and stores only a **salted, peppered HMAC** of the secret - never the secret
    itself - then returns a token pair.
 3. On later launches the client posts the same `device_id` + `device_secret`.
-   Asobi verifies the HMAC and resumes the **same** player (create-or-resume).
+   asobi verifies the HMAC and resumes the **same** player (create-or-resume).
 4. When the player is ready, they call `POST /api/v1/auth/guest/upgrade` with a
    username and password. The account becomes a normal password account and the
    device secret is revoked.
@@ -255,8 +313,8 @@ First call (new account):
 ```
 
 Later calls with the same credentials resume the same player and omit `created`.
-A wrong secret for a known `device_id` returns `401 invalid_device_secret` and
-never creates a second account.
+A wrong secret for a known `device_id` returns `401 guest.invalid_device_secret`
+and never creates a second account.
 
 ### Upgrade to a real account
 
@@ -297,66 +355,75 @@ Player id, progress, wallets, and inventory are preserved.
 | `401`  | `guest.already_upgraded`           | The account was already claimed; log in with its real credentials |
 | `403`  | `guest.disabled`                   | Guest auth is off - the game did not declare `guest_auth`, or no pepper is present |
 | `403`  | `auth.registration_closed`         | The deployment's registration posture refuses new accounts |
+| `403`  | `auth.password_registration_disabled` | From the shared registration guard. A closed deployment answers `auth.registration_closed` on the guest paths, so you should not see this one here |
 | `404`  | `player.not_found`                 | The upgrade token resolves to no player |
 | `409`  | `guest.device_already_registered`  | Two creates for the same device raced; retry - the retry resumes the existing guest |
 | `409`  | `guest.not_unclaimed`              | Upgrade target is not an unclaimed guest |
 | `409`  | `auth.username_taken`              | Upgrade username is already in use |
-| `500`  | `auth.password_registration_disabled` | Upgrade needs the password path, which this deployment disabled |
+| `422`  | `validation_failed`                | On upgrade: the new username or password failed validation. `details.fields` is per-field, for a form UI |
 | `500`  | `guest.create_failed`              | The player row could not be created |
 | `500`  | `internal`                         | The device resolves to an identity whose player no longer exists, or another server-side failure |
 | `503`  | `guest.capacity_reached`           | Global create limit or the unlinked-guest cap was hit |
 
 ### Configuration
 
-Guest auth is on **iff both** halves below are satisfied; either alone fails
-closed with `403 guest_auth_disabled`. The toggle belongs to the game, the pepper
-to the operator (ADR 0004: guest auth is declared by the game, peppered by the
-operator).
+Guest auth is on only if both halves below are satisfied; either alone fails
+closed with `403 guest.disabled`. The toggle belongs to the game, the pepper to
+the operator (ADR 0004).
 
 **1. The game declares the toggle.** `guest_auth` is a boolean game global,
-declared like `match_size` or `bots` - in `match.lua` for a single-mode game, or
+declared like `match_size` - in `match.lua` for a single-mode game, or
 `config.lua` for a multi-mode game:
 
 ```lua
 guest_auth = true
 ```
 
-**2. The operator supplies the pepper** (and any abuse controls). The pepper is
-the one value that must never live in a bundle:
+**2. The operator supplies the pepper** and any abuse controls:
 
 ```erlang
 {asobi, [
-    %% Required. A key-id -> pepper map (>= 32 bytes each). Keep old keys for the
-    %% guest retention window so existing guests can still resume after rotation.
-    {guest_verifier_pepper, #{<<"v1">> => <<"a-32-byte-or-longer-secret......">>}},
-    {guest_verifier_key_id, <<"v1">>},
+    %% Required. A key-id -> pepper map, each pepper >= 32 bytes. Keep old key
+    %% ids for the guest retention window so existing guests still resume
+    %% after a rotation.
+    {guest_verifier_pepper, #{~"v1" => ~"a-32-byte-or-longer-secret......"}},
+    {guest_verifier_key_id, ~"v1"},
 
     %% Optional abuse controls.
     {guest_unlinked_cap, 100000},        %% max unclaimed guests, or `infinity`
 
-    %% Optional retention. Unset = permanent guests (never reaped). Set to a
-    %% number of seconds to delete unclaimed guests older than that.
+    %% Optional retention. Unset = permanent guests (never reaped). A number of
+    %% seconds deletes unclaimed guests older than that.
     {guest_reap_after, 2592000}          %% e.g. 30 days
 ]}
 ```
 
-There is no `ASOBI_GUEST_AUTH` env var. A self-hoster owns both sides: set
-`guest_auth = true` in Lua and provide the pepper via
-`ASOBI_GUEST_VERIFIER_PEPPER`. On managed cloud the pepper is provisioned per
-environment, so the same bundle is off in dev (no pepper) and on in prod.
+A bare binary is accepted too, as shorthand for a single key: with
+`{guest_verifier_pepper, ~"a-32-byte-or-longer-secret......"}` every verifier
+uses it whatever key id is recorded. Prefer the map, because the bare form has
+no way to rotate.
 
-The pepper is a server-side secret that makes a stolen database of verifiers
-useless without it - store it like any other secret (env/secret manager), not in
-source. Guest creation is additionally bounded by a global rate limiter and the
-per-IP auth limiter.
+`guest_verifier_key_id` defaults to `~"v1"`, so a map keyed `~"v1"` needs no
+second setting. A pepper under 32 bytes is treated as absent and guest auth
+stays off.
 
-## Linking Providers
+**`guest_verifier_pepper` in `sys.config` is the only mechanism that works.**
+The image declares an `ASOBI_GUEST_VERIFIER_PEPPER` environment variable, but
+nothing substitutes it into the rendered configuration and nothing reads it: a
+deployment that sets only that variable gets `403 guest.disabled` on every
+guest call, forever. Set the `sys.config` key.
 
-Players can link additional providers to their existing account. This allows
-them to sign in from different platforms (e.g., link both Google and Steam to
-the same player).
+The pepper is a server-side secret that makes a stolen table of verifiers
+useless without it, so keep it out of source and out of your game bundle. Guest
+creation is additionally bounded by a global rate limiter and the per-IP auth
+limiter.
 
-### Link a Provider
+## Linking providers
+
+A player can link additional providers to an existing account and then sign in
+from any of them.
+
+### Link a provider
 
 Requires an authenticated session.
 
@@ -371,25 +438,32 @@ curl -X POST http://localhost:8084/api/v1/auth/link \
 {"provider": "discord", "provider_uid": "123456789", "linked": true}
 ```
 
-### Unlink a Provider
+A provider account already linked to someone else answers
+`409 auth.provider_already_linked`.
 
-Asobi prevents unlinking the last auth method to avoid locking the player out.
+### Unlink a provider
+
+**The provider goes in the query string, not the body.** A `DELETE` carrying a
+JSON body is not read at all and answers `400 missing_field`.
 
 ```bash
-curl -X DELETE http://localhost:8084/api/v1/auth/unlink \
-  -H 'Authorization: Bearer <access_token>' \
-  -H 'Content-Type: application/json' \
-  -d '{"provider": "discord"}'
+curl -X DELETE 'http://localhost:8084/api/v1/auth/unlink?provider=discord' \
+  -H 'Authorization: Bearer <access_token>'
 ```
 
 ```json
 {"success": true}
 ```
 
-## WebSocket Authentication
+asobi refuses to unlink the last auth method, so a player cannot lock
+themselves out: if the account has no password and no other linked provider,
+the call answers `422 auth.last_auth_method`. An unlinked provider answers
+`404 auth.identity_not_found`.
 
-After obtaining an access token (from any auth method), connect to the
-WebSocket and authenticate:
+## WebSocket authentication
+
+After obtaining an access token from any auth method, connect to the WebSocket
+and authenticate:
 
 ```json
 {
@@ -398,43 +472,26 @@ WebSocket and authenticate:
 }
 ```
 
-The token works the same regardless of which provider was used to obtain it.
+The token works the same regardless of which provider issued it.
 
-## SDK Integration
+## SDK integration
 
-The same Google sign-in flow across the SDKs. The platform SDK returns an ID
-token; hand it to Asobi and the access token is stored internally.
+Every SDK wraps these routes, stores the token pair and refreshes it on a 401.
+The platform SDK returns an ID token; hand it to `auth.oauth` with the provider
+name. See your SDK's README for the exact method names and the device-credential
+helper covered under [Guest](#guest-anonymous).
 
-<!-- tabs -->
-**Unity (C#)**
-```csharp
-string idToken = googleSignIn.IdToken;
-var response = await asobi.Auth.OAuth("google", idToken);
-// response.SessionToken is now set automatically
-```
-**Godot (GDScript)**
-```gdscript
-var id_token = google_sign_in.get_id_token()
-var result = await asobi.auth.oauth("google", id_token)
-# Session token is stored internally
-```
-**Dart / Flutter / Flame**
-```dart
-final idToken = googleSignIn.currentUser!.authentication.idToken!;
-final result = await asobi.auth.oauth('google', idToken);
-// Session token is stored internally
-```
-**Defold (Lua)**
-```lua
-local id_token = google_sign_in.get_id_token()
-asobi.auth.oauth("google", id_token, function(result)
-    -- Session token is stored internally
-end)
-```
-<!-- /tabs -->
+## Inspecting players
 
-## Next Steps
+The console has a Players screen, searchable by username and display name. It
+shows the ops projection only: `id`, `username`, `display_name`, `avatar_url`,
+`metadata`, `inserted_at` and `updated_at`. It does not show linked providers,
+guest status, device verifiers or tokens, and it cannot ban, reset a password,
+revoke a session or unlink anything - the ops plane is reads. See
+[Operator console](console.md).
 
-- [In-App Purchases](iap.md) -- receipt validation for Apple and Google
-- [REST API](rest-api.md) -- full API reference
-- [WebSocket Protocol](websocket-protocol.md) -- real-time message types
+## Next steps
+
+- [In-app purchases](iap.md) - receipt validation for Apple and Google
+- [REST API](rest-api.md) - full API reference
+- [WebSocket protocol](websocket-protocol.md) - real-time message types

--- a/guides/benchmarks.md
+++ b/guides/benchmarks.md
@@ -1,21 +1,27 @@
 # Benchmarks
 
-Performance measurements for Asobi on a single node. All tests run client and
-server on the same machine (8 cores, shared schedulers), so real-world
-deployments with separate client machines will see higher server throughput.
+Single-node performance measurements. Client and server run on the same
+machine, so a real deployment with the load generator elsewhere will see higher
+server throughput than the tables below.
+
+Measured on 2026-04-02 at commit `8069c02`. Re-run them yourself before you
+size anything: the numbers below are one machine on one day, not a promise.
 
 ## Test environment
 
-- **CPU**: 8 cores
-- **OTP**: 28
-- **PostgreSQL**: 17 (Docker, max_connections=500, shared_buffers=256MB)
-- **DB pool**: 200 connections
-- **Single Erlang node**, no clustering
+- 8 cores, client and server sharing them
+- Erlang/OTP 28 and PostgreSQL 17, what the image was built on at that commit.
+  asobi builds on OTP 29 today - see [Self-hosting](self-hosting.md)
+- PostgreSQL in Docker with `max_connections=500`, `shared_buffers=256MB`
+- Database pool: 200 connections (the `dev_sys.config.src` default the CT
+  profile runs with)
+- One Erlang node, no clustering
 
 ## WebSocket throughput
 
-Heartbeat round-trip: client sends `session.heartbeat`, server replies with
-timestamp. Measures the full WebSocket pipeline including JSON encode/decode.
+Heartbeat round-trip: the client sends `session.heartbeat`, the server replies
+with a timestamp. This measures the whole WebSocket pipeline including JSON
+encode and decode.
 
 | Connections | Messages | Throughput | RTT p50 | RTT p99 | Memory/conn |
 |-------------|----------|------------|---------|---------|-------------|
@@ -23,97 +29,103 @@ timestamp. Measures the full WebSocket pipeline including JSON encode/decode.
 | 3,500 | 7,000,000 | 83,000 msg/sec | 4.4ms | 6.5ms | ~15KB |
 | 7,000 | 695,800 | 39,000 msg/sec | 5.8ms | 19.9ms | ~13KB |
 
-**Peak sustained**: ~83,000 messages/sec with 3,500 concurrent connections.
+Peak sustained: ~83,000 messages/sec at 3,500 concurrent connections.
 
-At 7,000 connections the per-message throughput drops because the benchmark
-client competes with the server for CPU on the same machine.
+At 7,000 connections per-message throughput drops because the benchmark client
+is competing with the server for CPU on the same machine.
 
 ### Blast mode
 
-Fire-and-forget: all messages sent before waiting for replies. Measures raw
+Fire-and-forget: all messages sent before waiting for any reply. Measures raw
 server processing capacity.
 
 | Connections | Messages each | Total delivered | Throughput |
 |-------------|---------------|-----------------|------------|
 | 3,500 | 2,000 | 7,044,000 | 83,000 msg/sec |
 
-All messages delivered with zero loss.
+All messages delivered, none lost.
 
 ## HTTP REST API
 
-100 concurrent players, each running the full lifecycle: register, login, then
-API reads.
+100 concurrent players, each running register, login, then API reads.
 
 | Endpoint | p50 | p95 | p99 |
 |----------|-----|-----|-----|
-| POST /auth/register | 1,463ms | 1,464ms | 1,464ms |
-| POST /auth/login | 724ms | 1,278ms | 1,308ms |
-| GET /matches | 8ms | 45ms | 64ms |
-| GET /friends | 7ms | 99ms | 133ms |
-| GET /wallets | 11ms | 272ms | 280ms |
-| GET /players/:id | 14ms | 191ms | 194ms |
+| `POST /api/v1/auth/register` | 1,463ms | 1,464ms | 1,464ms |
+| `POST /api/v1/auth/login` | 724ms | 1,278ms | 1,308ms |
+| `GET /api/v1/matches` | 8ms | 45ms | 64ms |
+| `GET /api/v1/friends` | 7ms | 99ms | 133ms |
+| `GET /api/v1/wallets` | 11ms | 272ms | 280ms |
+| `GET /api/v1/players/:id` | 14ms | 191ms | 194ms |
 
-Registration and login are slow by design: pbkdf2 with 100,000 iterations is
-CPU-intensive but correct for password security. API reads are sub-15ms p50.
+Register and login are slow on purpose: pbkdf2 at 100,000 iterations is meant
+to cost CPU. Everything else is sub-15ms at p50.
 
 ## Game type suitability
 
-### Mobile / casual (turn-based, party, puzzle)
+### Mobile and casual (turn-based, party, puzzle)
 
-Excellent fit. Sub-10ms WebSocket RTT, 3,000+ CCU per node. Most mobile games
-need <100 messages/sec per player, so a single node handles thousands of
-concurrent players comfortably.
+Good fit. Sub-10ms WebSocket RTT, thousands of concurrent connections per node.
+Most mobile games send well under 100 messages/sec per player.
 
-### MMO (persistent world)
+### Persistent worlds
 
-Viable for zone servers. 3,000-7,000 concurrent connections per node with good
-latency. A 20,000 CCU MMO would need 5-10 nodes. Erlang's `pg`-based clustering
-is designed for this.
+Viable per world. 3,000-7,000 concurrent connections per node with acceptable
+latency.
+
+One world lives entirely on one node and does not migrate, so a node is not a
+slice of a shared world - it is a set of separate worlds. Reaching 20,000 CCU
+across 5-10 nodes therefore means running 5-10 sets of worlds, with players
+sharded across them by your own routing. If your design needs one world larger
+than a single node can hold, adding nodes does not help. See
+[Clustering](clustering.md#the-scaling-unit-is-a-world-not-a-node).
 
 ### Competitive real-time (FPS, fighting, racing)
 
-Not the target. WebSocket (TCP) has a 5-25ms RTT floor. These genres need UDP
-transport with <3ms latency. Consider Photon or a custom UDP relay alongside
-Asobi for the game state, using Asobi for everything else (auth, matchmaking,
-economy, social, leaderboards).
+Not the target. WebSocket over TCP has a 5-25ms RTT floor and these genres want
+UDP under 3ms. Run a UDP transport for game state alongside asobi and use asobi
+for everything else: auth, matchmaking, economy, social, leaderboards.
 
 ## Bottlenecks and tuning
 
 ### Authentication under load
 
-pbkdf2 saturates CPU during login storms (1,000+ simultaneous registrations).
-Mitigations:
+pbkdf2 saturates CPU during login storms. Mitigations:
 
-- **Reverse proxy rate limiting** on `/auth/*` endpoints
-- **Auth result caching** for repeated token validations
-- **Multiple nodes** behind a load balancer to spread pbkdf2 work
+- Rate-limit `/api/v1/auth/*` at the reverse proxy. asobi's own limiter is
+  per node, so it is `N x` looser across a cluster - see
+  [Clustering](clustering.md#what-is-per-node).
+- More nodes behind a load balancer, to spread the pbkdf2 work.
 
 ### Database pool
 
-The default pool size matters. With 10 connections, 100+ concurrent DB
-operations queue up. Recommended:
+The pool is `pool_size` under the `kura` application in `sys.config`. What
+ships:
 
-| Deployment | pool_size | PG max_connections |
-|------------|-----------|--------------------|
-| Development | 50 | 100 |
-| Production (single node) | 200 | 500 |
-| Production (cluster) | 100 per node | 500-1000 |
+| Config | `pool_size` |
+|--------|-------------|
+| `config/prod_sys.config.src` (the image) | 20 |
+| `config/dev_sys.config.src` (dev and CT) | 200 |
+
+The production default of 20 is deliberately conservative, because every node
+opens its own pool and PostgreSQL's `max_connections` is a fleet-wide budget:
+`nodes x pool_size` has to fit inside it with room for your own tooling. Raise
+it when you see queueing on database-bound endpoints, and raise
+`max_connections` to match.
 
 ### Memory
 
-WebSocket connections use ~13-20KB each. A node with 8GB RAM can sustain
-~100,000 connections from memory alone. The practical limit is CPU (message
-processing) not memory.
+WebSocket connections cost ~13-20KB each, so at the concurrency measured above
+memory is not the constraint. CPU spent on message processing is.
 
-## Running benchmarks
+## Running the benchmarks
 
 ```bash
 # HTTP load test (default 100 players)
 ASOBI_LOAD_N=500 rebar3 ct --suite=asobi_load_bench
 
-# WebSocket benchmark
-# Phase 1: Register players (cached after first run)
-# Phase 2: Connect and blast heartbeats
+# WebSocket benchmark. Phase 1 registers players (cached after the first run),
+# phase 2 connects and blasts heartbeats.
 ASOBI_BENCH_PLAYERS=5000 \
 ASOBI_WS_N=5000 \
 ASOBI_WS_MSGS=2000 \
@@ -121,13 +133,14 @@ ASOBI_WS_WAVE=200 \
 rebar3 ct --suite=asobi_ws_bench
 ```
 
-Environment variables:
-
-| Variable | Default | Description |
-|----------|---------|-------------|
+| Variable | Default | Meaning |
+|----------|---------|---------|
 | `ASOBI_LOAD_N` | 100 | HTTP benchmark: concurrent players |
 | `ASOBI_BENCH_PLAYERS` | 1000 | WS benchmark: players to register |
 | `ASOBI_BENCH_BATCH` | 50 | WS benchmark: registration batch size |
 | `ASOBI_WS_N` | 500 | WS benchmark: concurrent connections |
 | `ASOBI_WS_MSGS` | 200 | WS benchmark: messages per connection |
 | `ASOBI_WS_WAVE` | 200 | WS benchmark: connections per wave |
+
+Both suites need a running PostgreSQL 17 - see
+[Self-hosting](self-hosting.md).

--- a/guides/clustering.md
+++ b/guides/clustering.md
@@ -1,76 +1,57 @@
 # Clustering
 
-Run multiple asobi nodes as one cluster for horizontal scale of connections and
-matches, plus automatic failover. Presence, chat, and cross-match messaging are
-cluster-safe out of the box via the BEAM's process groups (`pg`).
+asobi is one Erlang/OTP node holding the game backend, the Lua runtime and the
+operator console. Several of those nodes can form a cluster over the BEAM's
+distribution protocol and process groups (`pg`), for connection capacity and
+for failover.
 
-> #### asobi is single-node by design for gameplay {: .info}
->
-> A match lives on one node; the world server's zones for a given world live on
-> one node. Clustering is for connection termination, cross-node messaging, and
-> failover - not for live cross-node zone migration. Shard heavy load at the app
-> level (for example, route players to a region's cluster).
+Read the per-node list below before you put a second node behind a load
+balancer. Several subsystems are node-local, and most of them fail by getting
+quietly worse rather than by returning an error.
 
-## What's cluster-safe
+## The scaling unit is a world, not a node
 
-- **`pg`-scoped process groups** - presence, chat channels, and world/match
-  `whereis` lookups resolve across nodes.
-- **Player sessions** - a session on node A can send to a match on node B; the
-  send is proxied via a `pg` lookup of the match's owning process.
-- **Storage** - Postgres is shared, so everything persistent is consistent
-  across nodes.
+A world lives entirely on the node that created it. So does a match. Neither
+migrates. Horizontal scale therefore means *more* worlds and matches, never a
+bigger one: if a single world is the thing that is full, the answer is to shard
+it in your game design (regions, instances, shards), not to add a node.
 
-## What isn't
-
-- **The matchmaker queue is per-node.** One `gen_server` per node, and its
-  tickets live in that process's own state - nothing is shared and nothing is
-  persisted. Two players who queue for the same mode against different nodes
-  will not be matched with each other, and each node forms matches only from
-  its own queue.
-
-  Plan for it. Either send all matchmaking traffic for a mode to one node, or
-  accept that effective queue depth is your real depth divided by node count -
-  which shows up as longer waits and weaker matches, not as an error. The ops
-  plane reports the queue of whichever node answered
-  (`GET /api/v1/ops/matchmaker`), so a cluster's console readings are a
-  fraction of the fleet-wide total.
-
-- **Matches and worlds do not migrate between nodes.** If the owning node dies,
-  its active matches are lost (their state persists in Postgres for post-mortem,
-  but play does not resume elsewhere).
-- **ETS caches** (zone entity snapshots, rate-limit counters) are per-node. Hot
-  paths assume local access.
-- **The operator console's session is per-node**, and so is the secret its CSRF
-  token is derived from. A console login is only valid on the node that issued
-  it, so behind a round-robin load balancer roughly `(N-1)/N` of the console's
-  requests answer 403 and drop the operator back to the sign-in screen. Give
-  `/console` and `/api/v1/ops` a sticky route, or point the console at one node
-  directly.
-- **Rate limits are counted per-node.** The 5/s bucket on `/console/session`
-  that resists credential guessing becomes `5 x N` across a cluster.
-- **Luerl VMs** are per-process and per-node - there is no shared script state
-  across nodes.
+If the owning node dies, its live matches and worlds die with it. Match results
+already written to Postgres survive; play does not resume elsewhere.
 
 ## Forming a cluster
 
-asobi uses the BEAM's distribution protocol. Give each node a long name, share a
-cookie, and let the `asobi_cluster` discovery loop connect them. The image reads
-only `ASOBI_PORT`, `ASOBI_DB_*`, and `ASOBI_CORS_ORIGINS` from the environment;
-set the node name and cookie with the standard VM flags:
+The image is driven by environment variables, and that includes the node name
+and the cookie. `config/vm.args.src` renders `-name asobi@${ASOBI_NODE_HOST}`
+and `-setcookie ${ERLANG_COOKIE}`, so every node shares the base name `asobi`
+and one cookie:
 
 ```
--name asobi@10.0.0.1 -setcookie <shared-secret>
+ASOBI_NODE_HOST=10.0.0.1
+ERLANG_COOKIE=<shared-secret>
 ```
+
+`ghcr.io/widgrensit/asobi` also reads `ASOBI_PORT`, `ASOBI_DB_HOST`,
+`ASOBI_DB_NAME`, `ASOBI_DB_USER`, `ASOBI_DB_PASSWORD`, `ASOBI_DB_SOCKET_OPTS`
+and `ASOBI_CORS_ORIGINS`, and the operator console reads five more - see
+[Operator console](console.md).
+
+> #### Change the cookie {: .warning}
+>
+> The image ships `ERLANG_COOKIE` defaulting to the literal `asobi`, so that
+> `bin/asobi remote` works out of the box in a single container. Anyone who can
+> reach the distribution port of a node still running that default has a shell
+> on your VM. Set your own before you expose distribution.
 
 `asobi_cluster` is a `gen_server` that periodically resolves its peers and
-connects to any it isn't already connected to. It never disconnects a node;
-failover is left to the BEAM and the load balancer.
+connects to any it is not already connected to. It never disconnects a node;
+failover is left to the BEAM and to the load balancer.
 
 ## Service discovery
 
 Clustering is opt-in: with no `cluster` key set, `asobi_cluster` does not start
-and the node runs standalone. Configure the discovery strategy under the `asobi`
-app's `cluster` key to enable it. Two strategies are supported.
+and the node runs standalone. Configure the discovery strategy under the
+`asobi` app's `cluster` key to enable it. Two strategies are supported.
 
 <!-- tabs -->
 **DNS (Kubernetes headless service)**
@@ -78,7 +59,7 @@ app's `cluster` key to enable it. Two strategies are supported.
 {asobi, [
     {cluster, #{
         strategy => dns,
-        dns_name => <<"asobi-headless.default.svc.cluster.local">>,
+        dns_name => ~"asobi-headless.default.svc.cluster.local",
         poll_interval => 10000
     }}
 ]}
@@ -95,40 +76,143 @@ app's `cluster` key to enable it. Two strategies are supported.
 ```
 <!-- /tabs -->
 
-DNS resolves the peer addresses of the headless service; EPMD walks a fixed
+DNS resolves the peer addresses of the headless service; EPMD walks the fixed
 `hosts` list. Either way asobi derives each peer's node name by reusing the
 current node's base name (the part before `@`) and connects. `poll_interval` is
-the rediscovery period in milliseconds (default 10000).
+the rediscovery period in milliseconds, default 10000.
 
 > #### Secure the distribution port {: .warning}
 >
 > EPMD binds `0.0.0.0:4369` and the distribution port range is unbounded by
 > default; the cookie is the only protection. For anything beyond a trusted
-> private network, constrain the port range and enable TLS for distribution in
-> `vm.args` (`inet_dist_listen_min`/`max`, `-proto_dist inet_tls`). See the
-> [Threat model](security-threat-model.md#single-node-beam-distribution).
+> private network, constrain the port range and enable TLS for distribution.
+> See the [Threat model](security-threat-model.md#erlang-distribution).
+
+Add to `vm.args`:
+
+```
+-kernel inet_dist_listen_min 9100 inet_dist_listen_max 9105
+-proto_dist inet_tls
+-ssl_dist_optfile /etc/asobi/ssl_dist.config
+```
+
+## What is cluster-wide
+
+- **`pg` process groups.** Presence, chat delivery, leaderboard liveness and
+  world/match `whereis` lookups all resolve across nodes.
+- **Player sessions.** A session on node A can send to a match on node B; the
+  send is proxied through a `pg` lookup of the owning process.
+- **Chat message delivery.** A message is fanned out to every joined pid in the
+  `pg` group, wherever it lives.
+- **Postgres.** Everything persistent is one database and is consistent across
+  nodes: players, matches, economy, tournaments, notifications, leaderboard
+  entries and chat messages.
+- **`online_players`.** Presence counts pg members across the whole cluster.
+
+## What is per-node
+
+This is the complete list. Other guides state the one item their own subject
+needs and link here.
+
+- **The matchmaker queue and its tickets.** One `gen_server` per node, tickets
+  in that process's own map. There is no ticket schema and nothing is shared or
+  persisted. Two players who queue for the same mode against different nodes
+  never match each other, and each node forms matches only from its own queue.
+  Effective queue depth is your real depth divided by node count, which shows
+  up as longer waits and weaker matches, not as an error. Either route all
+  matchmaking for a mode to one node, or size for the division.
+- **The console session store and the secret its CSRF token is derived from.**
+  Both are per node, and the secret is regenerated on every boot. A console
+  login is valid only on the node that issued it, so behind a round-robin
+  balancer roughly `(N-1)/N` of console requests answer 403 and drop the
+  operator back to the sign-in screen. Give `/console` and `/api/v1/ops` a
+  sticky route, or point the console at one node.
+- **Rate-limit buckets.** Counted per node, so the 5/s bucket in front of
+  `/console/session` is really `5 x N` across the cluster, and so is every
+  other limit.
+- **The auth cache.** Access-token lookups are cached in a node-local ETS table
+  for 60s by default (`asobi.auth_cache_ttl_ms`). Revocation invalidates the
+  entry on the node that performed it; another node can keep honouring the
+  token until its own entry expires.
+- **The chat-channel registry.** Each node keeps its own registry of channel
+  processes, so the same channel id can have a process on several nodes at
+  once. Delivery is still cluster-wide; what is local is the process and what
+  it holds.
+- **The DM history buffer.** `GET /api/v1/dm/:player_id/history` answers from
+  the last 100 messages held in the channel process on the node that answered,
+  so two nodes give two different answers. `GET /api/v1/chat/:channel_id/history`
+  reads Postgres and does not have this problem.
+- **The player-to-world table.** `asobi_player_worlds` is a node-local ETS
+  table, and `session.connect` consults only the local one to restore a
+  player's world. A player who reconnects to a different node is not rejoined
+  to their world and gets **no error**: the connect succeeds, the world is
+  simply gone from their session. Pin a player's socket to one node.
+- **Zone entity snapshots and every other ETS cache**, including the 500ms
+  lobby listing cache below. Hot paths assume local access.
+- **Luerl VMs.** Per process and per node; there is no shared script state.
+
+## Ops reads across a cluster
+
+`/api/v1/ops/features`, `/api/v1/ops/matchmaker` and
+`/api/v1/ops/chat/channels` read node-local state and describe only the node
+that answered. Every other ops route reads Postgres and is cluster-consistent.
+
+`/api/v1/ops/stats` is per node - process count, run queue, memory, uptime -
+with one exception: `online_players` is fleet-wide. Summing `/stats` across N
+nodes multiplies the player count by N. That is why the payload carries `node`.
+
+Every node needs the same ops secret. The secret is compared against the
+answering node's own `ops_secret`, so if the values differ, whether an operator
+can sign in at all depends on which node the balancer picked.
+
+## Lobby listing cost scales with fleet size
+
+Browsing worlds or matches enumerates the `pg` groups and issues one
+synchronous `get_info` call per live world or match, across every node. A 500ms
+per-node cache sits in front of it, which caps the fan-out at two refreshes per
+second per node, but the cost of each refresh grows with the number of worlds
+in the whole cluster, not on one node.
 
 ## Routing players to nodes
 
 Put a load balancer in front of the cluster with a sticky WebSocket cookie, or
-hash on `player_id`. This keeps a player's session pinned to one node;
-cross-node calls happen only for matches or worlds the player joins on a
-different node.
+hash on `player_id`. Sticky routing is not an optimisation here: it is what
+makes reconnect-into-a-world, console sessions and matchmaking queue depth
+behave. Cross-node calls then happen only for a match or world the player
+joined on another node.
 
-## Deployment
+## Draining and restarts
 
-Rolling restarts are safe: drain a node (stop accepting new matches, let
-existing ones finish), upgrade it, and let it rejoin. Sessions on the drained
-node reconnect to another node when the load balancer re-routes them.
+asobi has no drain facility. There is no way to tell a node to stop accepting
+new matches while finishing the ones it has.
+
+What you can do:
+
+1. Take the node out of rotation at the load balancer. `GET /ready` is the
+   probe to point it at.
+2. Wait long enough for players to reconnect elsewhere. You are choosing this
+   number, not asobi.
+3. Stop the node. On shutdown, `/ready` flips to 503 and the node waits
+   `shutdown_delay` (5s in the shipped production config) before tearing down
+   the database pool. That is a load-balancer drain window, not a
+   match-length one.
+
+Matches and worlds still running on the node die with it, however long you
+wait. Plan rolling restarts for a quiet window, or keep modes short enough that
+waiting actually empties the node.
 
 ## Observability
 
-`asobi` emits telemetry events (`[asobi, match, *]`, `[asobi, world, *]`,
-`[asobi, matchmaker, *]`). Wire them to Prometheus via
+asobi emits telemetry events under `[asobi, match, _]`, `[asobi, world, _]`,
+`[asobi, zone, _]`, `[asobi, matchmaker, _]`, `[asobi, ws, _]` and others, all
+from `asobi_telemetry`. Wire them to Prometheus via
 `telemetry_metrics_prometheus`, or ship them to any OpenTelemetry collector.
+Attach per node and label the series by node name: nothing here is aggregated
+for you.
 
 ## Next steps
 
 - [Configuration](configuration.md) - the full `cluster` config key.
-- [Performance tuning](performance-tuning.md) - per-node tick and BEAM knobs.
+- [Performance tuning](performance-tuning.md) - per-node tick and broadcast costs.
+- [Operator console](console.md) - the console behind a load balancer.
 - [Threat model](security-threat-model.md) - the distribution trust boundary.

--- a/guides/comparison.md
+++ b/guides/comparison.md
@@ -1,78 +1,130 @@
 # Comparison
 
-How Asobi compares to other open-source game backend platforms.
+How asobi compares to other game backend platforms.
 
-## Feature Matrix
+asobi is one Erlang/OTP node containing the game backend, the Lua runtime and
+the operator console. There are two front doors into it: run the image
+(`ghcr.io/widgrensit/asobi`) and write Lua, or depend on the Hex package and
+write Erlang. Same node, same features, different surface.
 
-| Feature | Asobi | Nakama | Colyseus | PlayFab |
+The asobi column is checked against this repository. The other columns are
+summarised from each vendor's own public documentation
+([Nakama](https://heroiclabs.com/docs/nakama/),
+[Colyseus](https://docs.colyseus.io/),
+[PlayFab](https://learn.microsoft.com/en-us/gaming/playfab/)) and were last
+read on 2026-08-06. Check them against the vendor before you make a decision
+on one.
+
+## Feature matrix
+
+| Feature | asobi | Nakama | Colyseus | PlayFab |
 |---------|:-----:|:------:|:--------:|:-------:|
-| **Runtime** | BEAM (Erlang/OTP) | Go | Node.js | Cloud |
-| **Authentication** | Built-in | Built-in | Plugin | Built-in |
-| **Anonymous / Guest Auth** | Built-in (upgradeable) | Built-in | Manual | Built-in |
-| **Player Management** | Built-in | Built-in | Manual | Built-in |
-| **Real-Time Multiplayer** | WebSocket | WebSocket | WebSocket | WebSocket |
-| **Server-Authoritative Game Loop** | Built-in (tick-based) | Lua scripting | Room-based | CloudScript |
-| **Matchmaking** | Query-based | Query-based | Manual | Built-in |
-| **Leaderboards** | ETS + PostgreSQL | Built-in | Manual | Built-in |
-| **Virtual Economy** | Wallets, store, inventory | IAP validation | Manual | Built-in |
-| **Friends / Groups** | Built-in | Built-in | Manual | Built-in |
-| **Chat** | Built-in (channels) | Built-in | Manual | Manual |
-| **Tournaments** | Built-in | Built-in | Manual | Manual |
-| **Cloud Saves** | Built-in | Storage API | Manual | Built-in |
-| **Notifications** | Built-in | Built-in | Manual | Built-in |
-| **Background Jobs** | Shigoto (built-in) | Manual | Manual | Scheduled tasks |
-| **Admin Dashboard** | Arizona LiveView | Built-in | Monitor | Portal |
-| **Database** | PostgreSQL (Kura ORM) | CockroachDB | MongoDB / custom | Managed |
-| **Self-Hosted** | Yes | Yes | Yes | No |
+| Runtime | BEAM (Erlang/OTP) | Go | Node.js | Cloud |
+| Authentication | Built-in | Built-in | Plugin | Built-in |
+| Anonymous / guest auth | Built-in, upgradeable, opt-in | Built-in | Manual | Built-in |
+| Player management | Built-in | Built-in | Manual | Built-in |
+| Real-time multiplayer | WebSocket | WebSocket | WebSocket | WebSocket |
+| Server-authoritative game loop | Built-in, tick-based | Lua / Go / TS runtime | Room-based | CloudScript |
+| Matchmaking | Modes plus pluggable strategies | Query-based | Manual | Built-in |
+| Leaderboards | ETS reads, PostgreSQL persistence | Built-in | Manual | Built-in |
+| Virtual economy | Wallets, store, inventory | IAP validation | Manual | Built-in |
+| Friends / groups | Built-in | Built-in | Manual | Built-in |
+| Chat | Built-in, channels plus DMs | Built-in | Manual | Manual |
+| Tournaments | Built-in | Built-in | Manual | Manual |
+| Cloud saves | Built-in | Storage API | Manual | Built-in |
+| Notifications | Built-in | Built-in | Manual | Built-in |
+| Background jobs | Shigoto, built-in | Manual | Manual | Scheduled tasks |
+| Custom server-side logic | Lua callbacks plus extension RPC | Runtime modules and RPCs | Room handlers | CloudScript |
+| Operator console | Built-in, read-only | Nakama Console, mutating | Monitor | Game Manager |
+| Database | PostgreSQL, Kura ORM | PostgreSQL or CockroachDB | MongoDB / custom | Managed |
+| Self-hosted | Yes | Yes | Yes | No |
 
-## Runtime Characteristics
+Two rows are worth reading twice.
 
-| Concern | Asobi (BEAM) | Nakama (Go) | Colyseus (Node.js) |
+The console is a React SPA served from `priv/console` by the same node that
+serves the game. Every core ops route is a read. The only route that mutates is
+`/api/v1/ops/ext/:extension/:action`, and its behaviour comes from an installed
+extension - so there is no ban, kick, grant, refund or match-end button. Nakama
+Console and PlayFab Game Manager both mutate; if you are moving from one of
+those, that is a real gap. See [Operator console](console.md).
+
+Custom server-side logic that is not per-match goes over the WebSocket as
+`rpc.call` with `{protocol: 1, method, params}`, answered by `rpc.ok` or
+`rpc.error` and correlated by `cid`. All seven client SDKs speak it. That is
+the replacement for a Nakama RPC, a PlayFab CloudScript function and a Hathora
+custom message. See [Extensions](extensions.md).
+
+## Runtime characteristics
+
+| Concern | asobi (BEAM) | Nakama (Go) | Colyseus (Node.js) |
 |---------|-------------|-------------|-------------------|
-| **Garbage Collection** | Per-process -- isolated per match | Stop-the-world -- affects all matches | Stop-the-world -- affects all rooms |
-| **Fault Tolerance** | OTP supervision -- crashed matches restart | Panic recovery -- manual | Process crash -- manual |
-| **Hot Code Upgrade** | Native -- zero-downtime deploys | Restart required | Restart required |
-| **Pub/Sub** | `pg` module -- cluster-native | Built-in + optional Redis | Built-in (single node) |
-| **In-Memory State** | ETS -- zero serialization | In-process maps | In-process objects |
-| **Clustering** | Distributed Erlang -- built in | etcd / Consul | Redis (presence only) |
-| **Scheduling** | Preemptive -- fair across all processes | Cooperative goroutines | Single-threaded event loop |
-| **Connection Density** | ~500K+ per node | ~100K per node | ~10K per node |
+| Garbage collection | Per-process, isolated per match | Stop-the-world | Stop-the-world |
+| Fault tolerance | OTP supervision, crashed matches restart | Panic recovery, manual | Process crash, manual |
+| Live game-logic reload | Lua re-evaluated in place on the next tick | Restart required | Restart required |
+| Pub/sub | `pg`, cluster-native | Built-in plus optional Redis | Built-in, single node |
+| In-memory state | ETS and process heaps | In-process maps | In-process objects |
+| Clustering | Distributed Erlang, built in | etcd / Consul | Redis, presence only |
+| Scheduling | Pre-emptive, fair across all processes | Cooperative goroutines | Single-threaded event loop |
 
-## When to Choose Asobi
+Live reload is a Lua mechanism, not an OTP release upgrade: the runtime stats
+the script file each tick, and a changed mtime re-executes the script body
+against the running Luerl state, re-declaring globals and functions while
+in-flight game state survives. It needs the game directory to be a live mount.
+asobi ships no `appup` or `relup`, so upgrading the node itself is a restart.
 
-- You want a **single deployable** with auth, matchmaking, economy, social, and real-time multiplayer
-- You need **fault-tolerant game sessions** that survive crashes without losing state
-- You want **hot-reloadable Lua** so bug-fixes ship without kicking players
-- You want **zero-downtime deploys** for game logic updates
-- You're building for **high concurrency** (many simultaneous matches/rooms)
-- You prefer **self-hosted Apache-2** over closed managed clouds, with a real exit guarantee (see [exit.md](exit.md))
-- You want a **PostgreSQL-backed** system with a proper ORM
+Connection density on a single node is **3,000-7,000 concurrent WebSocket
+connections** measured on 8 cores, at 4.4ms p50 round-trip with 3,500
+connections. Each connection costs ~13-20KB, so at that concurrency the ceiling
+is CPU spent on message processing, not memory. Figures and method are in
+[Benchmarks](benchmarks.md).
 
-## Don't know Erlang?
+## When to choose asobi
 
-You don't need to. Use [**asobi_lua**](https://github.com/widgrensit/asobi_lua) — the
-same engine packaged as a Docker image with Lua scripting. Write your match
-logic in a `.lua` file, `docker compose up`, you're running. The Erlang is
-underneath but you never touch it.
+- You want a single deployable with auth, matchmaking, economy, social and
+  real-time multiplayer.
+- You need fault-tolerant game sessions that survive crashes without losing
+  state.
+- You want hot-reloadable Lua so bug fixes ship without kicking players.
+- You are building for many simultaneous matches or worlds.
+- You prefer self-hosted Apache-2.0 over a closed managed cloud, with a real
+  exit runbook (see [Exit guarantee](exit.md)).
+- You want a PostgreSQL-backed system with a proper ORM.
 
-The Erlang-library path (depending on `asobi` directly via rebar.config) is
-for teams that already write OTP and want to compose asobi with the rest of
-their release.
+## When to choose something else
 
-## When to Choose Something Else
+- You need sub-3ms UDP latency for a twitch FPS, fighting game or racer. Pair
+  asobi with a UDP relay, or use a physics-first product for the simulation.
+- You need deep LiveOps tooling (A/B testing, segmentation, push campaigns)
+  today.
+- You need a fully managed cloud at hyperscaler breadth. asobi's managed
+  version is [asobi.dev/cloud](https://asobi.dev/cloud), which is the same
+  open-source core rather than a different product.
+- You are building a single-player game that only needs analytics and IAP.
+  Analytics plus a store validator is cheaper than any backend here.
 
-- You need **sub-3ms UDP latency** for a twitch FPS / fighting game / racer. Pair asobi with a UDP relay, or use Photon Fusion / Quantum for the physics.
-- You need **deep LiveOps tooling** (A/B testing, segmentation, push campaigns) today. PlayFab still leads here, though it's an operational/trust trade-off post-v2 migration.
-- You need a **fully managed cloud** and are willing to pay cloud-scale prices. Our managed tier opens later in 2026; until then, self-host.
-- You're building a **single-player** game that only needs analytics and IAP. Firebase Analytics + a simple store validator is cheaper than any backend here.
+## Clustering
+
+Multiple nodes share Postgres and `pg`-scoped presence, chat and process
+lookups. Three things stay node-local and change how you deploy: the matchmaker
+queue, the rate-limit buckets and the console session store, so the console
+needs a sticky route and players queuing against different nodes never match
+each other. [Clustering](clustering.md) has the full list.
 
 ## Client SDKs
 
-First-class SDKs for **Godot, Defold, Unity, Unreal, JavaScript/TypeScript, Dart/Flutter, Flame**
-— see the [asobi_lua README](https://github.com/widgrensit/asobi_lua#client-sdks) for the table.
+Seven first-class SDKs: [Godot](https://github.com/widgrensit/asobi-godot),
+[Defold](https://github.com/widgrensit/asobi-defold),
+[LÖVE](https://github.com/widgrensit/asobi-love2d),
+[Unity](https://github.com/widgrensit/asobi-unity),
+[Unreal](https://github.com/widgrensit/asobi-unreal),
+[JavaScript/TypeScript](https://github.com/widgrensit/asobi-js) and
+[Dart/Flutter](https://github.com/widgrensit/asobi-dart).
+[flame_asobi](https://github.com/widgrensit/flame_asobi) is a Flame bridge on
+top of the Dart SDK rather than an eighth protocol implementation. The table
+with guides and demos is in the [README](../README.md#client-sdks).
 
-## Migrating from another backend?
+## Migrating from another backend
 
-- [**from Hathora**](migrate-from-hathora.md) — shutdown 2026-05-05
-- [**from PlayFab**](migrate-from-playfab.md)
-- [**from Nakama self-host**](migrate-from-nakama.md)
+- [From Hathora](migrate-from-hathora.md) - shutdown 2026-05-05
+- [From PlayFab](migrate-from-playfab.md)
+- [From Nakama self-host](migrate-from-nakama.md)

--- a/guides/configuration.md
+++ b/guides/configuration.md
@@ -1,21 +1,18 @@
 # Configuration
 
-Asobi supports two configuration paths depending on how you use it.
+asobi is one node with two surfaces. Run the image and configure it from the
+environment plus your Lua scripts, or depend on the Hex package and configure it
+in `sys.config`. This page is the reference for both.
 
-> #### Do you even need this file? {: .info}
->
-> On Asobi Cloud (`asobi deploy`) and the `asobi_lua` Docker image you write
-> no config file at all - the platform supplies sane defaults and you tune the
-> few knobs that matter through environment variables. You only edit
-> `sys.config` when you build the release from source and embed asobi as an
-> Erlang dependency.
+Version floors, supported Postgres and the image's architecture live in
+[Self-hosting](self-hosting.md#requirements).
 
 ## Lua (Docker)
 
-For Lua game developers using the Docker image, configuration lives in
-your Lua scripts. No Erlang syntax needed.
+For Lua game developers using the image, configuration lives in your Lua
+scripts. No Erlang syntax needed.
 
-### Game Mode Config
+### Game mode config
 
 Declare settings as globals at the top of your match script:
 
@@ -29,12 +26,26 @@ bots = { script = "bots/arena_bot.lua" }
 
 | Global | Required | Default | Description |
 |--------|----------|---------|-------------|
-| `match_size` | yes | -- | Minimum players to start a match |
+| `match_size` | yes | none | Minimum players to start a match |
 | `max_players` | no | `match_size` | Maximum players per match |
-| `strategy` | no | `"fill"` | `"fill"`, `"skill_based"`, or custom |
-| `bots` | no | none | `{ script = "path/to/bot.lua" }` |
+| `strategy` | no | `"fill"` | `"fill"`, `"skill_based"`, or a custom module |
+| `bots` | no | none | `{ script = "path/to/bot.lua" }` - see [Bots](lua-bots.md) |
+| `game_type` | no | `"match"` | `"match"` or `"world"` |
+| `state_strategy` | no | none | `"shared"` selects the encode-once broadcast path |
+| `guest_auth` | no | `false` | Declares that this game offers anonymous play. The operator still has to supply a pepper |
+| `registration` | no | none | `"open"`, `"oauth_only"` or `"closed"`. The operator's `sys.config` wins when it sets one |
 
-### Multiple Game Modes
+World-mode games (`game_type = "world"`) read a further set of globals -
+`tick_rate`, `grid_size`, `zone_size`, `view_radius`, `empty_grace_ms`,
+`player_ttl_ms`. [World server](world-server.md) documents those.
+
+**Where you put `guest_auth` and `registration` matters.** They are read from
+`match.lua` in single-mode and from `config.lua` in multi-mode. A game with a
+`config.lua` manifest that declares `guest_auth = true` in `match.lua` instead
+gets nothing, silently: the config loader reads `config.lua` when it exists and
+never looks at `match.lua`.
+
+### Multiple game modes
 
 Add a `config.lua` manifest mapping mode names to scripts:
 
@@ -46,28 +57,52 @@ return {
 }
 ```
 
-### Infrastructure Config
+### Infrastructure config
 
-Infrastructure settings come from environment variables:
+Infrastructure settings come from environment variables. Every default below is
+the image's own `ENV`; consuming asobi as a dependency, these do not exist and
+you write `sys.config` instead.
 
 | Variable | Default | Description |
 |----------|---------|-------------|
-| `ASOBI_PORT` | `8084` | HTTP/WebSocket port |
+| `ASOBI_PORT` | `8084` | HTTP and WebSocket port |
 | `ASOBI_DB_HOST` | `db` | PostgreSQL host |
 | `ASOBI_DB_NAME` | `asobi` | Database name |
 | `ASOBI_DB_USER` | `postgres` | Database user |
 | `ASOBI_DB_PASSWORD` | `postgres` | Database password |
-| `ASOBI_DB_SOCKET_OPTS` | `inet` (set by asobi_lua image; empty when consuming asobi directly) | Erlang term fragment spliced into the kura `socket_options` list. Examples: `inet`, `inet6`, `inet, {nodelay, true}`. Set to `inet6` for IPv6-only Postgres networks. |
-| `ASOBI_CORS_ORIGINS` | `*` | Allowed CORS origins |
-| `ASOBI_NODE_HOST` | `127.0.0.1` | Erlang node hostname |
-| `ERLANG_COOKIE` | `asobi_cookie` | Erlang distribution cookie |
+| `ASOBI_DB_SOCKET_OPTS` | `inet` | Erlang term fragment spliced into kura's `socket_options` list. `inet`, `inet6`, `inet, {nodelay, true}`. Set `inet6` for IPv6-only Postgres networks |
+| `ASOBI_CORS_ORIGINS` | none | Allowed CORS origin. Effectively required for any browser client: unset renders an empty `Access-Control-Allow-Origin`, which no browser accepts |
+| `ASOBI_NODE_HOST` | `127.0.0.1` | Erlang node hostname, in `-name asobi@...`. Not a bind address |
+| `ERLANG_COOKIE` | `asobi` | Erlang distribution cookie. The default is the literal string `asobi` |
+
+The database port is **not** a variable. It is fixed at `5432` in the image's
+`sys.config`, so a Postgres on another port means supplying your own.
 
 ## Erlang (sys.config)
 
-For Erlang OTP projects that add asobi as a dependency, all configuration
-lives in `sys.config` under the `{asobi, [...]}` key.
+For Erlang OTP projects that add asobi as a dependency, configuration lives in
+`sys.config` under the `{asobi, [...]}` key.
 
-### Game Modes
+### Which application key
+
+Everything below goes under `{asobi, [...]}`.
+
+The Lua runtime used to be its own OTP application, so the keys it owns -
+`max_heap_words`, `max_reductions_per_ms`, `reload_mode`,
+`config_watch_interval`, `dev_errors`, `terrain_providers` and `rate_limits` -
+are still read from `asobi_lua` first and `asobi` second
+(`asobi_lua_env:get_env/2`). An existing `{asobi_lua, [...]}` block keeps
+working and there is nothing to migrate. Put new configuration under `{asobi,
+[...]}`.
+
+Everything else, `game_dir` and `game_modes` included, is an `asobi` key only
+and always was.
+
+The module names have not moved either: `asobi_lua_config`, `asobi_lua_api`,
+`asobi_lua_loader` and friends are current, and so is `ASOBI_LUA_RELOAD`. Only
+the *image* name changed - see [Glossary](glossary.md#asobi).
+
+### Game modes
 
 ```erlang
 {game_modes, #{
@@ -80,7 +115,7 @@ lives in `sys.config` under the `{asobi, [...]}` key.
 }}
 ```
 
-Lua scripts work too:
+Lua scripts work too, in the same release:
 
 ```erlang
 {game_modes, #{
@@ -93,12 +128,11 @@ Lua scripts work too:
 }}
 ```
 
-`{lua, ...}` needs a scripting runtime in the release. asobi itself has no Lua
-dependency: [asobi_lua](https://github.com/widgrensit/asobi_lua) registers the
-modules that run scripted modes (`asobi_game_modes:register_game_mode/2`) when it
-starts. Consume asobi directly without it and every `{lua, _}` mode fails with
-`{error, lua_runtime_unavailable}` — matchmaking rejects the mode as unknown and
-world creation refuses it. Erlang-module modes are unaffected.
+Luerl is a hard dependency of asobi and `asobi_app:start/2` registers the Lua
+providers itself, so `{lua, _}` modes work in a stock release with no extra
+application. `{error, lua_runtime_unavailable}` survives only as the answer for
+a mode *kind* that has no registered provider, which a stock release does not
+have.
 
 Shorthand (Erlang module only):
 
@@ -108,35 +142,45 @@ Shorthand (Erlang module only):
 }}
 ```
 
-### Mode Options
+### Mode options
 
 | Option | Default | Description |
 |--------|---------|-------------|
 | `module` | required | Erlang module or `{lua, "path.lua"}` |
 | `match_size` | `2` | Players needed to start a match |
-| `max_players` | `10` | Maximum players per match |
-| `strategy` | `fill` | Matchmaking strategy: `fill`, `skill_based`, or custom module |
-| `skill_window` | `200` | Initial skill difference allowed (skill_based only) |
-| `skill_expand_rate` | `50` | Window expansion per 5 seconds (skill_based only) |
-| `bots` | `#{}` | Bot configuration. Read by [asobi_lua](https://github.com/widgrensit/asobi_lua), not by asobi — see [Bots](lua-bots.md) |
-| `listed` | `false` for matches, `true` for worlds | Whether instances of this mode appear in discovery (`match.list` / `world.list`). **Matches are unlisted by default** — a matchmaker-spawned match is already assigned to its players, so opt in explicitly. |
-| `quick_play` | `true` | Worlds only. Whether `world.find_or_create` may place a player into an existing world of this mode. Independent of `listed` — see [World Server](world-server.md#visibility). |
+| `max_players` | `match_size` for matches, `500` for worlds | Maximum players per instance |
+| `strategy` | `fill` | Matchmaking strategy: `fill`, `skill_based`, or a custom module |
+| `skill_window` | `200` | Initial skill difference allowed (`skill_based` only) |
+| `skill_expand_rate` | `50` | Window expansion per 5 seconds (`skill_based` only) |
+| `bots` | `#{}` | Bot configuration - see [Bots](lua-bots.md) |
+| `listed` | `false` for matches, `true` for worlds | Whether instances appear in discovery (`match.list` / `world.list`). Matches are unlisted by default: a matchmaker-spawned match is already assigned to its players, so opt in explicitly |
+| `quick_play` | `true` | Worlds only. Whether `world.find_or_create` may place a player into an existing world of this mode. Independent of `listed` - see [World server](world-server.md#visibility) |
 
-### Operator Modes vs Game-Declared Modes
+### Operator modes and game-declared modes
 
 Modes come from two independent places and asobi keeps them apart (ADR 0006):
 
 - **Operator modes** are the ones above, in your `sys.config` `game_modes`.
   asobi never rewrites that key.
-- **Game-declared modes** are what a Lua game declares in its `match.lua` or
+- **Game-declared modes** are what a Lua game declares in `match.lua` or a
   `config.lua` manifest. Loading a game replaces that set wholesale, so a mode
   you delete from `config.lua` is gone the next time the config loads instead
   of lingering until a restart.
 
 The effective registry is the game-declared set with the operator set on top:
-an operator mode wins a name clash and a game bundle can never drop or
-redefine it. Read it with `asobi_game_config:modes/0` - the raw `game_modes`
-app-env key is only the operator half.
+an operator mode wins a name clash and a game bundle can never drop or redefine
+it. Read it with `asobi_game_config:modes/0`. The raw `game_modes` app-env key
+is only the operator half.
+
+## Game directory
+
+```erlang
+{game_dir, "/app/game"}
+```
+
+Where the Lua loader looks for `config.lua`, `match.lua` and every script a
+mode names. `/app/game` is the image's default and the mount point it declares.
+There is no environment variable for it.
 
 ## Matchmaker
 
@@ -147,15 +191,21 @@ app-env key is only the operator half.
 }}
 ```
 
+The queue and its tickets live in this node's own process. Players queuing
+against different nodes never match each other - see
+[Clustering](clustering.md).
+
 ## Sessions
 
-Session token lifetime is handled by Nova's `nova_auth_session` — configure
-there (not under `asobi`). See the Nova docs for token/refresh TTL settings.
+Nothing to configure. Access tokens last 60 minutes and refresh tokens 30 days,
+from nova_auth's defaults, and `asobi_auth:config/0` does not override them.
+Changing either means editing that function.
 
-## Rate Limiting
+## Rate limiting
 
-Per-route-group rate limits using sliding window algorithm via
-[Seki](https://github.com/Taure/seki).
+Per-route-group sliding windows via [Seki](https://github.com/Taure/seki).
+**Buckets are per node**, so a 5/s limit is 5 x N across a cluster; size them
+for one node and read [Clustering](clustering.md) before you rely on a number.
 
 ```erlang
 {rate_limits, #{
@@ -165,14 +215,75 @@ Per-route-group rate limits using sliding window algorithm via
 }}
 ```
 
-Each route group has its own per-IP default (window in ms): `auth` 5/1000,
-`register` 3/1000, `iap` 10/1000, `api` 300/1000, `ws_connect` 60/1000, and the
-global (not per-IP) guest-create bound `guest_global` 100/1000. Override any
-group under `rate_limits`; unset groups keep their default.
+| Group | Default | Keyed on |
+|-------|---------|----------|
+| `auth` | 5 / 1000 ms | IP |
+| `register` | 3 / 1000 ms | IP |
+| `iap` | 10 / 1000 ms | IP |
+| `api` | 300 / 1000 ms | IP |
+| `ws_connect` | 60 / 1000 ms | IP |
+| `join` | 10 / 60000 ms | player |
+| `rehome` | 5 / 1000 ms | player |
+| `guest_global` | 100 / 1000 ms | a constant (global) |
+| `rehome_global` | 200 / 1000 ms | a constant (global) |
+| `script_log` | 3 / 10000 ms | the failing call site |
 
-## WebSocket Origin allowlist
+`register` has its own bucket because `/auth/register` runs the password KDF as
+its only cost gate. `script_log` bounds log lines from a script that fails on
+every tick, not the telemetry counter behind them. `rehome_global` is a
+placeholder default: size it from your real concurrent-player target.
 
-By default the `/ws` upgrade accepts any `Origin` — web builds are served from
+Override any group; unset groups keep their default.
+
+## Request body cap
+
+`asobi_body_cap_plugin` runs before Nova buffers a request body, so an
+oversized POST is rejected before it reaches the heap.
+
+```erlang
+{nova, [
+    {plugins, [
+        {pre_request, asobi_body_cap_plugin, #{
+            max_body => 1048576,
+            require_content_length => true
+        }}
+    ]}
+]}
+```
+
+| Option | Default | Description |
+|--------|---------|-------------|
+| `max_body` | `1048576` (1 MiB) | Bodies larger than this get `413 payload_too_large` |
+| `require_content_length` | `true` | A body with no `content-length` gets `411 length_required` rather than being streamed |
+
+Per-route checks (cloud save, storage) still apply on top of this floor. The
+image configures both values already.
+
+## Pre-auth client gate
+
+An optional gate in front of the anonymous auth-create routes, for a CAPTCHA or
+an attestation check. Unset, it is a no-op.
+
+```erlang
+{client_gate, my_captcha_gate},
+{client_gate_timeout, 5000},
+{client_gate_on_error, deny}
+```
+
+| Key | Default | Description |
+|-----|---------|-------------|
+| `client_gate` | unset | Module implementing `asobi_client_gate`. Unset disables the gate entirely |
+| `client_gate_timeout` | `5000` | Milliseconds to wait for the gate's verdict |
+| `client_gate_on_error` | `deny` | What a crashed or timed-out gate means. Anything but `skip` rejects; `skip` trades the check for availability |
+
+A rejected request gets `403 client_gate_denied`, with the gate's own reason in
+`details.reason` (`client_gate_unavailable` when the gate itself failed). It
+runs after the rate limiter, so a flood is shed by the cheap in-memory check
+before it reaches an external verification service.
+
+## WebSocket origin allowlist
+
+By default the `/ws` upgrade accepts any `Origin`: web builds are served from
 arbitrary studio and hosting domains, so a strict default would break them.
 
 To harden a deployment against cross-site WebSocket hijacking, set an
@@ -185,27 +296,26 @@ allowlist:
 ]}
 ```
 
-When set, a browser upgrade whose `Origin` is not listed is closed with
-`1008 origin_rejected` and emits `[asobi, ws, origin_rejected]`. Leaving it
-unset (or empty) keeps the open default.
+When set, a browser upgrade whose `Origin` is not listed is closed with `1008
+origin_rejected` and emits `[asobi, ws, origin_rejected]`. Leaving it unset or
+empty keeps the open default.
 
-Match is **exact** against the value the browser sends, so copy that verbatim:
-scheme + host + non-default port only — **no trailing slash, no path, all
-lowercase, punycode (`xn--...`) for internationalised domains**, and each
-entry a binary (`~"..."`), not a string. A trailing slash, an explicit `:443`,
-or an uppercase host silently matches nothing and locks out real users. A
-value that is not a list of binaries is treated as a misconfiguration and
-**fails closed** (rejects everything) with a logged error, rather than
-silently reverting to allow-all.
+Match is exact against the value the browser sends, so copy that verbatim:
+scheme, host and non-default port only. No trailing slash, no path, all
+lowercase, punycode (`xn--...`) for internationalised domains, and each entry a
+binary rather than a string. A trailing slash, an explicit `:443` or an
+uppercase host silently matches nothing and locks out real users. A value that
+is not a list of binaries is treated as a misconfiguration and fails closed,
+rejecting everything, with a logged error.
 
-This is independent of [CORS](#cors): CORS governs XHR/fetch, not the WebSocket
-handshake, so configuring one does not affect the other.
+This is independent of [CORS](#cors): CORS governs XHR and fetch, not the
+WebSocket handshake.
 
-Native clients (Defold, Unity, Unreal, etc.) send no `Origin` header and are
-never affected — an absent `Origin` always passes, since a non-browser client
-cannot be a CSWSH vector. The socket also does nothing until it presents a
-valid token in the first `session.connect` frame, so this is defence in depth,
-not the primary auth gate.
+Native clients (Defold, Unity, Unreal) send no `Origin` header and are never
+affected. An absent `Origin` always passes, since a non-browser client cannot
+be a CSWSH vector. The socket also does nothing until it presents a valid token
+in the first `session.connect` frame, so this is defence in depth, not the
+primary auth gate.
 
 ## Deprecated `game.*` extension frames
 
@@ -218,18 +328,16 @@ They are removed at the 1.0 wire break.
 {ws_legacy_game_frames, false}
 ```
 
-Set this once every client on the deployment dispatches on `module.*`, and
-each extension message drops from two frames to one. `game.message` is
-asobi_lua's `game.send/2`, which a script may call per player per tick, so on
-a chatty game the compat frame is a real doubling of that path. Any client
-still listening for `game.*` goes silent the moment you set it. Default
-`true`. See
-[the protocol guide](https://asobi.dev/docs/protocols/websocket).
+Set this once every client on the deployment dispatches on `module.*`, and each
+extension message drops from two frames to one. `game.message` carries
+`game.send/2`, which a script may call per player per tick, so on a chatty game
+the compatibility frame doubles that path. Any client still listening for
+`game.*` goes silent the moment you set it. Default `true`. See
+[WebSocket protocol](websocket-protocol.md).
 
 ## CORS
 
-CORS is handled by `nova_cors_plugin` in the Nova plugin chain — configure
-it under `{nova, [{plugins, [...]}]}`:
+CORS is handled by `nova_cors_plugin` in the Nova plugin chain:
 
 ```erlang
 {nova, [
@@ -239,32 +347,42 @@ it under `{nova, [{plugins, [...]}]}`:
 ]}
 ```
 
+In the image this is `ASOBI_CORS_ORIGINS`, and it has no default.
+
 ## Clustering
 
-Optional multi-node clustering via Erlang distribution.
+Optional multi-node clustering via Erlang distribution. Both forms below match
+[Clustering](clustering.md), which is the guide for this.
 
-### DNS Strategy (recommended for Fly.io/Kubernetes)
+### DNS strategy (Fly.io, Kubernetes)
 
 ```erlang
 {cluster, #{
     strategy => dns,
-    dns_name => "my-game.internal",
+    dns_name => ~"asobi-headless.default.svc.cluster.local",
     poll_interval => 10000
 }}
 ```
 
-### EPMD Strategy (for static hosts)
+`dns_name` must be a binary. A string crashes the discovery server on every
+poll.
+
+### EPMD strategy (static hosts)
 
 ```erlang
 {cluster, #{
     strategy => epmd,
-    hosts => ['node1@host1', 'node2@host2']
+    hosts => ['host-a', 'host-b']
 }}
 ```
 
-## Authentication Providers
+`hosts` are bare hostnames, not node names. asobi derives each peer's node name
+by reusing this node's basename, so `'node@host'` in that list produces
+`asobi@node@host`, which resolves to nothing.
 
-### OAuth/OIDC
+## Authentication providers
+
+### OAuth and OIDC
 
 ```erlang
 {oidc_providers, #{
@@ -281,15 +399,17 @@ Optional multi-node clustering via Erlang distribution.
 }}
 ```
 
-Every provider needs `issuer`, `client_id`, and `client_secret` - asobi discovers
-the rest (authorize/token/JWKS endpoints) from the issuer's
-`.well-known/openid-configuration` document. A provider entry missing
-`issuer` fails asobi's boot - see [Authentication](authentication.md) for
-the full supported-provider table and per-provider setup notes.
+Every provider needs `issuer`, `client_id` and `client_secret`. asobi discovers
+the rest (authorize, token and JWKS endpoints) from the issuer's
+`.well-known/openid-configuration` document. A provider entry with no `issuer`,
+or an issuer that is not `https://`, is logged and disabled on its own; the node
+still boots and the other providers are unaffected - see
+[Authentication](authentication.md) for the full supported-provider table and
+per-provider notes.
 
-`base_url` is the public origin asobi uses to build OAuth/OIDC redirect URIs
-(defaults to `~"http://localhost:8082"`). Set it to your deployed URL so the
-redirect that providers call back to matches what you registered:
+`base_url` is the public origin asobi uses to build redirect URIs (default
+`~"http://localhost:8082"`). Set it to your deployed URL so the redirect
+providers call back to matches what you registered:
 
 ```erlang
 {base_url, ~"https://mygame.com"}
@@ -302,7 +422,7 @@ redirect that providers call back to matches what you registered:
 {steam_app_id, ~"480"}
 ```
 
-### Apple/Google IAP
+### Apple and Google IAP
 
 ```erlang
 {apple_bundle_id, ~"com.example.mygame"},
@@ -318,12 +438,12 @@ Without it Apple receipt verification is refused.
 ## Guest (anonymous) auth
 
 Guest auth lets a device create a throwaway player without credentials and
-upgrade it to a real account later. It is **opt-in and fails closed**: the guest
-endpoints return `403 guest_auth_disabled` until the **game** declares
-`guest_auth = true` in its Lua config **and** the **operator** sets a
-`guest_verifier_pepper` (ADR 0004). The toggle is a game global, not a
-`sys.config` key - see [Authentication](authentication.md#guest-anonymous). This
-page covers the operator half: the pepper and abuse controls.
+upgrade it to a real account later. It is opt-in and fails closed: the guest
+endpoints return `403 guest.disabled` until the **game** declares `guest_auth =
+true` in its Lua config and the **operator** sets a `guest_verifier_pepper`
+(ADR 0004). The game half is a Lua global, not a `sys.config` key - see
+[Authentication](authentication.md#guest-anonymous). This page covers the
+operator half.
 
 ```erlang
 %% Required. A key-id -> pepper map (>= 32 bytes each). Keep old key ids for the
@@ -341,22 +461,27 @@ page covers the operator half: the pepper and abuse controls.
 
 | Key | Default | Description |
 |-----|---------|-------------|
-| `guest_verifier_pepper` | none | Key-id -> pepper map (each pepper >= 32 bytes) or a single >= 32-byte binary. Presence is the operator's on switch |
+| `guest_verifier_pepper` | none | Key-id -> pepper map, or a single binary. Each pepper must be at least 32 bytes; a shorter one is treated as absent. Presence is the operator's on switch |
 | `guest_verifier_key_id` | `~"v1"` | Which pepper key id to use when minting new verifiers |
 | `guest_unlinked_cap` | `100000` | Soft ceiling on unclaimed guests, or `infinity` |
-| `guest_reap_after` | unset | Seconds; unset disables the reaper (guests are permanent) |
+| `guest_reap_after` | unset | Seconds; unset disables the reaper, so guests are permanent |
 
-The pepper is a server-side secret kept **outside** the database - store it in
-an env var or secret manager, never in source. To rotate, add a new key id and
-point `guest_verifier_key_id` at it; keep the old key ids for at least the
-retention window so existing guests can still resume. Guest creation is bounded
-by the per-IP auth limiter plus the global `guest_global` create limit.
+**In the image today this needs a `sys.config`.** The Dockerfile declares
+`ASOBI_GUEST_VERIFIER_PEPPER`, but nothing substitutes it into `sys.config`, so
+setting the variable configures nothing and guest auth stays closed. Mount a
+`sys.config` with the pepper until that is fixed.
+
+The pepper is a server-side secret kept outside the database: keep it in a
+secret manager, never in source. To rotate, add a new key id and point
+`guest_verifier_key_id` at it, keeping the old ids for at least the retention
+window so existing guests can still resume. Guest creation is bounded by the
+per-IP `auth` limiter plus the global `guest_global` limit.
 
 ## Ops plane
 
 The `/api/v1/ops` routes are for a game-operations console, not a game client,
-and they carry their own credential. **Fails closed**: unset the key and every
-ops request is rejected, so a deployment that never reads this page is closed
+and they carry their own credential. Fails closed: unset the key and every ops
+request is rejected, so a deployment that never reads this page is closed
 rather than open. There is no default credential.
 
 ```erlang
@@ -368,23 +493,28 @@ rather than open. There is no default credential.
 |-----|---------|-------------|
 | `ops_secret` | none | Operator bearer token for `/api/v1/ops`. Unset rejects every ops request |
 
-Send it as `Authorization: Bearer <ops_secret>`. It is compared in constant
-time and never leaves the server, so keep it in an env var or secret manager,
-never in source. Player and guest tokens are rejected here - the ops plane
-never consults the player token store.
+32 bytes is a recommendation here, not a rule: `asobi_ops_auth` accepts any
+non-empty binary. `ops_token_secret` below and `guest_verifier_pepper` above
+*are* length-checked and silently treat a short value as unset, so the three do
+not behave alike.
 
-One secret is one privilege level: whoever holds it holds every ops capability
-class, including `config`. Restrict who can reach the console with a reverse
-proxy, and set `x-asobi-operator` per person for attribution in the audit
-trail - it is a label, never authority. See
-[REST API](rest-api.md#ops-authentication).
+Send it as `Authorization: Bearer <ops_secret>`. It is compared in constant time
+and never leaves the server. Player and guest tokens are rejected here: the ops
+plane never consults the player token store.
+
+One secret is one privilege level: whoever holds it holds every capability
+class, including `config`. Restrict who can reach the plane with a reverse
+proxy, and set `x-asobi-operator` per person for attribution in the audit trail
+- it is a label, never authority. See
+[REST API](rest-api.md#ops-authentication) for the per-route reference and
+[Operator console](console.md) for the operator narrative and for what the plane
+can and cannot do.
 
 ### Minted tokens (managed environments)
 
 A managed environment takes a second kind of ops credential: a short-lived,
-env-scoped token minted by the control plane after it has authenticated the
-tenant and checked they own this environment. Self-hosting needs none of this
-and can skip it.
+env-scoped token minted by a control plane after it has authenticated the tenant
+and checked they own this environment. Self-hosting needs none of this.
 
 ```erlang
 {ops_token_secret, ~"${ASOBI_OPS_TOKEN_SECRET}"},
@@ -396,10 +526,10 @@ and can skip it.
 | `ops_token_secret` | none | A per-environment secret that signs ops tokens and nothing else. At least 32 bytes; shorter is treated as unset |
 | `env_id` | none | This environment's id. A token minted for another one is refused |
 
-It is deliberately **not** the credential the engine authenticates with. A
-value that both proves who the engine is and signs the operator credentials it
-accepts is one leak away from doing both for an attacker, and deriving one
-from the other prevents confusion but not shared compromise.
+It is deliberately not the credential the engine authenticates with. A value
+that both proves who the engine is and signs the operator credentials it
+accepts is one leak away from doing both for an attacker, and deriving one from
+the other prevents confusion but not shared compromise.
 
 Rotating it revokes every ops token outstanding for the environment at once,
 which is the only revocation there is.
@@ -408,21 +538,20 @@ Both or neither: a node that knows the secret but not which environment it is
 cannot check a token's `env` claim, so it refuses every minted token rather
 than accepting one issued for somebody else's environment.
 
-Unlike `ops_secret`, a minted token carries **only the capability classes it
-was minted with**, so a tenant whose role maps to `read` and `player_data`
-cannot reach a `config` route with it. The role name never arrives here; the
-control plane maps it to classes at mint time.
+Unlike `ops_secret`, a minted token carries only the capability classes it was
+minted with, so a tenant whose role maps to `read` and `player_data` cannot
+reach a `config` route with it. The role name never arrives here; the control
+plane maps it to classes at mint time.
 
-The lifetime is capped at 15 minutes **by this node**, not by the minter. A
-token signed with a longer one is refused, because there is no revocation list
-to fall back on if the minting side ever issues a bad one.
+The lifetime is capped at 15 minutes by this node, not by the minter. A token
+signed with a longer one is refused, because there is no revocation list to
+fall back on if the minting side ever issues a bad one.
 
 ## Operator console
 
-A browser console for the ops plane, served by this node at `/console`.
-
-**Off by default.** Nova starts one listener, so the console shares the game
-port; an operator surface on a public port has to be asked for.
+A browser console for the ops plane, served by this node at `/console`. Off by
+default: Nova starts one listener, so the console shares the game port, and an
+operator surface on a public port has to be asked for.
 
 ```erlang
 {console, true},
@@ -435,57 +564,30 @@ port; an operator surface on a public port has to be asked for.
 | `console_session_ttl` | `43200` | Session lifetime in seconds, clamped to 60-86400. Absolute: it is not extended by use |
 | `console_secure_cookie` | `false` | Force `Secure` on the session cookies. Set it behind a TLS terminator that does not send `x-forwarded-proto` |
 | `console_api_base` | none | Absolute `https://host[:port]` origin the console should call instead of this one. Also widens `connect-src`. Anything that is not a bare origin is ignored |
-| `console_label` | none | Names this deployment in the tab title and the console header, so several open consoles are distinguishable |
+| `console_label` | none | Names this deployment in the tab title and the console header |
 | `console_production` | `false` | Marks a deployment to be careful in. The console colours its label |
 
-### From the environment
-
-Running a release rather than writing a `sys.config`? Every key above has an
-environment variable, read at boot. A variable overrides `sys.config` only when
-it is set, so the two can coexist.
-
-| Variable | Sets |
-|----------|------|
-| `ASOBI_CONSOLE` | `console`. `1`, `true`, `yes` or `on` enable it; anything else, including a typo, leaves it off |
-| `ASOBI_OPS_SECRET_FILE` | `ops_secret`, read from a file. **Preferred** |
-| `ASOBI_OPS_SECRET` | `ops_secret`, read from the variable itself |
-| `ASOBI_CONSOLE_LABEL` | `console_label` |
-| `ASOBI_CONSOLE_PRODUCTION` | `console_production` |
-
-Prefer the file: it keeps the secret out of `docker inspect`, out of the
-process environment, and out of a compose file that tends to end up in git. A
-trailing newline is stripped, so the usual `openssl rand -hex 32 > secret`
-works. If the file is named but unreadable or empty, the console stays off and
-says so - it does **not** fall back to `ASOBI_OPS_SECRET`, because a deployment
-that mounted a secret and got the path wrong must not come up quietly using
-something else.
-
-Enabling the console without a secret leaves it off and logs an error. The node
-still starts: the game is the product and the console is an accessory, so an
-operator surface that is misconfigured must not take players offline.
+`console`, `console_label` and `console_production` also read
+`ASOBI_CONSOLE`, `ASOBI_CONSOLE_LABEL` and `ASOBI_CONSOLE_PRODUCTION`, and
+`ops_secret` reads `ASOBI_OPS_SECRET_FILE` or `ASOBI_OPS_SECRET`. The other
+three - `console_session_ttl`, `console_secure_cookie` and `console_api_base` -
+have no environment variable and need a `sys.config`. A variable overrides
+`sys.config` only when it is set, so the two coexist.
 
 There is no `ASOBI_DB_PASSWORD_FILE`. The database password is substituted into
 `sys.config` before any Erlang runs, so it cannot be read from a file the way
-these can.
+the ops secret can.
 
-The console does not hold `ops_secret`. It posts it once to
-`/console/session`, gets back an `HttpOnly` cookie plus a derived CSRF token,
-and sends the cookie and the `x-csrf-token` header on every later request. A
-cookie without the header is refused, which is what stops a cross-site request
-reaching the plane.
+Sessions live in memory. The session store and the CSRF secret are per node, so
+the console needs a sticky route behind a load balancer and a restart signs
+everyone out - see [Clustering](clustering.md) and
+[Operator console](console.md), which owns turning it on, signing in, what the
+screens show and the troubleshooting.
 
-Sessions live in memory: restarting the node signs everyone out.
+## Vote templates
 
-Enabling the console does not change the bearer transport, and disabling it
-does not close the ops plane - CI and the CLI keep working either way.
-
-Serving it over plain HTTP is only reasonable on a loopback or a private
-network. `Secure` is set automatically when the request is HTTPS or arrives
-with `x-forwarded-proto: https`.
-
-## Vote Templates
-
-Define reusable vote configurations:
+Reusable vote configurations, merged with the per-vote config from your game
+module:
 
 ```erlang
 {vote_templates, #{
@@ -493,16 +595,9 @@ Define reusable vote configurations:
         method => ~"plurality",
         window_ms => 15000,
         visibility => ~"live"
-    },
-    ~"boon_pick" => #{
-        method => ~"plurality",
-        window_ms => 15000,
-        visibility => ~"live"
     }
 }}
 ```
-
-Templates are merged with per-vote config from your game module.
 
 ## World capacity
 
@@ -512,6 +607,10 @@ Bounds on persistent world creation, enforced as a DoS backstop:
 {world_max_per_player, 5},   %% default 5
 {world_max, 1000}            %% default 1000
 ```
+
+A player at the per-player cap gets `429 world.player_limit_reached`; once the
+global cap is reached further creates get `503 world.capacity_reached`. The
+global cap is checked first.
 
 ## Join rate
 
@@ -525,47 +624,47 @@ Joins are bounded per player, not per IP:
 
 Joining is how a client reaches a world's roster and leaving is free, so an
 unbounded join rate lets one account enumerate every live world by joining,
-reading `world.joined`, and leaving. The default (10 per minute) is generous
-for real play and turns a sweep of a full deployment from seconds into hours
-per identity. Exceeding it returns `join_rate_limited` and emits
-`[asobi, join, rate_limited]`.
+reading `world.joined` and leaving. The default (10 per minute) is generous for
+real play and turns a sweep of a full deployment from seconds into hours per
+identity. Exceeding it returns `join_rate_limited` and emits `[asobi, join,
+rate_limited]`.
 
 This bounds the cost of a sweep; it does not make worlds private. For that,
 implement `join/3` in your game module and reject unauthorised joins - see
-[WebSocket Protocol](websocket-protocol.md).
-
-A player at the per-player cap gets `429`; once the global cap is reached
-further creates get `503`.
+[WebSocket protocol](websocket-protocol.md).
 
 ## Zone crossing rate
 
 For `world`-mode games, re-homing a player across a zone boundary is bounded
-per player, not per IP:
+per player and, separately, globally:
 
 ```erlang
 {rate_limits, #{
-    rehome => #{algorithm => sliding_window, limit => 5, window => 1000}
+    rehome => #{algorithm => sliding_window, limit => 5, window => 1000},
+    rehome_global => #{algorithm => sliding_window, limit => 200, window => 1000}
 }}
 ```
 
 Each crossing updates part of the player's interest ring and resends a full
 zone snapshot to any newly-subscribed zone, so an unbounded rate lets one
-client force that work every tick by parking on (or jittering across) a zone
-boundary. The default (5/sec) bounds the worst case on top of the crossing's
-own hysteresis margin (see [World Server](world-server.md)); it caps sustained
-crossing speed at `limit * zone_size` units/sec, so a fast-moving game (a
-vehicle, flight sim, or racer) on a small `zone_size` may need to raise this.
-Denied crossings are not dropped input - the player's position still updates
-within their current zone, they just don't re-home that tick. Exceeding the
+client force that work every tick by parking on a zone boundary. The per-player
+default (5/sec) bounds the worst case on top of the crossing's own hysteresis
+margin (see [World server](world-server.md)); it caps sustained crossing speed
+at `limit * zone_size` units/sec, so a fast-moving game on a small `zone_size`
+may need to raise it. The global bucket bounds the aggregate load N concurrent
+attackers can push into the world's single terrain store.
+
+Denied crossings are not dropped input: the player's position still updates
+within their current zone, they just do not re-home that tick. Exceeding the
 limit emits `[asobi, rehome, rate_limited]`.
 
 ## Terrain provider allowlist
 
 For Lua large-world games, only allowlisted terrain generators can be named
-from Lua. This is an `asobi_lua` key (not `asobi`):
+from Lua:
 
 ```erlang
-{asobi_lua, [
+{asobi, [
     {terrain_providers, [asobi_terrain_flat, asobi_terrain_perlin]}
 ]}
 ```
@@ -575,7 +674,7 @@ The default allows `asobi_terrain_flat` and `asobi_terrain_perlin`.
 ## Per-call upper bounds
 
 These runtime limits bound the cost of a single request. They are not
-configurable - they are documented here so you can size clients accordingly:
+configurable; they are here so you can size clients accordingly.
 
 | Limit | Value |
 |-------|-------|
@@ -607,7 +706,7 @@ Database configuration is under the `kura` application key:
 ]}
 ```
 
-## Background Jobs (Shigoto)
+## Background jobs (Shigoto)
 
 ```erlang
 {shigoto, [
@@ -615,7 +714,7 @@ Database configuration is under the `kura` application key:
 ]}
 ```
 
-## Full Example (Erlang sys.config)
+## Full example (Erlang sys.config)
 
 ```erlang
 [
@@ -648,9 +747,8 @@ Database configuration is under the `kura` application key:
                 strategy => fill,
                 bots => #{
                     enabled => true,
-                    fill_after_ms => 8000,
                     min_players => 4,
-                    script => <<"game/bots/chaser.lua">>
+                    script => ~"game/bots/chaser.lua"
                 }
             }
         }}
@@ -658,7 +756,7 @@ Database configuration is under the `kura` application key:
 ].
 ```
 
-## Full Example (Lua Docker)
+## Full example (Lua and Docker)
 
 ```yaml
 # docker-compose.yml
@@ -676,7 +774,7 @@ services:
       retries: 5
 
   asobi:
-    image: ghcr.io/widgrensit/asobi_lua:latest
+    image: ghcr.io/widgrensit/asobi:latest
     depends_on:
       postgres: { condition: service_healthy }
     ports:
@@ -686,6 +784,7 @@ services:
     environment:
       ASOBI_DB_HOST: postgres
       ASOBI_DB_NAME: my_game_dev
+      ASOBI_CORS_ORIGINS: https://play.yourgame.com
 ```
 
 ```lua
@@ -713,6 +812,8 @@ end
 
 ## Next steps
 
-- [Self-hosting](https://github.com/widgrensit/asobi_lua/blob/main/guides/self-hosting.md) - running the image.
-- [Clustering](clustering.md) - multi-node config.
+- [Self-hosting](self-hosting.md) - requirements, the production compose, and
+  what to check before you go live.
+- [Clustering](clustering.md) - multi-node config and what is per node.
+- [Operator console](console.md) - turning the console on and using it.
 - [Performance tuning](performance-tuning.md) - the tick and BEAM knobs.

--- a/guides/console.md
+++ b/guides/console.md
@@ -1,0 +1,328 @@
+# Operator console and the ops API
+
+asobi serves an operator console at `/console` and a game-operations HTTP API
+at `/api/v1/ops/*`. One node, one listener: both answer on the same port the
+game does - `8084` in the image - and ship in the same release.
+
+Neither is on by default, and they are gated separately.
+
+`/console` is served only when `console` is true. Every console route answers
+404 otherwise.
+
+`/api/v1/ops/*` is always mounted and admits nobody until an ops secret is
+configured, so on a stock deployment every request to it answers 403. Turning
+the console off does not close the ops plane; unsetting the secret does. (A
+managed environment has a second credential - see
+[Minted tokens](configuration.md#minted-tokens-managed-environments) - which
+needs `ops_token_secret` and `env_id`, neither set by default.)
+
+The two look coupled because enabling the console without a secret turns the
+console back off, below.
+
+This plane is read-only. If you came here for moderation actions, skip to
+[What it cannot do](#what-it-cannot-do) first.
+
+## Turning it on
+
+Two settings. The console flag, and a credential for it to check.
+
+In the image, both come from the environment:
+
+| Variable | Sets |
+| --- | --- |
+| `ASOBI_CONSOLE` | Serve `/console`. `1`, `true`, `yes` or `on` enable it; anything else, including a typo, leaves it off |
+| `ASOBI_OPS_SECRET_FILE` | The ops secret, read from a file. Preferred |
+| `ASOBI_OPS_SECRET` | The ops secret, read from the variable itself |
+| `ASOBI_CONSOLE_LABEL` | Names this deployment in the tab title and the console header |
+| `ASOBI_CONSOLE_PRODUCTION` | Marks a deployment to be careful in. The console colours its label |
+
+A file beats the variable, and it never falls back to it. A named file that is
+missing, unreadable or empty logs `ops_secret_file_unreadable` or
+`ops_secret_file_empty` and leaves the secret unset - a deployment that mounted
+a secret and got the path wrong must not come up quietly using something else.
+A trailing newline is stripped, so `openssl rand -hex 32 > ops_secret.txt`
+works as written.
+
+Enabling the console with no secret leaves the console **off**, logs
+`console_disabled_without_secret` at error level, and starts the node anyway.
+The game is the product; a misconfigured operator surface must not take players
+offline. On success the node logs `console_enabled`.
+
+The compose fragment, matching the production compose in
+[Self-hosting](self-hosting.md):
+
+```yaml
+services:
+  asobi:
+    image: ghcr.io/widgrensit/asobi:latest
+    environment:
+      ASOBI_CONSOLE: "true"
+      ASOBI_OPS_SECRET_FILE: /run/secrets/ops_secret
+      ASOBI_CONSOLE_LABEL: prod
+      ASOBI_CONSOLE_PRODUCTION: "true"
+    secrets: [ops_secret]
+
+secrets:
+  ops_secret:
+    file: ./ops_secret.txt
+```
+
+The container runs as the unprivileged user `asobi`, so whatever mounts the
+secret has to leave it readable by that user. A file mode that only the owner
+can read, mounted with a different owner, produces
+`ops_secret_file_unreadable` and a console that stays off.
+
+Not using the image? The same two settings in a `sys.config`:
+
+```erlang
+{asobi, [
+    {console, true},
+    {ops_secret, ~"a-32-byte-or-longer-random-secret"}
+]}
+```
+
+An OS variable overrides `sys.config` only when it is set, so the two forms
+coexist. [Configuration](configuration.md#operator-console) has the full key
+table, including the three keys that have no environment variable.
+
+## Signing in
+
+Browsing to `/console` on a node that has it enabled gives a sign-in screen
+with two fields: **Operator secret**, which is the `ops_secret` value, and an
+optional name that defaults to `operator` and becomes the label on the session.
+The page posts the secret once and does not keep it.
+
+Underneath, `POST /console/session` exchanges a credential for a session. Two
+are accepted:
+
+```json
+{"secret": "...", "label": "your name"}
+```
+
+for the operator secret, and
+
+```json
+{"token": "..."}
+```
+
+for a short-lived token minted by a control plane. The managed path also
+accepts the token as a form POST, and answers that with a redirect to
+`/console` - which is how a dashboard hands a browser over without the token
+ever entering a URL, a referrer or an access log.
+
+Either way the response sets two cookies: an `HttpOnly` session cookie the page
+cannot read, and a script-readable CSRF cookie it can. Every later ops read
+needs **both** the session cookie and the value of the CSRF cookie sent back as
+an `x-csrf-token` header. A cookie on its own is not a credential here, which
+is what makes a cross-site request that arrives with the browser's cookies
+attached answer 403 rather than data.
+
+`GET /console/session` reports the current actor - display name, source,
+capability classes, and whether the identity behind it is attested. `DELETE
+/console/session` ends the session and clears both cookies; logging out twice
+is not an error.
+
+Sessions last 12 hours by default. `console_session_ttl` changes that and is
+clamped to 60-86400 seconds. Expiry is absolute: reading does not extend it.
+
+The session store and the secret the CSRF token is derived from are per node
+and per boot. Restarting a node signs everyone out of it, and that is the
+correct coupling rather than a gap - it is also the only revocation a session
+has apart from logging out.
+
+## What the console shows
+
+Nine screens, all of them reads:
+
+- **Overview** - online players, node version, queue depth, installed
+  extensions, and the runtime panel from `/api/v1/ops/stats`, polled every two
+  seconds.
+- **Players** - the player list, searchable across username and display name.
+- **Matches** - the recorded match history, with the game-authored result on
+  the detail page. Core writes one row per match when it finishes, so every row
+  reads `finished` whatever the status filter offers.
+- **Matchmaker** - one row per mode, deepest queue first, refreshed every three
+  seconds.
+- **Leaderboards** - boards rather than scores, then one board's persisted
+  entries.
+- **Economy** - the item catalogue and the store listings, side by side.
+- **Chat** - the channels running on this node, then one channel's persisted
+  history, searchable by message content.
+- **Tournaments** - the tournament rows, with a `live` column that says whether
+  a process is actually behind an `active` row.
+- **Notifications** - the send history, filterable by read state.
+
+What a reader arriving from another console will look for and not find:
+
+- No worlds screen, no votes screen, no IAP screen.
+- No wallets and no inventory. Both exist in the product; neither is on this
+  plane.
+- The players screen shows the ops projection only: `id`, `username`,
+  `display_name`, `avatar_url`, `metadata`, `inserted_at`, `updated_at`. No
+  linked providers, no guest status, no device verifiers.
+- The matches screen is the **finished-match record**. Live matches are visible
+  only through the player-facing `GET /api/v1/matches/live`.
+
+## What it cannot do
+
+Core's ops routes are all reads. The only route that mutates is
+`/api/v1/ops/ext/:extension/:action`, and its behaviour comes from an installed
+extension.
+
+So there is no ban, no grant, no refund, no broadcast, no ticket cancel and no
+match end. If you arrived expecting Nakama Console, PlayFab Game Manager or the
+Hathora console, that expectation gap is real and this is where it is.
+
+The one mutating route takes its method, its handler and its capability class
+from an installed extension's manifest. The console cannot invoke it today;
+that surface is HTTP only. See [Extensions](extensions.md) for how an extension
+declares one.
+
+## Capability classes
+
+Three: `read`, `player_data` and `config`. Every route on the plane carries
+exactly one, and membership of that class in the caller's capabilities is the
+only authorisation decision anywhere in the plane. A route with no class is
+denied, so an untagged or mis-mounted route is closed rather than open.
+
+Core tags only `read` routes today. `player_data` and `config` exist for
+extension actions and for the classes a minted token can carry.
+
+What proves what:
+
+- The **operator secret** proves all three. One secret is one privilege level:
+  whoever holds it holds `config`.
+- A **minted token** proves only the classes it carries, and its lifetime is
+  capped at 900 seconds by the node that verifies it, not by whatever minted it.
+- A **console session** inherits its credential's classes and expires no later
+  than that credential does. A fifteen-minute token cannot buy a twelve-hour
+  session with wider capabilities.
+
+Every rejection is `403` carrying the shared error object, whatever the cause:
+
+```json
+{"error": {"code": "forbidden", "message": "The caller may not perform this action.", "details": {}}}
+```
+
+Nothing configured, wrong secret and wrong capability class are deliberately
+indistinguishable to a caller guessing. Player bearer tokens never reach this
+plane at all - it never consults the player token store.
+
+## Calling the ops API directly
+
+The same routes answer a bearer token, which is what CI, a CLI or a script
+uses:
+
+```bash
+curl -sS -H "Authorization: Bearer $ASOBI_OPS_SECRET" \
+  "https://game.example.com/api/v1/ops/players?limit=20&sort=inserted_at&order=desc"
+```
+
+[REST API](rest-api.md#ops) has the per-route reference: the shared list
+parameters, the sortable fields per endpoint, and the lookup shapes.
+[Ops authentication](rest-api.md#ops-authentication) covers `x-asobi-operator`,
+the attribution label a shared secret cannot supply on its own.
+
+One route belongs here rather than there, because it is the one an operator
+reaches for first:
+
+```bash
+curl -sS -H "Authorization: Bearer $ASOBI_OPS_SECRET" \
+  https://game.example.com/api/v1/ops/stats
+```
+
+```json
+{
+  "data": {
+    "node": "asobi@10.0.0.4",
+    "online_players": 412,
+    "process_count": 5183,
+    "process_limit": 1048576,
+    "run_queue": 0,
+    "scheduler_count": 8,
+    "memory_total": 184549376,
+    "memory_processes": 92274688,
+    "memory_ets": 12582912,
+    "memory_binary": 25165824,
+    "uptime_ms": 864000000
+  }
+}
+```
+
+It touches no database, so it still answers when Postgres is the thing that is
+unwell - which is when you are most likely to be asking. `online_players` is
+`null` rather than an error if presence is briefly unavailable; every other
+field is a VM read that cannot fail.
+
+## Behind more than one node
+
+The session store and the CSRF secret are per node, so behind a round-robin
+proxy roughly `(N-1)/N` of console requests answer 403 and drop the operator
+back to the sign-in screen. Give `/console` and `/api/v1/ops` a sticky route,
+or point the console at one node directly.
+
+Every node needs the **same** ops secret. If they differ, which node answers
+decides whether signing in works at all.
+
+`/api/v1/ops/features`, `/matchmaker` and `/chat/channels` read node-local
+state; everything else on the plane reads Postgres and is cluster-consistent. A
+chat channel running on another node is simply absent from the list, though the
+member count beside a channel that is present is fleet-wide.
+`/stats` reports `node` for exactly this reason - the numbers are that node's,
+apart from `online_players`, which is fleet-wide because presence is a
+cluster-wide process group. Summing it across nodes multiplies your concurrency
+figure by `N`.
+
+[Clustering](clustering.md) holds the complete list of what is per node.
+
+## Production notes
+
+The console shares the game port. Anyone who can reach your game can reach
+`/console`, so put it behind TLS and restrict who reaches it - allowlist at the
+proxy, or require another layer in front of `/console` and `/api/v1/ops`.
+
+`Secure` is set on both cookies when the request is HTTPS or arrives with
+`x-forwarded-proto: https`. Behind a terminator that sends neither, set
+`console_secure_cookie`. They are `SameSite=Lax` rather than `Strict`, because
+the managed hand-off arrives as a cross-site POST and a `Strict` cookie would
+not be sent on the redirect that follows it. `Lax` still refuses to send them
+on a cross-site POST or an XHR, and the `x-csrf-token` header is the defence
+doing the work.
+
+`console_secure_cookie`, `console_api_base` and `console_session_ttl` have no
+environment variable and need a `sys.config`.
+
+`POST /console/session` shares the 5/s auth rate limiter, which is the bucket
+that resists credential guessing. `/api/v1/ops/*` falls through to the 300/s
+API limiter. Both are counted per node.
+
+## Troubleshooting
+
+**`/console` returns 404.** The console is not enabled on the node that
+answered. Every console route answers the same 404 an unknown asset gets, so a
+deployment with the console switched off is indistinguishable from one that has
+it on and was asked for a file that does not exist.
+
+**`/console` returns 503.** The console bundle is missing from the release.
+This is a build problem, not a configuration one.
+
+**The node is up but the console is off.** Grep the boot log for
+`console_disabled_without_secret`, `ops_secret_file_unreadable` and
+`ops_secret_file_empty`. The line that says it worked is `console_enabled`.
+
+**Every ops call answers 403.** One of three things: no secret is configured,
+the presented secret is wrong, or the credential does not carry the class the
+route needs. The body is identical in all three cases, deliberately. Check the
+node log for `ops request rejected: no ops_secret configured`, which is emitted
+for the first case only.
+
+**Sign-in works, then everything 403s a moment later.** A round-robin proxy in
+front of more than one node. Make the route sticky.
+
+## Next
+
+- [REST API](rest-api.md#ops) - the per-route ops reference.
+- [Configuration](configuration.md#operator-console) - every console key.
+- [Self-hosting](self-hosting.md) - the production compose this fits into.
+- [Clustering](clustering.md) - what is per node.
+- [Extensions](extensions.md) - declaring an operator action.

--- a/guides/economy.md
+++ b/guides/economy.md
@@ -1,20 +1,18 @@
 # Economy
 
-Asobi provides a full virtual economy system: wallets, transactions, item
-definitions, a store catalog, and player inventory.
+Wallets, transactions, item definitions, a store catalogue and player
+inventory.
 
-> #### Windows {: .info}
->
-> Run the `curl` examples in Git Bash or WSL, or use PowerShell's
-> `Invoke-RestMethod` with the same URL and a JSON `-Body`. Authenticated calls
-> add `-Headers @{ Authorization = 'Bearer <token>' }`.
+Run the `curl` examples in Git Bash or WSL on Windows, or use PowerShell's
+`Invoke-RestMethod` with the same URL and a JSON `-Body`. Authenticated calls
+add `-Headers @{ Authorization = 'Bearer <token>' }`.
 
 ## Wallets
 
-Each player can have multiple wallets, one per currency. All balance changes
-are recorded as transactions for a full audit trail.
+Each player can have one wallet per currency. Every balance change is recorded
+as a transaction row, so the wallet's history is a full audit trail.
 
-### List Wallets
+### List wallets
 
 ```bash
 curl http://localhost:8084/api/v1/wallets \
@@ -22,55 +20,136 @@ curl http://localhost:8084/api/v1/wallets \
 ```
 
 ```json
-[
-  {"id": "...", "currency": "gold", "balance": 1000},
-  {"id": "...", "currency": "gems", "balance": 50}
-]
+{
+  "wallets": [
+    {"currency": "gold", "balance": 1000},
+    {"currency": "gems", "balance": 50}
+  ]
+}
 ```
 
-<!-- tabs -->
-**Lua**
+The response is an object, and each entry carries `currency` and `balance`
+only - the wallet's `id` is stripped on the way out and no route accepts one.
+
+### In Lua
+
+`game.economy.*` calls return the wrapped envelope: a table with either an `ok`
+field or an `error` field. `balance` never returns a number, so comparing its
+result numerically silently misbehaves.
+
 ```lua
-local balance = game.economy.balance(player_id)
-```
-**Erlang**
-```erlang
-{ok, Wallet} = asobi_economy:get_or_create_wallet(PlayerId, <<"coins">>),
-{ok, _} = asobi_economy:debit(PlayerId, <<"coins">>, 50, #{}).
-```
-<!-- /tabs -->
+local result = game.economy.balance(player_id)
+if result.error then
+  game.log("warning", "balance lookup failed", { reason = result.error })
+  return state
+end
 
-### Transaction History
+local gold = 0
+for _, wallet in ipairs(result.ok) do
+  if wallet.currency == "gold" then gold = wallet.balance end
+end
+```
+
+`grant`, `debit` and `purchase` use the same envelope. See
+[The game.* API](lua-api.md) for the full list and the two return conventions.
+
+```lua
+game.economy.grant(player_id, "gold", 100, "match_reward")
+game.economy.debit(player_id, "gold", 50, "respawn_fee")
+game.economy.purchase(player_id, listing_id)
+```
+
+### In Erlang
+
+```erlang
+{ok, Wallet} = asobi_economy:get_or_create_wallet(PlayerId, ~"gold"),
+{ok, _} = asobi_economy:grant(PlayerId, ~"gold", 100, #{reason => ~"match_reward"}),
+{ok, _} = asobi_economy:debit(PlayerId, ~"gold", 50, #{reason => ~"respawn_fee"}).
+```
+
+`get_or_create_wallet/2` creates the wallet with balance 0 if it is missing.
+`grant/4` and `debit/4` each run in one transaction holding the wallet lock
+described under [Purchase](#purchase).
+
+### Transaction history
 
 ```bash
-curl http://localhost:8084/api/v1/wallets/gold/history \
+curl 'http://localhost:8084/api/v1/wallets/gold/history?limit=100' \
   -H 'Authorization: Bearer <token>'
 ```
+
+```json
+{
+  "transactions": [
+    {
+      "id": "...",
+      "wallet_id": "...",
+      "amount": -500,
+      "balance_after": 500,
+      "reason": "purchase",
+      "reference_type": "store_listing",
+      "reference_id": "...",
+      "metadata": {},
+      "inserted_at": "..."
+    }
+  ]
+}
+```
+
+Newest first. `limit` defaults to 50 and is clamped to 1-200.
 
 ## Items
 
-Items are defined once via `asobi_item_def` and granted to players as
+Items are defined once as `asobi_item_def` rows and granted to players as
 `asobi_player_item` instances.
 
-### Item Definitions
+### Item definitions
 
-Item definitions are global -- they describe what an item is:
+An item definition is global and describes what an item is:
 
-- `slug` -- unique identifier (e.g., `"sword_of_fire"`)
-- `name` -- display name
-- `category` -- weapon, armor, consumable, etc.
-- `rarity` -- common, rare, epic, legendary
-- `stackable` -- whether multiple instances stack into one slot
-- `metadata` -- arbitrary JSON for game-specific attributes
+| Column | Meaning |
+|---|---|
+| `slug` | Unique identifier, e.g. `"sword_of_fire"` |
+| `name` | Display name |
+| `category` | Free-form, e.g. weapon, armour, consumable |
+| `rarity` | One of `common`, `uncommon`, `rare`, `epic`, `legendary`. Defaults to `common` and is validated |
+| `stackable` | A boolean, defaulting to `true` |
+| `metadata` | Arbitrary JSON for game-specific attributes |
 
-### Player Inventory
+`stackable` is metadata for your game to interpret. Nothing in asobi reads it:
+the purchase path always inserts a fresh `asobi_player_item` row with
+`quantity` 1 and never merges into an existing stack, whatever `stackable`
+says. If you want stacking, do it in your own grant path.
+
+### Player inventory
 
 ```bash
-curl http://localhost:8084/api/v1/inventory \
+curl 'http://localhost:8084/api/v1/inventory?limit=100' \
   -H 'Authorization: Bearer <token>'
 ```
 
-### Consuming Items
+```json
+{
+  "items": [
+    {
+      "id": "...",
+      "item_def_id": "...",
+      "player_id": "...",
+      "quantity": 1,
+      "metadata": {},
+      "acquired_at": "...",
+      "updated_at": "..."
+    }
+  ]
+}
+```
+
+Newest acquisition first. `limit` defaults to 50 and is clamped to 1-200.
+
+There is no Lua call for inventory. Read it over REST, or query
+`asobi_player_item` from Erlang.
+
+### Consuming items
 
 ```bash
 curl -X POST http://localhost:8084/api/v1/inventory/consume \
@@ -79,78 +158,131 @@ curl -X POST http://localhost:8084/api/v1/inventory/consume \
   -d '{"item_id": "...", "quantity": 1}'
 ```
 
+```json
+{"success": true, "remaining_quantity": 0}
+```
+
+Consuming the whole stack deletes the row. `quantity` must be a positive
+integer no greater than 1,000,000.
+
 ## Store
 
-The store is a catalog of items available for purchase with in-game currency.
+The store is a catalogue of items purchasable with in-game currency.
 
-### Browse Store
+### Browse the store
 
 ```bash
-curl http://localhost:8084/api/v1/store \
+curl 'http://localhost:8084/api/v1/store?currency=gold' \
   -H 'Authorization: Bearer <token>'
 ```
 
 ```json
-[
-  {
-    "id": "...",
-    "item_def_id": "...",
-    "currency": "gold",
-    "price": 500,
-    "active": true
-  }
-]
+{
+  "listings": [
+    {
+      "id": "...",
+      "item_def_id": "...",
+      "currency": "gold",
+      "price": 500,
+      "active": true,
+      "valid_from": null,
+      "valid_until": null,
+      "metadata": {}
+    }
+  ]
+}
 ```
+
+Only `active` listings are returned. The optional `currency` parameter filters
+to one currency.
+
+`valid_from` and `valid_until` are columns on the listing and are returned, but
+**asobi does not enforce the window**. A listing with a `valid_until` in the
+past is still purchasable as long as `active` is true. Treat the two columns as
+data for your own scheduling job to act on by flipping `active`.
 
 ### Purchase
 
-Purchases are atomic: the wallet is debited and the item is granted in a
-single database transaction via Kura Multi.
+`listing_id` is the store listing's **UUID**, the `id` from the browse
+response. Listings have no slug, and no route accepts one.
 
 ```bash
 curl -X POST http://localhost:8084/api/v1/store/purchase \
   -H 'Authorization: Bearer <token>' \
   -H 'Content-Type: application/json' \
-  -d '{"listing_id": "..."}'
+  -d '{"listing_id": "0198c4f2-..."}'
 ```
+
+```json
+{
+  "success": true,
+  "item": {
+    "id": "...",
+    "item_def_id": "...",
+    "player_id": "...",
+    "quantity": 1,
+    "metadata": {},
+    "acquired_at": "...",
+    "updated_at": "..."
+  }
+}
+```
+
+`item` is the inserted `player_items` row, not the item definition. Read
+`item_def_id` to find out what it is.
 
 <!-- tabs -->
 **Lua**
 ```lua
-game.economy.purchase(player_id, "shop:starter_pack")
+local result = game.economy.purchase(player_id, listing_id)
+if result.error then
+  game.log("info", "purchase refused", { reason = result.error })
+end
 ```
 **Erlang**
 ```erlang
-{ok, _} = asobi_economy:purchase(PlayerId, <<"shop:starter_pack">>).
+{ok, Item} = asobi_economy:purchase(PlayerId, ListingId).
 ```
 <!-- /tabs -->
 
-Items are granted through the store/purchase flow or by writing an
-`asobi_player_item` row via `asobi_repo` - there is no `grant_item/3` helper.
+The debit and the item grant happen in **one database transaction**, serialised
+by a Postgres advisory lock keyed on `(player_id, currency)`. Any concurrent
+transaction touching the same wallet blocks until this one commits or rolls
+back, which is what makes a double-spend impossible without rewriting the query
+layer to use `SELECT ... FOR UPDATE`.
 
-## Server-Side Operations
+Items are granted through this path or by writing an `asobi_player_item` row
+via `asobi_repo`. There is no `grant_item/3` helper.
 
-For admin or game logic that needs to grant/debit currency or items
-programmatically:
+## Error codes
 
-```erlang
-%% Grant currency
-asobi_economy:grant(PlayerId, ~"gold", 100, #{reason => ~"match_reward"}).
+| Status | Code | Meaning |
+|---|---|---|
+| `402` | `economy.insufficient_funds` | The wallet does not hold enough of this currency |
+| `400` | `economy.listing_inactive` | The listing exists but `active` is false |
+| `500` | `economy.purchase_failed` | The purchase could not be completed |
+| `404` | `inventory.item_not_found` | No inventory item with this id |
+| `403` | `forbidden` | The item exists but belongs to another player |
+| `400` | `inventory.insufficient_quantity` | The stack holds fewer than the amount asked |
+| `400` | `inventory.invalid_quantity` | `quantity` is missing, not a positive integer, or over the cap |
 
-%% Debit currency
-asobi_economy:debit(PlayerId, ~"gold", 50, #{reason => ~"store_purchase"}).
+Every one arrives in the shared shape:
 
-%% Read a wallet (creates one with balance 0 if missing)
-{ok, #{balance := Bal}} = asobi_economy:get_or_create_wallet(PlayerId, ~"gold").
-
-%% Purchase a store listing (atomically debits wallet and grants item)
-{ok, _} = asobi_economy:purchase(PlayerId, ListingId).
+```json
+{"error": {"code": "economy.insufficient_funds", "message": "...", "details": {}}}
 ```
 
-All economy operations use ACID transactions to prevent double-spending
-or inconsistent state.
+## Inspecting the economy
+
+The console has an Economy screen: the item catalogue, then the store listings
+below it. It is the catalogue only - it reads, and it cannot
+create a listing, grant an item or adjust a balance. Wallets and inventory are
+not on that plane at all; query the `wallets`, `transactions` and
+`player_items` tables directly for those. See
+[Operator console](console.md).
 
 ## Next steps
 
 - [Authentication](authentication.md) - player identity behind wallets and purchases.
-- [REST API](rest-api.md) - the wallet, store, inventory, and IAP endpoints.
+- [In-app purchases](iap.md) - real-money receipts, which do not touch wallets on their own.
+- [REST API](rest-api.md) - the wallet, store and inventory endpoints.

--- a/guides/exit.md
+++ b/guides/exit.md
@@ -1,131 +1,144 @@
 # If asobi disappears tomorrow
 
-This is a one-page runbook for keeping your game alive if Widgrens IT AB
-(the company behind asobi) vanishes, pivots to AI, gets acquired, or
-otherwise ceases to exist. **We wrote it because you shouldn't have to
-trust us.**
+A runbook for keeping your game alive if Widgrens IT AB, the company behind
+asobi, vanishes, pivots, gets acquired or otherwise stops. It exists because
+you should not have to trust us.
 
 ## What we commit to
 
-1. **Apache-2.0 forever.** The [asobi library](https://github.com/widgrensit/asobi)
-   and [asobi_lua runtime](https://github.com/widgrensit/asobi_lua) are
-   published under Apache-2.0. **We will never relicense** — no BSL, no
-   SSPL, no Business Source dual-track. If we need to change the licence
-   we'll fork our own project under a new name rather than take Apache-2
-   away from you.
-2. **No closed-core.** Every feature in the public repos is the feature you
-   run. Our commercial cloud runs the same binary you can pull from
-   `ghcr.io/widgrensit/asobi_lua:latest`.
-3. **Public Docker images mirrored.** Published to GitHub Container Registry
-   under `ghcr.io/widgrensit/*`. GHCR is free to pull without auth; you can
-   also mirror to your own registry.
-4. **No mandatory phone-home, no licence check-in.** The runtime works
-   indefinitely without talking to us.
-5. **Git history is the source of truth.** No force-pushes to release tags.
-   No rewritten history on `main`.
+1. **Apache-2.0 forever.** [asobi](https://github.com/widgrensit/asobi) is
+   published under Apache-2.0, and that includes the Lua runtime and the
+   operator console, which are part of the same repository. We will never
+   relicense: no BSL, no SSPL, no dual track. If the licence ever has to
+   change we will fork our own project under a new name rather than take
+   Apache-2.0 away from you.
+2. **No closed core.** Every feature in the public repository is the feature
+   you run. Our commercial cloud runs the same image you can pull from
+   `ghcr.io/widgrensit/asobi:latest`.
+3. **Public images mirrored.** Published to GitHub Container Registry under
+   `ghcr.io/widgrensit/*`. GHCR is free to pull without authentication, and you
+   can mirror to your own registry.
+4. **No phone-home and no licence check-in.** The node works indefinitely
+   without talking to us.
+5. **Git history is the source of truth.** No force-pushes to release tags, no
+   rewritten history on `main`.
 
-## If we disappear, here's what to do
+## If we go quiet, here is what to do
 
 ### 1. Pin a known-good version
 
-As soon as you see us go quiet (no commits / no Discord / no blog posts for
-30+ days), pin your deployment to a specific Docker image digest:
+As soon as you notice us gone quiet - no commits, no releases, nothing for 30
+days or more - pin your deployment to a specific image digest:
 
 ```yaml
 # docker-compose.yml
 services:
   asobi:
-    # Before: ghcr.io/widgrensit/asobi_lua:latest
-    # After: pinned by digest
-    image: ghcr.io/widgrensit/asobi_lua@sha256:<digest-of-your-last-known-good>
+    image: ghcr.io/widgrensit/asobi@sha256:<digest-of-your-last-known-good>
 ```
 
-Grab the digest from `docker pull` output or the
-[GHCR package page](https://github.com/widgrensit/asobi_lua/pkgs/container/asobi_lua).
+Get the digest from `docker pull` output or from the
+[GHCR package page](https://github.com/widgrensit/asobi/pkgs/container/asobi).
 
 ### 2. Mirror the image to your own registry
 
 ```bash
-docker pull ghcr.io/widgrensit/asobi_lua:latest
-docker tag ghcr.io/widgrensit/asobi_lua:latest \
-           your-registry.example.com/asobi_lua:v-$(date +%Y-%m-%d)
-docker push your-registry.example.com/asobi_lua:v-$(date +%Y-%m-%d)
+docker pull ghcr.io/widgrensit/asobi:latest
+docker tag ghcr.io/widgrensit/asobi:latest \
+           your-registry.example.com/asobi:v-$(date +%Y-%m-%d)
+docker push your-registry.example.com/asobi:v-$(date +%Y-%m-%d)
 ```
 
-Point your `docker-compose.yml` / k8s manifest at `your-registry.example.com`.
-You now own the runtime.
+Point your compose file or k8s manifest at `your-registry.example.com`. You now
+own the runtime.
 
 ### 3. Fork the source
 
+One repository. The game backend, the Lua runtime and the operator console are
+all in it.
+
 ```bash
 git clone https://github.com/widgrensit/asobi.git
-git clone https://github.com/widgrensit/asobi_lua.git
-# Push both to your own remote.
 ```
 
-Both repos include the full history. You can build the Docker image yourself:
+Push it to your own remote. The full history comes with it, and you can build
+the image yourself:
 
 ```bash
-cd asobi_lua
-docker build -t myorg/asobi_lua:from-fork .
+cd asobi
+docker build -t myorg/asobi:from-fork .
 ```
 
-### 4. Export your data
+### 4. Export everything
 
-Every piece of state in asobi lives in PostgreSQL (the one you host). There
-is **no state outside your database**. To produce a cold-storage backup:
+Two things make up a running deployment, and a backup of only the first is not
+a backup.
+
+**Your database.** All persistent state lives in the PostgreSQL you host:
+players, wallets, transactions, inventories, match records, votes, IAP
+transactions, leaderboards, chat history, cloud saves.
 
 ```bash
-# Full logical backup
 docker compose exec postgres pg_dump -U postgres my_game > backup-$(date +%Y-%m-%d).sql
-
-# Binary backup (faster to restore)
-docker compose exec postgres pg_basebackup -U postgres -D /backup -Fp
 ```
 
-Restoring onto any stock PostgreSQL server (any version within pgo's
-supported range) gets you back a functional asobi tenant.
+**Your game scripts.** These are not in the database and they are not in the
+image. They are the directory you mount at `/app/game` - `match.lua`,
+`config.lua`, world scripts, bot scripts, anything they require. That directory
+is the game. Keep it in version control and back it up alongside the dump.
 
-### 5. Update OTP / Postgres yourself
+```bash
+tar czf game-$(date +%Y-%m-%d).tar.gz ./game
+```
+
+Restore both onto stock PostgreSQL and the image you mirrored, and you have a
+functioning deployment.
+
+#### Do not lose the operator surface
+
+The console and the ops API are configured entirely from the environment, so
+they live in your compose file rather than in the database or the game
+directory. A custodian who rebuilds from a dump and a script tarball and
+forgets them ends up with a working game and no way to look at it.
+
+Carry `ASOBI_CONSOLE` and the ops secret (`ASOBI_OPS_SECRET_FILE`, or
+`ASOBI_OPS_SECRET`) across with the rest of your deployment configuration, and
+carry the secret file itself. See [Operator console](console.md).
+
+### 5. Update OTP and Postgres yourself
 
 asobi depends on standard, long-lived open-source infrastructure:
 
-- **Erlang/OTP** ≥ 28. Upgrade path: drop in a newer OTP version, run
-  `rebar3 compile`. asobi spec-is-clean and tested against recent OTP;
-  upstream OTP is Ericsson's responsibility and they don't disappear.
-- **PostgreSQL** ≥ 15. Standard `pg_upgrade` works.
-- **Lua** 5.3 via [Luerl](https://github.com/rvirding/luerl). Rob Virding
-  (the V in BEAM) maintains Luerl in Apache-2 as well.
+- **Erlang/OTP.** Ericsson maintains it and does not disappear.
+- **PostgreSQL.** Standard `pg_upgrade` works.
+- **Lua 5.3 via [Luerl](https://github.com/rvirding/luerl)**, also Apache-2.0.
 
-None of these depend on us being alive.
+The tested combination is in the Requirements section of
+[Self-hosting](self-hosting.md#requirements). Older or newer versions may well
+work; they are not what CI runs, so verify before you commit to one.
 
-### 6. Join the community fork
+### 6. Join a community fork
 
-If we go dark, it's likely someone in the Discord — or the closest thing
-the Discord becomes — will pick up maintenance. Keep an eye on:
+If we go dark, someone is likely to pick up maintenance. Watch:
 
-- GitHub forks of `widgrensit/asobi` and `widgrensit/asobi_lua`
-- The `#operations` channel on the [Asobi Discord](https://discord.gg/vYSfYYyXpu)
-- The Erlang Forum (`erlangforums.com`) and the #gamedev tag
+- GitHub forks of `widgrensit/asobi`
+- The `#operations` channel on the [Discord](https://discord.gg/vYSfYYyXpu)
+- The Erlang Forum (`erlangforums.com`), `#gamedev`
 
-## What isn't here
+## What is not covered here
 
-This guide covers the open-source library + runtime only. The commercial
-`asobi.dev` cloud (opens later in 2026) is a separate layer: if we shut down
-the managed service, we'll give you:
+This page covers the open-source node. The commercial `asobi.dev` cloud is a
+separate layer. If we shut the managed service down, we commit to:
 
-- 60 days' notice minimum, in writing, before shutdown
-- A one-click **"export everything to a Docker bundle"** button that
-  produces a runnable self-host package with your data, your scripts, and
-  your PostgreSQL dump
-- Best-effort migration help through the shutdown date
+- 60 days' notice minimum, in writing
+- an export of your data, your scripts and your PostgreSQL dump in a form you
+  can self-host
+- best-effort migration help through the shutdown date
 
-The open-source side stays open-source regardless.
+The open-source side stays open source regardless.
 
-## Questions?
+## Questions
 
 Open an issue, post in the Discord `#operations` channel, or email
-`hello@asobi.dev`. If none of those still exist — fork the code, export
-your Postgres, and you're the custodian now.
-
-We'd rather earn your trust by making leaving easy.
+`hello@asobi.dev`. If none of those still exist, fork the code, export your
+Postgres and your game directory, and you are the custodian now.

--- a/guides/extensions.md
+++ b/guides/extensions.md
@@ -6,16 +6,16 @@ it cannot discover.
 
 No new packaging concept, no new lifecycle, nothing to learn beyond OTP.
 
-> This contract is **experimental**. The wire freezes, because SDK users vendor
-> by copying source. This module does not, until a real second consumer has
-> said what it is missing.
+This contract is experimental. The wire freezes, because SDK users vendor by
+copying source. The manifest does not, until a real second consumer has said
+what it is missing.
 
 ## Installing one
 
 ```erlang
 %% your_game_app/rebar.config
 {deps, [
-    {asobi,        {git, "https://github.com/widgrensit/asobi.git", {tag, "v0.50.0"}}},
+    {asobi, "~> 0.68"},
     {asobi_quests, {git, "https://github.com/you/asobi_quests.git", {tag, "v1.0.0"}}}
 ]}.
 
@@ -27,27 +27,33 @@ Two lines. Removing an extension is deleting them; its tables survive until
 deliberately purged, because destroying player progress on a dependency change
 is the wrong default.
 
-`asobi_quests` depends on `asobi`. Your app depends on both. asobi never
-depends on an extension: every extension depends on asobi, so the reverse edge
-is a cycle relx sorts into a build failure and Hex rejects outright.
+`asobi_quests` depends on `asobi` and your app depends on both. asobi never
+depends on an extension, so the reverse edge is a cycle relx sorts into a build
+failure and Hex rejects outright.
 
 Validate the set before you boot it:
 
 ```erlang
-{project_plugins, [{asobi, {git, "https://github.com/widgrensit/asobi.git", {tag, "v0.50.0"}}}]}.
+{project_plugins, [{asobi, {git, "https://github.com/widgrensit/asobi.git", {tag, "v0.68.2"}}}]}.
 ```
 
 ```sh
 rebar3 asobi check
 ```
 
+Pin the plugin to the same tag as the dependency. Core's reserved names come
+from the plugin's own copy of asobi, so a skewed pin validates against the
+wrong reserved set.
+
 This is the gate. asobi validates the same set again at boot, but a boot-time
 failure is raised from inside Nova's route compilation and surfaces with Nova's
 crash context rather than a legible asobi error.
 
-## Who calls an extension
+The published image `ghcr.io/widgrensit/asobi` runs a release built from a
+fixed application set at image build time, so installing a third-party
+extension means building your own release from the Hex package.
 
-Two consumption paths, and an extension wants both.
+## Who calls an extension
 
 | Caller | Path | For |
 |---|---|---|
@@ -76,11 +82,7 @@ lua()  -> #{~"quests" =>
               #{~"progress" => #{mfa     => {asobi_quests_lua, progress, 2},
                                  args    => [binary, integer],
                                  effects => write,
-                                 vms     => [match, world]},
-                ~"status"   => #{mfa     => {asobi_quests_lua, status, 1},
-                                 args    => [binary],
-                                 effects => none,
-                                 vms     => [match, world, zone]}}}.
+                                 vms     => [match, world]}}}.
 
 sup()  -> [#{id    => asobi_quests_tracker,
              start => {asobi_quests_tracker, start_link, []}}].
@@ -96,32 +98,32 @@ codes() -> #{~"quests.already_claimed" =>
 ops()  -> #{~"define" => #{method => post,
                            mfa    => {asobi_quests_ops, define, 2},
                            class  => config}}.
-
-erase_player(PlayerId) ->
-    {ok, _} = asobi_repo:delete_all(by_player(asobi_quest_progress, PlayerId)),
-    ok.
 ```
+
+Discovery looks for a module literally named `<app>_extension` in the
+application's own module list (`application:get_key(App, modules)`). The
+`-behaviour` attribute is not what makes it found; the name is. Depending on
+asobi is not the filter either, or every game embedding asobi would be an
+extension.
 
 Only `info/0` is required. The rest default to nothing.
 
 - `rpc/0` - core cannot guess that `quests.claim` is `{asobi_quests_rpc, claim, 2}`.
   The arity is always 2; see [Writing an RPC handler](#writing-an-rpc-handler).
-- `lua/0` - the `game.<ns>.*` surface a Lua game calls. `effects` is not
-  decoration: probe VMs re-run the whole script body to ask `phases()` and swap
-  every `write` function for an inert stub, so a `write` declared `none` fires
-  twice on every match creation. `vms` may name `match`, `world` or `zone`;
-  `bot` is refused. See [Writing a Lua binding](#writing-a-lua-binding).
+- `lua/0` - the `game.<ns>.*` surface a Lua game calls. See
+  [Writing a Lua binding](#writing-a-lua-binding).
 - `sup/0` - child specs, if you want asobi supervising them.
-- `owns/0` - the closed statement of what this extension claims. Every kind is
-  derived from your own code as well, so `owns/0` is an assertion over the
-  derivation rather than its source.
-- `codes/0` - the error codes this extension mints. Core's set is closed, so
-  an undeclared code answers 500 and logs as a core defect.
+- `owns/0` - the closed statement of what this extension claims. See
+  [Namespaces](#namespaces).
+- `codes/0` - the error codes this extension mints. See
+  [Error codes](#error-codes).
 - `ops/0` - operator actions, reached on the ops plane rather than by a player.
   See [Writing an operator action](#writing-an-operator-action).
 - `erase_player/1` - how to erase one player, when your rows do not cascade.
-- `info/0` - the contract version, distinct from the package version, because a
-  minor release can change an experimental contract.
+  See [Deleting a player](#deleting-a-player).
+- `info/0` - `name` is the extension's identity and the root of everything it
+  owns. `extension_version` is recorded in the registry and printed by
+  `rebar3 asobi check`; nothing enforces it, and no behaviour changes with it.
 
 ## Writing an RPC handler
 
@@ -139,10 +141,43 @@ and gets back one of:
 {"type": "rpc.error", "cid": "c-1", "payload": {"error": {"code": "quests.already_claimed", "message": "...", "details": {}}}}
 ```
 
-`cid` is required here and validated server-side (1-64 printable ASCII bytes),
-unlike the optional echo the rest of the socket takes: it is the only way a
-client pairs a reply with the call it made. `params` and `result` are always
-objects, so either can grow a field without breaking a shipped client.
+See [WebSocket protocol](websocket-protocol.md) for the frames either side of
+this one. `cid` is required here and validated server-side (1-64 printable
+ASCII bytes), unlike the optional echo the rest of the socket takes: it is the
+only way a client pairs a reply with the call it made. `params` and `result`
+are always objects, so either can grow a field without breaking a shipped
+client.
+
+`protocol` is core's RPC payload version, currently `1`, and is unrelated to
+your `extension_version`. Any other value answers `rpc.unsupported_protocol`
+with `details.supported` listing what this node speaks. A node reports its own
+from `asobi_rpc:protocol/0`.
+
+You rarely build that frame by hand. Every client SDK wraps it, generates the
+`cid` and correlates the reply for you:
+
+```js
+// asobi-js: resolves with `result`, rejects with an AsobiRpcError
+try {
+  const { reward } = await ws.rpc("quests.claim", { quest_id: "q-1" });
+} catch (e) {
+  if (e.code === "quests.already_claimed") { /* domain outcome */ }
+}
+```
+
+```gdscript
+# asobi-godot: the reply arrives on the callable, keyed by the returned cid
+realtime.rpc_call("quests.claim", {"quest_id": "q-1"}, func(ok, data):
+    if ok: print(data["reward"])
+    else:  print(data["code"]))
+```
+
+Branch on `code`, never on `message`. The shape is the same in every SDK - a
+method name, a params object, and a reply that is either a result object or the
+shared error object - so a method you declare here is callable from all of them
+without a per-engine server change. `flame_asobi` is a Flame bridge over the
+Dart SDK rather than a protocol implementation of its own, so it inherits
+`rpc` from it.
 
 The handler is `(Params, Ctx)`, which is why the arity in `rpc/0` is always 2:
 
@@ -158,7 +193,7 @@ claim(#{~"quest_id" := QuestId}, #{player_id := PlayerId}) ->
 
 `{ok, map()} | {error, Code} | {error, Code, Details}`.
 
-The failure half is a **code**, never a status and never an object you build
+The failure half is a code, never a status and never an object you build
 yourself. Both are derived from the code - `asobi_error:status/1` and
 `asobi_error:object/2` - so two call sites cannot answer the same code
 differently, and a code you declared in `codes/0` reaches the client as
@@ -172,32 +207,55 @@ Everything else is a defect and answers `internal` with one logged line naming
 the method: a handler that raises, one that returns outside the contract, one
 declared at an arity other than 2, a result that cannot be JSON-encoded, and a
 code you did not declare in `codes/0`. The last one is how the closed code set
-survives this surface - every other call site's code is a binary literal
-checked at build time, and a handler's is a runtime term it could have built
-out of `params`.
+survives a surface where the code is a runtime term the handler could have
+built out of `params`.
 
-**Every declared method is player-scoped.** The caller is the authenticated
-player on that socket; an unauthenticated socket is refused before the method
-is looked up. There is deliberately no per-method capability class:
-`read | player_data | config` (ADR 0007) is an operator vocabulary that a
-player never holds, so tagging a socket method with one would make it deniable
-for every caller the dispatcher has. An operator-only method goes in `ops/0`
-instead - see [Writing an operator action](#writing-an-operator-action).
+### What the seam answers
 
-### Readiness
+| Code | Status | When |
+|---|---|---|
+| `rpc.unknown_method` | 404 | no installed extension declares that method, or `method` is not a string |
+| `rpc.invalid_cid` | 400 | `cid` missing, empty, over 64 bytes, or not printable ASCII |
+| `rpc.invalid_params` | 400 | `params` is not a JSON object |
+| `invalid_payload` | 400 | `payload` is not a JSON object |
+| `rpc.unsupported_protocol` | 400 | `protocol` is not this node's version |
+| `unauthenticated` | 401 | the socket has not completed `session.connect` |
+| `not_ready` | 503 | migrations have not finished on this node |
+| `internal` | 500 | the handler is at fault; see above |
 
-The route table compiles during Nova's boot; migrations run afterwards, from
-`asobi_app:start/2`. An extension endpoint is therefore reachable before its
-tables exist, so the dispatcher fails closed until migrations finish: every
-call answers `not_ready` (503) until then. You get this for free - there is
-nothing to call.
+A rejected `cid` comes back on a frame carrying no `cid` at all, because there
+is nothing trustworthy to echo. That one reply cannot be correlated: a client
+that sends a malformed `cid` gets an answer it must match by shape, not by id.
+
+### Before dispatch
+
+The socket applies two limits ahead of any of the above, so a chatty method has
+to be sized against them:
+
+- 64 KiB per text frame. A larger frame answers `payload_too_large`.
+- 60 messages per second per connection, in a fixed one-second window. Over it
+  answers `rate_limited`.
+
+Both answer on the legacy `error` frame with no `cid`, so neither is
+correlatable either. The budget is per connection, held in the socket's own
+state: it counts every frame the socket carries, not just `rpc.call`, and
+adding nodes does not widen it. The buckets that are counted per node are the
+HTTP and connect limiters - see [Clustering](clustering.md).
+
+### Every declared method is player-scoped
+
+The caller is the authenticated player on that socket; an unauthenticated
+socket is refused before the method is looked up. There is deliberately no
+per-method capability class: `read | player_data | config` is an operator
+vocabulary that a player never holds, so tagging a socket method with one would
+make it deniable for every caller the dispatcher has. An operator-only method
+goes in `ops/0` instead.
 
 ## Writing an operator action
 
-`rpc/0` is player-scoped by construction, so an admin action - defining a
-quest, correcting a counter, anything a player must never call - has no home
-there. `ops/0` is that home, and it is reached on the ops plane by an operator
-credential:
+`rpc/0` is player-scoped, so an admin action - defining a quest, correcting a
+counter, anything a player must never call - has no home there. `ops/0` is that
+home, reached on the ops plane by an operator credential:
 
 ```erlang
 -spec ops() -> asobi_extension:ops().
@@ -215,12 +273,25 @@ POST /api/v1/ops/ext/quests/define
 GET  /api/v1/ops/ext/quests/summary?filter=active
 ```
 
-You still declare no routes. Core owns exactly one - `/ext/:extension/:action`
-- and dispatches every declared action behind it, the same way it owns one
-WebSocket frame type and dispatches `rpc/0` behind that (ADR 0003).
+`/api/v1/ops/ext/:extension/:action` is the only mutating route on the whole
+ops plane, and this is what puts something behind it. Core's own ops routes are
+all reads. You still declare no routes: core owns `/ext/:extension/:action` and
+dispatches every declared action behind it, the same way it owns one WebSocket
+frame type and dispatches `rpc/0` behind that.
 
-A handler has the same shape as an RPC handler, because there is no reason for
-a second one:
+Know what gates it. On a stock deployment there is no `ops_secret`, so every
+bearer request is denied 403 and none of this is reachable. Once a secret is
+set, these routes are live whether or not the console is - `console` gates
+`/console` only, never the ops plane. A holder of the secret holds every
+capability class, so declaring `class => config` restricts which *minted* tokens
+reach an action, not which secret-holders do. See
+[Operator console](console.md).
+
+The console cannot invoke an ops action today. The surface is HTTP only, and
+`ops` is not among the capabilities `/api/v1/ops/features` reports for an
+extension - it reports `lua`, `rpc` and `tables`.
+
+Same handler shape as `rpc/0`:
 
 ```erlang
 -spec define(map(), asobi_ops_extension:ctx()) -> asobi_rpc:reply().
@@ -232,22 +303,47 @@ define(#{~"key" := Key}, #{actor := #{id := ActorId}}) ->
 ```
 
 `Params` is the decoded JSON body for a write and the parsed query string for
-a `get`. `Ctx` carries the actor that was admitted, so recording who asked
-needs no second lookup.
+a `get`. `Ctx` is `#{actor, extension, action}`, so recording who asked and
+what they reached needs no second lookup.
+
+Readiness guards this plane as well as the socket: until migrations finish,
+every action answers `not_ready` (503).
 
 Three things are core's, not yours:
 
-- **`class` is the whole authorisation.** `read | player_data | config` is
-  ADR 0007's vocabulary, the same one core's own ops routes carry. An action
-  is admitted when its class is in the caller's capabilities and never
-  otherwise. There is nothing to check inside your handler.
-- **An undeclared action is denied, not 404.** It has no class, and a route
-  with no class is refused - so an unknown extension, an unknown action and a
-  method the action does not answer all answer 403. Which extensions are
-  installed is not something an unauthorised caller gets to enumerate.
-- **Every method but `get` is audited.** Core wraps the call in a durable
-  audit row naming the operator before your function runs. You cannot opt out,
-  and declaring a method other than `get` is what opts in.
+- `class` is the whole authorisation. `read | player_data | config` is the same
+  vocabulary core's own ops routes carry. An action is admitted when its class
+  is in the caller's capabilities and never otherwise. There is nothing to
+  check inside your handler.
+- An undeclared action is denied, not 404. It has no class, and a route with no
+  class is refused - so an unknown extension, an unknown action and a method
+  the action does not answer all answer 403. Which extensions are installed is
+  not something an unauthorised caller gets to enumerate.
+- Every method but `get` is audited. Core runs your function inside
+  `asobi_ops_audit:mutation/4` and writes the row from what it returned. You
+  cannot opt out, and declaring a method other than `get` is what opts in.
+
+### What the audit records today
+
+The audit path understands `{ok, Succeeded, Failed} | {error, Reason}`. An ops
+handler returns `{ok, map()} | {error, Code} | {error, Code, Details}`, so only
+the two-element `{error, Code}` matches. Everything else raises inside the
+audit write, which is caught and downgraded to an error-level log line naming
+the action, the exception class and the reason.
+
+So today, a failing action returning `{error, Code}` records a durable row; a
+successful mutation and a raising one are logged, not recorded. The response to
+the caller is unaffected either way. Tracked as an open issue; do not build a
+compliance story on the row until it is closed.
+
+### Manifest validation
+
+Each of these is a build failure at `rebar3 asobi check`, and again at boot:
+
+- the action is one non-empty path segment, with no `/ . ? # %`
+- `method` is `get`, `post`, `put` or `delete`
+- `class` is `read`, `player_data` or `config`
+- `mfa` is `{Module, Function, 2}`
 
 ## Writing a Lua binding
 
@@ -280,13 +376,24 @@ or missing argument is `{ error = "argument 2 must be a integer" }` at the
 script's own call site, and a binding that raises or returns outside the
 contract is an error result plus one logged line naming the function.
 
-`args` types are `binary`, `integer`, `number`, `boolean`, `table` and `any`.
-Lua has a single number type, so a script writing `1` may hand over `1.0`; a
-whole float satisfies `integer`.
+`args` types are `binary`, `integer`, `number`, `boolean`, `table` and `any`,
+one per `mfa` argument. Lua has a single number type, so a script writing `1`
+may hand over `1.0`; a whole float satisfies `integer`.
 
-`vms` decides which VM kinds see the binding. A `match` binding is absent from
-a world's zone VMs, and its namespace table is not even created there. Bot VMs
-get no `game.*` surface at all today, so `vms => [bot]` installs nothing.
+`effects` is `write` or `none`, and it is not decoration: probe VMs re-run the
+whole script body to ask `phases()` and swap every `write` function for an
+inert stub, so a `write` declared `none` fires twice on every match creation.
+
+`vms` decides which VM kinds see the binding, and may name `match`, `world` or
+`zone`. A `match` binding is absent from a world's zone VMs, and its namespace
+table is not even created there.
+
+`bot` is refused at `rebar3 asobi check`, not ignored. A bot script is loaded
+with no `game` table at all - see [Bots](lua-bots.md) - so a binding declaring
+`bot` would install nothing, and a declaration that silently does nothing is a
+defect. Making it work was rejected: a bot has no `players.id`, so the argument
+every extension binding takes cannot be supplied. A bot decides from the state
+the match broadcasts and nothing more; put what it needs in that state.
 
 Core calls `{M, F, A}` fully qualified rather than holding a fun, so a code
 upgrade takes effect without waiting for every live match VM to end.
@@ -301,18 +408,21 @@ upgrade takes effect without waiting for every live match VM to end.
 | Domain logic | Nothing. They are modules; other code calls them | nothing |
 | RPC handlers | Cannot be inferred | `rpc/0` |
 | Lua namespace | Cannot be inferred | `lua/0` |
+| Operator actions | Cannot be inferred | `ops/0` |
+| Error codes | Cannot be inferred; the core set is closed | `codes/0` |
 | Supervised processes | Optional | `sup/0` |
 | Namespace ownership | Cannot be inferred | `owns/0` |
 
-Discovery walks the OTP application graph, filtering on "exports
-`<app>_extension`". Depending on asobi is not the filter: `asobi_engine` and
-every game that embeds asobi have it in their closure and none is an
-extension.
+`rebar3 asobi check` warns that an extension declaring neither `rpc/0` nor
+`lua/0` is "reachable by nobody". The check counts those two only, so the
+warning also fires for an extension whose entire surface is `ops/0`, which is
+reachable. It is spurious for that case and safe to ignore; tracked as an open
+issue.
 
 ## Prefer a library application
 
-If your extension has processes, **omit `mod` from your `.app.src`** and
-declare children via `sup/0`.
+If your extension has processes, omit `mod` from your `.app.src` and declare
+children via `sup/0`.
 
 ```
 asobi_sup  (one_for_one, 10/60)
@@ -321,29 +431,65 @@ asobi_sup  (one_for_one, 10/60)
        `- clans
 ```
 
-The reason is specific. Applications in a release are permanent by default, and
-in OTP a permanent application terminating takes the whole runtime with it. So
-a normal OTP app whose supervisor exceeds its restart intensity **kills the
-node** - matchmaking, presence, every live match. Under
-`asobi_extension_sup` an extension that exhausts its own budget goes dark,
-core logs which one, and the node survives.
+Applications in a release are permanent by default, and in OTP a permanent
+application terminating takes the whole runtime with it. So a normal OTP app
+whose supervisor exceeds its restart intensity kills the node - matchmaking,
+presence, every live match. Under `asobi_extension_sup` an extension that
+exhausts its own budget goes dark, core logs which one, and the node survives.
+This is the ordinary BEAM pattern: Ecto repos, Oban and Phoenix endpoints are
+all started in the host's tree rather than by the library.
 
-This is the ordinary BEAM pattern, not an invention: Ecto repos, Oban and
-Phoenix endpoints are all started in the host's tree rather than by the library.
-
-A normal OTP application with its own `mod` also works. You then own the
-failure mode, and the operator has to remember to mark it non-permanent in the
-release.
-
-**Consequence:** with no `mod` there is no `start/2` for one-time setup. ETS
-tables and config validation move into the `init/1` of a supervised worker, and
-`application:which_applications()` will not show the extension as running.
+An application with its own `mod` also works; you then own the failure mode,
+and the operator has to mark it non-permanent in the release. With no `mod`
+there is no `start/2` for one-time setup: ETS tables and config validation move
+into the `init/1` of a supervised worker.
 
 Per-extension restart limits default to 5 in 60 and are settable:
 
 ```erlang
 {asobi, [{extension_restart, #{intensity => 5, period => 60}}]}
 ```
+
+`sup/0` children are per node. A supervised `gen_server` holding state holds N
+copies of it across an N-node cluster, one per node, with nothing synchronising
+them; and matches and worlds do not migrate between nodes. See
+[Clustering](clustering.md).
+
+## Boot order and readiness
+
+The route table compiles during Nova's boot, inside `nova_sup:init/1`;
+migrations run afterwards, from `asobi_app:start/2`. An extension endpoint is
+therefore reachable before its tables exist, so both seams fail closed until
+migrations finish: every RPC call and every ops action answers `not_ready`
+(503) until then. You get this for free - there is nothing to call.
+
+```erlang
+case asobi_readiness:guard() of
+    ok -> dispatch(Extension, Action, Actor, Req);
+    {error, _Object} -> {asobi_error, ~"not_ready"}
+end.
+```
+
+Your `sup/0` children are on the other side of that seam and get two
+guarantees, so none of them needs a retry path:
+
+- They start in the order `sup/0` returns them, and after the children of every
+  extension your application depends on. That is OTP's own child order and
+  `asobi_extensions:resolve/0`'s dependency order; nothing sorts either.
+- `init/1` may query. Extension children start after migrations have run to
+  completion, so the pool is up and every table - core's and yours - exists.
+
+Two failure modes are worth stating plainly:
+
+- An invalid manifest set stops the node. `asobi_extensions:resolve/0` raises
+  `{asobi_extensions, Problems}` after logging each problem in prose, from
+  inside Nova's route compilation. The node does not start. This is why
+  `rebar3 asobi check` is the gate.
+- If migrations did not complete, `asobi_extension_sup` starts no extension at
+  all and logs which ones it did not start, and every extension seam answers
+  503. The alternative is every extension crash-looping into its own restart
+  budget and going dark anyway. The marker is written once, before this
+  supervisor exists, so it cannot flip later and there is nothing to retry.
 
 ## Namespaces
 
@@ -363,36 +509,20 @@ kind derives:
 
 So a collision is caught even before either extension has bothered with
 `owns/0`, and a queue you actually run is claimed whether or not you remembered
-to say so.
+to say so. That leaves `owns/0` one job: the closed-set assertion. Naming a
+kind at all says "this is the whole set", so anything derived outside it is a
+build failure - which is what catches a worker on `quests` under an `owns/0`
+saying `quest`.
 
-That leaves `owns/0` one job: it is the **closed-set assertion**. Naming a kind
-at all says "this is the whole set", so anything derived outside it is a build
-failure. That is what catches the typo - a worker on `quests`, an `owns/0`
-saying `quest` - which used to be invisible, because nothing read `owns.queues`
-at runtime.
+Core's reserved names derive from core itself by the same rules: Lua namespaces
+from `asobi_lua_surface:reserved_namespaces/0`, tables from core's schemas,
+queues from core's shigoto workers.
 
-Core's reserved names are derived from core itself, by the same two rules: Lua
-namespaces from
-`asobi_lua_surface`, tables from core's schemas, queues from core's shigoto
-workers, and RPC prefixes from the domains of `asobi_error:core_codes/0` - an
-RPC prefix and an error-code domain are the same token, so owning `storage`
-would mint codes inside core's closed code set.
-
-## Bots are not a target
-
-`vms` may name `match`, `world` or `zone`. `bot` is **refused at
-`rebar3 asobi check`**, not ignored.
-
-A bot script is loaded without any `game` table at all - see
-[Bots](lua-bots.md) - so a binding declaring `bot` would install nothing, and a
-declaration that silently does nothing is a defect. Making it work was the
-alternative and was rejected: `game.quests` in a bot VM would be one extension
-namespace floating in a `game` table with no `game.log`, `game.economy` or
-`game.storage` under it, and a bot has no `players.id` - `bot_Spark` is not a
-player row - so the argument every extension binding takes cannot be supplied.
-
-A bot decides from the state the match broadcasts and nothing more. Put what it
-needs in that state.
+Reserved RPC prefixes are the domains of `asobi_error:core_codes/0` plus every
+core Lua namespace, because an RPC prefix and an error-code domain are the same
+token. So `game`, `economy`, `leaderboard`, `storage`, `chat`, `spatial`,
+`zone` and `terrain` are all refused as RPC prefixes as well as Lua
+namespaces - owning `storage` would mint codes inside core's closed code set.
 
 ## Error codes
 
@@ -409,27 +539,27 @@ codes() -> #{~"quests.already_claimed" =>
 `{asobi_error, ~"quests.already_claimed"}` then answers 409 with the shared
 object and logs nothing.
 
-Every code must be `<domain>.<name>`, and the domain is an RPC prefix you own:
-a code domain and an RPC prefix are the same token, so `rebar3 asobi check`
-refuses a code in core's namespace or in another extension's, and refuses a
-bare one. The set is read once at boot, from the manifest, so it stays closed
-per deployment - a string arriving in a request or a Lua script still cannot
-become a code.
+Every code must be `<domain>.<name>` with the domain an RPC prefix you own, so
+`rebar3 asobi check` refuses a code in core's namespace or another extension's,
+and refuses a bare one. `status` must be 100-599 and `message` non-empty. The
+set is read once at boot, from the manifest, so it stays closed per
+deployment - a string arriving in a request or a Lua script cannot become a
+code.
 
 ## Tables
 
 Three distinct things, and only one creates a table:
 
-1. **The schema** - a `kura_schema` module. Describes.
-2. **The migration** - generated by `rebar3 kura compile`, never hand-written.
+1. The schema - a `kura_schema` module. Describes.
+2. The migration - generated by `rebar3 kura compile`, never hand-written.
    Creates.
-3. **`owns/0`** - reserves the name. Creates nothing.
+3. `owns/0` - reserves the name. Creates nothing.
 
 Rules:
 
-- An extension may foreign-key into core. **Core never foreign-keys into an
-  extension.**
-- **Extensions never alter core tables.** Use a sidecar table keyed on
+- An extension may foreign-key into core. Core never foreign-keys into an
+  extension.
+- Extensions never alter core tables. Use a sidecar table keyed on
   `player_id`. Two extensions both adding `level` to `players` is
   unrecoverable, and core adding the same column later is worse.
 - An extension FK into `players.id` must cascade or declare an erase path. A
@@ -440,12 +570,30 @@ Your migrations run from your own application: kura discovers them through
 `asobi_repo:migration_apps/0`, inside core's transaction and under one
 advisory lock.
 
+### A table extracted out of core
+
+`owns/0` and the migration that creates a table are separable, and one case
+needs them separate: a table that used to be core's.
+
+`asobi_seasons` owns `seasons`, but the `CREATE TABLE` sits in an asobi
+migration that has already run against live databases, and shares a file with a
+table core kept. So the extension ships a schema and no migration, and asobi
+keeps the history it cannot honestly disown. Ownership is the manifest's job;
+history is append-only.
+
+The operational consequence: core has no `seasons` schema, so `rebar3 kura
+compile` will offer to drop the table. Decline it. The same applies to any
+table extracted this way, and this is the shape of every future extraction. It
+only applies to a table core once created: a table an extension invents is
+created by the extension's own migration, like `quests`.
+
 ## Deleting a player
 
 Cascade or declare an erase path - and an undeclared `on_delete` lowers to
 `no_action`, so the foreign key `rebar3 kura compile` generates refuses the
 delete until you have picked one. The first row your extension writes for a
-player makes that player undeletable otherwise.
+player makes that player undeletable otherwise. The symptom of declaring
+neither is guests quietly ceasing to be reaped.
 
 Cascade is one line on the association:
 
@@ -457,8 +605,7 @@ Cascade is one line on the association:
 ```
 
 `rebar3 kura compile` carries that into the generated migration as
-`ON DELETE CASCADE`, and there is nothing else to write. The symptom of
-declaring neither is guests quietly ceasing to be reaped.
+`ON DELETE CASCADE`, and there is nothing else to write.
 
 Cascade is right for progress rows and wrong for a financial or audit row -
 the case that rejected a blanket cascade in the first place. Implement
@@ -476,39 +623,18 @@ once per installed extension in dependency order. Do not open a transaction of
 your own. Extensions run before core so an erase path can still read the
 player's core rows.
 
-**Erasure is atomic across every extension.** Returning `{error, Reason}` or
+Erasure is atomic across every extension. Returning `{error, Reason}` or
 raising aborts the whole deletion - no extension's rows go, core's rows stay,
-the player survives, and one logged line names the extension and the reason.
-Best-effort was rejected: an erasure that half-succeeds and reports success
-leaves an account gone with some extension's rows orphaned and nothing durable
-saying which, which is a worse answer to a data-subject request than one that
-fails loudly and can be retried.
-
-The corollary: an erase path doing work the transaction cannot undo - deleting
-a remote object, calling a third party - must be idempotent, because a later
-extension's failure rolls back everything around it and the deletion is retried.
+the player survives, and one logged line names the extension and the reason. So
+an erase path doing work the transaction cannot undo, such as deleting a remote
+object, must be idempotent: a later extension's failure rolls back everything
+around it and the deletion is retried.
 
 Omit `erase_player/1` when your rows cascade: it is the alternative to that
 declaration, not a second copy of it. Cascade lives on the column because the
-database is what enforces it, and a manifest key saying the same thing could
-disagree with the schema that actually decides - which is why this is a
-callback and not an `owns/0` key. Delete the rows or null the player reference
-and keep the ledger; core only needs the player row to be able to go.
-
-### A table extracted out of core
-
-`owns/0` and the migration that creates a table are separable, and one case
-needs them separate: a table that used to be core's.
-
-`asobi_seasons` owns `seasons`, but the `CREATE TABLE` sits in an asobi
-migration that has already run against live databases - and shares a file with
-a table core kept. So the extension ships a schema and no migration, and asobi
-keeps the history it cannot honestly disown. Ownership is the manifest's job;
-history is append-only.
-
-This is the shape of every future extraction, not a special case for seasons.
-It only applies to a table core once created: a table an extension invents is
-created by the extension's own migration, like `quests`.
+database is what enforces it, which is why this is a callback and not an
+`owns/0` key. Delete the rows or null the player reference and keep the ledger;
+core only needs the player row to be able to go.
 
 ## Counters
 
@@ -524,43 +650,43 @@ progress-shaped extension needs:
 ).
 ```
 
-One `INSERT ... ON CONFLICT ... DO UPDATE SET counter = t.counter + EXCLUDED.counter`,
+One statement, roughly
+`INSERT ... ON CONFLICT (...) DO UPDATE SET "counter" = "quest_progress"."counter" + EXCLUDED."counter"`,
 so two concurrent callers both land and the row is created if it is missing.
-The conflict target must be a primary key or covered by a unique index.
+The conflict target must be a primary key or covered by a unique index, and a
+field cannot be both a key and a counter.
 
 There is no general `query/2`. Every identifier `increment/3` interpolates is
 a field of the schema you pass and every value is a bound parameter, which is
 a promise raw SQL through the seam could not make.
 
-## Readiness
+## Testing
 
-The route table compiles during Nova's boot; migrations run afterwards, from
-`asobi_app:start/2`. An extension endpoint is therefore reachable before its
-tables exist, so core fails closed until migrations finish:
+Core's suites under `test/extensions/` are the worked examples.
 
-```erlang
-case asobi_readiness:guard() of
-    ok -> dispatch(Method, Params);
-    {error, Object} -> {asobi_error, 503, Object}
-end.
-```
+A fixture extension needs no `.app` file and no separate build.
+`asobi_fixture_app:install/3` hands `application:load/1` an application spec
+directly, with your manifest module in its `modules` list - exactly what
+discovery reads. `asobi_fixture_quests_extension` declares all of `rpc/0`,
+`lua/0`, `ops/0`, `codes/0` and `owns/0`; `asobi_fixture_minimal_extension` is
+the `info/0`-only case; `asobi_fixture_clans_extension` is a second extension
+whose application depends on the first, so start order is observable.
 
-The `not_ready` code is 503, because retrying works.
+Exercise `rpc/0` without a socket by calling the dispatcher directly.
+`asobi_rpc:handle(Cid, Payload, Caller)` takes the payload map and a caller of
+`#{player_id, session}` or the atom `unauthenticated`, and returns
+`{Cid, Outcome}` - no cowboy, no connection. `asobi_rpc_tests` is the pattern:
+reset the registry, install the fixture, `asobi_extensions:resolve()`,
+`asobi_readiness:mark_ready()`, call, assert. Reset both in teardown, because
+the registry and the readiness marker are `persistent_term`.
+`asobi_ops_extension:handle/1` takes a `cowboy_req` map, so the ops seam is
+tested from a hand-built map carrying `bindings` and `auth_data`;
+`asobi_ops_extension_tests` shows the shape.
 
-Your `sup/0` children are on the other side of that seam and get two guarantees,
-so none of them needs a retry path:
-
-- **They start in the order `sup/0` returns them**, and after the children of
-  every extension your application depends on. That is OTP's own child order and
-  `asobi_extensions:resolve/0`'s dependency order; nothing sorts either.
-- **`init/1` may query.** Extension children start after migrations have run to
-  completion, so the pool is up and every table - core's and yours - exists.
-
-If migrations did not complete, `asobi_extension_sup` starts **no extension at
-all** and logs which ones it did not start. The alternative is every extension
-crash-looping into its own restart budget and going dark anyway, with an OTP
-crash report as the only explanation. The marker is written once, before this
-supervisor exists, so it cannot flip later and there is nothing to retry.
+`rebar3 asobi check` belongs in your host release's CI, not the extension's
+own: it validates a whole installed set, and an extension built alone has
+nothing to collide with. Run it after `compile` (the provider already depends
+on it) and before anything boots the node.
 
 ## Where the logic goes
 
@@ -580,21 +706,6 @@ asobi_quests/
 those is a thin adapter over it, which is what makes one implementation
 reachable from a client call, a background job and a Lua binding.
 
-## Installing versus consuming
-
-**Consuming** an installed extension from Lua or from a client works on every
-tier. A bundled first-party extension is callable as `game.quests.*` by any Lua
-game, including on managed hosting.
-
-**Installing a third-party extension** is where the tier matters:
-
-    Library / self-host from your own release ....... yes
-    Self-host from the published container image .... no
-    Managed hosting ................................ first-party only
-
-The published image and the managed service run a fixed application set decided
-at image build time.
-
 ## Not sandboxed
 
 An extension runs in the same node, the same supervision tree and with the same
@@ -602,3 +713,10 @@ database credentials as core. `asobi_repo` is unrestricted, and `os:cmd/1`,
 `open_port/2` and `load_nif/2` are all reachable. Its migrations run with full
 DDL privilege. Treat installing one as you would treat any dependency with
 production credentials.
+
+## Next steps
+
+- [WebSocket protocol](websocket-protocol.md) - the frame `rpc.call` lives in.
+- [Operator console](console.md) - turning the ops plane on.
+- [Clustering](clustering.md) - what is per node and what is not.
+- [Lua API](lua-api.md) - the `game.*` surface your namespace joins.

--- a/guides/getting-started.md
+++ b/guides/getting-started.md
@@ -1,21 +1,20 @@
-# Getting Started
+# Getting started
 
-This guide walks you through setting up Asobi and creating your first game backend.
+asobi is one Erlang/OTP node holding the game backend, the Lua runtime and the
+operator console. There are two front doors onto it:
 
-> **Shells**: command blocks that differ per OS are shown for both bash (Linux,
-> macOS, Git Bash, or WSL on Windows) and PowerShell (Windows). Docker and rebar3
-> commands are identical on every platform and are shown once.
+- **[Lua + Docker](#lua--docker)** - run the image, write game logic in Lua. The default path.
+- **[Erlang OTP](#erlang-otp)** - depend on the Hex package and write game logic in Erlang.
 
-Choose your path:
-
-- **[Lua + Docker](#lua--docker)** -- write game logic in Lua, no Erlang needed
-- **[Erlang OTP](#erlang-otp)** -- add asobi as a dependency to your Erlang project
+Command blocks that differ per OS are shown for both bash (Linux, macOS, Git
+Bash, or WSL on Windows) and PowerShell (Windows). Docker and rebar3 commands
+are identical on every platform and are shown once.
 
 ## Lua + Docker
 
-The fastest way to start. You need [Docker](https://docs.docker.com/get-docker/) and
-nothing else. On Windows and macOS that is Docker Desktop; on Windows enable the
-WSL2 backend. `localhost` reaches the server the same way on all three.
+You need [Docker](https://docs.docker.com/get-docker/) and nothing else. On
+Windows and macOS that is Docker Desktop; on Windows enable the WSL2 backend.
+`localhost` reaches the server the same way on all three.
 
 ### 1. Create your project
 
@@ -111,7 +110,7 @@ services:
       retries: 5
 
   asobi:
-    image: ghcr.io/widgrensit/asobi_lua:latest
+    image: ghcr.io/widgrensit/asobi:latest
     depends_on:
       postgres: { condition: service_healthy }
     ports:
@@ -121,7 +120,16 @@ services:
     environment:
       ASOBI_DB_HOST: postgres
       ASOBI_DB_NAME: my_game_dev
+      ASOBI_CORS_ORIGINS: "*"
 ```
+
+The image was renamed from `ghcr.io/widgrensit/asobi_lua`; the old name still
+publishes for now, so change your compose file when convenient.
+
+`ASOBI_CORS_ORIGINS` has no default. Left unset, the node answers with an empty
+`Access-Control-Allow-Origin` and every browser request fails with nothing in
+the logs to explain it. `*` is right for local development; narrow it to your
+game's origins in production.
 
 ### 5. Start it
 
@@ -129,8 +137,8 @@ services:
 docker compose up -d
 ```
 
-Your game backend is running. Asobi reads your Lua scripts, sets up the
-database, and starts listening for WebSocket connections on port 8084.
+The node reads your Lua scripts, runs the database migrations, and listens for
+REST and WebSocket traffic on port 8084.
 
 ### 6. Verify it works
 
@@ -141,10 +149,10 @@ bash (Linux, macOS, Git Bash, WSL):
 ```bash
 curl -s localhost:8084/api/v1/auth/register \
   -H 'content-type: application/json' \
-  -d '{"username":"alice","password":"hunter2"}' | jq
+  -d '{"username":"alice","password":"hunter2"}'
 ```
 
-PowerShell (Windows) - no `curl`/`jq` install needed, `Invoke-RestMethod` parses the response:
+PowerShell (Windows), no `curl` install needed, `Invoke-RestMethod` parses the response:
 
 ```powershell
 Invoke-RestMethod -Uri http://localhost:8084/api/v1/auth/register `
@@ -152,46 +160,74 @@ Invoke-RestMethod -Uri http://localhost:8084/api/v1/auth/register `
   -Body '{"username":"alice","password":"hunter2"}'
 ```
 
-Expected response:
+A 200 with:
 
 ```json
 {
-  "player_id": "01HX...",
-  "session_token": "eyJ...",
+  "player_id": "550e8400-e29b-41d4-a716-446655440000",
+  "access_token": "...",
+  "refresh_token": "...",
   "username": "alice"
 }
 ```
 
-If you see that, everything is wired up — auth, database, REST, and the
-Lua runtime are all live. Save the `session_token` for the WebSocket
-handshake (see [WebSocket Protocol](websocket-protocol.md)).
+That means auth, the database, REST and the Lua runtime are all live.
 
-Common error responses:
+`access_token` is what the WebSocket handshake sends (see
+[Connect via WebSocket](#connect-via-websocket)) and what goes in the
+`Authorization: Bearer` header on REST calls. It is valid for 60 minutes.
+`refresh_token` buys a new pair from `POST /api/v1/auth/refresh` and is valid
+for 30 days. Neither TTL is configurable today.
 
-- `{"error": "missing_required_fields"}` — check your JSON shape.
-- Connection refused — the server hasn't finished booting; give it 10s
-  and retry, or check `docker compose logs asobi` for migration errors.
+Failures use one error object throughout:
+
+```json
+{"error": {"code": "missing_field", "message": "...", "details": {}}}
+```
+
+Branch on `code`, never on `message`. The ones you are likely to hit:
+
+- `missing_field` (400) - `username` or `password` absent, or not a string.
+- `auth.username_taken` (409) - a second run of the same command hits this.
+- `validation_failed` (422) - the username or password failed a field rule; `details.fields` names them.
+
+Connection refused means the node has not finished booting. Give it 10s, then
+check `docker compose logs asobi` for migration errors.
+
+### 7. Turn on the operator console (optional)
+
+Set `ASOBI_CONSOLE: "true"` and `ASOBI_OPS_SECRET_FILE` (pointing at a mounted
+secret file) on the `asobi` service, then browse to <http://localhost:8084/console>.
+Enabled without a secret, the console stays off and logs an error; the node
+still starts. See [Operator console](console.md).
 
 ### Hot-reloading Lua
 
-Edit any `.lua` file under `./lua/` and save. Asobi picks up the change
-**live** — in-flight matches keep running on the old code until they
-finish, new matches bind the new code. No restart, no reconnect.
+Edit `lua/match.lua`, a world script, or anything they `require`, and save. A
+running match re-executes the new script body on its next tick, in place: only
+globals and functions are reassigned, so players, counters and every other
+table already in the Lua state survive. A syntax error logs a warning and the
+match keeps running the old code until you fix the file.
 
-See the [Lua Scripting](lua-scripting.md) guide for the full callback
-reference and advanced patterns.
+Two things behave differently:
+
+- Mode-shape config (`match_size`, `max_players`, `strategy`, `bots`) is
+  re-read by a config watcher and applies to matches formed after the edit.
+  Matches already running consumed those values at formation.
+- A bot script is loaded when the bot process starts, so an edit reaches bots
+  spawned after it, not bots already in a match.
+
+See [Lua scripting](lua-scripting.md) for the full callback reference and
+[Lua API](lua-api.md) for the host functions available inside a script.
 
 ## Erlang OTP
 
-For Erlang developers who want full control.
-
 ### Prerequisites
 
-- Erlang/OTP 27+
-- PostgreSQL 15+
-- [rebar3](https://rebar3.org)
+rebar3, Erlang/OTP 28 or later, and PostgreSQL 16 or later. CI builds on OTP
+29.0.2 against Postgres 17.
 
-### 1. Create a New Project
+### 1. Create a new project
 
 ```bash
 rebar3 new app my_game
@@ -202,7 +238,7 @@ Add asobi to your dependencies in `rebar.config`:
 
 ```erlang
 {deps, [
-    {asobi, "~> 0.25"}
+    {asobi, "~> 0.68"}
 ]}.
 ```
 
@@ -212,7 +248,7 @@ Point rebar3 at a `sys.config` for the shell (added below):
 {shell, [{config, "./config/sys.config"}]}.
 ```
 
-### 2. Configure the Database
+### 2. Configure the database
 
 Create a PostgreSQL database:
 
@@ -220,10 +256,15 @@ Create a PostgreSQL database:
 createdb my_game_dev
 ```
 
-Create `config/sys.config`. Asobi is hosted by Nova, so Nova needs to be
-told to bootstrap the `asobi` application, which plugins to run, and
-which `pg` scopes to register. `shigoto` (background jobs) needs to know
-which DB pool to use, and `kura` needs the connection details:
+Create `config/sys.config`. asobi is hosted by Nova, so Nova needs to be told
+to bootstrap the `asobi` application, which plugins to run, and which `pg`
+scopes to register. `shigoto` (background jobs) needs to know which DB pool to
+use, and `kura` needs the connection details and its dialect.
+
+The plugin list below mirrors the one the shipped release uses
+(`config/prod_sys.config.src`). The order matters: the body cap runs before
+anything buffers a body, and the rate limiter runs before the client gate so
+a flood is shed before any external call.
 
 ```erlang
 [
@@ -234,16 +275,24 @@ which DB pool to use, and `kura` needs the connection details:
         {json_lib, json},
         {cowboy_configuration, #{port => 8084}},
         {plugins, [
+            {pre_request, asobi_body_cap_plugin, #{
+                max_body => 1048576,
+                require_content_length => true
+            }},
             {pre_request, nova_request_plugin, #{
                 decode_json_body => true,
                 parse_qs => true
             }},
-            {pre_request, nova_cors_plugin, #{allow_origins => <<"*">>}},
-            {pre_request, nova_correlation_plugin, #{}}
+            {pre_request, nova_cors_plugin, #{allow_origins => ~"*"}},
+            {pre_request, nova_correlation_plugin, #{}},
+            {pre_request, asobi_rate_limit_plugin, #{}},
+            {pre_request, asobi_client_gate_plugin, #{}},
+            {post_request, asobi_security_headers_plugin, #{}}
         ]}
     ]},
     {kura, [
         {repo, asobi_repo},
+        {backend, kura_backend_postgres},
         {host, "localhost"},
         {port, 5432},
         {database, "my_game_dev"},
@@ -263,31 +312,31 @@ which DB pool to use, and `kura` needs the connection details:
         {matchmaker, #{
             tick_interval => 1000,
             max_wait_seconds => 60
-        }},
-        {session, #{
-            token_ttl => 900,
-            refresh_ttl => 2592000
         }}
     ]},
     {pg, [{scope, [nova_scope, asobi_presence, asobi_chat]}]}
 ].
 ```
 
-> **Why `{bootstrap_application, asobi}`?** Nova is a web framework that
-> hosts one or more applications. Without this key Nova doesn't know
-> which app owns its router, and the release dies at boot with
-> `{error, no_nova_app_defined}`.
+Two keys people leave out and then debug for an hour:
 
-### 3. Start the Server
+`{bootstrap_application, asobi}` tells Nova which application owns the router.
+Without it the release dies at boot with `{error, no_nova_app_defined}`.
+
+`{backend, kura_backend_postgres}` tells kura which SQL dialect to compile to.
+Without it the node boots fine and then dies on its first query with
+`{no_dialect_configured, asobi_repo}`.
+
+### 3. Start the server
 
 ```bash
 rebar3 shell
 ```
 
-Asobi runs all database migrations automatically on startup. The server
-is now listening on the configured port.
+Database migrations run automatically on startup. The server is now listening
+on the configured port.
 
-## Register a Player
+## Register a player
 
 bash (Linux, macOS, Git Bash, WSL):
 
@@ -310,25 +359,29 @@ Response:
 ```json
 {
   "player_id": "550e8400-e29b-41d4-a716-446655440000",
-  "session_token": "SFMyNTY...",
+  "access_token": "...",
+  "refresh_token": "...",
   "username": "player1"
 }
 ```
 
 ## Connect via WebSocket
 
-Connect to `ws://localhost:8084/ws` and authenticate:
+Connect to `ws://localhost:8084/ws` and send the `access_token`:
 
 ```json
 {
   "type": "session.connect",
   "payload": {
-    "token": "SFMyNTY..."
+    "token": "..."
   }
 }
 ```
 
-## Implement Your Game
+A connection that never sends `session.connect` is closed by the idle-auth
+timer (1008, `idle_auth_timeout`).
+
+## Implement your game
 
 Create a module implementing the `asobi_match` behaviour:
 
@@ -352,7 +405,7 @@ handle_input(PlayerId, #{~"type" := ~"move", ~"x" := X, ~"y" := Y}, State) ->
     {ok, State#{players => Players#{PlayerId => #{x => X, y => Y}}}}.
 
 tick(State) ->
-    %% Called every tick -- advance your simulation
+    %% Called every tick - advance your simulation
     {ok, State}.
 
 get_state(_PlayerId, State) ->
@@ -368,12 +421,14 @@ Register it in your config:
 ]}
 ```
 
-## Next Steps
+## Next steps
 
-- [Lua Scripting](lua-scripting.md) -- write game logic in Lua (Docker or Erlang)
-- [Bots](lua-bots.md) -- add AI-controlled players
-- [Configuration](configuration.md) -- all configuration options
-- [REST API](rest-api.md) -- full API reference
-- [WebSocket Protocol](websocket-protocol.md) -- real-time message types
-- [Matchmaking](matchmaking.md) -- query-based player matching
-- [Economy](economy.md) -- wallets, items, and store
+- [Lua scripting](lua-scripting.md) - write game logic in Lua (Docker or Erlang)
+- [Lua API](lua-api.md) - the host functions a script can call
+- [Bots](lua-bots.md) - add AI-controlled players
+- [Configuration](configuration.md) - all configuration options
+- [Self-hosting](self-hosting.md) - requirements, production compose, operating notes
+- [REST API](rest-api.md) - full API reference
+- [WebSocket protocol](websocket-protocol.md) - real-time message types
+- [Matchmaking](matchmaking.md) - query-based player matching
+- [Economy](economy.md) - wallets, items, and store

--- a/guides/glossary.md
+++ b/guides/glossary.md
@@ -1,74 +1,108 @@
 # Project glossary
 
-You'll see several "asobi" names in docs, repos, and the Discord. Here's what
-each one is and when to reach for it. Read this page first if you're new —
-the names look interchangeable and aren't.
+Names you will meet across the docs, the repos and the Discord. Read this first
+if they blur together.
 
-## The open-source pieces
+## asobi
 
-**asobi** — the public Erlang library published on
-[Hex](https://hex.pm/packages/asobi). Depend on it in `rebar.config` if
-you're writing your game backend directly in Erlang/OTP and want match,
-matchmaking, world-server, voting, economy, and the rest as composable
-OTP behaviours. This is the library underneath everything.
+One project with two front doors.
 
-**asobi_lua** — the batteries-included runtime that wraps the `asobi`
-library with a [Luerl](https://github.com/rvirding/luerl) VM so you can
-write game logic in Lua without knowing Erlang. Ships as a Docker image at
-`ghcr.io/widgrensit/asobi_lua`. Most people start here.
+**As a runnable node.** The image `ghcr.io/widgrensit/asobi` is a complete
+game backend: the match and world servers, matchmaking, economy, social, chat,
+leaderboards, the Lua runtime and the operator console, in one Erlang/OTP
+release. The binary inside it is `bin/asobi`. Write `match.lua`, point the node
+at it, `docker compose up`.
 
-**Arena Shooter** — the flagship end-to-end sample: a full multiplayer game
-(server-authoritative movement and combat, matchmaking with bots, boons,
-round voting, a leaderboard), not a snippet.
+**As a Hex library.** [`asobi` on Hex](https://hex.pm/packages/asobi) is the
+same code as a dependency. Add `{asobi, "~> 0.68"}` to `rebar.config` and
+implement the `asobi_match` behaviour when you want a callback in Erlang rather
+than Lua.
+
+Lua is not a wrapper, an add-on or a separate runtime. It ships in the node.
+The `asobi_lua` repo is retired and its code lives here, under `src/lua/`.
+
+`asobi_lua` still appears in three places that are correct and must not be
+renamed: module names (`asobi_lua_config`, `asobi_lua_api`, `asobi_lua_loader`
+and friends), the `ASOBI_LUA_RELOAD` variable, and `{asobi_lua, [...]}` config
+blocks, which are still read - see
+[Which application key](configuration.md#which-application-key).
+
+The one stale `asobi_lua` is the image name. `ghcr.io/widgrensit/asobi_lua`
+still publishes, so an existing compose file keeps working; change it to
+`ghcr.io/widgrensit/asobi` when convenient.
 
 ## Client SDKs
 
-**asobi-godot, asobi-defold, asobi-unity, asobi-unreal, asobi-js,
-asobi-dart, flame_asobi** — one per engine, all talking to asobi over
-WebSocket + REST. See the [SDK table in the
-README](../README.md#client-sdks).
+One per engine, all speaking the same WebSocket and REST protocol:
+[asobi-love2d](https://github.com/widgrensit/asobi-love2d) (LÖVE),
+[asobi-defold](https://github.com/widgrensit/asobi-defold),
+[asobi-godot](https://github.com/widgrensit/asobi-godot),
+[asobi-unity](https://github.com/widgrensit/asobi-unity),
+[asobi-unreal](https://github.com/widgrensit/asobi-unreal),
+[asobi-js](https://github.com/widgrensit/asobi-js),
+[asobi-dart](https://github.com/widgrensit/asobi-dart) and
+[flame_asobi](https://github.com/widgrensit/flame_asobi). Full table with docs
+and demos in the [README](../README.md#client-sdks).
 
 ## The commercial layer
 
-**asobi.dev Cloud** — managed hosting, opening later in 2026. Same binary
-you can self-host today, with opinionated ops and flat per-container
-pricing. Join the waitlist at [asobi.dev/cloud](https://asobi.dev/cloud).
+**asobi.dev Cloud** - managed hosting, running the same node described above.
+Invite-only today, opening more widely toward the end of 2026.
+[asobi.dev/cloud](https://asobi.dev/cloud).
 
-If we disappear, the open-source pieces above are enough to run your game
-forever. See [exit.md](exit.md) for the runbook.
+The differences are operational, not functional. A cloud environment is created
+and fed Lua through the `asobi` CLI rather than a mounted `/app/game`, its
+console is reached from the dashboard rather than by holding an operator secret,
+and the environment's `sys.config` is not yours to write. Everything about the
+game itself - callbacks, protocol, error codes - is identical.
+
+If it disappears, the open-source node above is enough to run your game
+forever. See [exit.md](exit.md).
 
 ## Which one do I start with?
 
-- **"I want to write Lua."** → `asobi_lua`. Pull the Docker image, write
-  `match.lua`, `docker compose up`.
-- **"I want to write Erlang."** → `asobi`. Add it to `rebar.config`,
-  implement the `asobi_match` behaviour.
-- **"I want both."** → `asobi_lua` hosts your Lua code and is itself built
-  on the `asobi` library. You can drop from Lua into an Erlang behaviour
-  for a hot loop without leaving the process.
-- **"I just want hosting."** → self-host `asobi_lua` today, or join the
-  `asobi.dev/cloud` waitlist.
+Run the image and write Lua. That is the default path and it needs no Erlang.
+
+Depend on the Hex package if you are writing Erlang callbacks - a hot loop, a
+custom matchmaking strategy, an extension.
+
+You do not choose between them. The same node serves both, plus the console.
 
 ## Concepts, not projects
 
-These are vocabulary, not repositories. You'll see them throughout the
-docs:
+Vocabulary you will meet throughout the docs.
 
-- **Match** — a short-lived gameplay session. 2 to N players, finite
-  duration, result persisted. Runs as a `gen_server` under a supervisor.
-- **World** — a long-lived persistent environment. Players come and go,
-  state persists across disconnects. Think MMO zone, town, dungeon.
-- **Zone** — a spatial partition inside a world. Used for sharding large
-  worlds into loadable chunks.
-- **Session** — a player's authenticated connection. Survives
-  reconnection with a session token.
-- **Tenant** — a studio or account in the managed cloud. You don't see
-  this when self-hosting.
-- **Game** — the product you're shipping. One game may have many match
-  modes, worlds, and tenants.
+- **Match** - a short-lived gameplay session. 2 to N players, finite duration,
+  result persisted. One `gen_statem` under `asobi_match_sup`, ticking on a
+  state timeout.
+- **World** - a long-lived environment. Players come and go, state persists
+  across disconnects. Think MMO zone, town, dungeon. One world lives entirely
+  on one node.
+- **Zone** - a spatial partition inside a world, used to shard a large world
+  into separately ticked chunks.
+- **Session** - one process per connection, started when the socket sends
+  `session.connect` and ended when the socket closes. It does not survive the
+  connection: a reconnecting client presents the same token and gets a new
+  session.
+- **Console** - the operator UI this node serves at `/console`. Off until
+  `console` is set. See [Operator console](console.md).
+- **Ops plane** - the HTTP API at `/api/v1/ops/*` that the console reads. Its
+  own credential, separate from the console flag, and read-only apart from
+  extension actions.
+- **Capability class** - what an ops route is allowed to touch: `read`,
+  `player_data` or `config`. Every core ops route carries one.
+- **Extension** - an OTP application that depends on asobi, added to your
+  release, declaring a manifest. It can add RPC methods, workers, schemas and
+  ops actions without forking asobi. See [Extensions](extensions.md).
+- **RPC method** - how a client calls an extension. One WebSocket frame type:
+  `rpc.call` in with a `method` and `params`, `rpc.ok` or `rpc.error` back,
+  paired by `cid`.
+- **Tenant** - a studio or account in the managed cloud. Not a concept when
+  self-hosting.
+- **Game** - the product you are shipping. One game may have many match modes
+  and worlds.
 
-When two words compete (e.g. *match* vs *room*, *world* vs *realm*),
-asobi uses the first one. The [Nakama migration
-guide](migrate-from-nakama.md) and [Hathora migration
-guide](migrate-from-hathora.md) include mapping tables from competitor
-vocab to asobi vocab.
+When two words compete (*match* against *room*, *world* against *realm*),
+asobi uses the first. The [Nakama](migrate-from-nakama.md),
+[PlayFab](migrate-from-playfab.md) and [Hathora](migrate-from-hathora.md)
+migration guides carry mapping tables from competitor vocabulary.

--- a/guides/iap.md
+++ b/guides/iap.md
@@ -1,32 +1,35 @@
-# In-App Purchases
+# In-app purchases
 
-Asobi provides server-side receipt validation for Apple App Store and
-Google Play purchases. All IAP endpoints require an authenticated session.
+Server-side receipt validation for the Apple App Store and Google Play. Both
+endpoints require an authenticated session.
 
-## Why Server-Side Validation?
+There is no Lua path for IAP. Verification is an HTTP route the client calls
+directly; a game script cannot reach it.
 
-Client-side receipt validation can be spoofed. Always validate purchases on the
-server before granting items, currency, or premium features to a player.
+## Why server-side validation
+
+Client-side receipt checks can be spoofed. Validate on the server before
+granting items, currency or premium features.
+
+asobi verifies the receipt and records it. It does **not** credit a wallet or
+grant an item - map the returned `product_id` to whatever your game owes and
+call the [economy](economy.md) yourself.
 
 ## Apple App Store
 
-Validates signed transactions from StoreKit 2. The game client sends the
-JWS (JSON Web Signature) string obtained after a purchase.
+Validates signed transactions from StoreKit 2. The client sends the JWS string
+it got after the purchase.
 
 ```
 POST /api/v1/iap/apple
 ```
 
-### Example
-
 ```bash
 curl -X POST http://localhost:8084/api/v1/iap/apple \
-  -H 'Authorization: Bearer <session_token>' \
+  -H 'Authorization: Bearer <access_token>' \
   -H 'Content-Type: application/json' \
   -d '{"signed_transaction": "eyJhbGciOi..."}'
 ```
-
-### Response
 
 ```json
 {
@@ -34,56 +37,61 @@ curl -X POST http://localhost:8084/api/v1/iap/apple \
   "transaction_id": "2000000123456789",
   "original_transaction_id": "2000000123456789",
   "purchase_date": 1711700000000,
-  "expires_date": null,
+  "expires_date": "undefined",
   "quantity": 1,
   "type": "Consumable",
-  "valid": true
+  "valid": true,
+  "duplicate": false
 }
 ```
 
+`valid` is `false` only when `expires_date` is in the past, which happens for
+an expired subscription and nothing else. A consumable has no `expires_date`
+and is always `valid: true` when it verifies at all - every other failure is an
+error response, not `valid: false`.
+
+A field the store's payload does not carry comes back as the **string**
+`"undefined"`, not JSON `null` - here `expires_date`,
+`original_transaction_id` and `product_id`, and on the Google side
+`purchase_time` and `consumption_state`. Treat `"undefined"` as absent.
+
 ### Configuration
+
+Apple validation needs the bundle id **and** a trust anchor for the certificate
+chain. Both are required; configure only the first and every call fails.
 
 ```erlang
 {asobi, [
-    {apple_bundle_id, <<"com.example.game">>}
+    {apple_bundle_id, ~"com.example.game"},
+
+    %% One of these two. `apple_root_certs` takes a list of DER or PEM
+    %% binaries; `apple_root_cert_path` a file to read them from.
+    {apple_root_cert_path, ~"/etc/asobi/AppleRootCA-G3.cer"}
 ]}
 ```
 
-The `apple_bundle_id` must match your app's bundle identifier. Transactions
-with a mismatched bundle ID are rejected.
+Missing bundle id answers `iap.verification_failed` with
+`details.reason: "apple_iap_not_configured"`. Missing certificates answer the
+same code with `details.reason: "apple_root_cert_not_configured"`, and
+certificates that will not decode with `"apple_root_cert_invalid"`. A
+transaction whose `bundleId` does not match yours is rejected with
+`"bundle_id_mismatch"`.
 
-### Handling the Result
-
-After a successful validation, grant the purchase to the player using the
-economy system:
-
-```erlang
-case asobi_iap:verify_apple(SignedTransaction) of
-    {ok, #{product_id := ProductId, valid := true}} ->
-        %% Map product ID to in-game currency/items
-        grant_purchase(PlayerId, ProductId);
-    {ok, #{valid := false}} ->
-        %% Subscription expired or purchase invalid
-        {error, expired};
-    {error, Reason} ->
-        {error, Reason}
-end.
-```
+Get the Apple Root CA - G3 certificate from
+[Apple's PKI page](https://www.apple.com/certificateauthority/).
 
 ## Google Play
 
-Validates purchases using the Google Play Developer API. The game client sends
-the product ID and purchase token obtained from Google Play Billing.
+Validates purchases through the Google Play Developer API. The client sends the
+product id and the purchase token from Google Play Billing.
 
 ```
 POST /api/v1/iap/google
 ```
 
-### Example
-
 ```bash
 curl -X POST http://localhost:8084/api/v1/iap/google \
-  -H 'Authorization: Bearer <session_token>' \
+  -H 'Authorization: Bearer <access_token>' \
   -H 'Content-Type: application/json' \
   -d '{
     "product_id": "gems_100",
@@ -91,107 +99,128 @@ curl -X POST http://localhost:8084/api/v1/iap/google \
   }'
 ```
 
-### Response
-
 ```json
 {
   "product_id": "gems_100",
   "order_id": "GPA.1234-5678-9012-34567",
-  "purchase_time": 1711700000000,
+  "purchase_time": "1711700000000",
   "consumption_state": 0,
   "acknowledged": false,
-  "valid": true
+  "valid": true,
+  "duplicate": false
 }
 ```
 
+`product_id`, `order_id`, `purchase_time` and `consumption_state` are Google's
+own values passed through unchanged. `purchase_time` is Google's
+`purchaseTimeMillis`, which the Play Developer API serialises as a **string**
+because it is an int64 - parse it, do not assume a number.
+
+The Google path returns `valid: true` or an error. It never returns
+`valid: false`: a purchase Google reports as cancelled or pending is an error
+response, not a successful one with a flag.
+
 ### Configuration
 
-Google Play validation requires a service account with the
-`androidpublisher` scope.
+Google Play validation needs a service account with the `androidpublisher`
+scope.
 
-1. Create a service account in [Google Cloud Console](https://console.cloud.google.com/)
-2. Grant it access in Google Play Console → API access
-3. Download the JSON key file
+1. Create a service account in [Google Cloud Console](https://console.cloud.google.com/).
+2. Grant it access under Google Play Console, API access.
+3. Download the JSON key file and point asobi at it.
 
 ```erlang
 {asobi, [
-    {google_package_name, <<"com.example.game">>},
-    {google_service_account_key, <<"/path/to/service-account.json">>}
+    {google_package_name, ~"com.example.game"},
+    {google_service_account_key, ~"/path/to/service-account.json"}
 ]}
 ```
 
-### Purchase States
+### Purchase states
 
-| `consumptionState` | Meaning |
+| `consumption_state` | Meaning |
 |---|---|
 | `0` | Not consumed |
 | `1` | Consumed |
 
-| `acknowledged` | Meaning |
-|---|---|
-| `false` | Not yet acknowledged |
-| `true` | Acknowledged |
+`acknowledged` is `true` once Google's `acknowledgementState` is 1. Acknowledge
+purchases after granting, or Google refunds them automatically.
 
-## SDK Integration
+## Replay protection
 
-### Unity (C#)
+asobi persists every verified transaction to the `iap_transactions` table,
+keyed uniquely on `(provider, transaction_id)` - the Apple `transaction_id` or
+the Google `order_id`. Two consequences:
 
-```csharp
-// After a StoreKit 2 purchase (Apple)
-string signedTransaction = storeKit.Transaction.JwsRepresentation;
-var result = await asobi.IAP.VerifyApple(signedTransaction);
-if (result.Valid) {
-    // Purchase verified, items granted server-side
-}
+- The **same player** re-submitting a receipt gets `200` with
+  `"duplicate": true` and no second row. Re-submission is safe, so a client
+  that retries after a network failure cannot double-grant, provided your grant
+  path checks `duplicate`.
+- A **different player** submitting a receipt someone else already claimed gets
+  `409 iap.transaction_already_claimed`. A receipt belongs to one account.
 
-// After a Google Play purchase
-string purchaseToken = purchase.PurchaseToken;
-var result = await asobi.IAP.VerifyGoogle("gems_100", purchaseToken);
-if (result.Valid) {
-    // Purchase verified
-}
+A verified receipt carrying no transaction id at all is refused with
+`iap.missing_transaction_id` rather than stored unkeyed.
+
+## Error codes
+
+| Status | Code | `details.reason` examples |
+|---|---|---|
+| `400` | `missing_field` | The Apple body is missing `signed_transaction` |
+| `422` | `iap.verification_failed` | `apple_iap_not_configured`, `apple_root_cert_not_configured`, `apple_root_cert_invalid`, `bundle_id_mismatch`, `invalid_jws`, `invalid_jws_format`, `google_iap_not_configured`, `missing_required_fields` (the Google body is missing `product_id` or `purchase_token`), `purchase_not_found`, `purchase_cancelled`, `purchase_pending`, `google_api_error`, `google_api_unavailable` |
+| `422` | `iap.missing_transaction_id` | The verified receipt carries no transaction id |
+| `409` | `iap.transaction_already_claimed` | Another player already claimed this transaction |
+| `500` | `iap.record_failed` | The verified transaction could not be written |
+
+The reasons under `iap.verification_failed` name an internal verification step.
+They are diagnostics, not a contract: branch on the code, log the reason.
+
+```json
+{"error": {"code": "iap.verification_failed", "message": "...", "details": {"reason": "bundle_id_mismatch"}}}
 ```
 
-### Godot (GDScript)
+## Handling the result
 
-```gdscript
-# Apple
-var result = await asobi.iap.verify_apple(signed_transaction)
-if result.valid:
-    print("Purchase verified: ", result.product_id)
+### In Erlang
 
-# Google
-var result = await asobi.iap.verify_google("gems_100", purchase_token)
-if result.valid:
-    print("Purchase verified: ", result.order_id)
+```erlang
+case asobi_iap:verify_apple(SignedTransaction) of
+    {ok, #{product_id := ProductId, valid := true}} ->
+        grant_purchase(PlayerId, ProductId);
+    {ok, #{valid := false}} ->
+        {error, subscription_expired};
+    {error, Reason} ->
+        {error, Reason}
+end.
 ```
 
-### Dart / Flutter / Flame
+`verify_google/1` takes **one map** with binary keys, not two arguments:
 
-```dart
-// Apple
-final result = await asobi.iap.verifyApple(signedTransaction);
-if (result.valid) {
-  // Grant items
-}
-
-// Google
-final result = await asobi.iap.verifyGoogle('gems_100', purchaseToken);
-if (result.valid) {
-  // Grant items
-}
+```erlang
+{ok, Result} = asobi_iap:verify_google(#{
+    ~"product_id" => ~"gems_100",
+    ~"purchase_token" => PurchaseToken
+}).
 ```
 
-## Security Notes
+Neither function records the transaction or binds it to a player - that is the
+controller's job. Calling `asobi_iap` directly skips replay protection.
 
-- Always validate receipts server-side, never trust the client alone
-- Check the `product_id` matches what you expect before granting items
-- For Apple subscriptions, check `expires_date` and `valid` together
-- For Google, acknowledge purchases after granting to prevent refund abuse
-- Log all IAP validations for audit and dispute resolution
+### From a client
 
-## Next Steps
+Every SDK wraps these two routes and returns the response above unchanged,
+including `valid` and `duplicate`. See your SDK's README for the exact method
+names.
 
-- [Authentication](authentication.md) -- auth methods and provider linking
-- [Economy](economy.md) -- wallets, currencies, and store
-- [REST API](rest-api.md) -- full API reference
+## Inspecting purchases
+
+The console has no IAP screen. Verified transactions land in the
+`iap_transactions` table - `player_id`, `provider`, `transaction_id`,
+`original_transaction_id`, `product_id`, `inserted_at` - so query the database
+for dispute resolution. See [Operator console](console.md).
+
+## Next steps
+
+- [Authentication](authentication.md) - auth methods and provider linking.
+- [Economy](economy.md) - the wallets and items you grant after a receipt verifies.
+- [REST API](rest-api.md) - full API reference.

--- a/guides/large-worlds.md
+++ b/guides/large-worlds.md
@@ -1,136 +1,159 @@
-# Large Worlds
+# Large worlds
 
-Scale the world server to handle massive tile-based maps with lazy zone
-loading, terrain data serving, and configurable zone lifecycle management.
+Running the world server over a big tile map: how zones come and go, and how
+terrain is served.
 
-Everything here is game logic and config. It is written once and runs the same
-whether you deploy to managed Cloud (`asobi deploy`, console.asobi.dev) or
-self-host your own release of asobi + asobi_lua. The one exception - shipping a
-custom terrain generator - is called out under [Terrain Data](#terrain-data).
+Everything here is game logic and config. It is the same whether you run the
+image and write Lua or depend on the Hex package and write Erlang. The one
+exception, shipping a custom terrain generator, is called out under
+[Terrain data](#terrain-data).
 
-## Lazy Zone Loading
+## Zones are created on demand above grid_size 100
 
-By default, all zones in a world are spawned at startup. For large worlds
-(thousands of zones), enable lazy loading so zones are created on demand when a
-player enters. The config keys are globals at the top of your world script.
+A world with `grid_size > 100` creates zones lazily, when a player joins or
+moves into one. At or below 100 it pre-warms every zone at startup. That
+threshold is the deployment's behaviour and there is no configuration key that
+changes it.
 
-<!-- tabs -->
-**Lua**
+Two more numbers are fixed the same way:
+
+- **Zone idle: 30s.** A zone becomes reap-eligible 30s after its last touch, or
+  immediately when its last occupant leaves. The sweep that acts on that runs
+  every 10s.
+- **Active zones: 10,000 per world.** This is a hard ceiling, not a
+  recommendation. A world that needs more concurrent zones than that needs
+  bigger zones (`zone_size`) or a smaller grid.
+
+A mode script declares the map itself:
+
 ```lua
--- world.lua
-game_type         = "world"
-grid_size         = 2000
-zone_size         = 64
-lazy_zones        = true
-zone_idle_timeout = 30000
-max_active_zones  = 10000
+-- lua/world.lua
+game_type   = "world"
+match_size  = 1
+max_players = 200
+grid_size   = 2000
+zone_size   = 64
+view_radius = 1
 ```
 
-**Erlang**
+`match_size` is required in every mode script, world modes included; the loader
+rejects a script without it. A file named `world.lua` is only loaded when a
+`config.lua` maps a mode name to it:
+
+```lua
+-- lua/config.lua
+return {
+    frontier = "world.lua",
+}
+```
+
+A complete, runnable pair lives in
+[`examples/world-walkers`](https://github.com/widgrensit/asobi/tree/main/examples/world-walkers).
+
+In Erlang the same keys are mode config, and the mode declares `module`:
+
 ```erlang
-Config = #{
-    game_module => my_world,
-    grid_size => 2000,
-    zone_size => 64,
-    lazy_zones => true,
-    zone_idle_timeout => 30000,
-    max_active_zones => 10000
-}.
+{asobi, [
+    {game_modes, #{
+        ~"frontier" => #{
+            type => world,
+            module => my_world,
+            grid_size => 2000,
+            zone_size => 64
+        }
+    }}
+]}.
 ```
-<!-- /tabs -->
 
-With `lazy_zones` on:
+`game_module` is an internal key of the world server, derived from `module`.
+Setting it in mode config does nothing.
 
-- Zones are created when a player joins or moves into them.
-- Interest zones (adjacent to the player) only subscribe if already loaded.
-- Idle zones are snapshotted to the database and terminated after `zone_idle_timeout`.
-- `max_active_zones` caps concurrent zone processes and prevents runaway memory.
-
-`lazy_zones` auto-enables when `grid_size > 100`. For small worlds
-(`grid_size <= 100`) all zones are pre-warmed at startup regardless of the
-setting.
-
-## Zone Lifecycle
-
-Each zone follows this lifecycle:
+## Zone lifecycle
 
 ```
-[not loaded] --ensure_zone--> [active] --no subscribers--> [idle]
-     ^                                                        |
-     |                    idle_timeout expires                 |
-     +---<---snapshot + terminate---<---reap---<--------------+
+[not loaded] --ensure_zone--> [active] --last occupant leaves--> [idle]
+     ^                                                             |
+     |                    reap sweep (every 10s)                   |
+     +---<-------------- stop, if empty ------------<--------------+
 ```
 
 A zone with subscribers resets its idle timer each tick. When subscribers drop
-to zero and the zone has no tickable entities, it enters BEAM hibernation to
-reduce memory, then is snapshotted and reaped once `zone_idle_timeout` expires.
+to zero and the zone holds no NPCs, it hibernates to shrink its heap.
 
 A reap is a proposal, not an order. A zone that still holds entities declines
-it, and a join or crossing that finds its zone reaped between resolving the pid
-and placing the player transparently starts a replacement zone and re-places
-them there.
+it and re-touches its own timer; only an empty zone stops. A join or crossing
+that finds its zone reaped between resolving the pid and placing the player
+transparently starts a replacement zone and places them there.
 
-## Terrain Data
+Zone state is **not** snapshotted on the way out. Zone persistence exists in
+the zone process but no configuration path reaches it, so entities in a
+reaped zone are gone. Do not design a world that depends on a zone's contents
+surviving the players leaving it - write anything durable to your own tables
+from a callback.
 
-Terrain is separate from entities. Tile chunks are served as compressed binary
-blobs when a player subscribes to a zone, not through the tick/delta loop.
+`persistent = true` in a mode's config does one reachable thing today: it keeps
+an emptied world alive instead of finishing it.
 
-Asobi does not define what terrain is. A provider returns the bytes of the chunk
-at a `{X, Y}` coordinate; Asobi caches that blob in the terrain store and ships
-it to clients verbatim. The payload is whatever your provider produces. A
-complete, runnable provider lives in
+## Terrain data
+
+Terrain is separate from entities. Tile chunks are served when a player
+subscribes to a zone, not through the tick and delta loop.
+
+asobi does not define what terrain is. A provider returns the bytes of the
+chunk at a `{X, Y}` coordinate; asobi caches that blob in the terrain store and
+ships it to clients verbatim, base64-encoded inside a JSON `world.terrain`
+frame. The payload is whatever your provider produces. A complete, runnable
+provider lives in
 [`examples/world-terrain`](https://github.com/widgrensit/asobi/tree/main/examples/world-terrain).
 
 The split is: Lua selects a provider, Erlang implements one.
 
-### Selecting a Provider
+### Selecting a provider
 
 Your world script names its provider from `terrain_provider`, returning the
-module name and its args as a keyed table.
+module name and its arguments as a keyed table.
 
-<!-- tabs -->
-**Lua**
 ```lua
--- world.lua
 function terrain_provider(config)
     return { module = "asobi_terrain_perlin", args = { seed = 42 } }
 end
 ```
 
-**Erlang**
+In Erlang:
+
 ```erlang
 terrain_provider(Config) ->
     {asobi_terrain_perlin, #{seed => maps:get(seed, Config, 42)}}.
 ```
-<!-- /tabs -->
 
 Return `nil` (Lua) or `none` (Erlang) for a world with no terrain.
 
 Two providers ship built in: `asobi_terrain_flat` and `asobi_terrain_perlin`.
 The name is checked against an allowlist rather than resolved as an arbitrary
-module, so a script cannot name `gen_server` or any other loaded module. A name
-that is not on the list is rejected with `terrain_provider_not_allowed`.
+module, so a script cannot name `gen_server` or anything else that happens to
+be loaded. A name that is not on the list logs a `terrain_provider_not_allowed`
+warning and the world starts with **no terrain store at all** - clients receive
+no `world.terrain` message, rather than an empty one.
 
-**Cloud:** the two built-in providers are available with no configuration.
-
-**Self-hosted:** extend the allowlist to admit your own provider. This is an
-`asobi_lua` key, set in sys.config - see
-[Terrain provider allowlist](configuration.md#terrain-provider-allowlist):
+To admit your own provider, extend the allowlist in `sys.config`:
 
 ```erlang
-{asobi_lua, [
+{asobi, [
     {terrain_providers, [asobi_terrain_flat, asobi_terrain_perlin, my_terrain]}
 ]}
 ```
 
-A custom provider is a compiled Erlang module, so shipping one means running
-your own release: it is a self-hosted feature. On managed Cloud, stick to the
-built-ins.
+See [Terrain provider allowlist](configuration.md#terrain-provider-allowlist),
+and [Which application key](configuration.md#which-application-key) if you still
+have an `{asobi_lua, [...]}` block.
 
-### Terrain Provider Behaviour (Erlang)
+A custom provider is a compiled Erlang module, so shipping one means building
+your own release.
 
-Implement `asobi_terrain_provider` to supply terrain data. This is Erlang only,
-the same split as matchmaker strategies.
+### Terrain provider behaviour (Erlang)
+
+Implement `asobi_terrain_provider`. There is no Lua path for this, the same
+split as matchmaker strategies.
 
 ```erlang
 -module(my_terrain).
@@ -140,7 +163,7 @@ the same split as matchmaker strategies.
 init(Config) ->
     {ok, Config}.
 
-load_chunk({X, Y}, State) ->
+load_chunk({_X, _Y}, _State) ->
     {error, not_found}.
 
 generate_chunk({X, Y}, Seed, State) ->
@@ -149,19 +172,19 @@ generate_chunk({X, Y}, Seed, State) ->
     {ok, Bin, State}.
 ```
 
-`load_chunk/2` loads from file or database; returning `{error, not_found}` falls
-back to `generate_chunk/3` for procedural generation.
+`load_chunk/2` loads from file or database; returning `{error, not_found}`
+falls back to `generate_chunk/3` for procedural generation.
 
-When a player subscribes to a zone, they receive a `world.terrain` message with
-the compressed chunk data (base64-encoded in JSON).
-
-### Terrain Encoding
+### Terrain encoding
 
 `asobi_terrain` encodes tiles as compact binaries:
 
-- Default format: 4 bytes per tile (2B tile_id, 1B flags, 1B elevation).
-- 64x64 chunk = 16KB raw, typically 2-4KB compressed.
-- Custom formats via the `format` parameter.
+- Default format: 4 bytes per tile (2B tile_id, 1B flags, 1B elevation), 64x64
+  tiles per chunk.
+- A 64x64 chunk is 16KB raw, typically 2-4KB compressed.
+- Other tile sizes and chunk dimensions via `encode_chunk/2`.
+
+A tile is `{X, Y, TileId, Flags, Elevation}`:
 
 ```erlang
 Tiles = [{0, 0, 1, 0, 10}, {3, 5, 200, 15, 255}],
@@ -169,21 +192,19 @@ Bin = asobi_terrain:encode_chunk(Tiles),
 Compressed = asobi_terrain:compress_chunk(Bin).
 ```
 
-### Terrain Store
+### Terrain store
 
 The terrain store is an ETS-backed cache that lazy-loads chunks from the
-provider. It starts automatically when the game returns a terrain provider.
-Chunks are cached after first load.
+provider. It starts automatically when the game returns a terrain provider, and
+caches each chunk after first load. It is per node, like every other cache -
+see [Clustering](clustering.md#what-is-per-node).
 
-## Zone Lifecycle Callbacks
+## Zone lifecycle callbacks
 
 A world script can react to zones loading and unloading. Both callbacks are
 optional.
 
-<!-- tabs -->
-**Lua**
 ```lua
--- world.lua
 function on_zone_loaded(cx, cy, state)
     local zone_state = { biome = "plains" }
     return zone_state, state
@@ -194,7 +215,8 @@ function on_zone_unloaded(cx, cy, state)
 end
 ```
 
-**Erlang**
+In Erlang:
+
 ```erlang
 -callback terrain_provider(Config :: map()) ->
     {Module :: module(), ProviderArgs :: map()} | none.
@@ -205,49 +227,47 @@ end
 -callback on_zone_unloaded(Coords :: {integer(), integer()}, GameState :: term()) ->
     {ok, GameState1 :: term()}.
 ```
-<!-- /tabs -->
 
-## Configuration Reference
+## Configuration reference
 
-| Key | Default | Description |
-|-----|---------|-------------|
-| `grid_size` | `10` | Zones per dimension |
-| `zone_size` | `200` | World units per zone |
-| `lazy_zones` | `grid_size > 100` | Enable on-demand zone loading |
-| `zone_idle_timeout` | `30000` | Milliseconds before idle zones are reaped |
-| `max_active_zones` | `10000` | Maximum concurrent zone processes |
+| Key | Default | What it does |
+|-----|---------|--------------|
+| `grid_size` | `10` | Zones per dimension. Above 100, zones load on demand. |
+| `zone_size` | `200` | World units per zone. |
+| `view_radius` | `1` | Zone radius a player subscribes to. 0 means own zone only. |
+| `tick_rate` | `50` | Milliseconds per world tick. |
+| `max_players` | `500`, but `match_size` in a Lua script | Players per world. |
+| `persistent` | `false` | Keep an emptied world alive instead of finishing it. |
 
-## Scaling Guidelines
+## Scaling guidelines
 
-Asobi is single-node by design. These figures are per node.
+One world lives entirely on one node, so these are per world and per node. More
+nodes means more worlds, not a bigger world - see
+[Clustering](clustering.md#the-scaling-unit-is-a-world-not-a-node).
 
-| Map Size | Zones | Recommended Config |
-|----------|-------|--------------------|
-| Small (1K x 1K) | 100 | Default (eager loading) |
-| Medium (10K x 10K) | 10,000 | `lazy_zones = true` |
-| Large (128K x 128K) | 4,000,000 | Lazy + terrain provider + tuned idle timeout |
+A world can hold at most 10,000 active zones at once. Grids above roughly
+100x100 only work because most of the map is unloaded most of the time: with
+typical player clustering, expect a few hundred live zone processes. If your
+players do not cluster, the ceiling is what you will hit, and the fix is a
+larger `zone_size`.
 
-For large worlds, expect 200-500 concurrent zone processes per node with typical
-player clustering. The BEAM handles this efficiently; the bottleneck is
-serialisation and network I/O, not process count.
+The bottleneck at that scale is serialisation and network I/O, not process
+count. The BEAM is comfortable with thousands of zone processes; the tick that
+encodes deltas for all of them is what runs out of time first.
 
 ## Checkpoint
 
-1. Set `game_type = "world"`, `grid_size = 2000` and `lazy_zones = true` in
-   `world.lua`, then start your world (Cloud: `asobi deploy`; self-hosted: your
-   release).
-2. Connect a client and move into a zone. On the server, confirm only a handful
-   of zones are active, not four million:
-
-   ```
-   Active zones climb as players spread out, and idle zones vanish after
-   zone_idle_timeout - not all grid_size^2 zones at once.
-   ```
+1. Put a `config.lua` mapping a mode to `world.lua`, with `game_type = "world"`,
+   `match_size = 1` and `grid_size = 2000`, then start your world.
+2. Connect a client and move into a zone. Only a handful of zones should be
+   active, not four million: active zones climb as players spread out and fall
+   again as they leave, and no zone is created until somebody enters it.
 3. If you named a `terrain_provider`, the subscribing client receives a
-   `world.terrain` message with a non-empty base64 chunk. An empty chunk or a
-   `terrain_provider_not_allowed` log means the name is not on the allowlist.
+   `world.terrain` message with a non-empty base64 chunk. No `world.terrain`
+   message at all, plus a `terrain_provider_not_allowed` warning in the log,
+   means the name is not on the allowlist.
 
 ## Next
 
-[Performance Tuning](performance-tuning.md) - spatial-grid indexing, adaptive
-tick rates, and shared-state broadcast for busy zones.
+[Performance tuning](performance-tuning.md) - spatial queries, shared-state
+broadcast, and what the zone tick costs.

--- a/guides/lobbies.md
+++ b/guides/lobbies.md
@@ -2,40 +2,55 @@
 
 How to gather players before a game starts.
 
-Asobi has no `Lobby` object. That is a deliberate choice, not a gap - a
-lobby is a *state*, not a type, and asobi already has two things that hold
-players before a game begins. This guide is about picking one and wiring it
-up, because the pieces are documented separately and the flow is not
-obvious from any one of them.
+asobi has no `Lobby` object. A lobby is a state, not a type, and asobi already
+has two things that hold players before a game begins. This guide is about
+picking one and wiring it up.
 
 ## Which one
 
 | | Waiting match | Persistent world |
 |---|---|---|
 | Use for | gather N players, play, done | a hub people return to between games |
-| Processes | 1 | ~6 (instance sup, zone sup, zone, ticker, server) |
+| Who can create one | an Erlang caller in the release, or the matchmaker | any client, over `world.create` or `POST /api/v1/worlds` |
+| Processes | 1 | 6 (instance sup, zone sup, zone manager, one zone, ticker, world server) |
 | Ticks while idle | none | yes, at `tick_rate` |
 | Presence | you broadcast it | free, from the tick loop |
-| Lifetime | starts at `min_players`, times out after 60s | survives empty if `persistent` |
+| Lifetime | starts at `min_players`, gives up after 60s | survives empty if `persistent` |
 
-For "gather four players and start", use a **waiting match**. A world is a
-spatial simulation; running one so people can stand still is the expensive
-way round.
+A waiting match is the cheaper shape, but the row above that decides it is
+"who can create one". Read the next section before choosing it.
 
 ## Waiting match
 
-A match starts in the `waiting` state and only transitions to `running`
-when `min_players` is reached. That waiting period is the lobby.
+A match starts in the `waiting` state and transitions to `running` when
+`min_players` is reached. That waiting period is the lobby.
 
-```lua
--- arena.lua
-match_size  = 4      -- min_players: the match starts when the 4th player joins
-max_players = 4
-listed      = true   -- so match.list can find it
+**No client-facing call brings a waiting match into existence.**
+`asobi_match_sup:start_match/1` is the only thing that creates a match, and its
+only caller in the release is the matchmaker - which spawns a match with
+`min_players` already equal to the group it just formed, so the waiting state
+lasts as long as the join fan-out and no longer. There is no `match.create`
+frame and no `POST /api/v1/matches`.
+
+So the waiting-match lobby is an **Erlang-only** route: it needs a module in
+your release that calls `asobi_match_sup:start_match/1` with a `min_players`
+higher than the number of players it seeds, and `listed => true` so clients can
+find it.
+
+```erlang
+{ok, Pid} = asobi_match_sup:start_match(#{
+    mode         => ~"arena",
+    game_module  => my_arena,
+    game_config  => #{},
+    min_players  => 4,
+    max_players  => 4,
+    listed       => true
+}).
 ```
 
-A waiting match holds one process and one 60-second timer. It does not tick
-until it starts, so idle lobbies cost close to nothing.
+**If you are writing Lua, use a world instead.** A world is the only session a
+client can create, so it is the only lobby a Lua-only game can build. Skip to
+[Persistent world as a hub](#persistent-world-as-a-hub).
 
 ### Letting players find it
 
@@ -44,18 +59,61 @@ GET /api/v1/matches/live        REST
 match.list                      WebSocket
 ```
 
-Both filter on `mode` and `has_capacity`. Matches are **unlisted by
-default** - a matchmaker-spawned match is already assigned to its players
-and has no reason to be browsable - so a mode opts in with `listed = true`.
+Both filter on `mode` and `has_capacity`. Matches are unlisted by default - a
+matchmaker-spawned match is already assigned to its players and has no reason to
+be browsable - so a mode opts in with `listed = true`.
 
 Do not use `GET /api/v1/matches` for this. It reads the match record table:
 finished matches, an audit trail, nothing joinable. See
 [REST API](rest-api.md).
 
+### The 60-second timeout
+
+A match that does not reach `min_players` within 60 seconds stops itself. That
+value is fixed (`?WAITING_TIMEOUT` in `asobi_match_server`) and is not exposed
+per mode. Fine for quick play; too short if you want players assembling at their
+own pace.
+
+## Persistent world as a hub
+
+For a town square people return to between games, use a world. This is the path
+a client can drive on its own.
+
+```lua
+-- hub.lua
+game_type   = "world"
+persistent  = true    -- stays alive when empty; without this it dies on the last leave
+grid_size   = 1       -- one zone: no spatial partitioning needed to stand around
+tick_rate   = 200     -- 5 Hz is plenty; the 50ms default is for action games
+match_size  = 1
+```
+
+`listed` and `quick_play` are not Lua globals - the loader does not read them,
+so writing them in a script does nothing. Both default to true, which is what a
+hub wants: it is browsable and `world.find_or_create` drops everyone into the
+same one. Changing either needs an operator `game_modes` entry for that mode,
+which replaces the script's mode config rather than merging into it - so
+declare `module => {lua, "hub.lua"}` and the rest of the shape in it too.
+
+`persistent` is the flag that makes it a hub rather than a session. Without it a
+world finishes the moment the last player leaves, so the next player gets a
+fresh empty one.
+
+Presence is free here: worlds tick and broadcast zone state, so players see each
+other without you broadcasting anything. `world:<WorldId>` chat works and is
+gated on world membership.
+
+Nothing creates the hub at boot. The first `world.find_or_create` instantiates
+it and it stays up from then on; after a restart the first player recreates it.
+
+Worlds are subject to `world_max_per_player` (5) and `world_max` (1000) - see
+[World capacity](configuration.md#world-capacity).
+
 ### Private lobbies
 
-Share a code out of band and check it on the way in. The join context is
-whatever the client put in the join payload; asobi never reads it.
+Because only a world can be created by a client, a code-gated private lobby is a
+world too. Share a code out of band and check it on the way in. The join context
+is whatever the client put in the join payload; asobi never reads it.
 
 ```lua
 function join(player_id, state, ctx)
@@ -68,77 +126,54 @@ function join(player_id, state, ctx)
 end
 ```
 
-Combine with `listed = false` for a lobby that is reachable only by code.
-See [Join context](websocket-protocol.md#join-context).
+Hiding it from the browser needs `listed => false` in an Erlang `game_modes`
+entry; a Lua-only game cannot set it, so its code-gated world stays listed and
+the join callback is the whole gate. `listed` and `quick_play` are properties
+of the mode, not of one instance, so every world of that mode is equally
+hidden. See [Join context](websocket-protocol.md#join-context).
 
 ### Telling the room someone arrived
 
-Core does not push a join notification to the players already waiting. That
-is deliberate: `match.left` is a reply to the leaver rather than a
-broadcast, so co-member notification is the game's decision throughout, and
-what a lobby shows differs per game - a bare count, a full roster, nothing
-until it fills.
+Core does not push a join notification to the players already waiting. That is
+deliberate: what a lobby shows differs per game - a bare count, a full roster,
+nothing until it fills.
 
 `game.broadcast` from your join callback is the whole of it, as above. It
-reaches every player currently in the match, and the example above arrives
-client-side as `{"type": "match.lobby_update", "payload": {"players": ...}}`.
-Naming rules and the SDK-side handler for these are in
-[Custom events](websocket-protocol.md#custom-events).
+reaches every player currently in the session, and the example above arrives
+client-side as `{"type": "world.lobby_update", "payload": {"players": ...}}` -
+`match.lobby_update` from a match script. Naming rules and the SDK-side handler
+are in [Custom events](websocket-protocol.md#custom-events).
 
 ### Chat in a lobby
 
-There is no `match:` chat channel scheme. `world:<WorldId>` exists and is
-gated on world membership; matches have no equivalent. Use `game.broadcast`
-with your own message shape.
+There is no `match:` channel scheme. `world:<WorldId>`, `zone:<WorldId>:<X>,<Y>`
+and `prox:<WorldId>:<X>,<Y>` exist and are gated on world membership; matches
+have no equivalent, so a match lobby uses `game.broadcast` with your own message
+shape.
 
-The `room:` scheme is not open-join - it resolves to a group membership check.
-`room:<group_id>` now correctly authorises the members of `<group_id>`
-([asobi#209](https://github.com/widgrensit/asobi/issues/209), resolved).
+The `room:` scheme is not open-join - `room:<GroupId>` resolves to a membership
+check against that group.
 
-### The 60-second timeout
+## Seeing what players see
 
-A match that does not reach `min_players` within 60 seconds stops itself.
-That value is currently fixed (`?WAITING_TIMEOUT` in `asobi_match_server`)
-and is not exposed per mode. Fine for quick play; too short if you want
-players assembling at their own pace.
-
-## Persistent world as a hub
-
-For a town square people return to between games, use a world.
-
-```lua
--- hub.lua
-game_type   = "world"
-persistent  = true    -- stays alive when empty; without this it dies on the last leave
-grid_size   = 1       -- one zone: no spatial partitioning needed to stand around
-tick_rate   = 200     -- 5 Hz is plenty; the 50ms default is for action games
-listed      = true
-quick_play  = true    -- world.find_or_create drops everyone into the same one
-match_size  = 1
-```
-
-`persistent` is the flag that makes it a hub rather than a session. Without
-it a world finishes the moment the last player leaves, so the next player
-gets a fresh empty one.
-
-Presence is free here: worlds tick and broadcast zone state, so players see
-each other without you broadcasting anything. `world:<WorldId>` chat works
-and is gated on world membership.
-
-Nothing creates the hub at boot. The first `world.find_or_create`
-instantiates it and it stays up from then on; after a restart the first
-player recreates it, restoring snapshots if `persistent`.
-
-Worlds are subject to `world_max_per_player` (5) and `world_max` (1000) -
-see [World capacity](configuration.md#world-capacity).
+The console's Matches screen is the **finished-match record**, not the live
+list: core writes one row when a match ends, so a waiting lobby never appears
+there. To see what a player browsing sees, call `GET /api/v1/matches/live`.
+There is no worlds screen either; use `GET /api/v1/worlds`. See
+[Operator console](console.md).
 
 ## Not included
 
-- **Ready-up.** No first-class ready state. Track it in your own game state
-  and broadcast it; the join context and `game.broadcast` are enough.
+- **Ready-up.** No first-class ready state. Track it in your own game state and
+  broadcast it; the join context and `game.broadcast` are enough. A game that
+  wants a shared one can ship it as an extension method and call it over the
+  `rpc.call` frame - see [Extensions](extensions.md).
 - **Party.** You cannot queue as a group through the matchmaker. Play with
-  specific people by sharing a match id or a join code.
+  specific people by sharing a world id or a join code, or add party grouping as
+  an extension.
 - **Rich filters.** Discovery filters on `mode` and `has_capacity` only.
-  Anything richer belongs in your strategy module.
-- **Member roster API.** The joiner receives the roster on `match.joined`;
-  there is no separate "who is here" call. Keep the list in your game state.
+  Anything richer belongs in your strategy module, or in an extension method
+  that returns the filtered list.
+- **Member roster API.** The joiner receives the roster on `match.joined` /
+  `world.joined`; there is no separate "who is here" call. Keep the list in your
+  game state, or expose it as an extension method.

--- a/guides/lua-api.md
+++ b/guides/lua-api.md
@@ -1,0 +1,320 @@
+# The game.* API
+
+Everything a game script can call. [Lua scripting](lua-scripting.md) is the
+walkthrough; this is the reference.
+
+The `game` table is installed into match, world and zone VMs. Bot scripts load
+into a sandboxed VM with **no `game` table at all** - see
+[Lua bots](lua-bots.md).
+
+## How to read this page
+
+There are two return conventions and you have to know which one you are
+looking at.
+
+The persistence-style calls - `economy.*`, `storage.*`,
+`leaderboard.top/rank/around`, `terrain.get_chunk`, `notify`, `notify_many` -
+return a wrapped table. Index into `.ok`:
+
+```lua
+local result = game.economy.balance(player_id)
+if result.error then
+  game.log("warning", "balance lookup failed", { reason = result.error })
+  return
+end
+for _, wallet in ipairs(result.ok) do
+  game.log("info", wallet.currency .. " = " .. wallet.balance)
+end
+```
+
+The plain calls - `broadcast`, `send`, `chat.send`, `zone.spawn`,
+`zone.despawn`, `terrain.preload`, `leaderboard.submit`, `spatial.*` - return
+their value directly:
+
+```lua
+local hits = game.spatial.query_radius(state.entities, 100, 100, 50)
+for _, hit in ipairs(hits) do
+  game.log("info", hit.id .. " at " .. hit.distance)
+end
+```
+
+One exception cuts across both: calling anything with the wrong number or type
+of arguments returns `{ error = "..." }` naming the shape it wanted, whichever
+convention that call normally uses. So a plain call that suddenly returns a
+table is an argument mistake, not a failure of the operation.
+
+## Identity and logging
+
+```lua
+game.id()                                -- a UUIDv7 string
+game.log(level, message)
+game.log(level, message, meta)
+```
+
+`level` is one of `"debug"`, `"info"`, `"warn"`, `"warning"` or `"error"`.
+`"warn"` and `"warning"` are the same level. Anything else returns
+`{ error = "..." }`.
+
+The line goes through the host logger, so it lands in the node's structured
+JSON stream rather than breaking it. `print` and `eprint` do not exist for that
+reason.
+
+`message` is capped at 500 characters and is **truncated** past that. `meta` is
+capped at 2 KB of encoded JSON and is **not** truncated: over the cap the whole
+table is replaced by `{"_truncated": true}`, and a table that will not encode
+becomes `{"_unencodable": true}`. Keep meta small and structured.
+
+Logging is rate limited: 30 lines a second per match or per zone, and 300 a
+second across the node. Over budget `game.log` returns `false` and the line is
+dropped, so a script failing on every tick cannot drown its neighbours.
+
+## Messaging
+
+```lua
+game.broadcast(event, payload)           -- to every player in the match
+game.send(player_id, message)            -- to one player
+```
+
+`event` must be 1-64 characters of `[A-Za-z0-9_-]` and must not be one of the
+names asobi emits itself: `state`, `tick`, `terrain`, `list`, `left`, `joined`,
+`finished`, `phase_changed`, `matched`, `matchmaker_failed`,
+`matchmaker_expired`, `vote_start`, `vote_tally`, `vote_result`,
+`vote_vetoed`. A rejected name returns `{ error = "..." }` at the call site
+rather than being dropped silently downstream - the client would otherwise be
+unable to tell a forged `match.finished` from a real one.
+
+`broadcast` works from a match, a world and a zone. A match script's event
+reaches clients as `match.<event>`; a world or zone script's reaches them as
+`world.<event>`, because the world server is bound as the broadcast target in
+both.
+
+The encoded payload is capped at 64 KB. Past that the event is dropped and the
+node logs `game_broadcast_rejected` - `broadcast` has already returned `true`
+by then, because the fan-out is asynchronous. Do not put a whole world snapshot
+in one event.
+
+`send` reaches the client as a `module.message` frame carrying
+`{"module": "lua", "message": ...}`, which is why it takes any Lua value rather
+than a table. See [WebSocket protocol](websocket-protocol.md).
+
+## Economy
+
+```lua
+game.economy.grant(player_id, currency, amount)
+game.economy.grant(player_id, currency, amount, reason)
+game.economy.debit(player_id, currency, amount)
+game.economy.debit(player_id, currency, amount, reason)
+game.economy.balance(player_id)
+game.economy.purchase(player_id, listing_id)
+```
+
+`amount` is truncated to an integer. `reason` is a free-form string that lands
+on the transaction row.
+
+`balance` returns `{ ok = { { currency = "...", balance = N }, ... } }` - every
+wallet the player holds, not one figure.
+
+`purchase` takes a **store-listing id**, not an item slug. That is the `id`
+field of an entry in `GET /api/v1/store`, a UUID. Passing a slug fails.
+
+There is no inventory namespace. Inventory is REST (`GET /api/v1/inventory`,
+`POST /api/v1/inventory/consume`) and Erlang only.
+
+## Leaderboards
+
+```lua
+game.leaderboard.submit(board_id, player_id, score)   -- true | false
+game.leaderboard.top(board_id, count)                 -- { ok = entries }
+game.leaderboard.rank(board_id, player_id)            -- { ok = rank }
+game.leaderboard.around(board_id, player_id, count)   -- { ok = entries }
+```
+
+`score` is truncated to an integer. `submit` is the odd one out: it returns a
+plain boolean, not a wrapped result. `rank` returns
+`{ error = "not_found" }` for a player with no entry on the board.
+
+## Notifications
+
+```lua
+game.notify(player_id, type, subject)
+game.notify(player_id, type, subject, data)
+game.notify_many(player_ids, type, subject)
+game.notify_many(player_ids, type, subject, data)
+```
+
+`notify_many` returns `{ ok = ids }` listing the players it reached. A partial
+fan-out is a shorter list, not an error, so compare the length if that matters
+to you.
+
+## Storage
+
+```lua
+game.storage.get(collection, key)
+game.storage.set(collection, key, value)
+game.storage.player_get(player_id, collection, key)
+game.storage.player_set(player_id, collection, key, value)
+```
+
+Two distinct namespaces, not one with an optional owner. `get`/`set` write
+global rows; `player_get`/`player_set` write rows owned by a player. A global
+key and a player key of the same name are different rows.
+
+The global namespace is reachable **only from Lua**. The REST storage routes
+are hard-scoped to per-player rows, so nothing a client sends can read or
+overwrite what `game.storage.set` wrote. That makes it the right place for
+server-authoritative configuration and the wrong place for anything a client
+needs to fetch directly.
+
+## Chat
+
+```lua
+game.chat.send(channel_id, sender_id, content)        -- true
+```
+
+`sender_id` is whoever the message should appear to be from; nothing here
+checks that the sender is in the channel. The channel process is started if it
+is not already running, with `channel_type` `"room"`. Delivery and persistence
+are asynchronous, so `true` means the message was handed off, not that it is on
+disk.
+
+## Spatial
+
+Three shapes, and mixing them up is the usual mistake.
+
+**Entity-list and zone forms.** `query_radius` takes either:
+
+```lua
+game.spatial.query_radius(entities, x, y, radius)
+game.spatial.query_radius(entities, x, y, radius, opts)
+game.spatial.query_radius(x, y, radius)               -- zone context required
+```
+
+`query_rect` is zone-only:
+
+```lua
+game.spatial.query_rect(x1, y1, x2, y2)               -- zone context required
+```
+
+The entity-list forms return `{ id = ..., entity = ..., distance = ... }` per
+hit. The zone forms return `{ id = ..., x = ..., y = ... }` per hit - no
+`entity` and no `distance`. Without zone context the zone forms return
+`{ error = "... requires zone context" }`.
+
+**Entity-list only.**
+
+```lua
+game.spatial.nearest(entities, x, y, n)
+game.spatial.nearest(entities, x, y, n, opts)
+```
+
+**Two entities.**
+
+```lua
+game.spatial.in_range(entity_a, entity_b, range)      -- boolean
+game.spatial.distance(entity_a, entity_b)             -- number
+```
+
+`opts` on `query_radius` and `nearest` accepts:
+
+| Key | Value |
+| --- | --- |
+| `type` | A type string, or a list of them, to include |
+| `exclude` | An entity id, or a list of them, to drop |
+| `max_results` | Cap on hits returned |
+| `sort` | `"nearest"` or `"farthest"` |
+
+Anything else in `opts` is ignored.
+
+## World mode only
+
+```lua
+game.zone.spawn(template_id, x, y)                    -- true | false
+game.zone.spawn(template_id, x, y, overrides)         -- true | false
+game.zone.despawn(entity_id)                          -- true
+game.terrain.get_chunk(cx, cy)                        -- { ok = data }
+game.terrain.preload(coords_list)                     -- true
+```
+
+`spawn` returns `false` for a template the zone does not declare - the spawn
+itself is asynchronous, so the return says "the template resolved", not
+"something exists now". It reads the zone's live template set, so a hot reload
+that adds a template takes effect without a restart.
+
+`terrain.preload` takes a list of tables carrying `cx`/`cy` (or `x`/`y`).
+Entries it cannot read are skipped rather than raising.
+
+`zone.*` needs zone context and `terrain.*` needs a terrain store, so all of
+these are world-mode only. Called anywhere else they return
+`{ error = "... not available ..." }`. See [World server](world-server.md).
+
+## Extension namespaces
+
+An installed [extension](extensions.md) declares its own `game.<namespace>`,
+installed in the same window as core's, so it reads like a core call:
+
+```lua
+local result = game.quests.progress(player_id, "first_blood")
+if result.ok then
+  game.log("info", "quest advanced")
+end
+```
+
+Extension bindings use the wrapped `{ ok = ... }` / `{ error = "..." }`
+envelope, whoever wrote them. An extension may bind into match, world and zone
+VMs; `bot` is refused at `rebar3 asobi check` rather than installing nothing.
+
+## Standard library
+
+The Lua standard library is present apart from what the sandbox clears, with
+two functions replaced:
+
+- `math.random()` returns a float in `[0, 1)`. `math.random(n)` returns an
+  integer in `[1, n]`. `math.random(a, b)` returns an integer in `[a, b]`; an
+  empty interval (`a > b`) raises, as in standard Lua. Non-integer bounds are
+  truncated towards zero, where standard Lua raises.
+- `math.sqrt(n)` returns `0.0` for negative input rather than NaN.
+
+Both are backed by the BEAM's `rand` and `math`. `math.randomseed` still
+exists, but it seeds Luerl's own generator, which the replaced `math.random`
+never reads - so seeded determinism is not available.
+
+`os` keeps `os.clock`, `os.date`, `os.difftime` and `os.time`.
+
+`require("name")` and `require("dir.name")` load `<dir of the loaded
+script>/name.lua` and `<dir of the loaded script>/dir/name.lua`. Results are
+cached, and the cache is cleared on hot reload so an edited module is re-read.
+A symlinked module file is refused.
+
+## What is not there
+
+- **No `package` table and no `package.path`.** `require` is asobi's own and
+  resolves relative to the directory of the script that was loaded. Dotted
+  names work (`require("bots.chaser")`); parent traversal and absolute paths do
+  not.
+- **No `coroutine`.** Luerl 1.5.1 does not implement it.
+- **No `io`, `load`, `loadstring`, `dofile`, `loadfile`, `print` or
+  `eprint`**, and `os` keeps only its harmless half - `os.execute`, `os.exit`,
+  `os.getenv`, `os.remove`, `os.rename` and `os.tmpname` are cleared to `nil`,
+  so `os.execute == nil` is a predicate a script can check.
+- Scripts run on **Luerl 1.5.1**, with Lua 5.3 semantics, not the reference
+  implementation. Upstream describes the 5.2-to-5.3 migration as in progress,
+  so treat anything exotic as worth testing rather than assumed.
+
+## Limits
+
+Every callback except `handle_input` runs in a child process under a
+wall-clock budget, a 5,000,000-word per-eval heap cap and a reduction budget.
+Exceeding any of them discards that callback's result and keeps the previous
+Lua state; the match or zone survives.
+
+`handle_input` is the exception, and it is deliberate: it runs inline, because
+at high input rates the spawn cost dominates the Lua work. It has no budget of
+any kind, so an infinite loop there hangs that one match or zone indefinitely,
+with no supervisor restart to recover it. Bound your own loops.
+[Sandbox and limits](security-sandbox.md) has the numbers and the reasoning.
+
+## Next
+
+- [Lua scripting](lua-scripting.md) - callbacks, modules, the walkthrough.
+- [World server](world-server.md) - zones, terrain, the world callbacks.
+- [Extensions](extensions.md) - adding a `game.<namespace>` of your own.

--- a/guides/lua-bots.md
+++ b/guides/lua-bots.md
@@ -1,30 +1,43 @@
 # Bots
 
-Asobi includes built-in bot support. Bots run as server-side processes that
-join matches as regular players -- no fake clients, no network overhead. The
-AI logic runs in the same tick loop as the game.
+Bots are server-side processes that join matches as ordinary players. There
+are no fake clients and no network hop; a bot's decisions go through the same
+`handle_input` path a human's do.
 
 ## When to use bots
 
-- Fill empty slots so matches start immediately instead of waiting for a full lobby.
+- Fill empty slots so matches start instead of waiting for a full lobby.
 - A tutorial or single-player sandbox with scripted opponents.
-- Load-testing your tick loop without spawning real WebSocket sessions.
-- Replay / record-and-replay testing.
+- Load-testing a tick loop without spawning real WebSocket sessions.
+- Replay and record-and-replay testing.
 
-## How It Works
+## How it works
 
-1. A player queues for matchmaking
-2. If no match is found within the configured wait time, Asobi adds bots
-3. Bots join the match like regular players
-4. Each tick, the bot calls a `think()` function to decide its input
-5. Bot input goes through the same `handle_input` path as real players
+1. A player queues for matchmaking.
+2. Every 8 seconds the spawner looks at each mode with someone queued. If
+   fewer are queued than the mode's bot target, it queues bots for the
+   difference.
+3. The matchmaker forms a match from the queue as usual, bots included.
+4. Within about 2 seconds of the match appearing, the spawner starts an AI
+   process for each `bot_`-prefixed player in it.
+5. That process calls `think(bot_id, state)` on its own fixed 100 ms loop and
+   sends the result as input.
+
+No waiting period gates any of this. The spawner's only test is "are fewer
+queued for this mode than its target", so with a target of 4 and one human
+waiting, three bots are queued at the next 8-second check. A mode with nobody
+queued is skipped, so bots never start a match on their own. The one wait
+setting that exists, `max_wait_seconds` (60 by default, under `{asobi,
+[{matchmaker, #{max_wait_seconds => N}}]}`), expires an unmatched ticket
+instead - it does not trigger bot fill.
+
+Bot fill is per node, because the matchmaker queue is per node. Each node
+fills its own queue from its own view. See [Clustering](clustering.md).
 
 ## Configuration
 
-### Lua (Docker)
-
-Enable bots by adding `bots` to your match script globals and a `names`
-list to your bot script:
+Add a `bots` table to the match script's globals, and a `names` list to the
+bot script:
 
 ```lua
 -- match.lua
@@ -33,10 +46,6 @@ max_players = 8
 strategy = "fill"
 bots = { script = "bots/chaser.lua", min_players = 4 }
 ```
-
-`bots.min_players` is optional and defaults to `match_size`. `bots.enabled`
-is also optional and defaults to `true` (set it to `false` to keep the
-table around, e.g. to declare `min_players`, while disabling bot-fill).
 
 ```lua
 -- bots/chaser.lua
@@ -47,18 +56,32 @@ function think(bot_id, state)
 end
 ```
 
-The platform reads `names` from your bot script at runtime. Bot names are
-prefixed with `bot_` (e.g., `bot_Spark`).
+`bots.script` is resolved relative to the match script's own directory, and a
+path that escapes it is rejected with a warning.
 
-The spawner checks the queue every 8 seconds (a fixed interval, not tunable) and
-fills a waiting match with bots up to the mode's `min_players`, capped at
-`max_players` so a small `match_size`/`max_players` mode never overshoots into
-a second, bot-only match. Both settings below live in the game mode's `bots`
-map — there are no bot environment variables.
+`bots.min_players` is the fill target. From Lua it defaults to `match_size`.
+It is clamped at 64, and a larger value is clamped with a warning in the log.
+The target is also capped at the mode's `max_players`, so a
+`match_size = 2` / `max_players = 2` mode never overshoots into a second,
+bot-only match.
 
-### Erlang (sys.config)
+`bots.enabled` defaults to `true`; declaring the table at all is the opt-in.
+Set it to `false` to keep the table (to declare `min_players`, say) with fill
+turned off.
 
-For Erlang OTP projects, configure bots in `sys.config`:
+Bot ids are `bot_` plus a name from the list, taken in order: `bot_Spark`,
+`bot_Blitz`. Past the end of the list they fall back to their position in the
+fill, so the sixth bot of a batch with five names is `bot_6` and the seventh
+is `bot_7`. Give the list at least as many names as the largest fill you
+expect.
+
+With no `names` global, or none the platform can read, the defaults are
+`Spark`, `Blitz`, `Volt`, `Neon` and `Pulse`.
+
+A bot joins through the normal match join, so the script's
+`join(player_id, state)` runs for it exactly as for a human.
+
+### In Erlang
 
 ```erlang
 {game_modes, #{
@@ -74,53 +97,73 @@ For Erlang OTP projects, configure bots in `sys.config`:
 }}
 ```
 
-Bot names are read from the bot script's `names` global. If not defined,
-defaults to `["Spark", "Blitz", "Volt", "Neon", "Pulse"]`.
+Two differences from the Lua path. `min_players` here defaults to **4**, not
+to `match_size`, when the key is absent. And `names` can be set directly in
+the `bots` map, in which case the bot script's `names` global is never read:
 
-## Writing a Bot AI Script
+```erlang
+bots => #{enabled => true, names => [~"Ada", ~"Grace"], script => <<"game/bots/chaser.lua">>}
+```
 
-A bot script defines a single function: `think(bot_id, state)`. It receives
-the current game state and returns an input table -- the same format a real
-player would send. That is the whole callback surface: a bot script has no
-`on_join` / `on_leave` / `on_message` hooks; it only ever produces the next
-input from the current state (plus an optional `names` list, below).
+The 64 clamp applies here too, at spawn time.
 
-Since the bot only decides from `state`, difficulty is a property of the
-script, not a config knob: throttle a reaction-time delay or degrade the target
-selection by keying private per-bot state off `bot_id` in a module-level table.
+## Writing a bot AI script
+
+A bot script defines one function: `think(bot_id, state)`. It receives the
+current game state and returns an input table, in the same format a real
+player would send. That is the whole callback surface: no `on_join`,
+`on_leave` or `on_message` hooks, just the next input from the current state,
+plus the optional `names` list.
+
+Because a bot decides only from `state`, difficulty is a property of the
+script rather than a config knob: throttle a reaction delay or degrade target
+selection by keying per-bot state off `bot_id` in a module-level table.
 
 ### What a bot script gets
 
-A bot script is loaded into the same hardened Luerl state a match script
-starts from, but **without** the `game.*` API. That namespace is installed
-only for match and world scripts; inside a bot's `think`, `game` is `nil`.
-There is no `game.economy`, `game.log`, `game.storage` or `game.leaderboard`
-for a bot.
+A bot script loads into the same hardened Luerl state a match script starts
+from, but **without** the `game.*` API. That namespace is installed only for
+match, world and zone scripts; inside `think`, `game` is `nil`. There is no
+`game.log`, `game.economy`, `game.storage` or `game.leaderboard` for a bot.
 
 An installed [extension](extensions.md) cannot add one either. `bot` is not a
-VM kind an extension's `lua/0` may name, and declaring it is a build failure
-rather than a binding that quietly installs nothing.
+VM kind an extension's `lua/0` may name, and declaring it fails the build
+rather than installing a binding that quietly does nothing.
 
 What is available:
 
 - The Lua standard library, minus what the sandbox clears. `io`, `package`,
   `load`, `loadfile`, `loadstring`, `dofile`, `print`, `eprint` and
   `os.execute` / `os.exit` / `os.getenv` / `os.remove` / `os.rename` /
-  `os.tmpname` are all `nil` (see [Sandbox model](security-sandbox.md)).
-- `require("module")`, resolved relative to the bot script's own directory --
+  `os.tmpname` are all `nil`. See [Sandbox model](security-sandbox.md).
+- `require("module")`, resolved relative to the bot script's own directory, so
   `require("targeting")` reads `<bot script dir>/targeting.lua`. Dotted paths
   work; parent traversal and absolute paths are rejected.
 - `math.random` and `math.sqrt`, backed by the BEAM's `rand` and `math`.
-- The two arguments of `think(bot_id, state)`, plus whatever the script
-  itself defines at the top level. `state` is the match state as broadcast to
+- The two arguments of `think(bot_id, state)`, plus whatever the script itself
+  defines at the top level. `state` is the match state as broadcast to
   players, so a bot sees what a client sees and nothing more.
 
-Anything else has to come through the match script: put the value in the
-state the match broadcasts, and the bot reads it from `state`.
+Anything else has to come through the match script: put the value in the state
+the match broadcasts and read it from `state`.
 
-Each `think` call runs under a 50 ms wall-clock budget and a heap cap. A
-timeout, an error, or a missing `think` falls back to the built-in default AI
-(below).
+Bots do not work in a shared-state mode. A mode that declares
+`state_strategy = "shared"` broadcasts one pre-encoded payload to every
+recipient, and a bot cannot decode it, so `state` stays an empty table for the
+bot's whole life, the phase never advances past `playing`, and the default AI
+returns an empty input. There is no error and no log line. Use per-player
+`get_state` in any mode you want bots in - see
+[Performance tuning](performance-tuning.md) for what the shared path buys and
+what it costs.
+
+Each `think` call runs under a 50 ms wall-clock budget, a heap cap and a
+reduction budget. A timeout, a heap or CPU overrun, an error, or a missing
+`think` falls back to the built-in default AI below.
+
+That fallback is silent to the client, so it is also logged: a persistently
+broken `think` produces `bot_think_error_falling_back_to_default_ai` with the
+bot id and the reason, once a minute per bot. Grep for it when a bot has
+stopped behaving like your script and started behaving like the default AI.
 
 ```lua
 -- game/bots/chaser.lua
@@ -130,13 +173,11 @@ function think(bot_id, state)
     local me = players[bot_id]
     if not me then return {} end
 
-    -- Find nearest enemy
     local target = find_nearest(bot_id, me, players)
     if not target then
         return wander()
     end
 
-    -- Chase and shoot
     local dist = distance(me, target)
     return {
         right = target.x > me.x,
@@ -179,26 +220,16 @@ function wander()
 end
 ```
 
-## Multiple Bot Types
+## Multiple bot types
 
-Create different AI scripts for different playstyles:
-
-```
-game/bots/
-├── chaser.lua    -- rushes nearest player
-├── sniper.lua    -- stays back, long range
-├── healer.lua    -- supports teammates
-└── camper.lua    -- holds position, ambushes
-```
-
-Currently, all bots in a game mode use the same script. To vary behavior,
-add randomization inside your `think()` function:
+Every bot in a game mode runs the same script. To vary behaviour, branch
+inside `think`:
 
 ```lua
 local STRATEGIES = { "aggressive", "defensive", "random" }
 
 function think(bot_id, state)
-    -- Use bot_id hash to pick consistent strategy per bot
+    -- bot_id length picks a stable strategy per bot
     local strategy = STRATEGIES[(#bot_id % #STRATEGIES) + 1]
 
     if strategy == "aggressive" then
@@ -213,29 +244,32 @@ end
 
 ## Default AI
 
-If no bot script is configured, bots use a built-in default AI that:
+With no bot script configured, or when `think` fails, bots run a built-in AI
+that finds the nearest living enemy, moves towards it, shoots within 200
+units with slight aim jitter, and wanders when nothing is alive to chase.
 
-- Finds the nearest living enemy
-- Moves toward them
-- Shoots when within range (200 units)
-- Adds slight aim randomization
-- Wanders randomly if no targets are alive
+It reads `players`, and each player's `x`, `y` and `hp`, from the broadcast
+state. A bot with no entry of its own under `players` sends an empty input;
+one whose peers carry no `hp` finds nothing alive to chase and wanders
+instead.
 
-This works for most arena-style games out of the box.
+## Boon picking and voting
 
-## Auto Boon Pick and Voting
+Bots handle two phases without any script code:
 
-Bots automatically handle game phases:
+- Boon pick: the bot picks the first offered option immediately.
+- Voting: the bot casts a random vote after a delay of 1 to 4 seconds.
 
-- **Boon pick**: Bots pick the first available option immediately
-- **Voting**: Bots cast a random vote after a 1-3 second delay
+The boon pick is driven by the broadcast state: the phase comes from
+`state.phase` (`"boon_pick"`), and the offers from `state.boon_offers`. The
+vote is not - it is driven by the `vote_start` match event, which carries the
+vote id and the options the bot picks from. A `state.phase` of `"voting"` or
+`"vote_pending"` only stops the bot sending input while the vote runs.
 
-This behavior is built-in and doesn't require any bot script code.
+## Bot ids
 
-## Bot IDs
-
-Bot player IDs are prefixed with `bot_` followed by their display name
-(e.g., `bot_Spark`, `bot_Blitz`). Your game logic can check for bots:
+Bot player ids are `bot_` followed by the display name, so game logic can test
+for them:
 
 ```lua
 function is_bot(player_id)
@@ -243,22 +277,24 @@ function is_bot(player_id)
 end
 ```
 
-Clients receive bot players in the normal game state. Whether to show them
-differently (e.g., "AI" tag) is up to the client.
+Clients receive bots in the normal game state. Whether to mark them in the UI
+is up to the client.
 
 ## Bots and presence
 
-A bot is tracked with `asobi_presence:track_bot/2`. That makes it a delivery
-target for everything the match server broadcasts -- state, match events,
-votes -- exactly like a connected player session.
+A bot is tracked with `asobi_presence:track_bot/2`, which makes it a delivery
+target for everything the match server broadcasts (state, match events, votes)
+exactly like a connected player session. It receives the shared-state broadcast
+too, but cannot read it - see [What a bot script gets](#what-a-bot-script-gets).
 
 It deliberately does not make the bot *online*:
 
-- `asobi_presence:online_count/0` counts connected humans only. Bots are
-  never added to it, so your concurrency figure stays a real player count and
-  bot-fill (which is driven by how few humans are queued) cannot feed itself.
-- Bots emit no `player_online` / `player_offline` presence broadcasts, so
-  friend lists and presence subscribers never see a bot appear or disappear.
+- `asobi_presence:online_count/0` counts connected humans only. Bots are never
+  added to it, so the concurrency figure stays a real player count. Bot fill
+  does not read it: it reads the matchmaker queue, where the bots it queued
+  count like anyone else, which is what stops the fill feeding itself.
+- Bots emit no `player_online` / `player_offline` broadcasts, so friend lists
+  and presence subscribers never see a bot appear or disappear.
 
 `asobi_presence:get_status/1` on a bot id does answer `online`, because that
 function reports whether the id is addressable. Filter on the `bot_` prefix
@@ -266,6 +302,8 @@ if you need the human answer.
 
 ## Next steps
 
-- [Lua scripting](lua-scripting.md) - the `game.*` API, which match and world
-  scripts get and bots do not (see [What a bot script gets](#what-a-bot-script-gets)).
-- [Trust model](security-trust-model.md) - a bot's `think` runs bounded, like any callback.
+- [The game.\* API](lua-api.md) - what match and world scripts can call, and
+  bots cannot (see [What a bot script gets](#what-a-bot-script-gets)).
+- [Lua scripting](lua-scripting.md) - the match callbacks a bot's input feeds.
+- [Trust model](security-trust-model.md) - a bot's `think` runs bounded, like
+  any callback.

--- a/guides/lua-scripting.md
+++ b/guides/lua-scripting.md
@@ -1,27 +1,24 @@
-# Lua Scripting
+# Lua scripting
 
-Write your game logic in Lua instead of Erlang. Asobi runs Lua scripts
-inside the BEAM via [Luerl](https://github.com/rvirding/luerl), giving you
-the fault tolerance and concurrency of OTP with a language game developers
-already know.
+asobi is one Erlang/OTP node containing the game backend, the Lua runtime and
+the operator console. There are two ways in: run the image and write Lua, which
+is what this guide covers, or depend on the Hex package and write Erlang, which
+is the same node through its other surface.
 
-No Erlang knowledge required. No compilation step. Just Lua files and Docker.
+Lua runs inside the BEAM via [Luerl](https://github.com/rvirding/luerl), so a
+script gets OTP's fault tolerance and concurrency without a separate process,
+a compilation step or a toolchain.
 
-## Quick Start with Docker
-
-The fastest way to get started -- no Erlang toolchain needed:
+## Quick start
 
 ```bash
 mkdir my_game && cd my_game
-mkdir -p lua/bots
+mkdir -p game/bots
 ```
 
-Create your match script:
+Write `game/match.lua`:
 
 ```lua
--- lua/match.lua
-
--- Game mode config
 match_size = 2
 max_players = 8
 strategy = "fill"
@@ -71,12 +68,12 @@ function get_state(player_id, state)
 end
 ```
 
-Create a `docker-compose.yml`:
+Write `docker-compose.yml`:
 
 ```yaml
 services:
   postgres:
-    image: postgres:16
+    image: postgres:17
     environment:
       POSTGRES_USER: postgres
       POSTGRES_PASSWORD: postgres
@@ -88,34 +85,71 @@ services:
       retries: 5
 
   asobi:
-    image: ghcr.io/widgrensit/asobi_lua:latest
+    image: ghcr.io/widgrensit/asobi:latest
     depends_on:
       postgres: { condition: service_healthy }
     ports:
       - "8084:8084"
     volumes:
-      - ./lua:/app/game:ro
+      - ./game:/app/game
     environment:
       ASOBI_DB_HOST: postgres
       ASOBI_DB_NAME: my_game_dev
+      ASOBI_DB_PASSWORD: postgres
 ```
-
-Start it:
 
 ```bash
 docker compose up -d
 ```
 
-That's it. Your game is running. Asobi reads your Lua scripts from the
-mounted volume, discovers the game mode from `match.lua`, and handles
-everything else -- database, authentication, matchmaking, WebSockets.
+asobi reads the scripts from the mounted directory, derives the game mode from
+`match.lua`, and serves the database, authentication, matchmaking and
+WebSocket layers around it.
 
-### Multiple Game Modes
+The directory it reads is `/app/game`. Change it with `{asobi, [{game_dir,
+"/some/other/path"}]}` in `sys.config` if you are not using this compose file.
 
-For games with more than one mode, add a `config.lua` manifest:
+## Editing while it runs
+
+Edit a script and save it; the next tick picks it up. There is no restart and
+no rebuild.
+
+The bridge stats the script on every tick and re-evaluates the new file body
+against the running Luerl state when the mtime moves. Re-evaluating the body
+redeclares globals and redefines functions in place, so in-flight state
+survives: players, counters and tables stay exactly as they were, because
+nothing re-runs `init()`. Changing what `tick` does takes effect on the next
+tick, for matches already in progress.
+
+A file that fails to load logs `lua hot reload failed` with the reason, records
+the new mtime so the same broken file is not retried every tick, and keeps
+running the last good code. Fix the file and save again.
+
+The `require` cache is cleared on reload, so an edited module a script
+`require`s is re-read too.
+
+Mode-shape edits are separate. `match_size`, `max_players`, `strategy`, the
+`bots` table and the `config.lua` manifest are consumed when a match is
+*formed*, before any match server exists, so a per-tick reload is structurally
+blind to them. A watcher polls the manifest and every registered mode script
+every 1500 ms and re-runs the config loader when an mtime moves. New matches
+get the new shape; running matches keep the values they started with.
+
+Turn the whole thing off with `ASOBI_LUA_RELOAD=off` or `{asobi,
+[{reload_mode, off}]}`. That skips the per-tick stat and stops the watcher
+polling, which is what a sealed production image wants: its mtimes never move
+anyway. Anything other than `off` means `auto`, so a typo cannot silently
+disable reload.
+
+Put all of it under `{asobi, [...]}`. An existing `{asobi_lua, [...]}` block
+from before the merge still works for the runtime's own settings - see
+[Which application key](configuration.md#which-application-key).
+
+## Multiple game modes
+
+For more than one mode, add a `config.lua` manifest:
 
 ```lua
--- lua/config.lua
 return {
     arena = "arena/match.lua",
     ctf   = "ctf/match.lua"
@@ -124,7 +158,7 @@ return {
 
 ```
 my_game/
-├── lua/
+├── game/
 │   ├── config.lua
 │   ├── arena/
 │   │   └── match.lua
@@ -133,19 +167,19 @@ my_game/
 └── docker-compose.yml
 ```
 
-Each match script declares its own config as globals. When `config.lua`
-exists, Asobi reads it instead of looking for a top-level `match.lua`.
-When there is no `config.lua`, a single `match.lua` is loaded as the
-`"default"` game mode.
+Each match script declares its own config as globals. When `config.lua` exists
+it is read instead of a top-level `match.lua`. With no `config.lua`, a single
+`match.lua` is loaded as the `"default"` mode. A mode script path that escapes
+the game directory is rejected.
 
-## Match Script Globals
+## Match script globals
 
-Declare your game mode settings as globals at the top of your match script.
-Asobi reads these at startup before calling any callbacks.
+Declare the mode's settings as globals at the top of the script. asobi reads
+them before any callback runs.
 
 ```lua
 match_size   = 4                          -- required: min players to start
-max_players  = 10                         -- optional: max per match (defaults to match_size)
+max_players  = 10                         -- optional: max per match
 strategy     = "fill"                     -- optional: "fill" or "skill_based"
 bots         = { script = "bots/ai.lua" } -- optional: enable bot filling
 guest_auth   = true                       -- optional: allow anonymous guest play
@@ -154,54 +188,47 @@ registration = "closed"                   -- optional: signup posture
 
 | Global | Required | Default | Description |
 |--------|----------|---------|-------------|
-| `match_size` | yes | -- | Minimum players needed to start a match |
+| `match_size` | yes | - | Minimum players needed to start a match. Must be a positive integer |
 | `max_players` | no | `match_size` | Maximum players per match |
-| `strategy` | no | `"fill"` | Matchmaking strategy |
-| `bots` | no | none | Bot configuration (see [Bots](lua-bots.md)) |
-| `guest_auth` | no | `false` | Enable anonymous guest play. Also requires an operator-supplied pepper; on iff both are present (asobi ADR 0004) |
-| `registration` | no | `"open"` | Signup posture: `"open"`, `"oauth_only"` (no password signup), or `"closed"` (no new players at all). The operator layer wins: this applies only when the release's `sys.config` leaves `registration` unset |
-| `lazy_zones` | no | auto | On-demand zone loading (auto-enabled for grids > 100) |
-| `zone_idle_timeout` | no | 30000 | Milliseconds before an idle zone is reaped |
-| `max_active_zones` | no | 10000 | Maximum concurrent zones in memory |
-| `spatial_grid_cell_size` | no | none | Cell size for spatial grid indexing (enables grid acceleration) |
-| `cold_tick_divisor` | no | 10 | Tick rate divisor for cold (unoccupied) zones |
+| `strategy` | no | `"fill"` | `"fill"` or `"skill_based"` |
+| `game_type` | no | `"match"` | `"world"` routes the script through the world bridge - see [World server](world-server.md) |
+| `state_strategy` | no | per-player | `"shared"` broadcasts one payload to everyone; see below |
+| `bots` | no | none | Bot configuration - see [Bots](lua-bots.md) |
+| `guest_auth` | no | `false` | Offer anonymous no-account play. Also requires an operator-supplied pepper; on only when both are present (ADR 0004) |
+| `registration` | no | `"open"` | `"open"`, `"oauth_only"` (no password signup) or `"closed"` (no new players). The operator layer wins: this applies only when the release's `sys.config` leaves `registration` unset |
 
-For a single-mode game these globals live in `match.lua`. In a multi-mode game
-(a `config.lua` manifest that maps modes to match scripts), deployment-wide
-settings such as `guest_auth` and `registration` go in `config.lua`, not the
-per-mode scripts.
+`strategy` is not validated. A value that is neither `"fill"` nor
+`"skill_based"` falls back to `fill`, and nothing is logged - check the
+spelling yourself.
 
-## Using with Erlang Projects
+`state_strategy = "shared"` routes the mode to a different bridge, one that
+calls `get_state` **once per tick with one argument** and broadcasts a single
+pre-encoded payload to every subscriber. It is the right choice when every
+player sees the same world, and it changes the signature you must write:
 
-If you're building an Erlang OTP application, add `asobi_lua` as a
-dependency in your `rebar.config`:
+```lua
+state_strategy = "shared"
 
-```erlang
-{deps, [
-    {asobi_lua, {git, "https://github.com/widgrensit/asobi_lua.git", {tag, "v0.1.0"}}}
-]}.
+function get_state(state)
+    return { players = state.players }
+end
 ```
 
-Configure Lua game modes in your `sys.config`:
+A script written against the two-argument `get_state(player_id, state)` will
+not work under `"shared"`, and vice versa. Bots do not work under `"shared"`
+either - see [Lua bots](lua-bots.md#what-a-bot-script-gets).
 
-```erlang
-{asobi, [
-    {game_modes, #{
-        ~"arena" => #{
-            module => {lua, "game/match.lua"},
-            match_size => 4,
-            max_players => 8
-        }
-    }}
-]}
-```
+World mode adds its own globals (`tick_rate`, `grid_size`, `zone_size`,
+`view_radius`, `player_ttl_ms` and more). They live in
+[World server](world-server.md) rather than here.
 
-The Lua config loader only runs when a game directory with scripts exists.
-Erlang projects with their own `sys.config` are completely unaffected.
+For a single-mode game these globals live in `match.lua`. In a multi-mode game,
+the deployment-wide ones - `guest_auth` and `registration` - are read from
+`config.lua`, not from the per-mode scripts.
 
 ## Callbacks
 
-Every Lua match script must define these functions:
+Six callbacks are required.
 
 ### `init(config)`
 
@@ -217,7 +244,7 @@ function init(config)
 end
 ```
 
-### `join(player_id, state)`
+### `join(player_id, state)` or `join(player_id, state, ctx)`
 
 Called when a player joins. Returns the updated state.
 
@@ -232,6 +259,29 @@ function join(player_id, state)
 end
 ```
 
+The optional third argument carries the join context the client sent with
+`match.join`, and it is the only way a Lua game implements join codes, invites
+or passwords:
+
+```lua
+function join(player_id, state, ctx)
+    state.players[player_id] = {
+        hp = 100,
+        spectator = state.join_code ~= nil and ctx.code ~= state.join_code
+    }
+    return state
+end
+```
+
+Declaring two parameters keeps working unchanged - Lua discards the extra
+argument.
+
+`ctx` is validated before it reaches the script: a flat table, at most 8 keys,
+keys up to 64 bytes, scalar values up to 256 bytes, no nesting. asobi never
+interprets, echoes or logs it. Returning the updated state is the only
+supported outcome, so a failed check has to be expressed in the state you
+return, as above.
+
 ### `leave(player_id, state)`
 
 Called when a player leaves. Returns the updated state.
@@ -245,19 +295,17 @@ end
 
 ### `handle_input(player_id, input, state)`
 
-Called when a player sends input via WebSocket. The `input` table contains
-whatever the client sent. Returns the updated state.
+Called when a player sends input over the WebSocket. `input` is whatever the
+client sent. Returns the updated state.
 
 ```lua
 function handle_input(player_id, input, state)
     local p = state.players[player_id]
     if not p or p.hp <= 0 then return state end
 
-    -- Movement
     if input.right then p.x = p.x + p.speed end
     if input.left then p.x = p.x - p.speed end
 
-    -- Shooting
     if input.shoot and input.aim_x then
         table.insert(state.projectiles, {
             x = p.x, y = p.y,
@@ -272,13 +320,13 @@ function handle_input(player_id, input, state)
 end
 ```
 
+This is the one callback with no execution budget - see
+[Limits](#limits-and-what-happens-when-you-hit-them).
+
 ### `tick(state)`
 
-Called every tick (default 10 times per second). Advance your simulation here.
-Returns the updated state.
-
-To signal that the match is finished, set `_finished` and `_result` on the
-state:
+Called every tick. A match ticks every 100 ms, and a match script cannot
+change that. Advance the simulation and return the updated state.
 
 ```lua
 function tick(state)
@@ -298,8 +346,8 @@ end
 
 ### `get_state(player_id, state)`
 
-Called every tick for each player. Returns the state visible to that player.
-Use this for fog-of-war, hiding other players' data, etc.
+Called every tick for each player. Returns the state that player may see - use
+it for fog of war, hidden hands, anything the client must not be told.
 
 ```lua
 function get_state(player_id, state)
@@ -311,12 +359,13 @@ function get_state(player_id, state)
 end
 ```
 
-### `vote_requested(state)` (optional)
+Under `state_strategy = "shared"` this becomes `get_state(state)`.
 
-Called after each tick. Return a vote configuration table to start a player
-vote, or `nil` to skip. Votes can be triggered at any point during gameplay -
-between rounds, after a boss kill, when a player levels up, or any other
-game event.
+### Optional callbacks
+
+`vote_requested(state)` is called after each tick. Return a vote configuration
+to start a player vote, or `nil` to skip. Votes can start at any point:
+between rounds, after a boss kill, on a level-up.
 
 ```lua
 function vote_requested(state)
@@ -336,38 +385,11 @@ function vote_requested(state)
 end
 ```
 
-Mid-game example (roguelike ability choice):
+The match keeps running while a vote is active, and several votes can run at
+once. See [Voting](voting.md).
 
-```lua
-function vote_requested(state)
-    if state.pending_vote then
-        local vote = state.pending_vote
-        state.pending_vote = nil
-        return vote
-    end
-    return nil
-end
-
-function tick(state)
-    -- Trigger a vote when party reaches XP threshold
-    if state.party_xp >= state.next_level_xp and not state.pending_vote then
-        state.pending_vote = {
-            template = "choose_ability",
-            options = random_abilities(3),
-            method = "plurality",
-            window_ms = 15000
-        }
-    end
-    return state
-end
-```
-
-The game keeps running while a vote is active. Multiple votes can run
-simultaneously.
-
-### `vote_resolved(template, result, state)` (optional)
-
-Called when a vote completes. `result.winner` contains the winning option ID.
+`vote_resolved(template, result, state)` is called when a vote completes;
+`result.winner` is the winning option id.
 
 ```lua
 function vote_resolved(template, result, state)
@@ -378,10 +400,16 @@ function vote_resolved(template, result, state)
 end
 ```
 
+`phases(config)`, `on_phase_started(phase_name, state)` and
+`on_phase_ended(phase_name, state)` drive a session's lifecycle stages -
+warmup, combat, results. Define `phases/1` and the engine walks the list in
+order. See [Phases](phases.md).
+
 ## Modules and `require()`
 
-Split your game into multiple files using Lua's `require()`. Asobi
-automatically sets `package.path` to your script's directory.
+Split a game across files with `require()`. There is no `package` table and no
+`package.path` to set: `require` is asobi's own and resolves relative to the
+directory of the script that was loaded.
 
 ```
 game/
@@ -420,16 +448,18 @@ function M.move_projectiles(state)
 end
 
 function M.check_collisions(state)
-    -- collision detection logic
     return state
 end
 
 return M
 ```
 
-## Finishing a Match
+Dotted names work: `require("bots.chaser")` loads `bots/chaser.lua`. Parent
+traversal, absolute paths and symlinked module files are rejected.
 
-Set `_finished = true` and `_result` on your state table in `tick()`:
+## Finishing a match
+
+Set `_finished = true` and `_result` on the state table in `tick()`:
 
 ```lua
 function tick(state)
@@ -445,178 +475,82 @@ function tick(state)
 end
 ```
 
-The `_result` table is sent to all players via the `match.finished` WebSocket
-event. Structure it however you like -- clients will receive it as JSON.
+`_result` is sent to every player as the `match.finished` event. Structure it
+however you like; clients receive it as JSON.
 
-## Available Functions
+## The game.* API
 
-Your Lua scripts have access to:
+Scripts call engine features through the `game` table: logging, broadcasts,
+economy, leaderboards, notifications, storage, chat, spatial queries, and any
+namespace an installed [extension](extensions.md) declares. Around thirty
+functions, each with its own argument shapes and return convention.
 
-- **Standard Lua**: `table`, `string`, `math`, `utf8`, `bit32`, `pairs`,
-  `ipairs`, `next`, `type`, `tostring`, `tonumber`, `pcall`, `error`,
-  `assert`, `setmetatable`/`getmetatable`, `rawget`/`rawset`/`rawequal`/`rawlen`
-- **Time helpers**: `os.clock`, `os.date`, `os.difftime`, `os.time`
-- **`math.random(n)`**: integer in `[1, n]`. **`math.random(a, b)`**:
-  integer in `[a, b]`; an empty interval (`a > b`) raises, as in
-  standard Lua. Non-integer bounds are truncated toward zero (standard
-  Lua raises instead). The RNG is auto-seeded per match, so
-  **`math.randomseed` has no effect** — calling it is harmless, but
-  scripts cannot rely on seeded determinism.
-- **`math.sqrt(n)`**: square root. Negative input returns `0.0`.
-- **`require("foo.bar")`**: loads `foo/bar.lua` relative to your game
-  directory. Names are validated; `..`, `/`, and absolute paths are
-  rejected. Modules are cached, and `asobi_lua_match` clears the cache
-  on hot-reload so changes to required files pick up.
-- **`game.log(level, message[, meta])`**: structured logging - see
-  [Logging](#logging) below. `print` is removed; use this instead.
-- **`game.<extension>.*`**: any namespace an installed
-  [extension](extensions.md) declares, e.g. `game.quests.progress(...)`.
-  It reads like a core function and returns the same `{ ok = ... }` /
-  `{ error = "..." }` envelope.
+They are all in [The game.\* API](lua-api.md).
 
-The following are removed from the Lua environment:
+## World mode
 
-- **OS escape hatches**: `os.execute`, `os.exit`, `os.getenv`,
-  `os.remove`, `os.rename`, `os.tmpname`
-- **Code loaders**: `dofile`, `loadfile`, `load`, `loadstring`
-- **I/O**: the entire `io` library (`io.open`, `io.read`, `io.write`, ...)
-- **Package machinery**: `package` and the default `require`. Use the
-  asobi_lua-controlled `require/1` described above instead.
+Persistent or large-area games (open worlds, MMOs, big co-op maps) set
+`game_type = "world"` and use a different callback set built around zones,
+terrain and interest management.
 
-Every Lua callback also runs under a wall-clock timeout. A `while true do end`
-in any callback is killed when the budget elapses; the bridge logs a warning
-and continues with the previous state. See [SECURITY.md](../SECURITY.md#sandbox-model)
-for the full sandbox model and per-callback timeout limits.
-
-## World Mode: Large Sessions with Zones
-
-For persistent or large-area games (MMOs, open worlds), use world mode instead
-of match mode. World scripts support zone lifecycle and terrain features.
-
-### Zone Configuration
-
-Set zone globals at the top of your world script:
-
-```lua
-match_size = 1
-max_players = 100
-lazy_zones = true              -- load zones on demand
-zone_idle_timeout = 60000      -- reap idle zones after 60s
-max_active_zones = 500         -- cap concurrent zones
-spatial_grid_cell_size = 64    -- spatial grid cell size for fast queries
-cold_tick_divisor = 5          -- tick slower in unoccupied zones
-```
-
-### Terrain Provider (optional)
-
-Return a terrain provider module from `terrain_provider()`. The provider
-supplies compressed chunk data for each zone coordinate.
-
-```lua
-function terrain_provider(config)
-    return {
-        module = "my_terrain_provider",
-        args = { tileset = "overworld" }
-    }
-end
-```
-
-Return `nil` to disable terrain.
-
-### Zone Lifecycle Callbacks (optional)
-
-```lua
-function on_zone_loaded(cx, cy, state)
-    -- Called when a zone is lazily loaded
-    local zone_state = { biome = "plains", spawned = false }
-    return zone_state, state
-end
-
-function on_zone_unloaded(cx, cy, state)
-    -- Called when a zone is reaped after idle timeout
-    return state
-end
-```
-
-### Terrain API
-
-Inside your game scripts, query terrain via the `game.terrain` namespace:
-
-```lua
--- Get compressed chunk data for a coordinate
-local result = game.terrain.get_chunk(3, 7)
-
--- Preload chunks around the player
-game.terrain.preload({
-    { cx = 3, cy = 7 },
-    { cx = 4, cy = 7 },
-    { cx = 3, cy = 8 }
-})
-```
-
-### Spatial Queries (Zone-Based)
-
-Query entities in the current zone by position. These use the zone's spatial
-grid when `spatial_grid_cell_size` is set, falling back to brute-force scan.
-
-```lua
--- Find all entities within radius of a point
-local nearby = game.spatial.query_radius(100, 200, 50)
-for _, hit in ipairs(nearby) do
-    game.log("debug", "nearby entity", { id = hit.id, x = hit.x, y = hit.y })
-end
-
--- Find all entities inside a rectangle
-local in_area = game.spatial.query_rect(0, 0, 400, 300)
-```
-
-Both return a list of `{id, x, y}` tables.
-
-The entity-table variants (`game.spatial.query_radius(entities, x, y, radius)`)
-still work for client-side filtering without a zone process.
+[World server](world-server.md) owns that, and
+[Large worlds](large-worlds.md) covers scaling it.
 
 ## Logging
 
-`game.log` writes a structured line through the server's logger, so it shows
-up in the container's log stream and, on managed cloud, in the console log
-viewer for your environment (filter on `game.log`):
+`game.log` writes a structured line through the node's logger, so it lands in
+the container's JSON log stream:
 
 ```lua
 function handle_input(player_id, input, state)
     game.log("info", "input received", { player = player_id, kind = input.kind })
-    -- ...
     return state
 end
 ```
 
-- Levels: `"debug"`, `"info"`, `"warn"`/`"warning"`, `"error"`. Anything
+- Levels are `"debug"`, `"info"`, `"warn"`/`"warning"` and `"error"`. Anything
   else returns `{ error = ... }`.
-- `message` can be a string or any value (tables are rendered as JSON).
-  Messages are capped at 500 characters.
-- `meta` is an optional table of key/values, capped at 2 KB.
-- Logging is rate-limited (30 lines per second per match or zone, with a
-  node-wide cap of 300). Over budget, `game.log` returns `false` and the
-  line is dropped - so a log call in a tight tick loop degrades gracefully
-  instead of flooding the log stream. Self-hosting operators can tune both
-  budgets via `{asobi_lua, rate_limits}` if log-pipeline cost matters -
-  the defaults allow up to ~2.5 KB x 300 lines per second per node at
-  the ceiling.
+- `message` may be a string or any value (tables are rendered as JSON), and is
+  truncated at 500 characters.
+- `meta` is an optional table. Over 2 KB of encoded JSON it is **dropped
+  whole** and logged as `{"_truncated": true}`, not shortened - so split a
+  large payload across several calls, or log a summary instead.
+- Logging is rate limited to 30 lines a second per match or zone, with a
+  node-wide ceiling of 300. Over budget `game.log` returns `false` and the line
+  is dropped, so a log call in a tight tick loop degrades instead of flooding.
+  Self-hosters can tune both budgets via the `rate_limits` key.
 
-`print` does not exist in the sandbox; it was removed because it bypassed
-the structured log stream. `game.log` is the supported way to see what your
-server is doing.
+`print` and `eprint` do not exist: they wrote straight to stdout, breaking the
+structured stream and giving a tight loop an unmetered flood path.
 
-## Debugging Script Errors
+## Debugging script errors
 
-A runtime error in a callback never crashes the match: the server logs the
-error, keeps the previous state, and carries on. From the client that looks
-like the callback silently doing nothing. A common first-hour trap is
-`state.counter = state.counter + 1` when `init` never set `counter`, which
-fails every call with "bad arithmetic on nil".
+A runtime error in a callback does not crash the match. The server logs it,
+keeps the previous state and carries on, which from the client looks exactly
+like the callback doing nothing. The classic first-hour version is
+`state.counter = state.counter + 1` when `init` never set `counter`.
 
-During development, set `ASOBI_DEV_ERRORS=true` on the container to have
-each failing `handle_input` also send a `module.error` event to the player
-whose input triggered it:
+### Finding it in the logs
+
+Grep for `lua callback failed`. The line carries:
+
+- `callback` - which function failed.
+- `script` - the script's basename.
+- `reason_class` - `timeout` or `runtime_error`.
+- `detail` - the Lua error message, capped at 500 characters.
+- `suppressed_since_last` - how many identical failures were dropped since the
+  last line got through.
+
+That last field exists because these lines are rate limited to three every ten
+seconds per script and callback. A gap in the log is not the failure stopping;
+`suppressed_since_last` tells you what it really was. The telemetry counter
+behind it is not rate limited, so a dashboard sees the true rate.
+
+### Pushing errors to the client during development
+
+Set `ASOBI_DEV_ERRORS=true` (`1` also works) on the container, or
+`{asobi, [{dev_errors, true}]}` in `sys.config`. A failing `handle_input` then
+also sends a `module.error` event to the player whose input triggered it:
 
 ```json
 {"type": "module.error", "payload": {
@@ -627,17 +561,67 @@ whose input triggered it:
 }}
 ```
 
-The deprecated `game.error` name carries the same payload and is sent
-alongside it until the 1.0 wire break. See
-[WebSocket Protocol](websocket-protocol.md).
+The application-env key is consulted first and wins: with `{dev_errors,
+false}` set, `ASOBI_DEV_ERRORS=true` does nothing.
 
-Events are rate-limited to one per second per match. Leave the flag off in
-production (it is off by default): error messages can reveal script
-internals, and players should never see them.
+These events come from a failing `handle_input` in a match, and from a failing
+`handle_input` in a zone when the game runs in world mode. The rate limit is
+one event per second per bridge process, so per match or per zone. The
+deprecated `game.error` name carries the same payload alongside it until the
+1.0 wire break - see [WebSocket protocol](websocket-protocol.md).
 
-## Next Steps
+Leave the flag off in production; it is off by default. Error messages can
+reveal script internals and players should never see them.
 
-- [Bots](lua-bots.md) -- add AI-controlled players to your game
-- [Self-hosting](self-hosting.md) -- production deployment and live updates
-- [Configuration](https://asobi.dev/docs/configuration) -- all Asobi configuration options
-- [WebSocket Protocol](https://asobi.dev/docs/protocols/websocket) -- client-server message format
+## Limits and what happens when you hit them
+
+Every callback except `handle_input` runs in a child process under a wall-clock
+budget, a heap cap and a reduction budget. A `while true do end` there is
+killed at the deadline: the bridge logs, discards that call's result, keeps the
+previous state and carries on with the next tick.
+
+`handle_input` is the exception. It runs inline, because at high input rates
+the spawn cost dominates the actual Lua work, and it therefore has no budget at
+all. A runaway `handle_input` hangs that one match or zone indefinitely - no
+timeout fires and no supervisor restarts it. Bound your own loops.
+
+[Sandbox and limits](security-sandbox.md) has the per-callback numbers and the
+reasoning.
+
+## In Erlang
+
+The same node, configured from `sys.config` instead of from script globals:
+
+```erlang
+{deps, [
+    {asobi, "~> 0.68"}
+]}.
+```
+
+```erlang
+{asobi, [
+    {game_modes, #{
+        ~"arena" => #{
+            module => {lua, "game/match.lua"},
+            match_size => 4,
+            max_players => 8
+        }
+    }}
+]}
+```
+
+The operator's `game_modes` is never written by asobi and always wins a name
+clash with a script-declared mode of the same name. The Lua loader itself still
+runs at boot whether or not a game directory exists: with no `match.lua` and no
+`config.lua` it declares no modes, but it does write `guest_auth` (to `false`),
+which is what stops a stale `true` from a previous bundle surviving.
+
+## Next steps
+
+- [The game.\* API](lua-api.md) - everything a script can call.
+- [Bots](lua-bots.md) - AI-controlled players.
+- [World server](world-server.md) - zones and large sessions.
+- [Configuration](configuration.md) - every asobi setting.
+- [WebSocket protocol](websocket-protocol.md) - the client-server message
+  format.
+- [Self-hosting](self-hosting.md) - production deployment.

--- a/guides/matchmaking.md
+++ b/guides/matchmaking.md
@@ -1,17 +1,18 @@
 # Matchmaking
 
-Asobi ships a periodic-tick matchmaker (`asobi_matchmaker` gen_server) that
-groups tickets into matches using a per-mode strategy module.
+asobi ships a periodic-tick matchmaker (`asobi_matchmaker`) that groups tickets
+into matches using a per-mode strategy module.
 
-## How It Works
+## How it works
 
-1. Player submits a matchmaking ticket with a mode and optional properties.
-2. Matchmaker ticks periodically (default every 1 second).
-3. Each tick groups tickets by mode, and the mode's strategy module decides which tickets form a match.
-4. When a group is formed, a match is spawned.
-5. Players are notified via WebSocket (`match.matched`).
+1. A player submits a ticket with a mode and optional properties.
+2. The matchmaker ticks every `tick_interval` (1 second by default).
+3. Each tick groups tickets by mode, and the mode's strategy decides which
+   tickets form a match.
+4. When a group forms, a match or a world is spawned.
+5. Players are notified over the WebSocket as `match.matched`.
 
-## Submitting a Ticket
+## Submitting a ticket
 
 ### Via REST
 
@@ -40,66 +41,109 @@ curl -X POST http://localhost:8084/api/v1/matchmaker \
 ```
 **Erlang**
 ```erlang
-{ok, TicketId, Meta} = asobi_matchmaker:add(PlayerId, #{mode => <<"arena">>, properties => #{skill => 1200, region => <<"eu-west">>}}).
+{ok, TicketId, Meta} = asobi_matchmaker:add(PlayerId, #{mode => ~"arena", properties => #{skill => 1200, region => ~"eu-west"}}).
 ```
 <!-- /tabs -->
 
-The reply (the `matchmaker.queued` message over WS, the JSON body over REST)
-carries `ticket_id`, `status: "pending"`, and **`players_needed`** — the mode's
+The reply - the `matchmaker.queued` frame over WS, the JSON body over REST -
+carries `ticket_id`, `status: "pending"` and `players_needed`: the mode's
 `match_size`, or `null` if the mode declares none. Show it as "waiting for N
-players" so a queued client isn't staring at silence. The `Meta` map in the
+players" so a queued client is not staring at silence. The `Meta` map in the
 Erlang return holds the same `players_needed`.
 
-> **Testing solo?** A match only forms once `match_size` players have queued
-> (default **2** if your mode doesn't set one). One client queuing alone gets
-> `players_needed: 1` and then waits forever — that's expected, not a bug. Set
-> `match_size = 1` in your mode script to match instantly by yourself, or run
-> two clients. See [Configuration](#configuration) for where `match_size`
-> lives and why changing it needs a server restart.
+### Testing solo
 
-> **Always pass `mode` as a named/keyed field, never a bare positional
-> value** — `{mode = "arena"}` in Lua, `mode: "arena"` in JSON/TS, a typed
-> `mode` parameter elsewhere. A malformed options shape (e.g. Lua's
-> `{"arena"}`, which sets index `1`, not a `mode` field) silently falls back
-> to `"default"` instead of erroring. A multi-mode game gets `400 unknown_mode`
-> for it - `default` is just another key, and a `config.lua` manifest never
-> maps it. A **single-mode** game does not: its loader registers `default`
-> automatically, so the malformed call silently queues for the only mode
-> there is, with no error at all - the SDK-level guards below are your only
-> protection in that case. The Lua SDKs (asobi-defold, asobi-love2d) now
-> raise a loud error on this exact mistake; the typed SDKs (Dart, Unity,
-> Unreal, Godot) prevent it at compile/parse time via a required `mode`
-> parameter. asobi-js's WS transport is intentionally schema-less (see its
-> README), so a hand-rolled WS payload there is not protected by any SDK —
-> double-check the key name if you're sending `matchmaker.add` by hand.
+A match forms only once `match_size` players have queued, and a mode that
+declares no `match_size` groups in twos: `fill` falls back to 2, and
+`players_needed` comes back `null` because the mode itself declared nothing.
+One client queuing alone therefore waits.
 
-A ticket supports `mode` and `properties`. A
-query-language extension (numeric ranges, required keys, automatic skill
-window expansion) is on the roadmap but not shipped — do that filtering
-inside your strategy module instead.
+It does not wait forever. After `max_wait_seconds` (60 by default) the ticket
+expires and that player receives
 
-The matchmaker holds **one live ticket per player per mode**: submitting again
-while already queued returns your existing ticket rather than a second one, so a
-double-tapped "find match" cannot match you with yourself. An unregistered
-`mode` is rejected with `unknown_mode`, and a full queue with `queue_full`.
+```json
+{"type": "match.matchmaker_expired", "payload": {"ticket_id": "..."}}
+```
 
-If a match cannot start (for example the game's Lua `init` crashes), the
-matchmaker retries a few times, then sends the queued players a
-`matchmaker_failed` event with `reason: "match_start_failed"` rather than leaving
-them queued forever. Handle `matchmaker_failed` in your client.
+Handle that frame - a client that only listens for `match.matched` looks hung
+for a minute and then stays hung. To match instantly by yourself, set
+`match_size = 1` in your mode script; the change is picked up within about a
+second and a half (see [Configuration](#configuration)).
+
+### Always pass `mode` as a named field
+
+`{mode = "arena"}` in Lua, `mode: "arena"` in JSON/TS, a typed `mode` parameter
+elsewhere. A malformed options shape - Lua's `{"arena"}`, which sets index `1`
+rather than a `mode` field - silently falls back to `"default"`.
+
+A multi-mode game gets `matchmaker.unknown_mode` for it: `default` is just
+another key, and a `config.lua` manifest never maps it. A single-mode game does
+not, because its loader registers `default` automatically, so the malformed call
+silently queues for the only mode there is. The Lua SDKs (asobi-defold,
+asobi-love2d) raise a loud error on this exact mistake; the typed SDKs (Dart,
+Unity, Unreal, Godot) prevent it at compile time via a required `mode`
+parameter. asobi-js's WS transport is intentionally schema-less, so a
+hand-rolled `matchmaker.add` payload there is not protected by any SDK.
+
+A ticket supports `mode` and `properties` only. There is no query language for
+numeric ranges, required keys or automatic skill-window expansion - do that
+filtering inside your strategy module.
+
+The matchmaker holds one live ticket per player per mode: submitting again while
+already queued returns the existing ticket rather than a second one, so a
+double-tapped "find match" cannot match you with yourself. An unregistered mode
+is rejected with `matchmaker.unknown_mode`, and a full queue with
+`matchmaker.queue_full`.
+
+## Checking a ticket
+
+```bash
+curl http://localhost:8084/api/v1/matchmaker/<ticket_id> \
+  -H 'Authorization: Bearer <token>'
+```
+
+```json
+{"id": "...", "mode": "arena", "status": "pending", "properties": {}, "submitted_at": 1711700000000}
+```
+
+The lookup is owner-scoped: another player's ticket id answers `403 forbidden`,
+an unknown one `404 matchmaker.ticket_not_found`.
+
+## When formation fails
+
+Two different stories, because matches and worlds are spawned differently.
+
+A **match** that fails to spawn - the game's Lua `init` crashed, say - is
+re-queued and retried. After three attempts the group is given up on and each
+player receives `match.matchmaker_failed`.
+
+A **world** spawn is detached from the matchmaker tick so a slow world cannot
+stall the queue, which leaves no handle to re-queue the group. Worlds therefore
+fail fast: the first error or crash notifies the players once, with no retry.
+
+Both paths use one of two coarse reasons, and neither ever carries the raw
+crash:
+
+| `reason` | Meaning |
+|---|---|
+| `match_start_failed` | The match or world could not be started, or the join fan-out crashed |
+| `no_game_module` | The mode resolves to no game module - unconfigured, or a Lua mode in a release with no scripting runtime |
+
+```json
+{"type": "match.matchmaker_failed", "payload": {"reason": "match_start_failed"}}
+```
+
+Handle `match.matchmaker_failed` in your client alongside
+`match.matchmaker_expired`.
 
 ## Strategies
 
-Strategy is selected per mode via the `strategy` key in `game_modes`. Two
-are built in:
+Strategy is selected per mode via the `strategy` key. Two are built in:
 
-- `fill` (default) — first-come-first-matched, groups players in submission
+- `fill` (default) - first-come-first-matched, grouping players in submission
   order until `match_size` is reached.
-- `skill_based` — sorts tickets by `properties.skill` and pairs within an
-  expanding window (configurable via `skill_window` and
-  `skill_expand_rate`).
-
-Select one with the `strategy` global in your mode script:
+- `skill_based` - sorts tickets by `properties.skill` and pairs within an
+  expanding window (`skill_window`, `skill_expand_rate`).
 
 ```lua
 -- ranked.lua
@@ -107,19 +151,17 @@ match_size = 4
 strategy   = "skill_based"   -- "fill" (default) or "skill_based"
 ```
 
-The built-in strategies map to modules: `fill` is `asobi_matchmaker_fill`
-and `skill_based` is `asobi_matchmaker_skill`. Strategy is configured per
-game mode only - there is no top-level `matchmaker_strategy` key.
+The names map to `asobi_matchmaker_fill` and `asobi_matchmaker_skill`. Strategy
+is per game mode only; there is no top-level `matchmaker_strategy` key.
 
-**Writing a new strategy is Erlang only.** `strategy` takes either a
-built-in name or an Erlang module name, and there is no Lua callback for
-grouping tickets. If your matching rules do not fit `fill` or
-`skill_based`, you need an Erlang module in the release alongside your Lua
-scripts.
+Writing a new strategy is Erlang only. `strategy` takes either a built-in name
+or an Erlang module name, and there is no Lua callback for grouping tickets. If
+your rules fit neither built-in, you need a module in the release alongside your
+Lua scripts.
 
-## Custom Strategies (Erlang)
+### In Erlang
 
-Implement `asobi_matchmaker_strategy` (a single `match/2` callback):
+Implement `asobi_matchmaker_strategy`, a single `match/2` callback:
 
 ```erlang
 -module(my_matchmaker).
@@ -130,26 +172,13 @@ Implement `asobi_matchmaker_strategy` (a single `match/2` callback):
 -spec match([map()], map()) -> {[[map()]], [map()]}.
 match(Tickets, Config) ->
     Size = maps:get(match_size, Config, 4),
-    %% Return {Matched, Unmatched}, where Matched is a list of
-    %% groups (each group a list of tickets that form a match).
+    %% {Matched, Unmatched}, where Matched is a list of groups and each
+    %% group is a list of tickets that form one match.
     group_by_size(Tickets, Size).
 ```
 
-Wire it up per mode:
+Wire it up per mode, from Erlang:
 
-<!-- tabs -->
-**Lua**
-
-A Lua game declares its mode as script globals. Point `strategy` at your
-Erlang module by name:
-
-```lua
--- ranked.lua
-match_size = 4
-strategy   = "my_matchmaker"
-```
-
-**Erlang**
 ```erlang
 {asobi, [
     {game_modes, #{
@@ -161,7 +190,14 @@ strategy   = "my_matchmaker"
     }}
 ]}
 ```
-<!-- /tabs -->
+
+A Lua `strategy` global resolves `"fill"` and `"skill_based"` and nothing else.
+Any other name stays a string, misses the module lookup and falls back to
+`fill` without a word, so a custom strategy cannot be named from a mode
+script.
+
+A group that repeats the same player is dropped back to the queue rather than
+spawning a degenerate self-match, whatever a strategy returns.
 
 ## Configuration
 
@@ -169,36 +205,53 @@ strategy   = "my_matchmaker"
 {asobi, [
     {matchmaker, #{
         tick_interval => 1000,       %% ms between matchmaker ticks
-        max_wait_seconds => 60,      %% max wait before timeout
-        max_queue => 10000           %% max live tickets before add returns queue_full
+        max_wait_seconds => 60,      %% ticket lifetime before it expires
+        max_queue => 10000           %% live tickets before add returns queue_full
     }}
 ]}
 ```
 
-`match_size`, `strategy`, and the rest of a mode's shape are read into
-`game_modes` **once at server boot**. Editing them in a mode script and
-hot-reloading does not change them for the matchmaker — restart the server to
-pick up a new `match_size` (see the solo-testing note above if you just want
-to test alone).
+`match_size`, `strategy` and the rest of a mode's shape are read into
+`game_modes` at boot, and a config watcher polls the manifest and each mode
+script for changes. With the default reload mode, editing `match_size` in a
+mode script is picked up for **new** matches within about 1.5 seconds. Matches
+already running keep the `match_size` they formed with.
 
-## Playing With Friends
+A restart is needed in two cases: a sealed bundle, where `reload_mode` is `off`
+or `ASOBI_LUA_RELOAD=off` and the watcher never polls at all; and a game whose
+`game_modes` live in an Erlang `sys.config` rather than in Lua, which nothing
+rescans.
 
-> Gathering players before a game starts is covered in [Lobbies](lobbies.md).
+## Per node
 
+The matchmaker queue is per node. Tickets live in one gen_server's own state -
+there is no ticket table in Postgres - so players queuing against different
+nodes never match each other, and a restart drops every waiting ticket. Behind a
+load balancer this is the fact that decides whether matchmaking works at all;
+see [Clustering](clustering.md).
 
-The matchmaker has no party grouping. It queues individual players, and a
-ticket cannot bring other players with it.
+## Playing with friends
 
-To play with someone specific, skip the queue: create a match or world,
-share its id or a join code out of band, and have them join directly. Gate
-entry by implementing `join/3` in your game module and checking the join
-context - see [WebSocket Protocol](websocket-protocol.md#join-context). To
-let friends find your session in a browser instead, see
-[World Server](world-server.md).
+Gathering players before a game starts is covered in [Lobbies](lobbies.md).
 
-Matchmaker-mediated party grouping would mean weighting tickets by party
-size, which changes what `match_size` means for every strategy module. It
-is not shipped, and a `party` field on a ticket is not accepted.
+The matchmaker has no party grouping. It queues individual players, a ticket
+cannot bring others with it, and a `party` field on a ticket is not accepted.
+Party weighting would change what `match_size` means for every strategy module,
+which is why it is not shipped. A game that needs it can add the grouping call
+as an extension method and reach it over the `rpc.call` frame - see
+[Extensions](extensions.md).
+
+To play with someone specific, skip the queue. **Worlds are the only session a
+client can create**: `world.create` over the WebSocket, or
+`POST /api/v1/worlds`. Share the returned `world_id` or a join code out of band
+and have them `world.join` it. Matches are created by the matchmaker or by an
+Erlang caller inside the release, and by nothing else - there is no
+`match.create` frame and no `POST /api/v1/matches`.
+
+Gate entry by implementing `join/3` in your game module and checking the join
+context - see [WebSocket protocol](websocket-protocol.md#join-context). To let
+friends find your session in a browser instead, see
+[World server](world-server.md).
 
 ## Cancelling
 
@@ -213,14 +266,21 @@ asobi_matchmaker:remove(PlayerId, TicketId).
 ```
 <!-- /tabs -->
 
-Or via REST:
+Or over REST:
 
 ```bash
 curl -X DELETE http://localhost:8084/api/v1/matchmaker/<ticket_id> \
   -H 'Authorization: Bearer <token>'
 ```
 
+## Watching the queue
+
+The console has a Matchmaker screen: one row per mode, deepest queue first. It
+reads the queue and cannot act on it - there is no cancel-ticket button, and the
+numbers are this node's queue only. See [Operator console](console.md).
+
 ## Next steps
 
-- [WebSocket protocol](websocket-protocol.md) - the `matchmaker.*` and `match.matched` messages.
+- [WebSocket protocol](websocket-protocol.md) - the `matchmaker.*` and `match.*` frames.
 - [Configuration](configuration.md) - per-mode matchmaker tuning.
+- [Clustering](clustering.md) - what a second node does to the queue.

--- a/guides/migrate-from-hathora.md
+++ b/guides/migrate-from-hathora.md
@@ -1,148 +1,67 @@
 # Migrating from Hathora to asobi
 
-**Hathora's game-hosting service shuts down on 2026-05-05.** If you're reading
-this with a running game on `hathora.dev` or `hathora.cloud`, this guide walks
-you from "we need a new backend by May" to "we're running on asobi and we
-never have to do this again."
+Hathora's game-hosting service shut down on 2026-05-05. This guide takes you
+from "we need a new backend" to a running asobi deployment.
+
+Nobody has migrated a Hathora game to asobi end to end yet. The asobi-side
+endpoints and events below are verified against this repository; the
+Hathora-side method names are from memory of the pre-shutdown SDK and may have
+drifted. The fastest route is pairing with us in the
+[Discord](https://discord.gg/vYSfYYyXpu) `#migrations` channel.
+
+This guide targets studios on Hathora's managed service. Self-hosted
+`hathora-core` users have a different problem - skip to
+[Self-hosted Hathora users](#self-hosted-hathora-users).
+
+## What asobi is
+
+One Erlang/OTP node containing the game backend, the Lua runtime and the
+operator console. Two ways in: run `ghcr.io/widgrensit/asobi` and write Lua, or
+depend on the Hex package and write Erlang. Same node either way.
 
 ## Today, in 15 minutes
 
-Before you read the rest of this guide, do these five things in this order.
-They get you unblocked even if the full port takes a week:
+Four steps. They unblock you even if the full port takes a week.
 
-1. **Stand up a local asobi backend.** Drop this `docker-compose.yml` into an
-   empty directory:
-   ```yaml
-   services:
-     postgres:
-       image: postgres:17
-       environment: { POSTGRES_USER: postgres, POSTGRES_PASSWORD: postgres, POSTGRES_DB: my_game }
-       healthcheck: { test: ["CMD-SHELL", "pg_isready -U postgres"], interval: 5s }
-     asobi:
-       image: ghcr.io/widgrensit/asobi_lua:latest
-       depends_on: { postgres: { condition: service_healthy } }
-       ports: ["8084:8084"]
-       environment: { ASOBI_DB_HOST: postgres, ASOBI_DB_NAME: my_game }
-   ```
-   Then `docker compose up -d`. HTTP is on `:8084`, WebSocket is on `/ws`.
-2. **Register one player** — the asobi equivalent of `HathoraClient.loginAnonymous`:
-   ```bash
-   curl -s localhost:8084/api/v1/auth/register \
-     -H 'content-type: application/json' \
-     -d '{"username":"test","password":"test1234"}'
-   # → { "username": "test", "player_id": "019de3...", "session_token": "wRqvop92/..." }
-   ```
-   That `session_token` is what your client passes in `Authorization: Bearer …`
-   from here on, in place of any Hathora auth token.
-3. **Queue for matchmaking** to confirm the matchmaker works end-to-end:
-   ```bash
-   curl -s localhost:8084/api/v1/matchmaker \
-     -H 'content-type: application/json' \
-     -H 'authorization: Bearer wRqvop92/...' \
-     -d '{"mode":"default","properties":{}}'
-   # → { "status": "pending", "ticket_id": "019de3..." }
-   ```
-4. **Join the Discord** [`#migrations` channel](https://discord.gg/vYSfYYyXpu).
-   Drop your Hathora setup (engine, language, lobby vs matchmaker,
-   server-authoritative vs P2P) — we will tell you which sections of this
-   guide actually apply to you and which to skip.
-5. **Open a tracking issue** at
-   [github.com/widgrensit/asobi/issues](https://github.com/widgrensit/asobi/issues)
-   so we know you exist. We are prioritising migration help over feature work
-   until 2026-05-05.
+**1. Write a minimal game.** asobi loads Lua from `/app/game`, and without a
+mode declared there the matchmaker has nothing to match on. In an empty
+directory:
 
-That is the panic checklist. You are no longer locked out as of step 1.
-Everything below is the full port.
+```lua
+-- lua/match.lua
 
-> **Draft notice.** This guide is a starting point, not a battle-tested
-> playbook — nobody has yet migrated a Hathora game to asobi end-to-end.
-> The asobi-side endpoint and event names below are **verified against the
-> current code**. The Hathora-side method names come from our memory of the
-> pre-shutdown SDK and may have drifted. **The fastest path to a working
-> migration is pairing with us in the
-> [Discord](https://discord.gg/vYSfYYyXpu) `#migrations` channel** — we'll
-> walk through your specific setup rather than you fighting this doc in the
-> dark.
+match_size = 2
 
-> This guide targets studios on Hathora's *managed* service. If you're a
-> self-hosted `hathora-core` user your situation is different — skip to
-> [§ Self-hosted Hathora users](#self-hosted-hathora-users).
+function init(_config)
+    return { players = {} }
+end
 
-## TL;DR
+function join(player_id, state)
+    state.players[player_id] = { score = 0 }
+    return state
+end
 
-1. Your game-server logic (C#, Go, Node, whatever it is today) **keeps
-   running in its own process** while you migrate.
-2. You bring up an asobi_lua container. Your game-server talks to it over
-   WebSocket like it would any other auth/matchmaker/leaderboard service.
-3. You port the Hathora-specific calls — `createLobby`, `getRoomInfo`,
-   `listActivePublicLobbies`, `HathoraClient.loginAnonymous`, etc. — to the
-   asobi equivalents in the table below.
-4. Once asobi is doing auth/matchmaking/lobbies, you drop Hathora entirely
-   and either (a) keep running your existing server code in a plain
-   container on Hetzner / Fly / Scaleway or (b) fold your game logic into an
-   asobi Lua script and let asobi host that too.
+function leave(player_id, state)
+    state.players[player_id] = nil
+    return state
+end
 
-Option (b) is more work up front, but it means no game-server container at
-all. For most Hathora games the game-server is a few hundred lines of
-state-mutation code — well within the scope of a `match.lua` file.
+function handle_input(_player_id, _input, state)
+    return state
+end
 
-## Why asobi specifically
+function tick(state)
+    return state
+end
 
-The reason you're reading this is that Hathora pivoted to AI. We don't want
-that to be you again.
+function get_state(_player_id, state)
+    return { players = state.players }
+end
+```
 
-- **Apache-2.0, open-source, self-hostable.** The engine is at
-  [github.com/widgrensit/asobi](https://github.com/widgrensit/asobi) and the
-  Docker runtime is at
-  [github.com/widgrensit/asobi_lua](https://github.com/widgrensit/asobi_lua).
-  Fork it. Mirror it. Run it on your own hardware. Our [exit
-  guide](exit.md) is a 1-page runbook for keeping your game alive if we
-  vanish tomorrow.
-- **No CCU billing.** Managed asobi cloud (opening later in 2026) is flat
-  per-container. Self-host is free.
-- **Hot-reload Lua.** Edit your match logic, save, connected matches pick it
-  up — no rebuild, no redeploy, no kicked players.
-- **One container, one Postgres.** No CockroachDB. No Redis. No Kubernetes.
-- **Matchmaking, lobbies, rooms, leaderboards, economy, chat, friends,
-  tournaments, voting, phases, reconnection** are all already there
-  — see the [feature list](../README.md#features). Seasons ship as an
-  extension.
-- **Godot and Defold SDKs are first-class**, alongside Unity/Unreal/JS/Flutter.
-- **EU-hosted, GDPR-ready, NIS2-aware** if that matters to you.
-
-## Concept map
-
-| Hathora | asobi | Notes |
-|---|---|---|
-| Application | asobi deployment | One container per environment (dev/live). |
-| Room | Match | An OTP process per match, state kept in the process heap with ETS backup. |
-| Process | *(no equivalent)* | asobi doesn't spin a container per match. One container hosts thousands of matches as BEAM processes. Simpler ops. |
-| Lobby | Matchmaker ticket + Match in "waiting" phase | Players hit `/matchmaker/tickets`; when `match_size` is reached the match transitions to "running". |
-| Region | Deployment location | Deploy one container per region. No region abstraction baked in — you pick where to run the container. |
-| Matchmaker (2.0) | `asobi_matchmaker` | Pluggable strategies (`fill`, `skill_based`); custom via `asobi_matchmaker_strategy` behaviour. |
-| `HathoraClient.loginAnonymous` | `POST /api/v1/auth/guest` | Device-backed anonymous auth: pass `device_id` + `device_secret`, get a real player back. Opt-in - the game declares `guest_auth` and the operator sets a pepper. Claim the account later with `POST /api/v1/auth/guest/upgrade`. See [Authentication](authentication.md). |
-| `HathoraClient.loginGoogle` | `POST /api/v1/auth/oauth` | OAuth/OIDC flow. |
-| `createLobby` / `createRoom` / queue | `POST /api/v1/matchmaker` body `{"mode":"default","properties":{}}` | Response: `{"ticket_id":"...","status":"pending"}`. |
-| Ticket poll | `GET /api/v1/matchmaker/:ticket_id` | |
-| Cancel | `DELETE /api/v1/matchmaker/:ticket_id` | |
-| `listActivePublicLobbies` | `GET /api/v1/matches/live` | Live, joinable matches. Filter with `mode` and `has_capacity`. Matches are **unlisted by default** - a mode opts in with `listed => true`. Not to be confused with `GET /api/v1/matches`, which reads the match record table (finished matches, an audit trail). |
-| `getConnectionInfo(roomId)` | WebSocket upgrade on `GET /ws` | See [§ WebSocket handshake](#websocket-handshake) — first frame must authenticate. |
-| `ping` region API | *(none)* | If you need client-side region selection, probe each deployment endpoint yourself. |
-| Hathora SDK | asobi SDKs | [asobi-unity](https://github.com/widgrensit/asobi-unity), [asobi-unreal](https://github.com/widgrensit/asobi-unreal), [asobi-js](https://github.com/widgrensit/asobi-js), [asobi-godot](https://github.com/widgrensit/asobi-godot), [asobi-defold](https://github.com/widgrensit/asobi-defold), [asobi-dart](https://github.com/widgrensit/asobi-dart), [flame_asobi](https://github.com/widgrensit/flame_asobi). |
-| Hathora Console | Built-in operator console at `/console` | Match and player inspection. Tenants, games and API keys are an [asobi cloud](https://asobi.dev) concern, not a self-hosted one. |
-| `hathora.yml` | `docker-compose.yml` | Plain Compose, no proprietary spec. |
-| Process-hour billing | Flat per-container | No surprise invoices. |
-
-## Migration path
-
-### Phase 1 — stand up asobi alongside Hathora (1 day)
-
-Run asobi on the same cloud (or locally) without touching the Hathora
-deployment. Goal: verify auth, a lobby, and a match work end-to-end from
-your client.
+**2. Stand the backend up.** Next to `lua/`:
 
 ```yaml
-# docker-compose.yml
 services:
   postgres:
     image: postgres:17
@@ -150,202 +69,274 @@ services:
       POSTGRES_USER: postgres
       POSTGRES_PASSWORD: postgres
       POSTGRES_DB: my_game
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U postgres"]
+      interval: 5s
 
   asobi:
-    image: ghcr.io/widgrensit/asobi_lua:latest
-    depends_on: [postgres]
+    image: ghcr.io/widgrensit/asobi:latest
+    depends_on:
+      postgres: { condition: service_healthy }
     ports: ["8084:8084"]
     volumes: ["./lua:/app/game:ro"]
     environment:
       ASOBI_DB_HOST: postgres
       ASOBI_DB_NAME: my_game
+      ASOBI_CORS_ORIGINS: "http://localhost:5173"
+      ASOBI_CONSOLE: "true"
+      ASOBI_OPS_SECRET_FILE: /run/secrets/ops_secret
+    secrets: [ops_secret]
+
+secrets:
+  ops_secret:
+    file: ./ops_secret.txt
 ```
 
-Put a minimal `lua/match.lua` in place (see the [asobi_lua
-README](https://github.com/widgrensit/asobi_lua#quick-start)) and bring it
-up:
+`openssl rand -hex 32 > ops_secret.txt`, then `docker compose up -d`. HTTP is on
+`:8084`, the WebSocket is on `/ws`, the console is on `/console`.
+
+`ASOBI_CORS_ORIGINS` is not optional for a browser client: unset, the node
+sends an empty `Access-Control-Allow-Origin` and every fetch from a page is
+blocked.
+
+**3. Register one player.**
 
 ```bash
-docker compose up -d
-curl localhost:8084/api/v1/auth/register \
+curl -s localhost:8084/api/v1/auth/register \
   -H 'content-type: application/json' \
   -d '{"username":"test","password":"test1234"}'
-# → { "player_id": "01HX...", "session_token": "...", "username": "test" }
+# { "player_id": "019de3...", "access_token": "...", "refresh_token": "...", "username": "test" }
 ```
 
-### Phase 2 — port the client SDK calls (2–5 days)
+`access_token` is what the client passes as `Authorization: Bearer ...` from
+here on. `refresh_token` buys a new pair from `POST /api/v1/auth/refresh`.
+There is no `session_token` anywhere in asobi.
 
-In your Unity / Unreal / JS / Godot client, replace the Hathora SDK with the
-asobi one for the same engine. The call shape is close but not identical:
+**4. Queue for matchmaking.**
 
-**Unity — before (Hathora):**
-```csharp
-var client = new HathoraClient("my-app-id");
-await client.LoginAnonymousAsync();
-var lobby = await client.CreateLobbyAsync(Visibility.Public, …);
-var info = await client.GetConnectionInfoAsync(lobby.RoomId);
-// then open a websocket to info.ExposedPort.Host:Port
+```bash
+curl -s localhost:8084/api/v1/matchmaker \
+  -H 'content-type: application/json' \
+  -H 'authorization: Bearer <access_token>' \
+  -d '{"mode":"default","properties":{}}'
+# { "ticket_id": "019de3...", "status": "pending" }
 ```
 
-**Unity — after (asobi):**
-```csharp
-var client = new AsobiClient("https://api.my-game.com");
-await client.Auth.RegisterAsync("alice", "hunter2");     // or LoginAsync
-await client.WebSocket.ConnectAsync();                    // /ws
-client.WebSocket.SendSessionConnect(sessionToken);        // first frame
-client.WebSocket.On("match.matched", OnMatched);          // payload: { match_id, players }
-await client.Matchmaker.QueueAsync(mode: "default");      // POST /api/v1/matchmaker
-```
+A 400 with `matchmaker.unknown_mode` means the node found no mode called
+`default`, which almost always means `lua/match.lua` is not mounted where step
+2 puts it.
 
-Matchmaker tickets resolve asynchronously over the WebSocket via the
-`match.matched` event (payload `{match_id, players}`). You can poll
-`GET /api/v1/matchmaker/:ticket_id` if you prefer.
+Then open a tracking issue at
+[github.com/widgrensit/asobi/issues](https://github.com/widgrensit/asobi/issues)
+and say hello in the [Discord](https://discord.gg/vYSfYYyXpu) `#migrations`
+channel with your setup: engine, language, lobby versus matchmaker,
+server-authoritative versus P2P. We will tell you which sections below apply to
+you.
 
-Do this one feature at a time: **auth first, then WebSocket handshake, then
-matchmaking, then the game-session messages**. Hathora and asobi can
-coexist in the client during this phase (different base URLs).
+## The full port, in outline
+
+1. Your game-server logic keeps running in its own process while you migrate.
+2. asobi comes up alongside it. Your game server talks to it over WebSocket
+   like any other auth, matchmaker or leaderboard service.
+3. You port the Hathora-specific calls to the equivalents in the concept map.
+4. Once asobi owns auth, matchmaking and lobbies, you drop Hathora and either
+   keep your game server in a plain container, or fold its logic into a
+   `match.lua` and delete the container.
+
+For most Hathora games the game server is a few hundred lines of state
+mutation, which is well within the scope of one Lua file.
+
+## Concept map
+
+| Hathora | asobi | Notes |
+|---|---|---|
+| Application | asobi deployment | One container per environment. |
+| Room | Match | One process per match; state lives in the process heap. |
+| Process | No equivalent | asobi does not spin a container per match. One container hosts thousands of matches as BEAM processes. |
+| Lobby | Matchmaker ticket plus a match in its waiting phase | `POST /api/v1/matchmaker`; when `match_size` is reached the match starts. |
+| Region | Deployment location | One container per region, chosen by you. There is no region abstraction. |
+| Matchmaker 2.0 | `asobi_matchmaker` | Strategies `fill` and `skill_based`, or your own via the `asobi_matchmaker_strategy` behaviour. |
+| `HathoraClient.loginAnonymous` | `POST /api/v1/auth/guest` | Device-backed anonymous auth: `device_id` plus `device_secret`, and you get a real player back. Claim it later with `POST /api/v1/auth/guest/upgrade`. Opt-in - see the note below the table. |
+| `HathoraClient.loginGoogle` | `POST /api/v1/auth/oauth` | OAuth/OIDC. |
+| `createLobby`, `createRoom`, queue | `POST /api/v1/matchmaker` | Body `{"mode": "...", "properties": {}}`, response `{"ticket_id": "...", "status": "pending"}`. |
+| Ticket poll | `GET /api/v1/matchmaker/:ticket_id` | |
+| Cancel | `DELETE /api/v1/matchmaker/:ticket_id` | |
+| `listActivePublicLobbies` | `GET /api/v1/matches/live` | Live, joinable matches; filter with `mode` and `has_capacity`. Matches are unlisted by default and a mode opts in with `listed => true` in the operator's `game_modes` config; the Lua config reader does not pick up a `listed` global. Not `GET /api/v1/matches`, which is the finished-match record table. |
+| `getConnectionInfo(roomId)` | WebSocket upgrade on `GET /ws` | See [WebSocket handshake](#websocket-handshake). The first frame must authenticate. |
+| Custom room messages | Extension RPC | Frame `rpc.call` with `{protocol: 1, method, params}`; replies `rpc.ok` `{result}` or `rpc.error` `{error: {code, message, details}}`, correlated by `cid`. All seven client SDKs support it. See [Extensions](extensions.md). |
+| `ping` region API | None | Probe each deployment endpoint yourself if you need client-side region selection. |
+| Hathora SDK | asobi SDKs | [Unity](https://github.com/widgrensit/asobi-unity), [Unreal](https://github.com/widgrensit/asobi-unreal), [JS/TS](https://github.com/widgrensit/asobi-js), [Godot](https://github.com/widgrensit/asobi-godot), [Defold](https://github.com/widgrensit/asobi-defold), [LÖVE](https://github.com/widgrensit/asobi-love2d), [Dart](https://github.com/widgrensit/asobi-dart), [Flame](https://github.com/widgrensit/flame_asobi). |
+| Hathora Console | Built-in operator console at `/console` | Off by default, and read-only. See the note below the table. |
+| `hathora.yml` | `docker-compose.yml` | Plain Compose, no proprietary spec. |
+
+Guest auth is off until two things are true: the game declares `guest_auth` in
+its Lua config, and the operator supplies a pepper of at least 32 bytes. Either
+one missing and `POST /api/v1/auth/guest` answers `guest.disabled`. See
+[Authentication](authentication.md).
+
+A stock node serves neither the console nor the ops API; you turn them on - see
+[Operator console](console.md). When you do, the plane is read-only apart from
+actions an extension declares. Coming from the Hathora console you will look for
+a restart-this-process button; there is not one, because there is no process per
+match to restart.
+
+## Migration path
+
+### Phase 1 - stand up asobi alongside Hathora (1 day)
+
+Use the compose file from step 2 above, on the same cloud or locally, without
+touching the Hathora deployment. Goal: auth, a lobby and a match working end to
+end from your client. Requirements and the production compose are in
+[Self-hosting](self-hosting.md).
+
+### Phase 2 - port the client SDK calls (2 to 5 days)
+
+Swap the Hathora SDK for the asobi SDK for the same engine. Do it one feature
+at a time: auth first, then the WebSocket handshake, then matchmaking, then the
+game-session messages. Hathora and asobi coexist in the client during this
+phase behind different base URLs.
+
+Matchmaker tickets resolve asynchronously over the WebSocket as `match.matched`
+with payload `{match_id, players}`. Polling
+`GET /api/v1/matchmaker/:ticket_id` works too.
+
+Each SDK's README carries its own call names; this guide does not restate them
+because they differ per language.
 
 ### WebSocket handshake
 
-Asobi expects every WebSocket client to authenticate with a `session.connect`
-frame *before* it can use any other WS message type. The payload field is
-**`token`** (the value of the `session_token` you got from register/login):
+asobi expects every WebSocket client to authenticate with a `session.connect`
+frame before any other message type is accepted. The payload field is `token`,
+carrying the `access_token` from register, login or guest:
 
 ```json
-{"type":"session.connect","payload":{"token":"eyJ..."}}
+{"type":"session.connect","payload":{"token":"<access_token>"}}
 ```
 
-The server replies `{"type":"session.connected","payload":{"player_id":"..."}}`
-when the token is accepted, or `{"type":"error","payload":{"reason":"invalid_payload"}}`
-if the field name is wrong. After successful auth the server routes
-match/matchmaker/chat/world events to this player. Other message types the server handles: `matchmaker.add`,
-`matchmaker.remove`, `match.input`, `match.join`, `match.leave`, `chat.send`,
-`chat.join`, `chat.leave`, `dm.send`, `presence.update`, `vote.cast`,
-`vote.veto`, `world.list`, `world.create`, `world.find_or_create`,
-`world.join`, `world.leave`, `session.heartbeat`.
+The server replies:
 
-Server-pushed event types follow the pattern `{domain}.{event}` — notably:
-`match.matched` (matched into a game), `match.state` (full state push),
-`match.finished`, `world.tick`, `world.terrain`, `chat.message`,
-`dm.message`, `error`.
-
-### Phase 3 — port the game logic (2 days – 2 weeks)
-
-You have two choices here.
-
-**Option A — keep your existing game server.** If you've got a lot of C#/Go
-server code you'd rather not rewrite, keep running it in its own container
-on Hetzner / Fly / Scaleway. Use asobi for auth, matchmaking, lobbies,
-leaderboards, and persistence. When the matchmaker fires `match.matched`,
-the client has a `session_token` from asobi — pass it (plus `player_id` and
-`match_id`) to your game server over your own connection, and have your
-game server validate the token with asobi before accepting input.
-
-> **Reality check:** the public asobi library does not ship a built-in
-> "server-to-server token validation" endpoint today — token verification
-> on your own server means calling `POST /api/v1/auth/refresh` with the
-> token, or adding a small validation route yourself. If this is a blocker
-> for you, ping us in Discord — it's a natural library addition and we'll
-> prioritise it.
-
-**Option B — fold the game logic into Lua.** Rewrite your tick / input /
-state logic as a `match.lua` file. The callbacks are:
-
-```lua
-function init(config)         -- once per match
-function join(player_id, state)
-function leave(player_id, state)
-function handle_input(player_id, input, state)
-function tick(state)           -- default 10Hz, configurable
-function get_state(player_id, state)   -- per-player view
+```json
+{"type":"session.connected","payload":{"player_id":"019de3..."}}
 ```
 
-For most Hathora games this is a few hundred lines of Lua. You get hot
-reload for free (edit + save + live matches update) and you delete a
-container.
+A missing or misspelled `token` field is not a shape error - it is treated as a
+token that did not resolve, so the reply is an error frame carrying the wire
+code `unauthenticated`:
 
-### Phase 4 — cut over (1 day)
+```json
+{"type":"error","payload":{"reason":"invalid_token","error":{"code":"unauthenticated","message":"The credentials are missing, expired, or invalid.","details":{}}}}
+```
 
-Flip a feature flag in the client to point at the asobi endpoint. Monitor
-for 24h. Shut Hathora down.
+After a successful handshake the server routes match, matchmaker, chat and
+world events to this player. The message types a client may send are:
+
+`session.connect`, `session.heartbeat`, `matchmaker.add`, `matchmaker.remove`,
+`match.join`, `match.leave`, `match.input`, `match.list`, `world.create`,
+`world.find_or_create`, `world.join`, `world.leave`, `world.input`,
+`world.list`, `chat.send`, `chat.join`, `chat.leave`, `dm.send`,
+`presence.update`, `vote.cast`, `vote.veto`, `rpc.call`.
+
+Server-pushed types follow `{domain}.{event}`: `match.matched`, `match.state`,
+`match.finished`, `world.tick`, `world.terrain`, `chat.message`, `dm.message`,
+`notification.new`, `error`, plus any leaf name your script broadcasts under
+`match.` or `world.`. The full reference is
+[WebSocket protocol](websocket-protocol.md).
+
+### Phase 3 - port the game logic (2 days to 2 weeks)
+
+**Option A - keep your existing game server.** If you have a lot of C# or Go
+server code you would rather not rewrite, keep running it in its own container.
+Use asobi for auth, matchmaking, lobbies, leaderboards and persistence. When
+the matchmaker fires `match.matched`, the client has an `access_token` from
+asobi; pass it, plus `player_id` and `match_id`, to your game server over your
+own connection, and have your game server check the token with asobi before
+accepting input.
+
+There is no dedicated server-to-server token-introspection route. Check a token
+by calling any authenticated GET with it (`GET /api/v1/friends` is a cheap one)
+and treating 200 as accepted, 401 as not. Two caveats before you build on it:
+no core route reliably reports the caller's own `player_id` - a friends,
+notifications or saves response carries it only on rows the player already has,
+and is empty otherwise - so a 200 proves the token is valid, not whose it is.
+And do not use `POST /api/v1/auth/refresh` for the check. That endpoint takes a
+`refresh_token`, not an access token, so an access token simply fails there;
+and a refresh token rotates the pair, with a second presentation of a rotated
+token revoking the whole token family and logging the player out. If you
+need real introspection, an extension can add it: an RPC handler receives the
+caller's `player_id` in its context. See [Extensions](extensions.md).
+
+**Option B - fold the game logic into Lua.** Rewrite your tick, input and state
+logic as a `match.lua`, using the six callbacks from step 1:
+
+- `init(config)` - once per match, returns the initial state
+- `join(player_id, state)` and `leave(player_id, state)`
+- `handle_input(player_id, input, state)` - one client `match.input` frame
+- `tick(state)` - every 100ms
+- `get_state(player_id, state)` - the per-player view
+
+Matches tick every 100ms and that is fixed; `tick_rate` is a world-mode
+setting. You get live reload for free - edit, save, and the next tick
+re-evaluates the file against the running state - and you delete a container.
+See [Lua scripting](lua-scripting.md).
+
+### Phase 4 - cut over (1 day)
+
+Point the client at the asobi endpoint behind a feature flag. Monitor for 24h.
+Shut Hathora down.
 
 ## Deploy story
 
-You can run asobi anywhere Docker runs. Common choices:
+asobi runs anywhere Docker runs. The managed version is
+[asobi.dev/cloud](https://asobi.dev/cloud), the same open-source core.
 
-| Host | Fit | Rough cost |
-|---|---|---|
-| **Hetzner Cloud** (CX22–CX42) | Best price/perf. EU-only if that matters. | €4–15 / month |
-| **Scaleway Serverless** | Auto-scale for dev / low traffic | Free tier → pay per req |
-| **Fly.io** | Multi-region one-liner | $5+/month/region |
-| **Clever Cloud** | git-push deploy, EU | €10+/month |
-| **Your laptop** | Development / LAN party | — |
+A single node holds 3,000-7,000 concurrent WebSocket connections in
+measurement, at 4.4ms p50 round-trip with 3,500 of them - see
+[Benchmarks](benchmarks.md). Most games' first deployment is one small machine
+plus a Postgres, which is where the saving against process-hour billing comes
+from.
 
-Typical Hathora cost for a small-indie game was **$200–800 / month** on
-process-hours. The same game on asobi at Hetzner is **€5–20 / month**,
-often 10–40× cheaper.
-
-## Pricing comparison
-
-| | Hathora (pre-shutdown) | asobi self-host | asobi managed (soon) |
-|---|---|---|---|
-| Pricing model | Process-hours ($0.03–0.15/hr) + bandwidth | Flat infra cost you choose | Flat per-container |
-| Free tier | Small credit | Unlimited | TBD |
-| 100 CCU | ~$50–150/mo | €5–15/mo infra | ~€9/mo |
-| 1,000 CCU | ~$300–800/mo | €15–50/mo infra | ~€29/mo |
-| Bandwidth surcharges | Yes | No (infra cost) | No |
-| Multi-region | First-class, auto | DIY (one container per region) | Per-region tier |
+If you plan on more than one node, read [Clustering](clustering.md) first: the
+matchmaker queue is per node, so players queuing against different nodes never
+match each other, rate limits are per node, and the console needs a sticky
+route.
 
 ## Self-hosted Hathora users
 
-If you run `hathora-core` on your own infra, your situation is better: you
-still own the stack. You can keep running it as long as it works. But the
-same migration strategy applies when you decide to move — asobi's single
-container + Postgres is operationally simpler than Hathora's Go monolith +
-Redis + Cockroach.
+If you run `hathora-core` on your own infrastructure you still own the stack
+and can keep running it as long as it works. The same migration strategy
+applies when you decide to move.
 
-## Things asobi does NOT do (yet)
+## Things asobi does not do
 
-Be honest with yourself before committing:
-
-- **No UDP transport.** WebSocket/TCP only. If you're a twitch FPS /
-  fighting game / racing game that needs sub-3ms physics, pair asobi with a
-  UDP relay (Photon, ENet server, custom). Use asobi for auth / matchmaker
-  / economy / leaderboard / social.
-- **No anonymous-login shortcut.** Auth is `username+password` or OAuth.
-  If your Hathora game used `loginAnonymous`, you'll generate a random
-  username/password in the client and persist it locally, or wire OAuth.
-- **No server-to-server token validation endpoint** in the public library
-  (see Option A note above).
-- **No auto multi-region.** Deploy one container per region yourself.
-- **No client-side prediction / rollback netcode primitives.** On the
-  roadmap.
-- **Pre-1.0 API.** Minor breaking changes possible until 1.0.
-- **Managed cloud opens later in 2026** — today, self-host.
+- **No UDP transport.** WebSocket over TCP only. A twitch FPS, fighting game or
+  racer that needs sub-3ms physics should pair asobi with a UDP relay and use
+  asobi for auth, matchmaking, economy, leaderboards and social.
+- **Guest auth is opt-in and off by default.** It exists and it is device-backed
+  rather than a throwaway username, but it stays off until the game declares
+  `guest_auth` and the operator supplies a pepper of at least 32 bytes.
+- **No server-to-server token introspection route.** See Option A above.
+- **No automatic multi-region.** One container per region, deployed by you.
+- **No client-side prediction or rollback netcode primitives.**
+- **Pre-1.0 API.** Minor breaking changes are possible until 1.0.
 
 ## Do this today
 
-- [ ] `git clone` [asobi_lua](https://github.com/widgrensit/asobi_lua) and
-  bring up `docker compose up` locally. Register a player. Confirm it works.
-- [ ] Pick a single SDK call in your client to port first (usually
-  `loginAnonymous`). Get it compiling against asobi.
-- [ ] Join the [Discord](https://discord.gg/vYSfYYyXpu). We'll help you debug.
-- [ ] Decide Option A (keep game server) vs Option B (Lua rewrite). Open
-  a thread in [Discussions](https://github.com/widgrensit/asobi_lua/discussions)
-  and we'll sanity-check.
-- [ ] Set a cutover date before 2026-05-05.
+- Run the compose from step 2 locally and register a player.
+- Pick one SDK call in your client to port first, usually `loginAnonymous`.
+- Join the [Discord](https://discord.gg/vYSfYYyXpu).
+- Decide Option A or Option B and open a thread in
+  [Discussions](https://github.com/widgrensit/asobi/discussions).
 
 ## Getting help
 
-- **Discord**: [#migrations](https://discord.gg/vYSfYYyXpu) channel
-- **Email**: hello@asobi.dev
-- **GitHub Discussions**: [widgrensit/asobi_lua/discussions](https://github.com/widgrensit/asobi_lua/discussions)
-
-We'll prioritise Hathora-migration support through May 2026.
+- Discord: [#migrations](https://discord.gg/vYSfYYyXpu)
+- Email: hello@asobi.dev
+- GitHub Discussions:
+  [widgrensit/asobi/discussions](https://github.com/widgrensit/asobi/discussions)
 
 ## See also
 
 - [Migrating from PlayFab](migrate-from-playfab.md)
 - [Migrating from Nakama self-host](migrate-from-nakama.md)
-- [Exit guarantee](exit.md) — if asobi disappears tomorrow
-- [Comparison vs Nakama, Colyseus, SpacetimeDB](comparison.md)
+- [Exit guarantee](exit.md)
+- [Comparison](comparison.md)

--- a/guides/migrate-from-nakama.md
+++ b/guides/migrate-from-nakama.md
@@ -1,86 +1,78 @@
 # Migrating from Nakama self-host to asobi
 
-You're running Nakama self-hosted on your own infra. It works. But maybe:
+You run Nakama self-hosted on your own infrastructure. It works. Migrate only
+if one of these applies:
 
-- You're tired of Nakama requiring **CockroachDB** (vs plain PostgreSQL
-  everywhere else in your stack)
-- You want **hot-reload of Lua** that doesn't drop sessions on deploy
-  (Nakama issue [#192](https://github.com/heroiclabs/nakama/issues/192) has
-  been open since 2018)
-- You're bumping into **spatial / MMO** use cases Nakama wasn't designed
-  for
-- You prefer **BEAM's fault-tolerance** over Go's recovery-from-panic
-  model for a stateful realtime server
-- You want **Apache-2** without the BSL-adjacent ambiguity in some
-  Heroic Cloud components
+- You want hot-reload of Lua that does not drop sessions on deploy. Editing a
+  Nakama runtime module means restarting the server.
+- You are hitting spatial or large-world use cases. asobi has zones, terrain
+  chunks and adaptive tick rates as first-class primitives; Nakama's match
+  handler is room-centric.
+- You prefer the BEAM's supervision model over recovering from panics in a
+  stateful realtime server.
+- You want a single Apache-2.0 codebase with no commercial-only companions.
 
-This guide walks you from a working Nakama deployment to an equivalent
-asobi deployment. It's the most straightforward of the three migration
-guides — Nakama and asobi are structurally the closest cousins in the
-OSS backend space.
+If none of those apply, stay on Nakama. Nakama and asobi are structurally the
+closest cousins in this space, which makes the port straightforward and also
+makes it pointless without a reason.
 
-> **Draft notice.** This guide is a starting point, not a playbook —
-> nobody has yet migrated a shipped Nakama title to asobi. The asobi-side
-> endpoints and events below are verified against the current code.
-> Nakama-side method names come from Nakama's public docs. **Pair with us
-> in the [Discord](https://discord.gg/vYSfYYyXpu) `#migrations` channel
-> if you hit an API gap.**
+Nobody has migrated a shipped Nakama title to asobi yet. The asobi-side
+endpoints and events below are verified against this repository; the
+Nakama-side names come from Nakama's public documentation. Pair with us in the
+[Discord](https://discord.gg/vYSfYYyXpu) `#migrations` channel if you hit a
+gap.
 
-## Why migrate at all
+## What asobi is
 
-Nakama is a fine product. We respect Heroic Labs. You should only migrate
-if one of these reasons applies to you:
-
-- **You need hot-reload.** Editing a Lua runtime module in Nakama requires
-  a full server restart, which drops connections. asobi does it live via
-  Luerl module swap.
-- **Your infra is Postgres-only.** Moving CockroachDB off your ops plate
-  is worth real money.
-- **You're building an MMO / large-world game.** asobi has spatial zones,
-  lazy-zone loading, terrain chunks, and adaptive tick rates as first-class
-  primitives. Nakama's match handler is room-centric.
-- **You want truly-free OSS.** Nakama is Apache-2 at the core but Heroic
-  Cloud has commercial-only components (Satori, Hiro) that ease adoption.
-  If you're committed to OSS-only, asobi is structurally simpler.
-
-If none of those apply, stay on Nakama. Honestly.
+One Erlang/OTP node containing the game backend, the Lua runtime and the
+operator console. Two ways in: run `ghcr.io/widgrensit/asobi` and write Lua, or
+depend on the Hex package and write Erlang. Same node either way.
 
 ## Concept map
 
-Nakama and asobi agree on most of the vocabulary:
-
 | Nakama | asobi | Notes |
 |---|---|---|
-| **Match** (authoritative) | Match | Same: a BEAM/goroutine process owning state. |
-| **Match handler** (Lua / TS / Go) | `asobi_match` behaviour / `match.lua` | Callbacks: init, join, leave, handle_input, tick, get_state. |
-| **Match Handler's LoopTick** | `tick(state)` | Same cadence (configurable). |
-| **Parties** | Not supported | No matchmaker party grouping. Play with friends by sharing a match/world id or a join code and joining directly; gate entry in `join/3`. |
-| **MatchmakerAdd** | `POST /api/v1/matchmaker` | Body: `{mode, properties}`. |
-| **Storage Engine** | `/api/v1/storage/:collection/:key` | Collection+key+owner model is the same. Public/Owner/None permissions. |
-| **Leaderboards** | Leaderboards (`/api/v1/leaderboards/:id`) | Submit/top/around queries. |
-| **Tournaments** | Tournaments (`/api/v1/tournaments`) | Scheduled, entry fees, rewards. |
-| **Friends** | Friends (`/api/v1/friends`) | Request/approve/block. |
-| **Groups** | Groups (`/api/v1/groups`) | Roles, join/leave/kick. |
-| **Chat channels** | Chat channels + WS `chat.send` / `chat.join` | Per-channel history. |
-| **Notifications** | Notifications (`/api/v1/notifications`) | Plus WS push. |
-| **Wallets** | Economy wallets (`/api/v1/wallets`) | Multi-currency ledgers. |
-| **Purchases** | Economy store (`/api/v1/store/purchase`) | Integrates with IAP verification. |
-| **Authentication (Device / Custom)** | `/api/v1/auth/guest` | Create-or-resume anonymous accounts from a device-held secret; upgrade later with `/auth/guest/upgrade`. Maps directly to `AuthenticateDevice`/`AuthenticateCustom`. |
-| **Authentication (Email)** | `/api/v1/auth/register` + `/login` | Username + password. |
-| **Authentication (Google / Apple / Steam / ...)** | `/api/v1/auth/oauth` | OAuth/OIDC. |
-| **RPC endpoints** | Nova controllers (Erlang) or Lua callbacks | For per-match logic, use Lua in `match.lua`. For cross-match workflows, write a Nova controller. |
-| **Hooks (`before_authenticate`, `after_friendAdd`)** | Nova plugins + match lifecycle callbacks | Pre- and post-request middleware in Nova. |
-| **Runtime Lua / TS / Go** | Luerl Lua (for match logic), Erlang/OTP (for the engine) | One scripting language (Lua); the engine is all OTP. |
-| **Nakama Console** | Built-in operator console at `/console` | Ships in asobi. Set `{console, true}` and an `ops_secret`. |
-| **`sessiontoken`** | `session_token` | Same concept, returned from `/register` or `/login`. |
-| **WebSocket** | `/ws` with `session.connect` first frame | See the Hathora guide's [WebSocket handshake](migrate-from-hathora.md#websocket-handshake) section for the protocol. |
+| Match (authoritative) | Match | A process owning state, one per match. |
+| Match handler | `match.lua`, or the `asobi_match` behaviour | Callbacks: `init`, `join`, `leave`, `handle_input`, `tick`, `get_state`. |
+| Match handler loop tick | `tick(state)` | Matches tick every 100ms and that is fixed. `tick_rate` is a world-mode global; worlds default to 50ms. |
+| Parties | Not supported | No matchmaker party grouping. Share a match or world id, or a join code, and join directly; gate entry in `join(player_id, state, ctx)`. |
+| MatchmakerAdd | `POST /api/v1/matchmaker` | Body `{"mode": "...", "properties": {}}`. Returns `{"ticket_id": "...", "status": "pending"}`. |
+| Storage engine | `GET/PUT/DELETE /api/v1/storage/:collection/:key` | Collection, key and owner, same model. Permissions are `read_perm` and `write_perm`, each `public` or `owner`. There is no `none`. |
+| Storage, shared/global rows | Lua `game.storage.get/set` | The HTTP routes only ever touch per-player rows. The global namespace (no owner) is reachable from Lua only. |
+| Leaderboards | `/api/v1/leaderboards/:id` | Submit, top, around. |
+| Tournaments | `/api/v1/tournaments` | Scheduled, entry fees, rewards. |
+| Friends | `/api/v1/friends` | Request, approve, block. |
+| Groups | `/api/v1/groups` | Roles, join, leave, kick. |
+| Chat channels | Chat channels plus WS `chat.send` / `chat.join` | Per-channel history. |
+| Notifications | `/api/v1/notifications` | Plus the `notification.new` WebSocket push. |
+| Wallets | Economy wallets (`/api/v1/wallets`) | Multi-currency ledgers. |
+| Purchases | Economy store (`/api/v1/store/purchase`) | Spends an in-game wallet balance. |
+| IAP receipts | `POST /api/v1/iap/apple`, `/api/v1/iap/google` | Verifies the receipt and records it once per transaction. It grants nothing: turning a verified receipt into currency or items is your game's job, via the economy or inventory API. |
+| Authentication (device / custom) | `POST /api/v1/auth/guest` | Create-or-resume from a device-held secret; claim later with `/api/v1/auth/guest/upgrade`. Opt-in - see the note below the table. |
+| Authentication (email) | `POST /api/v1/auth/register` and `/login` | Username plus password. |
+| Authentication (Google / Apple / Steam) | `POST /api/v1/auth/oauth` | OAuth/OIDC. |
+| RPC endpoints | Extension RPC over the WebSocket | Frame `rpc.call` with `{protocol: 1, method, params}`; replies `rpc.ok` `{result}` or `rpc.error` `{error: {code, message, details}}`, correlated by `cid`. All seven client SDKs support it. See [Extensions](extensions.md). |
+| Hooks (`before_authenticate`, `after_friendAdd`) | Nova plugins and match lifecycle callbacks | Pre- and post-request middleware in Nova. |
+| Runtime Lua / TS / Go | Lua for game logic, Erlang/OTP for the engine | One scripting language. |
+| Nakama Console | Built-in operator console at `/console` | Off by default, and read-only. See the note below the table. |
+| Session token | `access_token` plus `refresh_token` | Register and login return `player_id`, `access_token`, `refresh_token` and `username`. There is no `session_token` field. |
+| WebSocket | `/ws`, `session.connect` first frame | See the Hathora guide's [WebSocket handshake](migrate-from-hathora.md#websocket-handshake). |
+
+Guest auth is off until two things are true: the game declares `guest_auth` in
+its Lua config, and the operator supplies a pepper of at least 32 bytes. Either
+one missing and `POST /api/v1/auth/guest` answers `guest.disabled`. See
+[Authentication](authentication.md).
+
+A stock node serves neither the console nor the ops API; you turn them on - see
+[Operator console](console.md). When you do, the plane is read-only apart from
+actions an extension declares. If you run Nakama Console to ban and kick, budget
+for building that yourself.
 
 ## Migration path
 
-### Phase 1 — stand up asobi alongside Nakama (0.5 days)
+### Phase 1 - stand up asobi alongside Nakama (0.5 days)
 
 ```yaml
-# docker-compose.yml
 services:
   postgres:
     image: postgres:17
@@ -88,24 +80,43 @@ services:
       POSTGRES_USER: postgres
       POSTGRES_PASSWORD: postgres
       POSTGRES_DB: my_game
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U postgres"]
+      interval: 5s
 
   asobi:
-    image: ghcr.io/widgrensit/asobi_lua:latest
-    depends_on: [postgres]
+    image: ghcr.io/widgrensit/asobi:latest
+    depends_on:
+      postgres: { condition: service_healthy }
     ports: ["8084:8084"]
     volumes: ["./lua:/app/game:ro"]
     environment:
       ASOBI_DB_HOST: postgres
       ASOBI_DB_NAME: my_game
+      ASOBI_CORS_ORIGINS: "http://localhost:5173"
+      ASOBI_CONSOLE: "true"
+      ASOBI_OPS_SECRET_FILE: /run/secrets/ops_secret
+    secrets: [ops_secret]
+
+secrets:
+  ops_secret:
+    file: ./ops_secret.txt
 ```
 
-Note: plain PostgreSQL, no CockroachDB. If you currently run Nakama
-against Postgres-compatible Cockroach, you already have a backup strategy
-that works here.
+`./lua` must contain a `match.lua` before the matchmaker has anything to match
+on - see Phase 2 below, or [Getting started](getting-started.md) for a complete
+one. Without it, `POST /api/v1/matchmaker` answers `matchmaker.unknown_mode`.
 
-### Phase 2 — port the Lua runtime (1-3 days)
+`ASOBI_CORS_ORIGINS` is not optional for a browser client: unset, the node
+sends an empty `Access-Control-Allow-Origin` and every fetch from a page is
+blocked.
 
-Nakama's Lua API:
+Requirements and the production compose are in
+[Self-hosting](self-hosting.md).
+
+### Phase 2 - port the runtime (1-3 days)
+
+Nakama's Lua API is RPC-first:
 
 ```lua
 local nk = require("nakama")
@@ -117,11 +128,9 @@ end
 nk.register_rpc(foo, "my_rpc")
 ```
 
-asobi's Lua API differs in key ways — the match is the first-class unit,
-not an RPC:
+asobi's is match-first. The match is the unit; the file is `match.lua`:
 
 ```lua
--- match.lua
 match_size = 2
 
 function init(_config)
@@ -143,37 +152,45 @@ function handle_input(player_id, input, state)
 end
 ```
 
-For cross-match logic (leaderboards, global state, scheduled jobs):
+Cross-match logic has three homes:
 
-- `game.leaderboard.submit("global", player_id, score)` in Lua
-- Shigoto background jobs in Erlang for scheduled cross-match workflows
-- Nova controllers in Erlang for custom REST endpoints (equivalent to
-  Nakama RPCs)
+- `game.leaderboard.submit`, `game.economy.*`, `game.storage.*` and
+  `game.notify` are callable from any match script. See the
+  [Lua API](lua-api.md).
+- Anything a client must call by name, that is not tied to a match, becomes an
+  extension RPC method. That is the direct replacement for
+  `nk.register_rpc`, and it reaches the client as `rpc.call` on the same
+  WebSocket. See [Extensions](extensions.md).
+- Scheduled work runs as a Shigoto job in Erlang.
 
-If you have a lot of RPC-shaped logic (not per-match), budget Phase 2 for
-closer to a week.
+If most of your Nakama logic is RPC-shaped rather than per-match, budget closer
+to a week and expect to write an extension.
 
-### Phase 3 — migrate the storage schema (1-2 days)
+### Phase 3 - migrate the storage schema (1-2 days)
+
+asobi's table is `storage`, not `asobi_storage`. Permissions are two columns,
+`read_perm` and `write_perm`, each `public` or `owner`. `id` and `updated_at`
+have no database default, so the insert must supply them.
 
 ```bash
-# Export from Nakama's Postgres (or CockroachDB):
 pg_dump -U nakama -t storage -d nakama > storage-export.sql
-
-# Transform storage rows to asobi's asobi_storage schema
-psql -U postgres -d my_game -c "
-  INSERT INTO asobi_storage (player_id, collection, key, value, permissions)
-  SELECT user_id::uuid, collection, key, value::jsonb, 'owner'
-  FROM old_nakama_storage;
-"
 ```
 
-The same pattern applies to leaderboards, friends, groups, and wallets.
-Column names differ slightly (see the [Kura schemas](https://hexdocs.pm/asobi)
-for the target shape) but the data is 1:1 translatable.
+Load that dump into a staging table, then:
 
-### Phase 4 — port the client (2-5 days)
+```sql
+INSERT INTO storage (id, collection, key, player_id, value, version, read_perm, write_perm, updated_at)
+SELECT gen_random_uuid(), collection, key, user_id::uuid, value::jsonb, 1, 'owner', 'owner', now()
+FROM nakama_storage_import;
+```
 
-Nakama client SDKs and asobi client SDKs map cleanly:
+asobi mints UUIDv7 for rows it creates; `gen_random_uuid()` gives v4, which is
+fine for imported rows because nothing reads ordering off a storage id.
+
+The same one-off-script pattern applies to leaderboards, friends, groups and
+wallets. Column names differ; the schemas are in `src/` alongside each domain.
+
+### Phase 4 - port the client (2-5 days)
 
 | Nakama SDK | asobi SDK |
 |---|---|
@@ -182,87 +199,81 @@ Nakama client SDKs and asobi client SDKs map cleanly:
 | `nakama-defold` | [asobi-defold](https://github.com/widgrensit/asobi-defold) |
 | `nakama-unreal` | [asobi-unreal](https://github.com/widgrensit/asobi-unreal) |
 | `nakama-js` | [asobi-js](https://github.com/widgrensit/asobi-js) |
+| (none) | [asobi-love2d](https://github.com/widgrensit/asobi-love2d) |
+| (none) | [asobi-dart](https://github.com/widgrensit/asobi-dart) |
+| (none) | [flame_asobi](https://github.com/widgrensit/flame_asobi) |
 
-The Unity example:
+`AuthenticateCustom` and `AuthenticateDevice` both become guest auth. On the
+wire that is one POST and one WebSocket frame:
 
-```csharp
-// Before (Nakama)
-var client = new Client("defaultkey", "127.0.0.1", 7350, false);
-var session = await client.AuthenticateCustomAsync(deviceId);
-var socket = client.NewSocket();
-await socket.ConnectAsync(session);
-
-// After (asobi) - guest auth is the direct AuthenticateCustom/Device equivalent
-var client = new AsobiClient("https://api.my-game.com");
-await client.Auth.GuestAsync(deviceId, deviceSecret);   // POST /auth/guest, create-or-resume
-await client.WebSocket.ConnectAsync();
-client.WebSocket.SendSessionConnect(client.Session.Token);
+```bash
+curl -s localhost:8084/api/v1/auth/guest \
+  -H 'content-type: application/json' \
+  -d '{"device_id":"<stable device id>","device_secret":"<base64 of >= 32 random bytes>"}'
+# { "player_id": "019de3...", "access_token": "...", "refresh_token": "...",
+#   "username": "...", "guest": true, "created": true }
 ```
 
-### Phase 5 — cut over (1 day)
+```json
+{"type":"session.connect","payload":{"token":"<access_token>"}}
+```
 
-Flip the client's base URL via a feature flag. Monitor for 24h. Shut
-down the Nakama server.
+Your SDK wraps both. Each SDK's own README carries the call names; this guide
+does not restate them because they differ per language.
 
-## Things Nakama has that asobi doesn't (yet)
+### Phase 5 - cut over (1 day)
 
-- **Satori** (LiveOps platform). asobi's LiveOps story is rougher.
-- **Hiro** (progression system). asobi has tournaments and phases, plus
-  seasons and quests as extensions, but nothing as opinionated as Hiro.
-- **Go and TypeScript runtimes** as alternatives to Lua. asobi is Lua or
-  Erlang — no JS/TS runtime.
-- **Nakama Console** is further along than asobi's console today: asobi's ops
-  plane is read-only, so moderation still means a database write or a Lua
-  handler, not a button.
-- **Published case studies from AAA studios.** asobi is newer.
+Flip the client's base URL behind a feature flag. Monitor for 24h. Shut the
+Nakama server down.
 
-If you're deeply reliant on Satori, you'll need to build the equivalent
-in asobi or accept the feature loss.
+## What Nakama has that asobi does not
 
-## Things asobi has that Nakama doesn't
+- Satori. asobi's LiveOps story is rougher.
+- Hiro. asobi has tournaments and phases, and seasons ship as the
+  [`asobi_seasons`](https://github.com/widgrensit/asobi_seasons) extension, but
+  nothing as opinionated.
+- Go and TypeScript runtimes. asobi is Lua or Erlang.
+- A mutating operator console. asobi's ops plane is read-only, so moderation is
+  a database write, a Lua handler or an extension action.
+- Published case studies from large studios. asobi is newer.
 
-- **Hot-reload Lua** — the [Nakama issue #192](https://github.com/heroiclabs/nakama/issues/192)
-  that's been open since 2018
-- **Plain PostgreSQL** — no CockroachDB requirement
-- **Spatial zones / terrain** — purpose-built for large-world games
-- **Built-in voting** (plurality / ranked / approval / weighted)
-- **Phases** as a first-class primitive, and seasons as an extension
-- **Per-match process isolation** via OTP supervision — crashes never
-  leak between matches, no shared GC pauses
+## What asobi has that Nakama does not
 
-## Cost comparison
+- Live Lua reload without dropping players.
+- Spatial zones and terrain, purpose-built for large-world games.
+- Built-in voting (plurality, ranked, approval, weighted).
+- Phases as a first-class primitive.
+- Per-match process isolation under OTP supervision: a crash in one match does
+  not leak into another, and there is no shared stop-the-world GC.
 
-Self-hosted Nakama and self-hosted asobi have similar infrastructure
-costs at the low end. The main operational difference:
+## Cost
 
-| | Nakama self-host | asobi self-host |
-|---|---|---|
-| Database | CockroachDB (3-node recommended) | PostgreSQL (1 node is fine) |
-| Hot ops | Restart on deploy | Live module swap |
-| Clustering | Nakama's cluster mode + Consul | OTP `pg` / distributed Erlang |
-| Typical idle cost | €30-60/mo (Cockroach is memory-hungry) | €5-15/mo |
+Self-hosted Nakama and self-hosted asobi have similar infrastructure costs.
+Both run on PostgreSQL. The operational differences that show up in a bill are
+node count and how you deploy game-logic changes.
 
-If you're already running Postgres for other services, consolidating onto
-one DB flavour is a meaningful win.
+Node count is where asobi's clustering behaviour matters: the matchmaker queue
+is per node, so players queuing against different nodes never match each other,
+and rate limits are per node. Adding nodes is not free of design consequences.
+[Clustering](clustering.md) has the full list.
 
 ## Do this today
 
-- [ ] `git clone` [asobi_lua](https://github.com/widgrensit/asobi_lua),
-  `docker compose up`, register a test player.
-- [ ] Port one Nakama RPC or match handler to `match.lua`. Compare the
-  feel.
-- [ ] Join the [Discord](https://discord.gg/vYSfYYyXpu) `#migrations`
-  channel — tell us what your Lua runtime does and we'll sketch the port.
+- Run the Phase 1 compose locally and register a test player.
+- Port one Nakama match handler to `match.lua`. Compare the feel.
+- Join the [Discord](https://discord.gg/vYSfYYyXpu) `#migrations` channel and
+  tell us what your runtime modules do.
 
 ## Getting help
 
-- **Discord**: [#migrations](https://discord.gg/vYSfYYyXpu) channel
-- **Email**: hello@asobi.dev
-- **GitHub Discussions**: [widgrensit/asobi_lua/discussions](https://github.com/widgrensit/asobi_lua/discussions)
+- Discord: [#migrations](https://discord.gg/vYSfYYyXpu)
+- Email: hello@asobi.dev
+- GitHub Discussions:
+  [widgrensit/asobi/discussions](https://github.com/widgrensit/asobi/discussions)
 
 ## See also
 
 - [Migrating from Hathora](migrate-from-hathora.md)
 - [Migrating from PlayFab](migrate-from-playfab.md)
 - [Exit guarantee](exit.md)
-- [Comparison vs Nakama, Colyseus, SpacetimeDB](comparison.md)
+- [Comparison](comparison.md)

--- a/guides/migrate-from-playfab.md
+++ b/guides/migrate-from-playfab.md
@@ -1,89 +1,75 @@
 # Migrating from PlayFab to asobi
 
-If you're reading this, you've probably been through the PlayFab v2
-migration, watched features quietly get removed, or watched your Azure
-bill climb while the product got thinner. You're not alone — the
+For studios who have been through the PlayFab v2 migration, watched features
+get removed, or watched the Azure bill climb while the product got thinner. The
 [Imperium42 write-up](https://medium.com/@imperium42/the-silent-death-of-playfab-29614f5b9f15)
-catalogues the situation far better than we can.
+catalogues the situation.
 
-This guide walks you from "my PlayFab stack is working but brittle" to
-"I run my game on a Docker container I own."
+Nobody has migrated a shipped PlayFab title to asobi end to end yet. The
+asobi-side endpoints and events below are verified against this repository;
+PlayFab-side names come from Microsoft's public documentation. Pair with us in
+the [Discord](https://discord.gg/vYSfYYyXpu) `#migrations` channel.
 
-> **Draft notice.** This guide is a starting point, not a playbook — nobody
-> has yet migrated a shipped PlayFab title to asobi end-to-end. The
-> asobi-side endpoints and events below are verified against the current
-> code. PlayFab-side SDK names come from the public PlayFab documentation
-> and may have drifted. **The fastest path is pairing with us in the
-> [Discord](https://discord.gg/vYSfYYyXpu) `#migrations` channel.**
+## What asobi is
 
-## TL;DR
+One Erlang/OTP node containing the game backend, the Lua runtime and the
+operator console. Two ways in: run `ghcr.io/widgrensit/asobi` and write Lua, or
+depend on the Hex package and write Erlang. Same node either way. Apache-2.0,
+self-hostable, and the [exit guide](exit.md) is the runbook for keeping your
+game alive if we disappear.
 
-1. Your Unity/Unreal/JS game keeps shipping. You don't touch the client.
-2. Stand up asobi in parallel on Hetzner / Fly / your laptop.
-3. Port one PlayFab API domain at a time — usually **Auth → Player
-   Inventory → Virtual Currency → Leaderboards → Matchmaking**, in that
-   order.
-4. When all domains are ported, flip a feature flag to point at asobi and
-   retire the PlayFab Title.
+## The shape of the move
 
-## Why asobi specifically
-
-- **Apache-2.0, open-source, self-hostable.** Not a Microsoft product, not
-  a SaaS. The repos are [widgrensit/asobi](https://github.com/widgrensit/asobi)
-  and [widgrensit/asobi_lua](https://github.com/widgrensit/asobi_lua). See
-  the [exit guide](exit.md) if you want to know what happens if *we*
-  disappear.
-- **Flat infra cost.** PlayFab Essentials starts free but scales steeply
-  through compute-based tiers, Data Explorer add-ons, and dedicated
-  multiplayer server VMs. asobi is a single container whose cost you
-  control — a small Hetzner box (€5-15/mo) comfortably holds thousands of
-  players.
-- **Linux dedicated servers work.** Unlike PlayFab's Unreal OSS SDK which
-  historically forced Windows hosts (and their licensing costs), asobi
-  just runs in any Linux container.
-- **Hot-reload Lua.** Ship a fix at 11pm. Connected players stay connected.
-- **One matchmaking service.** Not three (Client::Matchmaker, Multiplayer
-  Matchmaking 2.0, OSS SDK) with no canonical guidance — just
-  `asobi_matchmaker` with pluggable strategies.
-- **Friends work.** Request, approve, block — all in the library.
-- **Lobbies hold state.** Our matchmaker tickets + match "waiting" phase
-  replace the v1 Lobby. Not the stateless read-only v2 Lobby that broke
-  half the games on PlayFab.
+1. Your Unity, Unreal or JS game keeps shipping. You do not touch the client on
+   day one.
+2. Stand up asobi in parallel.
+3. Port one PlayFab API domain at a time.
+4. When every domain is ported, flip a feature flag and retire the PlayFab
+   Title.
 
 ## Concept map
 
 | PlayFab | asobi | Notes |
 |---|---|---|
-| **Title** | Tenant / deployment | One Docker container per environment (dev/live). |
-| **TitleId** + SDK config | Base URL of your asobi deployment | No opaque ID — you point the SDK at a URL. |
-| **Entity (`master_player_account`)** | Player | Same concept: durable ID + profile. |
-| **Virtual Currency** | Economy | `game.economy.grant`, `debit`, `balance`, `purchase`. Multiple named currencies; per-player ledgers. |
-| **Catalog** | Store + inventory | `asobi_store_listing` + `asobi_item_def` tables; `/api/v1/store`. |
-| **Inventory** | Inventory | `game.player_items` in Lua / `/api/v1/inventory` REST. |
-| **CloudScript (JS functions)** | Lua in `match.lua` + REST controllers | Your server logic runs as part of the match process — no separate Functions runtime, no cold starts. |
-| **Matchmaking (Queue)** | `asobi_matchmaker` | Strategies: `fill`, `skill_based`, or bring your own via `asobi_matchmaker_strategy`. |
-| **Multiplayer Server (Build)** | Match process | No container-per-match. One Docker container hosts thousands of matches as BEAM processes. Simpler ops, cheaper. |
-| **Data → Player → KeyValue** | `/api/v1/storage/:collection/:key` | Per-player and shared collections with public/owner/none permissions. |
-| **Data → Title Data** | `/api/v1/storage/global/:key` | Use a well-known collection. |
-| **Data → Title Internal Data** | Erlang `sys.config` or Kura schema | Sensitive config stays out of the API. |
-| **Leaderboards + Statistics** | Leaderboards (`/api/v1/leaderboards/:id`) | ETS for microsecond reads, Postgres for persistence. |
-| **Friends list** | Friends (`/api/v1/friends`) | Request / approve / block / update status all work. |
-| **Player Groups** | Groups (`/api/v1/groups`) | Roles, member management, chat channel per group. |
-| **Push Notifications** | Notifications table + WS push | `match.notification` event or polled via `/api/v1/notifications`. |
-| **PlayFab Party (voice/chat)** | Chat channels + DM | Text only. For voice, pair asobi with Vivox / Dissonance / a WebRTC service. |
-| **Receipt validation (IAP)** | `/api/v1/iap/apple`, `/api/v1/iap/google` | Verifies Apple App Store and Google Play receipts. |
-| **Automation rules / webhooks** | Shigoto jobs | Write the rule as an Erlang callback or Lua handler. |
-| **Insights / Analytics** | `asobi_telemetry` + your pipeline | We emit telemetry; pipe to Prometheus / Grafana / ClickHouse. No hosted analytics yet. |
-| **Game Manager (web console)** | Built-in operator console at `/console` | Players, matches, leaderboards, economy, chat. Read-only today. |
+| Title | Deployment | One container per environment. |
+| TitleId plus SDK config | Base URL of your deployment | No opaque ID; you point the SDK at a URL. |
+| Entity (`master_player_account`) | Player | Durable ID plus profile. |
+| Virtual currency | Economy | `game.economy.grant`, `debit`, `balance`, `purchase` in Lua; `/api/v1/wallets` over REST. Multiple named currencies, per-player ledgers. |
+| Catalog | Store plus item definitions | `GET /api/v1/store`, `POST /api/v1/store/purchase`. |
+| Inventory | Inventory | `GET /api/v1/inventory` and `POST /api/v1/inventory/consume`, or Kura queries against the `asobi_player_item` schema (table `player_items`). There is no Lua binding for inventory. |
+| CloudScript (JS functions) | Lua callbacks, or an extension RPC method | Per-match logic goes in `match.lua`. Anything a client calls by name goes over the WebSocket as `rpc.call` - see below the table. No separate Functions runtime, no cold starts. |
+| Matchmaking (queue) | `POST /api/v1/matchmaker` | Modes plus pluggable strategies (`fill`, `skill_based`, or your own via the `asobi_matchmaker_strategy` behaviour). |
+| Multiplayer Server (build) | Match process | No container per match. One container hosts thousands of matches as BEAM processes. |
+| Data, player key-value | `/api/v1/storage/:collection/:key` | Per-player rows. Permissions are `read_perm` and `write_perm`, each `public` or `owner`. There is no `none`. |
+| Data, Title Data | Lua `game.storage.get/set` | The HTTP storage routes are scoped to per-player rows, so writing to a collection called `global` gives every player their own copy. The shared, owner-less namespace is reachable from Lua only. |
+| Data, Title Internal Data | Erlang `sys.config` or a Kura schema | Sensitive config stays off the player-facing API. |
+| Leaderboards and statistics | `/api/v1/leaderboards/:id` | ETS for reads, PostgreSQL for persistence. |
+| Friends list | `/api/v1/friends` | Request, approve, block, update status. |
+| Player groups | `/api/v1/groups` | Roles, member management, a chat channel per group. |
+| Push notifications | Notifications plus a WebSocket push | `GET /api/v1/notifications`, or the `notification.new` frame on the socket. This is in-game delivery, not APNs or FCM. |
+| PlayFab Party (voice and chat) | Chat channels plus DMs | Text only. For voice, pair asobi with a voice service. |
+| Receipt validation (IAP) | `POST /api/v1/iap/apple`, `/api/v1/iap/google` | Verifies an Apple or Google receipt and records it once per transaction. |
+| Granting from a receipt | Your game's job | Nothing is granted by the IAP endpoints. Turn a verified receipt into currency or items yourself through the economy or inventory API. |
+| Automation rules and webhooks | Shigoto jobs | Written as an Erlang callback. |
+| Insights and analytics | `asobi_telemetry` plus your own pipeline | Telemetry is emitted; there is no hosted analytics. |
+| Game Manager (web console) | Built-in operator console at `/console` | Off by default, and read-only. See the note below the table. |
+
+Custom server-side logic that is not tied to a match goes over the WebSocket:
+frame type `rpc.call` with `{protocol: 1, method, params}`, answered by
+`rpc.ok` `{result}` or `rpc.error` `{error: {code, message, details}}`,
+correlated by `cid`. All seven client SDKs support it. That is the CloudScript
+replacement. See [Extensions](extensions.md).
+
+A stock node serves neither the console nor the ops API; you turn them on - see
+[Operator console](console.md). When you do, the plane is read-only apart from
+actions an extension declares. If you use Game Manager to ban a player, refund a
+purchase or edit a catalogue item, budget for building that yourself.
 
 ## Migration path
 
-### Phase 1 — stand up asobi alongside PlayFab (1 day)
-
-Bring up asobi on a spare machine:
+### Phase 1 - stand up asobi alongside PlayFab (1 day)
 
 ```yaml
-# docker-compose.yml
 services:
   postgres:
     image: postgres:17
@@ -91,149 +77,159 @@ services:
       POSTGRES_USER: postgres
       POSTGRES_PASSWORD: postgres
       POSTGRES_DB: my_game
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U postgres"]
+      interval: 5s
 
   asobi:
-    image: ghcr.io/widgrensit/asobi_lua:latest
-    depends_on: [postgres]
+    image: ghcr.io/widgrensit/asobi:latest
+    depends_on:
+      postgres: { condition: service_healthy }
     ports: ["8084:8084"]
     volumes: ["./lua:/app/game:ro"]
     environment:
       ASOBI_DB_HOST: postgres
       ASOBI_DB_NAME: my_game
+      ASOBI_CORS_ORIGINS: "https://play.my-game.com"
+      ASOBI_CONSOLE: "true"
+      ASOBI_OPS_SECRET_FILE: /run/secrets/ops_secret
+    secrets: [ops_secret]
+
+secrets:
+  ops_secret:
+    file: ./ops_secret.txt
 ```
+
+`./lua` must contain a `match.lua` before the matchmaker has anything to match
+on - [Getting started](getting-started.md) has a complete one. Without it,
+`POST /api/v1/matchmaker` answers `matchmaker.unknown_mode`.
+
+`ASOBI_CORS_ORIGINS` is not optional for a browser build: unset, the node sends
+an empty `Access-Control-Allow-Origin` and every fetch from a page is blocked.
 
 ```bash
 docker compose up -d
-curl localhost:8084/api/v1/auth/register \
+curl -s localhost:8084/api/v1/auth/register \
   -H 'content-type: application/json' \
   -d '{"username":"alice","password":"hunter2"}'
-# → { "player_id": "...", "session_token": "...", "username": "alice" }
+# { "player_id": "019de3...", "access_token": "...", "refresh_token": "...", "username": "alice" }
 ```
 
-### Phase 2 — port Auth (2-5 days)
+There is no `session_token`. `access_token` is the Bearer credential;
+`refresh_token` buys a new pair from `POST /api/v1/auth/refresh`. Requirements
+and the production compose are in [Self-hosting](self-hosting.md).
 
-PlayFab auth paths map 1:1:
+### Phase 2 - port auth (2-5 days)
 
-`LoginWithCustomID` maps directly to guest auth - Asobi handles create-or-resume
-server-side, so there is no client-generated password to persist:
+`LoginWithCustomID` maps to guest auth. The client generates a random
+`device_secret` of at least 32 bytes on first launch and posts it with a stable
+`device_id`; the server creates the player, or resumes it on later launches:
 
-```csharp
-// Before (PlayFab)
-PlayFabClientAPI.LoginWithCustomID(new LoginWithCustomIDRequest {
-  CustomId = deviceId, CreateAccount = true
-}, OnSuccess, OnError);
-
-// After (asobi) — anonymous guest, create-or-resume from a device-held secret
-var client = new AsobiClient("https://api.my-game.com");
-await client.Auth.GuestAsync(deviceId, deviceSecret);   // POST /auth/guest
-// later, when the player signs up for real:
-// await client.Auth.UpgradeGuestAsync(username, password);
+```bash
+curl -s localhost:8084/api/v1/auth/guest \
+  -H 'content-type: application/json' \
+  -d '{"device_id":"<stable device id>","device_secret":"<base64 of >= 32 random bytes>"}'
 ```
 
-Store `deviceSecret` (>= 32 random bytes) in secure device storage; see the
-[Authentication guide](authentication.md#guest-anonymous).
+Treat `device_secret` as that account's password and keep it in secure device
+storage; every SDK does this for you. Claim the account later with
+`POST /api/v1/auth/guest/upgrade`.
 
-OAuth providers (Google, Apple, Steam) go through
-`POST /api/v1/auth/oauth` — same as PlayFab's `LoginWithGoogleAccount` etc.
+Guest auth is opt-in and off until two things are true: the game declares
+`guest_auth` in its Lua config, and the operator supplies a pepper of at least
+32 bytes. Either one missing and the endpoint answers `guest.disabled`. See
+[Authentication](authentication.md).
 
-### Phase 3 — port the data domains one at a time (1-2 weeks)
+OAuth providers go through `POST /api/v1/auth/oauth`, replacing
+`LoginWithGoogleAccount` and friends.
 
-Run PlayFab and asobi in parallel. For each domain:
+### Phase 3 - port the data domains one at a time (1-2 weeks)
 
-- Migrate the PlayFab data snapshot to asobi's Postgres schema (one-off
-  script per domain)
-- Dual-write: the client hits PlayFab AND asobi for the same action
-- Read from asobi; diff vs PlayFab for a day
-- Switch reads to asobi; keep PlayFab dual-write for rollback
-- After a week of clean asobi reads, stop writing to PlayFab
+Run PlayFab and asobi in parallel. Per domain:
 
-Order: **Leaderboards → Inventory → Virtual Currency → Storage → Friends →
-Groups → Matchmaking**. Leave matchmaking last because it's the most
-stateful handoff.
+- Migrate the PlayFab snapshot into asobi's Postgres schema with a one-off
+  script.
+- Dual-write: the client hits both for the same action.
+- Read from asobi, diff against PlayFab for a day.
+- Switch reads to asobi, keep the PlayFab write for rollback.
+- After a week of clean reads, stop writing to PlayFab.
 
-### Phase 4 — port CloudScript (2 days – 2 weeks)
+Order: leaderboards, inventory, virtual currency, storage, friends, groups,
+matchmaking. Matchmaking last, because it is the most stateful handoff.
 
-Rewrite each CloudScript function either as:
+### Phase 4 - port CloudScript (2 days to 2 weeks)
 
-- A **Lua callback** in `match.lua` (for per-match logic — e.g.
-  `handle_input`, `tick`)
-- An **asobi REST controller** in Erlang (for domain logic — economy
-  rules, tournament brackets, daily quest resets)
+Each CloudScript function becomes one of three things:
 
-If your PlayFab workload is CloudScript-heavy, budget more time for this
-phase. The upside: hot-reload replaces the CloudScript deploy loop.
+- A Lua callback in `match.lua`, for per-match logic.
+- An extension RPC method, for anything a client calls by name. This is the
+  closest equivalent and the one most CloudScript functions map onto. See
+  [Extensions](extensions.md).
+- A Shigoto job, for scheduled work such as a daily reset.
 
-### Phase 5 — cut over (1 day)
+The upside is that live Lua reload replaces the CloudScript deploy loop.
 
-Flip the SDK base URL from PlayFab to your asobi endpoint via a feature
-flag. Monitor for 24h. Retire the PlayFab Title.
+### Phase 5 - cut over (1 day)
 
-## Deploy story
+Flip the SDK base URL behind a feature flag. Monitor for 24h. Retire the
+PlayFab Title.
 
-| Host | Fit | Rough cost |
-|---|---|---|
-| **Hetzner Cloud** (CX22–CX42) | Best price/perf. EU-only. | €4–15 / month |
-| **Scaleway Serverless** | Auto-scale for dev / low traffic | Free tier → pay per req |
-| **Fly.io** | Multi-region one-liner | $5+/month/region |
-| **Clever Cloud** | git-push deploy, EU | €10+/month |
-| **On-prem (your datacentre)** | Regulated / sovereign workloads | Your hardware cost |
+## What asobi does not do
 
-A studio running PlayFab Multiplayer Servers at, say, $300/month in VM
-credits typically fits on a €15/month Hetzner CX32 box with asobi.
+- No hosted analytics dashboard. Telemetry is emitted; you pipe it somewhere.
+  This is the biggest gap against PlayFab Insights.
+- No A/B testing or segmentation framework.
+- No push notification service. Use APNs, FCM or a third party directly; the
+  built-in notifications are in-game only.
+- No hosted voice.
+- No player-support tooling. The console is read-only, so refunds, bans and
+  grants are your own code.
+- No Entity model. `player_id` is the primary key and you are not required to
+  model everything as an entity with objects.
 
-## Things asobi does NOT do (compared to PlayFab)
+## What asobi does that PlayFab does not
 
-- **No hosted analytics dashboard.** We emit telemetry; you pipe it
-  somewhere. PlayFab Insights is the biggest DX gap.
-- **No built-in A/B testing / segmentation framework.** Coming in 2026. For
-  now, roll it in your match logic.
-- **No push notification service.** Use OneSignal, Firebase Cloud
-  Messaging, or APNs directly.
-- **No hosted voice.** Pair with Vivox / Dissonance / Agora.
-- **No Title-as-a-product support tools** (refunds portal, player support
-  console). On the admin dashboard roadmap.
-- **No mandated Entity model.** asobi is pragmatic: player_id is the
-  primary key; you don't have to model everything as Entity-With-Objects.
+- Live Lua reload without dropping players.
+- Open source: read it, fork it, run it.
+- Linux servers throughout.
+- One matchmaker rather than several overlapping services.
+- Friends, groups, chat, votes, tournaments and phases as first-class
+  primitives; seasons ship as the
+  [`asobi_seasons`](https://github.com/widgrensit/asobi_seasons) extension.
+- Built-in voting: plurality, ranked, approval, weighted.
+- First-class Godot, Defold and LÖVE SDKs alongside Unity, Unreal, JS and
+  Dart, plus a Flame bridge on top of the Dart one.
 
-## Things asobi does that PlayFab doesn't
+## Cost
 
-- Hot-reload game logic without dropping players
-- Open-source — read the code, fork it, own it
-- Linux servers are first-class
-- One unified matchmaker, not three competing services
-- Friends / groups / chat / votes / tournaments / phases as first-class
-  primitives, not bolt-ons; seasons and quests as extensions
-- Built-in voting system (plurality, ranked, approval, weighted)
-- Godot and Defold SDKs at engine-parity with Unity
+PlayFab bills tiers, metered analytics and VM-minute multiplayer servers. asobi
+is a container whose cost you choose, plus a Postgres. A single node holds
+3,000-7,000 concurrent WebSocket connections in measurement - see
+[Benchmarks](benchmarks.md) - so most studios' first deployment is one small
+machine.
 
-## Cost comparison
-
-| | PlayFab Essentials | PlayFab paid | asobi self-host | asobi managed (soon) |
-|---|---|---|---|---|
-| Base | Free tier | $99+/mo | €5–20/mo infra | ~€9–29/mo |
-| Multiplayer servers | N/A | VM-minute billing | Same container | Included |
-| Analytics add-ons | Limited | Data Explorer metered | Bring your own stack | Bring your own |
-| Egress | N/A | Azure rates | Your host's rates | Flat |
-| Vendor lock-in | High (Azure) | High | None (Apache-2) | Exit runbook |
+If you plan to run more than one node, read [Clustering](clustering.md) first:
+the matchmaker queue is per node, so players queuing against different nodes
+never match each other, rate limits are per node, and the console needs a
+sticky route.
 
 ## Do this today
 
-- [ ] `git clone` [asobi_lua](https://github.com/widgrensit/asobi_lua) and
-  `docker compose up`. Register a player. Confirm it works.
-- [ ] Pick the smallest PlayFab API your game calls (often leaderboards
-  or a single CloudScript function). Port it to asobi in a feature flag.
-- [ ] Join the [Discord](https://discord.gg/vYSfYYyXpu) `#migrations`
-  channel. We'll sanity-check your staging order.
+- Run the Phase 1 compose locally and register a player.
+- Pick the smallest PlayFab API your game calls, usually leaderboards or one
+  CloudScript function, and port it behind a feature flag.
+- Join the [Discord](https://discord.gg/vYSfYYyXpu) `#migrations` channel.
 
 ## Getting help
 
-- **Discord**: [#migrations](https://discord.gg/vYSfYYyXpu) channel
-- **Email**: hello@asobi.dev
-- **GitHub Discussions**: [widgrensit/asobi_lua/discussions](https://github.com/widgrensit/asobi_lua/discussions)
+- Discord: [#migrations](https://discord.gg/vYSfYYyXpu)
+- Email: hello@asobi.dev
+- GitHub Discussions:
+  [widgrensit/asobi/discussions](https://github.com/widgrensit/asobi/discussions)
 
 ## See also
 
 - [Migrating from Hathora](migrate-from-hathora.md)
 - [Migrating from Nakama self-host](migrate-from-nakama.md)
 - [Exit guarantee](exit.md)
-- [Comparison vs Nakama, Colyseus, SpacetimeDB](comparison.md)
+- [Comparison](comparison.md)

--- a/guides/performance-tuning.md
+++ b/guides/performance-tuning.md
@@ -1,92 +1,68 @@
-# Performance Tuning
+# Performance tuning
 
-Optimisation features for high-throughput world and match servers. All are
-opt-in and backward compatible; existing configurations work unchanged.
+What costs CPU in a busy world or match server, and what you can actually
+change about it.
 
-Every feature here is game config or logic. It is identical on managed Cloud
-(`asobi deploy`, console.asobi.dev) and on a self-hosted release - the same
-script, the same globals. Only the base server URL your client SDK points at
-differs, and that is covered in [Getting Started](getting-started.md).
+Everything here is game logic. It is the same whether you run the image and
+write Lua or depend on the Hex package and write Erlang.
 
-## Spatial Grid Index
+## Spatial queries
 
-By default, spatial queries scan all entities in a zone (O(n)). For zones with
-many entities, enable the cell-based spatial grid for O(1) cell lookup plus a
-local scan. Set the cell size as a global in your world script.
+Spatial queries scan every entity in the zone. There is no index: the zone
+falls back to a linear scan on every query, always. Budget for O(n) per query
+and keep zone populations small enough that it does not matter.
 
-<!-- tabs -->
-**Lua**
-```lua
--- world.lua
-game_type              = "world"
-spatial_grid_cell_size = 16
-```
+Query from Lua through the `game.spatial` namespace:
 
-**Erlang**
-```erlang
-Config = #{
-    game_module => my_world,
-    spatial_grid_cell_size => 16
-}.
-```
-<!-- /tabs -->
-
-The grid is maintained automatically as entities are added, removed, or moved
-during ticks. Query it through the `game.spatial` namespace:
-
-<!-- tabs -->
-**Lua**
 ```lua
 -- inside zone_tick or handle_input, where the zone is in scope
 local hits = game.spatial.query_radius(100, 200, 50)
 ```
 
-**Erlang**
+In Erlang:
+
 ```erlang
 Results = asobi_zone:query_radius(ZonePid, {100.0, 200.0}, 50.0).
 ```
-<!-- /tabs -->
 
-`game.spatial` also offers `query_rect`, `nearest`, `in_range` and `distance`.
-Only `query_radius` and `query_rect` have zone-based forms and need a zone in
-scope; `nearest`, `in_range` and `distance` are entity-list forms
-(`game.spatial.query_radius(entities, x, y, radius)`) and work anywhere.
+Two forms read the zone and so need a zone in scope:
 
-When no `spatial_grid_cell_size` is configured, the zone falls back to the
-brute-force scan.
+- `query_radius(x, y, radius)`
+- `query_rect(x1, y1, x2, y2)`
 
-### Cell Size Guidelines
+The rest take their data as arguments and work anywhere:
 
-| Entity Density | Recommended Cell Size |
-|---------------|----------------------|
-| Sparse (< 50/zone) | Do not enable (overhead not worth it) |
-| Medium (50-200/zone) | 32-64 units |
-| Dense (200+/zone) | 8-16 units |
+- `query_radius(entities, x, y, radius[, opts])` and
+  `nearest(entities, x, y, n[, opts])` take a table of entities.
+- `in_range(entity_a, entity_b, range)` and `distance(entity_a, entity_b)` take
+  two entities, not a list. There is no entity-list form of either.
 
-## Broadcast Batching
+`query_rect` has no entity-list form: it is zone-only.
 
-Zone deltas are JSON-encoded once and the pre-encoded binary is sent to all
-subscribers, replacing N `json:encode` calls with exactly 1. This is automatic;
-no configuration needed. Subscribers receive `zone_delta_raw` messages that the
-WebSocket handler forwards without re-encoding.
+## Broadcast batching
 
-## Match State Broadcast (Shared vs Per-Player)
+Zone deltas are JSON-encoded once per tick and the pre-encoded binary is sent
+to every subscriber, replacing N `json:encode` calls with one. This is
+automatic. Subscribers receive `zone_delta_raw` messages that the WebSocket
+handler forwards without re-encoding.
+
+## Match state: shared or per player
 
 By default the match server calls `get_state(player_id, state)` once per player
-per tick and JSON-encodes each result. For games where every player sees the
-same world (FFA shooters, racing, party games), opt into a single shared encode:
-the server calls the state function once per tick, encodes once, and broadcasts
-the same binary to everyone. At 200 players and 10 ticks/sec this drops 2000
-encodes/sec to 10.
+per tick and encodes each result separately. For games where every player sees
+the same world (free-for-all shooters, racing, party games), opt into a single
+shared encode: the server calls the state function once per tick, encodes once,
+and broadcasts the same binary to everyone. At 200 players and 10 ticks/sec
+that is 10 encodes/sec instead of 2000.
 
 Opt in from your match script by declaring `state_strategy = "shared"` and
-defining a one-arg state function. Games that need per-player filtering (fog of
-war, hidden hand) keep the two-arg form and pay the per-player cost.
+defining a one-argument state function. Games that need per-player filtering
+(fog of war, a hidden hand) keep the two-argument form and pay the per-player
+cost.
 
-<!-- tabs -->
-**Lua**
 ```lua
 -- match.lua
+match_size     = 4
 state_strategy = "shared"
 
 function get_state(state)
@@ -94,83 +70,55 @@ function get_state(state)
 end
 ```
 
-**Erlang**
+A shared script is routed through `asobi_lua_match_shared`, which exports
+`get_state/1`.
+
+Lua bots do not work in a shared-state mode: they receive the pre-encoded
+broadcast and cannot decode it, so `think` is called with an empty table and
+never sees the match. Keep the two-argument form in any mode you fill with bots
+- see [Lua bots](lua-bots.md#what-a-bot-script-gets).
+
+In Erlang, export exactly one of `get_state/1` or `get_state/2`; the match
+server detects which is exported and switches broadcast strategy accordingly.
+
 ```erlang
 -callback get_state(GameState) -> SharedState.
 ```
-<!-- /tabs -->
 
-The asobi_lua bridge routes a shared script through `asobi_lua_match_shared`,
-which exports `get_state/1`. In Erlang, export exactly one of `get_state/1` or
-`get_state/2`; the match server detects which and switches broadcast strategy.
-For multi-mode games, declare `state_strategy` in the mode's config, not in a
-shared file - see [Configuration](configuration.md).
+For multi-mode games, declare `state_strategy` in the mode's config rather than
+in a shared file - see [Configuration](configuration.md).
 
-## Adaptive Tick Rates
+## Zone tick, hibernation and reaping
 
-Zones with no subscribers tick at a reduced rate to save CPU. Set the divisor as
-a global.
+Every active zone in a world ticks at the world's `tick_rate`. There is no hot
+and cold split and nothing promotes or demotes a zone; if the zone is active,
+it ticks.
 
-<!-- tabs -->
-**Lua**
-```lua
--- world.lua
-cold_tick_divisor = 10
-```
+What does happen automatically:
 
-**Erlang**
-```erlang
-Config = #{cold_tick_divisor => 10}.
-```
-<!-- /tabs -->
+- A zone whose subscribers have dropped to zero **and** which holds no NPC
+  entities goes into BEAM hibernation on its next tick, collapsing its heap.
+  NPCs are the only entity type that keeps a zone awake.
+- The zone manager sweeps every 10s. A zone becomes eligible either the moment
+  its last occupant leaves, or after 30s without a touch. It is then *asked* to
+  stop: a zone still holding entities declines and re-touches its own timer, so
+  only an empty zone actually goes away. A join or crossing that finds its zone
+  reaped starts a replacement transparently.
 
-| Zone State | Tick Rate | When |
-|-----------|-----------|------|
-| Hot | Full (every tick) | Has subscribers |
-| Cold | 1/N (every Nth tick) | Entities but no subscribers |
-| Empty | Not ticked | No entities, no subscribers |
-
-Promotion and demotion between hot and cold are handled automatically by the
-zone manager based on subscriber presence, so a game script never manages tick
-state directly.
-
-## Binary Protocol
-
-For maximum throughput, a client can negotiate binary WebSocket frames instead
-of JSON. This is a client-side choice, identical on Cloud and self-hosted: set
-`binary_protocol: true` in the `session.connect` payload. JSON remains the
-default; binary is opt-in per connection.
-
-Binary frames use a Tag-Length-Value format:
-
-```
-[type:u8][length:u32be][payload:bytes]
-```
-
-| Tag | Type | Payload |
-|-----|------|---------|
-| 0x01 | Terrain chunk | coords (2x i32) + compressed data |
-| 0x02 | Entity deltas | tick (u64) + counted delta list |
-| 0x03 | Match state | Reserved |
-
-Terrain chunks save ~25% versus JSON+base64; entity deltas save 15-30% depending
-on field count. Frame encoding and decoding is handled by the server and SDKs -
-see the [WebSocket protocol](websocket-protocol.md) guide.
+Both of those are fixed in the deployment. See
+[Large worlds](large-worlds.md#zone-lifecycle) for what that means for a big
+map.
 
 ## Checkpoint
 
-1. Add `spatial_grid_cell_size = 16` to a busy `world.lua`, redeploy (Cloud:
-   `asobi deploy`; self-hosted: your release), and call
-   `game.spatial.query_radius(x, y, r)` from `zone_tick`. It returns the same
-   hits as before, now backed by the grid rather than a full scan.
-2. In a match where everyone shares one view, set `state_strategy = "shared"`
-   and a one-arg `get_state(state)`. With 100+ players connected, server encode
-   count per tick should drop from once-per-player to once total.
-3. Leave a zone with no subscribers. Confirm it ticks at roughly
-   `1 / cold_tick_divisor` of the hot rate, and that an empty zone stops ticking
-   entirely.
+1. In a match where everyone shares one view, set `state_strategy = "shared"`
+   and a one-argument `get_state(state)`. With 100+ players connected, encodes
+   per tick drop from once-per-player to once total.
+2. Leave a zone with no subscribers and no NPCs. Its process memory falls at
+   the next tick (hibernation), and it stops entirely at the next sweep once
+   it holds no entities at all.
 
 ## Next
 
-[Large Worlds](large-worlds.md) - lazy zone loading, terrain providers, and the
-zone lifecycle these tuning knobs sit on top of.
+[Large worlds](large-worlds.md) - the zone lifecycle and terrain providers
+these costs sit on top of.

--- a/guides/phases.md
+++ b/guides/phases.md
@@ -94,9 +94,7 @@ See the callback reference for the full callback list.
 
 ### What the client sees on the wire
 
-A **world** pushes `world.phase_changed` on every transition and again
-roughly every three seconds while a phase runs. The payload is the phase
-info block:
+A **world** pushes `world.phase_changed` on every transition:
 
 ```json
 {
@@ -106,16 +104,33 @@ info block:
     "phase": "combat",
     "remaining_ms": 118400,
     "config": {},
+    "timers": {},
     "world_id": "..."
   }
 }
 ```
 
-A **match** does not push a phase event. The match server runs the phase
-clock and your callbacks, but the client learns the phase by reading the
-`phase` block on the listing and join reply - `status`, `phase`,
-`remaining_ms` and the pending `start_condition`. Broadcast anything richer
-yourself from `on_phase_started`.
+It also re-sends the phase info periodically, and what a client actually
+receives is a **burst of identical frames**, not one frame every three seconds.
+The gate is a wall-clock check evaluated inside the tick loop, so it passes on
+every tick that falls in a qualifying second: at the default 20 Hz that is
+roughly twenty copies, once every three seconds. A slower `tick_rate` sends
+fewer, a faster one more.
+
+Dedupe on the client. Keep the last `(phase, status)` you rendered and ignore a
+frame that repeats it; use `remaining_ms` for the countdown rather than
+counting frames.
+
+Two other differences in the periodic frames worth handling: they carry no
+`world_id` (only the transition frame merges it in), and a world whose phases
+have all completed sends `{"status": "complete", "phase": "undefined"}` on
+repeat - the string, not `null`.
+
+A **match** does not push a phase event at all. The match server runs the phase
+clock and your callbacks, but the client learns the phase by reading the `phase`
+block on the listing and join reply - `status`, `phase`, `remaining_ms` and the
+pending `start_condition`. Broadcast anything richer yourself from
+`on_phase_started`.
 
 See [WebSocket protocol](websocket-protocol.md#worldphase_changed-server-push)
 for the frame envelope and [Lobbies](lobbies.md) for `game.broadcast`.
@@ -150,6 +165,23 @@ function, or the `players_ratio` and `event` start conditions - those need
 an Erlang game module. If a phase needs a timer, drive it from your own tick
 logic and `game.broadcast`, or move that game to Erlang.
 
+### Three ways a phase list fails quietly
+
+The decoder is forgiving, and three mistakes cost you a warning you will never
+see:
+
+- **A non-numeric `duration` becomes 0.** `duration = "10000"` is a string, so
+  the phase starts and ends in the same tick. Only a Lua number works.
+- **An unrecognised `start` falls back to `prev_ended`.** `start = "all-ready"`
+  or `start = "players"` is not rejected; the phase simply begins when the
+  previous one ends. The accepted values are exactly the table above.
+- **A phase table with no `name` is dropped from the list.** The rest of the
+  list still runs, so a three-phase game silently becomes a two-phase one.
+
+Only a non-list return from `phases()` logs anything. Check the phase names on
+the wire (`world.phase_changed`) or in the `phase` block on a listing before
+concluding a phase never fired.
+
 ## Seasons
 
 Seasons live in [`asobi_seasons`][seasons], an extension. asobi still creates
@@ -169,13 +201,16 @@ Phases, with a Lua world game running locally:
    world script.
 2. Join the world over the WebSocket and watch the frames. Within a few
    seconds you see `world.phase_changed` with `"phase": "warmup"`, then
-   after five seconds another with `"phase": "active"`.
+   after five seconds another with `"phase": "active"`. Expect repeats of the
+   same frame in between; that is the periodic re-send, not a second
+   transition.
 3. Call `world.list`; the entry carries a `phase` block with the live
    `phase` and `remaining_ms`.
 
-If the phase frames never arrive, confirm the game is a **world** (matches
-run phases but do not push them) and that `phases()` returns a list. A
-non-list logs a warning and is ignored.
+If the phase frames never arrive, confirm the game is a **world** (matches run
+phases but do not push them) and that `phases()` returns a list. A non-list
+logs a warning and is ignored. If some phases arrive and others do not, check
+the [three silent decoder failures](#three-ways-a-phase-list-fails-quietly).
 
 ## Next
 

--- a/guides/rest-api.md
+++ b/guides/rest-api.md
@@ -10,24 +10,26 @@ Authenticated endpoints require the `Authorization: Bearer <access_token>` heade
 > presence, and live game state are pushed over the [WebSocket
 > protocol](websocket-protocol.md), not polled here.
 
-> **Windows / PowerShell**: examples below use `curl` (Linux, macOS, Git Bash,
-> WSL). In PowerShell, translate any block by hand once - the shape is the same:
->
-> ```powershell
-> Invoke-RestMethod -Uri http://localhost:8084/api/v1/auth/register `
->   -Method Post -ContentType application/json `
->   -Body '{"username": "player1", "password": "secret123"}'
-> ```
->
-> Add auth with `-Headers @{ Authorization = "Bearer $token" }`.
-> `Invoke-RestMethod` parses the JSON response for you, so no `jq` is needed.
+**Windows / PowerShell.** The examples below use `curl` (Linux, macOS, Git
+Bash, WSL). In PowerShell, translate any block by hand once - the shape is the
+same:
+
+```powershell
+Invoke-RestMethod -Uri http://localhost:8084/api/v1/auth/register `
+  -Method Post -ContentType application/json `
+  -Body '{"username": "player1", "password": "secret123"}'
+```
+
+Add auth with `-Headers @{ Authorization = "Bearer $token" }`.
+`Invoke-RestMethod` parses the JSON response for you, so no `jq` is needed.
 
 ## Auth
 
 ```
 POST   /api/v1/auth/register        Register a new player
-POST   /api/v1/auth/login           Login, returns session token
-POST   /api/v1/auth/refresh         Refresh session token
+POST   /api/v1/auth/login           Sign in, returns an access + refresh pair
+POST   /api/v1/auth/refresh         Exchange a refresh token for a new pair
+POST   /api/v1/auth/logout          Revoke the current tokens
 POST   /api/v1/auth/oauth           OAuth / Steam token validation
 POST   /api/v1/auth/guest           Create or resume an anonymous guest
 POST   /api/v1/auth/guest/upgrade   Claim a guest account (username + password)
@@ -59,6 +61,27 @@ curl -X POST /api/v1/auth/login \
 {"player_id": "...", "access_token": "...", "refresh_token": "...", "username": "player1"}
 ```
 
+### Logout
+
+Unauthenticated, because it accepts a token that may already have expired.
+Send the refresh token in the body to kill the whole refresh family; the
+access token in the `Authorization` header is revoked too, so it cannot
+outlive its cache TTL.
+
+```bash
+curl -X POST /api/v1/auth/logout \
+  -H 'Content-Type: application/json' \
+  -H "Authorization: Bearer $ACCESS_TOKEN" \
+  -d '{"refresh_token": "..."}'
+```
+
+```json
+{"success": true}
+```
+
+Always **200**, including with no body and no header at all: logout is
+idempotent and reports nothing about which token was valid.
+
 ### Guest
 
 Anonymous device-based auth, opt-in via config. `POST /auth/guest` creates a
@@ -77,6 +100,10 @@ curl -X POST /api/v1/auth/guest \
 {"player_id": "...", "access_token": "...", "refresh_token": "...",
  "username": "guest_9c41e0b7a2d5f318", "created": true, "guest": true}
 ```
+
+`created` is present only on the call that created the player. A resume
+returns the same body without it, so treat a missing `created` as `false`
+rather than expecting the key.
 
 ## Players
 
@@ -97,10 +124,12 @@ POST /api/v1/worlds         Create a world
 `has_capacity=true`. Only worlds whose mode sets `listed` (the default) are
 returned. Results are cached for 500ms.
 
-`POST /api/v1/worlds` returns **201** with the world info, **429** when the
-player is at their per-player cap (`player_world_limit_reached`), and **503**
-when the global cap is reached (`world_capacity_reached`). See
-[World capacity](configuration.md#world-capacity).
+`POST /api/v1/worlds` returns **201** with the world info, **429**
+`world.player_limit_reached` when the player is at their per-player cap, and
+**503** `world.capacity_reached` when the global cap is reached. See
+[World capacity](configuration.md#world-capacity). The equivalent
+`world.create` failures over WebSocket carry no code of their own - see the
+[WebSocket protocol](websocket-protocol.md).
 
 `GET /api/v1/worlds/:id` returns **404** for an unknown id.
 
@@ -152,7 +181,7 @@ DELETE /api/v1/groups/:id/members/:player_id         Kick member
 ```
 GET  /api/v1/wallets                   List player wallets
 GET  /api/v1/wallets/:currency/history Transaction history
-GET  /api/v1/store                     List store catalog
+GET  /api/v1/store                     List store catalogue
 POST /api/v1/store/purchase            Purchase item
 GET  /api/v1/inventory                 List player items
 POST /api/v1/inventory/consume         Consume item
@@ -169,6 +198,20 @@ GET  /api/v1/leaderboards/:id/around/:player_id Around player
 POST /api/v1/leaderboards/:id                  Submit score
 ```
 
+`GET /api/v1/leaderboards/:id` accepts `?limit`, default 100, clamped to
+1-100. `GET .../around/:player_id` accepts `?range`, default 5, clamped to
+1-50, and returns that many entries either side. A non-numeric value falls
+back to the default rather than erroring.
+
+`POST /api/v1/leaderboards/:id` is **off by default** and answers **403**
+`leaderboard.client_submit_disabled`. Scores are normally submitted from game
+code, where the client cannot forge them. An operator opts a board in by
+listing its id under the `leaderboard_client_submit` application env, or by
+setting that to `all` - reasonable for a casual scoreboard where cheating
+does not matter, wrong for anything competitive.
+
+A board that is full answers **503** `leaderboard.capacity_reached`.
+
 ## Matchmaking
 
 ```
@@ -176,6 +219,15 @@ POST   /api/v1/matchmaker              Submit matchmaking ticket
 GET    /api/v1/matchmaker/:ticket_id   Check ticket status
 DELETE /api/v1/matchmaker/:ticket_id   Cancel ticket
 ```
+
+A ticket is only valid on the node that issued it. The queue lives in one
+process per node and there is no ticket table, so a status check or a cancel
+that lands on a second node answers **404** `matchmaker.ticket_not_found` for
+a ticket that is very much alive elsewhere. A cluster needs a sticky route
+pinning all three calls for one player to one node. Another player's ticket is
+**403** `forbidden`. See [Clustering](clustering.md).
+
+Ticket outcomes are pushed over WebSocket, not polled here.
 
 ## Tournaments
 
@@ -188,17 +240,27 @@ POST /api/v1/tournaments/:id/join      Join tournament
 ## Votes
 
 ```
-GET /api/v1/matches/:match_id/votes    List votes for a match (newest first, max 50)
-GET /api/v1/votes/:id                  Get a single vote with full results
+GET /api/v1/matches/:id/votes    List votes for a match (newest first, max 50)
+GET /api/v1/votes/:id            Get a single vote with full results
 ```
+
+The match list is **participant-only**: a caller who is not on the match's
+roster gets **403** `forbidden`, whether the match is live or finished. A
+vote whose visibility is `hidden` and whose status is not yet `resolved` has
+its `votes_cast` field withheld, so a participant cannot read who voted for
+what while the vote is still open.
 
 Voting itself happens over WebSocket. See the [Voting guide](voting.md).
 
 ## Chat
 
 ```
-GET /api/v1/chat/:channel_id/history   Message history (paginated)
+GET /api/v1/chat/:channel_id/history   Message history
 ```
+
+Requires membership of the channel: a non-member gets **403** `forbidden`, and
+so does a malformed channel id. `?limit` defaults to 50 and is clamped to
+1-200, oldest-first within the window.
 
 Real-time chat messages are sent and received over WebSocket.
 
@@ -233,6 +295,7 @@ DELETE /api/v1/storage/:collection/:key        Delete object
 ## Ops
 
 ```
+GET /api/v1/ops/stats                        Runtime health of this node
 GET /api/v1/ops/players                      Paginated player list
 GET /api/v1/ops/players/:id                  One player
 GET /api/v1/ops/matches                      Paginated match-record list
@@ -250,14 +313,38 @@ GET /api/v1/ops/chat/channels/:id/messages   Paginated channel history
 GET /api/v1/ops/tournaments                  Paginated tournament list
 GET /api/v1/ops/tournaments/:id              One tournament
 GET /api/v1/ops/notifications                Paginated sent notifications
+
+GET|POST|PUT|DELETE
+    /api/v1/ops/ext/:extension/:action       Dispatch to an installed extension
 ```
 
-The game-operations read plane, for a console rather than a game client. The
-lists differ from the ones above in three ways: they report a total, they
-accept a sort, and they page by offset.
+The game-operations plane, for a console rather than a game client. The lists
+differ from the ones above in three ways: they report a total, they accept a
+sort, and they page by offset.
+
+Core's ops routes are all reads. The only route that mutates is
+`/api/v1/ops/ext/:extension/:action`, and its behaviour comes from an
+installed extension.
 
 These routes do **not** accept player tokens. They are their own auth plane -
-see [Ops authentication](#ops-authentication) below.
+see [Ops authentication](#ops-authentication) below. For turning the console
+on, the environment variables and the operator narrative, see
+[Operator console](console.md).
+
+### What is node-local and what is not
+
+Four of these read live process state on the node that answers, so behind a
+load balancer two consecutive reads can disagree and neither is wrong:
+
+| Route | What it reads |
+| --- | --- |
+| `ops/stats` | This node's VM. `online_players` is the exception: presence is a cluster-wide process group, so that one gauge is fleet-wide. |
+| `ops/features` | This node's resolved extension set and configured capabilities. |
+| `ops/matchmaker` | This node's queue. The whole matchmaker is per node. |
+| `ops/chat/channels` | The chat channels running on this node. |
+
+Every other ops route reads Postgres and is therefore consistent whichever
+node answers. See [Clustering](clustering.md).
 
 Every list returns the same envelope:
 
@@ -276,8 +363,12 @@ Parameters shared by every ops list:
 | `page` | 1-based page number. Wins over `offset` when both are given. |
 | `offset` | Rows to skip. Clamped to 0-100000 and snapped down to a multiple of `limit`, so the `offset` in the response is the one the query ran with. |
 | `sort` | Field to sort by. Must be one of the fields listed below - anything else is **400**, never a silent fallback. |
-| `order` | `asc` (default) or `desc`. Anything else is **400**. |
-| `q` | Case-insensitive substring search. `%` and `_` are matched literally. |
+| `order` | `asc` (default) or `desc`, matched case-insensitively, so `DESC` works. Anything else is **400**. |
+| `q` | Case-insensitive substring search. `%` and `_` are matched literally. Only on the lists with something to search: not the queue, a board's entries, or listings. |
+
+`page` has its own ceiling of 10000 on top of the offset clamp, so the
+deepest reachable window is whichever of `page * limit` and 100000 is
+smaller.
 
 A malformed number is never an error: `?limit=abc` uses the default. A
 malformed *sort* always is, because ordering the wrong rows silently is worse
@@ -383,8 +474,8 @@ and `rewards` do.
 `player_id`, `type` and `read`, and searches the subject. It answers the
 question a broadcast raises: who received it, and how many have opened it.
 
-The ops plane is read-only, so there is no broadcast route here. The broadcast
-is an in-process entry point that writes an audit row - see
+Core's ops routes are all reads, so there is no broadcast route here. The
+broadcast is an in-process entry point that writes an audit row - see
 [Ops audit](#ops-audit).
 
 ### Leaderboards
@@ -464,7 +555,7 @@ data and waits on the capability model.
   "data": {
     "core": {
       "name": "asobi",
-      "version": "0.46.0",
+      "version": "0.68.2",
       "capabilities": [{ "name": "guest_auth", "enabled": true }]
     },
     "extensions": []
@@ -473,7 +564,9 @@ data and waits on the capability model.
 ```
 
 Capabilities report what is *configured*, not what is compiled in, and carry a
-boolean only - never the configured value.
+boolean only - never the configured value. `lua` is the one exception: it is a
+module check, and it is true in every stock release because the Lua runtime
+ships in asobi.
 
 `extensions` is the resolved extension set, in dependency order and in the
 same shape as `core`, so a client reads one row type:
@@ -492,6 +585,77 @@ table name. `[]` when nothing is installed.
 This is what a console reads to decide which of its built-in screens to
 render, and to surface a version it was not built against.
 
+### Stats
+
+`GET /api/v1/ops/stats` is the runtime health of **one node**. Everything in
+it comes from the VM or from presence, so it stays answerable when Postgres
+is the thing that is unwell.
+
+```json
+{
+  "data": {
+    "node": "asobi@10.0.1.7",
+    "online_players": 412,
+    "process_count": 8134,
+    "process_limit": 262144,
+    "memory_total": 184549376,
+    "memory_processes": 71303168,
+    "memory_ets": 12582912,
+    "memory_binary": 33554432,
+    "run_queue": 0,
+    "scheduler_count": 8,
+    "uptime_ms": 864000000
+  }
+}
+```
+
+`node` is in the response because every node serves its own copy of this
+endpoint and the numbers are per node. Behind a load balancer a reading
+without a node name is a reading you cannot act on: poll every node and key
+the results on this field.
+
+`online_players` is the one fleet-wide figure here, and it is `null` rather
+than an error if presence is momentarily unavailable. Memory gauges are
+bytes; `uptime_ms` is wall-clock milliseconds since this node booted.
+
+There is no push variant. The console polls.
+
+### Extension actions
+
+`/api/v1/ops/ext/:extension/:action` is the one ops route core owns on behalf
+of extensions, and the one route on the plane that can mutate. Everything
+about it comes from the installed extension's manifest: which actions exist,
+which HTTP method each answers, which capability class it needs, and what it
+does.
+
+An action nobody declared has no class, and an untagged route is denied, so
+an unknown extension, an unknown action and a method the action does not
+answer are all **403**, never 404. Enumerating which extensions are installed
+is not something an unauthorised caller gets to do. `GET /api/v1/ops/features`
+is where an authorised caller reads the installed set.
+
+A `get` action receives the parsed query string; any other method receives the
+decoded JSON body. Both arrive as a map with string keys. On success the
+handler's own object is the response body verbatim, with no `data` envelope
+around it, so this route does not share the shape the lists above use. A
+failure is the shared error object, carrying a code the extension declared -
+an undeclared code is refused and answered `internal`.
+
+Every method other than `get` is wrapped in the audit path, so an extension
+cannot write on this plane without core recording who asked. Declaring a
+method other than `get` is what opts an action in; there is nothing to
+configure.
+
+That recording is currently incomplete. Only a failure returned without
+details reaches `ops_audit_entries`; a successful call, and a failure carrying
+details, raise inside the audit path and are logged at error level as
+`ops audit row not written`, carrying the action but not the row's own
+fields. The call itself still runs and still answers normally. Ship your logs
+and treat them as part of the audit trail until that is fixed.
+
+While the node is still running migrations the route answers **503**
+`not_ready`, before the extension's handler runs.
+
 ### Ops authentication
 
 Ops routes sit behind an operator credential, never a player token. Send the
@@ -502,36 +666,99 @@ GET /api/v1/ops/players
 Authorization: Bearer <ops_secret>
 ```
 
-Configure it with the `ops_secret` application env (see
-[Configuration](configuration.md#ops-plane)). There is **no default**: a
-deployment that has not set one rejects every ops request. A player or guest
-token is rejected the same way - the ops plane never consults the player token
-store at all.
+There is **no default** secret. A deployment that has not set one rejects
+every ops request, so the plane is closed until an operator opens it. A player
+or guest token is rejected the same way: the ops plane never consults the
+player token store at all.
 
-Every rejection is `403` with `{"error": "forbidden"}`, whatever the cause. A
-caller cannot tell an unconfigured deployment from a wrong secret.
+The `console` setting gates the `/console` routes, not this one. An ops secret
+alone makes `/api/v1/ops/*` answerable without the console being on. For
+setting both, see [Operator console](console.md).
 
-A browser has a second transport for the same credential. `POST
-/console/session` with `{"secret": "..."}` exchanges the operator secret for
-an `HttpOnly` session cookie and a derived CSRF token; every later ops request
-then carries the cookie plus `x-csrf-token` instead of the bearer header. A
-cookie **without** a matching header is refused, so a cross-site request that
-arrives with the browser's cookies attached gets 403.
+Every rejection is **403** with the same body every other failure on this API
+returns:
 
-A bearer token wins when both are present. See
-[Configuration](configuration.md#operator-console).
+```json
+{"error": {"code": "forbidden", "message": "The caller may not perform this action.", "details": {}}}
+```
+
+That is the body whatever the cause. An unconfigured deployment, a wrong
+secret and a credential that lacks the route's capability class are
+indistinguishable to the caller, deliberately.
+
+A bearer token wins when both it and a console cookie are present.
 
 Each route carries exactly one capability class - `read`, `player_data` or
 `config` - and a request is admitted only if the credential holds that class.
-Everything above is `read`. Role names never appear on the wire.
+Every core route is `read`; an extension action's class comes from its
+manifest. Role names never appear on the wire.
 
-> #### One secret means one privilege level {: .warning}
->
-> The static secret resolves to all three classes, so anyone holding it holds
-> `config`. A studio cannot hand a community manager `player_data` without
-> also handing over everything else. Restrict who reaches the console at all
-> with a reverse proxy; per-person capabilities arrive with managed cloud,
-> which mints a short-lived token carrying an explicit capability list.
+### Console session
+
+A browser has a second transport for the same credential. These three routes
+are outside `/api/v1` and are not themselves behind the ops credential - the
+login endpoint cannot require the credential it exists to accept.
+
+```
+GET    /console/session   Who this browser is, if anyone
+POST   /console/session   Exchange a credential for a session
+DELETE /console/session   End the session
+```
+
+`POST` takes `{"secret": "..."}` and an optional `"label"`, the display name
+the audit trail carries for this session. It defaults to `operator`, it is
+self-asserted, and it is held to the same shape as the `x-asobi-operator`
+header.
+
+```bash
+curl -X POST http://localhost:8084/console/session \
+  -H 'Content-Type: application/json' \
+  -d '{"secret": "'"$ASOBI_OPS_SECRET"'", "label": "kaito"}'
+```
+
+```json
+{"data": {"display": "kaito", "expires_at": 1785355200, "csrf": "..."}}
+```
+
+Two cookies come back. `asobi_console` holds the session id and is `HttpOnly`,
+so page script cannot read it. `asobi_console_csrf` holds the CSRF token and
+is deliberately **not** `HttpOnly`, because the page has to send it back as an
+`x-csrf-token` header and holding it only in memory would end the session on
+every reload. Every later ops request carries the cookie plus that header
+instead of the bearer token; a cookie without a matching header is refused, so
+a cross-site request that arrives with the browser's cookies attached gets
+403. `DELETE` is the exception and needs the cookie only, since it can only
+ever destroy authority.
+
+Both cookies are `SameSite=Lax`, path `/`, and `Secure` whenever the request
+looks like TLS directly or through a proxy that says so. The `x-csrf-token`
+header, not the cookie attribute, is what stops a cross-site write.
+
+`GET` returns the actor behind the session and requires both the cookie and
+the header, like any other ops read.
+
+```json
+{"data": {"display": "kaito", "source": "local_user", "caps": ["read", "player_data", "config"], "attested": false}}
+```
+
+A session resolves only on the node that minted it: the store is an ETS table
+owned by one process on that node, and the secret the CSRF token is derived
+from is generated at boot. Restarting the node ends every session in flight,
+and a round-robin load balancer 403s most console requests. Pin the console to
+one node. Sessions expire absolutely, after 12 hours by default, and reading
+one does not extend it.
+
+Every route in this group answers **404** when the console is switched off,
+which is the same 404 an unknown path gets. For the model, the environment
+variables and the credentials, see [Operator console](console.md).
+
+**One secret means one privilege level.** The static secret resolves to all
+three classes, so anyone holding it holds `config`. A studio cannot hand a
+community manager `player_data` without handing over everything else. Restrict
+who reaches the console at all with a reverse proxy. Per-person capabilities
+need the second credential shape the plane accepts: a minted token carrying an
+explicit capability list and a short expiry, issued by a control plane rather
+than configured on the node.
 
 Optionally send `x-asobi-operator: <name>` to name the human behind a shared
 secret. It is attribution only: it is read after the credential is accepted,
@@ -541,14 +768,15 @@ dropped rather than trusted.
 
 ### Ops audit
 
-Every ops-plane mutation writes a row to `ops_audit_entries`, carrying the
-acting operator (`actor_id`, `actor_display`, `actor_source`,
+Every ops-plane mutation is wrapped so it writes a row to `ops_audit_entries`,
+carrying the acting operator (`actor_id`, `actor_display`, `actor_source`,
 `actor_attested`), the action, its subject, and when it happened. Reads are
 not audited.
 
-The routes above are all reads, so nothing above writes a row yet. The table
-exists ahead of the write plane, and the one operator mutation that already
-exists - broadcasting a notification - goes through it.
+Core's own routes are all reads, so none of them writes a row. Two things go
+through the audit path: an extension action reached over
+`/api/v1/ops/ext/:extension/:action`, and the in-process notification
+broadcast entry point.
 
 `actor_attested` is the important column. A name that came from
 `x-asobi-operator` is self-declared, so it is stored `false`; only a verified
@@ -559,10 +787,15 @@ identity is stored `true`. Treat an unattested name as a hint, not evidence.
 never recorded as a success. Per-subject reasons sit in `details` and are
 diagnostic only; the counts are what you query.
 
-Rows are append-only and core never prunes them. Retention is yours to set:
-delete by `occurred_at`, which leads both composite indexes. Nothing cascades
-into the table either, so deleting a player does not erase the record of what
-was done to them.
+Rows are append-only and core never prunes them, so retention is yours to set.
+No index leads on `occurred_at`: it is the second column of the
+`(actor_id, occurred_at)` and `(action, occurred_at)` composites, and the only
+other index is on `target_id`. A delete scoped to time alone therefore scans
+the table. Prune in batches, off-peak, or add an index on `occurred_at` if you
+intend to prune by time on a schedule.
+
+Nothing cascades into the table, so deleting a player does not erase the
+record of what was done to them.
 
 An audit write never fails the operation it describes. It runs after the
 change has already happened, so refusing the response could only invite a
@@ -580,9 +813,14 @@ A failing request returns its HTTP status and one object:
 - `code` is the contract. It is stable, machine-readable, and namespaced by
   domain (`storage.`, `save.`, `auth.`, `guest.`, `player.`, `match.`,
   `world.`, `matchmaker.`, `leaderboard.`, `economy.`, `inventory.`, `iap.`,
-  `social.`, `chat.`, `dm.`, `tournament.`, `notification.`, `vote.`, `ops.`)
-  or bare when it is cross-cutting (`rate_limited`, `forbidden`,
-  `validation_failed`, `internal`). Branch on this.
+  `social.`, `chat.`, `dm.`, `tournament.`, `notification.`, `vote.`, `ops.`,
+  `rpc.`, `console.`, `ws.`) or bare when it is cross-cutting
+  (`internal`, `rate_limited`, `join_rate_limited`, `payload_too_large`,
+  `invalid_json`, `invalid_message`, `invalid_payload`, `missing_field`,
+  `unknown_type`, `unauthenticated`, `forbidden`, `validation_failed`,
+  `length_required`, `client_gate_denied`, `not_ready`). Branch on this. The
+  whole set is one list in `asobi_error`, and an extension may add codes only
+  in its own domain.
 - `message` is prose for a human reading a log. It may be reworded at any
   time. Do not parse it.
 - `details` is **always** an object, `{}` when there is nothing to add, so no
@@ -601,23 +839,16 @@ a code; it arrives inside `details` instead. So a rejected sign-in reads:
 {"error": {"code": "auth.provider_rejected", "message": "The identity provider rejected the token.", "details": {"reason": "publisher_banned"}}}
 ```
 
-> #### Rollout {: .info}
->
-> Every route returns this shape, as does every WebSocket `error` frame. There
-> is no route left on the older, flat body (`{"error": "some_string"}`) and
-> none that answers a failure with an empty body.
->
-> The change is additive except for `error` itself, which went from a string
-> to the object. A route that already sent more than `error` still sends it,
-> unchanged and in the same place: `fields` and `errors` on a 422, `retry_after`
-> on a 429, `field` and `order` on an ops sort rejection, `reason` on a
-> registration-gate 403. Each of those is repeated inside `details`, so new
-> code can read one place. The one key that moved is the bespoke top-level
-> `message` on `POST /auth/guest` when guest auth is disabled; the same prose
-> is now `error.message`.
->
-> Statuses did not change. Routes that used to answer 403 or 404 with no body
-> answer the same status, now with the object in it.
+Every route returns this shape, as does every WebSocket `error` frame. No
+route is left on the older, flat body (`{"error": "some_string"}`), and none
+answers a failure with an empty body.
+
+A route that already sent more than `error` still sends it, unchanged and in
+the same place: `fields` and `errors` on a 422, `retry_after` on a 429,
+`field` or `order` on an ops sort rejection, `reason` on a
+`client_gate_denied` 403. Each is repeated inside `details`, so new code reads
+one place. Statuses are unchanged; a route that answered 403 or 404 with no
+body answers the same status with the object in it.
 
 ## Next steps
 

--- a/guides/security-auth.md
+++ b/guides/security-auth.md
@@ -1,112 +1,103 @@
-# Authentication & rate limiting
+# Authentication and rate limiting
 
-This guide documents how asobi authenticates clients, validates
-purchases, and bounds the brute-force surface. For the higher-level
-trust assumptions see [Threat model](security-threat-model.md).
+How asobi authenticates clients, validates purchases, and bounds what a single
+hostile request or a single hostile caller can cost. For the trust assumptions
+underneath, see [Threat model](security-threat-model.md).
 
 ## Session bearer tokens
 
-Every authenticated route is gated by `asobi_auth_plugin:verify/1`,
-which expects an `Authorization: Bearer <token>` header. Tokens are
-issued by `nova_auth_refresh:generate_pair/2` (via
-`asobi_auth_tokens:issue/2,3`) after a successful `register/1`,
-`login/1`, `refresh/1`, or OAuth flow. The caller receives an access
-token plus a single-use rotating refresh token. The plugin attaches
-`auth_data => #{player_id => Id, ...}` to the request map — controllers
-should pattern-match on that rather than parsing the header themselves.
+Every authenticated route is gated by `asobi_auth_plugin:verify/1`, which
+expects an `Authorization: Bearer <token>` header. Tokens are issued by
+`nova_auth_refresh:generate_pair/2` through `asobi_auth_tokens:issue/2,3` after
+a successful register, login, refresh or provider flow. The caller receives
+`player_id`, `access_token`, `refresh_token` and `username`; the refresh token
+is single-use and rotates. The plugin attaches `auth_data => #{player_id => Id,
+...}` to the request map, so controllers pattern-match on that rather than
+parsing the header again.
 
-On logout the presented access token is revoked via
-`nova_auth_refresh:delete_access_token/2` (wrapped by
-`asobi_auth_tokens:revoke_access/1`) so it cannot outlive the cache TTL.
+On logout the presented access token is revoked through
+`asobi_auth_tokens:revoke_access/1`, so it cannot outlive the cache TTL.
 
 ## Apple StoreKit 2 JWS verification
 
-`asobi_iap:verify_apple/1` parses an Apple-signed JWS receipt and
-verifies it end-to-end:
+`asobi_iap:verify_apple/1` parses an Apple-signed JWS receipt and verifies it
+end to end:
 
-1. Header `alg` is required to be `ES256`. Other algorithms are
-   rejected.
-2. The `x5c` chain is decoded (DER-encoded certificates, base64'd in
-   JWS order: leaf → intermediate → root).
-3. The chain is validated against a configured Apple Root CA via
-   `public_key:pkix_path_validation/3`. The root is not bundled: operators
-   point `apple_root_cert_path` (or `apple_root_certs`) at it, and
-   verification returns `apple_root_cert_not_configured` if neither is set.
-4. The signature on `<header>.<payload>` is verified with the leaf
-   cert's public key. A bit-flipped signature, swapped signature, or
-   any chain mismatch fails the verification.
+1. The header `alg` must be `ES256`. Every other algorithm is rejected.
+2. The `x5c` chain is decoded (DER certificates, base64 in JWS order: leaf,
+   intermediate, root).
+3. The chain is validated against a configured Apple root CA with
+   `public_key:pkix_path_validation/3`. The root is not bundled: set
+   `apple_root_cert_path` or `apple_root_certs`, or verification returns
+   `apple_root_cert_not_configured`.
+4. The signature over `<header>.<payload>` is verified with the leaf
+   certificate's public key. Only then is the payload returned, and a bundle id
+   that is not the configured one fails with `bundle_id_mismatch`. Expiry is
+   reported as a `valid` flag on the result rather than rejected.
 
-Failures return `{error, Reason}` with a sanitised reason atom. The
-controller (`asobi_iap_controller`) maps them to 400/401 responses
-without leaking JWS internals to the client.
+Failures return `{error, Reason}` with a sanitised reason binary.
+`asobi_iap_controller` returns them as
+`{"error": {"code": "iap.verification_failed", "message": ..., "details":
+{"reason": ...}}}` without leaking JWS internals.
+
+There is no Lua path to IAP verification. It is an Erlang-side call on the
+purchase route.
 
 ## Steam ticket validation
 
-`asobi_steam:validate_ticket/1` validates a hex-encoded Steam session
-ticket against the Steam Web API:
+`asobi_steam:validate_ticket/1` validates a hex-encoded session ticket against
+the Steam Web API:
 
-1. The ticket character class is enforced (`[0-9a-fA-F]+`, max 4096
-   bytes). Anything else is rejected before any HTTP call.
-2. All dynamic URL components (key, app id, ticket, steam id) are
-   passed through `uri_string:quote/1` so an `&` or `=` in user input
-   cannot inject query parameters into the Steam call.
+1. The ticket must be `[0-9a-fA-F]+` and at most 4096 bytes. Anything else is
+   rejected before any HTTP call.
+2. Every dynamic URL component (key, app id, ticket, steam id) goes through
+   `uri_string:quote/1`, so an `&` or `=` in client input cannot inject a query
+   parameter into the Steam call.
 
-The ticket validator is invoked from `asobi_oauth_controller` for
-`provider = "steam"` flows.
+It is invoked from `asobi_oauth_controller` for `provider = "steam"`.
 
 ## Guest device verifiers
 
-Anonymous/guest auth (`asobi_guest_controller`) lets a device create a
-player from a `{device_id, device_secret}` pair without credentials. It
-is secured to leak nothing useful even if the identity table is dumped:
+Guest auth (`asobi_guest_controller`) lets a device create a player from a
+`{device_id, device_secret}` pair with no credentials. It is built to leak
+nothing useful even if the identity table is dumped.
 
-- **Fails closed.** The controller serves guest routes only when
-  `guest_auth` is `true` **and** a `guest_verifier_pepper` is
-  configured; otherwise every guest endpoint returns `403
-  guest_auth_disabled`.
-- **The device secret is never stored.** The database holds a
-  *verifier*, not the secret. On creation the server draws a 16-byte
-  salt from `crypto:strong_rand_bytes/1` and combines it with a
-  server-side pepper (selected by key id) as
-  `crypto:mac(hmac, sha256, Pepper, <<Salt/binary, Secret/binary>>)`.
-  The result is stored in the identity's `provider_metadata`
-  (`salt` / `key_id` / `verifier` / `revoked`, all base64).
-- **Timing-safe comparison.** Resume verifies with
-  `crypto:hash_equals/2` so a wrong secret can't be recovered by
-  timing.
-- **The pepper lives outside the database.** It is a keyed secret
-  (env/secret manager), so a dumped verifier table is useless without
-  it, and it is rotatable: add a new key id, point
-  `guest_verifier_key_id` at it, and keep old key ids for the retention
-  window so existing guests still resume.
-- **Bounded input.** The secret must base64-decode to at least 32 bytes
-  (under a fixed upper cap) and the `device_id` must be non-empty and
-  at most 255 bytes, so an unauthenticated caller can't force
+- Fails closed. Guest routes serve only when `guest_auth` is true and a
+  `guest_verifier_pepper` is configured. Otherwise every guest endpoint returns
+  `guest.disabled` (403) and the misconfiguration is logged as
+  `guest_auth_misconfigured`.
+- The device secret is never stored. The row holds a verifier: a 16-byte random
+  salt plus `crypto:mac(hmac, sha256, Pepper, <<Salt/binary, Secret/binary>>)`,
+  kept in the identity's `provider_metadata` as `salt`, `key_id`, `verifier`
+  and `revoked`, with the salt and the verifier base64-encoded.
+- Resume compares with `crypto:hash_equals/2`, so a wrong secret is not
+  recoverable by timing.
+- The pepper lives outside the database, selected by key id. A dumped verifier
+  table is useless without it, and it rotates: add a key id, point
+  `guest_verifier_key_id` at it, keep the old ids for the retention window.
+  A pepper under 32 bytes is treated as absent, so a truncated value fails
+  closed rather than weakening the MAC.
+- Bounded input. The secret must base64-decode to between 32 and 128 bytes and
+  `device_id` is capped at 255 bytes, so an unauthenticated caller cannot force
   multi-megabyte HMAC work.
-- **Upgrade is compromise-recovery.** Claiming a guest
-  (`/auth/guest/upgrade`) calls `nova_auth_refresh:revoke_all/2` to kill
-  the entire token family a stolen device secret may have minted, then
-  deletes the guest identity so the secret can no longer resume the
-  now-claimed account.
-- **Safe reaping.** The optional `asobi_guest_reaper` (off unless
-  `guest_reap_after` is set) re-checks that a guest is still unclaimed
-  *inside* its delete transaction, so a concurrent upgrade wins the
-  race. The unlinked-guest cap reads a short-TTL cached count and fails
-  closed if the count can't be read.
+- Upgrade is compromise recovery. Claiming a guest calls
+  `nova_auth_refresh:revoke_all/2` to kill the token family a stolen device
+  secret may have minted, then deletes the guest identity so that secret can no
+  longer resume the claimed account.
+- Reaping is safe. The optional `asobi_guest_reaper` (off unless
+  `guest_reap_after` is set) re-checks that a guest is still unclaimed inside
+  its delete transaction, so a concurrent upgrade wins the race.
 
-> #### Assurance level {: .warning}
->
-> Treat guest accounts as low-assurance until they are upgraded. Anything
-> valuable - purchases, competitive ranking, cross-device identity -
-> should require a claimed account, not a guest session.
+Treat guest accounts as low assurance until they are upgraded. Anything
+valuable - purchases, competitive ranking, cross-device identity - should
+require a claimed account.
 
 ## Registration mode
 
-Registration is **open by default** and that is deliberate (see ADR 0002):
-one asobi deployment serves one game, the endpoint URL is the game
-identity, and a downloadable client cannot prove it is "your" client. The
-`registration` app-env setting bounds anonymous signup as a *deployment*
-decision:
+Registration is open by default and that is deliberate (ADR 0002): one asobi
+deployment serves one game, the endpoint URL is the game identity, and a
+downloadable client cannot prove it is your client. `registration` bounds
+anonymous signup as a deployment decision:
 
 ```erlang
 {registration, open}         %% default
@@ -114,48 +105,65 @@ decision:
 %% {registration, closed}
 ```
 
-| Mode | Password register | OAuth first-time | Guest first-time | Existing players |
-|------|-------------------|------------------|------------------|------------------|
-| `open` (default) | ✅ | ✅ | ✅ (if `guest_auth`) | ✅ |
-| `oauth_only` | ❌ `403` | ✅ | governed by `guest_auth` | ✅ |
-| `closed` | ❌ `403` | ❌ `403` | ❌ `403` | ✅ login/refresh/resume |
+| Mode | Password register | Provider first-time | Guest first-time | Existing players |
+|---|---|---|---|---|
+| `open` (default) | allowed | allowed | allowed if `guest_auth` | allowed |
+| `oauth_only` | denied, `auth.password_registration_disabled` | allowed | governed by `guest_auth` | allowed |
+| `closed` | denied, `auth.registration_closed` | denied, `auth.registration_closed` | denied, `auth.registration_closed` | login, refresh and resume all still work |
 
-`oauth_only` refuses only password registration; guest signup keeps
-following its own `guest_auth` toggle. `closed` freezes every new-player
-path while leaving all existing players able to authenticate. An
-unrecognised value falls back to `open` and logs a warning.
+A game bundle can also declare `script_registration`; the operator's
+`registration` key wins wherever it is set, so a bundle can choose a posture
+for a deployment that states none but can never widen one that does
+(`asobi_registration`). An unrecognised value falls back to `open`, and
+`log_mode/0` reports `invalid_registration_mode` at error level at boot.
 
-> **Footgun (flip before release).** The shipped `examples/` quickstarts
-> and `asobi_register_bench` register headless with username/password and
-> rely on the `open` default - do not change it in dev/CI. Choosing a
-> stricter posture is a production deployment decision, the same way Photon
-> documents flipping `AllowAnonymous` before release. asobi logs the active
-> mode at boot (`event => registration_mode`) so the posture is visible.
+The shipped `examples/` quickstarts and `asobi_register_bench` register
+headless with a username and password, so leave `open` alone in dev and CI.
+Choosing a stricter posture is a production decision. asobi logs the active
+mode at boot as `event => registration_mode`.
 
-## Per-route rate limits
+## Rate limits
 
-`asobi_rate_limit_plugin` is wired as a `pre_request` plugin in
-`config/{dev,prod}_sys.config.src`. It selects a Seki limiter group
-based on the request path:
+`asobi_rate_limit_plugin` runs as a `pre_request` plugin in
+`config/{dev,prod}_sys.config.src` and picks a Seki limiter group from the
+request path. Other limiters are checked at their own call sites. Every group
+is registered by `register_limiters` in `asobi_sup`, and every bucket is
+**per node**: in a cluster of N nodes an attacker gets N times the budget.
 
-| Path | Limiter | Default limit (req/sec/IP) |
-|------|---------|----------------------------|
-| `/api/v1/auth/register` | `asobi_register_limiter` | 3 |
-| `/api/v1/auth/*` (login, refresh, ...) | `asobi_auth_limiter` | 5 |
-| `/api/v1/iap/*` | `asobi_iap_limiter` | 10 |
-| everything else | `asobi_api_limiter` | 300 |
+| Group | Limiter | Keyed on | Default | Where |
+|---|---|---|---|---|
+| `register` | `asobi_register_limiter` | IP, or player id if the request carries a Bearer token | 3 / sec | `/api/v1/auth/register` |
+| `auth` | `asobi_auth_limiter` | same | 5 / sec | the rest of `/api/v1/auth/*`, and `POST /console/session` |
+| `iap` | `asobi_iap_limiter` | same | 10 / sec | `/api/v1/iap/*` |
+| `api` | `asobi_api_limiter` | same | 300 / sec | every other HTTP route |
+| `ws_connect` | `asobi_ws_connect_limiter` | IP | 60 / sec | the WebSocket upgrade, spent before the Origin check |
+| `join` | `asobi_join_limiter` | player id | 10 / 60 sec | the `match.join` and `world.join` WebSocket frames |
+| `guest_global` | `asobi_guest_global_limiter` | one constant key | 100 / sec | guest creation, node-wide |
+| `rehome` | `asobi_rehome_limiter` | player id | 5 / sec | world zone crossings |
+| `rehome_global` | `asobi_rehome_global_limiter` | one constant key | 200 / sec | world zone crossings, node-wide |
+| `script_log` | `asobi_script_log_limiter` | the call site's own key | 3 / 10 sec | repeated warning lines from a failing script or dropped input |
 
-`/api/v1/auth/register` gets its own tighter bucket (asobi#157): it runs
-the password KDF (pbkdf2_sha256, see `pbkdf2_iterations`) as its only
-cost gate, so sharing the login bucket let a signup flood both starve
-honest logins and amplify server CPU. The dedicated 3/sec cap isolates
-register and bounds the per-IP KDF cost. This is per-IP only; distributed
-abuse is deferred to the pre-auth gate in asobi#158.
+`rate_limit_key/1` buckets an authenticated caller on `player_id` and everyone
+else on the peer IP, so one abusive player throttles themselves rather than
+everyone behind their NAT. Anything that is not a `Bearer` scheme, or that
+reaches the plugin without `auth_data`, falls back to the IP bucket.
 
-The auth limiter is the brute-force gate for login: a 5/sec cap plus the
-pbkdf2_sha256 cost on `nova_auth_accounts:authenticate/3` makes online
-password guessing infeasible at internet scale. Operators can override
-the limits via the `asobi, rate_limits` env in their sys config:
+The two global buckets exist because a per-IP or per-player limit does not
+bound the aggregate: guest rows are minted unauthenticated, and every zone
+crossing calls into the one `asobi_terrain_store` the whole world shares, so N
+attackers each within their own budget still scale the load linearly.
+
+`/api/v1/auth/register` gets the tighter bucket because it runs the password
+KDF (pbkdf2_sha256, see `pbkdf2_iterations`) as its only cost gate. Sharing
+login's bucket let a signup flood both starve honest logins and amplify CPU.
+The auth bucket plus that same KDF on
+`nova_auth_accounts:authenticate/3` is the brute-force gate for login, and it
+is why `POST /console/session` shares it: same threat, same shape, one fewer
+knob to leave unset. Neither route carries a session, so in practice both are
+bucketed on the caller's IP, and distributed abuse is the client gate's
+problem rather than the limiter's.
+
+Override any group in your sys config:
 
 ```erlang
 {rate_limits, #{
@@ -166,91 +174,112 @@ the limits via the `asobi, rate_limits` env in their sys config:
 }}
 ```
 
-The dev / test sys config bumps all three to 1000 because CT bursts
-register/login calls against `127.0.0.1` and the production-default
-auth cap would fail the suites.
+The dev and test config raises `auth`, `register`, `iap` and `api` to 1000
+because CT fires bursts at `127.0.0.1` and the production auth cap would fail
+the suites.
+
+The Lua runtime registers two more groups of its own, `log` and `log_global`,
+which bound `game.log` volume rather than abuse. They read the same
+`rate_limits` key and their names are disjoint from the ones above, so one
+merged map carries both.
 
 ## Client gate (pre-auth)
 
 `asobi_client_gate` is a pluggable "is this traffic allowed in" seam on the
-anonymous auth-create routes (`/auth/register`, `/auth/oauth`,
-`/auth/guest`). It is distinct from `asobi_auth_plugin` ("who is the
-player"): a gate carries **no** player identity - its return type is
-deliberately narrow so an implementation cannot leak or forge identity.
+three anonymous auth-create routes: `/api/v1/auth/register`,
+`/api/v1/auth/oauth` and `/api/v1/auth/guest`. It is distinct from
+`asobi_auth_plugin`, which answers "who is the player": a gate carries no
+player identity, and its return type is deliberately narrow so an
+implementation cannot leak or forge one.
 
 ```erlang
 -callback verify(asobi_client_gate:context()) -> skip | {deny, Reason :: binary()}.
 ```
 
-The input is a **minimized context**, not the raw request - `#{ip, headers,
-path, token}`. The request map still holds the registration plaintext
-password at this point, and a traffic gate has no need for it; handing over
-only IP / headers / path / a `client_gate_token` field keeps a verbose or
-buggy third-party gate from logging or forwarding credentials.
+The input is a minimised context, not the raw request: `#{ip, headers, path,
+token}`. The request map still holds the registration plaintext password at
+that point, and a traffic gate has no use for it, so a verbose or buggy
+third-party gate cannot log or forward credentials.
 
-Wire an implementation with `{client_gate, my_gate_module}` in app env;
-**unset is a no-op**, so bots, dedicated servers, CI, headless clients and
-`asobi_register_bench` all keep working by default. `asobi_client_gate_plugin`
-runs immediately after the rate limiter and before the password KDF, so a
-denial (`403 registration_gate_denied`) never pays the pbkdf2 cost
-(asobi#157), and a register flood is shed by the cheap in-memory limiter
-before it can trigger an outbound siteverify.
+Wire an implementation with `{client_gate, my_gate_module}` in app env. Unset
+is a no-op, so bots, dedicated servers, CI and headless clients keep working by
+default. `asobi_client_gate_plugin` runs immediately after the rate limiter and
+before the password KDF, so a denial (`client_gate_denied`, 403) never pays the
+pbkdf2 cost and a register flood is shed by the cheap in-memory limiter before
+it can trigger an outbound siteverify.
 
-A configured gate that **crashes, hangs, or returns garbage fails closed**
-by default (`403 client_gate_unavailable`) - a security control that
-silently fails open is bypassable by knocking over the vendor. The gate call
-is bounded by `{client_gate_timeout, Ms}` (default 5000) so a stalled
-siteverify cannot pin the request process. Trade strictness for availability
-with `{client_gate_on_error, skip}`.
+A configured gate that crashes, hangs or returns garbage fails closed with
+`client_gate_denied` and a `client_gate_unavailable` reason: a control that
+silently fails open is bypassable by knocking over the vendor. The call is
+bounded by `{client_gate_timeout, Ms}` (default 5000) so a stalled siteverify
+cannot pin the request process. Trade strictness for availability with
+`{client_gate_on_error, skip}`.
 
-CAPTCHA / Turnstile / hCaptcha is the first *consumer* of this seam and
-ships **outside** core (asobi_engine or a contrib plugin): a vendor-specific
-external round-trip must not couple asobi's public request path to a SaaS.
+CAPTCHA, Turnstile and hCaptcha are consumers of this seam and ship outside
+core: a vendor round-trip must not couple asobi's request path to a SaaS.
 
-## DDoS / DoS surface notes
+## Per-request bounds
 
-These are the deliberate per-call upper bounds in the runtime that
-exist purely to bound the cost of a single hostile request:
+Deliberate upper bounds that exist to cap what one hostile request costs:
 
-- **Cloud saves** (`/saves/:slot`) — body capped at 256 KB; per-player
-  slot count capped at 10.
-- **Storage** (`/storage/:collection/:key`) — `read_perm` /
-  `write_perm` whitelisted to `["public", "owner"]`; arbitrary strings
-  rejected with 400.
-- **Inventory consume** — quantity range `[1, 1_000_000]`.
-- **Leaderboard** `top` / `around` — `?limit` clamped to 100, `?range`
-  to 50 (mitigates an O(N) ETS scan attack).
-- **Chat history** — `?limit` clamped to `[1, 200]`; channel
-  membership is enforced (DM participants, world joiners, group
-  members).
-- **DM send** — content capped at 2000 bytes; non-binary or empty
-  content rejected.
-- **Group chat / WS `chat.join`** — channel id namespaced
-  (`dm:`, `world:`, `zone:`, `prox:`, `room:`); per-connection cap of
-  32 simultaneously joined channels; idle channels stop after 60s
+- Request body - capped at 1 MiB by `asobi_body_cap_plugin`, before any bytes
+  are buffered onto the BEAM heap. A body with no `Content-Length` is rejected
+  with 411 `length_required`; over the cap is 413 `payload_too_large`.
+- WebSocket pre-auth - a socket that has not authenticated within 10 seconds is
+  closed with 1008 `idle_auth_timeout`. Override with
+  `asobi.ws_idle_auth_timeout_ms`.
+- Cloud saves (`/saves/:slot`) - 256 KB per save, 10 slots per player.
+- Storage (`/storage/:collection/:key`) - `read_perm` and `write_perm` limited
+  to `public` and `owner`; anything else is `storage.invalid_perm` (400). A
+  single object is capped at the same 256 KB as a save
+  (`storage.value_too_large`).
+- Inventory consume - quantity in `[1, 1000000]`.
+- Leaderboard `top` and `around` - `?limit` clamped to 100, `?range` to 50,
+  which bounds an O(N) scan.
+- Chat history - `?limit` clamped to `[1, 200]`, and channel membership is
+  enforced (DM participants, world joiners, group members).
+- Chat buffers - each channel keeps the last 100 messages in memory, and the
+  channel listing enumerates at most 1000 channels so the sort behind it stays
+  bounded.
+- DM send - content capped at 2000 bytes; empty or non-binary content rejected.
+- Chat channels - an id must be 1 to 256 bytes and carry one of six prefixes
+  (`global:`, `dm:`, `world:`, `zone:`, `prox:`, `room:`), a connection may
+  hold 32 joined channels at once, and an idle channel stops after 60 seconds
   with no live members.
-- **Per-player world creation** — capped via pg group; default 5
-  worlds per player, 1000 globally. Tunable via `world_max_per_player`
-  / `world_max` env.
-- **Matchmaker** — ticket reads and cancellations require ownership, so
-  one player cannot read or cancel another's ticket. A ticket carries only
-  the submitting player, so it cannot pull a non-consenting player into a
-  match.
+- World creation - 5 worlds per player and 1000 overall by default, counted
+  through a `pg` group so the count follows world process lifetime. Tunable
+  with `world_max_per_player` and `world_max`. Over either, the caller gets
+  `world.player_limit_reached` or `world.capacity_reached`.
+- Matchmaker - reading or cancelling a ticket requires ownership, and a ticket
+  carries only the player who submitted it, so nobody can be pulled into a
+  match without consenting.
 
 ## Test coverage
 
-Regressions for the items above live under `test/`:
+Regressions for the above live under `test/`:
 
-- `asobi_iap_SUITE.erl` — Apple JWS happy path + 14 negative cases
-  (bad alg, missing x5c, swapped signature, expired cert, untrusted
-  root, …).
-- `asobi_world_lobby_SUITE.erl` — F-9 per-player + global world caps.
-- `asobi_matchmaker_api_SUITE.erl` — ticket ownership + party-not-accepted
-  ownership.
-- `asobi_social_api_SUITE.erl` — F-10 chat history membership (DM,
-  group, non-member denial).
-- `asobi_dm_tests.erl` — F-11 length cap, empty-content rejection.
-- `asobi_guest_SUITE.erl` — guest create-or-resume, wrong-secret
-  rejection, upgrade + token revocation.
+- `asobi_iap_SUITE.erl` - 12 cases: 10 Apple (missing fields, not configured,
+  root not configured, invalid JWS, unsupported alg, missing `x5c`, invalid
+  signature, chain validation failure, wrong bundle id, valid receipt) and 2
+  Google (missing fields, not configured).
+- `asobi_guest_SUITE.erl` - create or resume, wrong-secret rejection, upgrade
+  and token revocation.
+- `asobi_world_lobby_SUITE.erl` - per-player and global world caps.
+- `asobi_matchmaker_api_SUITE.erl` - ticket ownership.
+- `asobi_social_api_SUITE.erl` - chat history membership (DM, group,
+  non-member).
+- `asobi_dm_tests.erl` - DM length cap and empty-content rejection.
+- `asobi_ops_auth_tests.erl` and `asobi_ops_token_tests.erl` - ops actor
+  resolution and minted-token verification.
+- `asobi_console_SUITE.erl`, `asobi_console_session_tests.erl` and
+  `asobi_console_routes_tests.erl` - console login, session and CSRF, and the
+  routes staying 404 while the console is off.
 
 Run with `rebar3 ct,eunit`.
+
+## Related
+
+- [Threat model](security-threat-model.md) - the trust boundaries these controls sit on.
+- [Known limitations](security-known-limitations.md) - what the runtime does not bound.
+- [Operator console](console.md) - the console and ops credentials, and how to turn them on.
+- [Sandbox model](security-sandbox.md) - the Lua side of the same story.

--- a/guides/security-known-limitations.md
+++ b/guides/security-known-limitations.md
@@ -1,91 +1,111 @@
 # Known limitations
 
-The asobi runtime closes a deliberate set of attack surfaces
-(documented in [Threat model](security-threat-model.md) and
-[Authentication & rate limiting](security-auth.md)). The list below
-is the complement: properties the runtime does **not** enforce, and
-where the responsibility lies.
+asobi closes a deliberate set of attack surfaces, documented in [Threat
+model](security-threat-model.md) and [Auth and rate
+limiting](security-auth.md). This page is the complement: what the runtime does
+not enforce, and where the responsibility sits instead.
 
-## Game module crashes can take the lobby down
+## A crashing game module takes matches with it
 
-`asobi_match_server` calls game-module callbacks (`Mod:join/2`,
-`Mod:tick/1`, `Mod:handle_input/3`, phase / vote callbacks) inline and
-**without** wrapping them in `try/catch`. This is intentional:
+`asobi_match_server` calls game-module callbacks in Erlang (`Mod:join/2`,
+`Mod:tick/1`, `Mod:handle_input/3`, phase and vote callbacks) inline, with no
+`try/catch`. That is intentional:
 
-- asobi is single-tenant by design — one VM owns the world processes
-  and there is no other game module to fail over to.
-- A crash is treated as a **bug** worth surfacing (transient restart,
-  intensity 10 / period 60). After 10 crashes in 60s the entire
-  `asobi_match_sup` falls over, intentionally taking the lobby with it
-  so an obviously broken game cannot keep churning silently.
-- For multi-tenant or sandboxed scenarios, layer `asobi_lua` or your
-  own sandbox on top — that is the place to put callback hardening.
+- One VM owns the world processes, and there is no other game module to fail
+  over to.
+- A crash is a bug worth surfacing. The match restarts (`transient`), and past
+  10 crashes in 60 seconds `asobi_match_sup` exits and `asobi_sup` restarts it,
+  taking every live match on the node with it, rather than letting a broken
+  game churn quietly.
 
-Because callbacks run inline with full BEAM access, a game module can read
-public ETS, spawn arbitrary processes, reach clustered nodes, and crash the
-lobby. Treat the game-module source as part of the trusted compute base — code
-review and sign its releases the same way you would the asobi binary itself. For
-untrusted scripting (community maps, modder content), use the
-[Lua sandbox](security-sandbox.md):
-Luerl runs scripts in a hardened state with OS/IO/code-loading APIs stripped and
-a wall-clock budget per callback.
+Because these callbacks run inline with full BEAM access, a game module can
+read public ETS, spawn processes, reach clustered nodes and crash the node.
+Treat its source as part of the trusted compute base: review it and sign its
+releases the way you would the asobi binary. If you need isolation inside your
+own module, run the hot-path logic in a worker process so a crash is contained.
 
-If you need callback isolation in your custom game module, run the
-hot-path logic in a worker process so a crash is contained.
+For untrusted scripting - community maps, modder content - write the game in
+Lua instead. Luerl runs scripts in a hardened state with OS, I/O and
+code-loading APIs stripped and a budget per callback: see [Sandbox
+model](security-sandbox.md).
 
-## Erlang distribution is enabled by default
+## Erlang distribution is on by default
 
 `config/vm.args.src` sets `-name asobi@${ASOBI_NODE_HOST}` and
-`-setcookie ${ERLANG_COOKIE}`. EPMD binds to `0.0.0.0:4369` and dist
-ports are unbounded; the cookie is the only protection. If the cookie
-leaks (env var, container snapshot, k8s secret), anyone with network
-reach to the dist port has full code-execution.
+`-setcookie ${ERLANG_COOKIE}`. EPMD listens on `0.0.0.0:4369`, the distribution
+port range is unbounded, and the cookie is the only protection. The published
+image ships a fixed, publicly known `ERLANG_COOKIE=asobi`, so any deployment
+that exposes the distribution port must override it.
 
-For single-node deploys, uncomment the localhost-bind line in
-`vm.args.src`. For clusters, configure `inet_dist_listen_min/max` and
-TLS for distribution. See [Threat model](security-threat-model.md).
+For a single node, uncomment the localhost bind in `vm.args.src`. For a
+cluster, constrain `inet_dist_listen_min/max` and turn on TLS for
+distribution. See [Threat model](security-threat-model.md#erlang-distribution).
 
-## Public ETS tables are reachable from any in-VM code
+## Public ETS is reachable from any in-VM code
 
 `asobi_world_state`, `asobi_player_worlds`, `asobi_match_state`,
-`asobi_chat_registry`, `asobi_zone_mgr` are all `public` named ETS
-tables. Plugins, custom game modules, and NIFs in the same BEAM can
-read or mutate them. asobi treats this as acceptable because all in-VM
-code is trusted by design (see [Threat model](security-threat-model.md)).
+`asobi_chat_registry`, `asobi_zone_mgr` and `asobi_terrain_cache` are all
+`public`. Plugins, game modules in Erlang and NIFs in the same BEAM can read or
+mutate them. asobi accepts that because all in-VM code is trusted by design.
+Lua has no ETS access; the `game.*` bridge is the only path from a script into
+host state.
 
-Any Lua sandbox layered on top (`asobi_lua`) MUST keep its sandbox out
-of these tables.
+## UUIDv7 ids leak a creation timestamp
 
-## UUIDv7 ids leak creation timestamp
+`asobi_id:generate/0` produces UUIDv7, whose high 48 bits are a millisecond
+timestamp. `player.id` lives forever and so reveals account-creation time
+wherever it is exposed. For unguessable, non-correlatable identifiers - auth
+tokens, invite codes - use `crypto:strong_rand_bytes/1`.
 
-`asobi_id:generate/0` produces UUIDv7. The high 48 bits are a
-millisecond timestamp. `player.id` lives forever and reveals account
-creation time when exposed. For unguessable, non-correlatable
-identifiers (auth tokens, invite codes, session secrets) use
-`crypto:strong_rand_bytes/1` — never `asobi_id:generate/0`.
+## In-VM compute and memory bounds are the OS's job
 
-## Compute / memory bounds are best-effort
+Per-request bounds exist (limits, body sizes, quantities: see [Auth and rate
+limiting](security-auth.md)), and Lua callbacks are separately bounded by a
+wall-clock timeout, a heap cap and a reduction budget (see [Sandbox
+model](security-sandbox.md#per-callback-budgets)). What is not bounded is
+trusted in-VM Erlang code: a game module, a plugin or a NIF gets no reduction
+count, no heap cap and no scheduler quota. Enforcement for those is at the OS
+or container layer:
 
-The runtime caps individual *requests* (limits, body sizes, quantities;
-see [Authentication & rate limiting](security-auth.md)). It does **not**
-enforce a per-process reduction count, heap cap, or scheduler quota.
-Enforcement of those happens at the OS / container layer:
+- Run with cgroup memory and CPU limits.
+- `vm.args` already ships `+P 1048576` and `+Q 65536`. Those are ceilings sized
+  for a large node; lower them to something your cgroup can actually back, so
+  the BEAM refuses a new process instead of the OOM killer taking the node.
+- A plugin or game module that allocates without bound will pressure the OS
+  allocator before anything in the VM notices.
 
-- Production deployments should run with cgroup memory + CPU limits.
-- Set `+P` (process limit) and `+Q` (port limit) in `vm.args` to
-  bound BEAM-level resources.
-- A long-running plugin or game module that allocates without bound
-  will pressure the OS allocator before any in-VM mechanism notices.
+## The release tree in the container is writable
 
-## Container release tree is writable
+The published `ghcr.io/widgrensit/asobi` image runs as the non-root `asobi`
+user, and its Dockerfile chowns all of `/app` to that user. So the release tree
+is writable by the process that runs it, and the image does not declare
+`--read-only`.
 
-The published `asobi_lua` image runs as the non-root `asobi` user but does not
-declare `--read-only`. The README example mounts `/app/game` as `:ro`, but that
-is the operator's responsibility, not the runtime's. For a hardened deployment,
-run with `docker run --read-only --tmpfs /tmp` and chown only the game directory
-to the runtime user — the rest of `/app` should stay root-owned and read-only.
+Making it read-only takes one extra step, because the boot script renders
+`sys.config` and `vm.args` from their `.src` templates at start and writes the
+result next to them. Add these flags to however you already run the image, on
+top of the database variables from [Self-hosting](self-hosting.md):
 
-## Next steps
+```
+docker run --read-only \
+  --tmpfs /tmp \
+  --tmpfs /run/asobi \
+  -e RELX_OUT_FILE_PATH=/run/asobi \
+  -v /srv/mygame:/app/game:ro \
+  -p 8084:8084 \
+  ghcr.io/widgrensit/asobi
+```
 
-- [Threat model](security-threat-model.md) - the trust assumptions this page's limits follow from.
-- [Auth & rate limiting](security-auth.md) - the per-request bounds the runtime does enforce.
+`RELX_OUT_FILE_PATH` must name a directory that already exists, or the script
+falls back to writing into `/app/releases/<vsn>` and the boot fails on a
+read-only filesystem. `/tmp` holds the pipe directory the release uses for
+`bin/asobi remote_console`. Mount the game directory read-only unless your game
+writes to it.
+
+## Related
+
+- [Threat model](security-threat-model.md) - the trust assumptions these limits follow from.
+- [Auth and rate limiting](security-auth.md) - the per-request bounds that do exist.
+- [Sandbox model](security-sandbox.md) - what the Lua sandbox removes, replaces and bounds.
+- [Trust model](security-trust-model.md) - what that sandbox is and is not a boundary against.
+- [Known limitations (Lua)](security-lua-known-limitations.md) - the sandbox's own sharp edges.

--- a/guides/security-lua-known-limitations.md
+++ b/guides/security-lua-known-limitations.md
@@ -1,109 +1,107 @@
 # Known limitations (Lua sandbox)
 
-The asobi_lua sandbox closes a deliberate set of attack surfaces
-(documented in [Sandbox model](security-sandbox.md)). The list below is
-the complement: properties the sandbox does **not** enforce. Operators
-who care about any of these should plan their deployment accordingly.
+The Lua sandbox closes a deliberate set of attack surfaces, documented in
+[Sandbox model](security-sandbox.md). This page is the complement: what it does
+not enforce. Plan the deployment around any of these that matter to you.
 
 ## Resource bounds
 
 ### The CPU bound is sampled, not exact
 
-asobi enforces three resource bounds on every callback that runs in a
-child process: a wall-clock timeout, a per-eval heap cap, and a
-reduction budget. The reduction budget is the CPU bound - without it a
-script could soak its full per-callback wall-clock budget every tick,
-because the timeout bounds latency, not work.
+Every callback that runs in a child process carries three bounds: a wall-clock
+timeout, a per-eval heap cap and a reduction budget. The reduction budget is
+the CPU bound, and it is needed because a timeout bounds latency, not work: a
+script can soak its whole wall-clock budget every tick and be killed at the
+deadline each time, burning a scheduler indefinitely.
 
-The budget is `asobi_lua.max_reductions_per_ms` (50,000 by default)
-multiplied by that callback's own wall-clock budget, so it scales with
-the callback: `tick` (500 ms) gets 25,000,000 reductions, a bot's
-`think` (50 ms) gets 2,500,000. Overrun surfaces as
-`{error, reductions_exhausted}`, distinct from `timeout` and
-`heap_exhausted`. As with the other two, the callback's result is
-discarded and the previous Lua state is kept - a match or zone is never
-torn down because one callback overran. Set the rate to `0` to disable
-the check.
+The budget is `max_reductions_per_ms` (50,000 by default) multiplied by that
+callback's own wall-clock budget, so it scales with the callback: `tick` at 500
+ms gets 25,000,000 reductions, a bot's `think` at 50 ms gets 2,500,000.
+Overrun surfaces as `{error, reductions_exhausted}`, distinct from `timeout`
+and `heap_exhausted`. As with the other two, the result is discarded and the
+previous Lua state is kept; a match or zone is never torn down because one
+callback overran. Set the rate to `0` to disable the check.
 
 Two limits are worth knowing:
 
-- The parent samples the child's reduction count every 10 ms, so a
-  script can overshoot by up to one interval's work before it is
-  killed. The budget bounds sustained CPU, not the instantaneous peak.
+- The parent samples the child's reduction count every 10 ms
+  (`?REDUCTION_POLL_MS`), so a script can overshoot by up to one interval's
+  work before it is killed. The budget bounds sustained CPU, not the
+  instantaneous peak.
 - asobi does not use `luerl_sandbox:run/3`, which offers the same idea
-  upstream: it evaluates a chunk, whereas asobi's hot path is
-  `luerl:call_function/3` against an already-loaded state. The polling
-  loop lives in the `bounded_eval` helper in `asobi_lua_loader`
-  instead, which already spawned and monitored the worker.
+  upstream. That function evaluates a chunk, whereas asobi's hot path is
+  `luerl:call_function/3` against an already-loaded state, so the polling loop
+  lives in `bounded_eval` in `asobi_lua_loader`, which had already spawned and
+  monitored the worker.
 
-`handle_input/3` is the exception: per ADR 0002 it runs in the calling
-process with no child, so none of the three bounds apply to it.
+`handle_input/3` is the exception: it runs inline in the calling process with
+no child, so none of the three bounds apply. Its cost is a hung match or zone
+process, not a supervisor event - see [handle-input is not a sandbox
+boundary](security-trust-model.md#handle-input-is-not-a-sandbox-boundary).
 
 ### The heap cap is per eval, not per script
 
-Every callback runs in a child process carrying `max_heap_size` with
-`kill => true` (`asobi_lua.max_heap_words`, 5,000,000 words by
-default), so a single runaway allocation is killed and surfaces as
-`{error, heap_exhausted}`. Nothing caps a script's *steady* footprint:
-a state that stays just under the limit is copied into every later
-eval, and the total across concurrent matches is unbounded. The decode
-depth cap (64 levels) bounds recursion at the bridge boundary, not
-table size.
+Each callback child carries `max_heap_size` with `kill => true`
+(`max_heap_words`, 5,000,000 words by default), so one runaway allocation is
+killed and surfaces as `{error, heap_exhausted}`. Nothing caps a script's
+steady footprint: a state that sits just under the limit is copied into every
+later eval, and the total across concurrent matches is unbounded. The decode
+depth cap of 64 levels bounds recursion at the bridge boundary, not table size.
 
-### Per-callback state copy cost is linear
+### The per-callback state copy is linear
 
-Each timeout-wrapped callback spawns a child process that takes a full
-copy of the Luerl state (`spawn(fun() -> call(..., St) end)`). Cost is
-linear in script-side allocation. A script that intentionally builds
-large stable tables forces every later callback to pay the copy. Watch
-for unexplained per-tick latency growth on long-lived matches.
+Each bounded callback spawns a child that takes a full copy of the Luerl state.
+Cost is linear in script-side allocation, so a script that deliberately builds
+large stable tables makes every later callback pay the copy. Watch for
+unexplained per-tick latency growth on long-lived matches.
 
 ## Deployment hygiene
 
-### The container release tree is writable
+### The release tree in the container is writable
 
-The shipped Dockerfile runs as the non-root `asobi` user but does not
-declare `--read-only`. The README example mounts `/app/game` `:ro`;
-that mode is the **operator's** responsibility, not the runtime's. We
-recommend `docker run --read-only --tmpfs /tmp` and chowning only
-`/app/game` to the runtime user (the rest of `/app` should stay
-root-owned + read-only).
+The published image runs as the non-root `asobi` user, but its Dockerfile
+chowns all of `/app` to that user and the image does not declare `--read-only`.
+Mounting the game directory `:ro` is the operator's move, not the runtime's.
+[Known limitations](security-known-limitations.md#the-release-tree-in-the-container-is-writable)
+carries the run command that makes the rest of the tree read-only.
 
-### Symlinks under the game dir
+### Symlinks under the game directory
 
-`require` rejects symlinks at resolve time, so a misplaced symlink
-under `<base>/foo.lua` no longer slips through. This is defense in
-depth: keep the game dir mounted read-only and the build pipeline
-should not produce symlinks in the first place.
+`require` refuses a symlink at resolve time, so a symlink at `<base>/foo.lua`
+is not followed. That is defence in depth: keep the game directory mounted
+read-only, and keep symlinks out of the build pipeline in the first place.
 
 ## Behavioural
 
 ### Mid-callback rollback is best-effort
 
-If a callback is killed by its wall-clock timeout *after* it has
-already issued a side-effecting `game.*` API call (e.g.
-`game.economy.debit`), the side effect persists. The Lua-side state
-reverts to the prior tick but the asobi-side ledger does not. Treat
-economy / leaderboard / storage mutations as **best-effort committed**.
-For high-stakes flows, checkpoint state before/after the API call so
-the next tick reconciles, or wrap mutations in a transactional helper
-tagged with the call's ref.
+If a callback is killed by its budget after it has already made a
+side-effecting `game.*` call (`game.economy.debit`, say), the side effect
+stands. The Lua state reverts to the previous tick; the asobi-side ledger does
+not. Treat economy, leaderboard and storage mutations as best-effort committed.
+For high-stakes flows, checkpoint state around the call so the next tick can
+reconcile.
 
-### Bot `think/2` errors fall back to the built-in default AI
+### A failing bot `think/2` falls back to the built-in AI
 
-A rate-limited `logger:warning` is emitted (one line per bot per
-minute) when the fallback fires so persistently-broken scripts are
-visible — see the `maybe_log_think_error` helper in `asobi_bot`.
-Operators who rely on bot scripts should still monitor behaviour
-externally; a silent fallback bot will keep playing the match without
-ever calling your custom AI.
+When `think/2` errors, `asobi_bot` substitutes the default AI and emits a
+rate-limited warning, one line per bot per minute (`maybe_log_think_error`).
+The match keeps running, so a broken bot script is visible in the logs but not
+in the gameplay. Monitor for it if you rely on bot scripts.
 
 ## Logging
 
-### `require_failed` error payload is truncated
+### The `require_failed` payload is truncated
 
-When `luerl:do/2` rejects a `require`'d file (non-Lua content,
-syntactically invalid Lua), the compiler error list is truncated to the
-first three entries before propagating. This prevents a binary file
-mistakenly placed under the game dir from dumping arbitrary bytes into
-the structured log pipeline.
+When `luerl:do/2` rejects a `require`d file - non-Lua content, invalid syntax -
+the compiler error list is cut to the first three entries plus a `truncated`
+marker before it propagates. A binary file placed under the game directory by
+mistake therefore cannot dump arbitrary bytes into the structured log pipeline.
+
+## Related
+
+- [Sandbox model](security-sandbox.md) - what the sandbox removes, replaces and bounds.
+- [Trust model](security-trust-model.md) - what it is and is not a boundary against.
+- [Known limitations](security-known-limitations.md) - the same for in-VM Erlang code.
+- [Threat model](security-threat-model.md) - the node-level trust boundaries.
+- [Auth and rate limiting](security-auth.md) - the request-side bounds.

--- a/guides/security-sandbox.md
+++ b/guides/security-sandbox.md
@@ -1,99 +1,108 @@
 # Sandbox model
 
-asobi_lua runs every Lua script in a hardened Luerl state. Sandbox
-construction lives in `asobi_lua_loader:new/1` and
-`asobi_lua_loader:init_sandboxed/0`.
+asobi runs every Lua script in a hardened Luerl state. Sandbox construction
+lives in `asobi_lua_loader:new/1` and `asobi_lua_loader:init_sandboxed/0`.
 
 ## Removed from the global environment
 
-The following standard-library entries are cleared (`= nil`) so a hostile
-script cannot reach them:
+These standard-library entries are erased (`strip_dangerous_globals/1` sets
+them to `nil`, which removes the key from the underlying table) so a script
+cannot reach them:
 
-- **OS escape hatches:** `os.execute`, `os.exit`, `os.getenv`,
-  `os.remove`, `os.rename`, `os.tmpname`
-- **Code loading:** `dofile`, `loadfile`, `load`, `loadstring`
-- **I/O:** the entire `io` library
-- **Package machinery:** the entire `package` library, plus the default
-  `require`
-- **Unstructured logging:** `print`, `eprint` — Luerl's defaults bypass
-  the structured logger and write straight to BEAM stdout. Use
-  `game.log(level, message[, meta])` instead: it routes a structured,
-  size-bounded line through the host logger behind a rate limit (per
-  match/zone plus a node-wide backstop), closing the two holes `print`
-  was removed for. See the Lua scripting guide's "Logging" section.
+- OS escape hatches - `os.execute`, `os.exit`, `os.getenv`, `os.remove`,
+  `os.rename`, `os.tmpname`
+- Code loading - `dofile`, `loadfile`, `load`, `loadstring`
+- I/O - the whole `io` library
+- Package machinery - the whole `package` library, plus the default `require`
+- Unstructured logging - `print` and `eprint`. Luerl's versions bypass the
+  structured logger and write straight to BEAM stdout. Use
+  `game.log(level, message[, meta])`, which routes a structured, size-bounded
+  line through the host logger behind a rate limit (per match or zone, plus a
+  node-wide backstop). See the Logging section of the Lua scripting guide.
 
-`os.clock`, `os.date`, `os.difftime`, and `os.time` remain available so
-games can timestamp.
+`os.clock`, `os.date`, `os.difftime` and `os.time` stay, so games can timestamp.
 
 ## Replaced
 
-- **`require/1`** is provided by asobi_lua. Names must match
-  `[A-Za-z_][A-Za-z0-9_]*(\.[A-Za-z_][A-Za-z0-9_]*)*` — letters, digits,
-  underscores, with `.` separating segments. Names like `../foo`,
-  `/etc/passwd`, `foo/bar`, `42`, or `''` are rejected. The validator
-  uses the `dollar_endonly` regex flag so `require("foo\n")` does not
-  slip through. The resolver joins the validated name to the directory
-  of the script that was loaded (e.g. `require("bots.chaser")` →
-  `<base>/bots/chaser.lua`) and reads the file with `file:read_file/1`.
-  Symlinks at the resolved path are rejected before reading. Module
-  results are cached in the Luerl state's private `_ASOBI_LOADED`
-  table; `asobi_lua_match` clears that cache on hot-reload so changed
-  modules pick up.
-- **`math.random`** dispatches to Erlang's `rand:uniform`. Single-arg
-  form returns an integer in `[1, N]`; no-arg form returns a float in
-  `[0, 1)`. The two-arg `math.random(a, b)` form upstream Lua exposes
-  is **not** supported.
-- **`math.sqrt`** dispatches to Erlang's `math:sqrt/1`. Negative input
-  returns `0.0` (upstream Lua returns NaN; Erlang would crash).
+`require/1` is asobi's own. A name must match
+`[A-Za-z_][A-Za-z0-9_]*(\.[A-Za-z_][A-Za-z0-9_]*)*` - letters, digits and
+underscores, with `.` separating segments. `../foo`, `/etc/passwd`, `foo/bar`,
+`42` and `''` are all rejected, and the validator runs with the
+`dollar_endonly` flag so `require("foo\n")` does not slip past the anchor. The
+resolver joins the validated name to the directory of the loaded script
+(`require("bots.chaser")` resolves to `<base>/bots/chaser.lua`) and reads it
+with `file:read_file/1`. A symlink at the resolved path is refused before the
+read. Results are cached in the state's `_ASOBI_LOADED` table, which
+`asobi_lua_reload` clears on hot-reload so a changed module is picked up.
 
-## Per-callback wall-clock limits
+`math.random` dispatches to `rand:uniform`. All three upstream forms work: no
+argument returns a float in `[0, 1)`, `math.random(n)` returns an integer in
+`[1, n]`, and `math.random(a, b)` returns an integer in `[a, b]`. An empty
+interval raises a proper Lua error, so `pcall` traps it.
 
-Every Lua callback the bridges call (init, tick, join, leave,
-get_state, vote_requested, vote_resolved, generate_world,
-phases, spawn_templates, on_phase_started/ended, on_zone_loaded/unloaded,
-on_world_recovered, terrain_provider, spawn_position, post_tick,
-zone_tick, bot `think`) runs in a child process with a wall-clock
-budget. A runaway script (`while true do end`, deep recursion, huge
-allocation) is killed when its budget elapses; the parent gen_server
-logs a warning and continues with the previous state. Limits are tuned
-per callback — init/generate_world get more time, per-tick callbacks
-get less. See the `?*_TIMEOUT` macros in `asobi_lua_match.erl` and
-`asobi_lua_world.erl`.
+`math.sqrt` dispatches to `math:sqrt/1`, and negative input returns `0.0`
+rather than crashing the process (upstream Lua returns NaN).
 
-**`handle_input/3` is the exception: it is _not_ wall-clock-bounded.** It runs
-inline for measured tail-latency wins at high input rates (ADR 0002), so a
-`while true do end` there hangs the match until the gen_server timeout (5 s) and
-the supervisor restarts the match — blast radius one match. It is not a sandbox
-boundary; see the [trust model](security-trust-model.md#per-callback-isolation).
+## Per-callback budgets
 
-The same wall-clock wrapper is applied to the **initial script body**
-load (`asobi_lua_loader:new/1`), the **hot-reload** path (in
-`asobi_lua_match`'s reload helper), and the **config manifest**
-evaluator (in `asobi_lua_config`). A `while true do end` at the top
-of `match.lua` therefore can no longer hang application start or the
-match gen_server.
+Every Lua callback the bridges call runs in a child process with three bounds:
+a wall-clock timeout, `max_heap_size` with `kill => true`, and a reduction
+budget. A runaway script - `while true do end`, deep recursion, a huge
+allocation - is killed, the parent logs a warning and keeps the previous Lua
+state, and the match or zone carries on. Failures surface as
+`{error, timeout}`, `{error, heap_exhausted}` or `{error, reductions_exhausted}`.
+
+The budgets are per callback: see the [trust
+model](security-trust-model.md#per-callback-budgets) for the full table and
+where each macro lives.
+
+`handle_input/3` is the exception. It runs inline in the calling process, so
+none of the three bounds apply to it. See [what that
+costs](security-trust-model.md#handle-input-is-not-a-sandbox-boundary).
+
+The same wrapper covers the three places script-author-controlled code is
+evaluated rather than called:
+
+| Path | Module | Budget |
+|---|---|---|
+| Initial script body | `asobi_lua_loader:new/3` | the caller's init budget: 1000 ms for a match, 2000 ms for a world, 5000 ms when a zone VM boots |
+| Hot-reload | `asobi_lua_reload` (`?RELOAD_TIMEOUT_MS`) | 5000 ms |
+| Config manifest | `asobi_lua_config` (`?CONFIG_TIMEOUT_MS`) | 2000 ms |
+
+So a `while true do end` at the top of `match.lua` cannot hang application
+start or the match process.
 
 ## Cross-script isolation
 
-Each match and each zone gets its own Luerl state. Globals, modules,
-and the require cache live inside that state — there is no shared
-table reachable from script code that crosses match boundaries.
+Each match and each zone gets its own Luerl state. Globals, modules and the
+require cache live inside that state, and no table reachable from script code
+crosses a match boundary.
 
 ## Atom exhaustion
 
-`asobi_lua_api`'s `safe_to_atom` helper and `terrain_provider`
-decoding both use `binary_to_existing_atom/1` so a Lua-supplied string
-cannot inflate the global atom table. Additionally, the terrain
-provider module name is matched against an explicit allowlist
-(`asobi_terrain_flat`, `asobi_terrain_perlin` by default; configurable
-via the `asobi_lua, terrain_providers` env) so a script cannot
-dispatch into arbitrary loaded modules even if the underlying atom
-already exists. There is a regression test in
-`asobi_lua_sandbox_tests` that fails if the limit is widened.
+`asobi_lua_api`'s `safe_to_atom` helper and the `terrain_provider` decoder both
+use `binary_to_existing_atom/1`, so a Lua-supplied string cannot inflate the
+global atom table. The terrain provider module is additionally matched against
+an explicit allowlist, so a script cannot dispatch into an arbitrary loaded
+module even when the atom already exists; a name outside the list is refused
+with a `terrain_provider_not_allowed` warning.
+`asobi_lua_sandbox_tests:atom_count_stable_under_unknown_keys_test/0` pins the
+atom-table property, and `asobi_lua_world_tests` pins the allowlist.
+
+The default list is `asobi_terrain_flat` and `asobi_terrain_perlin`, read
+through `asobi_lua_env:get_env(terrain_providers, ...)`.
 
 ## Decode depth cap
 
-`asobi_lua_api`'s deep-decode helper recurses on Lua-side tables;
-depth is capped at 64 levels and over-deep subtrees are replaced with
-the atom `too_deep`. A malicious script returning a 100k-deep table
-from a callback can no longer blow the parent process heap.
+`asobi_lua_api`'s deep-decode helper recurses over Lua-side tables with a depth
+cap of 64 levels; an over-deep subtree is replaced with the atom `too_deep`. A
+script returning a 100k-deep table from a callback cannot blow the parent
+process heap.
+
+## Related
+
+- [Trust model](security-trust-model.md) - what this sandbox is and is not a boundary against.
+- [Known limitations (Lua)](security-lua-known-limitations.md) - what it does not enforce.
+- [Threat model](security-threat-model.md) - the node-level trust boundaries around it.
+- [Known limitations](security-known-limitations.md) - the same for in-VM Erlang code.
+- [Auth and rate limiting](security-auth.md) - the request-side bounds.

--- a/guides/security-threat-model.md
+++ b/guides/security-threat-model.md
@@ -1,84 +1,122 @@
 # Threat model
 
-asobi is a **single-tenant, single-node** game backend library by
-design. The trust assumptions and architectural constraints below
-follow from that.
+asobi is one Erlang/OTP node holding the game backend, the Lua runtime and the
+operator console. One VM owns the match and world processes, the public ETS
+tables and the console session store. Single-node is the default posture and
+the assumptions below are written for it; [what a cluster
+changes](#what-changes-under-a-cluster) is a short list further down.
 
-## Trusted vs. untrusted code
+## Trusted and untrusted
 
 | Component | Status | Notes |
-|-----------|--------|-------|
-| asobi library code | trusted | this repo |
-| Loaded game module (`Mod:tick/1`, `Mod:join/2`, …) | **trusted** | callbacks run inline in the match gen_server. A crash in a callback restarts the match (transient + intensity 10) and can take the lobby down. |
-| Loaded NIFs | trusted | NIFs run in-VM; a misbehaving NIF crashes the BEAM. |
-| Loaded plugins | trusted | plugins observe / mutate every request and have full access to public ETS. |
-| Lua scripts (via `asobi_lua` runtime) | sandboxed | see `asobi_lua` SECURITY.md. The Lua sandbox sits *on top* of the asobi-side trust boundary; it is the place where untrusted-script hardening belongs. |
-| HTTP request bodies / WS payloads | untrusted | input validation lives in controllers / `asobi_ws_handler`. |
-| Bearer tokens, OAuth claims, IAP receipts | untrusted | verified via `asobi_auth_plugin`, `asobi_oauth_controller`, `asobi_iap`. |
+|---|---|---|
+| asobi code | trusted | this repo |
+| Game module in Erlang (`Mod:tick/1`, `Mod:join/2`, ...) | trusted | callbacks run inline in the match process. A crash restarts the match (`transient`, intensity 10 / period 60) |
+| NIFs | trusted | a misbehaving NIF crashes the BEAM |
+| Plugins | trusted | plugins see every request and can reach public ETS |
+| Lua under `/app/game` | sandboxed, author-trusted | mechanics in [Sandbox model](security-sandbox.md), boundary in [Trust model](security-trust-model.md) |
+| HTTP bodies and WebSocket payloads | untrusted | validated in the controllers and `asobi_ws_handler` |
+| Bearer tokens, provider claims, IAP receipts | untrusted | verified by `asobi_auth_plugin`, `asobi_oauth_controller`, `asobi_iap` |
+| Console bundle at `/console` | unauthenticated by design | the console route group in `asobi_router` is declared `security => false`: an index document, content-hashed assets and the login endpoint. No game data passes through it |
+| Ops callers on `/api/v1/ops/*` | untrusted until an actor resolves | `asobi_ops_auth:verify/1` resolves an actor or returns 403 with one body for every cause |
 
-## Single-node BEAM distribution
+The ops plane admits three credential sources, all resolving to the same actor
+shape: the operator secret presented as a bearer token (`static_secret`), a
+console session cookie plus its `x-csrf-token` header (`local_user`), and a
+short-lived token minted by asobi_saas (`cloud`). A player bearer token is
+never one of them - `asobi_ops_auth` does not consult the player auth cache at
+all. The mechanism, the environment variables and the credential handling live
+in [Operator console](console.md).
 
-`config/vm.args.src` boots with `-name` and `-setcookie`. EPMD binds to
-`0.0.0.0:4369` and the dist port range is unbounded. The cookie is the
-only protection.
+Both surfaces answer on the game port, and they are gated separately. `console`
+gates `/console` alone. The ops routes are always mounted and the credential is
+the only thing standing in front of them, so an `ops_secret` set for any reason
+exposes `/api/v1/ops/*` whether or not the console is on. Unsetting the secret
+is what closes the plane; a stock node has none. Core's ops routes are all
+reads, so the blast radius of a leaked secret is disclosure plus whatever
+actions an installed extension declares behind
+`/api/v1/ops/ext/:extension/:action`.
 
-For single-node deploys (the default), uncomment the localhost-bind
-line in `vm.args.src`:
+## Erlang distribution
+
+`config/vm.args.src` boots with `-name` and `-setcookie`. EPMD listens on
+`0.0.0.0:4369`, the distribution port range is unbounded, and the cookie is the
+only protection: anyone who can reach the port with the right cookie has code
+execution in the VM.
+
+The published image ships a fixed, publicly known `ERLANG_COOKIE=asobi`
+(`Dockerfile`). It is set because relx renders an empty value otherwise and
+`bin/asobi rpc` stops working, not because it is a secret. Any deployment that
+exposes the distribution port must override it.
+
+For a single node, uncomment the localhost bind in `vm.args.src`:
 
 ```
 -kernel inet_dist_use_interface "{127,0,0,1}"
 ```
 
-For clustered deploys via `asobi_cluster.erl` (k8s DNS discovery),
-constrain the dist port range and enable TLS for distribution:
+## What changes under a cluster
 
-```
--kernel inet_dist_listen_min 9100 inet_dist_listen_max 9105
--proto_dist inet_tls
--ssl_dist_optfile /etc/asobi/ssl_dist.config
-```
+Clustering is opt-in through `asobi_cluster`. It moves three things in this
+model:
+
+- Distribution stops being optional, so the cookie and the dist port range
+  become load-bearing. Constrain the range and turn on TLS for distribution:
+  `-kernel inet_dist_listen_min 9100 inet_dist_listen_max 9105`,
+  `-proto_dist inet_tls`, `-ssl_dist_optfile /etc/asobi/ssl_dist.config`.
+- Several bounds in this model are per node, so a cluster of N multiplies them
+  by N. Rate-limit buckets are the ones with security weight.
+- Console sessions and their CSRF secret are per node, so the console needs a
+  sticky route.
+
+[Clustering](clustering.md) holds the complete list of what is and is not
+shared between nodes.
 
 ## Public ETS tables
 
-These named ETS tables are `public` and hold live game state:
+These tables are `public` and hold live game state:
 
-- `asobi_world_state` (`asobi_world_sup`)
-- `asobi_player_worlds` (`asobi_world_sup`)
-- `asobi_match_state` (`asobi_match_sup`)
-- `asobi_chat_registry` (`asobi_chat_channel`)
-- `asobi_zone_mgr` (`asobi_zone_manager`)
+| Table | Created by | Named |
+|---|---|---|
+| `asobi_world_state` | `asobi_world_sup` | yes |
+| `asobi_player_worlds` | `asobi_world_sup` | yes |
+| `asobi_match_state` | `asobi_match_sup` | yes |
+| `asobi_chat_registry` | `asobi_chat_sup` | yes |
+| `asobi_zone_mgr` | `asobi_zone_manager` | only when a `name` option is passed, and then under that atom. Otherwise the table is unnamed and reached by reference |
+| `asobi_terrain_cache` | `asobi_terrain_store` | no |
 
-Anything in the same BEAM (game callbacks, plugins) can read, mutate,
-or delete entries. asobi treats this as acceptable because all in-VM
-code is trusted (above). Any sandboxed runtime layered on top
-(`asobi_lua`) MUST keep its sandbox out of these tables — Luerl is
-not given access to ETS.
+Anything in the same BEAM - game callbacks in Erlang, plugins, NIFs - can read,
+mutate or delete entries. asobi accepts that because all in-VM code is trusted
+above. Lua never reaches them: Luerl scripts are not given ETS access, and the
+`game.*` bridge is the only path from a script into host state.
 
-## UUIDv7 and timestamp leakage
+## UUIDv7 ids carry a timestamp
 
-`asobi_id:generate/0` produces UUIDv7 ids that embed a millisecond
-timestamp in the high 48 bits. Match ids, world ids, ticket ids, and
-`player.id` all use this generator. `player.id` is the long-lived
-case: the timestamp inside it reveals account-creation time, which is
-acceptable for a game backend but worth knowing if you build features
-on top.
+`asobi_id:generate/0` produces UUIDv7 (`jhn_uuid`), which embeds a millisecond
+timestamp in the high 48 bits. Match ids, world ids, ticket ids and `player.id`
+all use it. `player.id` is the long-lived case: the timestamp inside it reveals
+account-creation time. That is acceptable for a game backend, but worth knowing
+before you build a feature on top of it.
 
-If you ever need an unguessable, non-correlatable id (auth tokens,
-invite codes, etc.) generate them via `crypto:strong_rand_bytes/1`
-rather than `asobi_id:generate/0`.
+For an unguessable, non-correlatable id - auth tokens, invite codes - use
+`crypto:strong_rand_bytes/1`, not `asobi_id:generate/0`.
 
-## What the supervisor will tolerate
+## What the supervisors tolerate
 
-`asobi_match_sup` runs each match gen_server with `transient` restart
-and `intensity 10 / period 60`. After 10 crashes in 60s the entire
-match supervisor falls over, intentionally taking the lobby with it so
-an obviously broken game module cannot keep churning silently.
+`asobi_match_sup` runs each match with `restart => transient` under
+`intensity 10 / period 60`. Past 10 crashes in 60 seconds the match supervisor
+itself exits and `asobi_sup` restarts it, taking every live match on the node
+with it. That is deliberate: an obviously broken game module should stop, not
+churn quietly.
 
-`asobi_world_lobby_server` serializes `find_or_create/1` to close a
-documented TOCTOU race (two concurrent `find_or_create` for the same
-mode no longer spawn duplicate worlds).
+`asobi_world_lobby_server` serialises `find_or_create/1` through a single
+process so two concurrent calls for the same mode cannot both create a world.
 
-## Next steps
+## Related
 
-- [Auth & rate limiting](security-auth.md) - how clients are authenticated and the brute-force surface is bounded.
+- [Auth and rate limiting](security-auth.md) - how clients authenticate and what bounds a single hostile request.
 - [Known limitations](security-known-limitations.md) - the sharp edges this design accepts.
+- [Sandbox model](security-sandbox.md) - what the Lua sandbox removes, replaces and bounds.
+- [Trust model](security-trust-model.md) - what the Lua sandbox is and is not a boundary against.
+- [Known limitations (Lua)](security-lua-known-limitations.md) - the sandbox's own sharp edges.
+- [Operator console](console.md) - turning the console and ops API on, and the credentials they check.

--- a/guides/security-trust-model.md
+++ b/guides/security-trust-model.md
@@ -1,90 +1,109 @@
 # Trust model
 
-asobi_lua treats the mounted `/app/game` Lua scripts as **trusted** in
-the same sense your `/app/bin/asobi_lua` binary is trusted: you control
-what files end up there. The sandbox protects against incidental
-scripting bugs (infinite loops, missed nil checks, atom exhaustion via
-untrusted player input) and makes it harder for a *compromised*
-dependency or `require`'d module to escape. It is not a defence against
-a deliberate, all-Erlang-aware adversary with the ability to write
-`/app/game/match.lua`.
+asobi treats the Lua scripts mounted at `/app/game` as trusted in the same
+sense the `/app/bin/asobi` binary is trusted: you control what files end up
+there. The [sandbox](security-sandbox.md) protects against incidental scripting
+bugs - infinite loops, missed nil checks, atom exhaustion driven by player
+input - and makes it harder for a compromised dependency or a `require`d module
+to escape. It is not a defence against a deliberate, Erlang-aware adversary who
+can write `/app/game/match.lua`.
 
-## Verified negative results
+## Documented properties
 
-These are properties prior security audits looked at and confirmed
-hold. Documented here so future readers don't re-derive them.
+Three properties of the sandbox that are easy to re-derive wrongly, with where
+to check them.
 
-### `setmetatable(_G, ...)` and `setmetatable(os, ...)` are still allowed
+### Metatables cannot recover a stripped function
 
-The strip pass calls `set_table_keys` with `nil`, which Luerl's
-`set_table_key_key/4` *erases* the entry from the underlying ttdict —
-the key becomes truly absent, not "set to nil". A subsequent `__index`
-metatable on `os` (or `_G`) would intercept lookups for the absent
-keys. However, `__index` can only return values that exist in the
-script's reach, and the actual Erlang function references for
-`os.execute`, `os.exit`, etc. are stored exclusively inside the os
-table dict that was just erased. Once erased there is no Lua-reachable
-path to those function references — they are not stored elsewhere in
-the Luerl state. So metatable manipulation cannot recover stripped
-functions.
+`strip_dangerous_globals/1` in `asobi_lua_loader` sets each dangerous key to
+`nil`, and Luerl's `set_table_key_key/4` erases the entry from the underlying
+dict rather than storing a nil. So `setmetatable(_G, ...)` and
+`setmetatable(os, ...)` remain allowed, and an `__index` metatable does
+intercept lookups for the now-absent keys - but the Erlang function references
+for `os.execute` and the rest lived only in the dict entry that was erased.
+Nothing else in the Luerl state holds them, so there is no Lua-reachable path
+back to them.
 
-### `_ASOBI_LOADED` is reachable via `_G._ASOBI_LOADED`
+### `_ASOBI_LOADED` is visible to script code
 
-The require cache is installed as a global, fully visible to Lua. A
-script can iterate it, mutate it, delete entries. There's no privilege
-boundary inside a single Luerl state, so this is by design and
-acceptable. Cross-match isolation comes from each match having its own
-state; a script that clobbers its own cache only DoSes itself. The internal
-`lookup_loaded` helper in `asobi_lua_loader` handles a clobbered
-cache cleanly rather than crashing with `case_clause`.
+The require cache is installed as a global. A script can iterate it, mutate it
+or delete entries. There is no privilege boundary inside a single Luerl state,
+so this is by design: cross-match isolation comes from each match owning its
+own state, and a script that clobbers its own cache only denies itself.
+`lookup_loaded` in `asobi_lua_loader` turns a clobbered cache into a clean Lua
+error rather than a `case_clause` crash.
 
-### Atom-table inflation via `terrain_provider`
+### `terrain_provider` cannot inflate the atom table
 
-A Lua script that returns `{ module = "<some_atom>", ... }` from
-`terrain_provider/1` cannot inflate the atom table — the bridge uses
-`binary_to_existing_atom/1`. As of the F-* hardening pass the bridge
-also requires the target module to be on an explicit allowlist
-(`asobi_terrain_flat`, `asobi_terrain_perlin` by default; configurable
-via `application:get_env(asobi_lua, terrain_providers, ...)`) so a
-script that names an unrelated loaded module (`gen_server`, `rpc`,
-etc.) is rejected with a `terrain_provider_not_allowed` warning.
+A script returning `{ module = "<name>", ... }` from `terrain_provider/1`
+cannot mint an atom: the bridge uses `binary_to_existing_atom/1`. It also
+requires the module to be on an allowlist, so naming an unrelated loaded module
+(`gen_server`, `rpc`) is rejected with a `terrain_provider_not_allowed`
+warning. The default is `asobi_terrain_flat` and `asobi_terrain_perlin`, read
+through `asobi_lua_env:get_env(terrain_providers, ...)`.
 
-## Per-callback isolation
+## Per-callback budgets
 
-Most Lua callbacks run inside a child process spawned by the loader's
-`bounded_eval` wrapper with a wall-clock timeout and a
-`max_heap_size: kill => true`. A runaway loop or a runaway allocation
-in those callbacks crashes the child, the parent gen_server receives a
-`{error, timeout | heap_exhausted}` result, and the match continues.
+Almost every Lua callback runs inside a child process spawned by the
+`bounded_eval` helper in `asobi_lua_loader`, with a wall-clock timeout,
+`max_heap_size` with `kill => true`, and a reduction budget. A runaway loop or
+allocation kills
+the child, the parent gen_server sees `{error, timeout | heap_exhausted |
+reductions_exhausted}`, and the match or zone continues on its previous state.
 
-| Callback | Bridge | Bounded? | Budget |
+| Callback | Bridge | Bounded | Budget |
 |---|---|---|---|
-| `init/1` | match, world | yes | 1000-2000 ms |
-| `tick/1`, `zone_tick/2` | match, world | yes | 500 ms |
-| `get_state/{1,2}` | match, world | yes | 100 ms |
+| `init/1` | match, world | yes | 1000 ms match, 2000 ms world |
+| `generate_world/2` | world | yes | 5000 ms |
+| `tick/1`, `zone_tick/2`, `post_tick/2` | match, world | yes | 500 ms |
 | `join/2`, `leave/2` | match, world | yes | 200 ms |
-| `vote_*` | match | yes | 200 ms |
-| `phases/1` | match, world | yes | 1000-2000 ms |
-| `on_phase_*/2` | match, world | yes | 200 ms |
+| `get_state/{1,2}` | match, world | yes | 100 ms |
+| `spawn_position/2` | world | yes | 100 ms |
+| `vote_requested/1`, `vote_resolved/3` | match | yes | 200 ms |
+| `phases/1` | match, world | yes | 1000 ms match, 2000 ms world |
+| `on_phase_started/2`, `on_phase_ended/2` | match, world | yes | 200 ms |
+| `on_zone_loaded/3`, `on_zone_unloaded/3` | world | yes | 200 ms |
+| `spawn_templates/1` | world | yes | 2000 ms |
+| `on_world_recovered/2` | world | yes | 2000 ms |
 | `terrain_provider/1` | world | yes | 2000 ms |
-| **`handle_input/3`** | **match, world** | **NO** | **(see below)** |
+| bot `think/2` | bot | yes | 50 ms |
+| `handle_input/3` | match, world | **no** | see below |
 
-`handle_input/3` is the one callback that does **not** spawn-isolate.
-At realistic input rates (one tick × N players × the message rate)
-the per-call spawn cost dominated the actual Lua work (~30-50 µs spawn
-+ monitor + heap-cap setup vs ~50-200 µs of input handling). Removing
-the wrapper recovered measured tail-latency wins of 35-45 % at 200
-players × 10 Hz input. See ADR 0002.
+The macros are not all in one place. Match budgets are `?*_TIMEOUT` in
+`asobi_lua_match.erl` and world budgets are `?*_TIMEOUT` in
+`asobi_lua_world.erl`, but `get_state/1` on the shared-state path has its own
+`?GET_STATE_TIMEOUT` in `asobi_lua_match_shared.erl`, and the bot `think`
+budget is a literal `50` at the call site in `asobi_bot.erl` rather than a
+macro. Grep for `asobi_lua_loader:call(` if you need the authoritative set.
 
-The trade is explicit: a `while true do end` inside `handle_input` now
-hangs the match server until its caller's `gen_server:call/2` timeout
-trips (5 s default). The match supervisor then restarts the match
-process. Blast radius is one match.
+## handle-input is not a sandbox boundary
 
-`handle_input/3` is therefore **not a sandbox boundary**. It is a hot
-path for trusted-author scripts. Audit the inputs your match script
-accepts and avoid pattern-matching dispatch on attacker-controlled
-strings; otherwise, treat the same as you would any Erlang gen_server
-handle_call/2 implementation. Per-tick safety remains owned by
-`tick/1`, which still spawn-isolates and is the right place to
-enforce wall-clock fairness across players.
+`handle_input/3` is the one callback that does not spawn-isolate. At realistic
+input rates - one tick times N players times the message rate - the per-call
+spawn cost dominated the actual Lua work: roughly 30 to 50 microseconds of
+spawn, monitor and heap-cap setup against 50 to 200 microseconds of input
+handling. Removing the wrapper recovered measured tail-latency wins at 200
+players and 10 Hz input.
+
+What that costs is worth stating precisely, because it is not a supervisor
+event. Input arrives as a cast and is queued; the queue is drained inside the tick,
+by `apply_inputs/3` in `asobi_match_server` and in `asobi_zone`. There is no
+`gen_server:call` behind it and no call timeout to trip. A
+`while true do end` inside `handle_input` therefore hangs the match or
+zone process indefinitely: the tick stops, no supervisor restart happens, and
+every later call against that process times out in its own caller. Blast radius
+is one match or one zone. Recovery is manual.
+
+So treat `handle_input/3` as a hot path for trusted-author scripts, not as a
+boundary. Audit the inputs your script accepts, avoid dispatching on
+attacker-controlled strings, and treat it the way you would an Erlang
+`handle_call/3` you wrote yourself. Per-tick safety belongs in `tick/1`, which
+still spawn-isolates and is the right place to enforce fairness across players.
+
+## Related
+
+- [Sandbox model](security-sandbox.md) - what the sandbox removes, replaces and bounds.
+- [Known limitations (Lua)](security-lua-known-limitations.md) - what it does not enforce.
+- [Threat model](security-threat-model.md) - the node-level trust boundaries.
+- [Known limitations](security-known-limitations.md) - the same for in-VM Erlang code.
+- [Auth and rate limiting](security-auth.md) - the request-side bounds.

--- a/guides/self-hosting.md
+++ b/guides/self-hosting.md
@@ -1,146 +1,168 @@
-# Self-hosting asobi_lua
+# Self-hosting asobi
 
-This guide covers running asobi_lua in production on infrastructure you
-control. It is opinionated about how Lua game scripts get onto disk and
-when they reload, because that is the question every operator hits in
-the first week.
+asobi is one Erlang/OTP node containing the game backend, the Lua runtime and
+the operator console. Run the image and write Lua, or depend on the Hex package
+and write Erlang: same node, two surfaces. This guide covers running it in
+production on infrastructure you control.
 
-If you are evaluating asobi_lua locally, follow the
-[quickstart](../README.md#try-it-in-60-seconds) first — this guide assumes you
-have something working and now want it deployed.
+It is opinionated about how Lua scripts get onto disk and when they reload,
+because that is the question every operator hits in the first week.
+
+## Requirements
+
+- **Erlang/OTP 29.** The image is built on `erlang:29.0.4-slim`, and 29 is the
+  only entry in the CI test matrix (`.github/workflows/ci.yml`). Nothing older
+  is tested.
+- **PostgreSQL 17.** Every compose file in this repository runs `postgres:17`.
+- **linux/amd64.** The publish workflow declares no `platforms`, so the image
+  is built for the runner's architecture only. There is no arm64 image; on
+  Apple silicon it runs under emulation.
+- **One TCP port**, `8084` by default. Game clients, the REST API, the
+  WebSocket and the console all answer on it.
+
+Other guides link here rather than restating a floor.
 
 ## What ships in the container
 
-`ghcr.io/widgrensit/asobi_lua` is a Debian-trixie-slim runtime image
-built on top of Erlang/OTP 28.x. It expects:
+`ghcr.io/widgrensit/asobi` is a Debian-trixie-slim runtime image. It expects:
 
-- A Postgres 17+ database it can read and write (sessions, world
-  snapshots, leaderboards, IAP receipts).
+- A Postgres 17 database it can read and write.
 - A directory mounted at `/app/game/` containing your Lua scripts.
-- TCP `:8084` reachable by your matchmaker / game clients.
+- TCP `:8084` reachable by your clients.
 
-That's it. No sidecars, no message bus, no Redis. The container is
-stateless apart from `/app/game/`; restarting it loses no game state
-beyond what was kept only in memory.
+No sidecars, no message bus, no Redis. The container is stateless apart from
+`/app/game/`.
+
+It runs as the unprivileged user `asobi` (uid 999), so the mounted game
+directory and any secret file you mount have to be readable by that user. A
+secret mounted `0600` owned by root produces `ops_secret_file_unreadable` and a
+console that stays off.
+
+The script directory is the `game_dir` key, `/app/game` in the image. Mount
+somewhere else and set it in a `sys.config`; nothing reads it from the
+environment.
+
+The image fixes the Postgres port at `5432` (`config/prod_sys.config.src`). A
+database on a different port means supplying your own `sys.config`.
 
 ## Where Lua scripts live
 
-`/app/game/` is the search path for `require()` and the source of every
-Lua callback the runtime invokes (match handlers, world tick, bots).
-The runtime calls `filelib:last_modified/1` on these files between game
-ticks; if the mtime moves, it re-executes the script body against the
-existing Luerl state. See `asobi_lua_reload` for the primitive.
+`/app/game/` is the search path for `require()` and the source of every Lua
+callback the runtime invokes (match handlers, world tick, bots). Between game
+ticks the runtime calls `filelib:last_modified/1` on the script; if the mtime
+moves, it re-executes the script body against the existing Luerl state. See
+`asobi_lua_reload` for the primitive.
 
-You have four ways to put scripts there in production. Pick the one
-that matches how you ship code.
+You have four ways to put scripts there. Two of them exist.
 
-### Pattern 1 — Bake into the image (immutable)
+### Pattern 1: bake into the image (immutable)
 
-**When:** you treat game-script changes as deploys. Each release of
-your game is a new container image, rolled out via your existing
-container orchestrator (Kubernetes, Nomad, Fly, plain `docker compose
-up -d`).
-
-**How:** extend the asobi_lua image and `COPY` your scripts into
-`/app/game/`:
+You treat game-script changes as deploys. Each release of your game is a new
+container image, rolled out by whatever already rolls out your services.
 
 ```Dockerfile
-FROM ghcr.io/widgrensit/asobi_lua:latest
+FROM ghcr.io/widgrensit/asobi:latest
 COPY game/ /app/game/
 ```
 
-Build, push to your registry, and deploy as you would any service.
-mtime never changes inside a running container, so the per-tick
-`stat()` cost is essentially free, but no live reload happens —
-you ship code by shipping a container.
+mtime never changes inside a running container, so the per-tick `stat()` costs
+nothing and no live reload happens: you ship code by shipping a container.
 
-This is the safest model and the one we recommend by default. If you
-are not sure which pattern you want, start here.
+This is the safest model and the default recommendation. If you are not sure
+which pattern you want, start here.
 
-### Pattern 2 — Volume mount + atomic rename (live updates)
+### Pattern 2: volume mount plus atomic rename (live updates)
 
-**When:** you want to update scripts without rolling the runtime —
-e.g. during a live event, or because your design team iterates on
-balance numbers faster than your release train moves.
-
-**How:** mount a host directory (or a network volume your CI can
-write to) at `/app/game/`:
+You want to update scripts without rolling the node, during a live event or
+because balance numbers move faster than your release train.
 
 ```yaml
 services:
-  asobi_lua:
-    image: ghcr.io/widgrensit/asobi_lua:latest
+  asobi:
+    image: ghcr.io/widgrensit/asobi:latest
     volumes:
       - /srv/asobi/game:/app/game:ro
 ```
 
-When you ship new code, **always write the file under a temp name and
-`mv` it into place**. POSIX `rename(2)` is atomic; an editor's "save"
-that truncates and re-writes the file is not, and the runtime can
-observe a half-written file and crash the load.
+Always write the file under a temp name and `mv` it into place. POSIX
+`rename(2)` is atomic; an editor's save that truncates and rewrites is not, and
+the runtime can observe a half-written file.
 
 ```bash
-# Wrong — runtime may stat() while the file is empty
+# Wrong: the runtime may stat() while the file is empty
 cp build/match.lua /srv/asobi/game/match.lua
 
-# Right — atomic swap, runtime never sees a partial file
+# Right: atomic swap, the runtime never sees a partial file
 cp build/match.lua /srv/asobi/game/match.lua.tmp
 mv /srv/asobi/game/match.lua.tmp /srv/asobi/game/match.lua
 ```
 
-The next match/world tick picks up the new mtime and reloads. In-flight
-match state survives the reload because the script body re-declares
-globals and functions in place; existing locals and table fields are
-not touched unless the script explicitly re-runs `init()`.
+The next match or world tick picks up the new mtime and reloads. In-flight
+state survives, because the script body re-declares globals and functions in
+place; existing locals and table fields are untouched unless the script
+explicitly re-runs `init()`.
 
-For world zones, a reload that adds or changes `spawn_templates` also
-takes effect immediately: an already-running zone re-fetches its spawn
-template set on the tick right after the reload, so new templates
-become spawnable without restarting the zone. If the reloaded
-`spawn_templates` itself fails, the zone's existing templates are left
-untouched rather than cleared.
+For world zones, a reload that changes `spawn_templates` also takes effect
+immediately: a running zone re-fetches its template set on the reload tick
+itself, so new templates become spawnable without restarting the zone. If the
+reloaded `spawn_templates` itself fails, the zone keeps the templates it had
+rather than clearing them.
 
-If a new script has a syntax error, the runtime keeps running the old
-code, logs a warning, and remembers the new mtime so it does not retry
-the same broken file every tick. Fix the file, save again, and the
-next tick reloads. The same per-script rate limiting applies to any
-callback that starts failing on every tick (not just syntax errors) —
-the failure is logged at most a few times per window, not once per
-tick forever.
+A new script with a syntax error leaves the old code running, logs a warning,
+and records the new mtime so the same broken file is not retried every tick.
+Fix it, save again, and the next tick reloads. A callback that fails on every
+tick is logged under the `script_log` limiter, 3 lines per 10 seconds per
+script and callback, so a broken script does not drown the log.
 
-### Pattern 3 — Signal-driven reload (planned)
+### Pattern 3: signal-driven reload (planned, not shipped)
 
-A future `ASOBI_LUA_RELOAD=signal` mode and admin RPC will let you skip
-the per-tick `stat()` entirely and reload only when explicitly
-triggered (e.g. by your CI/CD pipeline, after the file is in place).
-This is the right model for very-high-zone-count deployments where the
-mtime-poll overhead becomes measurable. Tracked in
-[#TBD]; until it ships, use pattern 2.
+A `ASOBI_LUA_RELOAD=signal` mode that skips the per-tick `stat()` and reloads
+only when explicitly triggered does not exist. Until it does, use pattern 2 or
+turn reload off entirely.
 
-### Pattern 4 — Custom script source (planned)
+### Pattern 4: custom script source (planned, not shipped)
 
-If your scripts live somewhere other than a filesystem — Postgres, S3,
-git tags, a CMS — you will eventually want the planned
-`asobi_lua_source` behaviour, which dispatches to either the
-filesystem implementation or a custom loader. Until that lands, the
-practical workaround is a small sidecar that pulls from your source
-and writes to `/app/game/` using pattern 2. Tracked in [#TBD].
+If your scripts live in Postgres, S3, git tags or a CMS, the eventual answer is
+an `asobi_lua_source` behaviour dispatching to a custom loader. It does not
+exist. The workaround is a sidecar that pulls from your source and writes into
+`/app/game/` using pattern 2.
+
+## Mode-shape changes reload separately
+
+Hot reload re-executes a script body inside servers that already exist, so it
+cannot change how a match is *formed*. `match_size`, `strategy`, `max_players`
+and the `config.lua` mode manifest are read at formation time.
+
+A second poller handles those. `asobi_lua_config_watcher` stats `config.lua`,
+`match.lua` and every registered mode's script every 1500 ms and re-runs the
+config loader when an mtime moves, so new matches pick up the change. Running
+matches keep the values they formed with.
+
+`config_watch_interval` changes the interval. The watcher shares the hot-reload
+dial: with reload off it never scans at all. A failed reload keeps the
+last-good mode set and adopts the new mtimes anyway, so a broken file waits for
+your next edit rather than being retried forever.
 
 ## A minimal production compose
 
 Two files sit next to it, neither of which belongs in git:
 
 ```bash
-echo "ASOBI_DB_PASSWORD=$(openssl rand -hex 24)" > .env
+{
+  echo "ASOBI_DB_PASSWORD=$(openssl rand -hex 24)"
+  echo "ERLANG_COOKIE=$(openssl rand -hex 24)"
+} > .env
 openssl rand -hex 32 > ops_secret.txt
 printf '.env\nops_secret.txt\n' >> .gitignore
 ```
 
 `.env` is read by compose automatically and is the single source for the
-database password - Postgres and asobi both take it from there, so it cannot
-drift between them. `ops_secret.txt` is mounted as a file rather than passed as
-a variable, which keeps it out of `docker inspect` and out of the process
-environment.
+database password, so Postgres and asobi cannot drift apart. `ops_secret.txt`
+is mounted as a file rather than passed as a variable, which keeps it out of
+`docker inspect` and out of the process environment.
+
+The image was renamed from `ghcr.io/widgrensit/asobi_lua`; the old name still
+publishes for now, so change your compose file when convenient.
 
 ```yaml
 services:
@@ -159,8 +181,8 @@ services:
       retries: 5
     restart: unless-stopped
 
-  asobi_lua:
-    image: ghcr.io/widgrensit/asobi_lua:latest
+  asobi:
+    image: ghcr.io/widgrensit/asobi:latest
     depends_on:
       postgres:
         condition: service_healthy
@@ -173,7 +195,11 @@ services:
       # the password is substituted into sys.config before the VM starts, so
       # unlike the ops secret below it cannot be read from a file.
       ASOBI_DB_PASSWORD: ${ASOBI_DB_PASSWORD:?set ASOBI_DB_PASSWORD in .env}
-      ASOBI_NODE_HOST: 0.0.0.0
+      # No default. Unset renders an empty Access-Control-Allow-Origin, which
+      # no browser accepts, so put this deployment's real origin here.
+      ASOBI_CORS_ORIGINS: https://play.yourgame.com
+      # Distribution cookie. The image default is the literal `asobi`.
+      ERLANG_COOKIE: ${ERLANG_COOKIE:?set ERLANG_COOKIE in .env}
       # The operator console, on the game port. Drop these two lines to run
       # without it.
       ASOBI_CONSOLE: "true"
@@ -181,6 +207,11 @@ services:
     volumes:
       - /srv/asobi/game:/app/game:ro
     secrets: [ops_secret]
+    healthcheck:
+      test: ["CMD", "bin/asobi", "ping"]
+      interval: 10s
+      timeout: 5s
+      retries: 6
     ports:
       - "8084:8084"
     restart: unless-stopped
@@ -193,50 +224,73 @@ volumes:
   pgdata:
 ```
 
-Put this behind a TLS-terminating reverse proxy (Caddy, nginx,
-Traefik) — asobi speaks plain HTTP/WebSocket and expects the proxy
-to handle certificates.
+Put this behind a TLS-terminating reverse proxy (Caddy, nginx, Traefik). asobi
+speaks plain HTTP and WebSocket and expects the proxy to handle certificates.
 
-### Opening the console
+`ASOBI_NODE_HOST` is not in that compose on purpose. It names the Erlang node
+(`-name asobi@${ASOBI_NODE_HOST}` in `config/vm.args.src`), not a bind address;
+the port asobi listens on is `ASOBI_PORT`. The image default `127.0.0.1` is
+what you want for a single-node deploy.
 
-Browse to `/console` on the same host and port your game uses, and paste the
-contents of `ops_secret.txt`. That is the whole sign-in: the secret is
-exchanged once for an `HttpOnly` cookie plus a CSRF token, and the browser
-never holds it again.
+For a single node, also close distribution off. The shipped `vm.args` carries
+the line commented out:
 
-You get players, matches, the matchmaker, leaderboards, economy, chat,
-tournaments, notifications, and live runtime stats — the same console the
-managed cloud uses, because it ships in asobi itself.
-
-The console is on the **game port**, so anyone who can reach your game can
-reach `/console`. Restrict it at the proxy: allowlist your own address, or
-require an extra layer in front of `/console` and `/api/v1/ops`. If it did not
-come up, the node logs why at boot — `console_disabled_without_secret` means
-the secret file was missing, unreadable or empty.
-
-Name it if you run more than one:
-
-```yaml
-      ASOBI_CONSOLE_LABEL: prod
-      ASOBI_CONSOLE_PRODUCTION: "true"
+```
+-kernel inet_dist_use_interface "{127,0,0,1}"
 ```
 
-The label shows in the tab title, which is what tells two open consoles apart.
+Uncomment it in your own `vm.args` and the distribution port stops listening on
+anything but loopback, which is what makes a leaked cookie a local problem
+rather than a lateral-movement one. [Clustering](clustering.md) covers the
+multi-node case, where you need distribution and every node needs the same
+cookie.
+
+### Health endpoints
+
+The node serves three, unauthenticated, on the game port:
+
+| Path | Answers |
+| --- | --- |
+| `/live` | `200 {"status":"alive"}` as long as the VM responds. Liveness probe |
+| `/ready` | `200 {"status":"ready"}` once the critical database dependency has passed a health check, `503 {"status":"not_ready"}` before that. Readiness probe |
+| `/health` | The full report: dependency status, circuit-breaker and bulkhead state, and VM gauges |
+
+`/ready` is the one an orchestrator should gate traffic on. Kubernetes reads it
+with an `httpGet` probe.
+
+The compose healthcheck above uses `bin/asobi ping` instead, because the image
+carries no HTTP client: there is no `curl` and no `wget` in it.
+
+### The operator console
+
+A stock node serves neither: `/console` needs `console` to be true, and the ops
+routes reject everything until an `ops_secret` is configured. The two lines in
+the compose above set both. [Operator console](console.md) covers signing in,
+what the screens show, what the plane cannot do, and the cluster caveats.
+
+The plane is read-only apart from extension actions, so it is not where you ban
+a player or refund a purchase.
+
+Both share the game port, so anyone who can reach your game can reach
+`/console`. Restrict it at the proxy.
 
 ## Tuning knobs
 
-These are read at start time from your `sys.config`.
+All four go under `{asobi, [...]}`; an existing `{asobi_lua, [...]}` block also
+still works, see
+[Which application key](configuration.md#which-application-key).
 
 | Key | Default | What it does |
-|---|---|---|
-| `asobi_lua.max_heap_words` | `5_000_000` | Per-eval heap cap (in Erlang words) for every Lua callback the runtime invokes. If a single eval allocates past this, the eval process is killed by the VM and the runtime returns `{error, heap_exhausted}`. Persistent state held by the gen_server is not touched — only the runaway eval. Raise only if a single tick legitimately constructs a very large local structure; long-lived tables belong in the persistent Luerl state and cost nothing per eval. |
-| `asobi_lua.max_reductions_per_ms` | `50_000` | Per-eval CPU cap, as BEAM reductions allowed per millisecond of that callback's own wall-clock budget — so `tick` (500 ms) gets 25,000,000 and a bot's `think` (50 ms) gets 2,500,000. The timeout bounds latency but not work: without this, a script that spins is killed at its deadline and does it again next tick, holding a scheduler indefinitely. Overrun returns `{error, reductions_exhausted}`; the callback's result is discarded and the previous Lua state kept, exactly as for a timeout, so the match or zone survives. Sampled every 10 ms, so overshoot is bounded by one interval. Set to `0` to disable. |
-| `asobi_lua.reload_mode` (or env `ASOBI_LUA_RELOAD`) | `auto` | `auto` mtime-polls the script on every tick. `off` skips the poll entirely — appropriate for sealed-bundle prod where new code is a container restart, not a file change. Anything we don't recognise falls back to `auto` so a typo doesn't silently disable reload. |
+| --- | --- | --- |
+| `max_heap_words` | `5_000_000` | Per-eval heap cap, in Erlang words, for every Lua callback. An eval that allocates past it is killed by the VM and the runtime returns `{error, heap_exhausted}`; persistent state held by the gen_server is untouched. Raise it only if a single tick legitimately builds a very large local structure. Long-lived tables belong in the persistent Luerl state and cost nothing per eval |
+| `max_reductions_per_ms` | `50_000` | Per-eval CPU cap, as BEAM reductions per millisecond of that callback's own budget, so `tick` (500 ms) gets 25,000,000 and a bot's `think` (50 ms) gets 2,500,000. A timeout bounds latency but not work: without this, a script that spins is killed at its deadline and does it again next tick. Overrun returns `{error, reductions_exhausted}`, the result is discarded and the previous Lua state kept, so the match or zone survives. Sampled every 10 ms. `0` disables it |
+| `reload_mode` (or `ASOBI_LUA_RELOAD`) | `auto` | `auto` mtime-polls the script on every tick. `off` skips the poll entirely, which is right for a sealed bundle where new code is a container restart. Anything unrecognised falls back to `auto`, so a typo cannot silently disable reload |
+| `config_watch_interval` | `1500` | Milliseconds between mode-shape scans (above) |
 
 ```erlang
 %% sys.config
 [
-  {asobi_lua, [
+  {asobi, [
     {max_heap_words, 10_000_000},
     {max_reductions_per_ms, 50_000},
     {reload_mode, off}
@@ -244,54 +298,103 @@ These are read at start time from your `sys.config`.
 ].
 ```
 
-Or, in a Docker deploy, just set `ASOBI_LUA_RELOAD=off` in the container env.
+The first three are read per call, not at boot, so changing one through
+`application:set_env/3` takes effect without a restart.
+`config_watch_interval` is read once, when the watcher starts. In a Docker
+deploy, `ASOBI_LUA_RELOAD=off` in the container environment is the usual route.
 
 ## Validating Lua scripts in CI
 
-Before deploying a new `match.lua` or `world.lua`, run it through the
-loader in CI to catch syntax errors and sandbox violations without
-booting a full runtime:
+Load a script through the loader to catch syntax errors and sandbox violations
+without a database or a running node:
 
 ```bash
-docker run --rm -v "$PWD/lua:/g" ghcr.io/widgrensit/asobi_lua \
-  bin/asobi_lua eval 'asobi_lua_validate:cli(["/g/match.lua"]).'
+docker run --rm -v "$PWD/lua:/g" ghcr.io/widgrensit/asobi sh -c \
+  'erts-*/bin/erl -noshell -boot no_dot_erlang -pa lib/*/ebin \
+     -eval "asobi_lua_validate:cli([\"/g/match.lua\"])."'
 ```
 
 Exits 0 on a clean script, 1 with the loader's error reason on stderr
-otherwise. Pass multiple paths to validate them sequentially; the run
-exits on the first failure.
+otherwise. Pass more paths to validate them in sequence; it stops at the first
+failure.
+
+This runs a throwaway VM inside the image. Do not reach for `bin/asobi eval`:
+that evaluates on a *running* node, and `asobi_lua_validate:cli/1` ends in
+`halt/1`, which would stop your server.
+
+## Before you go to production
+
+- **The console is off** unless you turned it on. Leave it off if nobody needs
+  it; if you turn it on, put it behind the proxy restriction above.
+- **Guest auth is off** until the game declares `guest_auth = true` in its Lua
+  *and* the operator configures a pepper of at least 32 bytes. Both halves are
+  required (ADR 0004), and the operator half currently needs a `sys.config`:
+  `ASOBI_GUEST_VERIFIER_PEPPER` is declared in the image but never substituted,
+  so setting it alone does nothing.
+- **Hot reload is on** unless `ASOBI_LUA_RELOAD=off`. On a sealed image that is
+  a wasted `stat()` per tick; on a mounted volume it is the feature.
+- **Rate limits are per node.** A 5/s bucket is 5 x N across a cluster. The
+  development config loosens `auth`, `register`, `iap` and `api` to 1000/s for
+  the test suite; the production config does not.
+- **CORS is empty by default.** Set `ASOBI_CORS_ORIGINS` to your real origin or
+  every browser client fails preflight.
+- **`ERLANG_COOKIE` defaults to the literal `asobi`.** Change it, in every
+  node, before you expose distribution to anything.
+- **The database port is fixed at 5432** in the image. A different port needs
+  your own `sys.config`.
+
+## Upgrading
+
+### Which tag to run
+
+Every compose file in these guides says `:latest`, which is right for trying
+asobi and wrong for running it. `latest` follows the default branch, so a
+`docker compose pull` can move you across a schema change you did not choose.
+
+Pin a digest. It is the only tag on this image that cannot move under you:
+
+```yaml
+image: ghcr.io/widgrensit/asobi@sha256:<digest>
+```
+
+`docker pull ghcr.io/widgrensit/asobi:latest` prints the digest it resolved, and
+that is the value to paste. Move it when you have decided to upgrade, with a
+backup taken.
+
+Do not pin a version number on this image yet. `ghcr.io/widgrensit/asobi`
+carries a `0.13`-`0.23` semver series left over from an earlier publishing
+workflow: those are real but from April 2026, and they predate the Lua merge and
+the console. Version tags resume from the next release; until one exists, the
+only current tags are `latest`, `main` and the long commit SHA.
+
+### Rolling a new version
+
+Migrations run at boot, from `asobi_app:start/2`. A failure logs
+`migration_failed` and the node **starts anyway**, so a bad roll leaves a
+running node serving an old schema and answering requests. Extension routes
+answer `503 not_ready` in that state; core does not.
+
+Back up before you roll, and grep the boot log for `migrations_applied` after
+you do.
 
 ## Operating notes
 
-- **Database backups.** Postgres holds session tokens, world
-  snapshots, and leaderboards. Use `pg_dump` or `pg_basebackup` on
-  whatever cadence your data loss tolerance requires; nothing in
-  asobi_lua is recoverable from the runtime alone.
-- **Logs.** asobi_lua emits structured JSON via `nova_jsonlogger`.
-  Ingest them as JSON lines from container stdout.
-- **Crash dumps.** Erlang writes `erl_crash.dump` to the working
-  directory on a VM crash. In a container that means it is lost on
-  restart unless you mount a writable volume — we recommend leaving
-  it ephemeral; if you need post-mortem capability, mount a
-  short-retention volume at `/app`.
-- **Restarts are cheap.** The container takes single-digit seconds to
-  boot. In-flight matches are not preserved across restarts (they
-  rely on in-memory state); design clients to reconnect.
-- **The operator console.** Set `console` and `ops_secret` and the node
-  serves a browser console at `/console` (see
-  [Configuration](configuration.md#operator-console)). It shares the game
-  port, because Nova starts one listener, so treat `/console` and
-  `/api/v1/ops` as one thing when you decide what the internet can reach.
-  Both are off until configured. Console sessions are in memory and end with
-  the restart above.
+- **Database backups.** Postgres holds players, tokens, cloud saves,
+  leaderboards, economy, chat history, tournaments and IAP transactions.
+  `pg_dump` or `pg_basebackup` on whatever cadence your loss tolerance needs;
+  nothing in asobi is recoverable from the runtime alone.
+- **Logs.** Structured JSON via `nova_jsonlogger`, on container stdout. Ingest
+  them as JSON lines.
+- **Crash dumps.** Erlang writes `erl_crash.dump` to the working directory on a
+  VM crash, which in a container means it is lost on restart unless you mount a
+  writable volume. Leaving it ephemeral is fine; if you want post-mortems,
+  mount a short-retention volume at `/app`.
+- **Restarts.** In-flight matches and worlds live in memory and are not
+  preserved. Design clients to reconnect.
 
 ## What this guide does not cover
 
-- Multi-tenant hosting. The asobi managed cloud (and the private
-  `asobi_engine` image behind it) handles tenant isolation; the public
-  `asobi_lua` image is single-tenant.
-- Horizontal scaling beyond one node. Asobi clusters via standard
-  Erlang distribution; multi-node ops is its own topic and lives in
-  the `asobi` library docs.
-- Stripe / IAP / payments. Those are part of the managed cloud; the
-  open-source runtime ships only the IAP-receipt-validation primitive.
+- Multi-node operation. See [Clustering](clustering.md), which also holds the
+  complete list of what is per node.
+- Multi-tenant hosting. This image is single-tenant.
+- Payments. asobi ships the IAP receipt-validation primitive and nothing else.

--- a/guides/voting.md
+++ b/guides/voting.md
@@ -1,366 +1,390 @@
 # Voting
 
-Asobi includes an in-match voting system for roguelike-style group decisions
-such as path selection, item picks, event choices, and run modifiers.
+An in-session voting system for group decisions: path selection, item picks,
+event choices, run modifiers. It runs inside a match or a world.
 
-## How It Works
+## The namespace follows the session
 
-1. Game mode (or match server) starts a vote with options and a timed window
-2. Eligible players receive a `match.vote_start` event via WebSocket
-3. Players cast votes during the window
-4. When the window expires, votes are tallied and the result is broadcast
-5. The game mode receives the result via the `vote_resolved/3` callback
+Worlds run votes exactly as matches do, and the frames a client receives are
+named after the session it is in:
 
-## Starting a Vote
+| Session | Push frames |
+|---|---|
+| Match | `match.vote_start`, `match.vote_tally`, `match.vote_result`, `match.vote_vetoed` |
+| World | `world.vote_start`, `world.vote_tally`, `world.vote_result`, `world.vote_vetoed` |
 
-There are two ways to start a vote:
+A world client listening for `match.vote_start` receives nothing at all. Listen
+for the namespace your game runs in.
 
-### Automatic (via `vote_requested` callback)
+## How it works
 
-The match server polls the `vote_requested/1` callback after every tick. Return
-a vote config to start a vote, or `none`/`nil` to skip. This is the simplest
-approach and works for both Erlang and Lua game modules. Votes can be triggered
-at any point during gameplay - not just between rounds.
+1. The game asks for a vote, with options and a timed window.
+2. Eligible players receive `vote_start` in their session's namespace.
+3. Players cast votes during the window with the `vote.cast` frame.
+4. The window closes, votes are tallied and the result is broadcast.
+5. The game module's optional `vote_resolved` callback receives the result.
 
-<!-- tabs -->
-**Lua**
+## Starting a vote from Lua
+
+There are two Lua triggers, one per session type. Both are polled by the server
+after every tick.
+
+**A match script** implements `vote_requested(state)`. Return a config table to
+start a vote, or `nil` to skip:
+
 ```lua
 function vote_requested(state)
-    return { method = "plurality", options = {"map_a", "map_b"}, window_ms = 15000 }
+  if state.boss_defeated and not state.boon_picked then
+    return {
+      template  = "boon_pick",
+      options   = { { id = "shield", label = "Shield" },
+                    { id = "speed",  label = "Speed" } },
+      method    = "plurality",
+      window_ms = 15000
+    }
+  end
+  return nil
 end
 ```
-**Erlang**
-```erlang
-vote_requested(#{phase := vote_pending} = _GameState) ->
-    {ok, #{
-        template => ~"path_choice",
-        options => [
-            #{id => ~"jungle", label => ~"Jungle Path"},
-            #{id => ~"volcano", label => ~"Volcano Path"}
-        ],
-        window_ms => 15000,
-        method => ~"plurality"
-    }};
-vote_requested(_) ->
-    none.
+
+Returning `nil`, `false` or an empty table skips.
+
+An Erlang match module may also implement `vote_started/1`, which fires when a
+vote starts this way. The Lua bridge does not export it, so a Lua
+`vote_started` function is never called. Set your own flag inside
+`vote_requested` instead.
+
+**A world script** sets `state._vote` inside `post_tick`, because a world has no
+`vote_requested` callback:
+
+```lua
+function post_tick(tick, state)
+  if state.boss_hp <= 0 then
+    state._vote = {
+      template  = "boon_pick",
+      options   = { { id = "shield", label = "Shield" },
+                    { id = "speed",  label = "Speed" } },
+      method    = "plurality",
+      window_ms = 15000
+    }
+    state.boss_hp = 10000    -- clear the trigger so it does not re-fire
+  end
+  return state
+end
 ```
-<!-- /tabs -->
 
-When a vote starts this way, the optional `vote_started/1` callback is called
-to let the game module update its state (e.g. change phase).
+Clear whatever condition set `_vote`, or the next tick sets it again.
 
-### Manual (via match server API)
+### Known gap: a Lua config does not start a vote today
 
-Votes can also be started explicitly from a game mode callback:
+Both triggers are called and both decode your table, but the decoded table
+reaches the vote server with **string keys**, and the vote server reads atom
+keys. It therefore fails to start and the failure is swallowed at both call
+sites, so the vote silently never happens: no `vote_start` frame, no log line
+naming your script.
+
+This is a defect, not a design. Until it is fixed, a vote has to be started
+from Erlang. If you are writing a Lua-only game and you need voting now, this
+is the one feature you cannot reach.
+
+## Starting a vote from Erlang
+
+`asobi_match_server:start_vote/2` and `asobi_world_server:start_vote/2` take the
+session pid and a config map with **atom keys**. There is no Lua equivalent.
 
 ```erlang
-%% From inside a game module callback
 asobi_match_server:start_vote(MatchPid, #{
-    template => ~"path_choice",
-    options => [
-        #{id => ~"jungle", label => ~"Jungle Path"},
+    template   => ~"path_choice",
+    options    => [
+        #{id => ~"jungle",  label => ~"Jungle Path"},
         #{id => ~"volcano", label => ~"Volcano Path"},
-        #{id => ~"caves", label => ~"Ice Caves"}
+        #{id => ~"caves",   label => ~"Ice Caves"}
     ],
-    window_ms => 15000,
-    method => ~"plurality",
+    window_ms  => 15000,
+    method     => ~"plurality",
     visibility => ~"live"
 }).
 ```
 
-### Config Options
+An Erlang game module can also implement `vote_requested/1`, returning
+`{ok, Config}` or `none`, which the match server polls after every tick.
 
-| Key            | Type           | Default        | Description                        |
-|----------------|----------------|----------------|------------------------------------|
-| `options`      | `[map()]`      | required       | List of `#{id, label}` option maps |
-| `template`     | `binary()`     | `"default"`    | Template name (resolved from config) |
-| `window_ms`    | `pos_integer()`| `15000`        | Vote window in milliseconds        |
-| `method`       | `binary()`     | `"plurality"`  | `"plurality"`, `"approval"`, `"weighted"`, or `"ranked"` |
-| `visibility`   | `binary()`     | `"live"`       | `"live"` or `"hidden"`             |
-| `tie_breaker`  | `binary()`     | `"random"`     | `"random"` or `"first"`            |
-| `veto_enabled` | `boolean()`    | `false`        | Allow players to veto              |
-| `weights`      | `map()`        | `#{}`          | Voter weights for `"weighted"` method |
-| `max_revotes`  | `pos_integer()`| `3`            | Max times a voter can change their vote |
+The server fills in `match_id`, `match_pid`, `eligible` (every current player)
+and merged `weights` before the vote starts, so a caller never supplies them.
 
-The match server automatically fills in `match_id`, `match_pid`, and
-`eligible` (all current players) when starting the vote.
+Starting a vote in a match that has not started yet answers
+`{error, match_not_started}`, and in a paused match `{error, match_paused}`.
 
-## Voting Methods
+## Config reference
 
-### Plurality
+| Key | Type | Default | Description |
+|---|---|---|---|
+| `options` | `[map()]` | required | List of `#{id, label}` option maps |
+| `template` | `binary()` | `"default"` | Template name, resolved from `vote_templates` |
+| `vote_id` | `binary()` | generated | Override the vote id |
+| `window_ms` | `pos_integer()` | `15000` | Vote window in milliseconds |
+| `method` | `binary()` | `"plurality"` | `"plurality"`, `"approval"`, `"weighted"` or `"ranked"` |
+| `visibility` | `binary()` | `"live"` | `"live"` or `"hidden"` |
+| `tie_breaker` | `binary()` | `"random"` | `"random"` or `"first"` |
+| `veto_enabled` | `boolean()` | `false` | Allow an eligible voter to veto |
+| `weights` | `map()` | `#{}` | `#{voter_id => number()}` for `"weighted"` |
+| `max_revotes` | `pos_integer()` | `3` | Times a voter may change their vote |
+| `window_type` | `binary()` | `"fixed"` | `"fixed"`, `"ready_up"`, `"hybrid"` or `"adaptive"` |
+| `min_window_ms` | `pos_integer()` | `5000` | Minimum window before `"hybrid"` may close early |
+| `supermajority` | `float()` | `0.75` | Threshold for `"adaptive"` early close and for `require_supermajority` |
+| `require_supermajority` | `boolean()` | `false` | Winner must reach `supermajority` or the result is no-consensus |
+| `spectators` | `[binary()]` | `[]` | Spectator voter ids, a separate pool |
+| `spectator_weight` | `float()` | `0.3` | Spectator share of the merged score, 0.0-1.0 |
+| `quorum` | `float()` | `0.0` | Minimum fraction of eligible voters for a valid result. 0.0 disables |
+| `default_votes` | `map()` | `#{}` | `#{voter_id => option_id}` applied at resolution for absentees |
+| `delegation` | `map()` | `#{}` | `#{delegator_id => delegate_id}` |
 
-Each player picks exactly one option. The option with the most votes wins.
-Ties are broken by the configured `tie_breaker` strategy.
+`match_id`, `match_pid` and `eligible` are also config keys, but the session
+server supplies all three.
 
-### Approval
+## Voting methods
 
-Each player submits a list of all options they approve of. The option with
-the highest total approval count wins. Good for "avoid the worst option"
-scenarios.
+**Plurality.** Each player picks one option; most votes wins. Ties go to
+`tie_breaker`.
 
-### Weighted
+**Approval.** Each player submits a list of options they approve of; highest
+total approval wins. Good for "avoid the worst option".
 
-Each vote is multiplied by the voter's weight. Pass weights via config:
-
-```erlang
-asobi_match_server:start_vote(MatchPid, #{
-    options => Options,
-    method => ~"weighted",
-    weights => #{~"player1" => 3, ~"player2" => 1}
-}).
-```
-
-Players not in the weights map default to weight 1. Useful for
-performance-based voting or role-based voting.
-
-### Ranked Choice
-
-Each player submits a ranked list. The option with fewest first-choice votes
-is eliminated each round, and those votes transfer to the next preference.
-Continues until one option has a majority.
+**Weighted.** Each vote is multiplied by the voter's weight. Voters absent from
+the `weights` map count as 1.
 
 ```erlang
-asobi_match_server:start_vote(MatchPid, #{
-    options => Options,
-    method => ~"ranked"
-}).
+#{method => ~"weighted", weights => #{~"player1" => 3, ~"player2" => 1}}
 ```
 
-Clients send a list for `option_id`:
+**Ranked.** Each player submits a ranked list. The option with the fewest
+first-choice votes is eliminated each round and its votes transfer to the next
+preference, until one option has a majority. Clients send a list for
+`option_id`:
 
 ```json
 {"type": "vote.cast", "payload": {"vote_id": "...", "option_id": ["jungle", "caves", "volcano"]}}
 ```
 
-Live tallies show first-choice counts. The final result includes the winner
-after all elimination rounds.
+Live tallies show first-choice counts; the final result is the winner after all
+elimination rounds.
 
-## Spectator Voting
+## Window types
 
-Spectators are a separate voter pool whose votes are merged with player
-votes using a configurable weight ratio.
+Every type has `window_ms` as a hard upper bound.
+
+| `window_type` | Closes when |
+|---|---|
+| `"fixed"` | `window_ms` elapses. Simple and predictable |
+| `"ready_up"` | Every eligible voter has voted, or `window_ms` elapses |
+| `"hybrid"` | As `ready_up`, but not before `min_window_ms` |
+| `"adaptive"` | On reaching `supermajority` the remaining time shrinks to 3 seconds, giving latecomers a last chance. A later cast that breaks the supermajority does not restore the original window - the shortened timer keeps running |
+
+## Spectator voting
+
+Spectators are a separate pool merged with player votes:
 
 ```erlang
-asobi_match_server:start_vote(MatchPid, #{
-    options => Options,
-    spectators => [~"spec1", ~"spec2", ~"spec3"],
-    spectator_weight => 0.3  %% spectators get 30% influence, players 70%
-}).
+#{spectators => [~"spec1", ~"spec2"], spectator_weight => 0.3}
 ```
 
-Both pools are tallied independently, normalized, then merged:
-`score = player_normalized * (1 - spectator_weight) + spectator_normalized * spectator_weight`
+Both pools are tallied independently, normalised, then merged:
 
-For spectator-only votes (audience decides), set `eligible => []` and
+```
+score = player_normalised * (1 - spectator_weight) + spectator_normalised * spectator_weight
+```
+
+For an audience-decides vote, set `eligible => []` and
 `spectator_weight => 1.0`.
 
-## Async Voting
+## Async voting
 
-For non-real-time games where not all players are online simultaneously.
+For games where not everyone is online at once.
 
-### Quorum
+**Quorum.** `#{quorum => 0.5}` requires half the eligible voters to
+participate. Short of that, the result carries `winner => undefined` and
+`status => "no_quorum"`.
 
-Require a minimum fraction of eligible voters before the result is valid:
+**Default votes.** `#{default_votes => #{~"player2" => ~"opt_b"}}` applies a
+fallback at resolution time only. Defaults never count as active votes during
+the window, and an explicit vote overrides them.
 
-```erlang
-#{quorum => 0.5}  %% at least 50% must vote
-```
-
-If quorum is not met when the window expires, the result has
-`winner => undefined` and `status => "no_quorum"`.
-
-### Default Votes
-
-Set fallback votes for players who don't participate:
-
-```erlang
-#{default_votes => #{~"player2" => ~"opt_b", ~"player3" => ~"opt_a"}}
-```
-
-Defaults are applied at resolution time only — they don't count as active
-votes during the window. Players who vote explicitly override their default.
-
-### Delegation
-
-Let a player's vote follow another player's choice:
-
-```erlang
-#{delegation => #{~"player3" => ~"player1"}}
-```
-
-If player3 doesn't vote but player1 voted for `opt_a`, player3's vote
-becomes `opt_a` at resolution time. If the delegate also didn't vote,
+**Delegation.** `#{delegation => #{~"player3" => ~"player1"}}` makes player3's
+vote follow player1's at resolution time. If the delegate did not vote either,
 no vote is added.
 
-## Vote Templates
+## Vote templates
 
-Define reusable vote configurations in your app config. Per-call config
-overrides template defaults:
+Reusable configurations in app config. Per-call config overrides the template:
 
 ```erlang
 {asobi, [
     {vote_templates, #{
-        ~"boon_pick" => #{method => ~"plurality", window_ms => 15000, visibility => ~"live"},
-        ~"path_choice" => #{method => ~"approval", window_ms => 20000, visibility => ~"hidden"},
-        ~"weighted_pick" => #{method => ~"weighted", window_ms => 15000}
+        ~"boon_pick"   => #{method => ~"plurality", window_ms => 15000, visibility => ~"live"},
+        ~"path_choice" => #{method => ~"approval", window_ms => 20000, visibility => ~"hidden"}
     }}
 ]}
 ```
 
-Then start a vote with just the template name and options:
+```erlang
+asobi_match_server:start_vote(MatchPid, #{template => ~"boon_pick", options => Options}).
+```
+
+## Reacting to the result
+
+<!-- tabs -->
+**Lua**
+```lua
+function vote_resolved(template, result, state)
+  if template == "path_choice" then
+    state.current_path = result.winner
+  end
+  return state
+end
+```
+**Erlang**
+```erlang
+vote_resolved(~"path_choice", #{winner := WinnerId}, GameState) ->
+    {ok, GameState#{current_path => WinnerId}}.
+```
+<!-- /tabs -->
+
+The callback is optional. Without it the vote still runs and broadcasts, the
+game just does not react server-side.
+
+The Lua form works for a **match** script only. The world bridge does not
+export `vote_resolved/3`, so a Lua world script's `vote_resolved` is never
+called; an Erlang world module's is.
+
+## Majority tyranny mitigations
+
+**Frustration accumulator.** A player who votes for the losing option
+accumulates frustration; on the next vote their weight becomes
+`1 + frustration_count * frustration_bonus`, and winning resets it to 0. Three
+consecutive losses give a weight of 2.5. `frustration_bonus` defaults to `0.5`
+and the merged weights are attached to every vote the session starts, but only
+`method => "weighted"` reads them - plurality, approval and ranked count
+ballots, not weights. So the accumulator is armed by default and inert until a
+vote asks for weighting.
+
+**Supermajority requirement.** `require_supermajority => true` with a
+`supermajority` threshold. If no option reaches it, the result carries
+`winner => undefined` and `status => "no_consensus"`, and `vote_resolved`
+decides what happens next.
+
+**Veto tokens.** `veto_tokens_per_player` defaults to `0`, which disables veto
+tokens. A player spends one with the `vote.veto` frame, which cancels the
+current vote immediately. Exhausted tokens answer `no_veto_tokens`.
+
+`frustration_bonus` and `veto_tokens_per_player` are read from the map that
+starts the **session**, not from the vote config and not from `game_modes`.
+Nothing in the shipped create paths passes them: a matchmaker-spawned match and
+every world get the defaults above. Only Erlang code calling
+`asobi_match_sup:start_match/1` directly can set them.
 
 ```erlang
-asobi_match_server:start_vote(MatchPid, #{
-    template => ~"boon_pick",
-    options => Options
+asobi_match_sup:start_match(#{
+    mode                   => ~"arena",
+    game_module            => my_arena,
+    game_config            => #{},
+    min_players            => 4,
+    max_players            => 4,
+    frustration_bonus      => 0,
+    veto_tokens_per_player => 2
 }).
 ```
 
-## Window Types
+## Client protocol
 
-The `window_type` config controls when a vote closes. All types have a
-maximum `window_ms` timeout as a safety net.
-
-### Fixed (default)
-
-Vote runs for exactly `window_ms`, then closes. Simple and predictable.
-
-```erlang
-#{window_type => ~"fixed", window_ms => 15000}
-```
-
-### Ready-up
-
-Closes as soon as all eligible voters have cast a vote, or when `window_ms`
-expires. Best for small groups where everyone is engaged.
-
-```erlang
-#{window_type => ~"ready_up", window_ms => 30000}
-```
-
-### Hybrid
-
-Like ready-up, but enforces a minimum `min_window_ms` before early close.
-Prevents snap decisions while still closing early once everyone votes.
-
-```erlang
-#{window_type => ~"hybrid", window_ms => 30000, min_window_ms => 5000}
-```
-
-### Adaptive
-
-Starts with full `window_ms`, but when a supermajority threshold is reached,
-the remaining time shrinks to 3 seconds. Gives latecomers a last chance
-without forcing everyone to wait.
-
-```erlang
-#{window_type => ~"adaptive", window_ms => 20000, supermajority => 0.75}
-```
-
-If the supermajority is lost (e.g. someone changes their vote), the timer
-resets to the original remaining time.
-
-## Rate Limiting
-
-Voters can change their vote during the window, but are limited to
-`max_revotes` changes (default 3). After that, `{error, rate_limited}` is
-returned. The initial vote does not count against the limit.
-
-## Game Mode Integration
-
-Implement the optional `asobi_match` callbacks to react to vote results:
-
-```erlang
--module(my_roguelike).
--behaviour(asobi_match).
-
-%% ... init/1, join/2, leave/2, handle_input/3, get_state/2 ...
-
-vote_resolved(~"path_choice", #{winner := WinnerId}, GameState) ->
-    %% Apply the voted path to game state
-    {ok, GameState#{current_path => WinnerId}};
-vote_resolved(~"item_pick", #{winner := ItemId}, GameState) ->
-    {ok, add_item(ItemId, GameState)}.
-```
-
-Both callbacks are optional. If `vote_resolved/3` is not implemented, the
-vote still runs and broadcasts results to clients — the game mode just
-doesn't react server-side.
-
-## WebSocket Protocol
-
-### Casting a Vote (client to server)
+### Casting a vote
 
 ```json
 {
   "type": "vote.cast",
   "cid": "v1",
-  "payload": {
-    "vote_id": "...",
-    "option_id": "jungle"
-  }
+  "payload": {"vote_id": "...", "option_id": "jungle"}
 }
 ```
 
-For approval voting, `option_id` is a list:
-
-```json
-{"option_id": ["jungle", "caves"]}
-```
-
-Response:
+For approval and ranked voting, `option_id` is a list.
 
 ```json
 {"type": "vote.cast_ok", "cid": "v1", "payload": {"success": true}}
 ```
 
-Players can change their vote by sending another `vote.cast` during the
-window. The new vote replaces the previous one.
+Sending `vote.cast` again during the window replaces the previous vote, up to
+`max_revotes` changes. The initial vote does not count against the limit.
 
-### Server Push Events
+### Vetoing
 
-All vote events are broadcast to match players as `match.*` events:
+```json
+{"type": "vote.veto", "cid": "v2", "payload": {"vote_id": "..."}}
+```
 
-#### `match.vote_start`
+```json
+{"type": "vote.veto_ok", "cid": "v2", "payload": {"success": true}}
+```
 
-A new vote has started.
+### Errors
+
+Both frames answer a `{"type": "error"}` frame carrying the shared error object
+plus a `reason` field.
+
+| `reason` | `error.code` | Meaning |
+|---|---|---|
+| `not_in_match` | `match.not_in_match` | The connection is not joined to a match |
+| `vote_not_found` | `ws.request_failed` | No live vote with that id in this session |
+| `not_eligible` | `ws.request_failed` | The voter is not in the eligible or spectator pool |
+| `invalid_option` | `ws.request_failed` | `option_id` is not one of the vote's options |
+| `rate_limited` | `rate_limited` | `max_revotes` changes already used |
+| `vote_closed` | `ws.request_failed` | The window and its 500ms grace period have passed |
+| `veto_disabled` | `ws.request_failed` | `veto_enabled` is false for this vote |
+| `no_veto_tokens` | `ws.request_failed` | The player has spent every veto token |
+
+**A world player always gets `not_in_match`.** Both frames route on the
+session's `match_pid`, and joining a world sets `world_pid` instead, so a world
+vote can be started and broadcast but not cast from a client today. This is the
+same defect class as the Lua config above. Report both if they block you.
+
+### Grace period
+
+Votes arriving within 500ms of the window closing are still accepted, to absorb
+network latency.
+
+## Server push frames
+
+Shown here in the `match.` namespace; a world sends the same payloads under
+`world.`.
+
+`match.vote_start`:
 
 ```json
 {
   "type": "match.vote_start",
   "payload": {
     "vote_id": "...",
-    "options": [
-      {"id": "jungle", "label": "Jungle Path"},
-      {"id": "volcano", "label": "Volcano Path"},
-      {"id": "caves", "label": "Ice Caves"}
-    ],
+    "options": [{"id": "jungle", "label": "Jungle Path"}],
     "window_ms": 15000,
     "method": "plurality"
   }
 }
 ```
 
-#### `match.vote_tally`
-
-Running tally update (only with `"live"` visibility). Sent each time a vote
-is cast.
+`match.vote_tally`, sent on every cast, and only with `"live"` visibility:
 
 ```json
 {
   "type": "match.vote_tally",
   "payload": {
     "vote_id": "...",
-    "tallies": {"jungle": 2, "volcano": 1, "caves": 0},
+    "tallies": {"jungle": 2, "volcano": 1},
     "time_remaining_ms": 8432,
     "total_votes": 3
   }
 }
 ```
 
-#### `match.vote_result`
-
-Vote has closed and the winner is determined.
+`match.vote_result`:
 
 ```json
 {
@@ -368,130 +392,68 @@ Vote has closed and the winner is determined.
   "payload": {
     "vote_id": "...",
     "winner": "jungle",
-    "counts": {"jungle": 2, "volcano": 1, "caves": 0},
-    "distribution": {"jungle": 0.666, "volcano": 0.333, "caves": 0.0},
+    "counts": {"jungle": 2, "volcano": 1},
+    "distribution": {"jungle": 0.666, "volcano": 0.333},
     "total_votes": 3,
     "turnout": 1.0
   }
 }
 ```
 
-#### `match.vote_vetoed`
-
-A player has vetoed the vote (when `veto_enabled` is true).
+`match.vote_vetoed`:
 
 ```json
-{
-  "type": "match.vote_vetoed",
-  "payload": {
-    "vote_id": "...",
-    "vetoed_by": "player_id"
-  }
-}
+{"type": "match.vote_vetoed", "payload": {"vote_id": "...", "vetoed_by": "player_id"}}
 ```
 
-## REST API
+## Visibility
 
-### List votes for a match
+- `"live"` - running tallies are broadcast after each cast and included in
+  state queries.
+- `"hidden"` - no `vote_tally` frame is sent at all; the tallies arrive only in
+  `vote_result` when the vote closes, which prevents bandwagoning.
+
+Visibility governs the live frames only. It is not recorded on the persisted
+row, so a resolved hidden vote's per-voter ballots are readable in the history
+below exactly like a live one's.
+
+## Reading vote history
+
+There is no votes screen on the console. Two REST routes cover it, and both
+read the `votes` table, which is written **only when a vote resolves** - a vote
+in progress appears in neither.
+
+Every vote for a match, most recent 50, newest first:
 
 ```bash
 curl http://localhost:8084/api/v1/matches/<match_id>/votes \
   -H 'Authorization: Bearer <token>'
 ```
 
-Returns the most recent 50 votes for the match, ordered by newest first.
+```json
+{"votes": [{"id": "...", "match_id": "...", "template": "...", "method": "plurality", "options": [], "votes_cast": {}, "result": {}, "distribution": {}, "turnout": 1.0, "eligible_count": 3, "window_ms": 15000, "opened_at": "...", "closed_at": "...", "inserted_at": "..."}]}
+```
 
-### Get a single vote
+Restricted to participants of that match: anyone else gets `403 forbidden`.
+A world's votes are stored under the world id in the same `match_id` column, so
+the same route takes a world id - but only after the world finishes and writes
+its record, and only for the players still in it at that moment. While the
+world is live the participant check finds neither a record nor a match server
+and answers `403`.
+
+One vote by id:
 
 ```bash
 curl http://localhost:8084/api/v1/votes/<vote_id> \
   -H 'Authorization: Bearer <token>'
 ```
 
-## Visibility Modes
-
-- **`"live"`**: Running tallies are broadcast after each vote and included in
-  state queries. Creates excitement and enables strategic voting.
-- **`"hidden"`**: Tallies are not shown until the vote closes. Prevents
-  bandwagon effects. Only total vote count is visible during the window.
-
-## Veto
-
-When `veto_enabled` is true, any eligible voter can veto the vote. This
-immediately cancels it and notifies all players. Use sparingly — typically
-as a limited-use resource managed by the game mode.
-
-## Majority Tyranny Mitigations
-
-When the same majority always outvotes a minority, voting becomes
-frustrating. Asobi provides three configurable mitigations.
-
-### Frustration Accumulator
-
-Players who vote for the losing option accumulate frustration. On the
-next vote, their weight is boosted: `1 + frustration_count * frustration_bonus`.
-When they finally win, their frustration resets to 0.
-
-Configure at match level:
-
-```erlang
-asobi_match_sup:start_match(#{
-    game_module => MyGame,
-    frustration_bonus => 0.5  %% default 0.5, set 0 to disable
-}).
-```
-
-A player who lost 3 consecutive votes gets weight `1 + 3 * 0.5 = 2.5`,
-making their vote count 2.5x. This only applies to weighted voting or
-when frustration weights are merged (which happens automatically when
-starting votes via the match server).
-
-### Supermajority Requirement
-
-Force high-stakes votes to require a supermajority. If no option reaches
-the threshold, the result has `winner => undefined` and
-`status => "no_consensus"`.
-
-```erlang
-asobi_match_server:start_vote(MatchPid, #{
-    options => Options,
-    require_supermajority => true,
-    supermajority => 0.75  %% 75% required
-}).
-```
-
-The game mode's `vote_resolved/3` callback receives the no-consensus
-result and can decide what to do (random pick, re-vote, default option).
-
-### Veto Tokens
-
-Give players a limited number of vetoes per match. When used, the current
-vote is immediately cancelled. The game mode decides what happens next.
-
-Configure at match level:
-
-```erlang
-asobi_match_sup:start_match(#{
-    game_module => MyGame,
-    veto_tokens_per_player => 2  %% default 0 (disabled)
-}).
-```
-
-Clients use veto tokens via WebSocket:
-
-```json
-{"type": "vote.veto", "payload": {"vote_id": "..."}}
-```
-
-The match server checks token availability before forwarding to the vote
-server. Returns `{error, no_veto_tokens}` when exhausted.
-
-## Grace Period
-
-Votes arriving within 500ms after the window closes are still accepted to
-compensate for network latency.
+Unknown ids answer `404 vote.not_found`. This route is authenticated but not
+participant-scoped. See [Operator console](console.md) for what the console
+does cover.
 
 ## Next steps
 
-- [WebSocket protocol](websocket-protocol.md) - the `match.vote_*` push messages.
+- [WebSocket protocol](websocket-protocol.md) - the frame envelope.
+- [Phases](phases.md) - run a vote to decide what the next phase does.
 - [Configuration](configuration.md) - vote templates.

--- a/guides/websocket-protocol.md
+++ b/guides/websocket-protocol.md
@@ -92,10 +92,11 @@ has one; a client written from scratch needs one too.
 
 ### `session.connect`
 
-Authenticate the WebSocket connection. Must be the first message sent.
+Authenticate the WebSocket connection. Must be the first message sent. The
+token is the `access_token` from any auth route.
 
 ```json
-{"type": "session.connect", "payload": {"token": "session_token_here"}}
+{"type": "session.connect", "payload": {"token": "<access_token>"}}
 ```
 
 Response:
@@ -104,6 +105,10 @@ Response:
 {"type": "session.connected", "payload": {"player_id": "..."}}
 ```
 
+A bad or expired token answers `error` with reason `invalid_token` and code
+`unauthenticated`, and the socket stays open so the client can retry with a
+refreshed token.
+
 ### `session.heartbeat`
 
 Keep-alive ping. Send periodically to prevent timeout.
@@ -111,6 +116,41 @@ Keep-alive ping. Send periodically to prevent timeout.
 ```json
 {"type": "session.heartbeat", "payload": {}}
 ```
+
+Reply, carrying the server's clock in Unix milliseconds:
+
+```json
+{"type": "session.heartbeat", "cid": "h-1", "payload": {"ts": 1785312000000}}
+```
+
+The reply is the same type as the request. A client that switches on `type`
+alone must tolerate that; a `cid` distinguishes the reply from a push.
+
+### Limits
+
+Every bound below is enforced by the socket itself, and a client that
+reconnects or backs off needs all of them.
+
+| Bound | What happens |
+| --- | --- |
+| 60 messages per second per connection | Further frames in that second are answered with `error`, reason `rate_limited`. The connection stays open. |
+| 64 KiB per inbound frame | Answered with `error`, reason `payload_too_large`. Measured on the raw frame, before JSON parsing. |
+| 10s to send `session.connect` | The socket is closed with code 1008 and the reason `idle_auth_timeout`. Override with `asobi.ws_idle_auth_timeout_ms`. |
+| 60 connects per second per IP | The upgrade is closed with 1008 `rate_limited` before anything else runs. Tune under `asobi.rate_limits`, group `ws_connect`. |
+| Origin allowlist | A browser `Origin` outside `asobi.ws_allowed_origins` is closed with 1008 `origin_rejected`. With no allowlist configured every Origin passes, and a request with no `Origin` header always passes, because a native client sends none. |
+
+The message-rate window is a fixed 1000ms bucket, not a sliding one: a burst
+that straddles the boundary can put 120 frames through in two adjacent
+windows. Size a client's send rate against the limit, not against the burst.
+
+Joining is bounded separately, per player rather than per connection: 10
+world or match joins per 60 seconds, including `world.create` and
+`world.find_or_create`. The 11th is `error` with reason `join_rate_limited`
+and code `join_rate_limited`.
+
+The first two bounds are per connection. The connect-flood and join buckets
+are per node, so across a cluster the real ceiling is the figure above times
+the node count. See [Clustering](clustering.md).
 
 ## Matches
 
@@ -153,6 +193,18 @@ Joining is WebSocket-only by design: the join binds the match to your
 session so subsequent `match.input` is routed. There is no REST join, the
 same as for worlds.
 
+#### `match.joined` (reply)
+
+The full match info, including the roster:
+
+```json
+{"type": "match.joined", "cid": "j-1", "payload": {"match_id": "...", "mode": "arena", "status": "waiting", "player_count": 1, "max_players": 4, "players": ["..."], "listed": false}}
+```
+
+An unknown id is `match_not_found` (`match.not_found`); over the join rate
+it is `join_rate_limited`; a game module that refuses the join answers with
+whatever reason it returned, wrapped as `ws.request_failed`.
+
 #### Join context
 
 Both `match.join` and `world.join` accept an optional `ctx`, passed through
@@ -189,9 +241,11 @@ membership exists, so `join/2` can implement an allowlist but never a code.
 
 Bounded at the server: a flat object, at most 8 keys, keys up to 64 bytes,
 string values up to 256 bytes, plus integers and booleans. No nesting.
-Violations are rejected with `invalid_join_ctx`, `join_ctx_too_many_keys`,
-`join_ctx_key_too_long`, `join_ctx_value_too_long`, or
-`invalid_join_ctx_value`.
+Violations are rejected with `invalid_join_ctx`, `invalid_join_ctx_key`,
+`join_ctx_too_many_keys`, `join_ctx_key_too_long`, `join_ctx_value_too_long`,
+or `invalid_join_ctx_value`. None of the six has a code of its own, so each
+arrives as `ws.request_failed` with the reason in `details` - see
+[error](#error-server-push).
 
 **A join context does not make a world private.** Only a game that
 implements `join/3` and rejects unauthorised joins restricts entry; a game
@@ -223,10 +277,21 @@ request that caused it when there was one:
 ```
 
 - `error.code` is the contract - stable, machine-readable, and namespaced by
-  domain (`match.`, `world.`, `chat.`, `dm.`, `matchmaker.`) or bare when it is
-  cross-cutting (`rate_limited`, `unauthenticated`, `forbidden`). Branch on
-  this. It is the same code set the [REST API](rest-api.md#errors) returns, so
-  the same failure carries the same code on both surfaces.
+  domain (`match.`, `world.`, `chat.`, `dm.`, `matchmaker.`, `rpc.`, `ws.`) or
+  bare when it is cross-cutting (`rate_limited`, `join_rate_limited`,
+  `unauthenticated`, `forbidden`, `payload_too_large`, `invalid_json`,
+  `invalid_message`, `invalid_payload`, `missing_field`, `unknown_type`,
+  `internal`). Branch on this. Codes come from the same closed set the
+  [REST API](rest-api.md#errors) uses.
+- The two surfaces agree only where a failure has a first-class code. A
+  WebSocket reason that has one carries it, so `world_not_found` here and a
+  404 on `GET /api/v1/worlds/:id` are both `world.not_found`. Everything else
+  arrives as `ws.request_failed` with the reason in `details`, including
+  several common failures. On this page that covers the world capacity pair
+  (`world_capacity_reached`, `player_world_limit_reached`, which REST answers
+  as `world.capacity_reached` and `world.player_limit_reached`) and every
+  join-context rejection listed under [Join context](#join-context). Match a
+  reason string on `details.reason` for those, not a code.
 - `error.message` is prose for a human reading a log. Do not parse it.
 - `error.details` is **always** an object, `{}` when there is nothing to add.
 - `reason` is the original, flatter dialect. It is unchanged and still sent, so
@@ -244,9 +309,9 @@ string in `details`, so script-supplied text can never mint a code:
 ### `module.error` (server push)
 
 An extension callback error, sent to the player whose input triggered it.
-Only emitted when the extension runs with dev errors enabled (for
-asobi_lua, `ASOBI_DEV_ERRORS=true`); production runtimes keep script
-errors server-side.
+Only emitted when the extension runs with dev errors enabled (for asobi's
+Lua runtime, `ASOBI_DEV_ERRORS=true` or `{asobi_lua, [{dev_errors, true}]}`);
+production runtimes keep script errors server-side.
 
 `module` names the extension that produced the error. It is the only field
 asobi owns; the rest of the payload is the extension's.
@@ -257,7 +322,7 @@ asobi owns; the rest of the payload is the extension's.
 
 ### `module.message` (server push)
 
-A message addressed to one player by an extension - asobi_lua's
+A message addressed to one player by an extension - in Lua,
 `game.send(player_id, message)`. The message is wrapped rather than sent
 raw, because it may be any scripting value (string, number, table).
 
@@ -310,13 +375,10 @@ Server broadcasts game state updates to all players in the match.
 {"type": "match.state", "payload": {"players": {...}, "tick": 42}}
 ```
 
-### `match.started` (server push)
-
-Notification that a match has begun.
-
-```json
-{"type": "match.started", "payload": {"match_id": "...", "players": [...]}}
-```
+There is no "match started" frame. The match server notifies its players on
+`finished` and on nothing else, so a client learns the match began from
+`match.matched` (matchmaker) or `match.joined` (its own join reply), and
+then from the first `match.state`.
 
 ### `match.finished` (server push)
 
@@ -343,7 +405,30 @@ Leave the current match.
 {"type": "match.leave", "payload": {}}
 ```
 
+#### `match.left` (reply)
+
+```json
+{"type": "match.left", "cid": "l-1", "payload": {"success": true}}
+```
+
+Sent whether or not the connection was in a match, so leaving is safe to
+call unconditionally on teardown.
+
 ## Matchmaking
+
+The queue is per node. A ticket lives in the matchmaker process on the node
+that accepted it, there is no ticket table, and the matcher only ever sees
+that node's tickets. Two players who queue for the same mode against
+different nodes therefore never match each other, and a ticket id is
+meaningless on any other node. A cluster needs every matchmaker call from
+one player pinned to one node, and matchmaking only works at all if the
+whole population lands on one node or the fleet is deliberately partitioned
+by mode.
+
+World and match discovery and join are **not** subject to this. They resolve
+through a cluster-wide process registry rather than the matchmaker's own
+state, so `world.list`, `match.list`, `world.join` and `match.join` reach a
+world or match on any node. See [Clustering](clustering.md).
 
 ### `matchmaker.add`
 
@@ -353,6 +438,21 @@ Submit a matchmaking ticket.
 {"type": "matchmaker.add", "payload": {"mode": "arena", "properties": {"skill": 1200}}}
 ```
 
+#### `matchmaker.queued` (reply)
+
+```json
+{"type": "matchmaker.queued", "cid": "q-1", "payload": {"ticket_id": "...", "status": "pending", "players_needed": 4}}
+```
+
+`players_needed` is the mode's configured `match_size`, or `null` when the
+mode declares none. How many others are already waiting is deliberately not
+reported.
+
+A mode that resolves to no game module is `unknown_mode`
+(`matchmaker.unknown_mode`); a full queue is `queue_full`
+(`matchmaker.queue_full`). Re-adding for a mode you already have an open
+ticket for returns that same ticket rather than a second one.
+
 ### `matchmaker.remove`
 
 Cancel a matchmaking ticket.
@@ -361,18 +461,52 @@ Cancel a matchmaking ticket.
 {"type": "matchmaker.remove", "payload": {"ticket_id": "..."}}
 ```
 
-### `match.matched` (server push)
-
-Notification that the matchmaker paired you into a match.
+#### `matchmaker.removed` (reply)
 
 ```json
-{"type": "match.matched", "payload": {"match_id": "...", "players": [...]}}
+{"type": "matchmaker.removed", "cid": "r-1", "payload": {"success": true}}
 ```
 
-> Note: distinct from `match.joined`, which is the server's reply to a
-> client-initiated `match.join` message. Both signal "you're in a match
-> and `match.state` will follow," but only `match.matched` is fired
-> spontaneously by the matchmaker.
+Another player's ticket is `not_owner` (`forbidden`). An unknown ticket is
+`not_found`, which has no code of its own and arrives as `ws.request_failed`.
+A ticket issued by another node reads as unknown here.
+
+### `match.matched` (server push)
+
+Notification that the matchmaker paired you into a match. The join is
+already done: the matchmaker joins every paired player before sending this,
+so no `match.join` follows.
+
+```json
+{"type": "match.matched", "payload": {"match_id": "...", "players": ["...", "..."]}}
+```
+
+A mode whose matches are backed by a **world** rather than a match server
+sends a different payload on the same frame: `match_id` holds the world id,
+`mode` is present, and the roster is under `player_ids` rather than
+`players`. Read both keys if your game has any world-backed mode.
+
+Distinct from `match.joined`, which is the reply to a client-initiated
+`match.join`. Both mean "you are in a match and `match.state` will follow",
+but only `match.matched` arrives unprompted and without a `cid`.
+
+### `match.matchmaker_expired` (server push)
+
+Your ticket waited longer than `matchmaker.max_wait_seconds` (default 60)
+without being matched. It is gone; submit a new one to keep queuing.
+
+```json
+{"type": "match.matchmaker_expired", "payload": {"ticket_id": "..."}}
+```
+
+### `match.matchmaker_failed` (server push)
+
+A group formed but the match could not be started, so everyone in it is back
+out of the queue. `reason` is `match_start_failed` or `no_game_module`.
+
+```json
+{"type": "match.matchmaker_failed", "payload": {"reason": "match_start_failed"}}
+```
 
 ## Worlds
 
@@ -382,8 +516,10 @@ management. See [World server](world-server.md) for the model and
 
 ### `world.list`
 
-List running worlds. Optional filters: `mode` (string), `has_capacity`
-(bool — only worlds that aren't full).
+List running worlds. Optional filters: `mode` (string, up to 64 bytes) and
+`has_capacity` (bool - only worlds that are not full). A filter of the wrong
+type is rejected with `invalid_mode_filter` or `invalid_has_capacity_filter`
+rather than silently dropped.
 
 ```json
 {"type": "world.list", "payload": {"mode": "walkers", "has_capacity": true}}
@@ -399,7 +535,11 @@ Response:
 
 Create a new world for the given mode. Refuses with
 `world_capacity_reached` (global cap hit) or `player_world_limit_reached`
-(per-player cap hit). On success the caller is auto-joined.
+(per-player cap hit). Neither reason has a code of its own on this socket:
+both arrive as `ws.request_failed` with the reason in `details`, unlike
+`POST /api/v1/worlds`, which answers `world.capacity_reached` (503) and
+`world.player_limit_reached` (429). On success the caller is auto-joined and
+the reply is `world.joined`.
 
 ```json
 {"type": "world.create", "payload": {"mode": "walkers"}}
@@ -425,7 +565,7 @@ Join a specific world by id (e.g. one returned from `world.list`).
 
 ### `world.input`
 
-Send game input to your zone. The `payload` IS the input map — there is
+Send game input to your zone. The `payload` IS the input map - there is
 no inner `data` wrapper. Field names are entirely up to your game; the
 server only forwards the map verbatim to your `handle_input/3` callback.
 
@@ -434,7 +574,8 @@ server only forwards the map verbatim to your `handle_input/3` callback.
 ```
 
 The server routes the message to whichever zone owns your player
-entity — clients don't specify zone coordinates.
+entity - clients do not specify zone coordinates. Input sent while not in a
+zone is dropped with no reply at all.
 
 ### `world.leave`
 
@@ -457,7 +598,7 @@ player_count, grid_size, max_players, …).
 ### `world.tick` (server push)
 
 Per-zone delta broadcast. The first `world.tick` after `world.joined` is
-the **initial snapshot** for every entity in the zone — register your
+the **initial snapshot** for every entity in the zone - register your
 handler before sending the join message or you miss it.
 
 ```json
@@ -468,8 +609,8 @@ handler before sending the join message or you miss it.
 
 | `op` | Meaning | Fields |
 |------|---------|--------|
-| `"a"` | Added — full state | id + every field on the entity |
-| `"u"` | Updated — diff | id + only changed fields |
+| `"a"` | Added, full state | id + every field on the entity |
+| `"u"` | Updated, diff | id + only changed fields |
 | `"r"` | Removed | id only |
 
 ### `world.terrain` (server push)
@@ -502,19 +643,34 @@ the game module returned `{finished, Result, State}` from `post_tick`).
 
 ### `world.phase_changed` (server push)
 
-Phase transition for worlds that declare phases. Payload mirrors the
-match `match.phase_changed` event.
+Phase state for a world whose mode declares phases. Only worlds emit this;
+there is no match equivalent, so a client that wants phases in a match reads
+them out of `match.state` or has the script broadcast its own event.
 
 ```json
-{"type": "world.phase_changed", "payload": {"phase": "combat", "duration_ms": 60000}}
+{"type": "world.phase_changed", "payload": {"world_id": "...", "status": "active", "phase": "combat", "remaining_ms": 42000, "config": {}, "timers": {}}}
 ```
+
+`status` is `waiting`, `active` or `complete`, and it decides which other
+fields are present:
+
+| `status` | Fields beside `phase` |
+| --- | --- |
+| `waiting` | `start_condition` - what the phase is waiting for. |
+| `active` | `remaining_ms`, `config` (the phase's own config object) and `timers` (the phase's live timers, keyed by id). |
+| `complete` | None. `phase` is `null`. |
+
+The frame is sent on every transition, and again periodically while a phase
+runs, so a client must treat it as state rather than as an edge. `world_id`
+is present on the transition frame and absent from the periodic one; do not
+key off it.
 
 ## Chat
 
 Channel ids are namespaced: every id must start with one of these prefixes, and
-a frame whose channel id is missing or unprefixed is rejected with
-`channel_id_invalid`. The prefix lets the runtime route the message and enforce
-membership without a per-frame registry lookup.
+a `chat.join` whose channel id is missing or unprefixed is rejected with
+`invalid_channel_id` (`chat.invalid_channel_id`). The prefix lets the runtime
+route the message and enforce membership without a per-frame registry lookup.
 
 | Prefix   | Used for                                  | Membership rule |
 |----------|-------------------------------------------|-----------------|
@@ -553,12 +709,19 @@ The worked examples below use a `world:` channel, which authorises on world
 membership you already hold after `world.join`.
 
 A single connection may join at most **32 channels** at once; a 33rd is rejected
-with `too_many_channels`. Idle channels with no members stop after 60s; rejoining
-is cheap. Message `content` is capped at 2000 bytes and empty or non-binary
-content is rejected with `content_empty` / `content_too_large`.
+with `too_many_channels` (`chat.too_many_channels`). Idle channels with no
+members stop after 60s; rejoining is cheap.
 
-History (`GET /api/v1/chat/:channel_id/history`) requires membership and clamps
-`?limit` to 200; non-members get `403`.
+`chat.send` never answers with a size error. Content over 2000 bytes, and
+content that is not a string, is dropped with no reply at all, and empty
+content is accepted and broadcast. A client that needs either rejected has to
+check before sending. The only failure `chat.send` reports is `not_authorized`
+(`forbidden`), for a malformed channel id or a channel this player may not
+write to. `content_empty` and `content_too_large` are direct-message codes -
+see [Direct messages](#direct-messages).
+
+History (`GET /api/v1/chat/:channel_id/history`) requires membership; `?limit`
+defaults to 50 and clamps to 1-200, and a non-member gets `403`.
 
 ### `chat.join`
 
@@ -567,6 +730,18 @@ Join a chat channel. The channel id must be namespaced.
 ```json
 {"type": "chat.join", "payload": {"channel_id": "world:w_ancient_ruins"}}
 ```
+
+#### `chat.joined` (reply)
+
+```json
+{"type": "chat.joined", "cid": "c-1", "payload": {"channel_id": "world:w_ancient_ruins"}}
+```
+
+A malformed id is `invalid_channel_id` (`chat.invalid_channel_id`); a channel
+this player is not authorised for is `not_authorized` (`forbidden`).
+
+Joining does not replay history. Fetch it from
+`GET /api/v1/chat/:channel_id/history`.
 
 ### `chat.send`
 
@@ -587,10 +762,13 @@ A new message in a joined channel.
     "channel_id": "world:w_ancient_ruins",
     "sender_id": "...",
     "content": "Hello!",
-    "sent_at": "2025-01-15T10:30:00Z"
+    "sent_at": 1785312000000
   }
 }
 ```
+
+`sent_at` is Unix milliseconds, not an ISO string. The same field on the
+persisted history read is a timestamp column, so the two differ.
 
 ### `chat.leave`
 
@@ -599,6 +777,59 @@ Leave a chat channel.
 ```json
 {"type": "chat.leave", "payload": {"channel_id": "world:w_ancient_ruins"}}
 ```
+
+#### `chat.left` (reply)
+
+```json
+{"type": "chat.left", "cid": "c-2", "payload": {"channel_id": "world:w_ancient_ruins"}}
+```
+
+Sent whether or not the connection had joined that channel.
+
+## Direct messages
+
+A DM is a chat message on a `dm:` channel whose id is both player ids sorted
+and joined with colons, so both sides always name the same channel. The
+sender gets a reply carrying that id; the recipient gets a `dm.message`
+push. Both sides read history from `GET /api/v1/dm/:player_id/history`.
+
+### `dm.send`
+
+```json
+{"type": "dm.send", "cid": "d-1", "payload": {"recipient_id": "...", "content": "Hello!"}}
+```
+
+#### `dm.sent` (reply)
+
+```json
+{"type": "dm.sent", "cid": "d-1", "payload": {"channel_id": "dm:0197...:0198..."}}
+```
+
+| Reason | Code | Cause |
+| --- | --- | --- |
+| `content_empty` | `dm.content_empty` | `content` was the empty string. |
+| `content_too_large` | `dm.content_too_large` | `content` was over 2000 bytes. |
+| `blocked` | `dm.blocked` | The recipient has blocked the sender. |
+| `invalid_input` | `ws.request_failed` | `recipient_id` or `content` was not a string. |
+
+Unlike `chat.send`, these are real error frames: a DM that is too long or
+empty is refused rather than dropped.
+
+### `dm.message` (server push)
+
+Addressed to the recipient's session, not to the channel. The sender's own
+confirmation is the `dm.sent` reply.
+
+```json
+{"type": "dm.message", "payload": {"channel_id": "dm:0197...:0198...", "sender_id": "...", "content": "Hello!", "sent_at": 1785312000000}}
+```
+
+A recipient who is offline gets no push; the message is persisted either way
+and appears in history when they return.
+
+A connection that has also `chat.join`ed the `dm:` channel additionally
+receives the message as a `chat.message` on that channel. Handle one or the
+other, or a client that does both shows every DM twice.
 
 ## Voting
 
@@ -616,6 +847,19 @@ For approval voting, `option_id` is a list:
 {"type": "vote.cast", "payload": {"vote_id": "...", "option_id": ["jungle", "caves"]}}
 ```
 
+#### `vote.cast_ok` (reply)
+
+```json
+{"type": "vote.cast_ok", "cid": "v1", "payload": {"success": true}}
+```
+
+Casting while not in a match is `not_in_match` (`match.not_in_match`), and
+changing your vote more times than the vote's `max_revotes` allows (3 by
+default) is `rate_limited`. The refusals that come from the vote itself -
+`vote_not_found`, `vote_closed`, `not_eligible`, `invalid_option` - have no
+code of their own and arrive as `ws.request_failed` with the reason in
+`details`.
+
 ### `vote.veto`
 
 Use a veto token to cancel the current vote. Requires `veto_tokens_per_player > 0`
@@ -624,6 +868,16 @@ in match config and `veto_enabled` on the vote.
 ```json
 {"type": "vote.veto", "payload": {"vote_id": "..."}}
 ```
+
+#### `vote.veto_ok` (reply)
+
+```json
+{"type": "vote.veto_ok", "cid": "v2", "payload": {"success": true}}
+```
+
+An unknown vote is `vote_not_found`, a player out of tokens is
+`no_veto_tokens`, and a vote that did not enable vetoes is `veto_disabled`.
+None of the three has a code of its own either.
 
 ### `match.vote_start` (server push)
 
@@ -687,19 +941,23 @@ A player vetoed the vote.
 
 ### `presence.update`
 
-Update your online status.
+Set your own status string. `status` is the only field read; anything else in
+the payload is discarded. Omitting it sets `"online"`.
 
 ```json
-{"type": "presence.update", "payload": {"status": "in_game", "metadata": {"match_id": "..."}}}
+{"type": "presence.update", "cid": "p-1", "payload": {"status": "in_game"}}
 ```
 
-### `presence.changed` (server push)
-
-A friend's presence changed.
+#### `presence.updated` (reply)
 
 ```json
-{"type": "presence.changed", "payload": {"player_id": "...", "status": "online"}}
+{"type": "presence.updated", "cid": "p-1", "payload": {"status": "in_game"}}
 ```
+
+The status is not validated against a list, and it is not persisted: it lives
+for the length of the session. There is no push telling a client that another
+player's presence changed - a client that needs a friends list with live
+status polls for it.
 
 ## Notifications
 
@@ -777,6 +1035,7 @@ reflected back. Codes core itself adds for this surface:
 | `rpc.invalid_cid` | `cid` was missing, not a string, empty, over 64 bytes, or not printable ASCII |
 | `rpc.unsupported_protocol` | `details.supported` lists the versions this server speaks |
 | `rpc.invalid_params` | `params` was not an object |
+| `invalid_payload` | `payload` itself was not an object |
 | `unauthenticated` | The socket has not completed `session.connect` |
 | `not_ready` | The node is still running migrations. Retry |
 

--- a/guides/world-server.md
+++ b/guides/world-server.md
@@ -1,23 +1,22 @@
-# World Server
+# World server
 
-Build large-session multiplayer games with spatial partitioning. The world
-server handles 1--500+ players in a shared continuous space, automatically
-splitting the world into zone processes for parallelized tick simulation
-and interest-based state broadcasting.
+Large-session multiplayer with spatial partitioning. The world server holds
+players in a shared continuous space and splits that space into zone processes
+for parallelised tick simulation and interest-based state broadcasting.
 
-Use the world server when your game has players moving through a shared
-space (co-op dungeons, open worlds, large-scale survival). For arena-style
-games with smaller player counts, use the standard [match server](matchmaking.md).
+Use it when players move through a shared space: co-op dungeons, open worlds,
+large-scale survival. For arena-style games with smaller player counts, use the
+[match server](matchmaking.md).
 
-For massive tile-based worlds (10K+ zones), see [Large Worlds](large-worlds.md)
-for lazy zone loading, terrain data, and scaling configuration.
+For massive tile-based worlds, see [Large worlds](large-worlds.md) for lazy zone
+loading, terrain data and scaling configuration.
 
-## How It Works
+## How it works
 
-A world is divided into a grid of **zones** -- each zone is a separate
-Erlang process that owns the entities in its region. Players only receive
-updates from zones they can see (interest management), and each zone runs
-its tick in parallel across CPU cores.
+A world is divided into a grid of **zones**, each a separate Erlang process
+owning the entities in its region. A player receives updates only from the
+zones they can see (interest management), and each zone runs its tick in
+parallel across CPU cores.
 
 ```
 World (2000x2000 units, 10x10 grid)
@@ -36,35 +35,41 @@ P1 subscribes to the 9 zones around z1,0. P2 subscribes to the 9 zones
 around z2,1. They only overlap on 2 zones, so most of their traffic is
 independent.
 
-### Supervision Tree
+### Supervision tree
 
 Each world instance is its own supervisor:
 
 ```
 asobi_world_sup (one_for_one)
-├── asobi_world_registry         — tracks active worlds
-└── asobi_world_instance_sup     — dynamic, one per world
-    └── asobi_world_instance     — one_for_all per world
-        ├── asobi_zone_sup       — dynamic, one per zone cell
-        │   └── asobi_zone       — gen_server per grid cell
-        ├── asobi_world_ticker   — coordinates ticks across zones
-        └── asobi_world_server   — gen_statem: world lifecycle
+├── asobi_zone_snapshotter       - batched snapshot writer, one per node
+├── asobi_world_registry         - tracks active worlds on this node
+└── asobi_world_instance_sup     - dynamic, one child per world
+    └── asobi_world_instance     - one_for_all per world
+        ├── asobi_zone_sup       - dynamic, one child per live zone cell
+        │   └── asobi_zone       - gen_server per grid cell
+        ├── asobi_zone_manager   - owns which cells are live and reaps idle ones
+        ├── asobi_world_ticker   - coordinates ticks across zones
+        └── asobi_world_server   - gen_statem, world lifecycle
 ```
 
-### Tick Cycle
+The top three are node-wide singletons. Everything under
+`asobi_world_instance` is per world, which is why a world costs six processes
+before a single zone beyond the first.
 
-Every tick (default 20 Hz / 50ms):
+### Tick cycle
 
-1. Ticker sends `tick(N)` to all zones in parallel
-2. Each zone: applies queued player inputs, runs `zone_tick/2`, computes
-   deltas from previous state, broadcasts deltas to subscribers
-3. Each zone acks back to the ticker
-4. When all zones ack, ticker calls `post_tick/2` on the world server
-   for global game events (boss phases, quest triggers, vote requests)
+Every tick (default 20 Hz, 50ms):
 
-### Delta Compression
+1. The ticker sends `tick(N)` to every zone in parallel.
+2. Each zone applies queued player inputs, runs `zone_tick/2`, computes deltas
+   from the previous state and broadcasts them to its subscribers.
+3. Each zone acks back to the ticker.
+4. When every zone has acked, the ticker calls `post_tick/2` on the world
+   server for global events: boss phases, quest triggers, vote requests.
 
-Zones only send what changed since the last tick:
+### Delta compression
+
+Zones send only what changed since the last tick:
 
 ```json
 {
@@ -80,24 +85,26 @@ Zones only send what changed since the last tick:
 }
 ```
 
-- `u` -- updated (only changed fields)
-- `a` -- added (full entity state)
-- `r` -- removed
+- `u` - updated, only the changed fields
+- `a` - added, full entity state
+- `r` - removed
 
-## Lua Implementation
+## In Lua
 
-Most games write world logic in Lua and run the asobi_lua Docker image - no
-Erlang needed. The [Erlang behaviour](#erlang-implementation) below is the same
-model for teams embedding asobi as a library.
+Run `ghcr.io/widgrensit/asobi` and write a world script. The
+[Erlang behaviour](#in-erlang) below is the same model on the other surface of
+the same node, for a release that depends on the Hex package.
 
-World scripts follow the same pattern as match scripts but with
-zone-specific callbacks. Set `game_type = "world"` in your mode globals.
+World scripts follow the same pattern as match scripts, with zone-specific
+callbacks. Set `game_type = "world"` in your mode globals.
 
-> **Gotcha**: the global is **`game_type`**, not `type`. The Erlang
-> `sys.config` form uses the key `type`, but the Lua loader
-> reads `game_type`. A Lua script that sets `type = "world"` is
-> silently ignored — the script registers as a *match* mode and
-> `world.find_or_create` returns `mode_not_found`.
+The global is `game_type`, not `type`. The Erlang `sys.config` form uses the
+key `type`, but the Lua loader reads `game_type`. A Lua script setting
+`type = "world"` is silently ignored: it registers as a match mode, so
+`world.find_or_create` hands the match bridge to the world server, which then
+crashes on the world callbacks that bridge does not export (`spawn_position/2`,
+`zone_tick/2`, `post_tick/2`). There is no clean error for this - check
+`game_type` first.
 
 ```lua
 -- lua/world.lua
@@ -140,20 +147,11 @@ end
 function post_tick(tick, state)
     state.tick_count = tick
 
-    -- Boss defeated: trigger a vote
+    -- Boss defeated: next level, and tell every client
     if state.boss_hp <= 0 then
         state.boss_hp = 10000
         state.dungeon_level = state.dungeon_level + 1
-        state._vote = {
-            template = "boon_pick",
-            options = {
-                { id = "shield", label = "Shield Boost" },
-                { id = "speed",  label = "Speed Boost" },
-                { id = "damage", label = "Damage Boost" }
-            },
-            method = "plurality",
-            window_ms = 15000
-        }
+        game.broadcast("level_up", { level = state.dungeon_level })
     end
 
     -- Time limit: 30 minutes at 20 Hz
@@ -188,21 +186,32 @@ function get_state(player_id, state)
 end
 ```
 
-### Lua Callbacks
+### Lua callbacks
 
 | Function | Required | Description |
-|----------|----------|-------------|
-| `init(config)` | yes | Return initial global game state |
-| `join(player_id, state)` | yes | Handle player join, return state |
-| `join(player_id, state, ctx)` | no | Same, plus the client's join context. Declare the third parameter and it is used instead — see [Join context](websocket-protocol.md#join-context) |
-| `leave(player_id, state)` | yes | Handle player leave, return state |
-| `spawn_position(player_id, state)` | yes | Return `{x=N, y=N}` table |
-| `post_tick(tick, state)` | yes | Global tick logic. Set `_finished`/`_result` or `_vote` on state |
-| `generate_world(seed, config)` | no | Return table keyed by `"x,y"` strings |
+|---|---|---|
+| `init(config)` | yes | Return the initial global game state |
+| `join(player_id, state)` | yes | Player joined; return state |
+| `join(player_id, state, ctx)` | no | Same, plus the client's join context. Declare the third parameter and it is used instead - see [Join context](websocket-protocol.md#join-context) |
+| `leave(player_id, state)` | yes | Player left; return state |
+| `spawn_position(player_id, state)` | yes | Return a `{x=N, y=N}` table |
+| `post_tick(tick, state)` | yes | Global tick logic. Set `_finished` and `_result` on state to end the world |
+| `zone_tick(entities, zone_state)` | no | Per-zone simulation; return both |
+| `handle_input(player_id, input, entities)` | no | Apply one player's input to that zone's entities |
+| `generate_world(seed, config)` | no | Return a table keyed by `"x,y"` strings |
 | `get_state(player_id, state)` | no | Player-visible state |
-| `vote_resolved(template, result, state)` | no | Handle vote result |
+| `spawn_templates(config)` | no | See [Spawn templates](#spawn-templates) |
+| `phases(config)` | no | See [Phases](phases.md) |
+| `on_phase_started(name, state)` / `on_phase_ended(name, state)` | no | Phase transitions |
+| `on_zone_loaded(cx, cy, state)` / `on_zone_unloaded(cx, cy, state)` | no | See [Large worlds](large-worlds.md) |
+| `terrain_provider(config)` | no | See [Large worlds](large-worlds.md) |
+| `on_world_recovered(snapshot, state)` | no | The world process restarted and a snapshot was recovered |
 
-### Finishing a World
+`vote_resolved` is not on this list on purpose. The world bridge does not
+export it, so a Lua world script defining `vote_resolved` is never called. See
+[Voting](voting.md) for what does and does not reach a Lua world today.
+
+### Finishing a world
 
 Set `_finished` and `_result` on your state in `post_tick()`:
 
@@ -220,29 +229,14 @@ function post_tick(tick, state)
 end
 ```
 
-### Triggering Votes
+### Triggering votes
 
-Set `_vote` on your state in `post_tick()`:
+Setting `state._vote` in `post_tick` is the world's vote trigger, and the
+server does read it every tick. It does not start a vote today: the decoded
+table reaches the vote server with the wrong key type and the failure is
+swallowed. [Voting](voting.md) has the detail and the Erlang route that works.
 
-```lua
-function post_tick(tick, state)
-    if state.boss_hp <= 0 then
-        state._vote = {
-            template = "choose_path",
-            options = {
-                { id = "cave", label = "Dark Cave" },
-                { id = "forest", label = "Enchanted Forest" }
-            },
-            method = "plurality",
-            window_ms = 20000
-        }
-        state.boss_hp = nil  -- clear so vote doesn't re-trigger
-    end
-    return state
-end
-```
-
-## Erlang Implementation
+## In Erlang
 
 Implement the `asobi_world` behaviour:
 
@@ -287,7 +281,7 @@ handle_input(_PlayerId, _Input, Entities) ->
     {ok, Entities}.
 
 post_tick(TickN, #{boss_hp := HP} = State) when HP =< 0 ->
-    %% Boss defeated -- trigger an upgrade vote
+    %% Boss defeated - trigger an upgrade vote
     {vote, #{
         template => ~"boon_pick",
         options => [
@@ -309,7 +303,7 @@ post_tick(_TickN, State) ->
 
 | Callback | Required | Description |
 |----------|----------|-------------|
-| `init/1` | yes | Initialize global game state |
+| `init/1` | yes | Initialise global game state |
 | `join/2` | yes | Player joined the world |
 | `leave/2` | yes | Player left the world |
 | `spawn_position/2` | yes | Return `{ok, {X, Y}}` for new player placement |
@@ -318,7 +312,7 @@ post_tick(_TickN, State) ->
 | `post_tick/2` | yes | Global post-tick: return `{ok, State}`, `{vote, Config, State}`, or `{finished, Result, State}` |
 | `generate_world/2` | no | Procedural generation: `(Seed, Config) -> {ok, #{Coords => ZoneState}}` |
 | `get_state/2` | no | Per-player state view |
-| `vote_resolved/3` | no | Handle vote result (inherited from match voting) |
+| `vote_resolved/3` | no | Handle vote result. Not declared on the `asobi_world` behaviour: the world server looks for it with `erlang:function_exported/3`, so exporting it works but the compiler will not tell you if the arity is wrong |
 
 ### Entity keys
 
@@ -352,54 +346,65 @@ Register your world mode in `sys.config`:
 ```
 
 | Option | Default | Description |
-|--------|---------|-------------|
+|---|---|---|
 | `type` | `match` | Must be `world` for world server mode |
-| `grid_size` | 10 | Number of zones per axis (total = grid_size^2) |
-| `zone_size` | 200 | Units per zone side (world size = grid_size * zone_size) |
+| `module` | required | The game module, or `{lua, "path.lua"}` |
+| `grid_size` | 10 | Zones per axis; total zones = `grid_size^2` |
+| `zone_size` | 200 | Units per zone side; world size = `grid_size * zone_size` |
 | `tick_rate` | 50 | Milliseconds between ticks (50 = 20 Hz) |
-| `view_radius` | 1 | Zones visible in each direction from player's zone |
-| `rehome_margin` | 0.15 | Fraction of `zone_size` an entity (player or NPC) must clear past its zone's edge before re-homing to the neighbouring zone (see below) |
-| `max_players` | 500 | Maximum concurrent players per world |
-| `zone_idle_timeout` | 30000 | Milliseconds an empty zone lingers before it is released |
-| `empty_grace_ms` | 0 | Milliseconds a world with no players lingers before it finishes (0 = finish immediately) |
-| `snapshot_interval` | 600 | Ticks between zone snapshots (see [Snapshots](#snapshots)) |
-| `listed` | `true` | Whether worlds of this mode appear in `world.list` / `GET /api/v1/worlds` |
+| `view_radius` | 1 | Zones visible in each direction from the player's zone |
+| `max_players` | 500 | Concurrent players per world |
+| `persistent` | `false` | Keep the world alive with no players in it |
+| `empty_grace_ms` | 0 | Milliseconds an empty world lingers before finishing. 0 finishes immediately |
+| `player_ttl_ms` | 0 | Milliseconds a disconnected player's entity is held for reconnection |
+| `listed` | `true` | Whether worlds of this mode appear in `world.list` and `GET /api/v1/worlds` |
 | `quick_play` | `true` | Whether `world.find_or_create` may place a player into an existing world of this mode |
+| `chat` | `#{}` | See [Chat channels](#chat-channels) |
 
-#> Using a world as a persistent hub is covered in [Lobbies](lobbies.md).
+Using a world as a persistent hub is covered in [Lobbies](lobbies.md).
 
-An entity - player or NPC - must clear its zone's edge by `rehome_margin` (a
+### Four values you cannot set
+
+These four look like mode options and are not: the mode config never reaches
+the process that would read them, so every world runs on the built-in value.
+Plan around them as facts of the deployment, not knobs.
+
+| Value | What every world gets |
+|---|---|
+| Active zones per world | 10,000. See [Large worlds](large-worlds.md) for what happens at that ceiling |
+| Zone idle timeout | 30 seconds before an empty zone is released |
+| Rehome margin | 0.15 of `zone_size` (described below) |
+| Zone snapshot interval | 600 ticks, and moot - see [Snapshots](#snapshots) |
+
+An entity, player or NPC, must clear its zone's edge by the rehome margin (a
 fraction of `zone_size`) before re-homing to the neighbouring zone, so an
-entity parked on or jittering across a boundary doesn't re-home every tick.
-This means an entity's tracked zone can lag its true position by up to that
-margin near a boundary - an entity in a zone's entity map is not necessarily
-strictly within its rectangle.
+entity parked on or jittering across a boundary does not re-home every tick.
+An entity's tracked zone can therefore lag its true position by up to that
+margin near a boundary: an entity in a zone's entity map is not necessarily
+strictly inside that zone's rectangle.
 
-`game.zone.query_radius`/`query_rect` only search the calling zone's own
+The zone-based `game.spatial.query_radius(x, y, radius)` and
+`game.spatial.query_rect(x1, y1, x2, y2)` search only the calling zone's own
 entity map, so this lag has a direction that matters: an area geometrically
 inside zone A's rectangle can be occupied by an entity zone B still owns,
-because it hasn't cleared the margin yet. A query issued from zone A over
-that area misses it entirely. For NPCs this is a live gap, not just a
-terrain-lookup rounding concern - query_radius/query_rect are exactly how
-game code typically finds NPCs near a point, and the margin means that gap
-can persist (an NPC parked just past its zone's edge stays invisible to the
-neighbour's queries indefinitely, not just for the tick it takes to cross).
-Account for this if your NPC AI queries by position near zone edges - a
-terrain lookup or other bounding use should account for the same slack.
+because it has not cleared the margin yet. A query issued from zone A over that
+area misses it entirely, and the gap persists - an NPC parked just past its
+zone's edge stays invisible to the neighbour's queries indefinitely, not only
+for the tick it takes to cross. Account for that if your NPC AI queries by
+position near zone edges.
 
-The margin only bounds this slack for positions inside the world rectangle.
-An entity outside it entirely is clamped into the edge zone by `pos_to_zone`
-and stays owned by that zone at any distance past the edge - validate
-positions in your movement handler if your game trusts the zone rectangle as
-a hard bound. Also note that a band-parked NPC only stays visible to a
-neighbouring zone's *subscribers* (not its `query_radius`/`query_rect`
-callers) while `view_radius >= 1` keeps that neighbour touched every tick -
-at `view_radius = 0` the owning zone can idle out and persist the NPC under
-coordinates a player standing metres away never loads.
+The margin bounds this slack only for positions inside the world rectangle. An
+entity outside it entirely is clamped into the edge zone by `pos_to_zone` and
+stays owned by that zone at any distance past the edge, so validate positions
+in your movement handler if your game trusts the zone rectangle as a hard
+bound. A band-parked NPC also stays visible to a neighbouring zone's
+*subscribers* only while `view_radius >= 1` keeps that neighbour touched every
+tick; at `view_radius = 0` the owning zone can idle out under coordinates a
+player standing metres away never loads.
 
-See [Configuration](configuration.md) for the matching `rehome` rate limit on
-how often a player may re-home at all - NPCs re-home directly without going
-through that limiter, since asobi_zone owns them outright.
+See [Configuration](configuration.md) for the `rehome` rate limit on how often
+a player may re-home at all. NPCs re-home directly without going through that
+limiter, since `asobi_zone` owns them outright.
 
 ## Visibility
 
@@ -428,7 +433,7 @@ With `quick_play => false`, `world.find_or_create` returns
 `quick_play_disabled` rather than creating a world, since it could never
 find the one it just made.
 
-### Procedural Generation
+### Procedural generation
 
 Implement `generate_world/2` to provide initial state for each zone:
 
@@ -456,12 +461,13 @@ map of template id to template definition.
 
 A template has:
 
-- `type` -- the entity type applied to every spawned instance.
-- `base_state` -- a map merged into every entity spawned from the template.
-- `respawn` -- optional respawn policy: `strategy` (currently `timer`),
+- `type` - the entity type applied to every spawned instance.
+- `base_state` - a map merged into every entity spawned from the template.
+- `respawn` - optional respawn policy: `strategy` (currently `timer`),
   `delay` (milliseconds), `jitter` (milliseconds of random spread added to
   the delay), and `max_respawns` (cap, or `infinity`).
-- `persistent` -- whether a spawned entity survives a zone snapshot/restore.
+- `persistent` - whether a spawned entity would survive a zone snapshot and
+  restore (see [Snapshots](#snapshots) for why none is taken today).
   Lua entities default to `true`.
 
 At runtime, Lua scripts spawn from a template with
@@ -526,47 +532,67 @@ See the `examples/world-spawns` demo for a complete world script.
 
 ## Snapshots
 
-`asobi_zone_snapshotter` periodically persists each zone's entities and
-restores them on restart, before the zone accepts new subscribers. Tune the
-cadence with the `snapshot_interval` config key (default 600, measured in
-**ticks**, not milliseconds).
+`asobi_zone_snapshotter` is a batched writer that persists a zone's entities,
+zone state, entity timers and spawner state to the `zone_snapshots` table, and
+loads them back when a zone starts blank.
+
+**No world writes one today.** The zone reads a `persistence` flag, and the
+mode config that would set it emits `persistent` instead, so the flag is always
+false and both the periodic write and the restore-on-start are skipped. Setting
+`persistent = true` in a mode keeps a world alive when it empties; it does not
+survive a node restart.
+
+What does still work is a per-zone ETS backup written every 20 ticks. It is
+crash recovery for a zone process inside a running node, not durability across
+a restart.
+
+Do not build on cross-restart world state until this is fixed. A world's
+entities are in memory only.
 
 ## Subscriptions
 
 A player subscribes to the 3x3 neighbourhood of zones around their entity.
 Membership is recomputed as the player moves: entering a zone streams a
-snapshot of that zone's currently-visible entities, and leaving a zone stops
+snapshot of that zone's currently visible entities, and leaving a zone stops
 its updates.
 
-## WebSocket Protocol
+## WebSocket protocol
 
-World messages use the `world.*` namespace. See the full
-[WebSocket Protocol](websocket-protocol.md) for envelope format.
+World messages use the `world.*` namespace. See
+[WebSocket protocol](websocket-protocol.md) for the envelope.
 
-### Client to Server
+### Client to server
 
 | Type | Payload | Description |
-|------|---------|-------------|
+|---|---|---|
+| `world.create` | `{"mode": "..."}` | Create a world of this mode and join it |
+| `world.find_or_create` | `{"mode": "..."}` | Join an existing world of this mode, or create one |
 | `world.join` | `{"world_id": "..."}` | Join a specific world |
-| `world.leave` | `{}` | Leave current world |
+| `world.list` | `{"mode": "...", "has_capacity": true}` | Browse listed worlds |
+| `world.leave` | `{}` | Leave the current world |
 | `world.input` | `{"action": "move", "x": 100, "y": 200}` | Send input to your zone |
 
-### Server to Client
+### Server to client
 
 | Type | Payload | Description |
-|------|---------|-------------|
-| `world.joined` | `{world_id, status, player_count, grid_size}` | Join confirmed |
+|---|---|---|
+| `world.joined` | `{world_id, status, player_count, grid_size, ...}` | Join confirmed |
 | `world.left` | `{success: true}` | Leave confirmed |
 | `world.tick` | `{tick, updates: [{op, id, ...}]}` | Zone delta broadcast |
+| `world.phase_changed` | the phase info block | See [Phases](phases.md) |
+| `world.terrain` | `{coords, data}` | See [Large worlds](large-worlds.md) |
 | `world.finished` | `{world_id, result}` | World ended |
 
-### Input Routing
+A player already in a world who sends `world.join` for a different one is
+refused with `world.already_joined`; leave first.
 
-When you send `world.input`, the message is routed to the zone process
-that currently owns your player entity. You don't need to specify which
-zone -- the server tracks your position and routes automatically.
+### Input routing
 
-## Chat Channels
+`world.input` is routed to the zone process that currently owns your player
+entity. You do not name a zone: the server tracks your position and routes
+automatically.
+
+## Chat channels
 
 World chat is configuration-driven. Enable the channel types you need per
 game mode:
@@ -588,29 +614,25 @@ game mode:
 ]}
 ```
 
-Lua equivalent:
+There is no Lua equivalent: the loader reads no chat globals, so a script
+cannot turn a channel on. Chat is an operator `game_modes` entry, and that
+entry replaces the script's mode config for that name rather than merging into
+it - so a Lua world with chat needs the whole mode declared in `sys.config`,
+`module => {lua, "world.lua"}` included.
 
-```lua
--- In your world script globals
-chat_world     = true
-chat_zone      = true
-chat_proximity = 2
-```
-
-### Channel Types
+### Channel types
 
 | Type | Scope | Lifecycle |
-|------|-------|-----------|
-| **Global** | Every player in the game, across all worlds | Join on world join, leave on world leave |
-| **World** | All players in the world instance | Join on world join, leave on world leave |
-| **Zone** | Players in the same zone cell | Auto-swap when crossing zone boundaries |
-| **Proximity** | Players within N zones | Follows your interest radius, updates on zone change |
-| **Federation** | Federation members only | Managed by the social system (works automatically) |
+|---|---|---|
+| Global | Every player in the game, across all worlds | Join on world join, leave on world leave |
+| World | All players in the world instance | Join on world join, leave on world leave |
+| Zone | Players in the same zone cell | Auto-swap when crossing zone boundaries |
+| Proximity | Players within N zones | Follows your interest radius, updates on zone change |
 
-### How It Works
+### How it works
 
-Chat channels use the existing `asobi_chat_channel` system. The world
-server automatically manages subscriptions:
+Chat channels use the `asobi_chat_channel` system. The world server manages
+subscriptions:
 
 - **On join**: player is added to world chat and their spawn zone's chat
 - **On zone change**: old zone chat is left, new zone chat is joined.
@@ -634,31 +656,50 @@ declared in a mode's `chat.global` are authorised, so a client cannot mint
 new ones; names are up to 64 bytes of `a-z A-Z 0-9 _ - .` and anything else
 is dropped with a warning at join time.
 
-### No Chat Config
+### No chat config
 
-If you omit the `chat` key entirely, no chat channels are created. The
-world server runs without any chat overhead. Add channels later by
-updating your mode config.
+Omit the `chat` key and no channels are created. The world server then runs
+with no chat overhead. Add channels later by updating your mode config.
 
 ## Clustering
 
-Zones are regular Erlang processes. In a multi-node cluster, they
-distribute across nodes automatically via `pg`. A player on Node A can
-be subscribed to a zone on Node B -- Erlang distribution handles the
-message routing transparently.
+A world lives entirely on the node that created it. Its zones are local
+processes under that world's instance supervisor; nothing distributes them
+across nodes and there is no zone placement to configure. `pg` carries the
+registrations - world server pids by world id, zone pids by coordinates, player
+sessions, and the per-player and global world caps - but it registers
+processes, it never moves them.
 
-For large worlds, zones are distributed round-robin across cluster nodes:
+Horizontal scale therefore means more worlds, never a bigger one. If a single
+world is the thing that is full, shard it in your game design - regions,
+instances, shards. See [Clustering](clustering.md).
 
+## Inspecting a world
+
+The console has no worlds screen. Three things stand in for one:
+
+```bash
+# Every listed world, with player counts and phase blocks. Player-facing, so
+# it needs a player token, and unlisted modes never appear.
+curl http://localhost:8084/api/v1/worlds -H 'Authorization: Bearer <token>'
+
+# One world by id, including unlisted ones.
+curl http://localhost:8084/api/v1/worlds/<world_id> -H 'Authorization: Bearer <token>'
+
+# Node pressure: process count against the limit, run queue, memory, uptime.
+curl -H 'Authorization: Bearer <ops-secret>' \
+  http://localhost:8084/api/v1/ops/stats
 ```
-Node A: zones {0,0}..{4,4}  (25 zones)
-Node B: zones {5,0}..{9,4}  (25 zones)
-Node C: zones {0,5}..{4,9}  (25 zones)
-Node D: zones {5,5}..{9,9}  (25 zones)
-```
 
-## Next Steps
+`/ops/stats` is the one to watch when zones are the concern: every zone is a
+process, so a world grid and its idle-zone churn show up in `process_count` and
+`run_queue` before they show up anywhere else. A stock node serves neither the
+console nor the ops API - see [Operator console](console.md).
 
-- [Lua Scripting](lua-scripting.md) -- match-based Lua scripting
-- [Voting](voting.md) -- in-game voting system
-- [Matchmaking](matchmaking.md) -- how players enter worlds
-- [Clustering](clustering.md) -- multi-node deployment
+## Next steps
+
+- [Large worlds](large-worlds.md) - lazy zones, terrain, and the zone ceiling.
+- [Lua scripting](lua-scripting.md) - the match-side scripting model.
+- [Voting](voting.md) - in-session voting.
+- [Phases](phases.md) - the phase clock and `world.phase_changed`.
+- [Clustering](clustering.md) - multi-node deployment.

--- a/rebar.config
+++ b/rebar.config
@@ -126,8 +126,10 @@
         <<"README.md">>,
         <<"guides/getting-started.md">>,
         <<"guides/lua-scripting.md">>,
+        <<"guides/lua-api.md">>,
         <<"guides/lua-bots.md">>,
         <<"guides/configuration.md">>,
+        <<"guides/console.md">>,
         <<"guides/rest-api.md">>,
         <<"guides/websocket-protocol.md">>,
         <<"guides/matchmaking.md">>,
@@ -165,11 +167,14 @@
         {<<"Getting Started">>, [
             <<"guides/getting-started.md">>,
             <<"guides/lua-scripting.md">>,
+            <<"guides/lua-api.md">>,
             <<"guides/lua-bots.md">>,
-            <<"guides/comparison.md">>
+            <<"guides/comparison.md">>,
+            <<"guides/glossary.md">>
         ]},
         {<<"Guides">>, [
             <<"guides/configuration.md">>,
+            <<"guides/console.md">>,
             <<"guides/rest-api.md">>,
             <<"guides/websocket-protocol.md">>,
             <<"guides/matchmaking.md">>,
@@ -185,6 +190,16 @@
             <<"guides/phases.md">>,
             <<"guides/self-hosting.md">>,
             <<"guides/extensions.md">>
+        ]},
+        {<<"Migrating">>, [
+            <<"guides/migrate-from-nakama.md">>,
+            <<"guides/migrate-from-playfab.md">>,
+            <<"guides/migrate-from-hathora.md">>,
+            <<"guides/exit.md">>
+        ]},
+        {<<"Reference">>, [
+            <<"guides/architecture.md">>,
+            <<"guides/benchmarks.md">>
         ]},
         {<<"Security">>, [
             <<"guides/security-threat-model.md">>,

--- a/scripts/check-archived-refs.sh
+++ b/scripts/check-archived-refs.sh
@@ -17,13 +17,18 @@ set -euo pipefail
 # Repositories that are archived, and what to say instead. Add a row when you
 # archive something, in the same PR.
 ARCHIVED=(
-  "asobi_admin|the operator console ships in asobi - see guides/self-hosting.md"
+  "asobi_admin|the operator console ships in asobi - see guides/console.md"
+  "asobi_lua|the Lua runtime ships in asobi (src/lua/) - link this repo, and use the ghcr.io/widgrensit/asobi image"
 )
 
 # Docs a reader follows. Deliberately excludes docs/adr/: an ADR records a
 # decision as it stood, and rewriting that history to keep a linter quiet is
 # worse than the stale name.
-PATHS=(guides README.md docs/ARCHITECTURE.md)
+#
+# examples/ is in scope because a reader who runs an example is following it as
+# closely as a guide, and its READMEs are where a stale "install X too" line
+# survives longest.
+PATHS=(guides README.md docs/ARCHITECTURE.md examples CONTRIBUTING.md)
 
 fails=0
 for entry in "${ARCHIVED[@]}"; do

--- a/scripts/check-error-drift.sh
+++ b/scripts/check-error-drift.sh
@@ -21,20 +21,30 @@ fail=0
 # shared error object landed (plan item 1b) a controller names a code and never
 # a status, so the status a client sees is asobi_error's business, not the call
 # site's - and this guard has to resolve it the same way.
+#
+# Newlines are flattened first, as in src_pairs below: erlfmt reflows a long
+# entry across three lines, and a per-line regex missed those and fell through
+# to the 500 default - which is how the guide came to document a 403 as a 500.
 code_status() {
-	grep -oE '^\s*\{~"[a-z_.]+", ?[0-9]{3},' "$repo_root/src/asobi_error.erl" |
-		sed -E 's/^\s*\{~"([a-z_.]+)", ?([0-9]{3}),/\1 \2/'
+	tr '\n' ' ' <"$repo_root/src/asobi_error.erl" | tr -s ' ' |
+		grep -oE '\{ ?~"[a-z_.]+", ?[0-9]{3},' |
+		sed -E 's/\{ ?~"([a-z_.]+)", ?([0-9]{3}),/\1 \2/'
 }
 
 # Every "<status> <code>" pair a module returns. Newlines are flattened and runs
 # of spaces squeezed first, so erlfmt reflowing a return across lines can never
 # hide it from the regex. Both {asobi_error, Code} and {asobi_error, Code,
 # Details} are matched; the status comes from the table above.
+#
+# `asobi_error:legacy(Code, Details)` is matched too. It returns a rendered
+# `{json, ...}` rather than an {asobi_error, Code} tuple, so the tuple regex
+# alone missed every code raised through it - which is how the guest table came
+# to omit the 422 the upgrade path returns on a bad username or password.
 src_pairs() {
 	local codes
 	codes=$(
 		tr '\n' ' ' <"$1" | tr -s ' ' |
-			grep -oE '\{asobi_error, ?~"[a-z_.]+"' |
+			grep -oE '\{asobi_error, ?~"[a-z_.]+"|asobi_error:legacy\( ?~"[a-z_.]+"' |
 			sed -E 's/.*~"([a-z_.]+)"/\1/' | sort -u
 	)
 	[ -z "$codes" ] && return 0

--- a/src/lua/asobi_lua_validate.erl
+++ b/src/lua/asobi_lua_validate.erl
@@ -7,12 +7,16 @@ non-zero exit. Designed for CI use.
 
 ## Usage
 
-In a CI step running against the asobi_lua release image:
+In a CI step running against the release image:
 
 ```bash
-docker run --rm -v $(pwd)/lua:/g ghcr.io/widgrensit/asobi_lua \
-  bin/asobi_lua eval 'asobi_lua_validate:cli(["/g/match.lua"]).'
+docker run --rm -v "$PWD/lua:/g" ghcr.io/widgrensit/asobi sh -c \
+  'erts-*/bin/erl -noshell -boot no_dot_erlang -pa lib/*/ebin \
+     -eval "asobi_lua_validate:cli([\"/g/match.lua\"])."'
 ```
+
+A throwaway VM inside the image, not `bin/asobi eval`: `cli/1` ends in
+`halt/1`, so running it on a live node would stop the server.
 
 Exits 0 if the script loads clean, 1 with the loader's error reason
 on stderr otherwise. Multiple paths can be passed; they are validated

--- a/src/lua/asobi_lua_world.erl
+++ b/src/lua/asobi_lua_world.erl
@@ -16,7 +16,6 @@ function post_tick(tick, state)              -- return state (or state + vote/fi
 -- Optional:
 function generate_world(seed, config)        -- return zone_states table
 function get_state(player_id, state)         -- return state visible to player
-function vote_resolved(template, result, state) -- return updated state
 function phases(config)                      -- return list of phase definitions
 function on_phase_started(phase_name, state) -- return updated state
 function on_phase_ended(phase_name, state)   -- return updated state
@@ -27,11 +26,17 @@ function on_zone_loaded(cx, cy, state)       -- return zone_state, state
 function on_zone_unloaded(cx, cy, state)     -- return state
 ```
 
-asobi#253: after a hot reload (`ASOBI_LUA_RELOAD`/`reload_mode`), `spawn_templates_hint/1`
-tells the running zone to re-fetch `spawn_templates(config)` so an edited script's new
-templates become spawnable without restarting the zone. asobi_lua#110's `game.zone.spawn`
-guard reads that live set from a per-zone ETS table rather than a value snapshotted once
-into Ctx, so this stays correct across any number of hot reloads.
+`vote_resolved` is deliberately absent. `asobi_world_server` reaches it through
+`erlang:function_exported/3` and this module does not export it, so a Lua world
+script defining `vote_resolved` is never called. Match scripts are unaffected;
+see `guides/voting.md`.
+
+After a hot reload (`ASOBI_LUA_RELOAD`/`reload_mode`), `spawn_templates_hint/1`
+tells the running zone to re-fetch `spawn_templates(config)` so an edited
+script's new templates become spawnable without restarting the zone. The
+`game.zone.spawn` guard reads that live set from a per-zone ETS table rather
+than a value snapshotted once into Ctx, so this stays correct across any number
+of hot reloads.
 """.
 
 -behaviour(asobi_world).

--- a/src/ops/asobi_ops_features.erl
+++ b/src/ops/asobi_ops_features.erl
@@ -16,6 +16,11 @@ Capabilities report what is *configured*, not what is compiled in: a console
 needs to know whether Steam auth will work on this deployment, and "the module
 exists" does not answer that. Each entry is a name and a boolean only - never
 the configured value, which is usually a secret.
+
+`lua` is the exception and is a module check, because since the runtime merged
+into asobi there is nothing to configure: it is present in every stock release.
+It stays in the list so a console rendering against a stripped custom release
+still gets an answer rather than an absent key.
 """.
 
 -export([features/0, extensions/0, capabilities/0]).

--- a/src/world/asobi_world_sup.erl
+++ b/src/world/asobi_world_sup.erl
@@ -2,13 +2,13 @@
 -moduledoc """
 Top-level world supervisor.
 
-**Public ETS trust assumption (F-33)**: `asobi_world_state` and
+**Public ETS trust assumption**: `asobi_world_state` and
 `asobi_player_worlds` are `public` named ETS tables. Anything running
-in the same BEAM (game callbacks, plugins, etc.) can read and mutate
-them. asobi is single-tenant and the loaded code is trusted, so this
-is acceptable — but it's an explicit trust boundary worth surfacing
-in the threat model. Any sandboxed runtime layered on top of asobi
-(e.g. `asobi_lua`) MUST keep its sandbox out of these tables.
+in the same BEAM (game callbacks, plugins, extensions) can read and
+mutate them. asobi is single-tenant and the loaded code is trusted, so
+this is acceptable, but it is an explicit trust boundary. The Lua
+runtime in `src/lua/` runs in this same BEAM and its sandbox has to
+stay out of these tables; so does any other sandboxed runtime.
 """.
 -behaviour(supervisor).
 


### PR DESCRIPTION
Thirty-four agents audited all 33 guides against source, rewrote them, and adversarially re-checked every claim. **341 findings.** Three new files, 51 changed.

## The correction that matters most

Ten guides said the ops plane is off unless `console` is true and an `ops_secret` is set. **It is not.**

`asobi_router:routes/1` mounts `ops_routes()` unconditionally behind `asobi_ops_auth:verify/1`, and `asobi_console:enabled/0` is read *only* in `asobi_console_controller`. So `{console, false}` closes `/console` and leaves `/api/v1/ops/*` live - including `/ext/:extension/:action`, the one mutating route - for anyone holding the secret. Unsetting the secret is what actually closes it.

Operators were being taught a switch that does not do what they think. I verified this independently before accepting it. `guides/console.md` now holds the accurate split; the other nine link to it rather than restating it differently.

Two verifiers found this and both **declined to fix it**, because correcting one file would contradict the other nine - resolving it needed all ten together.

## Three new files

- **`guides/console.md`** - the flagship. The console had no guide at all across 33 guides, despite being what replaced `asobi_admin`. Serves self-hosters and cloud users from one document, because the cloud dogfoods what self-hosters get.
- **`guides/lua-api.md`**
- **`docs/adr/0008`** - records the image rename.

## Claims that did not survive checking

- README counted "five timer primitives"; `asobi_timer` exports four.
- `asobi_ops_features` claimed capabilities report what is *configured*, not compiled in - false for `lua`, which is a `module_available/1` check.
- `extensions.md` pinned asobi by git tag three paragraphs before telling you to use Hex, and rendered a counter upsert with a `t.` alias `asobi_repo:accumulate/2` never emits.

## A CI guard that was blind

`check-error-drift.sh` only matched inline `{asobi_error, Code}` tuples, so codes raised through `asobi_error:legacy/2` were invisible - which is how the guest table came to omit the `422 validation_failed` the upgrade path genuinely returns. Regex extended, row added.

I confirmed it **exits 1 with a row missing and 0 with it present**, rather than trusting a green run - the guard's whole value is that it can fail.

## Two moduledocs that shipped harmful instructions

Both publish to HexDocs:

- `asobi_lua_validate` told CI to run `cli/1` via `eval` on a running node. `cli/1` ends in `halt/1` - that stops the server.
- `asobi_lua_world` advertised a `vote_resolved` world callback it does not export. `asobi_world_server` reaches it via `function_exported/3`, so a Lua world script defining it is **silently never called**. Verified.

## Documented rather than blessed

In `state_strategy = "shared"`, `broadcast_shared_state/3` sends `{match_state_raw, _}` and `asobi_bot` only handles `{match_state, _}` - so a bot's state stays empty for its whole life, with no error. Recorded as a limitation in `lua-bots.md` and cross-linked from the two guides that recommend that path.

**This wants a code fix, not a caveat.** The text should be deleted when that lands.

## Checks

`fmt --check`, `xref`, `dialyzer` clean. **1621 EUnit passing.** `ex_doc` builds with zero warnings. Both doc guards pass. All 34 guides registered in `extras` **and** `groups_for_extras`; every internal link and anchor resolves.