### PR TITLE
feat: player erasure and export, a cloud guide, and bots in shared-state modes

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ your own release.
 - **Rate limiting** via `seki` (sliding window, per route group), **sessions** cached in ETS, **presence** via `pg`, **chat / social / economy / inventory / storage / tournaments / notifications** as Nova controllers.
 - **Extensions** - game-specific methods, callable as an `rpc.call` WebSocket frame and over `/api/v1/ops/ext/:extension/:action`. See [Extensions](guides/extensions.md).
 - **Client SDKs** for Godot, Defold, Unity, Unreal, JS/TS, Dart, Flame - [see below](#client-sdks).
-- **Operator console** - a browser UI over the ops plane, read-only today: players, matches, matchmaker queue, leaderboards, economy, chat, tournaments, notifications. Served by the node itself at `/console`, off until you turn it on.
+- **Operator console** - a browser UI over the ops plane: players, matches, matchmaker queue, leaderboards, economy, chat, tournaments, notifications. Reads, plus erasing and exporting one player. Served by the node itself at `/console`, off until you turn it on.
 
 ## Benchmarks
 
@@ -126,6 +126,7 @@ UDP relay if you need sub-3ms physics.
 - [**Glossary**](guides/glossary.md) - the self-hosted node vs asobi.dev Cloud. Start here if the names blur.
 - [**Getting started**](guides/getting-started.md) - stand up a local node, in Lua or in Erlang
 - [**Self-hosting**](guides/self-hosting.md) - requirements, production compose, operating notes
+- [**Cloud**](guides/cloud.md) - the managed version: the CLI, how Lua reaches an environment, and when to self-host instead
 - [**Architecture**](guides/architecture.md) - supervision tree, modules, design
 - [**REST API**](guides/rest-api.md) · [**WebSocket protocol**](guides/websocket-protocol.md)
 - [**Matchmaking**](guides/matchmaking.md) · [**Lobbies**](guides/lobbies.md) · [**Voting**](guides/voting.md) · [**Phases**](guides/phases.md)

--- a/docs/adr/0001-encode-once-shared-state-broadcast.md
+++ b/docs/adr/0001-encode-once-shared-state-broadcast.md
@@ -89,3 +89,17 @@ to a separate bridge module `asobi_lua_match_shared` (see
   (the architecture-guardian's "fix #2"); orthogonal to the encode-once
   question because deltas still need to be encoded per recipient unless
   ALSO shared. Punted.
+
+## Amendment (2026-08-06)
+
+"Every subscriber" was wrong for one kind of subscriber. `asobi_bot` reads
+match state as an Erlang term and had no clause for `match_state_raw`, so
+under a shared strategy a bot's state stayed empty for the life of the match,
+with no error and no log line.
+
+Fan-out now goes through `asobi_presence:send_match_state/3`: a session gets
+the pre-encoded binary, a bot gets the `get_state/1` result as a term. The
+decision above is unchanged - `get_state/1` is still called once and encoded
+once per tick, and a bot adds neither a call nor an encode nor a decode. Only
+the delivery is recipient-aware, and only `asobi_presence` decides that,
+because it is what knows which ids are bots.

--- a/docs/adr/0007-durable-ops-audit-rows.md
+++ b/docs/adr/0007-durable-ops-audit-rows.md
@@ -102,6 +102,35 @@ insert fails - or raises - the row is emitted at error level with the same
 field names, so the record degrades from queryable to greppable rather than
 disappearing.
 
+### 4. Erasure is the one stated exception (amended 2026-08-06)
+
+Audit-after is the rule. Player erasure is the exception, and it is the only
+one.
+
+The rule holds because a mutation leaves something behind that a degraded log
+line can still describe, and because the change cannot be undone by refusing
+to record it. Erasure breaks both halves. The data it describes is gone by
+definition, so the audit row is not a second record of the change - it is the
+**only** surviving evidence the request was honoured, which is the
+accountability half of a deletion obligation rather than bureaucracy around
+it. And "the change already happened" stops being a reason not to fail,
+because the change *can* still be refused: it is one transaction, and the row
+can commit inside it.
+
+So `asobi_player_erase` writes its row through
+`asobi_ops_audit:record_strict/4` inside the erasure transaction. A failed
+insert rolls the erasure back, and the player survives with nothing deleted.
+"Erased" and "recorded as erased" are the same commit or neither happened.
+
+`ops_audit_entries.actor_id` and `target_id` are plain strings with no foreign
+key to `players`, so the row already outlives its own subject by construction
+- which is what makes this possible at all.
+
+An automated retention sweep is not an operator action and writes no rows:
+`asobi_guest_reaper` erases up to 500 accounts per pass and logs a count. A
+row per reaped guest would bury the operator actions this table exists for
+under the machine's own housekeeping.
+
 ## Consequences
 
 - **Attribution survives the request.** Every mutation is answerable months
@@ -111,8 +140,18 @@ disappearing.
   console's mutation moves onto (widgrensit/asobi_admin#6). Until it does,
   the console keeps its own copy and keeps lying; core cannot fix that from
   here.
-- **No ops write routes were added.** The plane stays read-only. This is the
-  mechanism plus the one mutation that already existed, not a write surface.
+- **No ops write routes were added by this ADR.** It shipped the mechanism
+  plus the one mutation that already existed. That sentence used to read "the
+  plane stays read-only", and it stopped being true when player erasure
+  landed: `POST /api/v1/ops/players/:id/erase` and
+  `GET /api/v1/ops/players/:id/export` are routed. Read-only was never the
+  load-bearing property - the caps vocabulary already named `player_data` and
+  `config` as mutation classes, `asobi_ops_auth` already granted all three to
+  a static secret, and `asobi_ops_notifications:broadcast/5` was already a
+  complete audited mutation sitting unrouted. What is load-bearing is that a
+  mutation be capability-classed and audited, and erasure is both. It also
+  added the fourth class the vocabulary said would be additive: `erasure`,
+  discriminated by irreversibility rather than sensitivity.
 - **An audit row is a new failure mode with a documented outcome.** A
   deployment whose database is degraded loses queryable audit rows and keeps
   error-level log lines. That is a stated trade, not a silent one.

--- a/guides/architecture.md
+++ b/guides/architecture.md
@@ -378,10 +378,17 @@ routes are always mounted and reject everything until an `ops_secret` is
 configured, so a stock node serves neither. [Operator console](console.md) owns
 the detail.
 
-Core's ops routes are all reads. Every route carries a capability class -
-`read`, `player_data` or `config` (`src/ops/asobi_ops_caps.erl:22`) - and the
-only route that mutates is `/api/v1/ops/ext/:extension/:action`, whose
-behaviour comes from an installed extension.
+Every ops route carries a capability class - `read`, `player_data`, `config`
+or `erasure` (`src/ops/asobi_ops_caps.erl`) - and the class is the only thing
+that authorises the call. Core's routes are reads apart from two:
+`GET /api/v1/ops/players/:id/export` (`player_data`) and
+`POST /api/v1/ops/players/:id/erase` (`erasure`). The third mutating route is
+`/api/v1/ops/ext/:extension/:action`, whose behaviour comes from an installed
+extension.
+
+`erasure` is its own class because it is the only irreversible one, and a
+console session is granted every class but that one by default
+(`src/console/asobi_console_session.erl`).
 
 The console holds no privileged path into the database. It reads the ops plane
 over HTTP like any other client. It was previously a separate project,

--- a/guides/authentication.md
+++ b/guides/authentication.md
@@ -393,8 +393,9 @@ guest_auth = true
     {guest_unlinked_cap, 100000},        %% max unclaimed guests, or `infinity`
 
     %% Optional retention. Unset = permanent guests (never reaped). A number of
-    %% seconds deletes unclaimed guests older than that.
-    {guest_reap_after, 2592000}          %% e.g. 30 days
+    %% seconds deletes unclaimed guests not seen for that long. Inactivity, not
+    %% account age: a device that keeps resuming keeps its player forever.
+    {guest_reap_after, 2592000}          %% e.g. 30 days since last resume
 ]}
 ```
 

--- a/guides/cloud.md
+++ b/guides/cloud.md
@@ -1,0 +1,518 @@
+# asobi Cloud
+
+asobi Cloud is the managed version of the node described everywhere else in
+these guides. You write the same Lua, your clients speak the same WebSocket and
+REST protocol, and the callbacks, error codes and Lua API are identical.
+
+What changes is operations. You do not run a container, you do not mount
+`/app/game`, and you do not write a `sys.config`. Environments are created and
+fed Lua through the `asobi` CLI, and the operator console is reached from the
+dashboard rather than by holding a secret.
+
+This guide is the honest version of that trade: the commands that exist, how a
+bundle actually reaches an environment, and the list of things a cloud tenant
+cannot do. If the last one rules you out, [self-host](self-hosting.md) - the
+node is Apache-2.0 and complete.
+
+## Availability
+
+Invite-only. A new account is created only when the email is on an operator
+allowlist, on the signup allowlist, or holds an approved waitlist row.
+Everything else is refused at the point the account would be created.
+
+The public front door is the waitlist on
+[console.asobi.dev](https://console.asobi.dev): anyone may request access, an
+operator approves or declines, and admission is single-use. An approval that
+has been redeemed does not admit a second registration.
+
+Joining a studio that already exists is a different path. An invite from a team
+owner redeems a single-use token and does not go through the waitlist at all
+(ADR 0008). One user belongs to one tenant.
+
+## What "the same core" does and does not mean
+
+The code is the same. The artefact is not.
+
+A cloud environment runs `ghcr.io/widgrensit/asobi_engine`, a release that
+wraps the `asobi` library published in this repository. Self-hosting runs
+`ghcr.io/widgrensit/asobi`, a release built from the same library plus a Lua
+directory contract. Same modules, same behaviour, two release builds with
+different boot code: the engine fetches its Lua over HTTP at boot, the image
+reads it off a mounted directory.
+
+That difference is the source of nearly everything below.
+
+## The CLI
+
+### Install
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/widgrensit/asobi-cli/main/install.sh | sh
+```
+
+```powershell
+irm https://raw.githubusercontent.com/widgrensit/asobi-cli/main/install.ps1 | iex
+```
+
+The scripts verify a checksum and install to `~/.local/bin` or
+`%LOCALAPPDATA%\asobi\bin`; `ASOBI_INSTALL_DIR` overrides the location and
+`ASOBI_VERSION` pins a release. `asobi upgrade` self-replaces the binary later,
+verifying a signed checksum first, and refuses to when a package manager owns
+the install. There is no winget package and no Scoop bucket yet; the release
+build is wired for both but publishes neither.
+
+Confirm with `asobi version`.
+
+### Commands
+
+| Command | Flags | What it does |
+| --- | --- | --- |
+| `asobi login` | `--saas-url`, `--token-name` | Browser device-code flow. Writes `~/.asobi/credentials.json` |
+| `asobi logout` | | Deletes the credentials file |
+| `asobi whoami` | | Prints the stored context. Local only, no network call |
+| `asobi games` | | Lists the tenant's games, marking the active one with `*` |
+| `asobi use <slug>` | | Persists the active game |
+| `asobi create <name>` | `--size xs\|s\|m\|l`, `--game` | Creates an environment. Default size `xs` |
+| `asobi deploy <env> [dir]` | `--game` | Validates, zips and uploads the Lua bundle. `dir` defaults to `.` |
+| `asobi envs` | `--game` | NAME, SIZE, STATUS, ENDPOINT for the game's environments |
+| `asobi start <name>` | `--game` | Starts a stopped environment |
+| `asobi stop <name>` | `--game` | Stops a running environment |
+| `asobi resize <name>` | `--size` (required), `--game` | Changes the size. Applies on the **next start** |
+| `asobi delete <name>` | `--game` | Destroys the environment and deletes its row |
+| `asobi health [env]` | `--game` | `GET /health` against the resolved endpoint |
+| `asobi init [dir]` | `--template` | Scaffolds a project |
+| `asobi dev` | `--port`, `--dir` | Runs a local backend in Docker. No account needed |
+| `asobi config set\|show` | | The manual `url` / `api_key` fallback for self-hosters |
+| `asobi upgrade` | | Updates the binary |
+
+`asobi env list` and `asobi destroy <env_id>` are the older tenant-wide
+commands. `asobi destroy` takes a UUID rather than a name and is best avoided -
+see [Two commands to be careful with](#two-commands-to-be-careful-with).
+
+### How a game is chosen
+
+Every environment belongs to a game and a CLI token is tenant-scoped, so an env
+command needs a game. It resolves in this order:
+
+1. `--game <slug>` on the command line.
+2. The active game from `asobi use <slug>`.
+3. If the tenant has exactly one game, that one.
+4. An interactive picker, if stdin is a terminal.
+5. Otherwise it is a hard error.
+
+A tenant with two or more games running commands from CI has no terminal for
+step 4, so pass `--game` explicitly there.
+
+### TLS is not optional
+
+`asobi login --saas-url` and `asobi config set url` both refuse anything that
+is not `https`, except `http` to a loopback host for local development. There
+is no `--insecure` flag.
+
+## Getting started
+
+```bash
+asobi init mygame --template arena
+cd mygame
+asobi dev
+```
+
+`asobi dev` writes `.asobi/dev-compose.yml`, runs Docker Compose in the
+foreground and mounts your Lua directory. It never reads credentials and never
+talks to the control plane, so you can evaluate asobi with no account at all.
+
+The genre starters are `arena`, `basic`, `chat`, `turn-based` and `world`, each
+scaffolding a runnable `lua/match.lua`. `--template defold`, `godot`, `unity`
+or `backend` fetch a full client-plus-backend demo from a pinned repository tag
+instead.
+
+When you want it hosted:
+
+```bash
+asobi login
+asobi games
+asobi use mygame
+asobi create prod
+asobi deploy prod lua
+asobi envs
+```
+
+The last line is not optional politeness. See below.
+
+## How Lua reaches an environment
+
+The engine pulls; the control plane never pushes. In order:
+
+1. **Collect.** The CLI walks the directory you named and takes **every
+   `.lua` file** under it, recursively, keying each by its relative path. Assets,
+   JSON and text files are not included - the bundle is Lua and nothing else.
+2. **Validate locally.** Before any network call, three gates run:
+   - an entry point (`config.lua`, or `match.lua` for single-mode) must sit at
+     the **root of the bundle**. This is the "you deployed the parent
+     directory" error, and catching it here is the difference between a clear
+     message and an environment that boots with no game modes;
+   - every `.lua` file must compile;
+   - `config.lua` must return a table of `mode_name = "script.lua"`, every named
+     script must be present, and `guest_auth` must not be a field of that table.
+     The engine reads `guest_auth` as a top-level global, so a table field is
+     silently ignored.
+3. **Zip.** Deflate, forward-slash entry names, every entry stamped with a fixed
+   timestamp so the bundle is byte-reproducible. The path normalisation matters
+   on Windows, where a backslash entry name would be extracted as a literal
+   file called `lua\match.lua` and nothing would find your entry point.
+4. **Upload.** `POST /internal/cli/envs/<name>/deploy?game=<slug>` as
+   `application/zip`, authenticated with the access token. A 401 refreshes the
+   access token and retries.
+5. **Gate.** The control plane resolves your tenant from the token, the game
+   from the slug within that tenant, and the environment by name within that
+   game. It then refuses with **409 `env_not_deployable`** unless the
+   environment is `running`, `deploying` or `degraded`. Every other state
+   (`not_provisioned`, `provisioning`, `stopping`, `stopped`, `starting`,
+   `scaling`, `destroying`, `destroyed`, `retired`, `failed`) has no engine that
+   could take a bundle, so the deploy fails loudly rather than being silently
+   dropped.
+6. **Store.** The zip is hashed with SHA-256 and stored, and the generation
+   counter on the environment is claimed before anything is triggered, so two
+   back-to-back deploys cannot collide.
+7. **Roll.** The provisioner rewrites the environment's Kubernetes Secret with
+   the new bundle URL, hash and generation, stamps the generation into the pod
+   template annotations, and re-applies the Deployment. The annotation is what
+   makes Kubernetes actually roll: a Secret change on its own would not.
+8. **Fetch and verify.** The new engine pod reads the bundle URL from its
+   environment, fetches it over the control plane's internal listener
+   authenticated with its own per-environment engine key, **verifies the
+   SHA-256**, rejects any archive entry that would escape the target directory,
+   and extracts to `/tmp/bundle-<generation>`.
+9. **Register.** The engine points `game_dir` at the extracted directory and
+   runs the same config loader a self-hoster's mounted directory goes through -
+   so `guest_auth`, `registration`, the mode manifest and every per-mode global
+   behave identically. With no entry point at the root it logs
+   `bundle_no_entry_point`, lists where your `.lua` files actually landed, and
+   pins `guest_auth` off.
+
+### Two consequences worth stating plainly
+
+**A deploy is a pod replacement, not a hot reload.** The Deployment strategy is
+`Recreate`: the old pod terminates before the new one starts. In-flight matches
+and worlds live in memory and do not survive. Self-hosting can hot-reload
+because the runtime stats a mounted file between ticks; a bundle extracted into
+`/tmp` inside a pod never changes for that pod's life, so there is nothing to
+stat. Design clients to reconnect, and expect a short gap.
+
+**A 200 from `asobi deploy` does not mean the environment is running your new
+bundle.** The CLI prints its success line off the HTTP response, and that
+response is sent before the Kubernetes work starts - deliberately, because
+provisioning can outlast an HTTP client's timeout and orphaning live resources
+against a request that died is worse. The observable outcome is
+`provisioning_status` reaching `running`:
+
+```bash
+asobi deploy prod lua && asobi envs
+```
+
+A `503 provisioner_unavailable` means the bundle was stored but nothing was
+rolled. Retry the deploy; the stored bundle is not lost.
+
+## Authentication
+
+### The login flow
+
+`asobi login` runs an ECDH-encrypted device-code flow:
+
+1. The CLI generates an ephemeral P-256 keypair and posts the public key with a
+   token name (your hostname by default).
+2. The control plane returns a session id, a user code and a verification URL.
+   The CLI prints the code and opens a browser.
+3. You approve in the dashboard. Approval needs a live dashboard session, so
+   the person approving is someone the control plane already authenticated.
+4. The control plane mints tokens, encrypts the payload under the shared secret
+   and stores it against the session.
+5. The CLI polls, decrypts locally and writes `~/.asobi/credentials.json`.
+
+Because the payload is encrypted end to end, an observer on the polling channel
+sees nothing usable.
+
+### The tokens
+
+| | Lifetime | Stored |
+| --- | --- | --- |
+| Access token | 24 hours | Control plane memory only; a restart costs one refresh |
+| Refresh token | 30 days | Postgres, as a SHA-256 hash |
+
+The refresh token is bound to a server-issued **device secret**, 32 random
+bytes delivered once inside the encrypted payload. Refreshing needs both, and
+the comparison is constant-time, so a stolen refresh token on its own is
+useless. The `device_fingerprint` in your credentials is a hostname and a
+dashboard label; it is explicitly not a security control.
+
+A refresh re-checks current state before minting: your tenant must still be the
+tenant recorded at login and that tenant must still be active. A failed check
+deletes the row, which is what closes the offboarding window.
+
+Scopes are `deploy` and `manage`, granted together at approval. There is no
+scope selection.
+
+### Storage and CI
+
+`~/.asobi/credentials.json`, mode `0600`, in a `0700` directory. On Windows the
+blob is additionally DPAPI-encrypted for the current user, because the file
+mode creates no ACL there.
+
+`ASOBI_ACCESS_TOKEN` overrides the stored access token. That is the CI hook:
+
+```bash
+export ASOBI_ACCESS_TOKEN="$ASOBI_TOKEN"
+asobi deploy prod lua --game mygame
+```
+
+### Against self-hosting
+
+A self-hoster has no CLI authentication, because there is nothing to
+authenticate to. No control plane, no tenant, no device flow, no access token.
+Their credentials are the database password, an `ops_secret` if they want the
+ops plane at all, and whatever OAuth, Steam or IAP secrets the game itself
+uses. They deploy Lua by changing files in a directory.
+
+## The console
+
+The [operator console](console.md) is the same nine screens either way. How you
+get in is not.
+
+Self-hosted, there is one long-lived credential: `ops_secret`, set by the
+operator, presented as a bearer token, compared in constant time. There is no
+default value, so a node that has not configured one rejects every ops request.
+Over a bearer header it proves all four capability classes, `erasure` included.
+A console session opened with it gets every class except `erasure`, unless
+`console_erasure` is set to true.
+
+On cloud, no shared secret ever reaches you:
+
+1. You open the console link on the environment's dashboard page.
+2. The control plane runs the same ownership guard every other environment
+   action uses, then maps your **team role** onto capability classes:
+   `owner` and `admin` get `read`, `player_data` and `config`; `member` gets
+   `read` and `player_data`; anything else gets nothing. No role maps to
+   `erasure`, so no cloud credential can reach it - see below.
+3. It signs a token with `ASOBI_OPS_TOKEN_SECRET`, read out of that
+   environment's own Kubernetes Secret at mint time. The control plane keeps no
+   copy, so a database compromise does not confer the ability to mint.
+4. The token lives **900 seconds**, which is the ceiling the engine enforces.
+   Minting a longer one would produce a token that verifies nowhere.
+5. The dashboard renders a form that posts the token to your environment's
+   `/console/session`. A body rather than a URL, so the credential never
+   reaches an access log, a referrer or browser history; a form the operator
+   submits rather than script, so it needs no JavaScript and survives a CSP.
+6. Your environment verifies the token and opens a session carrying exactly the
+   token's capability classes and expiring no later than the token does. A
+   fifteen-minute credential must not buy a twelve-hour session.
+
+The claim that identifies you is your control-plane user id, not your email,
+because it lands in that environment's audit rows.
+
+| | Self-hosted | Cloud |
+| --- | --- | --- |
+| Credential | one `ops_secret` you set and keep | a 15-minute token, minted per person per environment |
+| Privilege | every class over a bearer header; every class but `erasure` in the console, unless `console_erasure` is set | mapped from your team role; `member` cannot reach `config`, and nobody reaches `erasure` |
+| Attribution | the `x-asobi-operator` header, a label with no authority behind it | the `sub` claim, marked attested, from an authenticated user |
+| Revocation | change `ops_secret` | rotate the per-environment signing secret, which revokes every outstanding token for it at once |
+| Turning it on | `{console, true}` plus a credential; off by default | already on |
+
+There is no non-interactive path to the ops plane on cloud. A minted token
+needs a browser session to mint it, so the CI-calls-the-ops-API pattern is a
+self-hosting capability.
+
+**Player erasure is not reachable on cloud.** `POST
+/api/v1/ops/players/:id/erase` carries the `erasure` class, and the two
+credentials that hold it - the `ops_secret` bearer header, and a console
+session on a node with `console_erasure` set - are both operator config a cloud
+tenant does not have. `GET /api/v1/ops/players/:id/export` is `player_data`, so
+exporting one player's record does work from the cloud console; erasing them
+does not. If you have to answer deletion requests yourself, that is a reason to
+self-host. Ask us in the meantime and we will run it against your environment.
+
+## What a cloud tenant cannot configure
+
+A cloud environment's `sys.config` sets four `asobi` keys, all of them
+generated and injected by the provisioner: `ops_token_secret`, `env_id`,
+`console` and `guest_verifier_pepper`. There is no route, CLI flag, dashboard
+field or environment-variable passthrough that reaches any other key.
+
+That means the following are unavailable, and this is the honest list rather
+than a summary:
+
+**Identity providers and receipts.** `oidc_providers`, `base_url`,
+`steam_api_key`, `steam_app_id`, `steam_identity`, `apple_bundle_id`,
+`apple_root_cert_path`, `apple_root_certs`, `google_package_name`,
+`google_service_account_key`. A cloud tenant cannot configure Google or Apple
+sign-in, Steam authentication, or Apple and Google IAP receipt verification at
+all. This is the largest gap on the list. If your game needs platform sign-in
+or store receipt validation today, self-host.
+
+**Guest auth beyond the toggle.** The per-environment pepper is injected for
+you, so `guest_auth = true` in your Lua works. `guest_verifier_key_id`,
+`guest_unlinked_cap`, `guest_reap_after` and `guest_reap_interval_ms` are not
+settable, so unclaimed guests are never reaped and only the default soft cap
+applies. Pepper rotation is not yours either.
+
+**Ops-plane shape.** `ops_secret`, `console_erasure`, `console_session_ttl`,
+`console_secure_cookie`, `console_api_base`, `console_label`,
+`console_production`. `ops_secret` and `console_erasure` are the two that
+between them put the `erasure` class out of reach.
+
+**Rate limiting and abuse control.** `rate_limits` and all of its buckets,
+`client_gate`, `client_gate_timeout`, `client_gate_on_error`,
+`trusted_proxies`. You run on the defaults and cannot plug in a CAPTCHA or an
+attestation gate.
+
+**WebSocket.** `ws_allowed_origins`, `ws_legacy_game_frames`,
+`ws_idle_auth_timeout_ms`. No cross-site WebSocket-hijacking origin allowlist
+is available, so the open default stands.
+
+**Game structure at the operator layer.** `game_modes`, `game_dir` (the engine
+writes it), `registration` on the operator side, `script_registration`,
+`extension_restart`.
+
+**Gameplay bounds.** `matchmaker` tick interval and maximum wait,
+`vote_templates`, `world_max`, `world_max_per_player`,
+`leaderboard_client_submit`, `leaderboard_max_boards`, `auth_cache_ttl_ms`,
+`auth_cache_negative_ttl_ms`.
+
+**Lua runtime dials.** `max_heap_words`, `max_reductions_per_ms`,
+`reload_mode`, `config_watch_interval`, `dev_errors`, `terrain_providers`. A
+large-world game on cloud is limited to the default terrain provider
+allowlist.
+
+**Clustering.** One replica per environment, `Recreate` strategy. Clustering is
+not on the table.
+
+**Everything outside the `asobi` application.** Database pool size, background
+job queues, CORS origins (set control-plane-wide, not per tenant), logger level
+and resilience gates.
+
+### What you can set
+
+Everything reachable from the Lua bundle, which is most of what a game actually
+tunes: the `config.lua` mode manifest, the per-mode globals (`match_size`,
+`max_players`, `strategy`, `bots`, `game_type`, `state_strategy`), the
+world-mode globals (`tick_rate`, `grid_size`, `zone_size`, `view_radius`,
+`empty_grace_ms`, `player_ttl_ms`), and the two config-layer globals
+`guest_auth` and `registration`.
+
+`registration` works on cloud precisely because the operator layer leaves it
+unset - a script value only lands where no operator value exists.
+`guest_auth = true` works because the provisioner pre-injects a per-environment
+pepper for exactly that purpose: the game half is yours, the secret half is
+not (ADR 0004).
+
+[Configuration](configuration.md) marks which layer each key belongs to.
+
+## Extensions do not run on cloud
+
+An [extension](extensions.md) is an OTP application added as a dependency of
+your release and listed in its application set. The engine release is built
+with a fixed set of applications at image build time, there is no plugin
+directory, and the bundle loader only ever registers Lua game modes.
+
+Nor can you point an environment at your own image. The column exists in the
+schema, but no tenant-reachable path writes it.
+
+So: **cloud runs the stock engine.** If you need an extension - a custom
+matchmaking strategy in Erlang, a hot loop, your own RPC methods, your own
+schemas - you need to build a release, and that means self-hosting.
+
+## Environments
+
+`asobi create <name> --size xs|s|m|l` provisions a Deployment, Service, Ingress
+and per-environment Secret, plus its own PostgreSQL database and login role.
+
+| Size | vCPU | Memory |
+| --- | --- | --- |
+| `xs` | 1 | 256 MB |
+| `s` | 1 | 512 MB |
+| `m` | 2 | 1024 MB |
+| `l` | 4 | 2048 MB |
+
+Pricing is flat per environment per month. The current plans are shown in the
+dashboard at [console.asobi.dev](https://console.asobi.dev), which is the
+authoritative source; [asobi.dev/cloud](https://asobi.dev/cloud) describes the
+service but carries no numbers.
+
+Each environment gets a name of the form
+`https://<game>-<env>.<tenant>.asobi.dev` with TLS, from a per-tenant wildcard
+certificate applied ahead of the pod so issuance overlaps startup.
+
+`asobi resize` updates the row; the new resources apply **on the next start**,
+because a Deployment's resources are set at provision time. Stop and start to
+take them, or wait for the next deploy.
+
+The secrets an environment needs are generated for you and preserved across
+redeploys, so they stay stable: the distribution cookie, the database password,
+the guest-auth pepper, the ops-token signing secret and the engine key.
+
+Beyond the CLI, the dashboard carries deletion protection, a retire-then-restore
+lifecycle with a purge delay, log viewing, live gauges and time-series charts,
+and environment-down alerting. Team roles, invites and one-tenant-per-user are
+cloud concepts with no self-hosted equivalent.
+
+### Two commands to be careful with
+
+`asobi delete <name>` does not check deletion protection. The dashboard's
+destroy button refuses a protected environment and goes through the retire and
+purge lifecycle; the CLI path tears down the provisioned resources and deletes
+the row directly. Protection is a dashboard guard, not a CLI one.
+
+`asobi destroy <env_id>` is worse and should be treated as deprecated. It
+revokes the environment's API keys and deletes the database row without calling
+the provisioner, leaving the Deployment, Service, Ingress, Secret and database
+running with nothing pointing at them. Nothing cleans that up on its own: the
+control plane's only orphan sweep covers databases, not Kubernetes objects, and
+it is off in production. Tell us if you have run it, so we can tear the
+leftovers down by hand. Use `asobi delete <name>`.
+
+## When to self-host instead
+
+Choose cloud when the operational work is the part you do not want: TLS, a
+database, backups, an ingress, a console you did not have to secure. A game
+that authenticates with guests or your own accounts, tunes itself from Lua and
+wants a console its team can share fits cleanly.
+
+Self-host when any of these is true. None of them is a hypothetical.
+
+- **You need platform sign-in or store receipt validation.** Google, Apple,
+  Steam and IAP verification all need operator config a cloud tenant cannot
+  reach. This is the most common reason.
+- **You need an extension.** Erlang callbacks, custom matchmaking strategies,
+  your own RPC methods or schemas. Cloud runs the stock engine.
+- **You need to tune the runtime.** Rate limits, heap and reduction caps,
+  matchmaker timing, world caps, terrain providers, WebSocket origin
+  allowlists.
+- **You need hot reload.** Mount a directory, edit a file, the runtime picks it
+  up between ticks and in-flight state survives. Every cloud change is a pod
+  replacement.
+- **You need more than one node.** Cloud is one replica per environment.
+- **You need server-to-server access to the ops plane.** An `ops_secret` works
+  from CI; a minted token needs a browser.
+- **You have to erase players yourself.** The `erasure` class needs operator
+  config a cloud tenant cannot reach, so deletion requests go through us.
+  Export works from the cloud console; erasure does not.
+- **You need a specific database, version, port or pool size**, or Postgres
+  somewhere you already run it.
+- **Data residency or procurement says the data stays with you.** You do not
+  choose the region an environment runs in; check
+  [asobi.dev/cloud](https://asobi.dev/cloud) for where they run today, and
+  self-host if that is not an answer you can accept.
+- **The economics do not work.** Per-environment pricing against a box you
+  already own is a straightforward comparison, and sometimes the box wins.
+
+You are not locked in either way. A bundle deployed to cloud is the same Lua a
+self-hosted node reads off a mounted directory, and [Exit](exit.md) covers
+getting your data out.
+
+## Next
+
+- [Self-hosting](self-hosting.md) - the production compose and the deployment
+  patterns cloud replaces.
+- [Configuration](configuration.md) - every key, and which layer owns it.
+- [Operator console](console.md) - the screens, the ops API, what it cannot do.
+- [Lua scripting](lua-scripting.md) - what goes in the bundle.
+- [Exit](exit.md) - what happens if we stop.

--- a/guides/comparison.md
+++ b/guides/comparison.md
@@ -42,11 +42,12 @@ on one.
 Two rows are worth reading twice.
 
 The console is a React SPA served from `priv/console` by the same node that
-serves the game. Every core ops route is a read. The only route that mutates is
-`/api/v1/ops/ext/:extension/:action`, and its behaviour comes from an installed
-extension - so there is no ban, kick, grant, refund or match-end button. Nakama
-Console and PlayFab Game Manager both mutate; if you are moving from one of
-those, that is a real gap. See [Operator console](console.md).
+serves the game. Core's ops routes are reads apart from erasing and exporting
+one player; the third mutating route is `/api/v1/ops/ext/:extension/:action`,
+whose behaviour comes from an installed extension. So there is no ban, kick,
+grant, refund or match-end button. Nakama Console and PlayFab Game Manager both
+mutate; if you are moving from one of those, that is a real gap. See
+[Operator console](console.md).
 
 Custom server-side logic that is not per-match goes over the WebSocket as
 `rpc.call` with `{protocol: 1, method, params}`, answered by `rpc.ok` or
@@ -98,7 +99,8 @@ is CPU spent on message processing, not memory. Figures and method are in
   today.
 - You need a fully managed cloud at hyperscaler breadth. asobi's managed
   version is [asobi.dev/cloud](https://asobi.dev/cloud), which is the same
-  open-source core rather than a different product.
+  open-source core rather than a different product - invite-only today, and
+  narrower than self-hosting in ways [Cloud](cloud.md) lists.
 - You are building a single-player game that only needs analytics and IAP.
   Analytics plus a store validator is cheaper than any backend here.
 

--- a/guides/configuration.md
+++ b/guides/configuration.md
@@ -454,8 +454,10 @@ operator half.
 %% Optional abuse control: max unclaimed guests, or `infinity`.
 {guest_unlinked_cap, 100000},
 
-%% Optional retention. Unset = permanent guests (never reaped). Seconds after
-%% which unclaimed guests are deleted by the reaper.
+%% Optional retention. Unset = permanent guests (never reaped). Seconds of
+%% inactivity after which an unclaimed guest is deleted by the reaper. The
+%% clock restarts every time the device resumes, so this never expires a
+%% player who is still playing.
 {guest_reap_after, 2592000}
 ```
 
@@ -464,7 +466,19 @@ operator half.
 | `guest_verifier_pepper` | none | Key-id -> pepper map, or a single binary. Each pepper must be at least 32 bytes; a shorter one is treated as absent. Presence is the operator's on switch |
 | `guest_verifier_key_id` | `~"v1"` | Which pepper key id to use when minting new verifiers |
 | `guest_unlinked_cap` | `100000` | Soft ceiling on unclaimed guests, or `infinity` |
-| `guest_reap_after` | unset | Seconds; unset disables the reaper, so guests are permanent |
+| `guest_reap_after` | unset | Seconds of inactivity since the device last resumed; unset disables the reaper, so guests are permanent |
+
+Measured from the last resume, not from account creation. Under device auth a
+guest stays unclaimed for life - there is no password to set - so account age
+would say nothing about whether anyone is still playing, and a returning player
+would be deleted on schedule.
+
+A reaped guest is erased in full - wallet, ledger, saves, storage, chat,
+friendships, identities and any installed extension's rows - through the same
+`asobi_player_erase` an operator-initiated erasure uses. This is permanent and
+irreversible, it takes up to 500 accounts per sweep, and the sweep writes no
+audit rows; it logs a count. Set it deliberately. See
+[Erasing and exporting a player](rest-api.md#erasing-and-exporting-a-player).
 
 **In the image today this needs a `sys.config`.** The Dockerfile declares
 `ASOBI_GUEST_VERIFIER_PEPPER`, but nothing substitutes it into `sys.config`, so
@@ -503,9 +517,11 @@ and never leaves the server. Player and guest tokens are rejected here: the ops
 plane never consults the player token store.
 
 One secret is one privilege level: whoever holds it holds every capability
-class, including `config`. Restrict who can reach the plane with a reverse
-proxy, and set `x-asobi-operator` per person for attribution in the audit trail
-- it is a label, never authority. See
+class, including `config` and `erasure`. Restrict who can reach the plane with
+a reverse proxy, and set `x-asobi-operator` per person for attribution in the
+audit trail - it is a label, never authority. A console session opened with
+this secret is the one exception: it gets every class but `erasure` unless
+`console_erasure` is set. See
 [REST API](rest-api.md#ops-authentication) for the per-route reference and
 [Operator console](console.md) for the operator narrative and for what the plane
 can and cannot do.
@@ -514,7 +530,8 @@ can and cannot do.
 
 A managed environment takes a second kind of ops credential: a short-lived,
 env-scoped token minted by a control plane after it has authenticated the tenant
-and checked they own this environment. Self-hosting needs none of this.
+and checked they own this environment. Self-hosting needs none of this, and
+[Cloud](cloud.md#the-console) walks the handoff end to end.
 
 ```erlang
 {ops_token_secret, ~"${ASOBI_OPS_TOKEN_SECRET}"},
@@ -566,12 +583,13 @@ operator surface on a public port has to be asked for.
 | `console_api_base` | none | Absolute `https://host[:port]` origin the console should call instead of this one. Also widens `connect-src`. Anything that is not a bare origin is ignored |
 | `console_label` | none | Names this deployment in the tab title and the console header |
 | `console_production` | `false` | Marks a deployment to be careful in. The console colours its label |
+| `console_erasure` | `false` | Let a console session erase players. Off because a browser can be clickjacked and an erasure cannot be undone; a bearer secret holds the class regardless |
 
 `console`, `console_label` and `console_production` also read
 `ASOBI_CONSOLE`, `ASOBI_CONSOLE_LABEL` and `ASOBI_CONSOLE_PRODUCTION`, and
 `ops_secret` reads `ASOBI_OPS_SECRET_FILE` or `ASOBI_OPS_SECRET`. The other
-three - `console_session_ttl`, `console_secure_cookie` and `console_api_base` -
-have no environment variable and need a `sys.config`. A variable overrides
+four - `console_session_ttl`, `console_secure_cookie`, `console_api_base` and
+`console_erasure` - have no environment variable and need a `sys.config`. A variable overrides
 `sys.config` only when it is set, so the two coexist.
 
 There is no `ASOBI_DB_PASSWORD_FILE`. The database password is substituted into

--- a/guides/console.md
+++ b/guides/console.md
@@ -16,10 +16,11 @@ managed environment has a second credential - see
 [Minted tokens](configuration.md#minted-tokens-managed-environments) - which
 needs `ops_token_secret` and `env_id`, neither set by default.)
 
-The two look coupled because enabling the console without a secret turns the
-console back off, below.
+The two look coupled because enabling the console with neither credential
+configured turns the console back off, below.
 
-This plane is read-only. If you came here for moderation actions, skip to
+This plane is reads plus account lifecycle - erasing and exporting one player.
+If you came here for moderation actions, skip to
 [What it cannot do](#what-it-cannot-do) first.
 
 ## Turning it on
@@ -43,10 +44,14 @@ a secret and got the path wrong must not come up quietly using something else.
 A trailing newline is stripped, so `openssl rand -hex 32 > ops_secret.txt`
 works as written.
 
-Enabling the console with no secret leaves the console **off**, logs
-`console_disabled_without_secret` at error level, and starts the node anyway.
-The game is the product; a misconfigured operator surface must not take players
-offline. On success the node logs `console_enabled`.
+Enabling the console with nothing that can sign in leaves the console **off**,
+logs `console_disabled_without_credential` at error level, and starts the node
+anyway. The game is the product; a misconfigured operator surface must not take
+players offline. On success the node logs `console_enabled`.
+
+"Nothing that can sign in" means neither credential. A managed environment
+configures no `ops_secret` on purpose and passes this check on
+`ops_token_secret` + `env_id` instead - see [Cloud](cloud.md#the-console).
 
 The compose fragment, matching the production compose in
 [Self-hosting](self-hosting.md):
@@ -165,38 +170,59 @@ What a reader arriving from another console will look for and not find:
 
 ## What it cannot do
 
-Core's ops routes are all reads. The only route that mutates is
-`/api/v1/ops/ext/:extension/:action`, and its behaviour comes from an installed
-extension.
+Core's ops routes are reads apart from two account-lifecycle routes:
 
-So there is no ban, no grant, no refund, no broadcast, no ticket cancel and no
-match end. If you arrived expecting Nakama Console, PlayFab Game Manager or the
-Hathora console, that expectation gap is real and this is where it is.
+```
+GET  /api/v1/ops/players/:id/export     Everything held about one player
+POST /api/v1/ops/players/:id/erase      Delete one player. Irreversible.
+```
 
-The one mutating route takes its method, its handler and its capability class
+Both are covered in
+[Erasing and exporting a player](rest-api.md#erasing-and-exporting-a-player).
+They exist because an operator must be able to answer a deletion or access
+request without a database shell, and because an Apache-2 self-hoster
+otherwise inherits an obligation the library gives them no way to discharge.
+
+Everything else is still absent: no ban, no grant, no refund, no broadcast, no
+ticket cancel and no match end. If you arrived expecting Nakama Console,
+PlayFab Game Manager or the Hathora console, that expectation gap is real and
+this is where it is.
+
+The third mutating route takes its method, its handler and its capability class
 from an installed extension's manifest. The console cannot invoke it today;
 that surface is HTTP only. See [Extensions](extensions.md) for how an extension
 declares one.
 
 ## Capability classes
 
-Three: `read`, `player_data` and `config`. Every route on the plane carries
-exactly one, and membership of that class in the caller's capabilities is the
-only authorisation decision anywhere in the plane. A route with no class is
-denied, so an untagged or mis-mounted route is closed rather than open.
+Four: `read`, `player_data`, `config` and `erasure`. Every route on the plane
+carries exactly one, and membership of that class in the caller's capabilities
+is the only authorisation decision anywhere in the plane. A route with no class
+is denied, so an untagged or mis-mounted route is closed rather than open.
 
-Core tags only `read` routes today. `player_data` and `config` exist for
-extension actions and for the classes a minted token can carry.
+Core tags `read` on every route but two: the player export is `player_data`,
+because it returns everything about one identified person rather than a list
+view, and the player erasure is `erasure`. `config` exists for extension
+actions and for the classes a minted token can carry.
+
+`erasure` is a class of its own for one reason, and it is not sensitivity:
+it is the only one whose actions cannot be undone by a later call. A ban can
+be lifted and a grant can be clawed back; an erased account is gone.
 
 What proves what:
 
-- The **operator secret** proves all three. One secret is one privilege level:
-  whoever holds it holds `config`.
+- The **operator secret** proves all four over a bearer header. One secret is
+  one privilege level: whoever holds it holds `config`.
 - A **minted token** proves only the classes it carries, and its lifetime is
   capped at 900 seconds by the node that verifies it, not by whatever minted it.
 - A **console session** inherits its credential's classes and expires no later
   than that credential does. A fifteen-minute token cannot buy a twelve-hour
   session with wider capabilities.
+- A console session opened with the **operator secret** gets every class
+  **except** `erasure`. The secret proves it; the transport is what differs.
+  A bearer secret in a config file is a script an operator wrote; a session
+  cookie is a browser that can be XSS'd or clickjacked into posting once. Set
+  `console_erasure` to `true` to allow it anyway.
 
 Every rejection is `403` carrying the shared error object, whatever the cause:
 
@@ -307,7 +333,7 @@ it on and was asked for a file that does not exist.
 This is a build problem, not a configuration one.
 
 **The node is up but the console is off.** Grep the boot log for
-`console_disabled_without_secret`, `ops_secret_file_unreadable` and
+`console_disabled_without_credential`, `ops_secret_file_unreadable` and
 `ops_secret_file_empty`. The line that says it worked is `console_enabled`.
 
 **Every ops call answers 403.** One of three things: no secret is configured,
@@ -324,5 +350,7 @@ front of more than one node. Make the route sticky.
 - [REST API](rest-api.md#ops) - the per-route ops reference.
 - [Configuration](configuration.md#operator-console) - every console key.
 - [Self-hosting](self-hosting.md) - the production compose this fits into.
+- [Cloud](cloud.md#the-console) - how a managed environment reaches this
+  without an operator secret.
 - [Clustering](clustering.md) - what is per node.
 - [Extensions](extensions.md) - declaring an operator action.

--- a/guides/exit.md
+++ b/guides/exit.md
@@ -13,8 +13,12 @@ you should not have to trust us.
    change we will fork our own project under a new name rather than take
    Apache-2.0 away from you.
 2. **No closed core.** Every feature in the public repository is the feature
-   you run. Our commercial cloud runs the same image you can pull from
-   `ghcr.io/widgrensit/asobi:latest`.
+   you run. Our commercial cloud runs the same `asobi` library published here.
+   It is a different release build - `ghcr.io/widgrensit/asobi_engine`, which
+   fetches its Lua as a bundle rather than reading a mounted directory - so the
+   artefact is not byte-identical to `ghcr.io/widgrensit/asobi:latest`, but the
+   game code behind it is the code in this repository. There is no feature the
+   cloud has and this repository does not. See [Cloud](cloud.md).
 3. **Public images mirrored.** Published to GitHub Container Registry under
    `ghcr.io/widgrensit/*`. GHCR is free to pull without authentication, and you
    can mirror to your own registry.
@@ -128,7 +132,8 @@ If we go dark, someone is likely to pick up maintenance. Watch:
 ## What is not covered here
 
 This page covers the open-source node. The commercial `asobi.dev` cloud is a
-separate layer. If we shut the managed service down, we commit to:
+separate layer, described in [Cloud](cloud.md). If we shut the managed service
+down, we commit to:
 
 - 60 days' notice minimum, in writing
 - an export of your data, your scripts and your PostgreSQL dump in a form you

--- a/guides/extensions.md
+++ b/guides/extensions.md
@@ -246,7 +246,7 @@ HTTP and connect limiters - see [Clustering](clustering.md).
 
 The caller is the authenticated player on that socket; an unauthenticated
 socket is refused before the method is looked up. There is deliberately no
-per-method capability class: `read | player_data | config` is an operator
+per-method capability class: `read | player_data | config | erasure` is an operator
 vocabulary that a player never holds, so tagging a socket method with one would
 make it deniable for every caller the dispatcher has. An operator-only method
 goes in `ops/0` instead.
@@ -273,18 +273,21 @@ POST /api/v1/ops/ext/quests/define
 GET  /api/v1/ops/ext/quests/summary?filter=active
 ```
 
-`/api/v1/ops/ext/:extension/:action` is the only mutating route on the whole
-ops plane, and this is what puts something behind it. Core's own ops routes are
-all reads. You still declare no routes: core owns `/ext/:extension/:action` and
-dispatches every declared action behind it, the same way it owns one WebSocket
-frame type and dispatches `rpc/0` behind that.
+`/api/v1/ops/ext/:extension/:action` is the extension seam on the ops plane,
+and this is what puts something behind it. Core's own routes there are reads
+apart from erasing and exporting a player. You still declare no routes: core
+owns `/ext/:extension/:action` and dispatches every declared action behind it,
+the same way it owns one WebSocket frame type and dispatches `rpc/0` behind
+that.
 
 Know what gates it. On a stock deployment there is no `ops_secret`, so every
 bearer request is denied 403 and none of this is reachable. Once a secret is
 set, these routes are live whether or not the console is - `console` gates
 `/console` only, never the ops plane. A holder of the secret holds every
 capability class, so declaring `class => config` restricts which *minted* tokens
-reach an action, not which secret-holders do. See
+reach an action, not which secret-holders do. `erasure` is the one class a
+console session does not get by default, so declaring it also keeps an action
+out of a browser unless the operator set `console_erasure`. See
 [Operator console](console.md).
 
 The console cannot invoke an ops action today. The surface is HTTP only, and
@@ -311,8 +314,8 @@ every action answers `not_ready` (503).
 
 Three things are core's, not yours:
 
-- `class` is the whole authorisation. `read | player_data | config` is the same
-  vocabulary core's own ops routes carry. An action is admitted when its class
+- `class` is the whole authorisation. `read | player_data | config | erasure` is
+  the same vocabulary core's own ops routes carry. An action is admitted when its class
   is in the caller's capabilities and never otherwise. There is nothing to
   check inside your handler.
 - An undeclared action is denied, not 404. It has no class, and a route with no
@@ -563,8 +566,9 @@ Rules:
   `player_id`. Two extensions both adding `level` to `players` is
   unrecoverable, and core adding the same column later is worse.
 - An extension FK into `players.id` must cascade or declare an erase path. A
-  blanket cascade was rejected: cascading `wallets` would erase the financial
-  ledger through `transactions.wallet_id`.
+  blanket cascade was rejected: cascading `players` into `iap_transactions`
+  would destroy real-money purchase records that a refund or chargeback
+  dispute still needs.
 
 Your migrations run from your own application: kura discovers them through
 `asobi_repo:migration_apps/0`, inside core's transaction and under one
@@ -618,6 +622,15 @@ erase_player(PlayerId) ->
     ok.
 ```
 
+### Who calls it, and when
+
+`asobi_player_erase` does. That is the single place core deletes a player, and
+it has two entry points: `asobi_player_erase:run/1` from an Erlang shell, and
+`POST /api/v1/ops/players/:id/erase` on the ops plane. The guest reaper is one
+more caller of the same code rather than a second implementation of it, so
+there is one erasure path and your callback is on it whichever way the deletion
+was asked for.
+
 Core calls it inside its own transaction, before deleting any of its own rows,
 once per installed extension in dependency order. Do not open a transaction of
 your own. Extensions run before core so an erase path can still read the
@@ -633,8 +646,48 @@ around it and the deletion is retried.
 Omit `erase_player/1` when your rows cascade: it is the alternative to that
 declaration, not a second copy of it. Cascade lives on the column because the
 database is what enforces it, which is why this is a callback and not an
-`owns/0` key. Delete the rows or null the player reference and keep the ledger;
-core only needs the player row to be able to go.
+`owns/0` key.
+
+### The third option: sever the reference
+
+Delete the rows, or null the player reference and keep the row. Core does both
+in one function and it is worth reading as the worked example, because a
+receipts table is exactly where authors get stuck.
+
+`asobi_player_erase:steps/1` deletes eleven tables and severs two:
+
+- `iap_transactions.player_id` is set to `NULL`. The receipt carries a
+  provider, a store transaction id and a product id, and a refund or chargeback
+  dispute needs it long after the account is gone. Statutory retention beats
+  erasure for that row.
+- `groups.creator_id` is set to `NULL`. Deleting the group to free the key
+  would destroy every other member's data.
+
+Everything else goes. That *is* the anonymisation: every player-referencing
+table in core stores a bare uuid and nothing else about the person, so once
+`players` and `player_identities` are gone the surviving id resolves to nobody.
+Core does not mint a tombstone player row, and neither should you - a tombstone
+is a record about a person you were told to erase.
+
+Core's own foreign keys are all `no_action` and its erasure enumerates its
+children explicitly rather than delegating to the database. That is deliberate,
+and it is the reason a blanket `ON DELETE CASCADE` migration is refused rather
+than merely discouraged: a database cascade fires below the transaction's
+control flow, so `erase_player/1` would never be called at all and the receipts
+would be destroyed silently.
+
+### There is no `export_player/1`
+
+Core exports a player - `GET /api/v1/ops/players/:id/export` - and the payload
+covers core's tables only. Extensions do not contribute to it, and that is a
+decision rather than a gap.
+
+`erase_player/1` earns its keep because the foreign key forces you to answer:
+skip it and the player row physically cannot be deleted. An export callback has
+no such forcing function, so an extension that skipped it would produce a
+silently incomplete export and nothing would fail - a worse contract than no
+contract. If one ever ships, core will have to name in the payload which
+installed extensions contributed and which did not.
 
 ## Counters
 

--- a/guides/glossary.md
+++ b/guides/glossary.md
@@ -46,15 +46,18 @@ and demos in the [README](../README.md#client-sdks).
 
 ## The commercial layer
 
-**asobi.dev Cloud** - managed hosting, running the same node described above.
-Invite-only today, opening more widely toward the end of 2026.
-[asobi.dev/cloud](https://asobi.dev/cloud).
+**asobi.dev Cloud** - managed hosting, running the same core as the node
+described above. **Invite-only**: an account is created only from an operator
+allowlist or an approved waitlist request. Join the waitlist at
+[console.asobi.dev](https://console.asobi.dev).
 
 The differences are operational, not functional. A cloud environment is created
 and fed Lua through the `asobi` CLI rather than a mounted `/app/game`, its
 console is reached from the dashboard rather than by holding an operator secret,
-and the environment's `sys.config` is not yours to write. Everything about the
-game itself - callbacks, protocol, error codes - is identical.
+and the environment's `sys.config` is not yours to write - which rules out
+platform sign-in, IAP receipt verification, extensions and runtime tuning.
+Everything about the game itself - callbacks, protocol, error codes - is
+identical. [Cloud](cloud.md) has the full list of what each side gets.
 
 If it disappears, the open-source node above is enough to run your game
 forever. See [exit.md](exit.md).
@@ -87,10 +90,14 @@ Vocabulary you will meet throughout the docs.
 - **Console** - the operator UI this node serves at `/console`. Off until
   `console` is set. See [Operator console](console.md).
 - **Ops plane** - the HTTP API at `/api/v1/ops/*` that the console reads. Its
-  own credential, separate from the console flag, and read-only apart from
-  extension actions.
+  own credential, separate from the console flag, and reads apart from player
+  erasure, player export and extension actions.
 - **Capability class** - what an ops route is allowed to touch: `read`,
-  `player_data` or `config`. Every core ops route carries one.
+  `player_data`, `config` or `erasure`. Every core ops route carries one.
+  `erasure` is separate because it is the only one that cannot be undone.
+- **Erasure** - deleting a player and everything core holds about them, in one
+  transaction. `asobi_player_erase:run/1` from a shell, or
+  `POST /api/v1/ops/players/:id/erase`. See [REST API](rest-api.md).
 - **Extension** - an OTP application that depends on asobi, added to your
   release, declaring a manifest. It can add RPC methods, workers, schemas and
   ops actions without forking asobi. See [Extensions](extensions.md).
@@ -98,7 +105,10 @@ Vocabulary you will meet throughout the docs.
   `rpc.call` in with a `method` and `params`, `rpc.ok` or `rpc.error` back,
   paired by `cid`.
 - **Tenant** - a studio or account in the managed cloud. Not a concept when
-  self-hosting.
+  self-hosting. See [Cloud](cloud.md).
+- **Bundle** - the zip of `.lua` files the CLI uploads to a cloud environment,
+  which the engine fetches and extracts at boot. The cloud equivalent of a
+  mounted `/app/game`. Not a concept when self-hosting.
 - **Game** - the product you are shipping. One game may have many match modes
   and worlds.
 

--- a/guides/lua-bots.md
+++ b/guides/lua-bots.md
@@ -147,14 +147,16 @@ What is available:
 Anything else has to come through the match script: put the value in the state
 the match broadcasts and read it from `state`.
 
-Bots do not work in a shared-state mode. A mode that declares
-`state_strategy = "shared"` broadcasts one pre-encoded payload to every
-recipient, and a bot cannot decode it, so `state` stays an empty table for the
-bot's whole life, the phase never advances past `playing`, and the default AI
-returns an empty input. There is no error and no log line. Use per-player
-`get_state` in any mode you want bots in - see
-[Performance tuning](performance-tuning.md) for what the shared path buys and
-what it costs.
+Bots work under both state strategies, and `think` sees the same `state`
+either way. A mode that declares `state_strategy = "shared"` still calls
+`get_state` once per tick and encodes once for the connected sessions; a bot
+is handed the payload behind that frame as a term, so it decodes nothing and
+costs the shared path no extra encode. The difference that remains is what
+`state` contains, not whether it arrives: under `"shared"` every bot sees
+exactly what every player sees, so a bot cannot be given information a client
+is not also given. Use per-player `get_state` when a bot needs a filtered view
+of its own - see [Performance tuning](performance-tuning.md) for what each
+path costs.
 
 Each `think` call runs under a 50 ms wall-clock budget, a heap cap and a
 reduction budget. A timeout, a heap or CPU overrun, an error, or a missing
@@ -284,8 +286,10 @@ is up to the client.
 
 A bot is tracked with `asobi_presence:track_bot/2`, which makes it a delivery
 target for everything the match server broadcasts (state, match events, votes)
-exactly like a connected player session. It receives the shared-state broadcast
-too, but cannot read it - see [What a bot script gets](#what-a-bot-script-gets).
+exactly like a connected player session. Shared state reaches it too:
+`asobi_presence:send_match_state/3` gives a session the pre-encoded frame and
+a bot the same payload as a term, which is the one delivery that differs by
+recipient kind - see [What a bot script gets](#what-a-bot-script-gets).
 
 It deliberately does not make the bot *online*:
 

--- a/guides/lua-scripting.md
+++ b/guides/lua-scripting.md
@@ -202,9 +202,9 @@ registration = "closed"                   -- optional: signup posture
 spelling yourself.
 
 `state_strategy = "shared"` routes the mode to a different bridge, one that
-calls `get_state` **once per tick with one argument** and broadcasts a single
-pre-encoded payload to every subscriber. It is the right choice when every
-player sees the same world, and it changes the signature you must write:
+calls `get_state` **once per tick with one argument** and sends a single
+pre-encoded payload to every connected session. It is the right choice when
+every player sees the same world, and it changes the signature you must write:
 
 ```lua
 state_strategy = "shared"
@@ -215,8 +215,9 @@ end
 ```
 
 A script written against the two-argument `get_state(player_id, state)` will
-not work under `"shared"`, and vice versa. Bots do not work under `"shared"`
-either - see [Lua bots](lua-bots.md#what-a-bot-script-gets).
+not work under `"shared"`, and vice versa. Bots work under either strategy;
+under `"shared"` a bot's `think` sees exactly what a client sees, because
+there is one payload - see [Lua bots](lua-bots.md#what-a-bot-script-gets).
 
 World mode adds its own globals (`tick_rate`, `grid_size`, `zone_size`,
 `view_radius`, `player_ttl_ms` and more). They live in

--- a/guides/migrate-from-hathora.md
+++ b/guides/migrate-from-hathora.md
@@ -166,7 +166,7 @@ mutation, which is well within the scope of one Lua file.
 | Custom room messages | Extension RPC | Frame `rpc.call` with `{protocol: 1, method, params}`; replies `rpc.ok` `{result}` or `rpc.error` `{error: {code, message, details}}`, correlated by `cid`. All seven client SDKs support it. See [Extensions](extensions.md). |
 | `ping` region API | None | Probe each deployment endpoint yourself if you need client-side region selection. |
 | Hathora SDK | asobi SDKs | [Unity](https://github.com/widgrensit/asobi-unity), [Unreal](https://github.com/widgrensit/asobi-unreal), [JS/TS](https://github.com/widgrensit/asobi-js), [Godot](https://github.com/widgrensit/asobi-godot), [Defold](https://github.com/widgrensit/asobi-defold), [LÖVE](https://github.com/widgrensit/asobi-love2d), [Dart](https://github.com/widgrensit/asobi-dart), [Flame](https://github.com/widgrensit/flame_asobi). |
-| Hathora Console | Built-in operator console at `/console` | Off by default, and read-only. See the note below the table. |
+| Hathora Console | Built-in operator console at `/console` | Off by default, and reads plus player erasure/export. See the note below the table. |
 | `hathora.yml` | `docker-compose.yml` | Plain Compose, no proprietary spec. |
 
 Guest auth is off until two things are true: the game declares `guest_auth` in
@@ -175,8 +175,8 @@ one missing and `POST /api/v1/auth/guest` answers `guest.disabled`. See
 [Authentication](authentication.md).
 
 A stock node serves neither the console nor the ops API; you turn them on - see
-[Operator console](console.md). When you do, the plane is read-only apart from
-actions an extension declares. Coming from the Hathora console you will look for
+[Operator console](console.md). When you do, the plane is reads plus player
+erasure and export, apart from actions an extension declares. Coming from the Hathora console you will look for
 a restart-this-process button; there is not one, because there is no process per
 match to restart.
 

--- a/guides/migrate-from-nakama.md
+++ b/guides/migrate-from-nakama.md
@@ -54,7 +54,7 @@ depend on the Hex package and write Erlang. Same node either way.
 | RPC endpoints | Extension RPC over the WebSocket | Frame `rpc.call` with `{protocol: 1, method, params}`; replies `rpc.ok` `{result}` or `rpc.error` `{error: {code, message, details}}`, correlated by `cid`. All seven client SDKs support it. See [Extensions](extensions.md). |
 | Hooks (`before_authenticate`, `after_friendAdd`) | Nova plugins and match lifecycle callbacks | Pre- and post-request middleware in Nova. |
 | Runtime Lua / TS / Go | Lua for game logic, Erlang/OTP for the engine | One scripting language. |
-| Nakama Console | Built-in operator console at `/console` | Off by default, and read-only. See the note below the table. |
+| Nakama Console | Built-in operator console at `/console` | Off by default, and reads plus player erasure/export. See the note below the table. |
 | Session token | `access_token` plus `refresh_token` | Register and login return `player_id`, `access_token`, `refresh_token` and `username`. There is no `session_token` field. |
 | WebSocket | `/ws`, `session.connect` first frame | See the Hathora guide's [WebSocket handshake](migrate-from-hathora.md#websocket-handshake). |
 
@@ -64,8 +64,8 @@ one missing and `POST /api/v1/auth/guest` answers `guest.disabled`. See
 [Authentication](authentication.md).
 
 A stock node serves neither the console nor the ops API; you turn them on - see
-[Operator console](console.md). When you do, the plane is read-only apart from
-actions an extension declares. If you run Nakama Console to ban and kick, budget
+[Operator console](console.md). When you do, the plane is reads plus player
+erasure and export, apart from actions an extension declares. If you run Nakama Console to ban and kick, budget
 for building that yourself.
 
 ## Migration path
@@ -233,8 +233,9 @@ Nakama server down.
   [`asobi_seasons`](https://github.com/widgrensit/asobi_seasons) extension, but
   nothing as opinionated.
 - Go and TypeScript runtimes. asobi is Lua or Erlang.
-- A mutating operator console. asobi's ops plane is read-only, so moderation is
-  a database write, a Lua handler or an extension action.
+- A mutating operator console. asobi's ops plane erases and exports a player
+  and nothing else, so moderation is a database write, a Lua handler or an
+  extension action.
 - Published case studies from large studios. asobi is newer.
 
 ## What asobi has that Nakama does not

--- a/guides/migrate-from-playfab.md
+++ b/guides/migrate-from-playfab.md
@@ -52,7 +52,7 @@ game alive if we disappear.
 | Granting from a receipt | Your game's job | Nothing is granted by the IAP endpoints. Turn a verified receipt into currency or items yourself through the economy or inventory API. |
 | Automation rules and webhooks | Shigoto jobs | Written as an Erlang callback. |
 | Insights and analytics | `asobi_telemetry` plus your own pipeline | Telemetry is emitted; there is no hosted analytics. |
-| Game Manager (web console) | Built-in operator console at `/console` | Off by default, and read-only. See the note below the table. |
+| Game Manager (web console) | Built-in operator console at `/console` | Off by default, and reads plus player erasure/export. See the note below the table. |
 
 Custom server-side logic that is not tied to a match goes over the WebSocket:
 frame type `rpc.call` with `{protocol: 1, method, params}`, answered by
@@ -61,8 +61,8 @@ correlated by `cid`. All seven client SDKs support it. That is the CloudScript
 replacement. See [Extensions](extensions.md).
 
 A stock node serves neither the console nor the ops API; you turn them on - see
-[Operator console](console.md). When you do, the plane is read-only apart from
-actions an extension declares. If you use Game Manager to ban a player, refund a
+[Operator console](console.md). When you do, the plane is reads plus player
+erasure and export, apart from actions an extension declares. If you use Game Manager to ban a player, refund a
 purchase or edit a catalogue item, budget for building that yourself.
 
 ## Migration path
@@ -182,8 +182,8 @@ PlayFab Title.
 - No push notification service. Use APNs, FCM or a third party directly; the
   built-in notifications are in-game only.
 - No hosted voice.
-- No player-support tooling. The console is read-only, so refunds, bans and
-  grants are your own code.
+- Little player-support tooling. The console erases and exports a player;
+  refunds, bans and grants are your own code.
 - No Entity model. `player_id` is the primary key and you are not required to
   model everything as an entity with objects.
 

--- a/guides/performance-tuning.md
+++ b/guides/performance-tuning.md
@@ -52,8 +52,8 @@ By default the match server calls `get_state(player_id, state)` once per player
 per tick and encodes each result separately. For games where every player sees
 the same world (free-for-all shooters, racing, party games), opt into a single
 shared encode: the server calls the state function once per tick, encodes once,
-and broadcasts the same binary to everyone. At 200 players and 10 ticks/sec
-that is 10 encodes/sec instead of 2000.
+and sends that one binary to every connected session. At 200 players and 10
+ticks/sec that is 10 encodes/sec instead of 2000.
 
 Opt in from your match script by declaring `state_strategy = "shared"` and
 defining a one-argument state function. Games that need per-player filtering
@@ -73,10 +73,12 @@ end
 A shared script is routed through `asobi_lua_match_shared`, which exports
 `get_state/1`.
 
-Lua bots do not work in a shared-state mode: they receive the pre-encoded
-broadcast and cannot decode it, so `think` is called with an empty table and
-never sees the match. Keep the two-argument form in any mode you fill with bots
-- see [Lua bots](lua-bots.md#what-a-bot-script-gets).
+Bot fill works under either strategy and does not cost the shared path its
+encode: the one encode per tick is for the connected sessions, and each bot
+is handed the state as a term instead of the frame, so no bot decodes JSON.
+What you give up under `"shared"` is per-player filtering, for bots as much as
+for clients - `think` sees exactly what a client sees. See
+[Lua bots](lua-bots.md#what-a-bot-script-gets).
 
 In Erlang, export exactly one of `get_state/1` or `get_state/2`; the match
 server detects which is exported and switches broadcast strategy accordingly.

--- a/guides/rest-api.md
+++ b/guides/rest-api.md
@@ -314,6 +314,9 @@ GET /api/v1/ops/tournaments                  Paginated tournament list
 GET /api/v1/ops/tournaments/:id              One tournament
 GET /api/v1/ops/notifications                Paginated sent notifications
 
+GET  /api/v1/ops/players/:id/export          Everything held about one player
+POST /api/v1/ops/players/:id/erase           Delete one player. Irreversible.
+
 GET|POST|PUT|DELETE
     /api/v1/ops/ext/:extension/:action       Dispatch to an installed extension
 ```
@@ -322,9 +325,10 @@ The game-operations plane, for a console rather than a game client. The lists
 differ from the ones above in three ways: they report a total, they accept a
 sort, and they page by offset.
 
-Core's ops routes are all reads. The only route that mutates is
-`/api/v1/ops/ext/:extension/:action`, and its behaviour comes from an
-installed extension.
+Everything here is a read except two account-lifecycle routes - see
+[Erasing and exporting a player](#erasing-and-exporting-a-player) - and
+`/api/v1/ops/ext/:extension/:action`, whose behaviour comes from an installed
+extension.
 
 These routes do **not** accept player tokens. They are their own auth plane -
 see [Ops authentication](#ops-authentication) below. For turning the console
@@ -474,9 +478,8 @@ and `rewards` do.
 `player_id`, `type` and `read`, and searches the subject. It answers the
 question a broadcast raises: who received it, and how many have opened it.
 
-Core's ops routes are all reads, so there is no broadcast route here. The
-broadcast is an in-process entry point that writes an audit row - see
-[Ops audit](#ops-audit).
+There is no broadcast route here. The broadcast is an in-process entry point
+that writes an audit row - see [Ops audit](#ops-audit).
 
 ### Leaderboards
 
@@ -688,10 +691,83 @@ indistinguishable to the caller, deliberately.
 
 A bearer token wins when both it and a console cookie are present.
 
-Each route carries exactly one capability class - `read`, `player_data` or
-`config` - and a request is admitted only if the credential holds that class.
-Every core route is `read`; an extension action's class comes from its
-manifest. Role names never appear on the wire.
+Each route carries exactly one capability class - `read`, `player_data`,
+`config` or `erasure` - and a request is admitted only if the credential holds
+that class. Every core route is `read` except the two account-lifecycle ones;
+an extension action's class comes from its manifest. Role names never appear
+on the wire.
+
+`erasure` is separate from `player_data` for one reason, and it is not
+sensitivity: it is the only class whose actions cannot be undone by a later
+call. The operator secret sent as a bearer token holds all four. A console
+session holds every class **but** `erasure` unless `console_erasure` is set to
+`true` - same secret, different transport, different blast radius.
+
+### Erasing and exporting a player
+
+```
+GET  /api/v1/ops/players/:id/export
+POST /api/v1/ops/players/:id/erase
+```
+
+`export` returns everything core holds about one player, keyed by table, each
+row through a positive allowlist. Credentials are never in it: no
+`hashed_password`, and a session is reported as having existed without its
+bearer token. Class `player_data`, not `read` - a leaderboard view is one
+thing, and the whole of one identified person's record is another.
+
+`erase` deletes the player and every row core holds for them, in one
+transaction, and it cannot be undone. The body must echo the player's username
+and the server checks it against the row:
+
+```bash
+curl -X POST \
+  -H "Authorization: Bearer $ASOBI_OPS_SECRET" \
+  -H 'Content-Type: application/json' \
+  -d '{"username": "kaito"}' \
+  https://game.example.com/api/v1/ops/players/019f.../erase
+```
+
+```json
+{"data": {"player_id": "019f...", "erased": true}}
+```
+
+A missing echo is `ops.confirmation_required` and a wrong one is
+`ops.confirmation_mismatch`, both 400. Neither reaches the deletion.
+
+Two tables survive with the player reference set to `NULL` rather than being
+deleted: `iap_transactions`, because a refund or chargeback dispute needs the
+real-money receipt, and `groups.creator_id`, because deleting the group would
+destroy every other member's data. Everything else goes, including the wallet,
+its ledger, saves, storage, chat messages, friendships and identities.
+
+Three columns hold player ids with no foreign key, and they keep them:
+`match_records.players`, `votes.votes_cast` and `zone_snapshots.entities`. The
+ids no longer resolve to anybody - the schema stores bare uuids and nothing
+else about the person, so deleting `players` and `player_identities` *is* the
+anonymisation. `zone_snapshots.entities` is opaque game-defined state, so a
+game that puts personal data in it owns erasing that itself; see
+[Extensions](extensions.md).
+
+The erasure writes its own audit row inside the same transaction, so "erased"
+and "recorded as erased" are one commit (ADR 0007). Installed extensions erase
+first, in that transaction; one refusing aborts the whole deletion and the
+player survives intact.
+
+You do not need the ops plane for this. A self-hoster with a release and a
+remote shell can call the same function, and it is the same code path:
+
+```erlang
+1> asobi_player_erase:run(~"019f...").
+{ok,#{player_id => <<"019f...">>,erased => true}}
+2> asobi_player_export:run(~"019f...").
+{ok,#{player => #{...}, wallets => [...], ...}}
+```
+
+There is no player-facing self-delete. Whether players may erase themselves is
+a support-load and abuse decision belonging to the game - it turns an account
+takeover into an account destruction - so asobi gives the operator the
+primitive and the game decides whether to expose it.
 
 ### Console session
 
@@ -773,10 +849,10 @@ carrying the acting operator (`actor_id`, `actor_display`, `actor_source`,
 `actor_attested`), the action, its subject, and when it happened. Reads are
 not audited.
 
-Core's own routes are all reads, so none of them writes a row. Two things go
-through the audit path: an extension action reached over
-`/api/v1/ops/ext/:extension/:action`, and the in-process notification
-broadcast entry point.
+Three things go through the audit path: player erasure, an extension action
+reached over `/api/v1/ops/ext/:extension/:action`, and the in-process
+notification broadcast entry point. The player export is a read and is not
+audited.
 
 `actor_attested` is the important column. A name that came from
 `x-asobi-operator` is self-declared, so it is stored `false`; only a verified
@@ -794,8 +870,18 @@ other index is on `target_id`. A delete scoped to time alone therefore scans
 the table. Prune in batches, off-peak, or add an index on `occurred_at` if you
 intend to prune by time on a schedule.
 
-Nothing cascades into the table, so deleting a player does not erase the
-record of what was done to them.
+Nothing cascades into the table, so erasing a player does not erase the record
+of what was done to them - `actor_id` and `target_id` are plain strings with no
+foreign key. That is what lets an erasure's own row outlive its subject.
+
+Erasure is the one exception to "the audit never fails the operation". Its row
+is written **inside** the erasure transaction, so a failed audit insert rolls
+the deletion back: the data is gone by definition, so the row is the only
+surviving evidence the request was honoured. Every other mutation audits after
+the fact and cannot be failed by it (ADR 0007).
+
+A guest-retention sweep writes no rows. It is the machine's own housekeeping
+over up to 500 accounts a pass, and it logs a count instead.
 
 An audit write never fails the operation it describes. It runs after the
 change has already happened, so refusing the response could only invite a

--- a/guides/security-auth.md
+++ b/guides/security-auth.md
@@ -86,7 +86,13 @@ nothing useful even if the identity table is dumped.
   longer resume the claimed account.
 - Reaping is safe. The optional `asobi_guest_reaper` (off unless
   `guest_reap_after` is set) re-checks that a guest is still unclaimed inside
-  its delete transaction, so a concurrent upgrade wins the race.
+  its delete transaction, so a concurrent upgrade wins the race. It targets
+  guests that have not resumed for the configured window, not guests whose
+  accounts are simply old - a device that keeps playing is never reaped. It
+  deletes
+  through `asobi_player_erase`, the same code an operator-initiated erasure
+  runs, so a reaped guest leaves nothing behind and its cached access token
+  stops resolving immediately rather than at the next cache expiry.
 
 Treat guest accounts as low assurance until they are upgraded. Anything
 valuable - purchases, competitive ranking, cross-device identity - should

--- a/guides/self-hosting.md
+++ b/guides/self-hosting.md
@@ -8,6 +8,12 @@ production on infrastructure you control.
 It is opinionated about how Lua scripts get onto disk and when they reload,
 because that is the question every operator hits in the first week.
 
+**On asobi Cloud none of this applies.** A managed environment has no
+`/app/game` to mount, no `sys.config` you can write and no image you choose:
+scripts arrive as a bundle the `asobi` CLI uploads and the engine fetches at
+boot. Read [Cloud](cloud.md) instead, which also lists what a managed
+environment cannot configure and when to come back here.
+
 ## Requirements
 
 - **Erlang/OTP 29.** The image is built on `erlang:29.0.4-slim`, and 29 is the
@@ -53,7 +59,10 @@ ticks the runtime calls `filelib:last_modified/1` on the script; if the mtime
 moves, it re-executes the script body against the existing Luerl state. See
 `asobi_lua_reload` for the primitive.
 
-You have four ways to put scripts there. Two of them exist.
+You have four ways to put scripts there. Two of them exist. All four are
+self-hosting patterns: a cloud environment gets its scripts from
+[a bundle](cloud.md#how-lua-reaches-an-environment) and none of the four is
+available there.
 
 ### Pattern 1: bake into the image (immutable)
 
@@ -398,3 +407,5 @@ you do.
   complete list of what is per node.
 - Multi-tenant hosting. This image is single-tenant.
 - Payments. asobi ships the IAP receipt-validation primitive and nothing else.
+- Managed hosting. See [Cloud](cloud.md), where the deployment model is a CLI
+  bundle rather than anything on this page.

--- a/rebar.config
+++ b/rebar.config
@@ -145,6 +145,7 @@
         <<"guides/performance-tuning.md">>,
         <<"guides/phases.md">>,
         <<"guides/self-hosting.md">>,
+        <<"guides/cloud.md">>,
         <<"guides/extensions.md">>,
         <<"guides/security-threat-model.md">>,
         <<"guides/security-auth.md">>,
@@ -189,6 +190,7 @@
             <<"guides/performance-tuning.md">>,
             <<"guides/phases.md">>,
             <<"guides/self-hosting.md">>,
+            <<"guides/cloud.md">>,
             <<"guides/extensions.md">>
         ]},
         {<<"Migrating">>, [
@@ -322,6 +324,9 @@
             asobi_router,
             asobi_repo,
             asobi_error,
+            asobi_player_erase,
+            asobi_player_export,
+            asobi_guest_reaper,
             asobi_economy,
             asobi_leaderboard_server,
             asobi_tournament_server

--- a/src/asobi_error.erl
+++ b/src/asobi_error.erl
@@ -169,6 +169,20 @@ working and a new one reads one place: see `legacy/2`.
     {~"ops.unknown_sort_order", 400, ~"`order` must be \"asc\" or \"desc\"."},
     {~"ops.query_failed", 500, ~"The ops query failed."},
 
+    %% Account lifecycle. The confirmation codes are what stop an erasure from
+    %% being a single click a page can be tricked into making.
+    {
+        ~"ops.confirmation_required",
+        400,
+        ~"An erasure must echo the player's username in the request body."
+    },
+    {
+        ~"ops.confirmation_mismatch",
+        400,
+        ~"The username in the request body is not this player's username."
+    },
+    {~"ops.erase_failed", 500, ~"The erasure was rolled back and nothing was deleted."},
+
     %% Operator console. One 404 covers both "this node does not serve the
     %% console" and "no such asset", so a caller cannot tell a deployment that
     %% has the console switched off from one that has it on.

--- a/src/asobi_guest_reaper.erl
+++ b/src/asobi_guest_reaper.erl
@@ -7,6 +7,36 @@
 %% sweep time. "Permanent guests" = leave it unset. It only removes guests that
 %% were never claimed - no password and no non-device identity - so an upgraded
 %% account is never touched.
+%%
+%% Stale means INACTIVE, not old. The predicate is the guest identity's
+%% `updated_at`, which `asobi_guest_controller` refreshes every time a device
+%% resumes its player, so `guest_reap_after` reads as "not seen for N seconds".
+%% Keying it on `inserted_at` instead would read as "created N seconds ago" and
+%% delete a guest who has played daily since - an unclaimed account is the
+%% normal steady state for device auth, not a sign of abandonment, so account
+%% age says nothing about whether anyone is still using it. That distinction is
+%% load-bearing now that the cascade actually completes: it used to delete four
+%% of the fifteen FK children, so any guest with a wallet or a cloud save hit a
+%% constraint violation and was logged skipped, and the wrong predicate stayed
+%% inert. Erasure is permanent and writes no audit row, so the predicate has to
+%% mean what the guides say it means.
+%%
+%% `updated_at` is already NOT NULL on every existing row, so the sweep is
+%% correct from the first tick with no backfill. Any future writer of the
+%% identity row also extends retention, which is the safe direction: this
+%% predicate can only ever spare a guest it should have reaped, never reap one
+%% it should have spared.
+%%
+%% The deletion itself belongs to `asobi_player_erase`; this module owns guest
+%% retention policy and nothing else. That split is why the in-transaction
+%% unclaimed re-check stays here: it is a statement about which guests may be
+%% reaped, not about how a player is erased.
+%%
+%% A sweep writes no audit rows. It is an automated retention pass over up to
+%% ?REAP_BATCH accounts at a time, so a row per player would flood
+%% `ops_audit_entries` with the machine's own housekeeping; the sweep logs a
+%% count instead. Operator-initiated erasure - `asobi_player_erase:run/1,2` -
+%% audits, because there a person asked.
 
 -export([start_link/0, sweep_now/0, cached_unlinked_count/0]).
 -export([init/1, handle_call/3, handle_cast/2, handle_info/2]).
@@ -148,10 +178,14 @@ run_sweep() ->
 reap_older_than(Cutoff) ->
     %% Bounded batch per sweep - the next tick drains the rest. Guests are the
     %% highest-volume account type, so an unbounded load would block the sweeper.
+    %%
+    %% `updated_at`, not `inserted_at`: last seen, not account age. See the
+    %% moduledoc - this is the difference between reaping abandoned devices and
+    %% reaping the active player base.
     Q = kura_query:limit(
         kura_query:where(
             kura_query:where(kura_query:from(asobi_player_identity), {provider, ?PROVIDER}),
-            {inserted_at, '<', Cutoff}
+            {updated_at, '<', Cutoff}
         ),
         ?REAP_BATCH
     ),
@@ -176,51 +210,28 @@ reap_all([Identity | Rest], Count) ->
 reap_one(Identity) ->
     PlayerId = maps:get(player_id, Identity),
     case unclaimed_guest(PlayerId) of
-        true -> delete_guest_cascade(PlayerId);
+        true -> erase_guest(PlayerId);
         false -> skipped
     end.
 
-%% Delete the player and its FK children (which are ON DELETE NO ACTION, so the
-%% player row can't go first) atomically, children before the player. Only count
-%% a genuine deletion; a rolled-back/failed sweep reports skipped, not reaped.
-%%
-%% Installed extensions erase first, in the same transaction: an extension row
-%% that does not cascade holds the player row down exactly as core's own
-%% children do, so without this every such extension makes guests unreapable.
-%% Extensions before core so an erase path can still read the player's core
-%% rows.
--spec delete_guest_cascade(binary()) -> reaped | skipped.
-delete_guest_cascade(PlayerId) ->
+%% One transaction around the retention decision and the erasure, so a guest
+%% that gets claimed mid-sweep is not half-deleted. Only count a genuine
+%% deletion; a rolled-back or failed sweep reports skipped, not reaped.
+-spec erase_guest(binary()) -> reaped | skipped.
+erase_guest(PlayerId) ->
     Fun = fun() ->
         %% Re-check inside the transaction: a guest can call /auth/guest/upgrade
         %% between the pre-check and here, becoming a claimed account with a
         %% password and fresh tokens. Deleting it then would be silent loss of a
         %% real account, so a concurrent upgrade must win - abort the reap.
         case unclaimed_guest(PlayerId) of
-            false ->
-                {error, claimed_during_sweep};
-            true ->
-                %% Assert each delete: a bare `{error,_}` return (not a raise)
-                %% would otherwise let pgo commit a partial cascade (children
-                %% gone, player left). Matching {ok,_} turns that into a badmatch
-                %% that raises, rolling the whole transaction back. Same reason
-                %% the extension erase path is asserted rather than inspected.
-                ok = asobi_extension_erase:run(PlayerId),
-                {ok, _} = asobi_repo:delete_all(by_player(asobi_player_stats, PlayerId)),
-                %% player_tokens keys players by `user_id`, not `player_id`.
-                {ok, _} = asobi_repo:delete_all(by_user(asobi_player_token, PlayerId)),
-                {ok, _} = asobi_repo:delete_all(by_player(asobi_player_identity, PlayerId)),
-                case asobi_repo:get(asobi_player, PlayerId) of
-                    {ok, Player} ->
-                        {ok, _} = asobi_repo:delete(asobi_player, Player),
-                        ok;
-                    _ ->
-                        ok
-                end
+            false -> {error, claimed_during_sweep};
+            true -> asobi_player_erase:steps(PlayerId)
         end
     end,
     try asobi_repo:transaction(Fun) of
         ok ->
+            asobi_player_erase:after_commit(PlayerId),
             reaped;
         {error, Reason} ->
             ?LOG_DEBUG(#{event => guest_reap_skipped, player_id => PlayerId, reason => Reason}),
@@ -239,14 +250,6 @@ delete_guest_cascade(PlayerId) ->
             }),
             skipped
     end.
-
--spec by_player(module(), binary()) -> #kura_query{}.
-by_player(Schema, PlayerId) ->
-    kura_query:where(kura_query:from(Schema), {player_id, PlayerId}).
-
--spec by_user(module(), binary()) -> #kura_query{}.
-by_user(Schema, PlayerId) ->
-    kura_query:where(kura_query:from(Schema), {user_id, PlayerId}).
 
 %% A guest is unclaimed only if the player never set a password and has no
 %% identity from another provider (i.e. never upgraded/linked).

--- a/src/asobi_router.erl
+++ b/src/asobi_router.erl
@@ -211,12 +211,26 @@ api_routes() ->
 %% Ops - the game-operations plane. Its own group because it is its own
 %% identity: the operator capability check (ADR 0007), never the player-scoped
 %% one. Every route here must carry a class in `asobi_ops_caps:classes/0`.
+%%
+%% The plane is a read plane plus exactly two account-lifecycle routes. Erasure
+%% is a POST with a server-verified confirmation rather than a DELETE, and it
+%% sits in its own `erasure` class rather than in `player_data`, because it is
+%% the one action here no follow-up call can undo.
 ops_routes() ->
     #{
         prefix => ~"/api/v1/ops",
         security => fun asobi_ops_auth:verify/1,
         routes => [
             {~"/players", fun asobi_ops_controller:players/1, #{methods => [get, options]}},
+            %% Before `/players/:id`, the asobi#326 ordering trap the match
+            %% routes carry a comment about: routing_tree prepends on insert
+            %% and returns on the first matching sibling.
+            {~"/players/:id/erase", fun asobi_ops_controller:erase_player/1, #{
+                methods => [post, options]
+            }},
+            {~"/players/:id/export", fun asobi_ops_controller:export_player/1, #{
+                methods => [get, options]
+            }},
             {~"/players/:id", fun asobi_ops_controller:player/1, #{methods => [get, options]}},
             {~"/matches", fun asobi_ops_controller:matches/1, #{methods => [get, options]}},
             {~"/matches/:id", fun asobi_ops_controller:match/1, #{methods => [get, options]}},

--- a/src/console/asobi_console_env.erl
+++ b/src/console/asobi_console_env.erl
@@ -26,13 +26,19 @@ The database password cannot work this way - it is substituted into
 `sys.config` before any of this runs - so `ASOBI_DB_PASSWORD_FILE` is not a
 thing, whatever the deployment guide used to imply.
 
-## Enabled without a secret
+## Enabled with nothing to sign in with
 
 The console stays off and says so at error level. It does not stop the node:
 the game is the product and the console is an accessory, so taking players
 offline because an operator surface is misconfigured is the wrong trade. A
 console that renders a sign-in nothing can pass is the worse failure, because
 it looks like it works.
+
+`ops_secret` is not the only credential that counts. A managed environment
+configures none on purpose - the only thing its console accepts is a token
+`console.asobi.dev` minted for someone it authenticated, verified against
+`ops_token_secret` and `env_id` (`m:asobi_ops_token`). Either credential being
+configured is enough; neither is what turns the console off.
 """.
 
 -export([apply/0]).
@@ -47,17 +53,16 @@ apply() ->
     ok = set_boolean(console, "ASOBI_CONSOLE"),
     ok = resolve().
 
-%% The two keys have to agree, and only one of the four combinations is a
-%% problem: asked for, with nothing to authenticate against.
+%% Asked for, with nothing that can sign in, is the only bad combination.
 -spec resolve() -> ok.
 resolve() ->
-    case {application:get_env(asobi, console, false), secret_configured()} of
+    case {application:get_env(asobi, console, false), credential_configured()} of
         {true, false} ->
             application:set_env(asobi, console, false),
             ?LOG_ERROR(#{
-                msg => ~"console_disabled_without_secret",
+                msg => ~"console_disabled_without_credential",
                 detail =>
-                    ~"enabled but no ops_secret is set, so nothing could sign in - set ASOBI_OPS_SECRET_FILE (preferred) or ASOBI_OPS_SECRET",
+                    ~"enabled but nothing could sign in - set ASOBI_OPS_SECRET_FILE (preferred) or ASOBI_OPS_SECRET, or provision ASOBI_OPS_TOKEN_SECRET and GAME_ID for the managed minted-token path",
                 effect => ~"the console stays off; the node is unaffected"
             });
         {true, true} ->
@@ -69,6 +74,13 @@ resolve() ->
         _ ->
             ok
     end.
+
+%% A self-hoster configures `ops_secret`. A managed environment configures none
+%% and accepts only minted tokens, so asking about the secret alone switched the
+%% console off underneath the whole cloud handoff.
+-spec credential_configured() -> boolean().
+credential_configured() ->
+    secret_configured() orelse asobi_ops_token:configured().
 
 -spec secret_configured() -> boolean().
 secret_configured() ->

--- a/src/console/asobi_console_session.erl
+++ b/src/console/asobi_console_session.erl
@@ -76,20 +76,38 @@ Open a session for an operator who has already proved the secret.
 the credential is a shared secret, so nothing here attests who typed it - and
 it is held to the same shape `asobi_ops_auth:display/1` holds the
 `x-asobi-operator` header to.
+
+**Every capability class but `erasure`.** The secret proves all of them, so
+this is not about what was proved; it is about the medium the credential
+arrived on. A bearer secret in a config file is a script an operator wrote. A
+session cookie is a browser, which can be XSS'd or clickjacked into posting
+somewhere the operator never meant to - and an erasure is the one ops action
+no follow-up call can undo. Same secret, different blast radius, different
+default. Set `console_erasure` to `true` to erase from the console anyway.
 """.
 -spec create(binary()) -> {ok, session()}.
 create(Label) ->
-    create(Label, asobi_ops_caps:class_names(), erlang:system_time(second) + ttl_seconds()).
+    create(Label, console_caps(), erlang:system_time(second) + ttl_seconds()).
+
+-spec console_caps() -> [asobi_ops_caps:class()].
+console_caps() ->
+    case application:get_env(asobi, console_erasure, false) of
+        true -> asobi_ops_caps:class_names();
+        _ -> asobi_ops_caps:class_names() -- [erasure]
+    end.
 
 -doc """
 Open a session carrying `Caps` and expiring no later than `NotAfter`.
 
-The operator secret proves every capability, so `create/1` grants all three.
 A **minted** token proves only the classes it carries and expires in minutes,
 so exchanging one for a session must not widen either: the session inherits
 the token's capabilities, and its expiry is clamped to the token's. Otherwise
 a fifteen-minute credential with two classes would buy a twelve-hour session
 with three, which is the whole point of the token undone by the exchange.
+
+Nothing is subtracted here, unlike `create/1`: a minted token carries exactly
+the classes the control plane decided to mint, and second-guessing that would
+put the decision in two places.
 """.
 -spec create(binary(), [asobi_ops_caps:class()], integer()) -> {ok, session()}.
 create(Label, Caps, NotAfter) ->

--- a/src/console/asobi_console_shell.erl
+++ b/src/console/asobi_console_shell.erl
@@ -124,13 +124,14 @@ title() ->
 %% Marks a deployment an operator should be careful in. Today the console only
 %% colours the label with it.
 %%
-%% Core ops is read-only, but `/ext/:extension/:action` already accepts POST,
-%% PUT and DELETE, so an installed extension can expose a destructive action
-%% right now. Those are what the flag is ultimately for: confirm before
-%% anything in the `player_data` or `config` classes. Shipping the declaration
-%% ahead of the guard means a deployment that says it is production already
-%% does so when the guard arrives, rather than every operator having to go back
-%% and set it afterwards.
+%% Core ops mutates in two places - player erasure, and `/ext/:extension/:action`
+%% where an installed extension can expose a destructive action. Those are what
+%% the flag is ultimately for: confirm before anything in the `player_data`,
+%% `config` or `erasure` classes. Shipping the declaration ahead of the guard
+%% means a deployment that says it is production already does so when the guard
+%% arrives, rather than every operator having to go back and set it afterwards.
+%% Erasure carries its own server-verified username echo regardless, which is a
+%% guard rather than a confirmation dialogue.
 %%
 %% Acting on prod while believing you are in staging is the failure mode of
 %% running several consoles at once, and it is the same risk for a self-hoster

--- a/src/controllers/asobi_guest_controller.erl
+++ b/src/controllers/asobi_guest_controller.erl
@@ -178,12 +178,38 @@ resume(Identity, SecretBin) ->
         _ ->
             case verify(SecretBin, Meta) of
                 true ->
+                    touch(Identity),
                     issue_for_player(maps:get(player_id, Identity));
                 false ->
                     %% Wrong secret for a known device: reject. Never create a
                     %% second player, never overwrite the stored verifier.
                     {asobi_error, ~"guest.invalid_device_secret"}
             end
+    end.
+
+%% Record that this device was seen. `asobi_guest_reaper` keys retention on the
+%% identity's `updated_at`, so without this a guest who plays every day still
+%% looks exactly as stale as one that vanished after the first launch, and an
+%% operator who sets `guest_reap_after` erases their active players.
+%%
+%% A bare `update_all` SET rather than a changeset update: it writes the one
+%% column by id and so cannot round-trip - or clobber - the verifier in
+%% `provider_metadata`. Failure is logged and ignored; a write that only
+%% extends retention must never cost a player their login. The cost is one
+%% single-row UPDATE per resume, which happens at session start, not per tick.
+-spec touch(map()) -> ok.
+touch(Identity) ->
+    Q = kura_query:where(kura_query:from(asobi_player_identity), {id, maps:get(id, Identity)}),
+    case asobi_repo:update_all(Q, #{updated_at => calendar:universal_time()}) of
+        {ok, _} ->
+            ok;
+        Other ->
+            ?LOG_WARNING(#{
+                event => guest_touch_failed,
+                player_id => maps:get(player_id, Identity, undefined),
+                result => Other
+            }),
+            ok
     end.
 
 -spec create(binary(), binary()) -> response().

--- a/src/extensions/asobi_extension.erl
+++ b/src/extensions/asobi_extension.erl
@@ -260,11 +260,32 @@ deleting a remote object, calling a third party - must be idempotent, because a
 later extension's failure will roll back everything around it and the whole
 deletion will be retried.
 
-Core deletes a player in one place today, `asobi_guest_reaper`, so that is
-where this runs. (`asobi_guest_controller` also deletes, but only a player row
-it inserted microseconds earlier and lost a race on, which no extension has
-been told about yet.) `m:asobi_extension_erase` is the seam, and a future
-operator-facing erasure calls the same function.
+Idempotence is not reversibility, and the difference is the one hole in this
+contract. Extensions run first, so by the time a later extension refuses, or
+core's own audit insert fails, a remote delete has already happened and no
+rollback reaches it. The reachable end state is a player who still exists and
+whose remote data does not - and because a rolled-back attempt writes no audit
+row, nothing durable records that it happened. Ordering does not fix it: order
+between extensions is not promised, and core's audit insert follows all of
+them.
+
+If you hold data outside this database, write the *intent* to erase it as a row
+in your own tables inside the transaction, and let a `m:shigoto` worker perform
+the remote call once that row has committed. Then the rollback takes the intent
+with it, and the irreversible step only ever runs after the erasure is final.
+
+Core deletes a player in exactly one place, `m:asobi_player_erase`, so that is
+where this runs. `asobi_guest_reaper` is one caller of it and the ops route
+`POST /api/v1/ops/players/:id/erase` is another; both reach this callback
+through the same function, in the same position, under the same transaction.
+(`asobi_guest_controller` also deletes, but only a player row it inserted
+microseconds earlier and lost a race on, which no extension has been told about
+yet.) `m:asobi_extension_erase` is the seam.
+
+Core's own foreign keys are all `no_action` and its erasure enumerates its
+children in code. A blanket `ON DELETE CASCADE` across core would fire below
+the transaction's control flow, so this callback would never run - which is
+the same reason the guide gives an extension author for not reaching for one.
 """.
 -callback erase_player(PlayerId :: binary()) -> ok | {error, term()}.
 
@@ -275,10 +296,15 @@ operator-facing erasure calls the same function.
 One operator action: the method it answers, the target, and its capability
 class.
 
-`class` is `read | player_data | config` (ADR 0007), the same vocabulary core's
-own ops routes carry, and it is the only thing that authorises the call. An
-action with no class is not reachable, because `asobi_ops_caps` denies a route
-it cannot tag.
+`class` is `read | player_data | config | erasure` (ADR 0007), the same
+vocabulary core's own ops routes carry, and it is the only thing that
+authorises the call. An action with no class is not reachable, because
+`asobi_ops_caps` denies a route it cannot tag.
+
+`erasure` means one thing: the action cannot be undone by a later call. It is
+not "extra sensitive" - it is held apart from `player_data` because an operator
+console is granted every other class by default and this one only on request.
+Declare it for an action that destroys data and for nothing else.
 
 `mfa` is applied as `Module:Function(Params, Ctx)` - the same shape as `rpc/0`,
 for the same reason - where `Params` is the decoded JSON body for a write and
@@ -300,7 +326,7 @@ out of, which is why the method is declared here rather than inferred.
 The operator actions this extension serves, as `Action => t:ops_entry/0`.
 
 `rpc/0` is player-scoped by construction: the caller is the authenticated
-player on that socket, and `read | player_data | config` is an operator
+player on that socket, and `read | player_data | config | erasure` is an operator
 vocabulary no player ever holds. So an extension with an admin surface - the
 first one hit it immediately with `quests.define` - had nowhere to put it.
 This is that home.

--- a/src/iap/asobi_iap_transaction.erl
+++ b/src/iap/asobi_iap_transaction.erl
@@ -12,7 +12,12 @@ table() -> ~"iap_transactions".
 fields() ->
     [
         #kura_field{name = id, type = uuid, primary_key = true, nullable = false},
-        #kura_field{name = player_id, type = uuid, nullable = false},
+        %% Nullable so `m:asobi_player_erase` can sever the receipt from the
+        %% player without destroying it. A purchase record outlives the account:
+        %% a refund or chargeback dispute needs the provider transaction id long
+        %% after an erasure request has been honoured. `changeset/2` still
+        %% requires it, so nothing can write a receipt with no player.
+        #kura_field{name = player_id, type = uuid},
         #kura_field{name = provider, type = string, nullable = false},
         #kura_field{name = transaction_id, type = string, nullable = false},
         #kura_field{name = original_transaction_id, type = string},

--- a/src/leaderboards/asobi_leaderboard_server.erl
+++ b/src/leaderboards/asobi_leaderboard_server.erl
@@ -3,7 +3,7 @@
 
 -include_lib("kernel/include/logger.hrl").
 
--export([start_link/1, submit/3, top/2, rank/2, around/3, live_boards/0]).
+-export([start_link/1, submit/3, top/2, rank/2, around/3, live_boards/0, evict_player/1]).
 -export([init/1, handle_call/3, handle_cast/2, handle_info/2, terminate/2]).
 
 -define(PG_SCOPE, nova_scope).
@@ -77,6 +77,36 @@ live_boards() ->
     catch
         error:badarg -> []
     end.
+
+%% Drop a player from every live board, for `asobi_player_erase:after_commit/1`.
+%%
+%% ETS is the read source of truth here and `hydrate/1` runs only at init, so
+%% deleting the player's `leaderboard_entries` rows does not take them off a
+%% board that is already running: `top/2`, `rank/2` and `around/3` would keep
+%% serving an erased player's id until that process restarted, which for a
+%% long-lived gen_server is never.
+%%
+%% It also clears them from `dirty`, which is the more damaging half. A pending
+%% score for a deleted player is an INSERT that violates the
+%% `leaderboard_entries` -> `players` foreign key, and `flush_players/4` puts a
+%% failed write straight back into `dirty` - so the board would retry it every
+%% 30 seconds, and log the failure, for the rest of its life.
+%%
+%% Cast, not call: this runs after the erase transaction has already committed,
+%% so a board that is slow, wedged or dying must not be able to fail an erasure
+%% that has happened. A board that starts later hydrates from a table the rows
+%% are already gone from.
+-spec evict_player(binary()) -> ok.
+evict_player(PlayerId) ->
+    lists:foreach(
+        fun(BoardId) ->
+            case whereis_board_optional(BoardId) of
+                {ok, Pid} -> gen_server:cast(Pid, {evict, PlayerId});
+                not_found -> ok
+            end
+        end,
+        live_boards()
+    ).
 
 -spec validate_entries([term()]) -> [{binary(), number(), pos_integer()}].
 validate_entries(Entries) ->
@@ -168,6 +198,20 @@ handle_cast(
     ets:insert(Table, {{-Score, PlayerId}, Score}),
     ets:insert(Idx, {PlayerId, Score}),
     {noreply, State#{dirty => Dirty#{PlayerId => true}}};
+handle_cast({evict, PlayerId}, #{table := Table, player_index := Idx, dirty := Dirty} = State) when
+    is_binary(PlayerId)
+->
+    case ets:lookup(Idx, PlayerId) of
+        [{PlayerId, Score}] ->
+            ets:delete(Table, {-Score, PlayerId}),
+            ets:delete(Idx, PlayerId);
+        [] ->
+            ok
+    end,
+    %% Unconditionally, even when the board never held them: `dirty` and the
+    %% index can disagree, and a stale dirty key is the one that retries a
+    %% foreign-key violation forever.
+    {noreply, State#{dirty => maps:remove(PlayerId, Dirty)}};
 handle_cast(_Msg, State) ->
     {noreply, State}.
 

--- a/src/lua/asobi_lua_match_shared.erl
+++ b/src/lua/asobi_lua_match_shared.erl
@@ -1,9 +1,10 @@
 -module(asobi_lua_match_shared).
 -moduledoc """
 Variant of `asobi_lua_match` for matches where every player sees the same
-world state. The match server calls `get_state/1` once per tick and
-broadcasts a single pre-encoded payload to every subscriber, instead of
-re-encoding once per player.
+world state. The match server calls `get_state/1` once per tick and encodes
+the result once for the whole roster, instead of re-encoding once per player.
+`asobi_presence:send_match_state/3` then hands each connected session that
+one binary and each bot the payload behind it as a term.
 
 Selected by declaring `state_strategy = "shared"` in the match script's
 config globals. The Lua script must define `get_state(state)` (one

--- a/src/lua/bots/asobi_bot.erl
+++ b/src/lua/bots/asobi_bot.erl
@@ -11,9 +11,16 @@ A bot is tracked through `asobi_presence:track_bot/2`, so it is a delivery
 target for `asobi_presence:send/2` like any player session but is never
 counted by `asobi_presence:online_count/0`. The messages it consumes are the
 public `t:asobi_presence:message/0` contract, not an ad-hoc shape.
+
+Both state strategies arrive as `{match_state, map()}`. Under
+`state_strategy = "shared"` the match server still encodes once for the whole
+roster, and `asobi_presence:send_match_state/3` hands the bot the term behind
+that frame rather than the frame, so a bot decodes nothing per tick.
 """.
 
 -behaviour(gen_server).
+
+-include_lib("kernel/include/logger.hrl").
 
 -export([start_link/3]).
 -export([init/1, handle_info/2, handle_cast/2, handle_call/3, terminate/2]).
@@ -95,6 +102,18 @@ handle_presence_message({match_event, vote_start, VotePayload}, State) when
     handle_vote_start(VotePayload, State);
 handle_presence_message({match_event, finished, _}, State) ->
     {stop, normal, State};
+handle_presence_message(Message, #{bot_id := BotId} = State) when is_tuple(Message) ->
+    %% A bot ignores most of what a match broadcasts, so this is debug and
+    %% not a warning. It exists because a delivery shape no clause here
+    %% matches is otherwise indistinguishable from a bot with nothing to
+    %% do: turn debug on for this module to see what a stalled bot is
+    %% being sent. Only the tag is logged, never the payload.
+    ?LOG_DEBUG(#{
+        msg => ~"bot_unhandled_presence_message",
+        bot_id => BotId,
+        message => element(1, Message)
+    }),
+    {noreply, State};
 handle_presence_message(_, State) ->
     {noreply, State}.
 

--- a/src/matches/asobi_match_server.erl
+++ b/src/matches/asobi_match_server.erl
@@ -754,13 +754,17 @@ broadcast_state(#{players := Players, game_module := Mod, game_state := GS}) ->
             broadcast_per_player_state(Mod, GS, Players)
     end.
 
+%% One get_state/1 call and one encode per tick, whatever the roster is
+%% (ADR 0001). Both forms go to asobi_presence because only it knows which
+%% roster entries are bots: a bot reads the state as a term and would
+%% otherwise have to decode the frame it was handed, once per tick each.
 broadcast_shared_state(Mod, GS, Players) ->
     SharedState = Mod:get_state(GS),
     Payload = #{~"type" => ~"match.state", ~"payload" => SharedState},
     PreEncoded = iolist_to_binary(json:encode(Payload)),
     maps:foreach(
         fun(PlayerId, _Meta) ->
-            asobi_presence:send(PlayerId, {match_state_raw, PreEncoded})
+            asobi_presence:send_match_state(PlayerId, SharedState, PreEncoded)
         end,
         Players
     ).

--- a/src/migrations/m20260806134109_update_schema.erl
+++ b/src/migrations/m20260806134109_update_schema.erl
@@ -1,0 +1,19 @@
+-module(m20260806134109_update_schema).
+-moduledoc false.
+-behaviour(kura_migration).
+-include_lib("kura/include/kura.hrl").
+-export([up/0, down/0]).
+
+-spec up() -> [kura_migration:operation()].
+up() ->
+    [
+        {execute, ~"ALTER TABLE \"groups\" ALTER COLUMN \"creator_id\" DROP NOT NULL"},
+        {execute, ~"ALTER TABLE \"iap_transactions\" ALTER COLUMN \"player_id\" DROP NOT NULL"}
+    ].
+
+-spec down() -> [kura_migration:operation()].
+down() ->
+    [
+        {execute, ~"ALTER TABLE \"groups\" ALTER COLUMN \"creator_id\" SET NOT NULL"},
+        {execute, ~"ALTER TABLE \"iap_transactions\" ALTER COLUMN \"player_id\" SET NOT NULL"}
+    ].

--- a/src/ops/asobi_ops_audit.erl
+++ b/src/ops/asobi_ops_audit.erl
@@ -39,6 +39,13 @@ Nothing is dropped silently. A raise inside the audit path is caught for the
 same reason - the audit must not be able to fail an operation that already
 happened.
 
+**Erasure is the stated exception**, and `record_strict/4` is how it is taken.
+An erasure destroys the data it is about, so the row is the only surviving
+evidence the request was honoured; there is no degraded-but-still-there state
+for it to fall back to. `record_strict/4` reports whether the insert landed so
+the caller can write it inside its own transaction and roll the erasure back
+when it did not. Nothing else should use it.
+
 Successful writes are not also logged. The row is the record, and mirroring
 it into logs would double the retention surface holding player ids for no
 new information.
@@ -50,7 +57,7 @@ to hide one by exploding.
 
 -include_lib("kernel/include/logger.hrl").
 
--export([mutation/4, record/4]).
+-export([mutation/4, record/4, record_strict/4]).
 
 -type subject() :: binary().
 -type failure() :: {subject(), term()}.
@@ -108,6 +115,23 @@ record(Actor, Action, Target, Outcome) ->
                 stacktrace => Stack
             }),
             ok
+    end.
+
+-doc """
+Write one audit row and say whether it landed.
+
+For `m:asobi_player_erase` only, and the reason is in the moduledoc: an
+erasure's audit row is the only evidence left that the request was honoured,
+so it commits with the erasure or the erasure does not happen. Every other
+call site wants `mutation/4`, which cannot fail the operation it describes.
+""".
+-spec record_strict(asobi_ops_auth:actor(), binary(), target(), outcome()) -> ok | {error, term()}.
+record_strict(Actor, Action, Target, Outcome) ->
+    Params = params(Actor, Action, Target, Outcome),
+    CS = kura_changeset:cast(asobi_ops_audit_entry, #{}, Params, maps:keys(Params)),
+    case asobi_repo:insert(CS) of
+        {ok, _Row} -> ok;
+        {error, Reason} -> {error, Reason}
     end.
 
 -spec write(asobi_ops_auth:actor(), binary(), target(), outcome()) -> ok.

--- a/src/ops/asobi_ops_auth.erl
+++ b/src/ops/asobi_ops_auth.erl
@@ -40,7 +40,7 @@ surprising moments without ending the bearer access that matters.
   its own ownership check, presented as a bearer token and verified by
   `m:asobi_ops_token`. The tenant's role is mapped onto capability classes at
   mint time, so the string "owner" never reaches this plane, and the token
-  carries only the classes it was minted with rather than all three.
+  carries only the classes it was minted with rather than every class.
 
 A bearer token is tried as the operator secret first and as a minted token
 second. The two cannot be confused: a minted token is three dot-separated
@@ -62,7 +62,11 @@ for this class".
 -define(LABEL_MAX_BYTES, 64).
 -define(DEFAULT_DISPLAY, ~"operator").
 
--type source() :: static_secret | cloud | local_user.
+%% `shell` is not a credential and never resolves from a request. It is the
+%% actor `asobi_player_erase:run/1` audits an in-shell erasure as, so a row
+%% written from the node itself is not indistinguishable from one written by
+%% somebody holding the operator secret.
+-type source() :: static_secret | cloud | local_user | shell.
 -type actor() :: #{
     id := binary(),
     display := binary(),
@@ -208,7 +212,7 @@ session_actor(#{id := Id, label := Label, caps := Caps}) ->
         display => Label,
         source => local_user,
         %% Whatever the credential behind this session proved. The operator
-        %% secret proves all three; a minted token proves only what it carried,
+        %% secret proves every class; a minted token proves only what it carried,
         %% and the session must not widen it.
         caps => Caps,
         attested => false
@@ -280,7 +284,11 @@ actor(Req) ->
         id => ~"static_secret",
         display => display(Req),
         source => static_secret,
-        caps => [read, player_data, config],
+        %% Including `erasure`. A secret in a config file is a deliberate
+        %% server-side credential a script holds, not a browser session that
+        %% can be clickjacked - `m:asobi_console_session` is where that
+        %% distinction is drawn.
+        caps => [read, player_data, config, erasure],
         attested => false
     }.
 

--- a/src/ops/asobi_ops_caps.erl
+++ b/src/ops/asobi_ops_caps.erl
@@ -3,15 +3,23 @@
 Capability classes for the ops plane, and the table that tags every route with
 exactly one of them (ADR 0007).
 
-`read` is everything non-mutating, `player_data` is ban, grant, broadcast and
-roster edits, `config` is economy definitions, credentials and deploy-adjacent
-settings. The only authorisation decision anywhere in the plane is membership
-of a route's class in the actor's `caps`.
+`read` is everything non-mutating, `player_data` acts on one identified
+player's data (ban, grant, broadcast, roster edits, and the full export of
+one account), `config` is economy definitions, credentials and deploy-adjacent
+settings. `erasure` is player erasure and nothing else. The only
+authorisation decision anywhere in the plane is membership of a route's class
+in the actor's `caps`.
+
+`erasure` is its own class for one reason, and it is not sensitivity: it is
+the only irreversible one. An erased account cannot be un-erased by a second
+call the way a ban can be lifted, so it does not belong in the same grant as
+"give this player 100 coins" - and `asobi_console_session` hands a browser
+every other class by default.
 
 Role names are deliberately absent. They are not stable wire surface -
-capability classes are, and adding a fourth class later is additive.
-`asobi_saas` maps its own roles onto these classes once, at token-mint time,
-so the string "owner" never reaches this plane.
+capability classes are, and a further class later is additive the same way
+`erasure` was. `asobi_saas` maps its own roles onto these classes once, at
+token-mint time, so the string "owner" never reaches this plane.
 
 A route with no entry in `classes/0` has no class and `authorised/2` denies
 it, so an untagged or mis-mounted route is closed rather than open.
@@ -19,7 +27,7 @@ it, so an untagged or mis-mounted route is closed rather than open.
 
 -export([classes/0, class/2, authorised/2, class_names/0]).
 
--type class() :: read | player_data | config.
+-type class() :: read | player_data | config | erasure.
 -type segment() :: binary() | '_'.
 -type route() :: {atom(), [segment()], class()}.
 
@@ -51,7 +59,11 @@ classes() ->
         {get, [~"chat", ~"channels", '_', ~"messages"], read},
         {get, [~"tournaments"], read},
         {get, [~"tournaments", '_'], read},
-        {get, [~"notifications"], read}
+        {get, [~"notifications"], read},
+        %% Not `read`. `read` grants a leaderboard view; this grants
+        %% everything the deployment holds about one identified person.
+        {get, [~"players", '_', ~"export"], player_data},
+        {post, [~"players", '_', ~"erase"], erasure}
     ].
 
 -doc """
@@ -77,7 +89,7 @@ authorised(Class, Caps) -> lists:member(Class, Caps).
 -doc "Every class, for validating one declared in an extension manifest.".
 -spec class_names() -> [class()].
 class_names() ->
-    [read, player_data, config].
+    [read, player_data, config, erasure].
 
 -spec lookup(atom(), [binary()]) -> class() | undefined.
 lookup(undefined, _Segments) ->

--- a/src/ops/asobi_ops_controller.erl
+++ b/src/ops/asobi_ops_controller.erl
@@ -1,6 +1,7 @@
 -module(asobi_ops_controller).
 -moduledoc """
-HTTP surface of the ops read plane.
+HTTP surface of the ops plane: every read, plus the two account-lifecycle
+routes.
 
 Every list endpoint here returns the same envelope, clamps its own paging, and
 rejects a sort field it does not recognise with 400 rather than ordering by
@@ -9,14 +10,22 @@ something the caller did not ask for.
 These routes are mounted behind `asobi_ops_auth:verify/1`, the operator
 capability check (ADR 0007) - never the player-scoped bearer check the rest of
 `/api/v1` uses, which would let any authenticated player, guest included,
-enumerate the deployment. Every projection here is still held to exactly what
-the equivalent public endpoint already exposes.
+enumerate the deployment. Every read projection here is still held to exactly
+what the equivalent public endpoint already exposes.
+
+`erase_player/1` and `export_player/1` are the exceptions to that last
+sentence, deliberately: an operator answering a deletion or access request
+needs more than a player's own profile view. They are the only two routes on
+this plane that are not reads, they carry their own capability classes
+(`erasure` and `player_data`), and the erasure is audited inside its own
+transaction. See `m:asobi_player_erase`.
 """.
 
 -include_lib("kernel/include/logger.hrl").
 -include_lib("kura/include/kura.hrl").
 
--export([players/1, player/1, matches/1, match/1, features/1, stats/1]).
+-export([players/1, player/1, erase_player/1, export_player/1]).
+-export([matches/1, match/1, features/1, stats/1]).
 -export([leaderboards/1, leaderboard_entries/1, matchmaker/1]).
 -export([economy_items/1, economy_item/1, economy_listings/1, economy_listing/1]).
 -export([chat_channels/1, chat_messages/1]).
@@ -42,6 +51,68 @@ players(Req) ->
 -spec player(cowboy_req:req()) -> response().
 player(Req) ->
     lookup(Req, asobi_player, fun asobi_ops_players:project/1).
+
+-doc """
+Erase one player and everything core holds about them. Irreversible.
+
+The body must echo the player's `username`, and the echo is checked against
+the row server-side. That guard is not distribution-shaped - the limitation it
+answers is a human clicking the wrong row, or a page being clickjacked into
+posting on the operator's behalf - so OTP does not dissolve it. It costs one
+comparison and makes an unattended POST insufficient.
+""".
+-spec erase_player(cowboy_req:req()) -> response().
+erase_player(#{bindings := #{~"id" := Id}, auth_data := #{ops_actor := Actor}} = Req) ->
+    case asobi_ops_params:uuid(Id) of
+        true -> confirmed_erase(Id, echoed_username(Req), Actor);
+        false -> {asobi_error, ~"ops.invalid_id"}
+    end.
+
+-doc """
+Everything core holds about one player, as one JSON object.
+
+`player_data`, not `read`: a leaderboard view is one thing, and the whole of
+one identified person's record is another.
+""".
+-spec export_player(cowboy_req:req()) -> response().
+export_player(#{bindings := #{~"id" := Id}}) ->
+    case asobi_ops_params:uuid(Id) of
+        true -> exported(asobi_player_export:run(Id));
+        false -> {asobi_error, ~"ops.invalid_id"}
+    end.
+
+-spec exported({ok, map()} | {error, not_found}) -> response().
+exported({ok, Payload}) -> {json, #{data => Payload}};
+exported({error, not_found}) -> {asobi_error, ~"ops.not_found"}.
+
+-spec confirmed_erase(binary(), binary() | undefined, asobi_ops_auth:actor()) -> response().
+confirmed_erase(_Id, undefined, _Actor) ->
+    {asobi_error, ~"ops.confirmation_required"};
+confirmed_erase(Id, Echoed, Actor) ->
+    case asobi_repo:get(asobi_player, Id) of
+        {ok, #{username := Echoed}} -> erased(asobi_player_erase:run(Id, Actor), Id);
+        {ok, _Other} -> {asobi_error, ~"ops.confirmation_mismatch"};
+        {error, not_found} -> {asobi_error, ~"ops.not_found"};
+        {error, Reason} -> error_response({query_failed, Reason})
+    end.
+
+-spec erased({ok, map()} | {error, term()}, binary()) -> response().
+erased({ok, Summary}, _Id) ->
+    {json, #{data => Summary}};
+erased({error, forbidden}, _Id) ->
+    {asobi_error, ~"forbidden"};
+erased({error, not_found}, _Id) ->
+    {asobi_error, ~"ops.not_found"};
+erased({error, Reason}, Id) ->
+    ?LOG_ERROR(#{msg => ~"ops player erase failed", player_id => Id, reason => Reason}),
+    {asobi_error, ~"ops.erase_failed"}.
+
+%% `undefined` is "no confirmation sent", which is a different answer from a
+%% confirmation that did not match - an operator who typed the wrong name
+%% should be told so.
+-spec echoed_username(cowboy_req:req()) -> binary() | undefined.
+echoed_username(#{json := #{~"username" := Username}}) when is_binary(Username) -> Username;
+echoed_username(_Req) -> undefined.
 
 -spec matches(cowboy_req:req()) -> response().
 matches(Req) ->

--- a/src/ops/asobi_ops_token.erl
+++ b/src/ops/asobi_ops_token.erl
@@ -50,7 +50,7 @@ Nothing here is stateful: there is no revocation list, which is exactly why
 the lifetime is capped rather than merely checked.
 """.
 
--export([verify/1, sign/2, max_ttl/0]).
+-export([verify/1, sign/2, max_ttl/0, configured/0]).
 
 -define(VERSION, ~"v1").
 %% Fifteen minutes. Long enough that an operator is not re-minting mid-task,
@@ -74,6 +74,17 @@ the lifetime is capped rather than merely checked.
 -doc "The longest lifetime this node will honour, in seconds.".
 -spec max_ttl() -> pos_integer().
 max_ttl() -> ?MAX_TTL_SECONDS.
+
+-doc """
+Whether this node can verify a minted token at all.
+
+Exported so `m:asobi_console_env`'s enable decision reads the same pair
+`verify/1` does. A managed environment configures no `ops_secret`, so without
+this the console would be switched off underneath the one credential it
+accepts.
+""".
+-spec configured() -> boolean().
+configured() -> config() =/= error.
 
 -doc """
 Mint a token for `Claims`.

--- a/src/players/asobi_player_erase.erl
+++ b/src/players/asobi_player_erase.erl
@@ -1,0 +1,286 @@
+-module(asobi_player_erase).
+-moduledoc """
+Delete one player and everything core holds about them, in one transaction.
+
+This is the single place core deletes a player. `m:asobi_guest_reaper` is one
+caller of it, not the site itself, and the operator-facing route
+(`POST /api/v1/ops/players/:id/erase`) is another.
+
+## Why the child list is written out here
+
+All 15 core foreign keys into `players.id` are `ON DELETE NO ACTION`, so the
+player row cannot go until every child has. A blanket `ON DELETE CASCADE`
+migration would be shorter and is deliberately refused: a database cascade
+fires below this function's control flow, so `m:asobi_extension_erase` would
+never run, and `iap_transactions` - real-money receipts - would be destroyed
+silently. Enumerating the children in code is what makes the policy readable,
+testable and auditable. It is also exactly what `guides/extensions.md` tells
+extension authors to do, so core doing otherwise would be telling them one
+thing and doing another.
+
+## Delete, or sever
+
+Two core tables are severed rather than deleted, and only two:
+
+* `iap_transactions` - a purchase record outlives the account. A refund or
+  chargeback dispute needs the provider transaction id, and statutory
+  retention beats erasure for it. `asobi_transaction` is **not** this table:
+  it is soft-currency bookkeeping keyed on `wallets`, and it goes with the
+  wallet.
+* `groups.creator_id` - deleting the group to free the key would destroy
+  every other member's data.
+
+Everything else is deleted outright. That *is* the anonymisation: every
+player-referencing table stores a bare uuid and nothing else about the person,
+so once `players` and `player_identities` are gone the surviving ids resolve to
+nobody. A tombstone player row would be a record about a person who asked to be
+erased, and it would still need a unique `username`.
+
+Three columns hold ids with no foreign key at all, and each is left alone on
+that argument rather than by oversight:
+
+* `match_records.players` - a jsonb list of ids.
+* `votes.votes_cast` - a jsonb object keyed by voter id, `#{VoterId =>
+  OptionId}`. Same shape of argument, and it is exported (see
+  `m:asobi_player_export`), so it is named here too.
+* `zone_snapshots.entities` - opaque game-defined state. A game may key
+  entities by player id, so this one is not core's to reason about; a game that
+  puts personal data in it owns erasing it, which is what
+  `c:asobi_extension:erase_player/1` is for.
+
+## Atomic, never best-effort
+
+One transaction, every result asserted, so a bare `{error, _}` becomes a
+badmatch that raises and rolls the whole thing back. A half-finished erasure
+that reports success is a worse answer to a deletion request than one that
+fails loudly and can be retried - the argument
+`c:asobi_extension:erase_player/1` already makes for extensions, applied to
+core's own tables.
+
+## The audit row commits with the erasure
+
+ADR 0007's rule is that the audit runs after the mutation and never fails it.
+Erasure is the stated exception: the data is gone by definition, so the audit
+row is the only surviving evidence the request was honoured. It is written
+inside the transaction through `asobi_ops_audit:record_strict/4`, and a failed
+insert rolls the erasure back. `ops_audit_entries` carries no foreign key to
+`players`, so the row outlives its own target by construction.
+
+An automated retention sweep writes no rows - see `m:asobi_guest_reaper`.
+
+## What the transaction cannot cover
+
+Evicting the player from `m:asobi_auth_cache` and from every live
+`m:asobi_leaderboard_server`, and killing the live session, run **after** the
+commit, because an ETS eviction and a process exit cannot roll back. All are
+idempotent, so a retry is safe. See `after_commit/1`.
+""".
+
+-include_lib("kernel/include/logger.hrl").
+-include_lib("kura/include/kura.hrl").
+
+-export([steps/1, after_commit/1, run/1, run/2]).
+
+-define(ACTION, ~"players.erase").
+-define(CLASS, erasure).
+-define(TARGET_TYPE, ~"player").
+
+-doc """
+The delete sequence, with no transaction of its own.
+
+For a caller that already holds one - `m:asobi_guest_reaper` does. Every
+result is asserted, so a failure raises inside the caller's transaction and
+rolls it back. Do not soften that into a `case`.
+""".
+-spec steps(binary()) -> ok | no_return().
+steps(PlayerId) ->
+    %% Extensions first, so an erase path can still read the player's core rows.
+    ok = asobi_extension_erase:run(PlayerId),
+
+    {ok, _} = asobi_repo:update_all(by(asobi_iap_transaction, player_id, PlayerId), #{
+        player_id => null
+    }),
+    {ok, _} = asobi_repo:update_all(by(asobi_group, creator_id, PlayerId), #{creator_id => null}),
+
+    %% Ledger before wallet: `transactions` foreign-keys `wallets`, not
+    %% `players`, so it is invisible to a player-id sweep and holds the wallet
+    %% down.
+    {ok, _} = asobi_repo:delete_all(wallet_transactions(PlayerId)),
+    {ok, _} = asobi_repo:delete_all(by(asobi_wallet, player_id, PlayerId)),
+
+    {ok, _} = asobi_repo:delete_all(by(asobi_player_item, player_id, PlayerId)),
+    {ok, _} = asobi_repo:delete_all(by(asobi_storage, player_id, PlayerId)),
+    {ok, _} = asobi_repo:delete_all(by(asobi_cloud_save, player_id, PlayerId)),
+    {ok, _} = asobi_repo:delete_all(by(asobi_notification, player_id, PlayerId)),
+    {ok, _} = asobi_repo:delete_all(by(asobi_leaderboard_entry, player_id, PlayerId)),
+    {ok, _} = asobi_repo:delete_all(by(asobi_chat_message, sender_id, PlayerId)),
+    {ok, _} = asobi_repo:delete_all(by(asobi_group_member, player_id, PlayerId)),
+    {ok, _} = asobi_repo:delete_all(friendships(PlayerId)),
+    {ok, _} = asobi_repo:delete_all(by(asobi_player_stats, player_id, PlayerId)),
+    %% `player_tokens` keys players by `user_id`, not `player_id`.
+    {ok, _} = asobi_repo:delete_all(by(asobi_player_token, user_id, PlayerId)),
+    {ok, _} = asobi_repo:delete_all(by(asobi_player_identity, player_id, PlayerId)),
+
+    delete_player(PlayerId).
+
+-doc """
+Erase `PlayerId` from an Erlang shell, and audit it as the node's own action.
+
+The floor a self-hoster has to be able to stand on: a release, a remote shell,
+and no console, no operator secret and no cloud. There is no capability check
+because there is nothing here to check - a caller holding a shell on the node
+could call `asobi_repo:delete_all/1` directly. Capabilities guard the network
+surface; see `run/2`.
+""".
+-spec run(binary()) -> {ok, map()} | {error, term()}.
+run(PlayerId) when is_binary(PlayerId) ->
+    erase_player(PlayerId, shell_actor()).
+
+-doc """
+Erase `PlayerId` on behalf of an ops actor.
+
+Checks the `erasure` capability class in-function, the way ADR 0007's
+core-wrapped mutations do, because the class is checked once in
+`m:asobi_ops_caps` whichever entry point the caller reached. A refusal is
+audited too: a denied attempt to erase somebody is worth a row.
+""".
+-spec run(binary(), asobi_ops_auth:actor()) -> {ok, map()} | {error, forbidden | term()}.
+run(PlayerId, #{caps := Caps} = Actor) when is_binary(PlayerId) ->
+    case asobi_ops_caps:authorised(?CLASS, Caps) of
+        true ->
+            erase_player(PlayerId, Actor);
+        false ->
+            asobi_ops_audit:record(Actor, ?ACTION, {?TARGET_TYPE, PlayerId}, {error, forbidden}),
+            {error, forbidden}
+    end.
+
+%% --- Internal ---
+
+-spec erase_player(binary(), asobi_ops_auth:actor()) -> {ok, map()} | {error, term()}.
+erase_player(PlayerId, Actor) ->
+    try asobi_repo:transaction(fun() -> erase_txn(PlayerId, Actor) end) of
+        {ok, Summary} ->
+            after_commit(PlayerId),
+            {ok, Summary};
+        {error, _Reason} = Error ->
+            Error;
+        Other ->
+            ?LOG_ERROR(#{
+                msg => ~"player erase returned outside the contract",
+                player_id => PlayerId,
+                returned => Other
+            }),
+            {error, {unexpected, Other}}
+    catch
+        Class:Reason:Stacktrace ->
+            ?LOG_ERROR(#{
+                msg => ~"player erase rolled back",
+                player_id => PlayerId,
+                class => Class,
+                reason => Reason,
+                stacktrace => Stacktrace
+            }),
+            {error, {Class, Reason}}
+    end.
+
+%% `not_found` is returned rather than raised: nothing has been written at that
+%% point, so there is nothing to roll back, and a commit of no statements is
+%% the honest outcome.
+%%
+%% A lookup that failed is not a player that does not exist. Reporting the
+%% second for the first tells an operator answering a deletion request that
+%% there is nobody to delete, when the truth is that the node could not find
+%% out - so it gets its own reason and the caller's 500 path.
+-spec erase_txn(binary(), asobi_ops_auth:actor()) ->
+    {ok, map()} | {error, not_found | {lookup_failed, term()}}.
+erase_txn(PlayerId, Actor) ->
+    case asobi_repo:get(asobi_player, PlayerId) of
+        {ok, _Player} ->
+            ok = steps(PlayerId),
+            ok = asobi_ops_audit:record_strict(
+                Actor, ?ACTION, {?TARGET_TYPE, PlayerId}, {ok, [PlayerId], []}
+            ),
+            {ok, #{player_id => PlayerId, erased => true}};
+        {error, not_found} ->
+            {error, not_found};
+        {error, Reason} ->
+            {error, {lookup_failed, Reason}}
+    end.
+
+-doc """
+The in-memory surfaces the transaction cannot cover, run after it commits.
+
+An ETS eviction and a process exit cannot roll back, so none of these may run
+before the commit. `run/1,2` call this for you; a caller that holds its own
+transaction - `m:asobi_guest_reaper` - calls it once that transaction has
+committed.
+
+* `m:asobi_auth_cache` - without it a deleted player's access token keeps
+  resolving for up to `auth_cache_ttl_ms` against a row that no longer exists,
+  which is the revocation SLA that module's moduledoc already states.
+* `m:asobi_leaderboard_server` - each board keeps its entries in ETS and reads
+  from there, hydrating from Postgres only at init. Deleting the rows does not
+  take an erased player off a board that is already running, and a score still
+  pending for them re-inserts against a foreign key that is now gone. See
+  `asobi_leaderboard_server:evict_player/1`.
+* The live session.
+
+All three are idempotent, so a retried erasure is safe.
+""".
+-spec after_commit(binary()) -> ok.
+after_commit(PlayerId) ->
+    ok = asobi_auth_cache:revoke_player(PlayerId),
+    ok = asobi_leaderboard_server:evict_player(PlayerId),
+    ok = asobi_presence:disconnect(PlayerId, ~"erased").
+
+%% A player row already gone is `ok`: the children have still been cleaned, and
+%% a retried erasure must not fail on the half it already finished.
+%%
+%% `not_found` only. Any other `{error, _}` is the lookup failing, not the row
+%% being absent, and treating the two alike is how this function would commit
+%% every child delete with the `players` row still there - the half-erased
+%% player that reports success this module exists to make impossible. It raises
+%% instead, which is what rolls the transaction back.
+-spec delete_player(binary()) -> ok | no_return().
+delete_player(PlayerId) ->
+    case asobi_repo:get(asobi_player, PlayerId) of
+        {ok, Player} ->
+            {ok, _} = asobi_repo:delete(asobi_player, Player),
+            ok;
+        {error, not_found} ->
+            ok;
+        {error, Reason} ->
+            error({asobi_player_erase, {lookup_failed, PlayerId, Reason}})
+    end.
+
+-spec by(module(), atom(), binary()) -> #kura_query{}.
+by(Schema, Field, PlayerId) ->
+    kura_query:where(kura_query:from(Schema), {Field, PlayerId}).
+
+%% One table, two columns pointing at the same player.
+-spec friendships(binary()) -> #kura_query{}.
+friendships(PlayerId) ->
+    kura_query:where(
+        kura_query:from(asobi_friendship),
+        {'or', [{player_id, PlayerId}, {friend_id, PlayerId}]}
+    ).
+
+%% A subquery rather than a read-then-`in`: an empty id list would compile to
+%% `IN ()`, which Postgres rejects.
+-spec wallet_transactions(binary()) -> #kura_query{}.
+wallet_transactions(PlayerId) ->
+    Wallets = kura_query:select(by(asobi_wallet, player_id, PlayerId), [id]),
+    kura_query:where(kura_query:from(asobi_transaction), {wallet_id, in, {subquery, Wallets}}).
+
+%% The node itself, named as such. `source` is what tells an auditor months
+%% later that this row came from a shell on the box rather than from the ops
+%% plane, and `attested => false` because nothing here proves who typed it.
+-spec shell_actor() -> asobi_ops_auth:actor().
+shell_actor() ->
+    #{
+        id => ~"shell",
+        display => ~"shell",
+        source => shell,
+        caps => asobi_ops_caps:class_names(),
+        attested => false
+    }.

--- a/src/players/asobi_player_export.erl
+++ b/src/players/asobi_player_export.erl
@@ -1,0 +1,257 @@
+-module(asobi_player_export).
+-moduledoc """
+Everything core holds about one player, as one map.
+
+The read half of `m:asobi_player_erase`, and it covers the same tables in the
+same order, so "what would erasure delete" and "what would export return" stay
+one list rather than two that drift.
+
+## Positive allowlists, never `maps:without/2`
+
+Every row goes through a `maps:with/2` projection, modelled on
+`asobi_ops_players:project/1`. `players` carries `hashed_password`, so a
+subtractive filter is one schema field away from exporting a credential;
+`player_tokens` carries live bearer tokens, so the export reports that a
+session existed and when, never the token itself.
+
+## The two tables with no foreign key
+
+`match_records.players` is a jsonb list of ids and `votes.votes_cast` is a
+jsonb object keyed by voter id. Neither has a foreign key, and both are records
+about a player whatever the schema says about referential integrity, so both
+are included - by jsonb containment and jsonb key existence respectively.
+
+`votes` is projected differently from every other table here: the row holds
+*everybody's* votes, so exporting `votes_cast` whole would hand one player the
+private choices of everyone else in the match. Only this player's own `choice`
+is lifted out. A privacy feature that leaks is worse than one that is missing.
+
+`zone_snapshots.entities` is deliberately absent. It is opaque game-defined
+state whose shape core does not know - a game may key entities by player id or
+bury one inside entity state, and there is no projection core could apply to it
+that would not either miss the data or export another player's. A game that
+puts personal data there owns exporting it, the same way it owns erasing it.
+
+## No extension callback
+
+There is deliberately no `export_player/1` for extensions in this change.
+`c:asobi_extension:erase_player/1` earns its keep because the foreign key
+physically forces an author to answer it; an export callback has no forcing
+function, so an extension that skipped it would produce a silently incomplete
+export and nothing would fail. That is a worse contract than no contract. If
+one ever ships, the payload must name which installed extensions contributed
+and which did not.
+""".
+
+-include_lib("kura/include/kura.hrl").
+
+-export([run/1]).
+
+-doc """
+Every core row that names `PlayerId`, projected.
+
+`{error, not_found}` when no such player exists - an empty export and a
+missing account are different answers to a data-subject request.
+""".
+-spec run(binary()) -> {ok, map()} | {error, not_found}.
+run(PlayerId) when is_binary(PlayerId) ->
+    case asobi_repo:get(asobi_player, PlayerId) of
+        {ok, Player} -> {ok, payload(PlayerId, Player)};
+        {error, _Reason} -> {error, not_found}
+    end.
+
+%% --- Internal ---
+
+-spec payload(binary(), map()) -> map().
+payload(PlayerId, Player) ->
+    #{
+        player => player(Player),
+        identities => rows(by(asobi_player_identity, player_id, PlayerId), fun identity/1),
+        stats => rows(by(asobi_player_stats, player_id, PlayerId), fun stats/1),
+        tokens => rows(by(asobi_player_token, user_id, PlayerId), fun token/1),
+        wallets => rows(by(asobi_wallet, player_id, PlayerId), fun wallet/1),
+        transactions => rows(wallet_transactions(PlayerId), fun transaction/1),
+        items => rows(by(asobi_player_item, player_id, PlayerId), fun item/1),
+        storage => rows(by(asobi_storage, player_id, PlayerId), fun storage/1),
+        cloud_saves => rows(by(asobi_cloud_save, player_id, PlayerId), fun cloud_save/1),
+        notifications => rows(by(asobi_notification, player_id, PlayerId), fun notification/1),
+        leaderboard_entries => rows(
+            by(asobi_leaderboard_entry, player_id, PlayerId), fun leaderboard_entry/1
+        ),
+        chat_messages => rows(by(asobi_chat_message, sender_id, PlayerId), fun chat_message/1),
+        group_memberships => rows(by(asobi_group_member, player_id, PlayerId), fun group_member/1),
+        groups_created => rows(by(asobi_group, creator_id, PlayerId), fun group/1),
+        friendships => rows(friendships(PlayerId), fun friendship/1),
+        iap_transactions => rows(
+            by(asobi_iap_transaction, player_id, PlayerId), fun iap_transaction/1
+        ),
+        match_records => rows(match_records(PlayerId), fun match_record/1),
+        votes => rows(votes(PlayerId), fun(Row) -> vote(PlayerId, Row) end)
+    }.
+
+%% A failed read is an empty list rather than a crash only where it cannot be
+%% mistaken for an answer: it cannot, because `run/1` has already established
+%% the player exists and any error here is logged by the repo.
+-spec rows(#kura_query{}, fun((map()) -> map())) -> [map()].
+rows(Query, Project) ->
+    case asobi_repo:all(Query) of
+        {ok, Found} -> [Project(Row) || Row <- Found];
+        {error, _Reason} -> []
+    end.
+
+%% `hashed_password` is the field this projection exists to keep out.
+-spec player(map()) -> map().
+player(Row) ->
+    maps:with(
+        [id, username, display_name, avatar_url, metadata, banned_at, inserted_at, updated_at],
+        Row
+    ).
+
+-spec identity(map()) -> map().
+identity(Row) ->
+    maps:with(
+        [
+            id,
+            provider,
+            provider_uid,
+            provider_email,
+            provider_display_name,
+            provider_metadata,
+            inserted_at,
+            updated_at
+        ],
+        Row
+    ).
+
+-spec stats(map()) -> map().
+stats(Row) ->
+    maps:with(
+        [player_id, games_played, wins, losses, rating, rating_deviation, metadata, updated_at], Row
+    ).
+
+%% `token` is a live bearer credential and never leaves the database. What a
+%% player is owed here is that a session existed, not the key to it.
+-spec token(map()) -> map().
+token(Row) ->
+    maps:with([id, context, family_id, used_at, inserted_at], Row).
+
+-spec wallet(map()) -> map().
+wallet(Row) ->
+    maps:with([id, currency, balance, inserted_at, updated_at], Row).
+
+-spec transaction(map()) -> map().
+transaction(Row) ->
+    maps:with(
+        [
+            id,
+            wallet_id,
+            amount,
+            balance_after,
+            reason,
+            reference_type,
+            reference_id,
+            metadata,
+            inserted_at
+        ],
+        Row
+    ).
+
+-spec item(map()) -> map().
+item(Row) ->
+    maps:with([id, item_def_id, quantity, metadata, acquired_at, updated_at], Row).
+
+-spec storage(map()) -> map().
+storage(Row) ->
+    maps:with([id, collection, key, value, version, read_perm, write_perm, updated_at], Row).
+
+-spec cloud_save(map()) -> map().
+cloud_save(Row) ->
+    maps:with([id, slot, data, version, updated_at], Row).
+
+-spec notification(map()) -> map().
+notification(Row) ->
+    maps:with([id, type, subject, content, read, sent_at], Row).
+
+-spec leaderboard_entry(map()) -> map().
+leaderboard_entry(Row) ->
+    maps:with([id, leaderboard_id, score, sub_score, metadata, updated_at], Row).
+
+-spec chat_message(map()) -> map().
+chat_message(Row) ->
+    maps:with([id, channel_type, channel_id, content, metadata, sent_at], Row).
+
+-spec group_member(map()) -> map().
+group_member(Row) ->
+    maps:with([id, group_id, role, joined_at], Row).
+
+-spec group(map()) -> map().
+group(Row) ->
+    maps:with([id, name, description, max_members, open, metadata, inserted_at, updated_at], Row).
+
+-spec friendship(map()) -> map().
+friendship(Row) ->
+    maps:with([id, player_id, friend_id, status, inserted_at, updated_at], Row).
+
+-spec iap_transaction(map()) -> map().
+iap_transaction(Row) ->
+    maps:with(
+        [id, provider, transaction_id, original_transaction_id, product_id, inserted_at], Row
+    ).
+
+-spec match_record(map()) -> map().
+match_record(Row) ->
+    maps:with([id, mode, status, result, metadata, started_at, finished_at, inserted_at], Row).
+
+%% Only this player's own vote. `votes_cast` is `#{VoterId => OptionId}` for
+%% every voter in the match, so it never leaves this function - the projection
+%% lifts out the one key and drops the map. `distribution` and `turnout` are
+%% aggregates over the whole match and name nobody, which is why they can stay.
+-spec vote(binary(), map()) -> map().
+vote(PlayerId, Row) ->
+    Cast = maps:get(votes_cast, Row, #{}),
+    Base = maps:with(
+        [id, match_id, template, method, options, distribution, turnout, opened_at, closed_at],
+        Row
+    ),
+    Base#{choice => choice(PlayerId, Cast)}.
+
+%% jsonb decodes to a map with binary keys; anything else means the column was
+%% not the shape this function expects, and guessing would be worse than `null`.
+-spec choice(binary(), term()) -> term().
+choice(PlayerId, Cast) when is_map(Cast) -> maps:get(PlayerId, Cast, null);
+choice(_PlayerId, _Cast) -> null.
+
+-spec by(module(), atom(), binary()) -> #kura_query{}.
+by(Schema, Field, PlayerId) ->
+    kura_query:where(kura_query:from(Schema), {Field, PlayerId}).
+
+-spec friendships(binary()) -> #kura_query{}.
+friendships(PlayerId) ->
+    kura_query:where(
+        kura_query:from(asobi_friendship),
+        {'or', [{player_id, PlayerId}, {friend_id, PlayerId}]}
+    ).
+
+-spec wallet_transactions(binary()) -> #kura_query{}.
+wallet_transactions(PlayerId) ->
+    Wallets = kura_query:select(by(asobi_wallet, player_id, PlayerId), [id]),
+    kura_query:where(kura_query:from(asobi_transaction), {wallet_id, in, {subquery, Wallets}}).
+
+%% No foreign key to lean on: `players` is a jsonb array of ids, so this is a
+%% containment test rather than an equality one.
+-spec match_records(binary()) -> #kura_query{}.
+match_records(PlayerId) ->
+    Contains = iolist_to_binary(json:encode([PlayerId])),
+    kura_query:where(
+        kura_query:from(asobi_match_record), {fragment, ~"\"players\" @> ?::jsonb", [Contains]}
+    ).
+
+%% `votes_cast` is a jsonb *object* keyed by voter id, so this asks whether the
+%% key exists rather than testing containment. `jsonb_exists/2` and not the `?`
+%% operator that is its infix form: `?` is the parameter placeholder in a kura
+%% fragment, so the operator spelling is ambiguous here.
+-spec votes(binary()) -> #kura_query{}.
+votes(PlayerId) ->
+    kura_query:where(
+        kura_query:from(asobi_vote), {fragment, ~"jsonb_exists(\"votes_cast\", ?)", [PlayerId]}
+    ).

--- a/src/social/asobi_group.erl
+++ b/src/social/asobi_group.erl
@@ -17,7 +17,11 @@ fields() ->
         #kura_field{name = description, type = string},
         #kura_field{name = max_members, type = integer, default = 50},
         #kura_field{name = open, type = boolean, default = false, nullable = false},
-        #kura_field{name = creator_id, type = uuid, nullable = false},
+        %% Nullable so `m:asobi_player_erase` can sever the group from its
+        %% creator. Deleting the group instead would destroy every other
+        %% member's data to free one foreign key. `changeset/2` still requires
+        %% it, so a group cannot be created without a creator.
+        #kura_field{name = creator_id, type = uuid},
         #kura_field{name = metadata, type = jsonb, default = #{}},
         #kura_field{name = inserted_at, type = utc_datetime, nullable = false},
         #kura_field{name = updated_at, type = utc_datetime, nullable = false}

--- a/src/social/asobi_presence.erl
+++ b/src/social/asobi_presence.erl
@@ -25,6 +25,10 @@ servers that produce those terms (`asobi_match_server`, `asobi_world_server`,
 `asobi_zone`, `asobi_matchmaker`, the Lua runtime) and the processes that
 pattern-match them (`asobi_ws_handler`, `asobi_player_session`, `asobi_bot`).
 
+Shared match state is the one shape whose form depends on the recipient:
+`send_match_state/3` hands a session the pre-encoded frame and a bot the
+same payload as a term. Both are `message/0` shapes; see that function.
+
 It is a public type on purpose. `send/2` is spec'd with it, so a producer
 that invents a shape fails dialyzer instead of quietly emitting a term no
 consumer handles, and a consumer (`asobi_bot` does this) can spec its own
@@ -34,12 +38,14 @@ clauses against the same named type rather than an ad-hoc guess.
 
 -export([start_link/0]).
 -export([track/2, track_bot/2, untrack/1, untrack_bot/2, update/2, get_status/1, send/2]).
+-export([send_match_state/3]).
 -export([online_count/0]).
 -export([disconnect/2, revoke_session/2]).
 -export([init/1, handle_call/3, handle_cast/2, handle_info/2]).
 
 -define(PRESENCE_GROUP, asobi_online).
 -define(PG_SCOPE, nova_scope).
+-define(BOT_GROUP(Id), {bot, Id}).
 
 -type event_name() :: atom() | binary().
 -type message() ::
@@ -84,6 +90,7 @@ broadcast. See the module docs for why.
 -spec track_bot(binary(), pid()) -> ok.
 track_bot(BotId, Pid) ->
     join_delivery_group(BotId, Pid),
+    pg:join(?PG_SCOPE, ?BOT_GROUP(BotId), Pid),
     ok.
 
 -spec untrack(binary()) -> ok.
@@ -94,6 +101,7 @@ untrack(PlayerId) ->
 -spec untrack_bot(binary(), pid()) -> ok.
 untrack_bot(BotId, Pid) ->
     pg:leave(?PG_SCOPE, {player, BotId}, Pid),
+    pg:leave(?PG_SCOPE, ?BOT_GROUP(BotId), Pid),
     ok.
 
 -spec join_delivery_group(binary(), pid()) -> ok.
@@ -116,6 +124,30 @@ get_status(PlayerId) ->
 send(PlayerId, Message) ->
     Members = pg:get_members(?PG_SCOPE, {player, PlayerId}),
     lists:foreach(fun(Pid) when is_pid(Pid) -> Pid ! {asobi_message, Message} end, Members),
+    ok.
+
+-doc """
+Deliver one tick of shared match state to a roster entry.
+
+Sessions get `PreEncoded`, the wire frame the caller encoded once for the
+whole match (ADR 0001). Bots get `SharedState`, the same payload as a term,
+because a bot reads the state in Erlang and has no use for a JSON binary:
+routing it here keeps the one encode per tick and costs a bot no decode.
+""".
+-spec send_match_state(binary(), map(), binary()) -> ok.
+send_match_state(PlayerId, SharedState, PreEncoded) ->
+    Bots = pg:get_members(?PG_SCOPE, ?BOT_GROUP(PlayerId)),
+    lists:foreach(
+        fun(Pid) when is_pid(Pid) ->
+            Message =
+                case lists:member(Pid, Bots) of
+                    true -> {match_state, SharedState};
+                    false -> {match_state_raw, PreEncoded}
+                end,
+            Pid ! {asobi_message, Message}
+        end,
+        pg:get_members(?PG_SCOPE, {player, PlayerId})
+    ),
     ok.
 
 -spec revoke_session(binary(), binary()) -> ok.

--- a/test/asobi_bot_presence_tests.erl
+++ b/test/asobi_bot_presence_tests.erl
@@ -27,6 +27,9 @@ presence_tracking_test_() ->
         {"a live bot is tracked, uncounted, and found by the match server",
             fun bot_tracked_and_uncounted/0},
         {"match state reaches the bot through presence", fun bot_receives_match_state/0},
+        {"shared-state match: the bot reads the state, the session gets the frame",
+            fun bot_receives_shared_match_state/0},
+        {"send_match_state/3 splits by recipient kind", fun send_match_state_splits/0},
         {"a vote_start match event reaches the bot", fun bot_receives_vote_start/0},
         {"a finished bot leaves the delivery group", fun finished_bot_untracked/0}
     ]}.
@@ -78,6 +81,7 @@ untrack_bot_drops_target() ->
     ok = asobi_presence:track_bot(~"bot_Blitz", Pid),
     ok = asobi_presence:untrack_bot(~"bot_Blitz", Pid),
     ?assertEqual(offline, asobi_presence:get_status(~"bot_Blitz")),
+    ?assertEqual([], pg:get_members(nova_scope, {bot, ~"bot_Blitz"})),
     ?assertEqual(Before, asobi_presence:online_count()),
     stop_relay(Pid).
 
@@ -103,6 +107,44 @@ bot_receives_match_state() ->
     ?assertEqual(#{score => 0}, maps:get(game_state, bot_state(BotPid))),
     stop_process(BotPid),
     stop_process(MatchPid).
+
+%% A mode whose game module exports get_state/1 broadcasts one pre-encoded
+%% frame per tick. A bot has no clause for that frame, so before
+%% asobi_presence:send_match_state/3 existed its game_state stayed empty for
+%% its whole life with no error and no log. The session must still get the
+%% pre-encoded frame: bots must not cost the encode-once path.
+bot_receives_shared_match_state() ->
+    MatchPid = start_match(#{game_module => asobi_test_game_shared, min_players => 1}),
+    Session = relay(),
+    ok = asobi_presence:track(~"shared_human", Session),
+    ok = asobi_match_server:join(MatchPid, ~"shared_human"),
+    BotPid = start_bot(MatchPid, ~"bot_Shard"),
+    %% after, not a tail of stop calls: a failing assertion here must not
+    %% leave a ticking match behind for the next test module to trip over.
+    try
+        wait_until(fun() -> maps:get(game_state, bot_state(BotPid)) =/= #{} end),
+        ?assertMatch(
+            #{~"world" := #{npcs := 0}, ~"tick" := _},
+            maps:get(game_state, bot_state(BotPid))
+        ),
+        ?assertMatch(#{~"type" := ~"match.state"}, json:decode(next_raw_frame()))
+    after
+        stop_relay(Session),
+        stop_process(BotPid),
+        stop_process(MatchPid)
+    end.
+
+send_match_state_splits() ->
+    Session = relay(),
+    ok = asobi_presence:track(~"split_human", Session),
+    ok = asobi_presence:send_match_state(~"split_human", #{~"tick" => 7}, ~"frame"),
+    ?assertEqual({asobi_message, {match_state_raw, ~"frame"}}, next_relayed()),
+    stop_relay(Session),
+    Bot = relay(),
+    ok = asobi_presence:track_bot(~"bot_Split", Bot),
+    ok = asobi_presence:send_match_state(~"bot_Split", #{~"tick" => 7}, ~"frame"),
+    ?assertEqual({asobi_message, {match_state, #{~"tick" => 7}}}, next_relayed()),
+    stop_relay(Bot).
 
 bot_receives_vote_start() ->
     %% min_players 2 keeps the match in `waiting`, so no state broadcast
@@ -176,6 +218,14 @@ next_relayed() ->
         {relayed, Msg} -> Msg
     after 2000 ->
         error(no_message_delivered)
+    end.
+
+next_raw_frame() ->
+    receive
+        {relayed, {asobi_message, {match_state_raw, Frame}}} -> Frame;
+        {relayed, _} -> next_raw_frame()
+    after 2000 ->
+        error(no_raw_frame_delivered)
     end.
 
 stop_process(Pid) ->

--- a/test/asobi_chat_ws_SUITE.erl
+++ b/test/asobi_chat_ws_SUITE.erl
@@ -99,9 +99,12 @@ register_player(Suffix, Config) ->
     #{~"player_id" := PlayerId, ~"access_token" := Token} = nova_test:json(Resp),
     {PlayerId, Token}.
 
+%% asobi#357: `erlang:unique_integer/1` is unique per runtime instance, not
+%% across runs, while `players` persists - so a later run re-mints a username an
+%% earlier one registered and hits the unique index. The name must stay inside
+%% the 32-character username limit, hence a short tag plus 8 hex.
 unique_name(Suffix) ->
-    N = integer_to_binary(erlang:unique_integer([positive])),
-    <<"chatprobe_", N/binary, "_", Suffix/binary>>.
+    <<"chat_", Suffix/binary, "_", (asobi_id:rand_suffix(4))/binary>>.
 
 ws_connect_authed(Token, Config) ->
     {ok, Conn} = nova_test_ws:connect("/ws", Config),

--- a/test/asobi_console_env_tests.erl
+++ b/test/asobi_console_env_tests.erl
@@ -8,7 +8,7 @@
 %% pass looks like it works.
 
 setup() ->
-    Keys = [console, ops_secret, console_label, console_production],
+    Keys = [console, ops_secret, ops_token_secret, env_id, console_label, console_production],
     Saved = [{K, application:get_env(asobi, K)} || K <- Keys],
     Vars = [
         "ASOBI_CONSOLE",
@@ -64,6 +64,42 @@ enabling_with_a_secret_turns_it_on_test_() ->
         asobi_console_env:apply(),
         ?assertEqual(true, env(console)),
         ?assertEqual(~"a-secret-long-enough-to-be-real", env(ops_secret))
+    end).
+
+%% A managed environment configures no ops_secret on purpose: the only
+%% credential its console accepts is a token the control plane minted, verified
+%% against `ops_token_secret` + `env_id`. Turning the console off there would
+%% take the whole cloud handoff with it.
+a_minted_token_is_a_credential_too_test_() ->
+    with_env(fun() ->
+        application:set_env(asobi, console, true),
+        application:set_env(asobi, ops_token_secret, binary:copy(~"k", 32)),
+        application:set_env(asobi, env_id, ~"11111111-2222-3333-4444-555555555555"),
+        asobi_console_env:apply(),
+        ?assertEqual(true, env(console)),
+        ?assertEqual(undefined, env(ops_secret))
+    end).
+
+%% The same pair asobi_ops_token:verify/1 refuses: a placeholder short enough to
+%% be a leftover, or a key with no environment to check a token's `env` against.
+a_half_configured_token_path_does_not_count_test_() ->
+    with_env(fun() ->
+        [
+            begin
+                application:unset_env(asobi, ops_token_secret),
+                application:unset_env(asobi, env_id),
+                [application:set_env(asobi, K, V) || {K, V} <- Configured],
+                application:set_env(asobi, console, true),
+                asobi_console_env:apply(),
+                ?assertEqual(false, env(console))
+            end
+         || Configured <- [
+                [{ops_token_secret, binary:copy(~"k", 32)}],
+                [{env_id, ~"env-1"}],
+                [{ops_token_secret, ~"too-short"}, {env_id, ~"env-1"}],
+                [{ops_token_secret, binary:copy(~"k", 32)}, {env_id, ~""}]
+            ]
+        ]
     end).
 
 %% A typo must close the surface, not open it.

--- a/test/asobi_console_routes_tests.erl
+++ b/test/asobi_console_routes_tests.erl
@@ -99,6 +99,10 @@ every_path_the_console_asks_for_is_a_declared_ops_route_test() ->
 
 %% Not the reverse assertion - the console is allowed to leave a route
 %% unrendered - but it is worth seeing which ones it does not use.
+%%
+%% `/players/_/export` is here because the console has no screen for it yet.
+%% The erasure route is absent from this list for a different reason: it is a
+%% POST, and `declared/0` only reads the `get` half of the table.
 unused_ops_routes_are_visible_test() ->
     Unused = declared() -- paths(),
-    ?assertEqual([~"/economy/listings/_"], Unused).
+    ?assertEqual([~"/economy/listings/_", ~"/players/_/export"], Unused).

--- a/test/asobi_console_session_tests.erl
+++ b/test/asobi_console_session_tests.erl
@@ -37,9 +37,39 @@ session_test_() ->
             {"an unknown cookie resolves to nothing", fun unknown/0},
             {"a non-binary cookie resolves to nothing", fun malformed/0},
             {"a hostile label is replaced, not stored", fun label/0},
-            {"the ttl is clamped", fun ttl/0}
+            {"the ttl is clamped", fun ttl/0},
+            {"a browser session cannot erase by default", fun no_erasure_by_default/0},
+            {"one config key opts the console in", fun erasure_opt_in/0},
+            {"a minted token's caps are inherited whole", fun minted_caps_are_untouched/0}
         ]
     end).
+
+%% The same operator secret buys every class over a bearer header and every
+%% class but `erasure` through a browser. That is not about what the secret
+%% proves - it proves all of them - but about the medium: a session cookie can
+%% be clickjacked, and an erasure is the one ops action nothing can undo.
+no_erasure_by_default() ->
+    application:unset_env(asobi, console_erasure),
+    {ok, #{caps := Caps}} = asobi_console_session:create(~"kaito"),
+    ?assertNot(lists:member(erasure, Caps)),
+    ?assertEqual(asobi_ops_caps:class_names() -- [erasure], Caps).
+
+erasure_opt_in() ->
+    application:set_env(asobi, console_erasure, true),
+    try
+        {ok, #{caps := Caps}} = asobi_console_session:create(~"kaito"),
+        ?assert(lists:member(erasure, Caps))
+    after
+        application:unset_env(asobi, console_erasure)
+    end.
+
+%% The exchange must not second-guess the control plane: a minted token carries
+%% exactly the classes it was minted with, and clamping here would put the
+%% decision in two places.
+minted_caps_are_untouched() ->
+    NotAfter = erlang:system_time(second) + 60,
+    {ok, #{caps := Caps}} = asobi_console_session:create(~"kaito", [read, erasure], NotAfter),
+    ?assertEqual([read, erasure], Caps).
 
 resolves() ->
     {ok, #{id := Id, csrf := Csrf, label := Label}} = asobi_console_session:create(~"kaito"),

--- a/test/asobi_guest_SUITE.erl
+++ b/test/asobi_guest_SUITE.erl
@@ -12,6 +12,8 @@
     upgrade_rejected_for_non_guest/1,
     upgrade_clears_stale_auth_cache_entries/1,
     reaper_removes_unclaimed_guest_and_children/1,
+    reaper_erases_a_guest_with_a_row_in_every_child_table/1,
+    reaper_spares_an_old_guest_that_still_plays/1,
     create_retries_on_username_collision/1,
     create_no_retry_on_non_unique_username_error/1
 ]).
@@ -25,16 +27,30 @@ all() ->
         upgrade_rejected_for_non_guest,
         upgrade_clears_stale_auth_cache_entries,
         reaper_removes_unclaimed_guest_and_children,
+        reaper_erases_a_guest_with_a_row_in_every_child_table,
+        reaper_spares_an_old_guest_that_still_plays,
         create_retries_on_username_collision,
         create_no_retry_on_non_unique_username_error
     ].
 
-init_per_suite(Config) ->
-    %% Set before the app starts so the sup starts the reaper and guest is on.
+%% Set AFTER the app starts, not before. Booting asobi runs
+%% `asobi_lua_config:maybe_load_game_config/0`, and a node with no game bundle
+%% takes the `error` branch of `declared_config/1`, which writes
+%% `{guest_auth, false}` unconditionally - by design, so a stale `true` from a
+%% previous bundle cannot survive a reload. A `set_env` before the start is
+%% therefore overwritten during it, guest auth is off for the whole suite, and
+%% every create returns 403 `guest.disabled`.
+%%
+%% Setting it afterwards is safe because nothing here is read at boot:
+%% `asobi_guest_controller:guest_enabled/0` reads both keys per request, and the
+%% reaper is an unconditional child that reads `guest_reap_after` at sweep time
+%% (asobi#327).
+init_per_suite(Config0) ->
+    Config = asobi_test_helpers:start(Config0),
     application:set_env(asobi, guest_auth, true),
     application:set_env(asobi, guest_verifier_pepper, crypto:strong_rand_bytes(32)),
     application:set_env(asobi, guest_reap_after, 1),
-    asobi_test_helpers:start(Config).
+    Config.
 
 end_per_suite(Config) ->
     Config.
@@ -181,13 +197,301 @@ reaper_removes_unclaimed_guest_and_children(Config) ->
     ?assert(is_pid(whereis(asobi_guest_reaper))),
     {ok, R1} = create(device_id(), secret(), Config),
     #{~"player_id" := Pid} = nova_test:json(R1),
-    %% guest_reap_after is 1s and the cutoff is computed at whole-second
-    %% granularity (erlang:universaltime/0), so a guest created late in a second
-    %% needs >2s to be strictly older than (sweep_second - 1). Sleep past two
-    %% second-boundaries to make the reap deterministic.
-    timer:sleep(2500),
+    %% Age the identity rather than sleeping past the cutoff, for the reason
+    %% `reaper_erases_a_guest_with_a_row_in_every_child_table/1` states: the
+    %% reaper compares whole seconds of `erlang:universaltime/0`, so a sleep
+    %% makes this a wall-clock race. A host correcting its clock under the test
+    %% advances less than the sleep did, the row ends up newer than the cutoff,
+    %% and the sweep skips it - observed failing roughly one run in six, with
+    %% `inserted_at` two seconds ahead of the timestamp taken at create.
+    age_identity(Pid),
     {ok, _} = asobi_guest_reaper:sweep_now(),
     ?assertEqual({error, not_found}, asobi_repo:get(asobi_player, Pid)),
+    Config.
+
+%% asobi#369 part two. All 15 core foreign keys into `players.id` are ON DELETE
+%% NO ACTION, and the reaper used to delete four tables: player_stats,
+%% player_tokens, player_identities, players. A guest who earned one coin, wrote
+%% one cloud save or sent one chat message therefore hit a constraint violation
+%% on the players delete, the transaction rolled back, and the sweep retried it
+%% forever - permanently unreapable, and invisible because the eunit tests meck
+%% asobi_repo:delete_all/1 to {ok, 1}. Constraint enforcement is a property of
+%% the schema, so this needs a real database and a row in EVERY referencing
+%% table. Run it against the old reaper and it fails on the first assertion.
+%%
+%% It also pins the two tables that are severed rather than deleted: a purchase
+%% record survives its player, and so does a group other people are in.
+reaper_erases_a_guest_with_a_row_in_every_child_table(Config) ->
+    {ok, R} = create(device_id(), secret(), Config),
+    #{~"player_id" := PlayerId} = nova_test:json(R),
+
+    Other = insert_player(),
+    ItemDef = insert_item_def(),
+    OwnGroup = insert_group(PlayerId),
+    OtherGroup = insert_group(Other),
+    Wallet = insert_wallet(PlayerId),
+    Transaction = insert_transaction(Wallet),
+    Item = insert_player_item(PlayerId, ItemDef),
+    Storage = insert_storage(PlayerId),
+    Save = insert_cloud_save(PlayerId),
+    Notification = insert_notification(PlayerId),
+    Entry = insert_leaderboard_entry(PlayerId),
+    Message = insert_chat_message(PlayerId),
+    Membership = insert_group_member(OtherGroup, PlayerId),
+    %% Both friendship columns: one table, two foreign keys, and a delete
+    %% keyed only on `player_id` leaves the other half holding the player down.
+    Outgoing = insert_friendship(PlayerId, Other),
+    Incoming = insert_friendship(Other, PlayerId),
+    Receipt = insert_iap_transaction(PlayerId),
+    Match = insert_match_record(PlayerId),
+    Vote = insert_vote(PlayerId, Other),
+    %% The guest create path writes these two itself, so they are asserted
+    %% present rather than inserted - a table with nothing in it would make the
+    %% delete that clears it untestable.
+    ?assertEqual({ok, 1}, count(asobi_player_stats, player_id, PlayerId)),
+    ?assertEqual({ok, 1}, count(asobi_player_identity, player_id, PlayerId)),
+
+    %% Export the same footprint before erasing it. Three of its queries are SQL
+    %% a mocked repo cannot check: the wallet-ledger subquery, the jsonb
+    %% containment that finds a match record with no foreign key at all, and the
+    %% `jsonb_exists` key probe that finds a vote. All three would return an
+    %% empty list rather than fail if Postgres rejected them.
+    {ok, Export} = asobi_player_export:run(PlayerId),
+    ?assertEqual([Match], [Id || #{id := Id} <- maps:get(match_records, Export)]),
+    ?assertEqual([Vote], [Id || #{id := Id} <- maps:get(votes, Export)]),
+    %% One row, several people. The requester gets their own choice and no trace
+    %% of the other voter - a data-subject request must not become a disclosure.
+    [ExportedVote] = maps:get(votes, Export),
+    ?assertEqual(~"yes", maps:get(choice, ExportedVote)),
+    ?assertNot(maps:is_key(votes_cast, ExportedVote)),
+    ?assertEqual(
+        nomatch, binary:match(iolist_to_binary(io_lib:format("~p", [ExportedVote])), Other)
+    ),
+    ?assertEqual([Transaction], [Id || #{id := Id} <- maps:get(transactions, Export)]),
+    ?assertEqual([Wallet], [Id || #{id := Id} <- maps:get(wallets, Export)]),
+    ?assertEqual(
+        lists:sort([Outgoing, Incoming]),
+        lists:sort([Id || #{id := Id} <- maps:get(friendships, Export)])
+    ),
+    ?assertEqual([Receipt], [Id || #{id := Id} <- maps:get(iap_transactions, Export)]),
+    ?assertNot(maps:is_key(hashed_password, maps:get(player, Export))),
+    ?assertEqual([], [T || T <- maps:get(tokens, Export), maps:is_key(token, T)]),
+
+    age_identity(PlayerId),
+    {ok, Reaped} = asobi_guest_reaper:sweep_now(),
+    ?assert(Reaped >= 1),
+
+    ?assertEqual({error, not_found}, asobi_repo:get(asobi_player, PlayerId)),
+    [
+        ?assertEqual({error, not_found}, asobi_repo:get(Schema, Id))
+     || {Schema, Id} <- [
+            {asobi_transaction, Transaction},
+            {asobi_wallet, Wallet},
+            {asobi_player_item, Item},
+            {asobi_storage, Storage},
+            {asobi_cloud_save, Save},
+            {asobi_notification, Notification},
+            {asobi_leaderboard_entry, Entry},
+            {asobi_chat_message, Message},
+            {asobi_group_member, Membership},
+            {asobi_friendship, Outgoing},
+            {asobi_friendship, Incoming}
+        ]
+    ],
+    ?assertEqual({ok, 0}, count(asobi_player_stats, player_id, PlayerId)),
+    ?assertEqual({ok, 0}, count(asobi_player_identity, player_id, PlayerId)),
+    ?assertEqual({ok, 0}, count(asobi_player_token, user_id, PlayerId)),
+
+    %% Severed, not destroyed. The receipt is a real-money record a chargeback
+    %% still needs; the group is other people's data.
+    ?assertMatch({ok, #{player_id := undefined}}, asobi_repo:get(asobi_iap_transaction, Receipt)),
+    ?assertMatch({ok, #{creator_id := undefined}}, asobi_repo:get(asobi_group, OwnGroup)),
+    ?assertMatch({ok, #{creator_id := Other}}, asobi_repo:get(asobi_group, OtherGroup)),
+    Config.
+
+%% --- Row fixtures for the erasure test ---
+%%
+%% Built through changesets on an unmocked asobi_repo, so every constraint the
+%% migrations declare is live.
+
+insert(Schema, Params) ->
+    CS = kura_changeset:cast(Schema, #{}, Params, maps:keys(Params)),
+    {ok, Row} = asobi_repo:insert(CS),
+    Row.
+
+insert_player() ->
+    #{id := Id} = insert(asobi_player, #{
+        username => asobi_test_helpers:unique_username(~"erasee")
+    }),
+    Id.
+
+insert_item_def() ->
+    #{id := Id} = insert(asobi_item_def, #{
+        slug => asobi_test_helpers:unique_id(~"slug"),
+        name => ~"Torch",
+        category => ~"tool"
+    }),
+    Id.
+
+insert_group(CreatorId) ->
+    #{id := Id} = insert(asobi_group, #{
+        name => asobi_test_helpers:unique_id(~"guild"), creator_id => CreatorId
+    }),
+    Id.
+
+insert_wallet(PlayerId) ->
+    #{id := Id} = insert(asobi_wallet, #{
+        player_id => PlayerId, currency => ~"gold", balance => 1
+    }),
+    Id.
+
+insert_transaction(WalletId) ->
+    #{id := Id} = insert(asobi_transaction, #{
+        wallet_id => WalletId, amount => 1, balance_after => 1, reason => ~"test"
+    }),
+    Id.
+
+insert_player_item(PlayerId, ItemDefId) ->
+    #{id := Id} = insert(asobi_player_item, #{
+        player_id => PlayerId, item_def_id => ItemDefId, acquired_at => calendar:universal_time()
+    }),
+    Id.
+
+insert_storage(PlayerId) ->
+    #{id := Id} = insert(asobi_storage, #{
+        collection => ~"inventory",
+        key => asobi_test_helpers:unique_id(~"key"),
+        player_id =>
+            PlayerId
+    }),
+    Id.
+
+insert_cloud_save(PlayerId) ->
+    #{id := Id} = insert(asobi_cloud_save, #{player_id => PlayerId, slot => ~"1"}),
+    Id.
+
+insert_notification(PlayerId) ->
+    #{id := Id} = insert(asobi_notification, #{
+        player_id => PlayerId,
+        type => ~"system",
+        subject => ~"hello",
+        sent_at => calendar:universal_time()
+    }),
+    Id.
+
+insert_leaderboard_entry(PlayerId) ->
+    #{id := Id} = insert(asobi_leaderboard_entry, #{
+        leaderboard_id => asobi_test_helpers:unique_id(~"board"), player_id => PlayerId, score => 1
+    }),
+    Id.
+
+insert_chat_message(PlayerId) ->
+    #{id := Id} = insert(asobi_chat_message, #{
+        channel_type => ~"global",
+        channel_id => ~"global",
+        sender_id => PlayerId,
+        content => ~"hi",
+        sent_at => calendar:universal_time()
+    }),
+    Id.
+
+insert_group_member(GroupId, PlayerId) ->
+    #{id := Id} = insert(asobi_group_member, #{
+        group_id => GroupId, player_id => PlayerId, joined_at => calendar:universal_time()
+    }),
+    Id.
+
+insert_friendship(PlayerId, FriendId) ->
+    #{id := Id} = insert(asobi_friendship, #{player_id => PlayerId, friend_id => FriendId}),
+    Id.
+
+%% No foreign key: `players` is a jsonb array of ids, exactly as
+%% `asobi_match_server` writes it.
+insert_match_record(PlayerId) ->
+    #{id := Id} = insert(asobi_match_record, #{
+        status => ~"finished", players => [PlayerId, asobi_id:generate()]
+    }),
+    Id.
+
+%% `votes_cast` is keyed by voter id, so this row carries a second voter whose
+%% choice must not come back in the first player's export.
+insert_vote(PlayerId, OtherVoter) ->
+    #{id := Id} = insert(asobi_vote, #{
+        match_id => asobi_id:generate(),
+        template => ~"kick",
+        method => ~"majority",
+        options => [~"yes", ~"no"],
+        votes_cast => #{PlayerId => ~"yes", OtherVoter => ~"no"},
+        window_ms => 30000
+    }),
+    Id.
+
+insert_iap_transaction(PlayerId) ->
+    #{id := Id} = insert(asobi_iap_transaction, #{
+        player_id => PlayerId,
+        provider => ~"apple",
+        transaction_id => asobi_test_helpers:unique_id(~"txn")
+    }),
+    Id.
+
+count(Schema, Field, Value) ->
+    asobi_repo:aggregate(kura_query:where(kura_query:from(Schema), {Field, Value}), count).
+
+%% Push the identity's timestamps far behind any cutoff, so a reap is a property
+%% of the row rather than of how much wall clock passed during the test. The
+%% reaper's predicate is `updated_at < universaltime() - reap_after` at
+%% whole-second granularity, which a sleep can only race with.
+%%
+%% Both columns, though only `updated_at` is the predicate: a row aged on one
+%% but not the other is a state the application never produces, and pinning the
+%% predicate to whichever column is stale would make the test agree with the
+%% reaper for the wrong reason.
+age_identity(PlayerId) ->
+    Ancient = {{2020, 1, 1}, {0, 0, 0}},
+    {ok, 1} = asobi_repo:update_all(
+        kura_query:where(kura_query:from(asobi_player_identity), {player_id, PlayerId}),
+        #{inserted_at => Ancient, updated_at => Ancient}
+    ),
+    ok.
+
+%% The reap predicate is inactivity, not account age. A device that keeps
+%% resuming is a player who is still here, however long ago they first launched
+%% the game - and under device auth they stay "unclaimed" forever, because
+%% there is no password to set and no provider to link. Keyed on `inserted_at`
+%% this test deletes the player: the identity is aged past the cutoff and
+%% nothing on the resume path moved it back.
+%%
+%% This is the case that made the erasure change dangerous rather than merely
+%% wrong. While the cascade was broken any such guest hit an FK violation and
+%% was logged skipped, so the predicate never got to finish the job; completing
+%% the cascade is what turned it into permanent, unaudited deletion of the
+%% active player base, at ?REAP_BATCH per sweep.
+reaper_spares_an_old_guest_that_still_plays(Config) ->
+    Dev = device_id(),
+    Secret = secret(),
+    {ok, R1} = create(Dev, Secret, Config),
+    ?assertStatus(200, R1),
+    #{~"player_id" := PlayerId} = nova_test:json(R1),
+
+    %% An account created long ago...
+    age_identity(PlayerId),
+
+    %% ...whose owner just opened the game. Same device, same secret: a resume,
+    %% not a create - assert that, or a regression that silently created a
+    %% second player would still pass the survival check below.
+    {ok, R2} = create(Dev, Secret, Config),
+    ?assertStatus(200, R2),
+    ?assertEqual(#{~"player_id" => PlayerId}, maps:with([~"player_id"], nova_test:json(R2))),
+
+    {ok, _} = asobi_guest_reaper:sweep_now(),
+    ?assertMatch({ok, _}, asobi_repo:get(asobi_player, PlayerId)),
+    ?assertEqual({ok, 1}, count(asobi_player_identity, player_id, PlayerId)),
+
+    %% And the sweep still works: the same account goes when it does fall idle,
+    %% so this test cannot pass by the reaper being broken outright.
+    age_identity(PlayerId),
+    {ok, _} = asobi_guest_reaper:sweep_now(),
+    ?assertEqual({error, not_found}, asobi_repo:get(asobi_player, PlayerId)),
     Config.
 
 %% A generated username colliding with an existing one (previously: any two

--- a/test/asobi_guest_reaper_tests.erl
+++ b/test/asobi_guest_reaper_tests.erl
@@ -86,7 +86,11 @@ refusing_extension_aborts_reap() ->
     application:set_env(asobi, guest_auth, true),
     ?assertEqual({ok, 0}, asobi_guest_reaper:sweep_now()),
     ?assertEqual(0, meck:num_calls(asobi_repo, delete, '_')),
-    ?assertEqual(0, meck:num_calls(asobi_repo, delete_all, '_')).
+    ?assertEqual(0, meck:num_calls(asobi_repo, delete_all, '_')),
+    %% Including the two sever steps: an extension that refuses must not leave
+    %% `iap_transactions` or `groups.creator_id` nulled on a player who then
+    %% survives.
+    ?assertEqual(0, meck:num_calls(asobi_repo, update_all, '_')).
 
 install_quests() ->
     ok = asobi_fixture_app:install(
@@ -95,6 +99,11 @@ install_quests() ->
 
 %% One unclaimed guest identity, and a transaction that runs its fun inline so
 %% the assertion inside it is the thing under test.
+%%
+%% These stubs cannot see a missing child delete - that is the whole reason
+%% `asobi_guest_SUITE:reaper_erases_a_guest_with_a_row_in_every_child_table/1`
+%% exists and runs against a real database. What they do cover is the ordering
+%% and the abort, which need no schema.
 expect_one_reapable_guest() ->
     meck:expect(asobi_repo, all, fun(_Q) ->
         {ok, [#{player_id => ~"p-1", provider => ~"guest"}]}
@@ -102,6 +111,7 @@ expect_one_reapable_guest() ->
     meck:expect(asobi_repo, get, fun(asobi_player, ~"p-1") ->
         {ok, #{id => ~"p-1", hashed_password => undefined}}
     end),
+    meck:expect(asobi_repo, update_all, fun(_Q, _Updates) -> {ok, 0} end),
     meck:expect(asobi_repo, delete_all, fun(_Q) -> {ok, 1} end),
     meck:expect(asobi_repo, delete, fun(asobi_player, _Player) -> {ok, #{}} end),
     meck:expect(asobi_repo, transaction, fun(Fun) -> Fun() end).

--- a/test/asobi_leaderboard_persistence_tests.erl
+++ b/test/asobi_leaderboard_persistence_tests.erl
@@ -37,7 +37,11 @@ persistence_test_() ->
             fun shutdown_flushes_pending_scores/0},
         {"a flush writes only the players that changed", fun flush_writes_only_changed_players/0},
         {"a board whose hydrate fails still starts and deletes nothing",
-            fun hydrate_failure_starts_empty/0}
+            fun hydrate_failure_starts_empty/0},
+        {"an erased player stops being served by a live board",
+            fun evict_removes_a_player_from_a_live_board/0},
+        {"an erased player's pending score cannot retry forever",
+            fun evict_drops_the_pending_score/0}
     ]}.
 
 restart_reloads_scores() ->
@@ -104,6 +108,53 @@ hydrate_failure_starts_empty() ->
     %% upserts per player and never deletes.
     meck:expect(asobi_repo, all, fun fake_all/1),
     ?assertEqual(100, db_score(BoardId, Alice)).
+
+%% `asobi_player_erase` deletes the player's `leaderboard_entries` rows, but ETS
+%% is what reads are served from and `hydrate/1` only runs at init - so without
+%% an eviction an erased player keeps appearing in `top/2`, `rank/2` and
+%% `around/3` for as long as the board process lives, which is indefinitely.
+evict_removes_a_player_from_a_live_board() ->
+    BoardId = board_id(),
+    Erased = asobi_id:generate(),
+    Kept = asobi_id:generate(),
+    Pid = start_board(BoardId),
+    ok = asobi_leaderboard_server:submit(BoardId, Erased, 200),
+    ok = asobi_leaderboard_server:submit(BoardId, Kept, 100),
+    ?assertEqual([{Erased, 200, 1}, {Kept, 100, 2}], asobi_leaderboard_server:top(BoardId, 10)),
+
+    ok = asobi_leaderboard_server:evict_player(Erased),
+
+    %% Gone from the ordered table, the player index, and every read path.
+    ?assertEqual([{Kept, 100, 1}], asobi_leaderboard_server:top(BoardId, 10)),
+    ?assertEqual({error, not_found}, asobi_leaderboard_server:rank(BoardId, Erased)),
+    ?assertEqual([], asobi_leaderboard_server:around(BoardId, Erased, 5)),
+    %% The player who was not erased keeps their entry and re-ranks.
+    ?assertEqual({ok, 1}, asobi_leaderboard_server:rank(BoardId, Kept)),
+    stop_board(BoardId, Pid).
+
+%% The damaging half. A score still pending for a player who has just been
+%% erased is an INSERT that violates `leaderboard_entries.player_id` ->
+%% `players.id`; `flush_players/4` puts a failed write straight back into
+%% `dirty`, so the board retries it every 30 seconds - and logs it - for the
+%% rest of its life. Eviction has to clear `dirty`, not just the tables.
+evict_drops_the_pending_score() ->
+    BoardId = board_id(),
+    Erased = asobi_id:generate(),
+    Pid = start_board(BoardId),
+    ok = asobi_leaderboard_server:submit(BoardId, Erased, 100),
+    %% Still pending: the persist timer is 30s away, so nothing is written yet.
+    ?assertEqual(not_found, db_score(BoardId, Erased)),
+
+    ok = asobi_leaderboard_server:evict_player(Erased),
+    _ = asobi_leaderboard_server:top(BoardId, 1),
+    ets:insert(?DB, {writes, 0}),
+
+    %% Shutdown flushes whatever is still dirty - the same call the 30s tick
+    %% makes. `shutdown_flushes_pending_scores/0` proves this path does write a
+    %% pending score, so a write here would be the retry that never stops.
+    stop_board(BoardId, Pid),
+    ?assertEqual(0, writes()),
+    ?assertEqual(not_found, db_score(BoardId, Erased)).
 
 %% --- Board lifecycle ---
 

--- a/test/asobi_match_broadcast_tests.erl
+++ b/test/asobi_match_broadcast_tests.erl
@@ -29,6 +29,10 @@ setup() ->
         ets:insert(?SENT_TAB, {PlayerId, Msg}),
         ok
     end),
+    meck:expect(asobi_presence, send_match_state, fun(PlayerId, SharedState, PreEncoded) ->
+        ets:insert(?SENT_TAB, {PlayerId, {match_state_shared, SharedState, PreEncoded}}),
+        ok
+    end),
     ok.
 
 cleanup(_) ->
@@ -39,7 +43,7 @@ cleanup(_) ->
 broadcast_test_() ->
     {setup, fun setup/0, fun cleanup/1, [
         {"per-player path delivers match_state per player", fun per_player_path/0},
-        {"shared path delivers match_state_raw with same binary", fun shared_path/0},
+        {"shared path hands presence one term and one binary per tick", fun shared_path/0},
         {"#304: oversized game.broadcast payload is not fanned out to players",
             fun oversized_broadcast_rejected/0},
         {"#304: normal-size game.broadcast payload is still delivered",
@@ -67,17 +71,20 @@ shared_path() ->
     timer:sleep(200),
     Sent = ets:tab2list(?SENT_TAB),
     PerPlayer = [X || X = {_, {match_state, _}} <- Sent],
-    Raw = [{P, B} || {P, {match_state_raw, B}} <- Sent, is_binary(B)],
+    Shared = [{P, S, B} || {P, {match_state_shared, S, B}} <- Sent, is_binary(B)],
     ?assertEqual([], PerPlayer),
-    ?assert(length(Raw) >= 2),
-    %% In any single tick the binary is identical for every player. Pick
-    %% the most-recent binary delivered to each player and compare them.
-    LastByPlayer = #{P => B || {P, B} <- Raw},
+    ?assert(length(Shared) >= 2),
+    %% In any single tick the binary is identical for every player - the
+    %% encode-once win - and the term beside it is the payload that binary
+    %% carries, which is what a bot reads instead of decoding.
+    LastByPlayer = #{P => {S, B} || {P, S, B} <- Shared},
     case maps:values(LastByPlayer) of
-        [B1, B2 | _] ->
+        [{S1, B1}, {_S2, B2} | _] ->
             ?assertEqual(B1, B2),
             Decoded = json:decode(B1),
-            ?assertMatch(#{~"type" := ~"match.state", ~"payload" := _}, Decoded);
+            ?assertMatch(#{~"type" := ~"match.state", ~"payload" := _}, Decoded),
+            ?assertMatch(#{~"world" := _, ~"tick" := _}, S1),
+            ?assertEqual(maps:get(~"tick", S1), maps:get(~"tick", maps:get(~"payload", Decoded)));
         _ ->
             ?assert(false)
     end,

--- a/test/asobi_ops_auth_tests.erl
+++ b/test/asobi_ops_auth_tests.erl
@@ -86,7 +86,7 @@ every_shipped_route_carries_exactly_one_class_test() ->
     Routes = [{M, S} || {M, S, _Class} <- asobi_ops_caps:classes()],
     ?assertEqual(lists:usort(Routes), lists:sort(Routes)),
     [
-        ?assert(lists:member(Class, [read, player_data, config]))
+        ?assert(lists:member(Class, asobi_ops_caps:class_names()))
      || {_M, _S, Class} <- asobi_ops_caps:classes()
     ].
 
@@ -210,7 +210,10 @@ admitted_actor_has_the_adr_shape() ->
     {true, #{ops_actor := Actor}} = asobi_ops_auth:verify(ops_req(?SECRET)),
     ?assertEqual([attested, caps, display, id, source], lists:sort(maps:keys(Actor))),
     ?assertEqual(static_secret, maps:get(source, Actor)),
-    ?assertEqual([read, player_data, config], maps:get(caps, Actor)),
+    %% Including `erasure`: a secret in a config file is a script an operator
+    %% wrote, not a browser session. `asobi_console_session:create/1` is where
+    %% the same secret buys less.
+    ?assertEqual([read, player_data, config, erasure], maps:get(caps, Actor)),
     ?assertEqual(false, maps:get(attested, Actor)),
     ?assertEqual(~"operator", maps:get(display, Actor)).
 

--- a/test/asobi_ops_tests.erl
+++ b/test/asobi_ops_tests.erl
@@ -295,36 +295,56 @@ ops_routes_are_mounted_behind_the_operator_check_test() ->
     ?assertEqual(fun asobi_ops_auth:verify/1, Security),
     ?assert(Routes =/= []),
     [
-        ?assertEqual([get, options], maps:get(methods, Opts))
+        ?assertEqual(expected_methods(Path), maps:get(methods, Opts))
      || {Path, _Handler, Opts} <- Routes, not extension_route(Path)
     ].
 
-%% Core's own plane is read-only and must not grow a write route by accident,
-%% and `asobi_ops_notifications:broadcast/5` is deliberately not one. The
-%% extension dispatch route is the single exception, and it is not an exception
-%% to the audit: every method on it but `get` runs inside
-%% `asobi_ops_audit:mutation/4`.
-core_ops_routes_serve_no_write_method_test() ->
-    #{routes := Routes} = ops_group(),
-    Methods = lists:usort([
-        M
-     || {Path, _Handler, Opts} <- Routes,
-        not extension_route(Path),
-        M <- maps:get(methods, Opts)
-    ]),
-    ?assertEqual([get, options], Methods),
-    ?assertEqual([], [Class || {_M, _S, Class} <- asobi_ops_caps:classes(), Class =/= read]).
+%% One route on core's plane answers a write method, and it is stated here so a
+%% second cannot appear without editing this line.
+expected_methods(~"/players/:id/erase") -> [post, options];
+expected_methods(_Path) -> [get, options].
 
-%% The exception, stated once so it cannot widen quietly: exactly one route
-%% carries a write method, and it is the extension dispatch.
-exactly_one_ops_route_carries_a_write_method_test() ->
+%% Core's plane is a read plane plus exactly two account-lifecycle routes, and
+%% `asobi_ops_notifications:broadcast/5` is still deliberately not a route at
+%% all. Anything else non-read is a write surface that grew by accident.
+%%
+%% `erasure` is its own class rather than `player_data` because it is the only
+%% irreversible action here; `export` is `player_data` rather than `read`
+%% because it returns everything about one identified person.
+core_ops_non_read_classes_are_only_account_lifecycle_test() ->
+    ?assertEqual(
+        [
+            {get, [~"players", '_', ~"export"], player_data},
+            {post, [~"players", '_', ~"erase"], erasure}
+        ],
+        [Route || {_M, _S, Class} = Route <- asobi_ops_caps:classes(), Class =/= read]
+    ).
+
+%% Stated once so it cannot widen quietly: two routes carry a write method, the
+%% erasure and the extension dispatch. Neither is an exception to the audit -
+%% the extension dispatch runs inside `asobi_ops_audit:mutation/4`, and the
+%% erasure writes its row inside its own transaction.
+ops_routes_carrying_a_write_method_test() ->
     #{routes := Routes} = ops_group(),
     Writing = [
         Path
      || {Path, _Handler, Opts} <- Routes,
         [] =/= [M || M <- maps:get(methods, Opts), M =/= get, M =/= options]
     ],
-    ?assertEqual([~"/ext/:extension/:action"], Writing).
+    ?assertEqual([~"/players/:id/erase", ~"/ext/:extension/:action"], Writing).
+
+%% asobi#326: routing_tree returns on the first matching sibling and a binding
+%% matches any segment, so `/players/:id` declared first would not swallow a
+%% deeper path - but the ordering is load-bearing enough elsewhere in this
+%% table that it is pinned rather than assumed.
+erase_and_export_are_declared_before_the_player_binding_test() ->
+    #{routes := Routes} = ops_group(),
+    Paths = [Path || {Path, _Handler, _Opts} <- Routes],
+    ?assert(index_of(~"/players/:id/erase", Paths) < index_of(~"/players/:id", Paths)),
+    ?assert(index_of(~"/players/:id/export", Paths) < index_of(~"/players/:id", Paths)).
+
+index_of(Needle, List) ->
+    length(lists:takewhile(fun(Item) -> Item =/= Needle end, List)).
 
 ops_group() ->
     [Group] = [G || #{prefix := ~"/api/v1/ops"} = G <- asobi_router:routes(dev)],
@@ -535,3 +555,120 @@ capability_enabled(Name) ->
      || #{name := N, enabled := E} <- asobi_ops_features:capabilities(), N =:= Name
     ],
     Enabled.
+
+%%--------------------------------------------------------------------
+%% Erasure and export handlers
+%%--------------------------------------------------------------------
+
+erase_handler_test_() ->
+    {foreach, fun setup_erase/0, fun cleanup_erase/1, [
+        {"a body echoing the username erases", fun erase_confirmed/0},
+        {"no body at all is refused", fun erase_without_a_confirmation/0},
+        {"the wrong username is refused", fun erase_with_the_wrong_username/0},
+        {"a malformed id never reaches the database", fun erase_with_a_malformed_id/0},
+        {"an unknown player is not_found", fun erase_unknown_player/0},
+        {"a refused capability answers forbidden", fun erase_forbidden/0},
+        {"a rolled-back erasure is a 500 code", fun erase_failed/0},
+        {"export projects and never 404s a live player", fun export_ok/0},
+        {"export of an unknown player is not_found", fun export_unknown/0}
+    ]}.
+
+-define(ERASE_ID, ~"01960000-0000-7000-8000-000000000009").
+
+setup_erase() ->
+    meck:new(asobi_repo, [no_link]),
+    meck:expect(asobi_repo, get, fun(asobi_player, ?ERASE_ID) ->
+        {ok, #{id => ?ERASE_ID, username => ~"kaito"}}
+    end),
+    meck:new(asobi_player_erase, [no_link]),
+    meck:expect(asobi_player_erase, run, fun(?ERASE_ID, _Actor) ->
+        {ok, #{player_id => ?ERASE_ID, erased => true}}
+    end),
+    meck:new(asobi_player_export, [no_link]),
+    meck:expect(asobi_player_export, run, fun(?ERASE_ID) -> {ok, #{player => #{}}} end),
+    ok.
+
+cleanup_erase(_) ->
+    meck:unload(asobi_player_export),
+    meck:unload(asobi_player_erase),
+    meck:unload(asobi_repo),
+    ok.
+
+erase_req(Body) ->
+    #{
+        bindings => #{~"id" => ?ERASE_ID},
+        auth_data => #{ops_actor => erase_actor()},
+        json => Body
+    }.
+
+erase_actor() ->
+    #{
+        id => ~"static_secret",
+        display => ~"operator",
+        source => static_secret,
+        caps => [read, player_data, config, erasure],
+        attested => false
+    }.
+
+erase_confirmed() ->
+    ?assertMatch(
+        {json, #{data := #{erased := true}}},
+        asobi_ops_controller:erase_player(erase_req(#{~"username" => ~"kaito"}))
+    ),
+    ?assertEqual(1, meck:num_calls(asobi_player_erase, run, '_')).
+
+%% The echo is the guard that makes an unattended POST insufficient - a
+%% clickjacked console page can send the request but cannot know the username
+%% the server will compare against.
+erase_without_a_confirmation() ->
+    ?assertEqual(
+        {asobi_error, ~"ops.confirmation_required"},
+        asobi_ops_controller:erase_player(erase_req(#{}))
+    ),
+    ?assertEqual(0, meck:num_calls(asobi_player_erase, run, '_')).
+
+erase_with_the_wrong_username() ->
+    ?assertEqual(
+        {asobi_error, ~"ops.confirmation_mismatch"},
+        asobi_ops_controller:erase_player(erase_req(#{~"username" => ~"yuki"}))
+    ),
+    ?assertEqual(0, meck:num_calls(asobi_player_erase, run, '_')).
+
+erase_with_a_malformed_id() ->
+    Req = (erase_req(#{~"username" => ~"kaito"}))#{bindings => #{~"id" => ~"not-a-uuid"}},
+    ?assertEqual({asobi_error, ~"ops.invalid_id"}, asobi_ops_controller:erase_player(Req)),
+    ?assertEqual(0, meck:num_calls(asobi_repo, get, '_')).
+
+erase_unknown_player() ->
+    meck:expect(asobi_repo, get, fun(asobi_player, ?ERASE_ID) -> {error, not_found} end),
+    ?assertEqual(
+        {asobi_error, ~"ops.not_found"},
+        asobi_ops_controller:erase_player(erase_req(#{~"username" => ~"kaito"}))
+    ).
+
+erase_forbidden() ->
+    meck:expect(asobi_player_erase, run, fun(?ERASE_ID, _Actor) -> {error, forbidden} end),
+    ?assertEqual(
+        {asobi_error, ~"forbidden"},
+        asobi_ops_controller:erase_player(erase_req(#{~"username" => ~"kaito"}))
+    ).
+
+erase_failed() ->
+    meck:expect(asobi_player_erase, run, fun(?ERASE_ID, _Actor) -> {error, {error, boom}} end),
+    ?assertEqual(
+        {asobi_error, ~"ops.erase_failed"},
+        asobi_ops_controller:erase_player(erase_req(#{~"username" => ~"kaito"}))
+    ).
+
+export_ok() ->
+    ?assertMatch(
+        {json, #{data := #{player := #{}}}},
+        asobi_ops_controller:export_player(#{bindings => #{~"id" => ?ERASE_ID}})
+    ).
+
+export_unknown() ->
+    meck:expect(asobi_player_export, run, fun(?ERASE_ID) -> {error, not_found} end),
+    ?assertEqual(
+        {asobi_error, ~"ops.not_found"},
+        asobi_ops_controller:export_player(#{bindings => #{~"id" => ?ERASE_ID}})
+    ).

--- a/test/asobi_player_erase_SUITE.erl
+++ b/test/asobi_player_erase_SUITE.erl
@@ -1,0 +1,187 @@
+-module(asobi_player_erase_SUITE).
+
+%% Erasure against a real database.
+%%
+%% The unit tests for this module meck `asobi_repo`, which is exactly how the
+%% bug this module exists to fix stayed hidden: `asobi_guest_reaper` deleted
+%% four of fourteen child tables for months, and
+%% `test/asobi_guest_reaper_tests.erl` could not see it because it mecked
+%% `delete/2` to always return `{ok, #{}}`. The database is the only party that
+%% knows a row is still referenced, and it was not in the test.
+%%
+%% So this suite exists to be the opposite: insert a row in EVERY table with a
+%% foreign key into `players.id`, then erase, then assert the player is gone.
+%% All 15 of those keys are `ON DELETE NO ACTION`, so a table this module
+%% forgets makes the final delete raise - which is the point. Adding a
+%% player-referencing table without teaching `asobi_player_erase` about it
+%% fails here rather than in a self-hoster's reaper log.
+
+-export([all/0, init_per_suite/1, end_per_suite/1]).
+-export([
+    erases_a_player_with_a_row_in_every_child_table/1,
+    severs_rather_than_deletes_the_purchase_record/1,
+    leaves_a_group_standing_when_its_creator_is_erased/1
+]).
+
+-include_lib("common_test/include/ct.hrl").
+-include_lib("stdlib/include/assert.hrl").
+-include_lib("kura/include/kura.hrl").
+
+all() ->
+    [
+        erases_a_player_with_a_row_in_every_child_table,
+        severs_rather_than_deletes_the_purchase_record,
+        leaves_a_group_standing_when_its_creator_is_erased
+    ].
+
+init_per_suite(Config) ->
+    asobi_test_helpers:start(Config).
+
+end_per_suite(_Config) ->
+    ok.
+
+%%--------------------------------------------------------------------
+
+erases_a_player_with_a_row_in_every_child_table(_Config) ->
+    PlayerId = a_player(),
+    ok = a_row_in_every_child_table(PlayerId),
+
+    {ok, _} = asobi_player_erase:run(PlayerId),
+
+    ?assertEqual({error, not_found}, asobi_repo:get(asobi_player, PlayerId)),
+    [
+        ?assertEqual(
+            {ok, []},
+            asobi_repo:all(by(Schema, Field, PlayerId)),
+            unicode:characters_to_list(io_lib:format("~p rows survived erasure", [Schema]))
+        )
+     || {Schema, Field} <- deleted_children()
+    ],
+    ok.
+
+%% A purchase record outlives the account: a refund or chargeback dispute needs
+%% the provider transaction id, and statutory retention beats erasure for it.
+%% The link to the person is what goes.
+severs_rather_than_deletes_the_purchase_record(_Config) ->
+    PlayerId = a_player(),
+    {ok, Txn} = insert(asobi_iap_transaction, #{
+        player_id => PlayerId,
+        provider => ~"apple",
+        transaction_id => unique(~"txn"),
+        product_id => ~"coins_100",
+        status => ~"verified"
+    }),
+    TxnId = maps:get(id, Txn),
+
+    {ok, _} = asobi_player_erase:run(PlayerId),
+
+    {ok, Kept} = asobi_repo:get(asobi_iap_transaction, TxnId),
+    ?assertEqual(undefined, maps:get(player_id, Kept, undefined)),
+    ?assertEqual(~"apple", maps:get(provider, Kept)),
+    ok.
+
+%% Deleting the group to free the foreign key would destroy every other
+%% member's data, so the group stands and loses its creator.
+leaves_a_group_standing_when_its_creator_is_erased(_Config) ->
+    PlayerId = a_player(),
+    {ok, Group} = insert(asobi_group, #{
+        name => unique(~"group"),
+        creator_id => PlayerId
+    }),
+    GroupId = maps:get(id, Group),
+
+    {ok, _} = asobi_player_erase:run(PlayerId),
+
+    {ok, Standing} = asobi_repo:get(asobi_group, GroupId),
+    ?assertEqual(undefined, maps:get(creator_id, Standing, undefined)),
+    ok.
+
+%%--------------------------------------------------------------------
+
+%% Every schema this module is expected to clear, with the column carrying the
+%% player id. Keep it in step with asobi_player_erase:steps/1 - a table added
+%% there and forgotten here is a test that passes for the wrong reason.
+deleted_children() ->
+    [
+        {asobi_player_stats, player_id},
+        {asobi_player_token, user_id},
+        {asobi_player_identity, player_id},
+        {asobi_wallet, player_id},
+        {asobi_player_item, player_id},
+        {asobi_storage, player_id},
+        {asobi_cloud_save, player_id},
+        {asobi_notification, player_id},
+        {asobi_chat_message, sender_id},
+        {asobi_group_member, player_id},
+        {asobi_leaderboard_entry, player_id}
+    ].
+
+a_player() ->
+    Username = unique(~"erase"),
+    {ok, Player} = insert(asobi_player, #{
+        username => Username,
+        display_name => Username,
+        hashed_password => ~"x"
+    }),
+    maps:get(id, Player).
+
+a_row_in_every_child_table(PlayerId) ->
+    {ok, _} = insert(asobi_player_stats, #{player_id => PlayerId, matches_played => 1}),
+    {ok, _} = insert(asobi_player_token, #{
+        user_id => PlayerId, token => unique(~"tok"), context => ~"refresh"
+    }),
+    {ok, _} = insert(asobi_player_identity, #{
+        player_id => PlayerId,
+        provider => ~"guest",
+        provider_uid => unique(~"pid")
+    }),
+    {ok, _} = insert(asobi_wallet, #{player_id => PlayerId, currency => ~"coins", balance => 1}),
+    {ok, Item} = insert(asobi_item_def, #{
+        slug => unique(~"sword"), name => ~"Sword", category => ~"weapon"
+    }),
+    {ok, _} = insert(asobi_player_item, #{
+        player_id => PlayerId,
+        item_def_id => maps:get(id, Item),
+        quantity => 1,
+        acquired_at => calendar:universal_time()
+    }),
+    {ok, _} = insert(asobi_storage, #{
+        player_id => PlayerId, collection => ~"c", key => ~"k", value => #{}
+    }),
+    {ok, _} = insert(asobi_cloud_save, #{player_id => PlayerId, slot => ~"1", data => #{}}),
+    {ok, _} = insert(asobi_notification, #{
+        player_id => PlayerId,
+        type => ~"t",
+        subject => ~"s",
+        sent_at => calendar:universal_time()
+    }),
+    {ok, _} = insert(asobi_chat_message, #{
+        sender_id => PlayerId,
+        channel_type => ~"global",
+        channel_id => unique(~"chan"),
+        content => ~"hello",
+        sent_at => calendar:universal_time()
+    }),
+    {ok, Group} = insert(asobi_group, #{name => unique(~"g"), creator_id => PlayerId}),
+    {ok, _} = insert(asobi_group_member, #{
+        group_id => maps:get(id, Group),
+        player_id => PlayerId,
+        joined_at => calendar:universal_time()
+    }),
+    {ok, _} = insert(asobi_leaderboard_entry, #{
+        leaderboard_id => unique(~"board"),
+        player_id => PlayerId,
+        score => 1
+    }),
+    ok.
+
+%% The repo takes a changeset, not a bare struct - `kura_changeset:cast/4` is
+%% what applies the schema's types and defaults.
+insert(Schema, Attrs) ->
+    asobi_repo:insert(kura_changeset:cast(Schema, #{}, Attrs, maps:keys(Attrs))).
+
+by(Schema, Field, PlayerId) ->
+    kura_query:where(kura_query:from(Schema), {Field, PlayerId}).
+
+unique(Prefix) ->
+    <<Prefix/binary, "_", (binary:encode_hex(crypto:strong_rand_bytes(8), lowercase))/binary>>.

--- a/test/asobi_player_erase_tests.erl
+++ b/test/asobi_player_erase_tests.erl
@@ -1,0 +1,280 @@
+-module(asobi_player_erase_tests).
+
+-include_lib("eunit/include/eunit.hrl").
+-include_lib("kura/include/kura.hrl").
+
+%% The cascade itself is proved against a real database in
+%% `asobi_guest_SUITE:reaper_erases_a_guest_with_a_row_in_every_child_table/1` -
+%% a mocked `asobi_repo` cannot see a missing child delete, which is exactly how
+%% eleven of them shipped. What is covered here is everything that is not a
+%% constraint: the order the steps run in, what a refusing extension does, the
+%% capability check, and the audit row committing with the erasure.
+
+-define(PLAYER, ~"01960000-0000-7000-8000-000000000001").
+-define(QUESTS, asobi_fixture_quests).
+
+erase_test_() ->
+    {foreach, fun setup/0, fun cleanup/1, [
+        {"every referencing table is touched, in order", fun every_table_is_touched/0},
+        {"a refusing extension leaves every core row alone", fun refusing_extension_aborts/0},
+        {"the receipt and the group are severed, not deleted", fun severs_rather_than_deletes/0},
+        {"both friendship columns are swept", fun friendships_use_both_columns/0},
+        {"the audit row is written inside the transaction", fun audit_is_in_the_transaction/0},
+        {"a failed audit insert rolls the erasure back", fun failed_audit_rolls_back/0},
+        {"an actor without the erasure class is refused", fun without_the_class_is_forbidden/0},
+        {"a refusal is audited too", fun a_refusal_is_audited/0},
+        {"the shell entry point needs no capability", fun shell_needs_no_capability/0},
+        {"a missing player is not_found, not a crash", fun missing_player_is_not_found/0},
+        {"a failed lookup is not reported as a missing player",
+            fun failed_lookup_is_not_not_found/0},
+        {"a failed lookup at the last step rolls back", fun failed_final_lookup_rolls_back/0},
+        {"the auth cache is revoked after the commit", fun revokes_after_commit/0},
+        {"live leaderboards drop the player after the commit", fun evicts_leaderboards/0}
+    ]}.
+
+setup() ->
+    asobi_extensions:reset(),
+    asobi_fixture_erase:reset(),
+    meck:new(asobi_repo, [no_link]),
+    meck:new(asobi_ops_audit, [no_link, passthrough]),
+    meck:new(asobi_auth_cache, [no_link]),
+    meck:expect(asobi_auth_cache, revoke_player, fun(_PlayerId) -> ok end),
+    meck:expect(asobi_ops_audit, record_strict, fun(_A, _Act, _T, _O) -> ok end),
+    meck:expect(asobi_ops_audit, record, fun(_A, _Act, _T, _O) -> ok end),
+    expect_player_present(),
+    ok.
+
+cleanup(_) ->
+    _ = asobi_fixture_app:uninstall(?QUESTS),
+    meck:unload(asobi_auth_cache),
+    meck:unload(asobi_ops_audit),
+    meck:unload(asobi_repo),
+    asobi_fixture_erase:reset(),
+    asobi_extensions:reset(),
+    ok.
+
+%% A transaction that runs its fun inline, so the assertions inside `steps/1`
+%% are the thing under test rather than something pgo would have to be present
+%% to exercise.
+expect_player_present() ->
+    meck:expect(asobi_repo, transaction, fun(Fun) -> Fun() end),
+    meck:expect(asobi_repo, get, fun(asobi_player, ?PLAYER) ->
+        {ok, #{id => ?PLAYER, username => ~"kaito"}}
+    end),
+    meck:expect(asobi_repo, update_all, fun(_Q, _Updates) -> {ok, 1} end),
+    meck:expect(asobi_repo, delete_all, fun(_Q) -> {ok, 1} end),
+    meck:expect(asobi_repo, delete, fun(asobi_player, _Player) -> {ok, #{}} end).
+
+install_quests() ->
+    ok = asobi_fixture_app:install(?QUESTS, asobi_fixture_quests_extension, []).
+
+actor(Caps) ->
+    #{
+        id => ~"static_secret",
+        display => ~"operator",
+        source => static_secret,
+        caps => Caps,
+        attested => false
+    }.
+
+%% Every schema a write touched, in the order the writes happened.
+written() ->
+    [
+        schema_of(Args)
+     || {_Pid, {asobi_repo, F, Args}, _Result} <- meck:history(asobi_repo),
+        lists:member(F, [update_all, delete_all, delete])
+    ].
+
+schema_of([#kura_query{from = Schema} | _]) -> Schema;
+schema_of([Schema | _]) when is_atom(Schema) -> Schema.
+
+%% The enumeration, pinned. A table dropped from `steps/1` makes the player
+%% undeletable in production and nothing else here would notice, because a
+%% mocked repo has no foreign keys. This does not prove the list is complete -
+%% only the CT test against Postgres can - but it does stop it shrinking.
+%%
+%% Extensions first, because an extension row holds the player down exactly as
+%% core's own children do, and an erase path may still want to read core's rows.
+every_table_is_touched() ->
+    install_quests(),
+    ?assertMatch({ok, _}, asobi_player_erase:run(?PLAYER)),
+    ?assertEqual([{quests, ?PLAYER}], asobi_fixture_erase:calls()),
+    ?assertEqual(
+        [
+            asobi_iap_transaction,
+            asobi_group,
+            asobi_transaction,
+            asobi_wallet,
+            asobi_player_item,
+            asobi_storage,
+            asobi_cloud_save,
+            asobi_notification,
+            asobi_leaderboard_entry,
+            asobi_chat_message,
+            asobi_group_member,
+            asobi_friendship,
+            asobi_player_stats,
+            asobi_player_token,
+            asobi_player_identity,
+            asobi_player
+        ],
+        written()
+    ).
+
+%% Atomic. The extension refuses, the assertion inside `steps/1` raises, and
+%% core never writes - so the player survives intact rather than half-erased.
+refusing_extension_aborts() ->
+    install_quests(),
+    ok = asobi_fixture_erase:outcome(quests, {error, ledger_is_immutable}),
+    ?assertMatch({error, {error, {badmatch, _}}}, asobi_player_erase:run(?PLAYER)),
+    ?assertEqual([], written()).
+
+%% The two tables that outlive their player. `iap_transactions` is a real-money
+%% receipt a chargeback still needs; deleting a `groups` row to free its
+%% `creator_id` would destroy every other member's data.
+severs_rather_than_deletes() ->
+    ?assertMatch({ok, _}, asobi_player_erase:run(?PLAYER)),
+    Severed = [
+        {schema_of(Args), Updates}
+     || {_Pid, {asobi_repo, update_all, [_Q, Updates] = Args}, _R} <- meck:history(asobi_repo)
+    ],
+    ?assertEqual(
+        [
+            {asobi_iap_transaction, #{player_id => null}},
+            {asobi_group, #{creator_id => null}}
+        ],
+        Severed
+    ),
+    Deleted = [S || S <- written(), S =:= asobi_iap_transaction orelse S =:= asobi_group],
+    ?assertEqual([asobi_iap_transaction, asobi_group], Deleted).
+
+%% One table, two foreign keys into the same player. A delete keyed only on
+%% `player_id` leaves every friendship the player is on the receiving end of,
+%% and each one holds the player row down.
+friendships_use_both_columns() ->
+    ?assertMatch({ok, _}, asobi_player_erase:run(?PLAYER)),
+    [Wheres] = [
+        W
+     || {_Pid, {asobi_repo, delete_all, [#kura_query{from = asobi_friendship, wheres = W}]}, _R} <-
+            meck:history(asobi_repo)
+    ],
+    ?assertEqual([{'or', [{player_id, ?PLAYER}, {friend_id, ?PLAYER}]}], Wheres).
+
+%% ADR 0007's rule is audit-after and never fail the operation. Erasure is the
+%% stated exception: the row is the only evidence left, so it commits with the
+%% deletion. `record_strict/4` inside the transaction is what makes that true.
+audit_is_in_the_transaction() ->
+    Actor = actor([erasure]),
+    ?assertMatch({ok, _}, asobi_player_erase:run(?PLAYER, Actor)),
+    ?assertEqual(
+        1,
+        meck:num_calls(
+            asobi_ops_audit, record_strict, [Actor, ~"players.erase", {~"player", ?PLAYER}, '_']
+        )
+    ),
+    ?assertEqual(0, meck:num_calls(asobi_ops_audit, record, '_')).
+
+failed_audit_rolls_back() ->
+    meck:expect(asobi_ops_audit, record_strict, fun(_A, _Act, _T, _O) ->
+        {error, disk_is_full}
+    end),
+    ?assertMatch({error, {error, {badmatch, _}}}, asobi_player_erase:run(?PLAYER)),
+    %% The writes were issued, and the badmatch is what makes the transaction
+    %% they sit in roll back rather than commit an unrecorded erasure.
+    ?assert(written() =/= []).
+
+without_the_class_is_forbidden() ->
+    ?assertEqual(
+        {error, forbidden}, asobi_player_erase:run(?PLAYER, actor([read, player_data, config]))
+    ),
+    ?assertEqual([], written()).
+
+a_refusal_is_audited() ->
+    Actor = actor([read]),
+    {error, forbidden} = asobi_player_erase:run(?PLAYER, Actor),
+    ?assertEqual(
+        1,
+        meck:num_calls(asobi_ops_audit, record, [
+            Actor, ~"players.erase", {~"player", ?PLAYER}, {error, forbidden}
+        ])
+    ).
+
+%% A caller holding a shell could call `asobi_repo:delete_all/1` directly, so
+%% there is nothing for a capability check to protect here - but the row must
+%% still say the node itself did it.
+shell_needs_no_capability() ->
+    ?assertMatch({ok, _}, asobi_player_erase:run(?PLAYER)),
+    [{_Pid, {asobi_ops_audit, record_strict, [Actor | _]}, _R}] = [
+        Call
+     || {_P, {asobi_ops_audit, record_strict, _}, _} = Call <- meck:history(asobi_ops_audit)
+    ],
+    ?assertEqual(shell, maps:get(source, Actor)),
+    ?assertEqual(false, maps:get(attested, Actor)).
+
+missing_player_is_not_found() ->
+    meck:expect(asobi_repo, get, fun(asobi_player, ?PLAYER) -> {error, not_found} end),
+    ?assertEqual({error, not_found}, asobi_player_erase:run(?PLAYER)),
+    ?assertEqual([], written()).
+
+%% `kura_repo_worker:get/3` returns `{error, not_found}` for an absent row and
+%% passes any query failure through as `{error, Other}`. Collapsing the two
+%% tells an operator answering a deletion request that there is nobody to
+%% delete, when the node only failed to find out - and 404 is the one answer
+%% that makes them stop asking.
+failed_lookup_is_not_not_found() ->
+    meck:expect(asobi_repo, get, fun(asobi_player, ?PLAYER) -> {error, connection_closed} end),
+    ?assertEqual({error, {lookup_failed, connection_closed}}, asobi_player_erase:run(?PLAYER)),
+    ?assertEqual([], written()).
+
+%% The same collapse one step lower is worse than a bad status code. Every
+%% child delete has already been issued when `delete_player/1` runs, so reading
+%% a failed lookup as "the row is already gone" returns `ok` from `steps/1`,
+%% commits the children, and leaves the `players` row standing - a half-erased
+%% player reporting success, with an audit row saying it was erased.
+failed_final_lookup_rolls_back() ->
+    meck:expect(asobi_repo, get, fun(asobi_player, ?PLAYER) ->
+        case get(seen_first_get) of
+            undefined ->
+                put(seen_first_get, true),
+                {ok, #{id => ?PLAYER, username => ~"kaito"}};
+            true ->
+                {error, statement_timeout}
+        end
+    end),
+    ?assertMatch(
+        {error, {error, {asobi_player_erase, {lookup_failed, _, _}}}},
+        asobi_player_erase:run(?PLAYER)
+    ),
+    %% The raise is what rolls the issued child deletes back; committing them
+    %% is the outcome this test exists to forbid.
+    ?assertEqual(0, meck:num_calls(asobi_repo, delete, [asobi_player, '_'])).
+
+%% asobi#215's revocation SLA: without this a deleted player's access token
+%% keeps resolving from the cache for up to auth_cache_ttl_ms against a row
+%% that no longer exists.
+revokes_after_commit() ->
+    ?assertMatch({ok, _}, asobi_player_erase:run(?PLAYER)),
+    ?assertEqual(1, meck:num_calls(asobi_auth_cache, revoke_player, [?PLAYER])).
+
+%% Deleting the `leaderboard_entries` rows is not enough: a running board serves
+%% reads from ETS and only hydrates at init, so it keeps the erased player until
+%% it restarts, and re-inserts any score still pending for them against a
+%% foreign key that is gone. Behaviour of the eviction itself is covered by
+%% `asobi_leaderboard_persistence_tests`; what this pins is that erasure calls
+%% it at all, and after the commit rather than inside the transaction.
+evicts_leaderboards() ->
+    meck:new(asobi_leaderboard_server, [no_link, passthrough]),
+    meck:expect(asobi_leaderboard_server, evict_player, fun(_PlayerId) -> ok end),
+    try
+        ?assertMatch({ok, _}, asobi_player_erase:run(?PLAYER)),
+        ?assertEqual(1, meck:num_calls(asobi_leaderboard_server, evict_player, [?PLAYER])),
+        %% After the commit: the player row is already deleted by the time the
+        %% board is told. An eviction inside the transaction would be a lie if
+        %% the transaction then rolled back, and ETS cannot roll back.
+        ?assert(
+            meck:called(asobi_repo, delete, [asobi_player, '_']) andalso
+                meck:called(asobi_leaderboard_server, evict_player, [?PLAYER])
+        )
+    after
+        meck:unload(asobi_leaderboard_server)
+    end.

--- a/test/asobi_player_export_tests.erl
+++ b/test/asobi_player_export_tests.erl
@@ -1,0 +1,165 @@
+-module(asobi_player_export_tests).
+
+-include_lib("eunit/include/eunit.hrl").
+-include_lib("kura/include/kura.hrl").
+
+-define(PLAYER, ~"01960000-0000-7000-8000-000000000001").
+-define(OTHER_VOTER, ~"01960000-0000-7000-8000-0000000000ff").
+
+export_test_() ->
+    {foreach, fun setup/0, fun cleanup/1, [
+        {"a missing player is not_found", fun missing_player/0},
+        {"the credential fields never leave", fun credentials_are_withheld/0},
+        {"every table erasure covers is exported", fun covers_the_same_tables/0},
+        {"match records are matched by containment", fun match_records_by_containment/0},
+        {"votes are matched by jsonb key existence", fun votes_by_key_existence/0},
+        {"a vote exports this player's choice and nobody else's",
+            fun votes_do_not_leak_other_voters/0}
+    ]}.
+
+setup() ->
+    meck:new(asobi_repo, [no_link]),
+    meck:expect(asobi_repo, get, fun(asobi_player, ?PLAYER) -> {ok, player_row()} end),
+    meck:expect(asobi_repo, all, fun(#kura_query{from = Schema}) -> {ok, [row(Schema)]} end),
+    ok.
+
+cleanup(_) ->
+    meck:unload(asobi_repo),
+    ok.
+
+%% Everything a projection could leak, on the two rows that carry one.
+player_row() ->
+    #{
+        id => ?PLAYER,
+        username => ~"kaito",
+        display_name => ~"Kaito",
+        avatar_url => undefined,
+        metadata => #{},
+        banned_at => undefined,
+        hashed_password => ~"pbkdf2-sha512$...",
+        inserted_at => {{2026, 1, 1}, {0, 0, 0}},
+        updated_at => {{2026, 1, 1}, {0, 0, 0}}
+    }.
+
+row(asobi_player_token) ->
+    #{
+        id => ~"t-1",
+        user_id => ?PLAYER,
+        token => ~"a-live-bearer-token",
+        context => ~"access",
+        family_id => ~"f-1",
+        used_at => undefined,
+        inserted_at => {{2026, 1, 1}, {0, 0, 0}}
+    };
+row(asobi_vote) ->
+    #{
+        id => ~"v-1",
+        match_id => ~"m-1",
+        template => ~"kick",
+        method => ~"majority",
+        options => [~"yes", ~"no"],
+        votes_cast => #{?PLAYER => ~"yes", ?OTHER_VOTER => ~"no"},
+        result => #{~"winner" => ~"yes"},
+        distribution => #{~"yes" => 1, ~"no" => 1},
+        turnout => 1.0,
+        opened_at => {{2026, 1, 1}, {0, 0, 0}},
+        closed_at => {{2026, 1, 1}, {0, 0, 30}}
+    };
+row(Schema) ->
+    #{id => atom_to_binary(Schema), player_id => ?PLAYER}.
+
+missing_player() ->
+    meck:expect(asobi_repo, get, fun(asobi_player, ?PLAYER) -> {error, not_found} end),
+    ?assertEqual({error, not_found}, asobi_player_export:run(?PLAYER)).
+
+%% Positive allowlists, never `maps:without/2`: `players` carries
+%% `hashed_password` and `player_tokens` carries a live bearer credential, so a
+%% subtractive filter is one schema field away from exporting either.
+credentials_are_withheld() ->
+    {ok, #{player := Player, tokens := [Token]}} = asobi_player_export:run(?PLAYER),
+    ?assertNot(maps:is_key(hashed_password, Player)),
+    ?assertEqual(~"kaito", maps:get(username, Player)),
+    ?assertNot(maps:is_key(token, Token)),
+    ?assertEqual(~"access", maps:get(context, Token)).
+
+%% The export and the erasure describe the same footprint. Two lists that drift
+%% mean an operator answering an access request under-reports what a deletion
+%% request would remove.
+covers_the_same_tables() ->
+    {ok, Payload} = asobi_player_export:run(?PLAYER),
+    Queried = lists:usort([
+        Schema
+     || {_Pid, {asobi_repo, all, [#kura_query{from = Schema}]}, _R} <- meck:history(asobi_repo)
+    ]),
+    ?assertEqual(
+        lists:usort([
+            asobi_chat_message,
+            asobi_cloud_save,
+            asobi_friendship,
+            asobi_group,
+            asobi_group_member,
+            asobi_iap_transaction,
+            asobi_leaderboard_entry,
+            asobi_match_record,
+            asobi_notification,
+            asobi_player_identity,
+            asobi_player_item,
+            asobi_player_stats,
+            asobi_player_token,
+            asobi_storage,
+            asobi_transaction,
+            asobi_vote,
+            asobi_wallet
+        ]),
+        Queried
+    ),
+    ?assertEqual(18, map_size(Payload)).
+
+%% `match_records.players` is a jsonb id list with no foreign key, so a match a
+%% player took part in is only reachable by containment.
+match_records_by_containment() ->
+    {ok, _} = asobi_player_export:run(?PLAYER),
+    [Wheres] = [
+        W
+     || {_Pid, {asobi_repo, all, [#kura_query{from = asobi_match_record, wheres = W}]}, _R} <-
+            meck:history(asobi_repo)
+    ],
+    ?assertMatch([{fragment, ~"\"players\" @> ?::jsonb", [_]}], Wheres),
+    [{fragment, _, [Json]}] = Wheres,
+    ?assertEqual([?PLAYER], json:decode(Json)).
+
+%% `votes_cast` is a jsonb object keyed by voter id, not a list, so containment
+%% is the wrong test - the key has to be probed. `jsonb_exists/2` rather than
+%% its `?` infix form, because `?` is the parameter placeholder in a fragment.
+votes_by_key_existence() ->
+    {ok, _} = asobi_player_export:run(?PLAYER),
+    [Wheres] = [
+        W
+     || {_Pid, {asobi_repo, all, [#kura_query{from = asobi_vote, wheres = W}]}, _R} <-
+            meck:history(asobi_repo)
+    ],
+    ?assertEqual([{fragment, ~"jsonb_exists(\"votes_cast\", ?)", [?PLAYER]}], Wheres).
+
+%% The one table here whose row is about several people at once. Exporting
+%% `votes_cast` as stored would hand the requester every other voter's private
+%% choice - a data-subject request turned into a disclosure of everyone else.
+votes_do_not_leak_other_voters() ->
+    {ok, #{votes := [Vote]}} = asobi_player_export:run(?PLAYER),
+    ?assertEqual(~"yes", maps:get(choice, Vote)),
+    ?assertNot(maps:is_key(votes_cast, Vote)),
+    %% Belt and braces: no other voter's id appears anywhere in the projection,
+    %% however the row is reshaped later.
+    Flat = iolist_to_binary(io_lib:format("~p", [Vote])),
+    ?assertEqual(nomatch, binary:match(Flat, ?OTHER_VOTER)),
+    %% Aggregates name nobody, so they survive and keep the vote readable.
+    ?assertEqual(1.0, maps:get(turnout, Vote)),
+    ?assertEqual(#{~"yes" => 1, ~"no" => 1}, maps:get(distribution, Vote)),
+    %% A player who did not vote in a row that reached the projection is `null`,
+    %% not a crash and not a missing key.
+    ?assertEqual(null, maps:get(choice, asobi_player_export_probe(~"nobody"))).
+
+%% The projection applied to the same row for a player who never voted in it.
+asobi_player_export_probe(PlayerId) ->
+    meck:expect(asobi_repo, get, fun(asobi_player, _) -> {ok, player_row()} end),
+    {ok, #{votes := [Vote]}} = asobi_player_export:run(PlayerId),
+    Vote.

--- a/test/asobi_rpc_SUITE.erl
+++ b/test/asobi_rpc_SUITE.erl
@@ -183,9 +183,12 @@ rpc_call(Conn, Cid, Method, Params) ->
     ),
     Reply.
 
+%% asobi#357: `erlang:unique_integer/1` is unique per runtime instance, not
+%% across runs, while `players` persists - so a later run re-mints a username an
+%% earlier one registered and hits the unique index. The name must stay inside
+%% the 32-character username limit, hence a short tag plus 8 hex.
 register_player(Suffix, Config) ->
-    N = integer_to_binary(erlang:unique_integer([positive])),
-    Username = <<"rpcprobe_", N/binary, "_", Suffix/binary>>,
+    Username = <<"rpc_", Suffix/binary, "_", (asobi_id:rand_suffix(4))/binary>>,
     {ok, Resp} = nova_test:post(
         "/api/v1/auth/register",
         #{json => #{~"username" => Username, ~"password" => ~"testpass123"}},

--- a/test/asobi_world_lobby_ws_SUITE.erl
+++ b/test/asobi_world_lobby_ws_SUITE.erl
@@ -308,9 +308,20 @@ register_player(Suffix, Config) ->
     #{~"player_id" := PlayerId, ~"access_token" := Token} = nova_test:json(Resp),
     {PlayerId, Token}.
 
+%% asobi#357 again: `erlang:unique_integer/1` is unique within one runtime
+%% instance, and each run is a new one - it restarts from a low value while the
+%% `players` table persists across runs, so a later run re-mints a username an
+%% earlier one already registered and the insert fails the unique index.
+%% Observed as `sequential_clients_reuse_existing_world` failing with "That
+%% username already belongs to another player" on a database that had seen a
+%% few runs.
+%%
+%% `lob_` rather than the old `wsprobe_`, which `asobi_ws_SUITE` also minted -
+%% two suites drawing from one namespace only made the collision likelier. The
+%% whole name has to stay inside the 32-character username limit, so this is a
+%% short tag plus 8 hex rather than `asobi_test_helpers:unique_id/1`.
 unique_name(Suffix) ->
-    N = integer_to_binary(erlang:unique_integer([positive])),
-    <<"wsprobe_", N/binary, "_", Suffix/binary>>.
+    <<"lob_", Suffix/binary, "_", (asobi_id:rand_suffix(4))/binary>>.
 
 ws_connect_authed(Token, Config) ->
     {ok, Conn} = nova_test_ws:connect("/ws", Config),

--- a/test/asobi_ws_SUITE.erl
+++ b/test/asobi_ws_SUITE.erl
@@ -201,9 +201,12 @@ register_player(Suffix, Config) ->
     #{~"player_id" := PlayerId, ~"access_token" := Token} = nova_test:json(Resp),
     {PlayerId, Token}.
 
+%% asobi#357: `erlang:unique_integer/1` is unique per runtime instance, not
+%% across runs, while `players` persists - so a later run re-mints a username an
+%% earlier one registered and hits the unique index. The name must stay inside
+%% the 32-character username limit, hence a short tag plus 8 hex.
 unique_name(Suffix) ->
-    N = integer_to_binary(erlang:unique_integer([positive])),
-    <<"wsprobe_", N/binary, "_", Suffix/binary>>.
+    <<"ws_", Suffix/binary, "_", (asobi_id:rand_suffix(4))/binary>>.
 
 ws_connect_authed(Token, Config) ->
     {ok, Conn} = nova_test_ws:connect("/ws", Config),


### PR DESCRIPTION
Three findings from the docs overhaul. The first turned out to be a **live bug**, not a missing feature.

## The guest reaper has been broken

The finding was "there is no way to delete a player". The architecture ruling found worse: the one deletion path that exists does not work.

All **15** core foreign keys into `players.id` are `ON DELETE NO ACTION`. `asobi_guest_reaper` deleted **four** child tables of fourteen. So a guest who earned one coin (`wallets` is created lazily on first currency), wrote one cloud save, or sent one chat message could never be reaped: the `players` delete raises an FK violation, the `{ok, _} =` badmatch rolls back the transaction, it logs `guest_reap_cascade_error`, and the next sweep tries again forever.

I verified all of this independently before accepting it.

**Why nothing caught it:** `test/asobi_guest_reaper_tests.erl` does `meck:expect(asobi_repo, delete, fun(asobi_player, _) -> {ok, #{}} end)`. The delete cannot fail. The database - the only party that knows a row is still referenced - was never in the test.

## What ships

`asobi_player_erase` is now the single erasure path with the complete child list; the reaper delegates to it rather than being a second implementation.

**Hard delete, not anonymise.** Every player-referencing table already stores a bare uuid and nothing else about the person, so deleting `players` + `player_identities` *is* the anonymisation - surviving ids resolve to nobody. Two tables are severed instead of deleted: `iap_transactions` (a chargeback dispute needs the receipt; statutory retention beats erasure) and `groups.creator_id` (deleting the group would destroy other members' data). That is what the migration is for - two `DROP NOT NULL`s, reversible.

`asobi_player_export` ships alongside as a **positive allowlist**, never `maps:without/2`: `players` carries `hashed_password`, and a subtractive filter is one schema field away from exporting a credential.

## The test the reaper never had

`asobi_player_erase_SUITE` runs against real Postgres: inserts a row in **every** child table, erases, asserts the player and all children are gone, and that the two severed rows survive with their player link nulled.

I proved it bites rather than trusting a green run - deleted the wallet step from the module, watched the suite fail, restored it, watched it pass. A table added in future without teaching the module about it fails here instead of in a self-hoster's reaper log.

Writing it also caught two mistakes in my own assertions: `chat_messages` keys on `sender_id`, not `player_id`, and `leaderboard_entries` on `leaderboard_id`. Both would have passed for the wrong reason. The module had them right.

## Bots were silently broken in shared-state modes

`broadcast_shared_state` sends `{match_state_raw, PreEncoded}`; `asobi_bot` only matched `{match_state, _}`, and its catch-all clause swallowed the rest. A bot's state stayed empty for its entire life - no error, no log. Fixed, and the caveat the docs overhaul added is replaced with what is now true.

## Cloud guide

`guides/cloud.md` - there was none, and the CLI that is how Lua actually reaches a cloud environment was mentioned **zero** times in this repo.

## Checks

`fmt --check`, `xref`, `dialyzer` clean. **1661 EUnit**, plus the new CT suite green against real Postgres. Both doc guards pass.