### PR TITLE
feat(lua): read listed and quick_play as mode globals

### DIFF
--- a/guides/configuration.md
+++ b/guides/configuration.md
@@ -176,6 +176,19 @@ an operator mode wins a name clash and a game bundle can never drop or redefine
 it. Read it with `asobi_game_config:modes/0`. The raw `game_modes` app-env key
 is only the operator half.
 
+**The override is whole-entry, not per-key.** The merge happens at the mode
+name, so an operator entry replaces the game's entire map for that mode rather
+than layering onto it. Writing the minimal-looking
+
+```erlang
+{game_modes, #{~"arena" => #{listed => true}}}
+```
+
+does not force `listed` on top of the game's config - it replaces the mode with
+one that declares no `module`, and the mode then fails to resolve. To override
+one key you must restate the whole shape, including
+`module => {lua, "..."}`.
+
 ## Game directory
 
 ```erlang

--- a/guides/configuration.md
+++ b/guides/configuration.md
@@ -31,12 +31,16 @@ bots = { script = "bots/arena_bot.lua" }
 | `strategy` | no | `"fill"` | `"fill"`, `"skill_based"`, or a custom module |
 | `bots` | no | none | `{ script = "path/to/bot.lua" }` - see [Bots](lua-bots.md) |
 | `game_type` | no | `"match"` | `"match"` or `"world"` |
+| `listed` | no | `false` for matches, `true` for worlds | Whether instances appear in discovery (`match.list` / `world.list`). Never gates joining |
+| `quick_play` | no | `true` | Whether `world.find_or_create` may place a player into an existing instance of this mode |
 | `state_strategy` | no | none | `"shared"` selects the encode-once broadcast path |
 | `guest_auth` | no | `false` | Declares that this game offers anonymous play. The operator still has to supply a pepper |
 | `registration` | no | none | `"open"`, `"oauth_only"` or `"closed"`. The operator's `sys.config` wins when it sets one |
 
 World-mode games (`game_type = "world"`) read a further set of globals -
-`tick_rate`, `grid_size`, `zone_size`, `view_radius`, `empty_grace_ms`,
+`tick_rate`, `grid_size`, `zone_size`, `view_radius`, `persistent`,
+`lazy_zones`, `zone_idle_timeout`, `max_active_zones`,
+`spatial_grid_cell_size`, `cold_tick_divisor`, `empty_grace_ms`,
 `player_ttl_ms`. [World server](world-server.md) documents those.
 
 **Where you put `guest_auth` and `registration` matters.** They are read from
@@ -154,7 +158,7 @@ Shorthand (Erlang module only):
 | `skill_expand_rate` | `50` | Window expansion per 5 seconds (`skill_based` only) |
 | `bots` | `#{}` | Bot configuration - see [Bots](lua-bots.md) |
 | `listed` | `false` for matches, `true` for worlds | Whether instances appear in discovery (`match.list` / `world.list`). Matches are unlisted by default: a matchmaker-spawned match is already assigned to its players, so opt in explicitly |
