### PR TITLE
docs: close the last four gaps from the docs audit

### DIFF
--- a/guides/comparison.md
+++ b/guides/comparison.md
@@ -107,10 +107,13 @@ is CPU spent on message processing, not memory. Figures and method are in
 ## Clustering
 
 Multiple nodes share Postgres and `pg`-scoped presence, chat and process
-lookups. Three things stay node-local and change how you deploy: the matchmaker
-queue, the rate-limit buckets and the console session store, so the console
-needs a sticky route and players queuing against different nodes never match
-each other. [Clustering](clustering.md) has the full list.
+lookups. Four things stay node-local and change how you deploy: the matchmaker
+queue, the rate-limit buckets, the console session store and the player-to-world
+table - so the console needs a sticky route, players queuing against different
+nodes never match each other, and a player who reconnects to a different node
+loses their world with no error. That last one is the only item here a player
+notices and an operator does not, which is why it belongs in the summary rather
+than only in the full list. [Clustering](clustering.md) has the rest.
 
 ## Client SDKs
 

--- a/guides/extensions.md
+++ b/guides/extensions.md
@@ -58,7 +58,7 @@ extension means building your own release from the Hex package.
 | Caller | Path | For |
 |---|---|---|
 | Game logic, in-match, server-side | `game.quests.progress(player_id, 1)` | "player killed something, +1" |
-| Game client, over the network | `asobi.rpc("quests.claim", ...)` | "give me my reward" |
+| Game client, over the network | an `rpc.call` frame - `ws.rpc(...)` in JS, `rpc_call(...)` in Godot, `realtime:rpc(...)` in Defold and LÖVE | "give me my reward" |
 | An operator, on the ops plane | `POST /api/v1/ops/ext/quests/define` | "add a daily quest" |
 
 An extension with only the wire cannot observe gameplay; one with only Lua
