### PR TITLE
ci: allow a manual CI re-run

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,12 @@ on:
   pull_request:
     branches: [main]
     paths-ignore: ['**.md', 'docs/**', 'LICENSE']
+  # Manual re-run. CI here only triggers on push and pull_request, so when a
+  # run is lost - a cancelled job, an Actions incident draining a backlog -
+  # there is no way to ask for another against main without pushing to it,
+  # which the PR-only workflow forbids. During the 2026-08-06 Actions outage
+  # main sat with no completed CI run for hours for exactly this reason.
+  workflow_dispatch:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}


### PR DESCRIPTION
CI triggers on `push` and `pull_request` only, so a lost run against main cannot be asked for again without pushing to main - which the PR-only workflow forbids.

Not hypothetical. During yesterday's Actions outage, #403 merged while jobs were being cancelled, and main sat with **no completed CI run for hours** with no way to request one. The queued reruns were themselves among the stuck jobs and never got a runner; only a freshly-triggered job ran.

This PR's own run doubles as the missing check on main's tree, since it merges into it.