### PR TITLE
fix: say why the unlinked-guest count failed, and stop re-asking a sick DB

### DIFF
--- a/src/asobi_guest_reaper.erl
+++ b/src/asobi_guest_reaper.erl
@@ -104,31 +104,39 @@ cached_unlinked_count() ->
             end
     end.
 
+%% A failed count is cached for the same TTL as a good one, and that is
+%% deliberate. `unknown` fails the create closed, so without caching it every
+%% single guest create re-runs a COUNT that is already failing - against a
+%% database that is, by construction, the thing having trouble. Caching the
+%% failure bounds the load on it to one attempt per TTL, and bounds the log
+%% volume to the same.
 -spec refresh_count(integer()) -> non_neg_integer() | unknown.
 refresh_count(Now) ->
-    case live_unlinked_count() of
-        N when is_integer(N) ->
-            Ttl =
-                case
-                    application:get_env(
-                        asobi, guest_unlinked_count_ttl_ms, ?DEFAULT_COUNT_TTL_MS
-                    )
-                of
-                    T when is_integer(T) -> T;
-                    _ -> ?DEFAULT_COUNT_TTL_MS
-                end,
-            true = ets:insert(?COUNT_CACHE, {count, N, Now + Ttl}),
-            N;
-        unknown ->
-            unknown
-    end.
+    Ttl =
+        case application:get_env(asobi, guest_unlinked_count_ttl_ms, ?DEFAULT_COUNT_TTL_MS) of
+            T when is_integer(T) -> T;
+            _ -> ?DEFAULT_COUNT_TTL_MS
+        end,
+    Count = live_unlinked_count(),
+    true = ets:insert(?COUNT_CACHE, {count, Count, Now + Ttl}),
+    Count.
 
+%% Answers `unknown` on any failure so the caller fails closed - and says why.
+%%
+%% This used to swallow the reason with a bare `_ -> unknown`, which made the
+%% failure undiagnosable from the node: `asobi_guest_controller` could report
+%% that it had been unable to count, but nothing anywhere said what the
+%% database had actually answered. That gap cost a real investigation
+%% (asobi#419), so the result is logged.
 -spec live_unlinked_count() -> non_neg_integer() | unknown.
 live_unlinked_count() ->
     Q = kura_query:where(kura_query:from(asobi_player_identity), {provider, ?PROVIDER}),
     case asobi_repo:aggregate(Q, count) of
-        {ok, N} when is_integer(N), N >= 0 -> N;
-        _ -> unknown
+        {ok, N} when is_integer(N), N >= 0 ->
+            N;
+        Other ->
+            ?LOG_WARNING(#{event => guest_count_failed, result => Other}),
+            unknown
     end.
 
 -spec handle_call(term(), gen_server:from(), map()) -> {reply, term(), map()}.

--- a/test/asobi_guest_SUITE.erl
+++ b/test/asobi_guest_SUITE.erl
@@ -18,7 +18,8 @@
     create_no_retry_on_non_unique_username_error/1,
     a_full_deployment_says_capacity_reached/1,
     an_uncountable_table_says_unavailable_not_capacity/1,
-    a_saturated_global_limiter_says_rate_limited/1
+    a_saturated_global_limiter_says_rate_limited/1,
+    a_failing_count_is_asked_once_per_ttl/1
 ]).
 
 all() ->
@@ -36,7 +37,8 @@ all() ->
         create_no_retry_on_non_unique_username_error,
         a_full_deployment_says_capacity_reached,
         an_uncountable_table_says_unavailable_not_capacity,
-        a_saturated_global_limiter_says_rate_limited
+        a_saturated_global_limiter_says_rate_limited,
+        a_failing_count_is_asked_once_per_ttl
     ].
 
 %% Set AFTER the app starts, not before. Booting asobi runs
@@ -621,5 +623,32 @@ a_saturated_global_limiter_says_rate_limited(Config) ->
     after
         ok = seki:delete_limiter(asobi_guest_global_limiter),
         ok = seki:new_limiter(asobi_guest_global_limiter, Restore)
+    end,
+    Config.
+
+%% A failing count fails the create closed, so without caching the failure every
+%% single guest create re-runs a COUNT against the database that is already
+%% having trouble - a create storm turns one struggling query into a flood of
+%% them. The failure is cached for the same TTL as a good count, so the load is
+%% one attempt per window whichever way the query goes.
+a_failing_count_is_asked_once_per_ttl(Config) ->
+    application:set_env(asobi, guest_unlinked_count_ttl_ms, 60000),
+    meck:new(asobi_repo, [passthrough]),
+    meck:expect(asobi_repo, aggregate, fun(_Q, count) -> {error, timeout} end),
+    try
+        ets:delete_all_objects(asobi_guest_count_cache),
+        ?assertEqual(unknown, asobi_guest_reaper:cached_unlinked_count()),
+        ?assertEqual(unknown, asobi_guest_reaper:cached_unlinked_count()),
+        ?assertEqual(unknown, asobi_guest_reaper:cached_unlinked_count()),
+        ?assertEqual(1, meck:num_calls(asobi_repo, aggregate, '_')),
+
+        %% And the create path still refuses, under the honest code.
+        {ok, R} = create(device_id(), secret(), Config),
+        ?assertStatus(503, R),
+        ?assertMatch(#{~"error" := #{~"code" := ~"guest.unavailable"}}, nova_test:json(R))
+    after
+        meck:unload(asobi_repo),
+        ets:delete_all_objects(asobi_guest_count_cache),
+        application:unset_env(asobi, guest_unlinked_count_ttl_ms)
     end,
     Config.


### PR DESCRIPTION
Found by pointing asobi#419's own diagnostic at production, where it stopped one level short.

**The failure reason was swallowed.** `live_unlinked_count/0` ended in a bare `_ -> unknown`, so `guest.unavailable` could say the node had been unable to count but never what Postgres actually answered. Two live environments - one ours, one a customer's - are intermittently refusing guest signup with `reason=unlinked_count_unavailable` as I write this, and the cause is still unknown precisely because nothing logged it. Now it does.

**A failed count was not cached, while a good one was.** So every guest create re-ran a COUNT that was already failing, against the database that was already struggling - a create storm turns one sick query into a flood of them, exactly when the deployment can least afford it. The failure now caches for the same TTL as a success, bounding both the database load and the log volume to one attempt per window.

New CT case pins the caching (three reads, one query) and that the create path still refuses with `guest.unavailable` underneath it.

15 guest-suite cases pass, 8 erase-suite, xref / dialyzer / fmt / error-drift clean, eqwalizer unchanged from baseline.