@@ -170,6 +170,30 @@ try {
 realtime.rpc_call("quests.claim", {"quest_id": "q-1"}, func(ok, data):
     if ok: print(data["reward"])
     else:  print(data["code"]))
+```
+
+Without an SDK - to check a method by hand, or from a language with no asobi
+SDK yet - it is two frames on the socket. RPC rides the game WebSocket, so this
+is `websocat` rather than `curl`, and the socket must be authenticated first:
+an `rpc.call` on an unauthenticated socket is rejected, because `rpc/0` is
+player-scoped and there is no player yet.
+
+```bash
+TOKEN=$(curl -sX POST https://your-host/api/v1/auth/login \
+  -H 'content-type: application/json' \
+  -d '{"username":"alice","password":"..."}' | jq -r .access_token)
+
+printf '%s\n%s\n' \
+  "{\"type\":\"session.connect\",\"cid\":\"1\",\"payload\":{\"token\":\"$TOKEN\"}}" \
+  '{"type":"rpc.call","cid":"2","payload":{"protocol":1,"method":"quests.claim","params":{"quest_id":"q-1"}}}' \
+  | websocat wss://your-host/ws
+```
+
+The reply carries the `cid` you sent, which is what lets several calls be in
+flight at once:
+
+```json
+{"type":"rpc.ok","cid":"2","payload":{"result":{"reward":100}}}
 ```
 
 Branch on `code`, never on `message`. The shape is the same in every SDK - a

--- a/guides/getting-started.md
+++ b/guides/getting-started.md
@@ -218,6 +218,49 @@ Two things behave differently:
 - A bot script is loaded when the bot process starts, so an edit reaches bots
   spawned after it, not bots already in a match.
 
+### Play it
+
+Everything above sets the game up. This runs it, and it is worth doing once
+before writing any more Lua - the loop it proves is the whole product.
+
+Register a player and keep the token:
+
+```bash
+TOKEN=$(curl -sX POST http://localhost:8084/api/v1/auth/register \
+  -H 'content-type: application/json' \
+  -d '{"username":"player1","password":"secret123"}' | jq -r .access_token)
+```
+
+Then open a socket, authenticate, and queue:
+
+```bash
+printf '%s\n%s\n' \
+  "{\"type\":\"session.connect\",\"cid\":\"1\",\"payload\":{\"token\":\"$TOKEN\"}}" \
+  '{"type":"matchmaker.add","cid":"2","payload":{"mode":"default"}}' \
+  | websocat ws://localhost:8084/ws
+```
+
+`mode` is `"default"` because a bare `lua/match.lua` with no `config.lua`
+registers one mode under that name.
+
+You will see `session.connected`, then `matchmaker.queued`, then **a pause of
+up to eight seconds**, then `match.matched` followed by `match.state` frames.
+
+The pause is the part worth understanding rather than waiting out. Your mode
+declares `match_size = 2` and you are one player, so nothing can form yet. The
+bot spawner checks the queue every eight seconds, sees somebody waiting in a
+mode that declares `bots`, and queues one - which is why bots never start a
+match on their own, and why your first match needs a human to want it. Remove
+the `bots` line and this command waits forever until a second player queues.
+
+Each `match.state` is the return value of your `tick` function, encoded and
+broadcast. That is the loop: your Lua ran on the server, and a client that
+speaks four JSON frames saw the result.
+
+From here a real client replaces `websocat` - see the
+[WebSocket protocol](websocket-protocol.md) for the full frame list, or pick an
+SDK from the [README](../README.md) and skip the frames entirely.
+
 See [Lua scripting](lua-scripting.md) for the full callback reference and
 [Lua API](lua-api.md) for the host functions available inside a script.
 
@@ -337,7 +380,7 @@ rebar3 shell
 Database migrations run automatically on startup. The server is now listening
 on the configured port.
 
-## Register a player
+### 4. Register a player
 
 bash (Linux, macOS, Git Bash, WSL):
 
@@ -366,7 +409,7 @@ Response:
 }
 ```
 
-## Connect via WebSocket
+### 5. Connect via WebSocket
 
 Connect to `ws://localhost:8084/ws` and send the `access_token`:
 
@@ -382,7 +425,7 @@ Connect to `ws://localhost:8084/ws` and send the `access_token`:
 A connection that never sends `session.connect` is closed by the idle-auth
 timer (1008, `idle_auth_timeout`).
 
-## Implement your game
+### 6. Implement your game
 
 Create a module implementing the `asobi_match` behaviour:
 

--- a/guides/self-hosting.md
+++ b/guides/self-hosting.md
@@ -237,6 +237,50 @@ volumes:
 Put this behind a TLS-terminating reverse proxy (Caddy, nginx, Traefik). asobi
 speaks plain HTTP and WebSocket and expects the proxy to handle certificates.
 
+### A worked Caddy block
+
+```caddy
+your-host.example.com {
+	# Caddy sends X-Forwarded-Proto by default, which is what asobi reads to
+	# decide whether the console's session cookie may be marked Secure. Behind
+	# a proxy that does NOT send it, set {console_secure_cookie, true} instead
+	# and the cookie is marked regardless.
+	reverse_proxy localhost:8084
+}
+```
+
+That is the whole thing. Caddy upgrades WebSockets and forwards the
+`X-Forwarded-*` headers without being asked, which is why the block is three
+lines - most of what a worked example usually spells out is default here.
+
+Two things it does **not** do, both of which matter later rather than now:
+
+- **CORS is asobi's, not the proxy's.** `ASOBI_CORS_ORIGINS` is what a browser
+  client is checked against; a proxy header will not stand in for it.
+- **One node only.** Behind a load balancer across several nodes, `/ws`,
+  `/console` and `/api/v1/ops` all need a **sticky** route. Sessions, console
+  logins and a player's world are all remembered on the node that made them -
+  see [Clustering](clustering.md), where the failure modes are listed and one
+  of them is silent.
+
+nginx needs the upgrade headers stated explicitly:
+
+```nginx
+location / {
+    proxy_pass         http://127.0.0.1:8084;
+    proxy_http_version 1.1;
+    proxy_set_header   Upgrade    $http_upgrade;
+    proxy_set_header   Connection "upgrade";
+    proxy_set_header   Host       $host;
+    proxy_set_header   X-Forwarded-Proto $scheme;
+    proxy_read_timeout 3600s;   # a game socket is idle between ticks
+}
+```
+
+The read timeout is the one people miss: nginx defaults to 60 seconds and will
+close a quiet WebSocket, which surfaces as players dropping on a timer nobody
+configured.
+
 `ASOBI_NODE_HOST` is not in that compose on purpose. It names the Erlang node
 (`-name asobi@${ASOBI_NODE_HOST}` in `config/vm.args.src`), not a bind address;
 the port asobi listens on is `ASOBI_PORT`. The image default `127.0.0.1` is


### PR DESCRIPTION
## Getting started never reached a running game

The Lua path ended at hot-reloading. A reader wrote `match.lua`, a bot script and a compose file, and **never once executed any of it**.

There is now a **Play it** step: register, open a socket, queue, watch `match.state` arrive. It also explains the pause, which matters more than it looks - `match_size = 2` and you are one player, so nothing can form until the bot spawner's **eight-second** check notices somebody waiting in a mode that declares `bots`. Without that sentence the guide looks broken for eight seconds, which is long enough to close the tab.

Verified against source: bots only fill a queue that already has someone in it, so a mode with nobody waiting is skipped and bots never start a match on their own.

**Structure went with it.** `Register a player`, `Connect via WebSocket` and `Implement your game` sat at top level *after* `## Erlang OTP`, so the outline read as though the Lua path stopped halfway and the Erlang path had three trailing sections. They are steps 4-6 of the Erlang path and now say so.

## The reverse proxy was one sentence

It named three proxies and stopped. There are now worked Caddy and nginx blocks, with the two things that actually bite:

- **nginx's 60-second default read timeout closes an idle game socket**, which surfaces as players dropping on a timer nobody configured.
- **CORS is asobi's business, not the proxy's** - a proxy header will not stand in for `ASOBI_CORS_ORIGINS`.

Plus the sticky-route requirement for a cluster, pointing at the failure modes in `clustering.md` - one of which is silent.

## The RPC callers table named an API that does not exist

`extensions.md` showed `asobi.rpc("quests.claim", ...)`. That is no SDK's API: it is `ws.rpc` in JS, `rpc_call` in Godot, `realtime:rpc` in Defold and LÖVE.

Added a raw two-frame example for checking a method by hand - **websocat, not curl**, because RPC rides the game socket, and with `session.connect` first because `rpc/0` is player-scoped and an unauthenticated socket is rejected. I checked the login response field is `access_token`, not `session_token`, before writing it.

## The comparison summary dropped the one that fails silently

It said three things stay node-local and named the three an *operator* notices. The fourth is the player-to-world table: reconnect to a different node and your world is gone, with no error - `asobi_ws_handler.erl:375` falls through to `_ -> ok` and sends `session.connected` as normal.

`clustering.md` already had it. The summary most readers stop at did not.

## Checks

All three doc guards green, `ex_doc` builds clean, every internal link resolves.