### PR TITLE
docs: the old image name is no longer rebuilt

### DIFF
--- a/guides/getting-started.md
+++ b/guides/getting-started.md
@@ -123,8 +123,9 @@ services:
       ASOBI_CORS_ORIGINS: "*"
 ```
 
-The image was renamed from `ghcr.io/widgrensit/asobi_lua`; the old name still
-publishes for now, so change your compose file when convenient.
+The image was renamed from `ghcr.io/widgrensit/asobi_lua`. That name is no
+longer rebuilt - tags already published keep working and are not going away,
+but they will not get fixes - so change your compose file.
 
 `ASOBI_CORS_ORIGINS` has no default. Left unset, the node answers with an empty
 `Access-Control-Allow-Origin` and every browser request fails with nothing in

--- a/guides/glossary.md
+++ b/guides/glossary.md
@@ -28,8 +28,8 @@ blocks, which are still read - see
 [Which application key](configuration.md#which-application-key).
 
 The one stale `asobi_lua` is the image name. `ghcr.io/widgrensit/asobi_lua`
-still publishes, so an existing compose file keeps working; change it to
-`ghcr.io/widgrensit/asobi` when convenient.
+is no longer rebuilt: tags already published keep working and are never
+deleted, but they receive no fixes. Use `ghcr.io/widgrensit/asobi`.
 
 ## Client SDKs
 

--- a/guides/self-hosting.md
+++ b/guides/self-hosting.md
@@ -170,8 +170,9 @@ database password, so Postgres and asobi cannot drift apart. `ops_secret.txt`
 is mounted as a file rather than passed as a variable, which keeps it out of
 `docker inspect` and out of the process environment.
 
-The image was renamed from `ghcr.io/widgrensit/asobi_lua`; the old name still
-publishes for now, so change your compose file when convenient.
+The image was renamed from `ghcr.io/widgrensit/asobi_lua`. That name is no
+longer rebuilt - tags already published keep working and are not going away,
+but they will not get fixes - so change your compose file.
 
 ```yaml
 services:


### PR DESCRIPTION
Three guides said `ghcr.io/widgrensit/asobi_lua` **"still publishes for now"**. True when written, false since the final build went out - publishing stopped yesterday, and that image now announces its own rename on every start.

Tags already published keep working and are never deleted. That is the part worth stating plainly: the reason to move is that nothing new lands there, not that anything breaks today.

`guides/glossary.md` is generated onto asobi.dev, so this also unsticks the site copy, which currently tells readers the opposite.