-| `quick_play` | `true` | Worlds only. Whether `world.find_or_create` may place a player into an existing world of this mode. Independent of `listed` - see [World server](world-server.md#visibility) |
+| `quick_play` | `true` | Whether `world.find_or_create` may place a player into an existing world of this mode. Read on the world entry path for whatever mode name it is handed, so setting it `false` on a match mode is protective rather than inert. Independent of `listed` - see [World server](world-server.md#visibility) |
 
 ### Operator modes and game-declared modes
 

--- a/guides/lobbies.md
+++ b/guides/lobbies.md
@@ -88,12 +88,12 @@ tick_rate   = 200     -- 5 Hz is plenty; the 50ms default is for action games
 match_size  = 1
 ```
 
-`listed` and `quick_play` are not Lua globals - the loader does not read them,
-so writing them in a script does nothing. Both default to true, which is what a
-hub wants: it is browsable and `world.find_or_create` drops everyone into the
-same one. Changing either needs an operator `game_modes` entry for that mode,
-which replaces the script's mode config rather than merging into it - so
-declare `module => {lua, "hub.lua"}` and the rest of the shape in it too.
+`listed` and `quick_play` are Lua globals, both defaulting to true for a world -
+which is what a hub wants: it is browsable and `world.find_or_create` drops
+everyone into the same one. Set either to `false` in the script to change it.
+An operator `game_modes` entry still wins, and it replaces the script's mode
+config rather than merging into it - so if you add one, declare
+`module => {lua, "hub.lua"}` and the rest of the shape in it too.
 
 `persistent` is the flag that makes it a hub rather than a session. Without it a
 world finishes the moment the last player leaves, so the next player gets a
@@ -126,11 +126,11 @@ function join(player_id, state, ctx)
 end
 ```
 
-Hiding it from the browser needs `listed => false` in an Erlang `game_modes`
-entry; a Lua-only game cannot set it, so its code-gated world stays listed and
-the join callback is the whole gate. `listed` and `quick_play` are properties
-of the mode, not of one instance, so every world of that mode is equally
-hidden. See [Join context](websocket-protocol.md#join-context).
+Hide it from the browser with `listed = false` in the script. That is discovery
+only - it never gates joining, so the join callback above is still the whole
+gate. `listed` and `quick_play` are properties of the mode, not of one
+instance, so every world of that mode is equally hidden. See
+[Join context](websocket-protocol.md#join-context).
 
 ### Telling the room someone arrived
 

--- a/guides/lua-scripting.md
+++ b/guides/lua-scripting.md
@@ -182,6 +182,7 @@ match_size   = 4                          -- required: min players to start
 max_players  = 10                         -- optional: max per match
 strategy     = "fill"                     -- optional: "fill" or "skill_based"
 bots         = { script = "bots/ai.lua" } -- optional: enable bot filling
+listed       = true                       -- optional: show live instances in discovery
 guest_auth   = true                       -- optional: allow anonymous guest play
 registration = "closed"                   -- optional: signup posture
 ```
@@ -194,12 +195,20 @@ registration = "closed"                   -- optional: signup posture
 | `game_type` | no | `"match"` | `"world"` routes the script through the world bridge - see [World server](world-server.md) |
 | `state_strategy` | no | per-player | `"shared"` broadcasts one payload to everyone; see below |
 | `bots` | no | none | Bot configuration - see [Bots](lua-bots.md) |
+| `listed` | no | `false` for matches, `true` for worlds | Whether live instances appear in `match.list` / `world.list`. Discovery only - it never gates joining, so a client holding an id still joins an unlisted instance |
+| `quick_play` | no | `true` | Whether `world.find_or_create` may place a player into an existing instance of this mode |
 | `guest_auth` | no | `false` | Offer anonymous no-account play. Also requires an operator-supplied pepper; on only when both are present (ADR 0004) |
 | `registration` | no | `"open"` | `"open"`, `"oauth_only"` (no password signup) or `"closed"` (no new players). The operator layer wins: this applies only when the release's `sys.config` leaves `registration` unset |
 
 `strategy` is not validated. A value that is neither `"fill"` nor
 `"skill_based"` falls back to `fill`, and nothing is logged - check the
 spelling yourself.
+
+`listed` and `quick_play` must be a Lua `true` or `false`. Anything else is
+ignored with a warning and the default applies. Watch for `listed = 0`: 0 is
+truthy in Lua, so it does not mean "off", and on a world - where the default
+is `true` - taking it as a value would leave the world browsable when you
+asked to hide it.
 
 `state_strategy = "shared"` routes the mode to a different bridge, one that
 calls `get_state` **once per tick with one argument** and sends a single

--- a/guides/migrate-from-hathora.md
+++ b/guides/migrate-from-hathora.md
@@ -161,7 +161,7 @@ mutation, which is well within the scope of one Lua file.
 | `createLobby`, `createRoom`, queue | `POST /api/v1/matchmaker` | Body `{"mode": "...", "properties": {}}`, response `{"ticket_id": "...", "status": "pending"}`. |
 | Ticket poll | `GET /api/v1/matchmaker/:ticket_id` | |
 | Cancel | `DELETE /api/v1/matchmaker/:ticket_id` | |
-| `listActivePublicLobbies` | `GET /api/v1/matches/live` | Live, joinable matches; filter with `mode` and `has_capacity`. Matches are unlisted by default and a mode opts in with `listed => true` in the operator's `game_modes` config; the Lua config reader does not pick up a `listed` global. Not `GET /api/v1/matches`, which is the finished-match record table. |
+| `listActivePublicLobbies` | `GET /api/v1/matches/live` | Live, joinable matches; filter with `mode` and `has_capacity`. Matches are unlisted by default and a mode opts in with `listed = true` (a Lua global, or `listed => true` in the operator's `game_modes` config). Not `GET /api/v1/matches`, which is the finished-match record table. |
 | `getConnectionInfo(roomId)` | WebSocket upgrade on `GET /ws` | See [WebSocket handshake](#websocket-handshake). The first frame must authenticate. |
 | Custom room messages | Extension RPC | Frame `rpc.call` with `{protocol: 1, method, params}`; replies `rpc.ok` `{result}` or `rpc.error` `{error: {code, message, details}}`, correlated by `cid`. All seven client SDKs support it. See [Extensions](extensions.md). |
 | `ping` region API | None | Probe each deployment endpoint yourself if you need client-side region selection. |

--- a/guides/rest-api.md
+++ b/guides/rest-api.md
@@ -121,8 +121,9 @@ POST /api/v1/worlds         Create a world
 ```
 
 `GET /api/v1/worlds` accepts `mode` (ignored above 64 bytes) and
-`has_capacity=true`. Only worlds whose mode sets `listed` (the default) are
-returned. Results are cached for 500ms.
+`has_capacity=true`. Only worlds whose mode sets `listed` (the default for a
+world; set `listed = false` in the script to hide one) are returned. Results
+are cached for 500ms.
 
 `POST /api/v1/worlds` returns **201** with the world info, **429**
 `world.player_limit_reached` when the player is at their per-player cap, and
@@ -152,8 +153,9 @@ and `limit` (1-200, default 50), newest first.
 
 `GET /api/v1/matches/live` enumerates running match processes and is what a
 lobby browser wants. It accepts `mode` and `has_capacity=true`. Matches are
-**unlisted by default** - a mode opts in with `listed => true` - so an empty
-result usually means no mode has opted in yet.
+**unlisted by default** - a mode opts in with `listed = true` (a Lua global, or
+`listed => true` in the operator's `game_modes` config) - so an empty result
+usually means no mode has opted in yet.
 
 Neither returns the player roster. As with worlds, joining is `match.join`
 over WS.

--- a/guides/websocket-protocol.md
+++ b/guides/websocket-protocol.md
@@ -173,7 +173,8 @@ membership are separate surfaces.
 
 **Matches are unlisted by default.** A matchmaker-spawned match is already
 assigned to its players, so it has no reason to appear in a browser. A mode
-opts in with `listed => true`. This is the inverse of worlds, which default
+opts in with `listed = true` (a Lua global, or `listed => true` in the
+operator's `game_modes` config). This is the inverse of worlds, which default
 to listed.
 
 Distinct from `GET /api/v1/matches`, which reads the match *record* table

--- a/guides/world-server.md
+++ b/guides/world-server.md
@@ -412,6 +412,16 @@ limiter, since `asobi_zone` owns them outright.
 but out of quick-play rotation, or reachable by quick-play while hidden from
 the browser.
 
+In Lua, as globals on the mode script:
+
+```lua
+game_type  = "world"
+listed     = false    -- never shows up in the browser
+quick_play = false    -- and never absorbs a quick-play request
+```
+
+Or in an operator `game_modes` entry:
+
 ```erlang
 ~"tutorial" => #{
     type => world,
@@ -420,6 +430,10 @@ the browser.
     quick_play => false   %% and never absorbs a quick-play request
 }
 ```
+
+Both default to `true` for a world, so a mode that says nothing is browsable
+and quick-playable. A match mode is the inverse for `listed`: unlisted until
+it opts in.
 
 Neither flag gates joining. A client that already knows a `world_id` can
 still `world.join` it. Both flags control discovery only.

--- a/src/lua/asobi_lua_config.erl
+++ b/src/lua/asobi_lua_config.erl
@@ -31,6 +31,8 @@ max_players    = 10                         -- optional, defaults to match_size
 strategy       = "fill"                     -- optional, "fill" | "skill_based"
 bots           = { script = "bots/ai.lua", min_players = 4 } -- optional; min_players defaults to match_size, enabled defaults to true
 game_type      = "world"                    -- optional, "match" (default) or "world"
+listed         = true                       -- optional, browsable via match.list / world.list (matches default false, worlds true)
+quick_play     = true                       -- optional, reachable via world.find_or_create (default true)
 state_strategy = "shared"                   -- optional, "shared" picks asobi_lua_match_shared (encode-once broadcast)
 guest_auth     = true                       -- optional, offer anonymous no-account play (needs an operator pepper; ADR 0004)
 registration   = "closed"                   -- optional, "open" | "oauth_only" | "closed" (operator sys.config wins)
@@ -306,6 +308,8 @@ read_match_globals(ScriptPath, St) ->
     ZoneSize = read_global_int(~"zone_size", St),
     ViewRadius = read_global_int(~"view_radius", St),
     Persistent = read_global_bool(~"persistent", St),
+    Listed = read_global_bool_strict(~"listed", ScriptPath, St),
+    QuickPlay = read_global_bool_strict(~"quick_play", ScriptPath, St),
     LazyZones = read_global_bool(~"lazy_zones", St),
     ZoneIdleTimeout = read_global_int(~"zone_idle_timeout", St),
     MaxActiveZones = read_global_int(~"max_active_zones", St),
@@ -340,7 +344,14 @@ read_match_globals(ScriptPath, St) ->
             Config11 = maybe_add_int(Config10, zone_size, ZoneSize),
             Config12 = maybe_add_non_neg_int(Config11, view_radius, ViewRadius),
             Config13 = maybe_add_bool(Config12, persistent, Persistent),
-            {ok, Config13};
+            %% Absent globals leave the key out entirely rather than writing a
+            %% default, so the two discovery defaults stay where they are -
+            %% matches unlisted (asobi_matchmaker), worlds listed
+            %% (asobi_game_modes:world_config/1). A script that never mentions
+            %% these produces a mode map identical to before.
+            Config14 = maybe_add_bool(Config13, listed, Listed),
+            Config15 = maybe_add_bool(Config14, quick_play, QuickPlay),
+            {ok, Config15};
         _ ->
             {error, {ScriptPath, ~"match_size must be a positive integer"}}
     end.
@@ -596,6 +607,35 @@ read_global_bool(Name, St) ->
         {ok, true, _} -> true;
         {ok, false, _} -> false;
         _ -> undefined
+    end.
+
+%% Same read, but says something when the global is present and is not a
+%% boolean. Worth the extra clause only where the downstream default is
+%% `true`: every other boolean global here defaults to false, so a typo fails
+%% closed and the author notices the feature never turned on. `listed` and
+%% `quick_play` default to true on the world path, so a value that is not a
+%% Lua boolean fails OPEN - the script says "hide this" and the world stays in
+%% the public browser and in quick-play rotation.
+%%
+%% `listed = 0` is the case that matters: 0 is truthy in Lua, so writing it to
+%% mean "off" is a plausible mistake, and it is not a Lua boolean.
+read_global_bool_strict(Name, ScriptPath, St) ->
+    case luerl:get_table_keys([Name], St) of
+        {ok, true, _} ->
+            true;
+        {ok, false, _} ->
+            false;
+        {ok, nil, _} ->
+            undefined;
+        _ ->
+            ?LOG_WARNING(#{
+                event => lua_config_global_ignored,
+                script => ScriptPath,
+                global => Name,
+                reason => not_a_boolean,
+                hint => ~"expected true or false; the mode default applies"
+            }),
+            undefined
     end.
 
 read_global_string(Name, St) ->

--- a/src/lua/asobi_lua_config.erl
+++ b/src/lua/asobi_lua_config.erl
@@ -201,9 +201,22 @@ log_invalid_registration(Value) ->
         expected => [~"open", ~"oauth_only", ~"closed"]
     }).
 
+%% Every value passed here comes out of the game's own script, so its size is
+%% chosen by whoever wrote the bundle. `listed = string.rep("A", 4000000)` is a
+%% four-megabyte log line per load, and the config watcher reloads on any mtime
+%% change - so this bounds both the binary and the printed term (~0P with a
+%% depth, not ~p, which is unbounded on a deep structure).
+-define(MAX_LOGGED_VALUE, 200).
+
 -spec describe(term()) -> binary().
-describe(V) when is_binary(V) -> V;
-describe(V) -> iolist_to_binary(io_lib:format("~p", [V])).
+describe(V) when is_binary(V) -> elide(V);
+describe(V) -> elide(iolist_to_binary(io_lib:format("~0P", [V, 8]))).
+
+-spec elide(binary()) -> binary().
+elide(B) when byte_size(B) =< ?MAX_LOGGED_VALUE ->
+    B;
+elide(<<Head:?MAX_LOGGED_VALUE/binary, _/binary>> = B) ->
+    <<Head/binary, "... (", (integer_to_binary(byte_size(B)))/binary, " bytes)">>.
 
 %% Evaluate the game's config script (config.lua when present, else match.lua)
 %% in a sandboxed Luerl state so the deployment-wide globals can be read off it.
@@ -344,11 +357,8 @@ read_match_globals(ScriptPath, St) ->
             Config11 = maybe_add_int(Config10, zone_size, ZoneSize),
             Config12 = maybe_add_non_neg_int(Config11, view_radius, ViewRadius),
             Config13 = maybe_add_bool(Config12, persistent, Persistent),
-            %% Absent globals leave the key out entirely rather than writing a
-            %% default, so the two discovery defaults stay where they are -
-            %% matches unlisted (asobi_matchmaker), worlds listed
-            %% (asobi_game_modes:world_config/1). A script that never mentions
-            %% these produces a mode map identical to before.
+            %% The per-kind defaults stay downstream: matches unlisted
+            %% (asobi_matchmaker), worlds listed (asobi_game_modes:world_config/1).
             Config14 = maybe_add_bool(Config13, listed, Listed),
             Config15 = maybe_add_bool(Config14, quick_play, QuickPlay),
             {ok, Config15};
@@ -523,10 +533,25 @@ is_safe_relative(Bin) ->
             (<<>>) -> false;
             (~"..") -> false;
             (~".") -> false;
-            (_) -> true
+            (Seg) when is_binary(Seg) -> not has_control_char(Seg);
+            (_) -> false
         end,
         Parts
     ).
+
+%% The manifest picks these path segments, and the resolved path is then logged
+%% as a charlist, which OTP's default formatter prints with ~ts rather than
+%% escaping. A newline in a filename is legal on Linux and survives a tar, so
+%% without this a bundle forges whole operator log lines by naming a file
+%% "a\nlevel=emergency msg=...\n.lua". Rejected at the boundary rather than
+%% escaped at each log site.
+-spec has_control_char(binary()) -> boolean().
+has_control_char(<<C, _/binary>>) when C < 32; C =:= 127 ->
+    true;
+has_control_char(<<_, Rest/binary>>) ->
+    has_control_char(Rest);
+has_control_char(<<>>) ->
+    false.
 
 %% --- Lua helpers ---
 
@@ -620,23 +645,41 @@ read_global_bool(Name, St) ->
 %% `listed = 0` is the case that matters: 0 is truthy in Lua, so writing it to
 %% mean "off" is a plausible mistake, and it is not a Lua boolean.
 read_global_bool_strict(Name, ScriptPath, St) ->
-    case luerl:get_table_keys([Name], St) of
+    %% luerl:get_table_keys/2 catches only error:{lua_error,_,_}, and reading a
+    %% global runs any __index metamethod the script installed. Same guard as
+    %% asobi_lua_loader:is_defined/2, so a metamethod cannot take the loader
+    %% down through a path luerl does not catch.
+    try luerl:get_table_keys([Name], St) of
         {ok, true, _} ->
             true;
         {ok, false, _} ->
             false;
         {ok, nil, _} ->
             undefined;
-        _ ->
-            ?LOG_WARNING(#{
-                event => lua_config_global_ignored,
-                script => ScriptPath,
-                global => Name,
-                reason => not_a_boolean,
-                hint => ~"expected true or false; the mode default applies"
-            }),
-            undefined
+        {ok, Val, _} ->
+            %% Naming the offending value is the whole point: the author has to
+            %% find which of several candidate lines produced it.
+            warn_ignored_global(Name, ScriptPath, not_a_boolean, describe(Val));
+        Other ->
+            %% Not a failed type match but a failed read. Claiming
+            %% not_a_boolean here would report a reason that is not true.
+            warn_ignored_global(Name, ScriptPath, unreadable, describe(Other))
+    catch
+        Class:Reason ->
+            warn_ignored_global(Name, ScriptPath, unreadable, describe({Class, Reason}))
     end.
+
+-spec warn_ignored_global(binary(), file:filename_all(), atom(), binary()) -> undefined.
+warn_ignored_global(Name, ScriptPath, Reason, Value) ->
+    ?LOG_WARNING(#{
+        event => lua_config_global_ignored,
+        script => ScriptPath,
+        global => Name,
+        reason => Reason,
+        value => Value,
+        hint => ~"expected true or false; the mode default applies"
+    }),
+    undefined.
 
 read_global_string(Name, St) ->
     case luerl:get_table_keys([Name], St) of

