### PR TITLE
fix(ci): stop :0 serving a four-month-old image

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -57,6 +57,15 @@ jobs:
             type=sha,format=long
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
+            # {{major}} is "0" on a 0.x line, and that tag already exists from a
+            # workflow deleted in #45 - orphaned, still pointing at an April 2026
+            # pre-Lua-merge, pre-console image that boots and looks fine. Emitting
+            # it here is what stops a stale tag serving four-month-old code to
+            # anyone who pinned the major.
+            #
+            # It is still a weak pin on 0.x, where minors are not compatible.
+            # guides/self-hosting.md tells readers to pin the minor or a digest.
+            type=semver,pattern={{major}}
             type=raw,value=latest,enable={{is_default_branch}}
 
       - name: Build and push


### PR DESCRIPTION
## Verified against ghcr

| Tag | Digest | Built |
|---|---|---|
| `latest`, `0.71`, `0.71.0` | `sha256:1052f65d` | **today** |
| `0`, `0.23`, `0.23.0` | `sha256:2ee24de5` | **2026-04-06** |

`ghcr.io/widgrensit/asobi:0` - the floating major, which is exactly what a careful operator pins - serves a **pre-Lua-merge, pre-console** image that boots and looks entirely plausible. No error, no warning, just four-month-old code.

It was published by a workflow deleted in #45 and orphaned ever since. The current workflow emits `{{version}}` and `{{major}}.{{minor}}` but never `{{major}}`, so it could never take that tag over.

Found by the docs overhaul's completeness critic, which checked the registry rather than the docs. I confirmed both digests directly before changing anything.

## What this does

Adds `type=semver,pattern={{major}}` so the next release claims `:0` and it stops being stale.

Not a deletion: existing tags stay pullable, and anyone pinned to `0.23.0` explicitly keeps exactly what they have.

## Honest caveat

`:0` is a weak pin on a 0.x line - minors are not compatible there, so tracking the major means taking breaking changes. `guides/self-hosting.md` (in #401) steers readers to a minor or a digest instead. This change is about the tag not being **actively wrong**, not about recommending it.