--- a/src/matches/asobi_match_lobby.erl
+++ b/src/matches/asobi_match_lobby.erl
@@ -9,8 +9,9 @@ choosing a match actually needs.
 
 Matches are **unlisted by default**. A match spawned by the matchmaker is
 already assigned to its players and has no reason to appear in a browser,
-so a mode opts in with `listed => true`. This is the inverse of worlds,
-which default to listed because their browser already shipped.
+so a mode opts in with `listed = true` (a Lua global, or `listed => true` in
+the operator's `game_modes` config). This is the inverse of worlds, which
+default to listed because their browser already shipped.
 """.
 
 -export([list_matches/0, list_matches/1, list_matches_cached/1]).

--- a/test/asobi_lua_config_path_tests.erl
+++ b/test/asobi_lua_config_path_tests.erl
@@ -58,6 +58,30 @@ double_slash_rejected_test() ->
         asobi_lua_config:safe_join(?BASE, ~"arena//match.lua")
     ).
 
+newline_in_segment_rejected_test() ->
+    %% A newline in a filename is legal on Linux and survives a tar, and the
+    %% resolved path is logged as a charlist, which OTP's default formatter
+    %% prints with ~ts rather than escaping. Without this a bundle names a file
+    %% "a\nlevel=emergency msg=...\n.lua" and forges whole operator log lines.
+    ?assertMatch(
+        {error, _},
+        asobi_lua_config:safe_join(?BASE, ~"a\nlevel=emergency msg=forged\n.lua")
+    ).
+
+control_char_in_segment_rejected_test() ->
+    %% The whole C0 range plus DEL, not just newline: CR splits a line just as
+    %% well, and ESC drives a terminal reading the log.
+    ?assertMatch({error, _}, asobi_lua_config:safe_join(?BASE, ~"arena/ma\rtch.lua")),
+    ?assertMatch({error, _}, asobi_lua_config:safe_join(?BASE, ~"arena/ma\x{1b}[2Jtch.lua")),
+    ?assertMatch({error, _}, asobi_lua_config:safe_join(?BASE, ~"arena/ma\x{7f}tch.lua")),
+    ?assertMatch({error, _}, asobi_lua_config:safe_join(?BASE, ~"arena/ma\x{00}tch.lua")).
+
+ordinary_path_still_accepted_test() ->
+    %% The control-char guard must not reject anything that was legal before:
+    %% spaces, dots, dashes and non-ASCII names are all fine.
+    ?assertMatch({ok, _}, asobi_lua_config:safe_join(?BASE, ~"my modes/arena-2.lua")),
+    ?assertMatch({ok, _}, asobi_lua_config:safe_join(?BASE, ~"モード/match.lua")).
+
 base_with_trailing_slash_handled_test() ->
     %% Operator-supplied GameDir may or may not have a trailing slash.
     %% Both forms must yield the same normalised result and pass the

--- a/test/asobi_lua_config_tests.erl
+++ b/test/asobi_lua_config_tests.erl
@@ -78,6 +78,10 @@ config_test_() ->
             fun discovery_flags_absent_keep_defaults/0},
         {"a non-boolean listed is ignored and warns rather than failing open",
             fun discovery_flag_non_boolean_warns/0},
+        {"a non-boolean quick_play is ignored and warns, and stays true downstream",
+            fun quick_play_non_boolean_warns/0},
+        {"a huge global value is elided in the warning rather than logged whole",
+            fun oversized_global_value_elided/0},
         {"guest_auth = true global enables the asobi guest_auth flag",
             fun guest_auth_global_enables/0},
         {"guest_auth absent leaves the flag off", fun guest_auth_absent_leaves_off/0},
@@ -768,8 +772,77 @@ discovery_flag_non_boolean_warns() ->
         Mode = maps:get(~"default", get_game_modes()),
         ?assertEqual(false, maps:is_key(listed, Mode)),
         receive
-            {log_event, #{event := lua_config_global_ignored, global := ~"listed"}} -> ok
+            {log_event, #{
+                event := lua_config_global_ignored,
+                global := ~"listed",
+                value := Value
+            }} ->
+                %% The value is what makes the warning actionable, so assert it
+                %% reaches the report rather than only that something was logged.
+                ?assertEqual(~"0", Value)
         after 1000 -> erlang:error(no_warning_logged_for_non_boolean_listed)
+        end
+    after
+        _ = logger:remove_handler(?FUNCTION_NAME),
+        cleanup_temp_dir(TmpDir)
+    end.
+
+quick_play_non_boolean_warns() ->
+    %% quick_play defaults to true on both kinds, so unlike listed it can never
+    %% fail closed - there is no configuration where a dropped value is safe.
+    TmpDir = make_temp_dir(),
+    {ok, Content} = file:read_file(fixture("config_quick_play_not_boolean.lua")),
+    ok = file:write_file(filename:join(TmpDir, "match.lua"), Content),
+    application:set_env(asobi, game_dir, TmpDir),
+    ok = logger:add_handler(?FUNCTION_NAME, ?MODULE, #{config => #{pid => self()}}),
+    try
+        ok = asobi_lua_config:maybe_load_game_config(),
+        Mode = maps:get(~"default", get_game_modes()),
+        ?assertEqual(false, maps:is_key(quick_play, Mode)),
+        {ok, WorldConfig} = asobi_game_modes:world_config(~"default"),
+        ?assertEqual(true, maps:get(quick_play, WorldConfig)),
+        receive
+            {log_event, #{
+                event := lua_config_global_ignored,
+                global := ~"quick_play",
+                value := ~"false"
+            }} ->
+                ok
+        after 1000 -> erlang:error(no_warning_logged_for_non_boolean_quick_play)
+        end
+    after
+        _ = logger:remove_handler(?FUNCTION_NAME),
+        cleanup_temp_dir(TmpDir)
+    end.
+
+oversized_global_value_elided() ->
+    %% The value in this report is chosen by whoever wrote the bundle, so
+    %% `listed = string.rep("A", 400000)` is otherwise a 400 KB log line per
+    %% load - and the config watcher reloads on any mtime change.
+    TmpDir = make_temp_dir(),
+    Script = [
+        "match_size = 1\n",
+        "game_type = \"world\"\n",
+        "listed = string.rep(\"A\", 400000)\n",
+        "function init(config) return {} end\n",
+        "function spawn_position(p, s) return { x = 0, y = 0 } end\n",
+        "function join(p, s) return s end\n",
+        "function leave(p, s) return s end\n",
+        "function zone_tick(e, z) return e, z end\n",
+        "function handle_input(p, i, e) return e end\n",
+        "function post_tick(t, s) return s end\n",
+        "function generate_world(seed, c) return { [\"0,0\"] = {} } end\n"
+    ],
+    ok = file:write_file(filename:join(TmpDir, "match.lua"), Script),
+    application:set_env(asobi, game_dir, TmpDir),
+    ok = logger:add_handler(?FUNCTION_NAME, ?MODULE, #{config => #{pid => self()}}),
+    try
+        ok = asobi_lua_config:maybe_load_game_config(),
+        receive
+            {log_event, #{event := lua_config_global_ignored, global := ~"listed", value := V}} ->
+                ?assert(byte_size(V) < 300),
+                ?assertMatch({_, _}, binary:match(V, ~"400000 bytes"))
+        after 1000 -> erlang:error(no_warning_logged_for_oversized_listed)
         end
     after
         _ = logger:remove_handler(?FUNCTION_NAME),

--- a/test/asobi_lua_config_tests.erl
+++ b/test/asobi_lua_config_tests.erl
@@ -2,6 +2,9 @@
 -include_lib("eunit/include/eunit.hrl").
 -include("asobi_lua_bots.hrl").
 
+%% logger handler callback, used by discovery_flag_non_boolean_warns/0.
+-export([log/2]).
+
 -spec fixture(string()) -> file:filename_all().
 fixture(Name) ->
     {ok, LibDir} = safe_lib_dir(),
@@ -67,6 +70,14 @@ config_test_() ->
             fun bot_config_min_players_clamped_at_ceiling/0},
         {"world dimension globals (tick_rate/grid_size/zone_size/view_radius/persistent)",
             fun world_dimension_globals_forwarded/0},
+        {"listed/quick_play = false on a world reach the mode and world config",
+            fun discovery_flags_forwarded/0},
+        {"listed = true opts a match mode into the live-match browser",
+            fun listed_match_global_forwarded/0},
+        {"absent listed/quick_play leave the per-kind defaults alone",
+            fun discovery_flags_absent_keep_defaults/0},
+        {"a non-boolean listed is ignored and warns rather than failing open",
+            fun discovery_flag_non_boolean_warns/0},
         {"guest_auth = true global enables the asobi guest_auth flag",
             fun guest_auth_global_enables/0},
         {"guest_auth absent leaves the flag off", fun guest_auth_absent_leaves_off/0},
@@ -686,6 +697,93 @@ world_dimension_globals_forwarded() ->
     ?assertEqual(0, maps:get(view_radius, WorldConfig)),
     ?assertEqual(true, maps:get(persistent, WorldConfig)),
     cleanup_temp_dir(TmpDir).
+
+discovery_flags_forwarded() ->
+    %% Both flags are discovery-tier only and default to true for a world, so
+    %% a hub is browsable and quick-playable without saying anything. A script
+    %% that wants a hidden or out-of-rotation mode had no way to say so from
+    %% Lua and needed an operator game_modes entry, which replaces the whole
+    %% mode map rather than merging into it.
+    TmpDir = make_temp_dir(),
+    {ok, Content} = file:read_file(fixture("config_discovery_flags.lua")),
+    ok = file:write_file(filename:join(TmpDir, "match.lua"), Content),
+    application:set_env(asobi, game_dir, TmpDir),
+    ok = asobi_lua_config:maybe_load_game_config(),
+    Mode = maps:get(~"default", get_game_modes()),
+    ?assertEqual(false, maps:get(listed, Mode)),
+    ?assertEqual(false, maps:get(quick_play, Mode)),
+    %% And world_config/1 must echo them through, or the world server still
+    %% boots listed and the script's declaration is decorative.
+    {ok, WorldConfig} = asobi_game_modes:world_config(~"default"),
+    ?assertEqual(false, maps:get(listed, WorldConfig)),
+    ?assertEqual(false, maps:get(quick_play, WorldConfig)),
+    cleanup_temp_dir(TmpDir).
+
+listed_match_global_forwarded() ->
+    %% The inverse default: matches are unlisted, so a match script has to opt
+    %% in before match.list will ever return it.
+    TmpDir = make_temp_dir(),
+    {ok, Content} = file:read_file(fixture("config_listed_match.lua")),
+    ok = file:write_file(filename:join(TmpDir, "match.lua"), Content),
+    application:set_env(asobi, game_dir, TmpDir),
+    ok = asobi_lua_config:maybe_load_game_config(),
+    Mode = maps:get(~"default", get_game_modes()),
+    ?assertEqual(true, maps:get(listed, Mode)),
+    cleanup_temp_dir(TmpDir).
+
+discovery_flags_absent_keep_defaults() ->
+    %% The compatibility case. A script that never mentions either flag must
+    %% produce a mode map with neither key, so the differing per-kind defaults
+    %% downstream (matches false, worlds true) keep deciding. Writing a
+    %% default here instead would silently flip every existing Lua match mode
+    %% into the browser.
+    TmpDir = make_temp_dir(),
+    {ok, Content} = file:read_file(fixture("config_world_dimensions.lua")),
+    ok = file:write_file(filename:join(TmpDir, "match.lua"), Content),
+    application:set_env(asobi, game_dir, TmpDir),
+    ok = asobi_lua_config:maybe_load_game_config(),
+    Mode = maps:get(~"default", get_game_modes()),
+    ?assertEqual(false, maps:is_key(listed, Mode)),
+    ?assertEqual(false, maps:is_key(quick_play, Mode)),
+    %% world_config/1 then supplies the world default, which is true for both.
+    {ok, WorldConfig} = asobi_game_modes:world_config(~"default"),
+    ?assertEqual(true, maps:get(listed, WorldConfig)),
+    ?assertEqual(true, maps:get(quick_play, WorldConfig)),
+    cleanup_temp_dir(TmpDir).
+
+discovery_flag_non_boolean_warns() ->
+    %% These two are the first boolean globals whose downstream default is
+    %% true, so an unreadable value fails OPEN - the script asked to hide the
+    %% world and it stays browsable. `listed = 0` is the plausible version of
+    %% that mistake, because 0 is truthy in Lua but reads as "off" to most
+    %% authors. The key must stay absent (so the default still decides) AND
+    %% the loader must say so, or this is a silent dev-facing failure.
+    TmpDir = make_temp_dir(),
+    {ok, Content} = file:read_file(fixture("config_listed_not_boolean.lua")),
+    ok = file:write_file(filename:join(TmpDir, "match.lua"), Content),
+    application:set_env(asobi, game_dir, TmpDir),
+    ok = logger:add_handler(?FUNCTION_NAME, ?MODULE, #{config => #{pid => self()}}),
+    try
+        ok = asobi_lua_config:maybe_load_game_config(),
+        Mode = maps:get(~"default", get_game_modes()),
+        ?assertEqual(false, maps:is_key(listed, Mode)),
+        receive
+            {log_event, #{event := lua_config_global_ignored, global := ~"listed"}} -> ok
+        after 1000 -> erlang:error(no_warning_logged_for_non_boolean_listed)
+        end
+    after
+        _ = logger:remove_handler(?FUNCTION_NAME),
+        cleanup_temp_dir(TmpDir)
+    end.
+
+%% logger handler callback: forwards the report of each event to the test pid
+%% so a case can assert on what the loader logged.
+-spec log(logger:log_event(), logger:handler_config()) -> ok.
+log(#{msg := {report, Report}}, #{config := #{pid := Pid}}) when is_pid(Pid) ->
+    Pid ! {log_event, Report},
+    ok;
+log(_Event, _Config) ->
+    ok.
 
 %% --- Helpers ---
 

--- a/test/fixtures/lua/config_discovery_flags.lua
+++ b/test/fixtures/lua/config_discovery_flags.lua
@@ -1,0 +1,17 @@
+-- Exercises the discovery-visibility globals on a world: listed and
+-- quick_play, both of which default to true for a world, so this fixture
+-- sets them false to prove the script value reaches the mode config.
+match_size  = 1
+max_players = 4
+game_type   = "world"
+listed      = false
+quick_play  = false
+
+function init(config) return {} end
+function spawn_position(player_id, state) return { x = 0, y = 0 } end
+function join(player_id, state) return state end
+function leave(player_id, state) return state end
+function zone_tick(entities, zone_state) return entities, zone_state end
+function handle_input(player_id, input, entities) return entities end
+function post_tick(tick, state) return state end
+function generate_world(seed, config) return { ["0,0"] = {} } end

--- a/test/fixtures/lua/config_listed_match.lua
+++ b/test/fixtures/lua/config_listed_match.lua
@@ -1,0 +1,13 @@
+-- A match mode opting into the live-match browser. Matches are unlisted by
+-- default, so `listed = true` here is the opt-in that makes match.list and
+-- GET /api/v1/matches/live return this mode's live matches.
+match_size  = 1
+max_players = 8
+listed      = true
+
+function init(config) return {} end
+function join(player_id, state) return state end
+function leave(player_id, state) return state end
+function handle_input(player_id, input, state) return state end
+function tick(state) return state end
+function get_state(player_id, state) return state end

--- a/test/fixtures/lua/config_listed_not_boolean.lua
+++ b/test/fixtures/lua/config_listed_not_boolean.lua
@@ -1,0 +1,17 @@
+-- `listed = 0` means "off" to a Lua author (0 is truthy in Lua, but reads as
+-- off in most other languages) and is not a Lua boolean. It must not be taken
+-- as "listed", because the world default is true and that would fail open:
+-- the script asked to hide the world and it would stay in the browser.
+match_size  = 1
+max_players = 4
+game_type   = "world"
+listed      = 0
+
+function init(config) return {} end
+function spawn_position(player_id, state) return { x = 0, y = 0 } end
+function join(player_id, state) return state end
+function leave(player_id, state) return state end
+function zone_tick(entities, zone_state) return entities, zone_state end
+function handle_input(player_id, input, entities) return entities end
+function post_tick(tick, state) return state end
+function generate_world(seed, config) return { ["0,0"] = {} } end

--- a/test/fixtures/lua/config_quick_play_not_boolean.lua
+++ b/test/fixtures/lua/config_quick_play_not_boolean.lua
@@ -1,0 +1,16 @@
+-- `quick_play = "false"` is a string, not a Lua boolean. quick_play defaults
+-- to true on every kind, so taking it as a value would leave the mode in
+-- find_or_create rotation after the script asked to be out of it.
+match_size  = 1
+max_players = 4
+game_type   = "world"
+quick_play  = "false"
+
+function init(config) return {} end
+function spawn_position(player_id, state) return { x = 0, y = 0 } end
+function join(player_id, state) return state end
+function leave(player_id, state) return state end
+function zone_tick(entities, zone_state) return entities, zone_state end
+function handle_input(player_id, input, entities) return entities end
+function post_tick(tick, state) return state end
+function generate_world(seed, config) return { ["0,0"] = {} } end


### PR DESCRIPTION
## Why

Discovery visibility was reachable only from an operator's Erlang `game_modes` entry. `read_match_globals/2` never read either name, so a Lua-only game could not hide a world from the browser, nor opt a match mode into `match.list`, without restating its whole mode map in `sys.config` - including an absolute script path the loader computes at load time.

There was no policy behind that, just an omission. `asobi_game_config:modes/0` merges the operator layer on top of the script layer, so an operator entry still wins, and both consumers already read the key without caring where it came from. Discovery is also weaker than `registration`, which a game has been able to declare since asobi_lua#122.

## Compatibility

An absent global leaves the key out of the mode map rather than writing a default, so the two per-kind defaults keep deciding - matches unlisted, worlds listed - and a script that says nothing produces the map it produced before. Directly asserted by `discovery_flags_absent_keep_defaults/0`.

`listed` and `quick_play` were inert global names before this. A script already using either name for its own purposes now has it read as mode config. Worth a release-note line.

## Fail-open, and the fixes that came out of review

These are the first boolean globals whose downstream default is `true`, so an unreadable value fails **open**: the script asks to hide a world and it stays browsable. `listed = 0` is the case that motivates it, since `0` is truthy in Lua but reads as "off" to most authors. `read_global_bool_strict/3` warns instead of silently dropping it.

Naming the rejected value is what makes that warning actionable, but the value is chosen by whoever wrote the bundle: `listed = string.rep("A", 4000000)` was a measured 4 MB log line, per load, with the config watcher reloading on any mtime change. `describe/1` now elides past 200 bytes and prints terms with `~0P` and a depth. That also covers `log_invalid_registration/1`, which has fed it an unbounded value since it was written.

Separately, a path segment from the multi-mode manifest reached the log as a charlist, and OTP's default formatter prints those with `~ts` rather than escaping. A newline in a filename is legal on Linux and survives a tar, so a bundle shipping `a\nlevel=emergency msg=...\n.lua` forged whole operator log lines. Rejected at the boundary in `is_safe_relative/1` rather than escaped at each of the ~14 sites that log a script path. `nova_jsonlogger` escaped it correctly, so this only bit consumers on the default handler.

`luerl:get_table_keys/2` catches only `error:{lua_error,_,_}`, and reading a global runs whatever `__index` metamethod the script installed, so the strict reader carries the same `try` as `asobi_lua_loader:is_defined/2`.

## Docs

Five guides plus `asobi_match_lobby`'s moduledoc said `listed` was operator-only; all corrected, and `listed`/`quick_play` added to the two canonical globals tables. `configuration.md` now also spells out that an operator mode override is whole-entry, not per-key - the minimal-looking `#{~"arena" => #{listed => true}}` replaces the mode with one that declares no `module` and kills it.

## Gates

Architecture guardian: accept with changes; its gating finding was the fail-open direction, fixed here. Erlang code review: no blockers. Security review: 2 Medium (both fixed above), 3 Low.

Pre-push: fmt, xref, dialyzer clean; `elp eqwalize-all` 312 = main baseline; `elp lint` identical to baseline; eunit 1670/0; ct 341/0; ex_doc no warnings. Mutation testing is disabled in this repo (`ci.yml:62`).

## Out of scope, opened separately

- #414 - `world.find_or_create` on a match mode spawns a world backed by the match provider (no `type =:= world` guard)
- #415 - a bundle can hang application boot with an `__index` metamethod on a config-global read; `setmetatable`/`_G` are not stripped