### PR TITLE
feat: backfill into running matches, a joinable flag, and script-driven bots

### DIFF
--- a/guides/lobbies.md
+++ b/guides/lobbies.md
@@ -59,13 +59,42 @@ GET /api/v1/matches/live        REST
 match.list                      WebSocket
 ```
 
-Both filter on `mode` and `has_capacity`. Matches are unlisted by default - a
-matchmaker-spawned match is already assigned to its players and has no reason to
-be browsable - so a mode opts in with `listed = true`.
+Both filter on `mode`, `has_capacity` and `joinable`. Matches are unlisted by
+default - a matchmaker-spawned match is already assigned to its players and has
+no reason to be browsable - so a mode opts in with `listed = true`.
 
 Do not use `GET /api/v1/matches` for this. It reads the match record table:
 finished matches, an audit trail, nothing joinable. See
 [REST API](rest-api.md).
+
+### Joining a match already in progress
+
+A `running` match accepts joins exactly as a `waiting` one does, so backfill is
+`match.list` then `match.join` with the `match_id` - there is no separate call
+and no backfill mode to turn on. Your `join` callback runs mid-match, so it has
+to cope with a player arriving into a live game state.
+
+Ask for both filters when you are looking for somewhere to play:
+
+```json
+{"type": "match.join", "payload": {"match_id": "..."}}
+```
+
+```
+match.list  { "has_capacity": true, "joinable": true }
+```
+
+They are different questions. A match with three free slots may have closed
+itself to new players; a full one has not closed, and may free a slot on the
+next leave. Every listing carries `joinable`, so a browser can show both and
+grey one out.
+
+To close a match to backfill, call
+[`game.match.set_joinable(false)`](lua-api.md#match) from the script - at the
+end of round one, once the objective spawns, whenever the game says so. A
+closed match answers `match.locked`; a full one answers `match.full`. To turn
+away one specific player rather than everybody, return `nil` from
+[`join`](lua-scripting.md#refusing-a-join) instead.
 
 ### The 60-second timeout
 
@@ -171,9 +200,12 @@ There is no worlds screen either; use `GET /api/v1/worlds`. See
 - **Party.** You cannot queue as a group through the matchmaker. Play with
   specific people by sharing a world id or a join code, or add party grouping as
   an extension.
-- **Rich filters.** Discovery filters on `mode` and `has_capacity` only.
-  Anything richer belongs in your strategy module, or in an extension method
-  that returns the filtered list.
+- **Rich filters.** Discovery filters on `mode`, `has_capacity` and `joinable`
+  only. Anything richer belongs in your strategy module, or in an extension
+  method that returns the filtered list.
+- **Backfill matchmaking.** The matchmaker builds matches out of the queue; it
+  never routes a queued player into a match that is already running. Backfill
+  is a client browsing and joining, not a strategy the matchmaker runs.
 - **Member roster API.** The joiner receives the roster on `match.joined` /
   `world.joined`; there is no separate "who is here" call. Keep the list in your
   game state, or expose it as an extension method.

--- a/guides/lua-api.md
+++ b/guides/lua-api.md
@@ -27,9 +27,9 @@ for _, wallet in ipairs(result.ok) do
 end
 ```
 
-The plain calls - `broadcast`, `send`, `chat.send`, `zone.spawn`,
-`zone.despawn`, `terrain.preload`, `leaderboard.submit`, `spatial.*` - return
-their value directly:
+The plain calls - `broadcast`, `send`, `chat.send`, `match.set_joinable`,
+`bots.add`, `bots.remove`, `zone.spawn`, `zone.despawn`, `terrain.preload`,
+`leaderboard.submit`, `spatial.*` - return their value directly:
 
 ```lua
 local hits = game.spatial.query_radius(state.entities, 100, 100, 50)
@@ -96,6 +96,64 @@ in one event.
 `send` reaches the client as a `module.message` frame carrying
 `{"module": "lua", "message": ...}`, which is why it takes any Lua value rather
 than a table. See [WebSocket protocol](websocket-protocol.md).
+
+## Match
+
+```lua
+game.match.set_joinable(open)            -- open or close the match to new joins
+```
+
+Match only. A closed match keeps running and keeps everyone already in it; the
+next player to try is answered `match.locked`, and `match.list` reports it with
+`joinable = false` so a browser can leave it out.
+
+This is the runtime half of joinability. `listed` decides whether a match is
+advertised at all, and an unlisted match is still joinable by id - hiding a
+match is not closing it.
+
+```lua
+function tick(state)
+    if state.round > 1 then
+        game.match.set_joinable(false)   -- no backfill past round one
+    end
+    return state
+end
+```
+
+Asynchronous, like `broadcast`: a join already in the mailbox ahead of the flag
+still gets in. Closing a match stops the next joiner, not one already through
+the door. To refuse a specific player instead, return `nil` from
+[`join`](lua-scripting.md#refusing-a-join).
+
+## Bots
+
+```lua
+game.bots.add(name)                      -- place a bot in this match
+game.bots.remove(bot_id)                 -- take one out
+```
+
+Match only. `name` is bare and gets the `bot_` prefix every bot id carries, so
+`game.bots.add("Spark")` puts `bot_Spark` in the roster; `remove` accepts either
+form. Names are 1-32 characters of `[A-Za-z0-9_-]`.
+
+This is the script-driven route in. The other one is queue fill - `bots.enabled`
+on a game mode, which tops the *matchmaker queue* up before a match exists (see
+[Bots](lua-bots.md)). The two are independent: leave `bots.enabled` off and
+nothing arrives that your script did not ask for.
+
+```lua
+function tick(state)
+    if state.humans_waiting and count(state.players) < 4 then
+        game.bots.add("Spark")
+    end
+    return state
+end
+```
+
+Both are asynchronous and neither reports failure at the call site: a match that
+is full, already holds that bot, or is at the 64-bot ceiling is a no-op with a
+line in the node log. A bot runs the mode's `bots.script` if it has one and the
+built-in AI otherwise.
 
 ## Economy
 

--- a/guides/lua-api.md
+++ b/guides/lua-api.md
@@ -103,9 +103,16 @@ than a table. See [WebSocket protocol](websocket-protocol.md).
 game.match.set_joinable(open)            -- open or close the match to new joins
 ```
 
-Match only. A closed match keeps running and keeps everyone already in it; the
-next player to try is answered `match.locked`, and `match.list` reports it with
-`joinable = false` so a browser can leave it out.
+Match only - a world or zone script gets `{ error = "..." }` back, because the
+call would otherwise reach the world server. A closed match keeps running and
+keeps everyone already in it; the next player to try is answered
+`match.locked`, and `match.list` reports it with `joinable = false` so a
+browser can leave it out.
+
+There is no config key and no default to set: a match opens joinable and the
+game closes it when the game decides. An Erlang game module does the same
+thing with `asobi_match_server:set_joinable(self(), false)` - its callbacks
+run in the match process, so `self()` is the match.
 
 This is the runtime half of joinability. `listed` decides whether a match is
 advertised at all, and an unlisted match is still joinable by id - hiding a
@@ -132,7 +139,8 @@ game.bots.add(name)                      -- place a bot in this match
 game.bots.remove(bot_id)                 -- take one out
 ```
 
-Match only. `name` is bare and gets the `bot_` prefix every bot id carries, so
+Match only - a world or zone script gets `{ error = "..." }` back. `name` is
+bare and gets the `bot_` prefix every bot id carries, so
 `game.bots.add("Spark")` puts `bot_Spark` in the roster; `remove` accepts either
 form. Names are 1-32 characters of `[A-Za-z0-9_-]`.
 

--- a/guides/lua-bots.md
+++ b/guides/lua-bots.md
@@ -11,7 +11,12 @@ are no fake clients and no network hop; a bot's decisions go through the same
 - Load-testing a tick loop without spawning real WebSocket sessions.
 - Replay and record-and-replay testing.
 
-## How it works
+There are two ways a bot gets into a match. **Queue fill** is automatic and
+answers "not enough humans are waiting". **`game.bots.add`** is your script
+placing one deliberately, at any point in the match. They are independent:
+leave `bots.enabled` off and nothing arrives that your script did not ask for.
+
+## How queue fill works
 
 1. A player queues for matchmaking.
 2. Every 8 seconds the spawner looks at each mode with someone queued. If
@@ -33,6 +38,30 @@ instead - it does not trigger bot fill.
 
 Bot fill is per node, because the matchmaker queue is per node. Each node
 fills its own queue from its own view. See [Clustering](clustering.md).
+
+## Placing a bot from a match script
+
+```lua
+game.bots.add("Spark")        -- bot_Spark joins this match
+game.bots.remove("bot_Spark") -- and leaves
+```
+
+This is the route to take when the *game* decides, not the queue: a co-op
+mission that needs an escort, a boss that fights alongside the players, a
+practice mode with no queue at all, a slot backfilled the moment a human
+drops. It works in `waiting` and in `running`, so a bot can arrive mid-match.
+
+`name` is bare and gets the `bot_` prefix here, so the roster shows
+`bot_Spark`; `remove` takes either form. Names are 1-32 characters of
+`[A-Za-z0-9_-]`. The bot runs the mode's `bots.script` if the mode has one and
+the built-in AI otherwise, so a mode can leave `bots.enabled` off - that flag
+governs queue fill only - and still configure a script.
+
+Both calls are asynchronous and neither fails at the call site. A match that is
+full, already holds that bot, or is at the 64-bot ceiling is a no-op with a line
+in the node log. The bot appears in your `players` table through the same `join`
+callback a human goes through, so a script that rejects unknown players will
+reject bots too.
 
 ## Configuration
 

--- a/guides/lua-scripting.md
+++ b/guides/lua-scripting.md
@@ -275,10 +275,10 @@ or passwords:
 
 ```lua
 function join(player_id, state, ctx)
-    state.players[player_id] = {
-        hp = 100,
-        spectator = state.join_code ~= nil and ctx.code ~= state.join_code
-    }
+    if ctx.code ~= state.join_code then
+        return nil, "wrong_code"
+    end
+    state.players[player_id] = { hp = 100 }
     return state
 end
 ```
@@ -288,9 +288,35 @@ argument.
 
 `ctx` is validated before it reaches the script: a flat table, at most 8 keys,
 keys up to 64 bytes, scalar values up to 256 bytes, no nesting. asobi never
-interprets, echoes or logs it. Returning the updated state is the only
-supported outcome, so a failed check has to be expressed in the state you
-return, as above.
+interprets, echoes or logs it.
+
+#### Refusing a join
+
+Return `nil` to refuse. A refused player is never added to the roster, and the
+state you were handed is discarded, so a refusal leaves no trace - a client
+cannot drive your script by being turned away over and over.
+
+The second return value is a reason, and it reaches the client:
+
+```lua
+return nil, "match_locked"
+```
+
+It is your game's vocabulary, not asobi's, so it travels in the error object's
+`details.refused_reason` under the fixed code `match.join_refused`. A script
+cannot mint an error code. Keep it to 64 bytes of `[A-Za-z0-9_-]`-ish printable
+ASCII; a reason outside that is dropped and the refusal stands without one.
+
+If you want the player in the match but not playing, return the state with a
+flag on them rather than refusing:
+
+```lua
+state.players[player_id] = { hp = 100, spectator = true }
+return state
+```
+
+A `join` that returns nothing at all is treated as a refusal and logged - it is
+almost always a missing `return state`.
 
 ### `leave(player_id, state)`
 

--- a/guides/matchmaking.md
+++ b/guides/matchmaking.md
@@ -230,6 +230,20 @@ nodes never match each other, and a restart drops every waiting ticket. Behind a
 load balancer this is the fact that decides whether matchmaking works at all;
 see [Clustering](clustering.md).
 
+## Backfill
+
+The matchmaker builds matches out of the queue. It never routes a queued player
+into a match that is already running, and there is no backfill strategy to
+enable.
+
+Backfill is a discovery flow instead: the client calls `match.list` with
+`has_capacity` and `joinable`, picks one, and joins it by id with `match.join`.
+A `running` match accepts joins exactly as a `waiting` one does. Your `join`
+callback runs mid-match, so it has to cope with a player arriving into a live
+game state, and the script decides when to stop taking them with
+[`game.match.set_joinable(false)`](lua-api.md#match). See
+[Lobbies](lobbies.md#joining-a-match-already-in-progress).
+
 ## Playing with friends
 
 Gathering players before a game starts is covered in [Lobbies](lobbies.md).

--- a/guides/rest-api.md
+++ b/guides/rest-api.md
@@ -220,10 +220,16 @@ matches, an audit trail, nothing you can join. It accepts `mode`, `status`
 and `limit` (1-200, default 50), newest first.
 
 `GET /api/v1/matches/live` enumerates running match processes and is what a
-lobby browser wants. It accepts `mode` and `has_capacity=true`. Matches are
-**unlisted by default** - a mode opts in with `listed = true` (a Lua global, or
-`listed => true` in the operator's `game_modes` config) - so an empty result
-usually means no mode has opted in yet.
+lobby browser wants. It accepts `mode`, `has_capacity=true` and
+`joinable=true|false`. Matches are **unlisted by default** - a mode opts in
+with `listed = true` (a Lua global, or `listed => true` in the operator's
+`game_modes` config) - so an empty result usually means no mode has opted in
+yet.
+
+Every entry carries `joinable`, and a browser looking for somewhere to play
+should filter on both it and `has_capacity`: a match with room may have closed
+itself to new players, and a full one has not closed. `running` matches are
+included, because a running match takes joins - that is how backfill works.
 
 Neither returns the player roster. As with worlds, joining is `match.join`
 over WS.

--- a/guides/websocket-protocol.md
+++ b/guides/websocket-protocol.md
@@ -163,13 +163,20 @@ the node count. See [Clustering](clustering.md).
 Browse live, joinable matches. Filters are optional.
 
 ```json
-{"type": "match.list", "payload": {"mode": "arena", "has_capacity": true}}
+{"type": "match.list", "payload": {"mode": "arena", "has_capacity": true, "joinable": true}}
 ```
 
 Reply payload is `{"matches": [...]}`, each entry carrying `match_id`,
-`mode`, `status`, `player_count` and `max_players`. The roster is not
-included; see [World Server](world-server.md) for why discovery and
+`mode`, `status`, `player_count`, `max_players` and `joinable`. The roster is
+not included; see [World Server](world-server.md) for why discovery and
 membership are separate surfaces.
+
+`has_capacity` and `joinable` are separate questions and a client looking for
+somewhere to play should ask both: a match with room may have closed itself to
+new players, and a full one has not closed - it may free a slot on the next
+leave. `joinable` accepts `false` too, for a browser that wants to show
+in-progress matches it cannot enter. A filter of the wrong type is rejected
+with `invalid_joinable_filter`.
 
 **Matches are unlisted by default.** A matchmaker-spawned match is already
 assigned to its players, so it has no reason to appear in a browser. A mode
@@ -194,17 +201,34 @@ Joining is WebSocket-only by design: the join binds the match to your
 session so subsequent `match.input` is routed. There is no REST join, the
 same as for worlds.
 
+A `running` match takes joins exactly as a `waiting` one does, so this is also
+how a player backfills into a game already in progress. There is no separate
+backfill call.
+
 #### `match.joined` (reply)
 
 The full match info, including the roster:
 
 ```json
-{"type": "match.joined", "cid": "j-1", "payload": {"match_id": "...", "mode": "arena", "status": "waiting", "player_count": 1, "max_players": 4, "players": ["..."], "listed": false}}
+{"type": "match.joined", "cid": "j-1", "payload": {"match_id": "...", "mode": "arena", "status": "waiting", "player_count": 1, "max_players": 4, "players": ["..."], "listed": false, "joinable": true}}
 ```
 
-An unknown id is `match_not_found` (`match.not_found`); over the join rate
-it is `join_rate_limited`; a game module that refuses the join answers with
-whatever reason it returned, wrapped as `ws.request_failed`.
+| Reason | Code | Means |
+|---|---|---|
+| `match_not_found` | `match.not_found` | No live match with that id |
+| `join_rate_limited` | `join_rate_limited` | Over 10 joins per 60 seconds |
+| `match_full` | `match.full` | No room. May free a slot on the next leave |
+| `match_locked` | `match.locked` | The game closed the match to new players |
+| `join_refused` | `match.join_refused` | The game turned this player away |
+
+`join_refused` carries the game's own reason string in
+`error.details.refused_reason` when the script gave one. It is game
+vocabulary, never an asobi code - see
+[Refusing a join](lua-scripting.md#refusing-a-join).
+
+```json
+{"type": "error", "cid": "j-1", "payload": {"reason": "join_refused", "error": {"code": "match.join_refused", "message": "The game refused this join. See `details.refused_reason`.", "details": {"refused_reason": "wrong_code"}}}}
+```
 
 #### Join context
 

--- a/priv/protocol/fixtures/match.joined.json
+++ b/priv/protocol/fixtures/match.joined.json
@@ -1,1 +1,1 @@
-{"type":"match.joined","cid":"3","payload":{"match_id":"01j8x000000000000000000001","mode":"demo","status":"waiting","player_count":1,"max_players":4,"players":["01j8x000000000000000000000"],"listed":false}}
+{"type":"match.joined","cid":"3","payload":{"match_id":"01j8x000000000000000000001","mode":"demo","status":"waiting","player_count":1,"max_players":4,"players":["01j8x000000000000000000000"],"listed":false,"joinable":true}}

--- a/priv/protocol/fixtures/match.list.json
+++ b/priv/protocol/fixtures/match.list.json
@@ -1,1 +1,1 @@
-{"type":"match.list","cid":"21","payload":{"matches":[{"match_id":"01j8x000000000000000000001","mode":"demo","status":"waiting","player_count":1,"max_players":4}]}}
+{"type":"match.list","cid":"21","payload":{"matches":[{"match_id":"01j8x000000000000000000001","mode":"demo","status":"waiting","player_count":1,"max_players":4,"joinable":true}]}}

--- a/src/asobi_error.erl
+++ b/src/asobi_error.erl
@@ -51,7 +51,7 @@ working and a new one reads one place: see `legacy/2`.
 -export([object/1, object/2, object/3]).
 -export([legacy/2, legacy_body/2]).
 -export([status/1, message/1, codes/0, core_codes/0, defined/1]).
--export([from_ws_reason/1, ws_reasons/0]).
+-export([from_ws_reason/1, from_ws_reason/2, ws_reasons/0]).
 -export([handle/3, register_handler/0]).
 
 -type code() :: binary().
@@ -220,6 +220,9 @@ working and a new one reads one place: see `legacy/2`.
     %% Matches, worlds, chat, matchmaking.
     {~"match.not_found", 404, ~"No live match exists with this id."},
     {~"match.not_in_match", 409, ~"This connection is not joined to a match."},
+    {~"match.full", 409, ~"The match has no room for another player."},
+    {~"match.locked", 409, ~"The match is closed to new players."},
+    {~"match.join_refused", 403, ~"The game refused this join. See `details.refused_reason`."},
     {~"world.not_found", 404, ~"No live world exists with this id."},
     {~"world.already_joined", 409, ~"This connection is already joined to a world."},
     {~"chat.invalid_channel_id", 400, ~"The channel id is not valid."},
@@ -250,6 +253,9 @@ working and a new one reads one place: see `legacy/2`.
     {~"not_authorized", ~"forbidden"},
     {~"not_in_match", ~"match.not_in_match"},
     {~"match_not_found", ~"match.not_found"},
+    {~"match_full", ~"match.full"},
+    {~"match_locked", ~"match.locked"},
+    {~"join_refused", ~"match.join_refused"},
     {~"world_not_found", ~"world.not_found"},
     {~"already_in_world", ~"world.already_joined"},
     {~"invalid_channel_id", ~"chat.invalid_channel_id"},
@@ -361,12 +367,24 @@ untouched; this maps it onto a code. A reason with no code of its own becomes
 must not be able to mint codes.
 """.
 -spec from_ws_reason(atom() | binary()) -> object().
-from_ws_reason(Reason) when is_atom(Reason) ->
-    from_ws_reason(atom_to_binary(Reason, utf8));
-from_ws_reason(Reason) when is_binary(Reason) ->
+from_ws_reason(Reason) ->
+    from_ws_reason(Reason, #{}).
+
+-doc """
+`from_ws_reason/1` with extra `details`.
+
+For the caller that has context the code alone cannot carry - the game's own
+refusal string behind `match.join_refused`, say. The details are additive:
+they never replace the code, so a script-supplied string still cannot become
+one.
+""".
+-spec from_ws_reason(atom() | binary(), details()) -> object().
+from_ws_reason(Reason, Details) when is_atom(Reason) ->
+    from_ws_reason(atom_to_binary(Reason, utf8), Details);
+from_ws_reason(Reason, Details) when is_binary(Reason), is_map(Details) ->
     case lists:keyfind(Reason, 1, ?WS_REASONS) of
-        {_, Code} -> object(Code);
-        false -> object(~"ws.request_failed", #{reason => Reason})
+        {_, Code} when is_binary(Code) -> object(Code, Details);
+        _ -> object(~"ws.request_failed", Details#{reason => Reason})
     end.
 
 -doc "The WebSocket reason -> code mapping, as `{Reason, Code}` pairs.".

--- a/src/controllers/asobi_match_controller.erl
+++ b/src/controllers/asobi_match_controller.erl
@@ -29,10 +29,16 @@ live(#{qs := Qs} = _Req) when is_binary(Qs) ->
             undefined -> Filters0;
             Mode -> Filters0#{mode => Mode}
         end,
-    Filters =
+    Filters2 =
         case proplists:get_value(~"has_capacity", Params) of
             ~"true" -> Filters1#{has_capacity => true};
             _ -> Filters1
+        end,
+    Filters =
+        case proplists:get_value(~"joinable", Params) of
+            ~"true" -> Filters2#{joinable => true};
+            ~"false" -> Filters2#{joinable => false};
+            _ -> Filters2
         end,
     {json, #{matches => asobi_match_lobby:list_matches_cached(Filters)}};
 live(_Req) ->

--- a/src/lua/asobi_lua_api.erl
+++ b/src/lua/asobi_lua_api.erl
@@ -151,6 +151,11 @@ api_surface(Ctx) ->
         {[~"game", ~"log"], none, fun_log(Ctx)},
         {[~"game", ~"broadcast"], write, fun_broadcast(Ctx)},
         {[~"game", ~"send"], write, fun_send()},
+        %% Match
+        {[~"game", ~"match", ~"set_joinable"], write, fun_match_set_joinable(Ctx)},
+        %% Bots
+        {[~"game", ~"bots", ~"add"], write, fun_bots_add(Ctx)},
+        {[~"game", ~"bots", ~"remove"], write, fun_bots_remove(Ctx)},
         %% Economy
         {[~"game", ~"economy", ~"grant"], write, fun_economy_grant()},
         {[~"game", ~"economy", ~"debit"], write, fun_economy_debit()},
@@ -533,6 +538,65 @@ fun_send() ->
                 error_result(~"send requires (player_id, message)", St)
         end
     end.
+
+%% --- Match ---
+
+%% Asynchronous, like game.broadcast and for the same reason: this runs inside
+%% the match server's own process, so a call would deadlock. The flag lands
+%% before the next message the match handles, and a join already sitting in the
+%% mailbox ahead of it is still accepted - closing a match stops the next
+%% joiner, not one already through the door.
+fun_match_set_joinable(#{match_pid := MatchPid}) ->
+    fun(Args, St) ->
+        case decode_args(Args, St) of
+            [Joinable] when is_boolean(Joinable) ->
+                asobi_match_server:set_joinable(MatchPid, Joinable),
+                {[true], St};
+            _ ->
+                error_result(~"match.set_joinable requires (boolean)", St)
+        end
+    end;
+fun_match_set_joinable(_) ->
+    fun(_, St) -> error_result(~"match.set_joinable not available (no match context)", St) end.
+
+%% --- Bots ---
+
+%% Bot fill via the matchmaker (`bots.enabled` on a mode) tops up the *queue*
+%% before a match exists. These two are the other half: a match script deciding
+%% for itself who is in the room, at any point in the match. Both are
+%% asynchronous for the same reason as set_joinable - asobi_bot joins the match
+%% from its own init, which would deadlock against a start_child issued from
+%% inside the match process.
+fun_bots_add(#{match_pid := MatchPid}) ->
+    fun(Args, St) ->
+        case decode_args(Args, St) of
+            [Name] when is_binary(Name) ->
+                case asobi_bot_spawner:validate_bot_name(Name) of
+                    ok ->
+                        asobi_bot_spawner:add_bot(MatchPid, Name),
+                        {[true], St};
+                    {error, Reason} ->
+                        error_result(Reason, St)
+                end;
+            _ ->
+                error_result(~"bots.add requires (name)", St)
+        end
+    end;
+fun_bots_add(_) ->
+    fun(_, St) -> error_result(~"bots.add not available (no match context)", St) end.
+
+fun_bots_remove(#{match_pid := MatchPid}) ->
+    fun(Args, St) ->
+        case decode_args(Args, St) of
+            [BotId] when is_binary(BotId) ->
+                asobi_bot_spawner:remove_bot(MatchPid, BotId),
+                {[true], St};
+            _ ->
+                error_result(~"bots.remove requires (bot_id)", St)
+        end
+    end;
+fun_bots_remove(_) ->
+    fun(_, St) -> error_result(~"bots.remove not available (no match context)", St) end.
 
 %% --- Economy ---
 

--- a/src/lua/asobi_lua_api.erl
+++ b/src/lua/asobi_lua_api.erl
@@ -546,18 +546,48 @@ fun_send() ->
 %% before the next message the match handles, and a join already sitting in the
 %% mailbox ahead of it is still accepted - closing a match stops the next
 %% joiner, not one already through the door.
-fun_match_set_joinable(#{match_pid := MatchPid}) ->
-    fun(Args, St) ->
-        case decode_args(Args, St) of
-            [Joinable] when is_boolean(Joinable) ->
-                asobi_match_server:set_joinable(MatchPid, Joinable),
-                {[true], St};
-            _ ->
-                error_result(~"match.set_joinable requires (boolean)", St)
+fun_match_set_joinable(#{match_pid := MatchPid} = Ctx) ->
+    match_only(
+        Ctx,
+        ~"match.set_joinable",
+        fun(Args, St) ->
+            case decode_args(Args, St) of
+                [Joinable] when is_boolean(Joinable) ->
+                    asobi_match_server:set_joinable(MatchPid, Joinable),
+                    {[true], St};
+                _ ->
+                    error_result(~"match.set_joinable requires (boolean)", St)
+            end
         end
-    end;
+    );
 fun_match_set_joinable(_) ->
     fun(_, St) -> error_result(~"match.set_joinable not available (no match context)", St) end.
+
+%% A world and a zone VM bind `match_pid` too - to the world server - so the
+%% presence of the key is not the gate, the VM kind is. Left ungated, both of
+%% these reach asobi_world_server: it answers `get_info` and `{join, _, _}`
+%% with the shapes the match server uses, so `bots.add` from a world script
+%% would quietly seat a bot in a world; and its `running/3` has no catch-all,
+%% so a `set_joinable` cast would kill the world and every player in it
+%% (the same shape as asobi#285/#290). Checked, not assumed.
+-spec match_only(map(), binary(), function()) -> function().
+match_only(Ctx, Name, Fun) ->
+    case vm_kind(Ctx) of
+        match ->
+            Fun;
+        Kind ->
+            fun(_, St) ->
+                error_result(
+                    iolist_to_binary([
+                        Name,
+                        ~" is only available in a match (this is a ",
+                        atom_to_binary(Kind),
+                        ~" script)"
+                    ]),
+                    St
+                )
+            end
+    end.
 
 %% --- Bots ---
 
@@ -567,34 +597,42 @@ fun_match_set_joinable(_) ->
 %% asynchronous for the same reason as set_joinable - asobi_bot joins the match
 %% from its own init, which would deadlock against a start_child issued from
 %% inside the match process.
-fun_bots_add(#{match_pid := MatchPid}) ->
-    fun(Args, St) ->
-        case decode_args(Args, St) of
-            [Name] when is_binary(Name) ->
-                case asobi_bot_spawner:validate_bot_name(Name) of
-                    ok ->
-                        asobi_bot_spawner:add_bot(MatchPid, Name),
-                        {[true], St};
-                    {error, Reason} ->
-                        error_result(Reason, St)
-                end;
-            _ ->
-                error_result(~"bots.add requires (name)", St)
+fun_bots_add(#{match_pid := MatchPid} = Ctx) ->
+    match_only(
+        Ctx,
+        ~"bots.add",
+        fun(Args, St) ->
+            case decode_args(Args, St) of
+                [Name] when is_binary(Name) ->
+                    case asobi_bot_spawner:validate_bot_name(Name) of
+                        ok ->
+                            asobi_bot_spawner:add_bot(MatchPid, Name),
+                            {[true], St};
+                        {error, Reason} ->
+                            error_result(Reason, St)
+                    end;
+                _ ->
+                    error_result(~"bots.add requires (name)", St)
+            end
         end
-    end;
+    );
 fun_bots_add(_) ->
     fun(_, St) -> error_result(~"bots.add not available (no match context)", St) end.
 
-fun_bots_remove(#{match_pid := MatchPid}) ->
-    fun(Args, St) ->
-        case decode_args(Args, St) of
-            [BotId] when is_binary(BotId) ->
-                asobi_bot_spawner:remove_bot(MatchPid, BotId),
-                {[true], St};
-            _ ->
-                error_result(~"bots.remove requires (bot_id)", St)
+fun_bots_remove(#{match_pid := MatchPid} = Ctx) ->
+    match_only(
+        Ctx,
+        ~"bots.remove",
+        fun(Args, St) ->
+            case decode_args(Args, St) of
+                [BotId] when is_binary(BotId) ->
+                    asobi_bot_spawner:remove_bot(MatchPid, BotId),
+                    {[true], St};
+                _ ->
+                    error_result(~"bots.remove requires (bot_id)", St)
+            end
         end
-    end;
+    );
 fun_bots_remove(_) ->
     fun(_, St) -> error_result(~"bots.remove not available (no match context)", St) end.
 

--- a/src/lua/asobi_lua_match.erl
+++ b/src/lua/asobi_lua_match.erl
@@ -22,7 +22,7 @@ The Lua script must define these functions:
 
 ```lua
 function init(config)        -- return initial game state table
-function join(player_id, state, ctx)  -- ctx is the client join context; return updated state
+function join(player_id, state, ctx)  -- return updated state, or nil[, reason] to refuse
 function leave(player_id, state)      -- return updated state
 function handle_input(player_id, input, state) -- return updated state
 function tick(state)         -- return state, or state + finished flag
@@ -127,6 +127,22 @@ Without this, `ctx` would reach asobi, find no `join/3` on the Lua bridge,
 fall back to `join/2` and be silently discarded - so every Lua game would
 be unable to implement join codes, invites or passwords despite the docs
 saying otherwise.
+
+Returning `nil` refuses the join, optionally with a reason string:
+
+```lua
+function join(player_id, state, ctx)
+    if state.locked then return nil, "match_locked" end
+    if ctx.code ~= state.join_code then return nil, "wrong_code" end
+    state.players[player_id] = { hp = 100 }
+    return state
+end
+```
+
+A refused player is never added to the roster and the Lua state is left
+exactly as it was before the call, so a refusal leaves no trace in the game
+state. The reason reaches the client; it is game vocabulary, so it travels
+in `details` and never becomes an asobi error code (see `m:asobi_error`).
 """.
 -spec join(binary(), map(), map()) -> {ok, map()} | {error, term()}.
 join(PlayerId, Ctx, #{lua_state := LuaSt, game_state := GS} = State) when is_map(Ctx) ->
@@ -134,12 +150,47 @@ join(PlayerId, Ctx, #{lua_state := LuaSt, game_state := GS} = State) when is_map
     %% already a Lua value, but Ctx arrives raw from the client.
     {EncCtx, LuaSt0} = luerl:encode(Ctx, LuaSt),
     case asobi_lua_loader:call(join, [PlayerId, GS, EncCtx], LuaSt0, ?JOIN_TIMEOUT) of
+        {ok, [Falsey | Rest], LuaSt1} when Falsey =:= nil; Falsey =:= false ->
+            {error, {join_refused, refusal_reason(Rest, LuaSt1)}};
         {ok, [GS1 | _], LuaSt1} ->
             {ok, State#{lua_state => LuaSt1, game_state => GS1}};
+        %% A `join` that falls off its end returns no values at all. Before
+        %% refusal existed this was a case_clause that killed the match
+        %% server and with it every player already in the roster; a script
+        %% bug must cost the author their own join, not the whole match.
+        {ok, [], _LuaSt1} ->
+            log_match_lua_error(
+                warning, join, join_returned_no_state, State, #{player_id => PlayerId}
+            ),
+            {error, {join_refused, undefined}};
         {error, Reason} ->
             log_match_lua_error(warning, join, Reason, State, #{player_id => PlayerId}),
             {error, Reason}
     end.
+
+%% The refusal reason is author-written and reaches a client, so it is bounded
+%% the same way a broadcast event name is: short, ASCII, no control bytes. An
+%% out-of-shape reason is dropped rather than rejected - the refusal itself is
+%% what matters, and failing it over a bad label would be worse.
+-define(MAX_REFUSAL_REASON, 64).
+
+-spec refusal_reason([dynamic()], dynamic()) -> binary() | undefined.
+refusal_reason([Value | _], LuaSt) ->
+    case luerl:decode(Value, LuaSt) of
+        Reason when is_binary(Reason), byte_size(Reason) =< ?MAX_REFUSAL_REASON, Reason =/= <<>> ->
+            case is_printable_ascii(Reason) of
+                true -> Reason;
+                false -> undefined
+            end;
+        _ ->
+            undefined
+    end;
+refusal_reason([], _LuaSt) ->
+    undefined.
+
+-spec is_printable_ascii(binary()) -> boolean().
+is_printable_ascii(Bin) ->
+    lists:all(fun(B) -> B >= 32 andalso B =< 126 end, binary_to_list(Bin)).
 
 -spec leave(binary(), map()) -> {ok, map()}.
 leave(PlayerId, #{lua_state := LuaSt, game_state := GS} = State) ->

--- a/src/lua/asobi_lua_surface.erl
+++ b/src/lua/asobi_lua_surface.erl
@@ -33,6 +33,8 @@ Three things live here, and only here:
 %% exists, so the root leads and every nested namespace follows it.
 -define(RESERVED_NAMESPACES, [
     [~"game"],
+    [~"game", ~"match"],
+    [~"game", ~"bots"],
     [~"game", ~"economy"],
     [~"game", ~"leaderboard"],
     [~"game", ~"storage"],

--- a/src/lua/bots/asobi_bot_spawner.erl
+++ b/src/lua/bots/asobi_bot_spawner.erl
@@ -5,6 +5,17 @@ Also starts bot AI processes when bots join matches.
 
 Bot names are read from the bot script's `names` global. If not defined,
 falls back to default generated names.
+
+`add_bot/2` and `remove_bot/2` are the other route in: a match script placing
+a bot itself, rather than a mode opting in to queue fill. Queue fill answers
+"not enough humans are waiting"; a script answers "this match wants a bot,
+now", which is a question only the game can answer. They share the
+`?MAX_BOT_FILL` ceiling, so a script cannot spawn processes without bound.
+
+Both run here rather than in the match server because `asobi_bot` joins its
+match from its own `init/1`: starting one from inside the match process would
+block that process in `supervisor:start_child/2` while the new bot waited on
+it to answer the join.
 """.
 
 -behaviour(gen_server).
@@ -13,10 +24,15 @@ falls back to default generated names.
 -include("asobi_lua_bots.hrl").
 
 -export([start_link/0]).
+-export([add_bot/2, remove_bot/2, validate_bot_name/1]).
 -export([init/1, handle_info/2, handle_cast/2, handle_call/3]).
 -ifdef(TEST).
--export([fill_mode/2]).
+-export([fill_mode/2, do_add_bot/2, do_remove_bot/2]).
 -endif.
+
+%% Same shape as a broadcast event name, and deliberately excludes `.`: the id
+%% reaches a client in the match roster and is used as a pg group key.
+-define(MAX_BOT_NAME, 32).
 
 -define(CHECK_INTERVAL, 8000).
 -define(SCAN_INTERVAL, 2000).
@@ -25,6 +41,48 @@ falls back to default generated names.
 -spec start_link() -> gen_server:start_ret().
 start_link() ->
     gen_server:start_link({local, ?MODULE}, ?MODULE, [], []).
+
+-doc """
+Place a bot in a live match. `Name` is bare - the `bot_` prefix every bot id
+carries is added here, so a script never has to know about it.
+
+Silently does nothing if the match is gone, full, already holds a bot by that
+name, or is already at the bot ceiling; a script calling this on every tick
+must not turn into an error stream.
+""".
+-spec add_bot(pid(), binary()) -> ok.
+add_bot(MatchPid, Name) when is_pid(MatchPid), is_binary(Name) ->
+    gen_server:cast(?MODULE, {add_bot, MatchPid, Name}).
+
+-doc """
+Remove a bot from a live match, by bare name or by full `bot_`-prefixed id -
+the roster a script reads holds the prefixed form, and a script that passes
+back what it read should not have to strip it.
+
+Stopping the bot process is what removes it: `asobi_bot:terminate/2` leaves
+the match on the way out.
+""".
+-spec remove_bot(pid(), binary()) -> ok.
+remove_bot(MatchPid, BotId) when is_pid(MatchPid), is_binary(BotId) ->
+    gen_server:cast(?MODULE, {remove_bot, MatchPid, BotId}).
+
+-doc "Whether `Name` is usable as a bot name, with the reason when it is not.".
+-spec validate_bot_name(binary()) -> ok | {error, binary()}.
+validate_bot_name(<<>>) ->
+    {error, ~"bot name must not be empty"};
+validate_bot_name(Name) when byte_size(Name) > ?MAX_BOT_NAME ->
+    {error, ~"bot name must be at most 32 bytes"};
+validate_bot_name(Name) when is_binary(Name) ->
+    case lists:all(fun is_bot_name_char/1, binary_to_list(Name)) of
+        true -> ok;
+        false -> {error, ~"bot name must be [A-Za-z0-9_-]"}
+    end.
+
+is_bot_name_char(C) when C >= $a, C =< $z -> true;
+is_bot_name_char(C) when C >= $A, C =< $Z -> true;
+is_bot_name_char(C) when C >= $0, C =< $9 -> true;
+is_bot_name_char(C) when C =:= $_; C =:= $- -> true;
+is_bot_name_char(_) -> false.
 
 -spec init([]) -> {ok, map()}.
 init([]) ->
@@ -45,7 +103,115 @@ handle_info(_, State) ->
     {noreply, State}.
 
 -spec handle_cast(term(), map()) -> {noreply, map()}.
-handle_cast(_, State) -> {noreply, State}.
+handle_cast({add_bot, MatchPid, Name}, State) when is_pid(MatchPid), is_binary(Name) ->
+    do_add_bot(MatchPid, Name),
+    {noreply, State};
+handle_cast({remove_bot, MatchPid, BotId}, State) when is_pid(MatchPid), is_binary(BotId) ->
+    do_remove_bot(MatchPid, BotId),
+    {noreply, State};
+handle_cast(_, State) ->
+    {noreply, State}.
+
+%% --- Script-driven bots ---
+
+-spec do_add_bot(pid(), binary()) -> ok.
+do_add_bot(MatchPid, Name) ->
+    BotId = <<"bot_", Name/binary>>,
+    try asobi_match_server:get_info(MatchPid) of
+        #{players := Players, mode := Mode, max_players := Max} when is_list(Players) ->
+            case add_bot_refusal(BotId, Players, Max) of
+                ok ->
+                    start_bot(MatchPid, BotId, bot_script(Mode));
+                {refused, Reason} ->
+                    ?LOG_INFO(#{
+                        msg => ~"bot not added", bot_id => BotId, reason => Reason
+                    }),
+                    ok
+            end;
+        _ ->
+            ok
+    catch
+        %% The match ended between the script's call and this cast. Nothing to
+        %% add a bot to, and nothing worth logging.
+        _:_ ->
+            ok
+    end.
+
+-spec add_bot_refusal(binary(), [binary()], pos_integer()) -> ok | {refused, atom()}.
+add_bot_refusal(BotId, Players, Max) ->
+    Bots = length([Id || Id <- Players, is_bot(Id)]),
+    case lists:member(BotId, Players) of
+        true ->
+            {refused, already_in_match};
+        false when length(Players) >= Max ->
+            {refused, match_full};
+        false when Bots >= ?MAX_BOT_FILL ->
+            {refused, bot_ceiling_reached};
+        false ->
+            ok
+    end.
+
+-spec start_bot(pid(), binary(), binary() | undefined) -> ok.
+start_bot(MatchPid, BotId, Script) ->
+    %% A bot with no script still plays - asobi_bot falls back to its built-in
+    %% AI - but that is nearly always an unconfigured mode rather than a
+    %% choice, so it is worth one line in the log.
+    case Script of
+        undefined ->
+            ?LOG_INFO(#{msg => ~"bot added with no script, using default AI", bot_id => BotId});
+        _ ->
+            ok
+    end,
+    case asobi_bot_sup:start_bot(MatchPid, BotId, Script) of
+        {ok, _} ->
+            ?LOG_INFO(#{msg => ~"bot AI started", bot_id => BotId});
+        {error, Reason} ->
+            ?LOG_WARNING(#{msg => ~"bot start failed", bot_id => BotId, reason => Reason})
+    end,
+    ok.
+
+%% Stopping the process is the removal: asobi_bot:terminate/2 leaves the match.
+%% Killing it instead would leave the roster to the match server's monitor,
+%% which under a reconnect policy holds the slot open for the grace window -
+%% a bot the script removed would linger.
+-spec do_remove_bot(pid(), binary()) -> ok.
+do_remove_bot(MatchPid, BotId0) ->
+    BotId =
+        case is_bot(BotId0) of
+            true -> BotId0;
+            false -> <<"bot_", BotId0/binary>>
+        end,
+    case asobi_presence:bot_pids(BotId) of
+        [] ->
+            %% A bot id in the roster with no live process (its AI crashed,
+            %% say) is still the script's to remove, so fall through to a
+            %% plain leave.
+            asobi_match_server:leave(MatchPid, BotId);
+        Pids ->
+            lists:foreach(fun(Pid) when is_pid(Pid) -> stop_bot(Pid) end, Pids)
+    end.
+
+%% Bots on the roster with no AI process yet. Skipping the ones that have one
+%% matters because a script can place a bot (add_bot/2) before this match is
+%% scanned for the first time, and starting a second process for the same id
+%% would put two AIs on one roster slot.
+-spec bots_needing_ai([term()]) -> [binary()].
+bots_needing_ai(Players) ->
+    [
+        Id
+     || Id <- Players,
+        is_binary(Id),
+        is_bot(Id),
+        asobi_presence:bot_pids(Id) =:= []
+    ].
+
+-spec stop_bot(pid()) -> ok.
+stop_bot(Pid) ->
+    try
+        gen_server:stop(Pid, normal, 5000)
+    catch
+        _:_ -> ok
+    end.
 
 -spec handle_call(term(), gen_server:from(), map()) -> {reply, ok, map()}.
 handle_call(_, _From, State) -> {reply, ok, State}.
@@ -155,22 +321,11 @@ start_bots_for_match(MatchId) ->
             try asobi_match_server:get_info(MatchPid) of
                 #{players := Players, mode := Mode} when is_list(Players) ->
                     BotScript = bot_script(Mode),
-                    BotPlayers = [Id || Id <- Players, is_bot(Id)],
                     lists:foreach(
-                        fun
-                            (BotId) when is_binary(BotId) ->
-                                case asobi_bot_sup:start_bot(MatchPid, BotId, BotScript) of
-                                    {ok, _} ->
-                                        logger:info(#{
-                                            msg => ~"bot AI started", bot_id => BotId
-                                        });
-                                    {error, _} ->
-                                        ok
-                                end;
-                            (_) ->
-                                ok
+                        fun(BotId) when is_binary(BotId) ->
+                            start_bot(MatchPid, BotId, BotScript)
                         end,
-                        BotPlayers
+                        bots_needing_ai(Players)
                     );
                 _ ->
                     ok

--- a/src/matches/asobi_match_lobby.erl
+++ b/src/matches/asobi_match_lobby.erl
@@ -24,10 +24,16 @@ list_matches() ->
     list_matches(#{}).
 
 -doc """
-List live matches with optional filters: `mode`, `has_capacity`, `listed`.
+List live matches with optional filters: `mode`, `has_capacity`, `listed`,
+`joinable`.
 
 Only `waiting` and `running` matches are returned; a `finished` match is
 history and a `paused` one cannot be joined.
+
+`has_capacity` and `joinable` are separate questions and both have to be
+asked to find a match that will actually take a player: a match with room
+can still have closed itself to new joins, and a full match is not locked -
+it may free a slot on the next leave.
 """.
 -spec list_matches(map()) -> [map()].
 list_matches(Filters) ->
@@ -40,20 +46,28 @@ Cached `list_matches/1` for request paths, mirroring
 Each uncached call issues one `gen_statem:call` per live match. That cost
 is paid even when every match is unlisted and the result is empty, so a
 flood of `match.list` messages would stall every match's mailbox. Keyed on
-`has_capacity` only - `mode` is client-controlled and unbounded, so keying
-on it would miss on every request and grow the table without bound.
+`has_capacity` and `joinable` only - both are bounded, so the table stays
+small, while `mode` is client-controlled and unbounded and keying on it
+would miss on every request and grow the table without bound.
 """.
 -spec list_matches_cached(map()) -> [map()].
 list_matches_cached(Filters) ->
     HasCapacity = maps:get(has_capacity, Filters, false),
+    Joinable = maps:get(joinable, Filters, undefined),
     Now = erlang:monotonic_time(millisecond),
-    Key = {asobi_match_server, HasCapacity},
+    Key = {asobi_match_server, HasCapacity, Joinable},
+    Base = #{has_capacity => HasCapacity, listed => true},
+    Inner =
+        case Joinable of
+            undefined -> Base;
+            _ -> Base#{joinable => Joinable}
+        end,
     All =
         case asobi_discovery:cache_lookup(Key, Now) of
             {hit, Matches} ->
                 Matches;
             miss ->
-                Matches = list_matches(#{has_capacity => HasCapacity, listed => true}),
+                Matches = list_matches(Inner),
                 asobi_world_lobby_server:cache_listing(Key, Matches, Now + ?LIST_CACHE_TTL_MS),
                 Matches
         end,
@@ -79,6 +93,11 @@ matches_filters(Info, Filters) ->
             {ok, Want} -> maps:get(listed, Info, false) =:= Want;
             error -> true
         end,
+    JoinableOk =
+        case maps:find(joinable, Filters) of
+            {ok, WantJoin} -> maps:get(joinable, Info, true) =:= WantJoin;
+            error -> true
+        end,
     Status = maps:get(status, Info, undefined),
     StatusOk = Status =:= waiting orelse Status =:= running,
-    ModeOk andalso CapOk andalso ListedOk andalso StatusOk.
+    ModeOk andalso CapOk andalso ListedOk andalso JoinableOk andalso StatusOk.

--- a/src/matches/asobi_match_server.erl
+++ b/src/matches/asobi_match_server.erl
@@ -37,7 +37,7 @@ the place to put callback hardening.
 -export([whereis/1]).
 
 -define(PG_SCOPE, nova_scope).
--export([start_vote/2, cast_vote/4, use_veto/3, broadcast_event/3]).
+-export([start_vote/2, cast_vote/4, use_veto/3, broadcast_event/3, set_joinable/2]).
 -export([callback_mode/0, init/1, terminate/3]).
 -export([waiting/3, running/3, paused/3, finished/3]).
 
@@ -149,6 +149,21 @@ use_veto(Pid, PlayerId, VoteId) ->
 broadcast_event(Pid, Event, Payload) ->
     gen_statem:cast(Pid, {broadcast_event, Event, Payload}).
 
+-doc """
+Open or close the match to new joins.
+
+A closed match keeps running and keeps its roster; it answers every further
+join with `match_locked`. This is the runtime half of joinability - `listed`
+decides whether a match is advertised by `m:asobi_match_lobby`, and an
+unlisted match is still joinable by id, so hiding a match is not closing it.
+
+Asynchronous because the caller is usually the match's own Lua VM
+(`game.match.set_joinable`), which runs inside this process.
+""".
+-spec set_joinable(pid(), boolean()) -> ok.
+set_joinable(Pid, Joinable) when is_boolean(Joinable) ->
+    gen_statem:cast(Pid, {set_joinable, Joinable}).
+
 -spec whereis(binary()) -> {ok, pid()} | error.
 whereis(MatchId) ->
     case pg:get_members(?PG_SCOPE, {asobi_match_server, MatchId}) of
@@ -201,6 +216,7 @@ init(Config) ->
                 min_players => maps:get(min_players, Config, ?DEFAULT_MIN_PLAYERS),
                 max_players => maps:get(max_players, Config, ?DEFAULT_MAX_PLAYERS),
                 listed => maps:get(listed, Config, false),
+                joinable => maps:get(joinable, Config, true),
                 started_at => undefined,
                 vote_frustration => #{},
                 veto_tokens => #{},
@@ -269,6 +285,8 @@ waiting({call, From}, {cast_vote, _PlayerId, _VoteId, _OptionId}, _State) ->
     {keep_state_and_data, [{reply, From, {error, match_not_started}}]};
 waiting({call, From}, {use_veto, _PlayerId, _VoteId}, _State) ->
     {keep_state_and_data, [{reply, From, {error, match_not_started}}]};
+waiting(cast, {set_joinable, Joinable}, State) ->
+    {keep_state, State#{joinable => Joinable}};
 waiting(cast, cancel, State) ->
     {stop, {shutdown, cancelled}, State}.
 
@@ -461,7 +479,9 @@ running(
     end;
 running(info, {vote_vetoed, VoteId, _Template}, State) ->
     Active = maps:remove(VoteId, maps:get(active_votes, State, #{})),
-    {keep_state, State#{active_votes => Active}}.
+    {keep_state, State#{active_votes => Active}};
+running(cast, {set_joinable, Joinable}, State) ->
+    {keep_state, State#{joinable => Joinable}}.
 
 %% --- paused state ---
 
@@ -541,6 +561,11 @@ paused(info, {'DOWN', _MonRef, process, DownPid, _Reason}, #{reconnect_state := 
         none ->
             keep_state_and_data
     end;
+%% A pause does not decide joinability, so an operator closing a match while
+%% it is paused must still be honoured - the cast catch-all below would drop
+%% it silently and the match would reopen on resume.
+paused(cast, {set_joinable, Joinable}, State) ->
+    {keep_state, State#{joinable => Joinable}};
 %% asobi#290: every call with no clause above (start_vote, cast_vote,
 %% use_veto, join) used to fall through to the catch-all, which never
 %% replies - gen_statem:call/2 defaults to timeout infinity, so the caller
@@ -621,10 +646,15 @@ handle_join(
     Ctx,
     #{players := Players, max_players := Max, game_module := Mod, game_state := GS} = State
 ) ->
-    case map_size(Players) >= Max of
-        true ->
+    %% Defaulted rather than matched: a match recovered from a backup written
+    %% by an older node has no `joinable` key, and such a match must stay
+    %% joinable rather than crash the join.
+    case {maps:get(joinable, State, true), map_size(Players) >= Max} of
+        {false, _} ->
+            {keep_state_and_data, [{reply, From, {error, match_locked}}]};
+        {true, true} ->
             {keep_state_and_data, [{reply, From, {error, match_full}}]};
-        false ->
+        {true, false} ->
             case asobi_game_join:invoke(Mod, PlayerId, Ctx, GS) of
                 {ok, GS1} ->
                     %% Monitor the player session so we can run reconnect grace
@@ -663,19 +693,38 @@ handle_join(
                         maps:get(match_id, State), PlayerId
                     ),
                     State2 = notify_phase_player_joined(State1),
-                    maybe_start(From, PlayerId, State2);
+                    %% The session learns its match_pid here, not from
+                    %% whoever called join/3. Mirrors asobi_world_server's
+                    %% {world_joined, ...}. Without it a player who joined by
+                    %% id - `match.join` after `match.list`, ie the backfill
+                    %% path - has no match_pid on their session, so their
+                    %% `match.input` is answered with `not_in_match` and
+                    %% their `match.leave` silently does nothing. The
+                    %% matchmaker used to send this itself, and only it, which
+                    %% is why the defect was invisible on the matchmade path.
+                    asobi_presence:send(PlayerId, {match_joined, self()}),
+                    maybe_start(From, State2);
                 {error, Reason} ->
                     {keep_state_and_data, [{reply, From, {error, Reason}}]}
             end
     end.
 
-maybe_start(From, _PlayerId, #{players := Players, min_players := Min} = State) when
+%% `started_at` is stamped on the waiting -> running transition only. Stamping
+%% it on every join that clears min_players would let each backfill join into
+%% an already-running match restart the clock, so the persisted match record
+%% would report a duration measured from the last joiner.
+maybe_start(From, #{players := Players, min_players := Min} = State) when
     map_size(Players) >= Min
 ->
-    {next_state, running, State#{started_at => erlang:system_time(millisecond)}, [
-        {reply, From, ok}
-    ]};
-maybe_start(From, _PlayerId, State) ->
+    case maps:get(started_at, State, undefined) of
+        undefined ->
+            {next_state, running, State#{started_at => erlang:system_time(millisecond)}, [
+                {reply, From, ok}
+            ]};
+        _ ->
+            {keep_state, State, [{reply, From, ok}]}
+    end;
+maybe_start(From, State) ->
     {keep_state, State, [{reply, From, ok}]}.
 
 handle_leave(PlayerId, #{players := Players, game_module := Mod, game_state := GS} = State) ->
@@ -684,6 +733,11 @@ handle_leave(PlayerId, #{players := Players, game_module := Mod, game_state := G
             keep_state_and_data;
         true ->
             asobi_telemetry:match_player_left(maps:get(match_id, State), PlayerId),
+            %% The counterpart to `match_joined`: a session that keeps a
+            %% match_pid after leaving sends its input to a match it is no
+            %% longer in, and never gets the `not_in_match` hint that exists
+            %% to make exactly that debuggable (asobi#236).
+            asobi_presence:send(PlayerId, {match_left, self()}),
             %% Demonitor the player session if we set one up at join time so
             %% a stale 'DOWN' message can't trigger a second leave path.
             case maps:get(monitor_ref, maps:get(PlayerId, Players, #{}), undefined) of
@@ -833,7 +887,8 @@ match_info(Status, #{match_id := MatchId, players := Players} = State, IncludeRo
         player_count => map_size(Players),
         mode => maps:get(mode, State, undefined),
         max_players => maps:get(max_players, State, ?DEFAULT_MAX_PLAYERS),
-        listed => maps:get(listed, State, false)
+        listed => maps:get(listed, State, false),
+        joinable => maps:get(joinable, State, true)
     },
     Base =
         case IncludeRoster of
@@ -850,11 +905,13 @@ Projection of `get_info/1` for callers who are not in the match.
 
 Mirrors `asobi_world_server:listing_info/1`. `get_info/1` carries the full
 `players` roster and the server-side `listed` flag; neither reaches a
-browsing client.
+browsing client. `joinable` does: a client browsing for a match to join has
+to be able to tell a match that will take it from one that has closed, and
+without it the only way to find out is to attempt the join and be refused.
 """.
 -spec listing_info(map()) -> map().
 listing_info(Info) ->
-    Base = maps:with([match_id, status, player_count, max_players, mode], Info),
+    Base = maps:with([match_id, status, player_count, max_players, mode, joinable], Info),
     case maps:get(phase, Info, undefined) of
         Phase when is_map(Phase) ->
             Base#{phase => maps:with([status, phase, remaining_ms, start_condition], Phase)};

--- a/src/matches/asobi_match_server.erl
+++ b/src/matches/asobi_match_server.erl
@@ -158,7 +158,10 @@ decides whether a match is advertised by `m:asobi_match_lobby`, and an
 unlisted match is still joinable by id, so hiding a match is not closing it.
 
 Asynchronous because the caller is usually the match's own Lua VM
-(`game.match.set_joinable`), which runs inside this process.
+(`game.match.set_joinable`), which runs inside this process. An Erlang game
+module is in the same position - its callbacks run here too - so it closes
+its own match with `set_joinable(self(), false)` from `tick/1`, `join/2` or
+any other callback.
 """.
 -spec set_joinable(pid(), boolean()) -> ok.
 set_joinable(Pid, Joinable) when is_boolean(Joinable) ->

--- a/src/matches/asobi_match_server.erl
+++ b/src/matches/asobi_match_server.erl
@@ -216,7 +216,11 @@ init(Config) ->
                 min_players => maps:get(min_players, Config, ?DEFAULT_MIN_PLAYERS),
                 max_players => maps:get(max_players, Config, ?DEFAULT_MAX_PLAYERS),
                 listed => maps:get(listed, Config, false),
-                joinable => maps:get(joinable, Config, true),
+                %% Not read from Config: a match that started closed could
+                %% never be joined, so it would sit in `waiting` until the
+                %% timeout killed it. Unlike `listed`, this is runtime-only -
+                %% `set_joinable/2` is the whole interface.
+                joinable => true,
                 started_at => undefined,
                 vote_frustration => #{},
                 veto_tokens => #{},

--- a/src/matches/asobi_matchmaker.erl
+++ b/src/matches/asobi_matchmaker.erl
@@ -530,7 +530,10 @@ join_matched_players(MatchPid, Mode, PlayerIds) ->
         lists:foreach(
             fun(PlayerId) when is_binary(PlayerId) ->
                 _ = asobi_match_server:join(MatchPid, PlayerId),
-                asobi_presence:send(PlayerId, {match_joined, MatchPid}),
+                %% `match_joined` is sent by asobi_match_server itself, on the
+                %% join it accepted. Sending it here as well announced a join
+                %% this fan-out never checked the result of, so a player whose
+                %% join was refused still ended up holding a match_pid.
                 asobi_presence:send(
                     PlayerId,
                     {match_event, matched, #{match_id => MatchId, players => PlayerIds}}

--- a/src/players/asobi_player_session.erl
+++ b/src/players/asobi_player_session.erl
@@ -88,6 +88,12 @@ handle_info({session_revoked, Reason}, #{ws_pid := WsPid} = State) ->
     {stop, {shutdown, session_revoked}, State};
 handle_info({asobi_message, {match_joined, MatchPid}}, State) ->
     {noreply, State#{match_pid => MatchPid}};
+%% Guarded on the pid: a leave from a match this session already moved on
+%% from would otherwise clear the match it is actually in.
+handle_info({asobi_message, {match_left, MatchPid}}, #{match_pid := MatchPid} = State) ->
+    {noreply, State#{match_pid => undefined}};
+handle_info({asobi_message, {match_left, _MatchPid}}, State) ->
+    {noreply, State};
 handle_info({asobi_message, {world_joined, WorldPid, ZonePid}}, State) ->
     {noreply, State#{world_pid => WorldPid, zone_pid => ZonePid}};
 handle_info({asobi_message, {world_zone_changed, ZonePid}}, State) ->

--- a/src/social/asobi_presence.erl
+++ b/src/social/asobi_presence.erl
@@ -38,6 +38,7 @@ clauses against the same named type rather than an ad-hoc guess.
 
 -export([start_link/0]).
 -export([track/2, track_bot/2, untrack/1, untrack_bot/2, update/2, get_status/1, send/2]).
+-export([bot_pids/1]).
 -export([send_match_state/3]).
 -export([online_count/0]).
 -export([disconnect/2, revoke_session/2]).
@@ -50,6 +51,7 @@ clauses against the same named type rather than an ad-hoc guess.
 -type event_name() :: atom() | binary().
 -type message() ::
     {match_joined, pid()}
+    | {match_left, pid()}
     | {match_state, map()}
     | {match_state_raw, binary()}
     | {match_event, event_name(), map()}
@@ -92,6 +94,11 @@ track_bot(BotId, Pid) ->
     join_delivery_group(BotId, Pid),
     pg:join(?PG_SCOPE, ?BOT_GROUP(BotId), Pid),
     ok.
+
+-doc "The live processes tracked as bot `BotId`, if any.".
+-spec bot_pids(binary()) -> [pid()].
+bot_pids(BotId) ->
+    [Pid || Pid <- pg:get_members(?PG_SCOPE, ?BOT_GROUP(BotId)), is_pid(Pid)].
 
 -spec untrack(binary()) -> ok.
 untrack(PlayerId) ->

--- a/src/world/asobi_world_lobby_server.erl
+++ b/src/world/asobi_world_lobby_server.erl
@@ -57,14 +57,25 @@ Store a computed listing against a bounded key with an absolute expiry.
 Async: the caller keeps the value it already computed; this only seeds the
 shared cache for the next reader.
 
-The key is `{ServerMod, HasCapacity}` - four keys total across worlds and
-matches. It must stay bounded and free of client-controlled values: keying
-on `mode` would let a client cycle distinct modes to miss on every request
-and grow the table without bound.
+The key is `{ServerMod, HasCapacity}` for worlds and
+`{ServerMod, HasCapacity, Joinable}` for matches - ten keys total across the
+two. Every element after the module has to be a bounded, non-client-controlled
+value: keying on `mode` would let a client cycle distinct modes to miss on
+every request and grow the table without bound. The guard enforces that shape
+rather than trusting the caller, which is why it is not simply `is_tuple/1`.
 """.
--spec cache_listing({module(), boolean()}, [map()], integer()) -> ok.
+-spec cache_listing(
+    {module(), boolean()} | {module(), boolean(), boolean() | undefined}, [map()], integer()
+) ->
+    ok.
 cache_listing({Mod, HasCapacity} = Key, Listing, ExpiresAt) when
     is_atom(Mod), is_boolean(HasCapacity)
+->
+    gen_server:cast(?MODULE, {cache_listing, Key, Listing, ExpiresAt});
+cache_listing({Mod, HasCapacity, Joinable} = Key, Listing, ExpiresAt) when
+    is_atom(Mod),
+    is_boolean(HasCapacity),
+    is_boolean(Joinable) orelse Joinable =:= undefined
 ->
     gen_server:cast(?MODULE, {cache_listing, Key, Listing, ExpiresAt}).
 

--- a/src/ws/asobi_ws_handler.erl
+++ b/src/ws/asobi_ws_handler.erl
@@ -854,6 +854,15 @@ join_match_and_reply(Cid, MatchPid, PlayerId, Ctx, State) ->
             Info = asobi_match_server:get_info(MatchPid),
             Reply = encode_reply(Cid, ~"match.joined", Info),
             {reply, {text, Reply}, State};
+        %% The game refused this player. The reason is the script's own
+        %% vocabulary, so it travels as a detail under a fixed asobi reason -
+        %% a script must not be able to mint an error code (see m:asobi_error).
+        {error, {join_refused, undefined}} ->
+            Reply = encode_error(Cid, ~"join_refused"),
+            {reply, {text, Reply}, State};
+        {error, {join_refused, Detail}} when is_binary(Detail) ->
+            Reply = encode_error(Cid, ~"join_refused", #{}, #{refused_reason => Detail}),
+            {reply, {text, Reply}, State};
         {error, Reason} ->
             Reply = encode_error(Cid, Reason),
             {reply, {text, Reply}, State}
@@ -980,12 +989,25 @@ encode_error(Cid, Reason) ->
     encode_error(Cid, Reason, #{}).
 
 encode_error(Cid, Reason, Extra) when is_map(Extra) ->
+    encode_error(Cid, Reason, Extra, #{}).
+
+%% `Extra` sits at the top of the payload, where the pre-object dialect put
+%% its per-reason keys; `Details` goes inside the error object, where a client
+%% reading only `error` can still see it. New context belongs in `Details`.
+encode_error(Cid, Reason, Extra, Details) when is_map(Extra), is_map(Details) ->
     Bin = to_reason_binary(Reason),
-    Payload = maps:merge(Extra#{reason => Bin}, asobi_error:from_ws_reason(Bin)),
+    Payload = maps:merge(Extra#{reason => Bin}, asobi_error:from_ws_reason(Bin, Details)),
     encode_reply(Cid, ~"error", Payload).
 
 to_reason_binary(R) when is_atom(R) -> atom_to_binary(R, utf8);
-to_reason_binary(R) when is_binary(R) -> R.
+to_reason_binary(R) when is_binary(R) -> R;
+%% Anything else is a term from deeper in the stack - a crashed Lua callback's
+%% `{lua_error, _}`, say. It reached here with no clause, and
+%% safe_handle_message/2 turned the function_clause into `invalid_payload`,
+%% blaming the client for a fault on the server. A structured term is never
+%% safe to forward (it can carry script internals), so it is reported as what
+%% it is and the detail stays in the logs.
+to_reason_binary(_) -> ~"internal".
 
 -spec reserved_event_names() -> [binary()].
 reserved_event_names() -> ?RESERVED_EVENT_NAMES.
@@ -1052,10 +1074,25 @@ build_listing_filters(Payload) ->
         {error, _} = E1 ->
             E1;
         {ok, A1} ->
-            case maps:find(~"has_capacity", Payload) of
-                error -> {ok, A1};
-                {ok, true} -> {ok, A1#{has_capacity => true}};
-                {ok, false} -> {ok, A1};
-                _ -> {error, ~"invalid_has_capacity_filter"}
+            Acc2 =
+                case maps:find(~"has_capacity", Payload) of
+                    error -> {ok, A1};
+                    {ok, true} -> {ok, A1#{has_capacity => true}};
+                    {ok, false} -> {ok, A1};
+                    _ -> {error, ~"invalid_has_capacity_filter"}
+                end,
+            case Acc2 of
+                {error, _} = E2 ->
+                    E2;
+                %% Unlike has_capacity, `false` is a filter and not the
+                %% absence of one: "show me the matches that have closed" is
+                %% a question a spectator browser asks. Worlds have no
+                %% joinable flag and ignore the key.
+                {ok, A2} ->
+                    case maps:find(~"joinable", Payload) of
+                        error -> {ok, A2};
+                        {ok, J} when is_boolean(J) -> {ok, A2#{joinable => J}};
+                        _ -> {error, ~"invalid_joinable_filter"}
+                    end
             end
     end.

--- a/test/asobi_bot_presence_tests.erl
+++ b/test/asobi_bot_presence_tests.erl
@@ -31,7 +31,8 @@ presence_tracking_test_() ->
             fun bot_receives_shared_match_state/0},
         {"send_match_state/3 splits by recipient kind", fun send_match_state_splits/0},
         {"a vote_start match event reaches the bot", fun bot_receives_vote_start/0},
-        {"a finished bot leaves the delivery group", fun finished_bot_untracked/0}
+        {"a finished bot leaves the delivery group", fun finished_bot_untracked/0},
+        {"bot_pids/1 finds a tracked bot and nothing else", fun bot_pids_resolves/0}
     ]}.
 
 setup() ->
@@ -84,6 +85,23 @@ untrack_bot_drops_target() ->
     ?assertEqual([], pg:get_members(nova_scope, {bot, ~"bot_Blitz"})),
     ?assertEqual(Before, asobi_presence:online_count()),
     stop_relay(Pid).
+
+%% asobi_bot_spawner:remove_bot/2 resolves a bot id to the process it has to
+%% stop through this. A player id must not resolve - stopping a session
+%% because a script asked to remove a bot of the same name would be the worst
+%% possible outcome.
+bot_pids_resolves() ->
+    BotPid = relay(),
+    PlayerPid = relay(),
+    ok = asobi_presence:track_bot(~"bot_Pulse", BotPid),
+    ok = asobi_presence:track(~"bot_Pulse_human", PlayerPid),
+    ?assertEqual([BotPid], asobi_presence:bot_pids(~"bot_Pulse")),
+    ?assertEqual([], asobi_presence:bot_pids(~"bot_Pulse_human")),
+    ?assertEqual([], asobi_presence:bot_pids(~"bot_NeverExisted")),
+    ok = asobi_presence:untrack_bot(~"bot_Pulse", BotPid),
+    ?assertEqual([], asobi_presence:bot_pids(~"bot_Pulse")),
+    stop_relay(BotPid),
+    stop_relay(PlayerPid).
 
 %% --- the bot process itself ---
 

--- a/test/asobi_bot_spawner_tests.erl
+++ b/test/asobi_bot_spawner_tests.erl
@@ -32,6 +32,121 @@ fill_mode_test_() ->
             fun fill_stops_on_queue_full_immediately/0}
     ]}.
 
+%% Script-driven bots: a match script placing one itself rather than the
+%% matchmaker topping up the queue.
+add_bot_test_() ->
+    {foreach, fun add_setup/0, fun add_cleanup/1, [
+        {"a bare name gets the bot_ prefix and starts", fun add_bot_prefixes_and_starts/0},
+        {"the mode's bot script is handed to the new bot", fun add_bot_uses_mode_script/0},
+        {"a bot already in the match is not added twice", fun add_bot_skips_duplicate/0},
+        {"a full match takes no bot", fun add_bot_skips_full_match/0},
+        {"the bot ceiling bounds a script that keeps adding", fun add_bot_stops_at_ceiling/0},
+        {"a match that ended between call and cast is not an error",
+            fun add_bot_tolerates_dead_match/0},
+        {"remove stops the bot process", fun remove_bot_stops_process/0},
+        {"remove accepts the prefixed id from the roster", fun remove_bot_accepts_prefixed/0},
+        {"removing a bot with no live process still leaves the match",
+            fun remove_bot_without_process_leaves/0}
+    ]}.
+
+name_test_() ->
+    [
+        ?_assertEqual(ok, asobi_bot_spawner:validate_bot_name(~"Spark")),
+        ?_assertEqual(ok, asobi_bot_spawner:validate_bot_name(~"a-b_9")),
+        ?_assertMatch({error, _}, asobi_bot_spawner:validate_bot_name(<<>>)),
+        ?_assertMatch({error, _}, asobi_bot_spawner:validate_bot_name(~"has space")),
+        ?_assertMatch({error, _}, asobi_bot_spawner:validate_bot_name(~"dotted.name")),
+        ?_assertMatch(
+            {error, _}, asobi_bot_spawner:validate_bot_name(binary:copy(~"x", 33))
+        )
+    ].
+
+add_setup() ->
+    case whereis(nova_scope) of
+        undefined -> pg:start_link(nova_scope);
+        _ -> ok
+    end,
+    application:set_env(asobi, game_modes, #{}),
+    meck:new(asobi_match_server, [non_strict, no_link]),
+    meck:new(asobi_bot_sup, [non_strict, no_link]),
+    meck:expect(asobi_bot_sup, start_bot, fun(_MatchPid, _BotId, _Script) -> {ok, self()} end),
+    meck:new(asobi_presence, [non_strict, no_link]),
+    meck:expect(asobi_presence, bot_pids, fun(_BotId) -> [] end),
+    ok.
+
+add_cleanup(_) ->
+    meck:unload(asobi_presence),
+    meck:unload(asobi_bot_sup),
+    meck:unload(asobi_match_server),
+    application:unset_env(asobi, game_modes).
+
+expect_match(Players, Mode, Max) ->
+    meck:expect(asobi_match_server, get_info, fun(_Pid) ->
+        #{players => Players, mode => Mode, max_players => Max}
+    end),
+    meck:expect(asobi_match_server, leave, fun(_Pid, _PlayerId) -> ok end).
+
+add_bot_prefixes_and_starts() ->
+    expect_match([~"p1"], ~"arena", 4),
+    asobi_bot_spawner:do_add_bot(self(), ~"Spark"),
+    ?assert(meck:called(asobi_bot_sup, start_bot, [self(), ~"bot_Spark", '_'])).
+
+add_bot_uses_mode_script() ->
+    application:set_env(asobi, game_modes, #{
+        ~"arena" => #{bots => #{script => ~"priv/lua/bot.lua"}}
+    }),
+    expect_match([~"p1"], ~"arena", 4),
+    asobi_bot_spawner:do_add_bot(self(), ~"Spark"),
+    ?assert(
+        meck:called(asobi_bot_sup, start_bot, [self(), ~"bot_Spark", ~"priv/lua/bot.lua"])
+    ).
+
+add_bot_skips_duplicate() ->
+    expect_match([~"p1", ~"bot_Spark"], ~"arena", 4),
+    asobi_bot_spawner:do_add_bot(self(), ~"Spark"),
+    ?assertEqual(0, meck:num_calls(asobi_bot_sup, start_bot, '_')).
+
+add_bot_skips_full_match() ->
+    expect_match([~"p1", ~"p2"], ~"arena", 2),
+    asobi_bot_spawner:do_add_bot(self(), ~"Spark"),
+    ?assertEqual(0, meck:num_calls(asobi_bot_sup, start_bot, '_')).
+
+add_bot_stops_at_ceiling() ->
+    Bots = [<<"bot_", (integer_to_binary(N))/binary>> || N <- lists:seq(1, ?MAX_BOT_FILL)],
+    expect_match(Bots, ~"arena", 1000),
+    asobi_bot_spawner:do_add_bot(self(), ~"OneTooMany"),
+    ?assertEqual(0, meck:num_calls(asobi_bot_sup, start_bot, '_')).
+
+add_bot_tolerates_dead_match() ->
+    meck:expect(asobi_match_server, get_info, fun(_Pid) -> exit({noproc, get_info}) end),
+    ?assertEqual(ok, asobi_bot_spawner:do_add_bot(self(), ~"Spark")),
+    ?assertEqual(0, meck:num_calls(asobi_bot_sup, start_bot, '_')).
+
+remove_bot_stops_process() ->
+    Bot = spawn_bot(),
+    meck:expect(asobi_presence, bot_pids, fun(~"bot_Spark") -> [Bot] end),
+    expect_match([~"bot_Spark"], ~"arena", 4),
+    asobi_bot_spawner:do_remove_bot(self(), ~"Spark"),
+    ?assertNot(is_process_alive(Bot)).
+
+remove_bot_accepts_prefixed() ->
+    Bot = spawn_bot(),
+    meck:expect(asobi_presence, bot_pids, fun(~"bot_Spark") -> [Bot] end),
+    expect_match([~"bot_Spark"], ~"arena", 4),
+    asobi_bot_spawner:do_remove_bot(self(), ~"bot_Spark"),
+    ?assertNot(is_process_alive(Bot)).
+
+remove_bot_without_process_leaves() ->
+    expect_match([~"bot_Ghost"], ~"arena", 4),
+    asobi_bot_spawner:do_remove_bot(self(), ~"Ghost"),
+    ?assert(meck:called(asobi_match_server, leave, [self(), ~"bot_Ghost"])).
+
+%% A stand-in for asobi_bot: gen_server:stop/3 is how removal works, so the
+%% double has to be a real gen_server.
+spawn_bot() ->
+    {ok, Pid} = gen_server:start(asobi_bot_spawner_tests_stub, [], []),
+    Pid.
+
 setup() ->
     application:set_env(asobi, game_modes, #{}),
     meck:new(asobi_matchmaker, [non_strict, no_link]),

--- a/test/asobi_bot_spawner_tests_stub.erl
+++ b/test/asobi_bot_spawner_tests_stub.erl
@@ -1,0 +1,11 @@
+-module(asobi_bot_spawner_tests_stub).
+-moduledoc "A minimal gen_server standing in for asobi_bot in removal tests.".
+-behaviour(gen_server).
+
+-export([init/1, handle_call/3, handle_cast/2]).
+
+init([]) -> {ok, #{}}.
+
+handle_call(_Msg, _From, State) -> {reply, ok, State}.
+
+handle_cast(_Msg, State) -> {noreply, State}.

--- a/test/asobi_error_tests.erl
+++ b/test/asobi_error_tests.erl
@@ -124,6 +124,40 @@ ws_reason_and_rest_agree_on_the_code_test() ->
      || {Reason, Code} <- Shared
     ].
 
+%% A closed match and a full one are the same 409 but different codes: a
+%% client retries the second and gives up on the first.
+match_join_failures_have_their_own_codes_test() ->
+    ?assertMatch(
+        #{error := #{code := ~"match.full"}}, asobi_error:from_ws_reason(match_full)
+    ),
+    ?assertMatch(
+        #{error := #{code := ~"match.locked"}}, asobi_error:from_ws_reason(match_locked)
+    ),
+    ?assertMatch(
+        #{error := #{code := ~"match.join_refused"}},
+        asobi_error:from_ws_reason(~"join_refused")
+    ).
+
+%% The game's own refusal string is carried as a detail. It must never
+%% displace the code - that is the whole reason details exist.
+refusal_detail_rides_along_without_minting_a_code_test() ->
+    ?assertEqual(
+        #{
+            error => #{
+                code => ~"match.join_refused",
+                message => asobi_error:message(~"match.join_refused"),
+                details => #{refused_reason => ~"wrong_code"}
+            }
+        },
+        asobi_error:from_ws_reason(~"join_refused", #{refused_reason => ~"wrong_code"})
+    ).
+
+details_do_not_rescue_an_unmapped_reason_test() ->
+    ?assertMatch(
+        #{error := #{code := ~"ws.request_failed", details := #{reason := ~"nope"}}},
+        asobi_error:from_ws_reason(~"nope", #{extra => 1})
+    ).
+
 ws_reason_accepts_an_atom_test() ->
     ?assertEqual(
         asobi_error:from_ws_reason(~"queue_full"),

--- a/test/asobi_lua_api_tests.erl
+++ b/test/asobi_lua_api_tests.erl
@@ -36,6 +36,10 @@ api_test_() ->
         {"game.bots.add places a bot", fun game_bots_add/0},
         {"game.bots.add rejects an out-of-shape name", fun game_bots_add_bad_name/0},
         {"game.bots.remove removes one", fun game_bots_remove/0},
+        {"match.set_joinable is refused in a world VM", fun set_joinable_world_vm/0},
+        {"match.set_joinable is refused in a zone VM", fun set_joinable_zone_vm/0},
+        {"bots.add is refused in a world VM", fun bots_add_world_vm/0},
+        {"bots.remove is refused in a world VM", fun bots_remove_world_vm/0},
         {"game.send forwards to presence", fun game_send/0},
         {"game.send preserves a plain string message", fun game_send_string/0},
         {"game.economy.grant calls engine", fun game_economy_grant/0},
@@ -274,6 +278,34 @@ game_bots_remove() ->
     St = install_api(),
     {ok, [true | _], _} = eval("return game.bots.remove('bot_Spark')", St),
     ?assert(meck:called(asobi_bot_spawner, remove_bot, [self(), ~"bot_Spark"])).
+
+%% A world and a zone VM bind `match_pid` to the *world* server, so these
+%% would otherwise reach asobi_world_server: bots.add would seat a bot in a
+%% world (it answers get_info and join with the same shapes), and
+%% set_joinable would hit a cast its running/3 has no clause for and take the
+%% world down with every player in it.
+set_joinable_world_vm() ->
+    assert_refused_off_match("return game.match.set_joinable(false).error", install_api_world()),
+    ?assertNot(meck:called(asobi_match_server, set_joinable, '_')).
+
+set_joinable_zone_vm() ->
+    assert_refused_off_match(
+        "return game.match.set_joinable(false).error", install_api_with_zone()
+    ),
+    ?assertNot(meck:called(asobi_match_server, set_joinable, '_')).
+
+bots_add_world_vm() ->
+    assert_refused_off_match("return game.bots.add('Spark').error", install_api_world()),
+    ?assertNot(meck:called(asobi_bot_spawner, add_bot, '_')).
+
+bots_remove_world_vm() ->
+    assert_refused_off_match("return game.bots.remove('bot_Spark').error", install_api_world()),
+    ?assertNot(meck:called(asobi_bot_spawner, remove_bot, '_')).
+
+assert_refused_off_match(Code, St) ->
+    {ok, [Error | _], _} = eval(Code, St),
+    ?assert(is_binary(Error)),
+    ?assertNotEqual(nomatch, binary:match(Error, ~"only available in a match")).
 
 game_send() ->
     St = install_api(),
@@ -979,6 +1011,13 @@ install_api() ->
 install_api_with_zone() ->
     {ok, St0} = asobi_lua_loader:new(fixture("test_match.lua")),
     Ctx = #{match_id => ~"test-match", match_pid => self(), zone_pid => self()},
+    asobi_lua_api:install(Ctx, St0).
+
+%% The shape asobi_lua_world:make_ctx/1 builds: `vm => world`, and `match_pid`
+%% pointing at the world server rather than a match.
+install_api_world() ->
+    {ok, St0} = asobi_lua_loader:new(fixture("test_match.lua")),
+    Ctx = #{vm => world, match_id => ~"test-world", match_pid => self()},
     asobi_lua_api:install(Ctx, St0).
 
 %% asobi_lua#110 + asobi#253: known_template/2 reads the live template set

--- a/test/asobi_lua_api_tests.erl
+++ b/test/asobi_lua_api_tests.erl
@@ -30,6 +30,12 @@ api_test_() ->
         {"game.broadcast rejects an over-long event name", fun game_broadcast_long_name/0},
         {"game.broadcast rejects every core-reserved name",
             fun game_broadcast_rejects_all_reserved/0},
+        {"game.match.set_joinable closes the match", fun game_match_set_joinable/0},
+        {"game.match.set_joinable reopens it", fun game_match_set_joinable_true/0},
+        {"game.match.set_joinable rejects a non-boolean", fun game_match_set_joinable_bad_arg/0},
+        {"game.bots.add places a bot", fun game_bots_add/0},
+        {"game.bots.add rejects an out-of-shape name", fun game_bots_add_bad_name/0},
+        {"game.bots.remove removes one", fun game_bots_remove/0},
         {"game.send forwards to presence", fun game_send/0},
         {"game.send preserves a plain string message", fun game_send_string/0},
         {"game.economy.grant calls engine", fun game_economy_grant/0},
@@ -107,6 +113,12 @@ setup() ->
     meck:expect(asobi_id, generate, fun() -> ~"test-uuid-v7" end),
     meck:new(asobi_match_server, [no_link]),
     meck:expect(asobi_match_server, broadcast_event, fun(_, _, _) -> ok end),
+    meck:expect(asobi_match_server, set_joinable, fun(_, _) -> ok end),
+    %% passthrough: the same module owns validate_bot_name/1, which the
+    %% game.bots.add binding calls for real before it casts.
+    meck:new(asobi_bot_spawner, [passthrough, no_link]),
+    meck:expect(asobi_bot_spawner, add_bot, fun(_, _) -> ok end),
+    meck:expect(asobi_bot_spawner, remove_bot, fun(_, _) -> ok end),
     meck:new(asobi_presence, [non_strict, no_link]),
     meck:expect(asobi_presence, send, fun(_, _) -> ok end),
     meck:new(asobi_economy, [no_link]),
@@ -162,6 +174,7 @@ cleanup(_) ->
     meck:unload([
         asobi_id,
         asobi_match_server,
+        asobi_bot_spawner,
         asobi_presence,
         asobi_economy,
         asobi_leaderboard_server,
@@ -227,6 +240,40 @@ assert_broadcast_rejected(Code) ->
     {ok, [Error | _], _} = eval(Code, St),
     ?assert(is_binary(Error)),
     ?assertNot(meck:called(asobi_match_server, broadcast_event, '_')).
+
+game_match_set_joinable() ->
+    St = install_api(),
+    {ok, [true | _], _} = eval("return game.match.set_joinable(false)", St),
+    ?assert(meck:called(asobi_match_server, set_joinable, [self(), false])).
+
+game_match_set_joinable_true() ->
+    St = install_api(),
+    {ok, [true | _], _} = eval("return game.match.set_joinable(true)", St),
+    ?assert(meck:called(asobi_match_server, set_joinable, [self(), true])).
+
+game_match_set_joinable_bad_arg() ->
+    St = install_api(),
+    {ok, [Error | _], _} = eval("return game.match.set_joinable('yes').error", St),
+    ?assert(is_binary(Error)),
+    ?assertNot(meck:called(asobi_match_server, set_joinable, '_')).
+
+game_bots_add() ->
+    St = install_api(),
+    {ok, [true | _], _} = eval("return game.bots.add('Spark')", St),
+    ?assert(meck:called(asobi_bot_spawner, add_bot, [self(), ~"Spark"])).
+
+%% Bounded at the call site so the author sees the problem, rather than
+%% discovering a bot named with a space in the roster later.
+game_bots_add_bad_name() ->
+    St = install_api(),
+    {ok, [Error | _], _} = eval("return game.bots.add('has space').error", St),
+    ?assert(is_binary(Error)),
+    ?assertNot(meck:called(asobi_bot_spawner, add_bot, '_')).
+
+game_bots_remove() ->
+    St = install_api(),
+    {ok, [true | _], _} = eval("return game.bots.remove('bot_Spark')", St),
+    ?assert(meck:called(asobi_bot_spawner, remove_bot, [self(), ~"bot_Spark"])).
 
 game_send() ->
     St = install_api(),

--- a/test/asobi_lua_match_tests.erl
+++ b/test/asobi_lua_match_tests.erl
@@ -179,7 +179,12 @@ init_refuse_match() ->
 
 join_nil_refuses() ->
     {ok, State0} = init_refuse_match(),
-    ?assertEqual({error, {join_refused, undefined}}, asobi_lua_match:join(~"silent", State0)).
+    ?assertEqual({error, {join_refused, undefined}}, asobi_lua_match:join(~"silent", State0)),
+    %% Lua has two falsey values and `return cond and state or false` is an
+    %% ordinary way to write this, so `false` has to refuse as well as `nil`.
+    ?assertEqual(
+        {error, {join_refused, ~"also_refused"}}, asobi_lua_match:join(~"falsey", State0)
+    ).
 
 join_refusal_carries_reason() ->
     {ok, State0} = init_refuse_match(),
@@ -203,11 +208,27 @@ join_refusal_leaves_no_trace() ->
 %% is dropped - the refusal still stands, it just loses its label.
 join_refusal_reason_too_long() ->
     {ok, State0} = init_refuse_match(),
-    ?assertEqual({error, {join_refused, undefined}}, asobi_lua_match:join(~"shouty", State0)).
+    ?assertEqual({error, {join_refused, undefined}}, asobi_lua_match:join(~"shouty", State0)),
+    %% The cap is inclusive: 64 bytes travel, 65 do not.
+    ?assertEqual(
+        {error, {join_refused, binary:copy(~"y", 64)}},
+        asobi_lua_match:join(~"at_limit", State0)
+    ),
+    ?assertEqual(
+        {error, {join_refused, undefined}}, asobi_lua_match:join(~"over_limit", State0)
+    ).
 
 join_refusal_reason_not_ascii() ->
     {ok, State0} = init_refuse_match(),
-    ?assertEqual({error, {join_refused, undefined}}, asobi_lua_match:join(~"binary", State0)).
+    ?assertEqual({error, {join_refused, undefined}}, asobi_lua_match:join(~"binary", State0)),
+    %% Pins the low edge of the printable range: 31 is out, 32 (space) is in.
+    ?assertEqual({error, {join_refused, undefined}}, asobi_lua_match:join(~"control", State0)),
+    %% And the high one: 126 (~) is the last character that survives, 127
+    %% (DEL) is not.
+    ?assertEqual(
+        {error, {join_refused, ~"a space and a ~"}}, asobi_lua_match:join(~"edges", State0)
+    ),
+    ?assertEqual({error, {join_refused, undefined}}, asobi_lua_match:join(~"del", State0)).
 
 join_refusal_reason_not_a_string() ->
     {ok, State0} = init_refuse_match(),

--- a/test/asobi_lua_match_tests.erl
+++ b/test/asobi_lua_match_tests.erl
@@ -28,6 +28,13 @@ lua_match_test_() ->
         {"join/3 passes the client context to lua", fun join_ctx_reaches_lua/0},
         {"join/3 context is optional for a two-arg lua join", fun join_ctx_ignored_by_old_script/0},
         {"join/2 still works and sends an empty context", fun join_two_arg_sends_empty_ctx/0},
+        {"returning nil refuses the join", fun join_nil_refuses/0},
+        {"a refusal reason reaches the caller", fun join_refusal_carries_reason/0},
+        {"a refused join leaves the game state untouched", fun join_refusal_leaves_no_trace/0},
+        {"an oversized refusal reason is dropped", fun join_refusal_reason_too_long/0},
+        {"a non-ascii refusal reason is dropped", fun join_refusal_reason_not_ascii/0},
+        {"a non-string refusal reason is dropped", fun join_refusal_reason_not_a_string/0},
+        {"a join that returns nothing refuses instead of crashing", fun join_no_return_refuses/0},
         {"leave removes player", fun leave_removes_player/0},
         {"handle_input updates player position", fun input_moves_player/0},
         {"handle_input handles boon pick", fun input_boon_pick/0},
@@ -166,6 +173,49 @@ join_two_arg_sends_empty_ctx() ->
     {ok, State1} = asobi_lua_match:join(~"p1", State0),
     #{~"rejected" := Rejected} = asobi_lua_match:get_state(~"p1", State1),
     ?assertEqual(1, Rejected, "no ctx means no code, so this script refuses").
+
+init_refuse_match() ->
+    asobi_lua_match:init(#{lua_script => fixture("join_refuse.lua")}).
+
+join_nil_refuses() ->
+    {ok, State0} = init_refuse_match(),
+    ?assertEqual({error, {join_refused, undefined}}, asobi_lua_match:join(~"silent", State0)).
+
+join_refusal_carries_reason() ->
+    {ok, State0} = init_refuse_match(),
+    ?assertEqual(
+        {error, {join_refused, ~"wrong_code"}},
+        asobi_lua_match:join(~"p1", #{~"code" => ~"NOPE"}, State0)
+    ),
+    ?assertMatch({ok, _}, asobi_lua_match:join(~"p1", #{~"code" => ~"OPEN"}, State0)).
+
+%% A refused join must not be able to advance the game state - otherwise a
+%% client could drive a script by being turned away over and over.
+join_refusal_leaves_no_trace() ->
+    {ok, State0} = init_refuse_match(),
+    {error, _} = asobi_lua_match:join(~"silent", State0),
+    {error, _} = asobi_lua_match:join(~"silent", State0),
+    {ok, State1} = asobi_lua_match:join(~"p1", #{~"code" => ~"OPEN"}, State0),
+    #{~"attempts" := Attempts} = asobi_lua_match:get_state(~"p1", State1),
+    ?assertEqual(1, Attempts).
+
+%% The reason is author-written and reaches a client, so an out-of-shape one
+%% is dropped - the refusal still stands, it just loses its label.
+join_refusal_reason_too_long() ->
+    {ok, State0} = init_refuse_match(),
+    ?assertEqual({error, {join_refused, undefined}}, asobi_lua_match:join(~"shouty", State0)).
+
+join_refusal_reason_not_ascii() ->
+    {ok, State0} = init_refuse_match(),
+    ?assertEqual({error, {join_refused, undefined}}, asobi_lua_match:join(~"binary", State0)).
+
+join_refusal_reason_not_a_string() ->
+    {ok, State0} = init_refuse_match(),
+    ?assertEqual({error, {join_refused, undefined}}, asobi_lua_match:join(~"numeric", State0)).
+
+join_no_return_refuses() ->
+    {ok, State0} = asobi_lua_match:init(#{lua_script => fixture("join_no_return.lua")}),
+    ?assertEqual({error, {join_refused, undefined}}, asobi_lua_match:join(~"p1", State0)).
 
 join_adds_player() ->
     {ok, State0} = init_match(),

--- a/test/asobi_match_api_SUITE.erl
+++ b/test/asobi_match_api_SUITE.erl
@@ -8,7 +8,8 @@
     list_matches_with_records/1,
     list_matches_filter_mode/1,
     show_match/1,
-    show_match_not_found/1
+    show_match_not_found/1,
+    live_matches_filter_joinable/1
 ]).
 
 all() -> [{group, match_api}].
@@ -20,7 +21,8 @@ groups() ->
             list_matches_with_records,
             list_matches_filter_mode,
             show_match,
-            show_match_not_found
+            show_match_not_found,
+            live_matches_filter_joinable
         ]}
     ].
 
@@ -131,3 +133,64 @@ show_match_not_found(Config) ->
     ),
     ?assertStatus(404, Resp),
     Config.
+
+%% `/matches/live` reads live processes, not the record table the rest of this
+%% suite uses. A closed match must drop out of `joinable=true` and be the only
+%% thing left under `joinable=false`, so a lobby browser can tell "join this"
+%% from "watch this".
+live_matches_filter_joinable(Config) ->
+    Open = start_listed_match(~"live_open"),
+    Closed = start_listed_match(~"live_closed"),
+    ok = asobi_match_server:set_joinable(Closed, false),
+    timer:sleep(50),
+    try
+        ?assertEqual([~"live_open"], live_modes("?joinable=true", Config)),
+        ?assertEqual([~"live_closed"], live_modes("?joinable=false", Config)),
+        ?assertEqual(
+            [~"live_closed", ~"live_open"], lists:sort(live_modes("", Config))
+        ),
+        ?assertMatch([#{~"joinable" := true}], live_entries("?mode=live_open", Config))
+    after
+        stop_match(Open),
+        stop_match(Closed)
+    end,
+    Config.
+
+start_listed_match(Mode) ->
+    {ok, Pid} = asobi_match_sup:start_match(#{
+        game_module => asobi_test_game,
+        mode => Mode,
+        listed => true,
+        min_players => 2,
+        max_players => 4,
+        tick_rate => 50
+    }),
+    Pid.
+
+%% `shutdown`, not `kill`: these are transient children of asobi_match_sup, so
+%% an abnormal exit is restarted and the replacement match ticks on into
+%% whichever suite runs next.
+stop_match(Pid) ->
+    Ref = monitor(process, Pid),
+    exit(Pid, shutdown),
+    receive
+        {'DOWN', Ref, process, Pid, _} -> ok
+    after 5000 -> ok
+    end.
+
+%% The listing cache is keyed on the filters and lives 500ms, so a query made
+%% right after set_joinable could otherwise read a pre-close listing.
+live_entries(Query, Config) ->
+    timer:sleep(600),
+    {ok, Resp} = nova_test:get(
+        "/api/v1/matches/live" ++ Query, #{headers => auth(Config)}, Config
+    ),
+    ?assertStatus(200, Resp),
+    #{~"matches" := Matches} = nova_test:json(Resp),
+    [M || M <- Matches, lists:member(maps:get(~"mode", M, undefined), modes_under_test())].
+
+live_modes(Query, Config) ->
+    [maps:get(~"mode", M) || M <- live_entries(Query, Config)].
+
+modes_under_test() ->
+    [~"live_open", ~"live_closed"].

--- a/test/asobi_match_lobby_tests.erl
+++ b/test/asobi_match_lobby_tests.erl
@@ -53,8 +53,60 @@ match_lobby_test_() ->
         {"listed => true opts a match into discovery", fun listed_opts_in/0},
         {"listing drops the roster and the flag", fun listing_drops_roster/0},
         {"filters by mode", fun filters_by_mode/0},
-        {"has_capacity excludes a full match", fun filters_by_capacity/0}
+        {"has_capacity excludes a full match", fun filters_by_capacity/0},
+        {"a listing says whether the match will take a player", fun listing_carries_joinable/0},
+        {"joinable => true excludes a closed match", fun filters_by_joinable/0},
+        {"joinable => false finds only the closed ones", fun filters_by_not_joinable/0},
+        {"a closed match with room is still excluded by joinable",
+            fun capacity_and_joinable_are_separate/0}
     ]}.
+
+listing_carries_joinable() ->
+    Pid = start_match(#{mode => ~"joinable_mode", listed => true}),
+    [M] = asobi_match_lobby:list_matches(#{listed => true, mode => ~"joinable_mode"}),
+    ?assert(maps:get(joinable, M)),
+    stop_match(Pid).
+
+filters_by_joinable() ->
+    Open = start_match(#{mode => ~"jf_open", listed => true}),
+    Closed = start_match(#{mode => ~"jf_closed", listed => true}),
+    ok = asobi_match_server:set_joinable(Closed, false),
+    timer:sleep(50),
+    Modes = [maps:get(mode, M) || M <- asobi_match_lobby:list_matches(#{joinable => true})],
+    ?assert(lists:member(~"jf_open", Modes)),
+    ?assertNot(lists:member(~"jf_closed", Modes)),
+    stop_match(Open),
+    stop_match(Closed).
+
+filters_by_not_joinable() ->
+    Open = start_match(#{mode => ~"jn_open", listed => true}),
+    Closed = start_match(#{mode => ~"jn_closed", listed => true}),
+    ok = asobi_match_server:set_joinable(Closed, false),
+    timer:sleep(50),
+    Modes = [maps:get(mode, M) || M <- asobi_match_lobby:list_matches(#{joinable => false})],
+    ?assert(lists:member(~"jn_closed", Modes)),
+    ?assertNot(lists:member(~"jn_open", Modes)),
+    stop_match(Open),
+    stop_match(Closed).
+
+%% Room and willingness are different questions: a match with three free
+%% slots that has closed itself must not come back as somewhere to join.
+capacity_and_joinable_are_separate() ->
+    Pid = start_match(#{mode => ~"cj_mode", listed => true, max_players => 4}),
+    ok = asobi_match_server:join(Pid, ~"p1"),
+    ok = asobi_match_server:set_joinable(Pid, false),
+    timer:sleep(50),
+    ?assertEqual(
+        1,
+        length(asobi_match_lobby:list_matches(#{mode => ~"cj_mode", has_capacity => true}))
+    ),
+    ?assertEqual(
+        [],
+        asobi_match_lobby:list_matches(#{
+            mode => ~"cj_mode", has_capacity => true, joinable => true
+        })
+    ),
+    stop_match(Pid).
 
 unlisted_by_default() ->
     Pid = start_match(#{mode => ~"unlisted_mode"}),
@@ -78,7 +130,7 @@ listing_drops_roster() ->
     ok = asobi_match_server:join(Pid, ~"p1"),
     [M] = asobi_match_lobby:list_matches(#{listed => true, mode => ~"roster_mode"}),
     ?assertEqual(
-        lists:sort([match_id, status, player_count, max_players, mode]),
+        lists:sort([match_id, status, player_count, max_players, mode, joinable]),
         lists:sort(maps:keys(M)),
         "listing key set is a security contract - widen it deliberately"
     ),

--- a/test/asobi_match_server_tests.erl
+++ b/test/asobi_match_server_tests.erl
@@ -107,7 +107,18 @@ match_server_test_() ->
                 fun grace_expiry_of_last_player_stops_match/0}},
         {timeout, 15,
             {"grace expiry with players left keeps the match running",
-                fun grace_expiry_with_players_left_keeps_match/0}}
+                fun grace_expiry_with_players_left_keeps_match/0}},
+        {"join tells the session which match it joined", fun join_notifies_session/0},
+        {"leave tells the session it is out", fun leave_notifies_session/0},
+        {"a refused join notifies nobody", fun refused_join_notifies_nobody/0},
+        {"a match defaults to joinable", fun joinable_by_default/0},
+        {"set_joinable(false) closes the match to new joins", fun set_joinable_closes/0},
+        {"a locked match reopens on set_joinable(true)", fun set_joinable_reopens/0},
+        {"locked beats full", fun locked_reported_before_full/0},
+        {"a locked match keeps the players it has", fun locked_keeps_roster/0},
+        {"joinable survives a pause", fun set_joinable_while_paused/0},
+        {"backfill into a running match does not restart the clock",
+            fun backfill_keeps_started_at/0}
     ]}.
 
 %% --- Tests ---
@@ -807,6 +818,118 @@ fake_session(PlayerId) ->
     end),
     ok = pg:join(nova_scope, {player, PlayerId}, Pid),
     Pid.
+
+%% --- session notification, joinable, backfill ---
+
+%% asobi#423: the session used to learn its match_pid only from the
+%% matchmaker, so a player who found a match with match.list and joined it by
+%% id held no match_pid at all - their input was answered `not_in_match` and
+%% their leave did nothing.
+join_notifies_session() ->
+    meck:reset(asobi_presence),
+    Pid = start_match(),
+    ok = asobi_match_server:join(Pid, ~"p_notify"),
+    ?assert(meck:called(asobi_presence, send, [~"p_notify", {match_joined, Pid}])),
+    stop(Pid).
+
+leave_notifies_session() ->
+    Pid = start_match(),
+    ok = asobi_match_server:join(Pid, ~"p_left_a"),
+    ok = asobi_match_server:join(Pid, ~"p_left_b"),
+    meck:reset(asobi_presence),
+    ok = asobi_match_server:leave(Pid, ~"p_left_a"),
+    timer:sleep(50),
+    ?assert(meck:called(asobi_presence, send, [~"p_left_a", {match_left, Pid}])),
+    stop(Pid).
+
+refused_join_notifies_nobody() ->
+    meck:reset(asobi_presence),
+    Pid = start_match(),
+    ?assertMatch(
+        {error, {join_refused, ~"not_today"}}, asobi_match_server:join(Pid, ~"refuse_me")
+    ),
+    ?assertEqual(0, maps:get(player_count, asobi_match_server:get_info(Pid))),
+    ?assertNot(meck:called(asobi_presence, send, [~"refuse_me", {match_joined, Pid}])),
+    stop(Pid).
+
+joinable_by_default() ->
+    Pid = start_match(),
+    ?assert(maps:get(joinable, asobi_match_server:get_info(Pid))),
+    stop(Pid).
+
+set_joinable_closes() ->
+    Pid = start_match(),
+    ok = asobi_match_server:join(Pid, ~"p_lock1"),
+    ok = asobi_match_server:set_joinable(Pid, false),
+    ?assertMatch({error, match_locked}, asobi_match_server:join(Pid, ~"p_lock2")),
+    ?assertNot(maps:get(joinable, asobi_match_server:get_info(Pid))),
+    stop(Pid).
+
+set_joinable_reopens() ->
+    Pid = start_match(),
+    ok = asobi_match_server:set_joinable(Pid, false),
+    ?assertMatch({error, match_locked}, asobi_match_server:join(Pid, ~"p_reopen1")),
+    ok = asobi_match_server:set_joinable(Pid, true),
+    ?assertEqual(ok, asobi_match_server:join(Pid, ~"p_reopen2")),
+    stop(Pid).
+
+%% A closed match and a full one are different states and a client acts on
+%% them differently: full may free a slot on the next leave, locked will not.
+locked_reported_before_full() ->
+    Pid = start_match(#{min_players => 1, max_players => 1}),
+    ok = asobi_match_server:join(Pid, ~"p_lf1"),
+    ok = asobi_match_server:set_joinable(Pid, false),
+    ?assertMatch({error, match_locked}, asobi_match_server:join(Pid, ~"p_lf2")),
+    stop(Pid).
+
+locked_keeps_roster() ->
+    Pid = start_match(),
+    ok = asobi_match_server:join(Pid, ~"p_keep1"),
+    ok = asobi_match_server:join(Pid, ~"p_keep2"),
+    ok = asobi_match_server:set_joinable(Pid, false),
+    timer:sleep(50),
+    Info = asobi_match_server:get_info(Pid),
+    ?assertEqual(2, maps:get(player_count, Info)),
+    ?assertEqual(running, maps:get(status, Info)),
+    stop(Pid).
+
+set_joinable_while_paused() ->
+    Pid = start_match(#{min_players => 1}),
+    ok = asobi_match_server:join(Pid, ~"p_pause_lock"),
+    timer:sleep(50),
+    ok = asobi_match_server:pause(Pid),
+    ok = asobi_match_server:set_joinable(Pid, false),
+    timer:sleep(50),
+    ok = asobi_match_server:resume(Pid),
+    ?assertMatch({error, match_locked}, asobi_match_server:join(Pid, ~"p_pause_lock2")),
+    stop(Pid).
+
+%% started_at is the match clock the persisted record reports a duration
+%% from. Stamping it on every join past min_players meant each backfill
+%% joiner restarted it.
+backfill_keeps_started_at() ->
+    Self = self(),
+    meck:new(asobi_telemetry, [passthrough, no_link]),
+    meck:expect(asobi_telemetry, match_finished, fun(_MatchId, DurationMs, _Result) ->
+        Self ! {duration, DurationMs},
+        ok
+    end),
+    try
+        Pid = start_match(#{min_players => 1, max_players => 4}),
+        ok = asobi_match_server:join(Pid, ~"p_clock1"),
+        timer:sleep(120),
+        ok = asobi_match_server:join(Pid, ~"p_clock2"),
+        ok = asobi_match_server:cancel(Pid),
+        receive
+            {duration, DurationMs} ->
+                ?assert(DurationMs >= 100)
+        after 5000 ->
+            ?assert(false)
+        end,
+        stop(Pid)
+    after
+        meck:unload(asobi_telemetry)
+    end.
 
 stop(Pid) ->
     case is_process_alive(Pid) of

--- a/test/asobi_matchmaker_isolation_tests.erl
+++ b/test/asobi_matchmaker_isolation_tests.erl
@@ -38,7 +38,14 @@ match_exits_mid_fanout() ->
     ?assertEqual(
         ok, asobi_matchmaker:join_matched_players(Match, ~"m1", [~"p1", ~"p2", ~"p3"])
     ),
-    ?assert(meck:called(asobi_presence, send, [~"p1", {match_joined, Match}])),
+    %% `match_joined` is the match server's to send, on the join it accepted.
+    %% What the fan-out owns is the `matched` event, so that is what is
+    %% asserted here - a fake match never sends the other half.
+    ?assert(
+        meck:called(asobi_presence, send, [
+            ~"p1", {match_event, matched, '_'}
+        ])
+    ),
     ?assert(failed_notified(~"p1")),
     ?assert(failed_notified(~"p3")).
 
@@ -49,7 +56,14 @@ live_match_notifies_all() ->
         ({join, _, _}) -> {reply, ok}
     end),
     ?assertEqual(ok, asobi_matchmaker:join_matched_players(Match, ~"m1", [~"p1", ~"p2"])),
-    ?assert(meck:called(asobi_presence, send, [~"p1", {match_joined, Match}])),
+    %% `match_joined` is the match server's to send, on the join it accepted.
+    %% What the fan-out owns is the `matched` event, so that is what is
+    %% asserted here - a fake match never sends the other half.
+    ?assert(
+        meck:called(asobi_presence, send, [
+            ~"p1", {match_event, matched, '_'}
+        ])
+    ),
     ?assert(
         meck:called(asobi_presence, send, [
             ~"p2", {match_event, matched, #{match_id => ~"match-2", players => [~"p1", ~"p2"]}}

--- a/test/asobi_protocol_coverage_tests.erl
+++ b/test/asobi_protocol_coverage_tests.erl
@@ -206,7 +206,8 @@ listing_fixtures_match_the_projection_test() ->
         max_players => 2,
         mode => ~"m",
         players => [~"p"],
-        listed => true
+        listed => true,
+        joinable => true
     }),
     ?assertEqual(
         MatchKeys,

--- a/test/asobi_test_game.erl
+++ b/test/asobi_test_game.erl
@@ -7,7 +7,10 @@
 init(_Config) ->
     {ok, #{players => #{}, tick_count => 0}}.
 
--spec join(binary(), map()) -> {ok, map()}.
+-spec join(binary(), map()) -> {ok, map()} | {error, term()}.
+%% A game refusing a player, for the tests that need one.
+join(<<"refuse_", _/binary>>, _State) ->
+    {error, {join_refused, ~"not_today"}};
 join(PlayerId, #{players := Players} = State) ->
     {ok, State#{players => Players#{PlayerId => #{score => 0}}}}.
 

--- a/test/asobi_ws_SUITE.erl
+++ b/test/asobi_ws_SUITE.erl
@@ -11,7 +11,9 @@
     ws_match_input_not_in_match_hint/1,
     ws_match_input_hint_rate_limited/1,
     ws_script_error_rendered_as_extension_error/1,
-    ws_matchmaker_add_omitted_mode_rejected/1
+    ws_matchmaker_add_omitted_mode_rejected/1,
+    ws_backfill_join_binds_the_session/1,
+    ws_join_a_locked_match_is_refused/1
 ]).
 
 all() ->
@@ -23,7 +25,9 @@ all() ->
         ws_match_input_not_in_match_hint,
         ws_match_input_hint_rate_limited,
         ws_script_error_rendered_as_extension_error,
-        ws_matchmaker_add_omitted_mode_rejected
+        ws_matchmaker_add_omitted_mode_rejected,
+        ws_backfill_join_binds_the_session,
+        ws_join_a_locked_match_is_refused
     ].
 
 init_per_suite(Config) ->
@@ -190,6 +194,106 @@ ws_idle_auth_timeout_closes(Config) ->
     Config.
 
 %% --- helpers (mirrors asobi_chat_ws_SUITE) ---
+
+%% asobi#423: the whole backfill path over a real socket. A player who finds a
+%% match with match.list and joins it by id must end up bound to it - the
+%% matchmaker used to be the only thing that told the session which match it
+%% was in, so this join left the session with no match_pid: input came back
+%% `not_in_match` and leave silently did nothing. Both are only observable
+%% through the socket, which is why this is a suite case and not a unit test.
+ws_backfill_join_binds_the_session(Config) ->
+    {PlayerId, Token} = register_player(~"backfill", Config),
+    Conn = ws_connect_authed(Token, Config),
+    MatchPid = start_test_match(),
+    MatchId = maps:get(match_id, asobi_match_server:get_info(MatchPid)),
+
+    ok = nova_test_ws:send_json(
+        #{
+            ~"type" => ~"match.join",
+            ~"cid" => ~"bf1",
+            ~"payload" => #{~"match_id" => MatchId}
+        },
+        Conn
+    ),
+    {ok, Joined} = recv_until(
+        fun(M) -> maps:get(~"type", M, undefined) =:= ~"match.joined" end, Conn
+    ),
+    ?assertMatch(#{~"payload" := #{~"joinable" := true}}, Joined),
+
+    %% Input from a bound session is applied silently. The hint frame is the
+    %% failure signal, so its absence is the assertion.
+    ok = nova_test_ws:send_json(
+        #{~"type" => ~"match.input", ~"payload" => #{~"action" => ~"move"}}, Conn
+    ),
+    ?assertEqual(
+        {error, predicate_not_matched},
+        recv_until(
+            fun(M) ->
+                maps:get(~"reason", maps:get(~"payload", M, #{}), undefined) =:= ~"not_in_match"
+            end,
+            Conn,
+            5
+        )
+    ),
+
+    %% `match.left` is answered unconditionally, so the reply proves nothing.
+    %% What proves the leave landed is the match emptying and stopping. Asserted
+    %% before the socket closes, because closing the session would empty the
+    %% match on its own through the server's monitor and hide a leave that did
+    %% nothing.
+    Ref = monitor(process, MatchPid),
+    ok = nova_test_ws:send_json(#{~"type" => ~"match.leave", ~"cid" => ~"bf2"}, Conn),
+    {ok, _} = recv_until(
+        fun(M) -> maps:get(~"type", M, undefined) =:= ~"match.left" end, Conn
+    ),
+    receive
+        {'DOWN', Ref, process, MatchPid, {shutdown, empty}} -> ok
+    after 5000 ->
+        ct:fail({leave_did_not_reach_the_match, PlayerId})
+    end,
+    nova_test_ws:close(Conn),
+    Config.
+
+ws_join_a_locked_match_is_refused(Config) ->
+    {_, Token} = register_player(~"locked", Config),
+    Conn = ws_connect_authed(Token, Config),
+    MatchPid = start_test_match(),
+    MatchId = maps:get(match_id, asobi_match_server:get_info(MatchPid)),
+    ok = asobi_match_server:set_joinable(MatchPid, false),
+
+    ok = nova_test_ws:send_json(
+        #{
+            ~"type" => ~"match.join",
+            ~"cid" => ~"lk1",
+            ~"payload" => #{~"match_id" => MatchId}
+        },
+        Conn
+    ),
+    {ok, Reply} = recv_until(
+        fun(M) -> maps:get(~"type", M, undefined) =:= ~"error" end, Conn
+    ),
+    nova_test_ws:close(Conn),
+    ?assertMatch(
+        #{
+            ~"payload" := #{
+                ~"reason" := ~"match_locked",
+                ~"error" := #{~"code" := ~"match.locked"}
+            }
+        },
+        Reply
+    ),
+    Config.
+
+%% min_players => 1 so the match is `running` from the first join, which is
+%% the state a backfill joiner actually meets.
+start_test_match() ->
+    {ok, Pid} = asobi_match_sup:start_match(#{
+        game_module => asobi_test_game,
+        min_players => 1,
+        max_players => 4,
+        tick_rate => 50
+    }),
+    Pid.
 
 register_player(Suffix, Config) ->
     Username = unique_name(Suffix),

--- a/test/fixtures/lua/join_no_return.lua
+++ b/test/fixtures/lua/join_no_return.lua
@@ -1,0 +1,27 @@
+-- A `join` that falls off its end and returns nothing. An author bug, and
+-- before refusal existed it killed the match server and everyone in it.
+
+function init(config)
+	return {players = {}}
+end
+
+function join(player_id, state, ctx)
+	state.players[player_id] = true
+end
+
+function leave(player_id, state)
+	state.players[player_id] = nil
+	return state
+end
+
+function handle_input(player_id, input, state)
+	return state
+end
+
+function tick(state)
+	return state
+end
+
+function get_state(player_id, state)
+	return {}
+end

--- a/test/fixtures/lua/join_refuse.lua
+++ b/test/fixtures/lua/join_refuse.lua
@@ -1,0 +1,44 @@
+-- Refusing a join. `nil` alone refuses without a reason, `nil, "..."` refuses
+-- with one, and the state is only ever returned for a player who is let in.
+
+function init(config)
+	return {players = {}, locked = false, attempts = 0}
+end
+
+function join(player_id, state, ctx)
+	state.attempts = state.attempts + 1
+	if player_id == "silent" then
+		return nil
+	end
+	if player_id == "shouty" then
+		return nil, string.rep("x", 200)
+	end
+	if player_id == "binary" then
+		return nil, "\1\2\3"
+	end
+	if player_id == "numeric" then
+		return nil, 42
+	end
+	if ctx and ctx.code ~= "OPEN" then
+		return nil, "wrong_code"
+	end
+	state.players[player_id] = true
+	return state
+end
+
+function leave(player_id, state)
+	state.players[player_id] = nil
+	return state
+end
+
+function handle_input(player_id, input, state)
+	return state
+end
+
+function tick(state)
+	return state
+end
+
+function get_state(player_id, state)
+	return {attempts = state.attempts}
+end

--- a/test/fixtures/lua/join_refuse.lua
+++ b/test/fixtures/lua/join_refuse.lua
@@ -10,11 +10,29 @@ function join(player_id, state, ctx)
 	if player_id == "silent" then
 		return nil
 	end
+	if player_id == "falsey" then
+		return false, "also_refused"
+	end
 	if player_id == "shouty" then
 		return nil, string.rep("x", 200)
 	end
+	if player_id == "at_limit" then
+		return nil, string.rep("y", 64)
+	end
+	if player_id == "over_limit" then
+		return nil, string.rep("y", 65)
+	end
+	if player_id == "del" then
+		return nil, "delete\127me"
+	end
 	if player_id == "binary" then
 		return nil, "\1\2\3"
+	end
+	if player_id == "control" then
+		return nil, "unit\31separator"
+	end
+	if player_id == "edges" then
+		return nil, "a space and a ~"
 	end
 	if player_id == "numeric" then
 		return nil, 42


### PR DESCRIPTION
A forum post asked for four things around joining matches that have already
started. Two already existed and one of those was broken; two did not.

## Already there, and broken

`match.list` discovers live matches and a `running` match accepts joins, so
backfill needed no new call. But the session only ever learned its `match_pid`
from the matchmaker, so a player who found a match and joined it by id - the
backfill path - was left unbound: their `match.input` came back
`not_in_match` and their `match.leave` silently did nothing.

`asobi_match_server` now sends `match_joined` on the join it accepted,
mirroring `asobi_world_server`, and `match_left` on the way out so a stale
`match_pid` cannot outlive the match. The matchmaker's own send goes away with
it - it fired even when the join it announced had failed, because the fan-out
discards the join result.

`ws_backfill_join_binds_the_session` drives the whole path over a real socket.
Reverting the one-line fix makes it fail with exactly the `not_in_match` frame
a player would have hit.

## New

**A runtime `joinable` flag.** `game.match.set_joinable(false)` closes a match
to new players without ending it; further joins get `match_locked`. Reported
in every listing and filterable in `match.list`, `GET /api/v1/matches/live`
and `asobi_match_lobby`.

Deliberately separate from `has_capacity`: a match with three free slots may
have closed itself, and a full one has not - it may free a slot on the next
leave. A client looking for somewhere to play asks both.

There is no config key. `listed` is static because "should this mode be
browsable" is a property of the mode; "will this match take another player
right now" is a property of the moment, and a match that started closed could
never be joined at all.

**Lua `join` can refuse.** `return nil, "reason"` (and `return false` - Lua has
two falsey values and `return cond and state or false` is ordinary). Replaces
the documented workaround of admitting the player with a spectator flag.

A refused player never reaches the roster and the Lua state is discarded, so a
refusal leaves no trace - a client cannot drive a script by being turned away
repeatedly. The reason is game vocabulary and rides in
`details.refused_reason` under the fixed code `match.join_refused`; a script
still cannot mint a code. Bounded at 64 bytes of printable ASCII.

**`game.bots.add/remove`.** A match script placing bots itself instead of
relying on matchmaker queue fill. Routed through `asobi_bot_spawner` because
`asobi_bot` joins from its own `init/1` - starting one from inside the match
process would block that process in `supervisor:start_child/2` while the new
bot waited on it to answer the join. Shares the `MAX_BOT_FILL` ceiling.
Independent of `bots.enabled`, which governs queue fill only.

## Fixed along the way

- A Lua `join` that returned nothing was a `case_clause` that killed the match
  server and everyone in it. Now a logged refusal - a script bug should cost
  the author their own join, not the whole match.
- `started_at` was restamped by every join past `min_players`, so each
  backfill joiner restarted the clock the persisted match duration is measured
  from.
- A non-atom reason at the socket hit no `to_reason_binary/1` clause;
  `safe_handle_message` caught the `function_clause` and answered
  `invalid_payload`, blaming the client for a server-side fault. Now
  `internal`.
- The bot scan only ran once per match id, so a script-placed bot would never
  have got an AI - and could have got a second one. It now skips bots that
  already have a process.
- `game.match.*` and `game.bots.*` matched on `match_pid`, which a world and a
  zone VM also bind - to the world server. `asobi_world_server` answers
  `get_info` and `{join, _, _}` with the same shapes, so `bots.add` from a
  world script would have quietly seated a bot in a world; and its `running/3`
  has no catch-all, so the `set_joinable` cast would have died on
  `function_clause` and taken the world down with every player in it. Both now
  gate on `vm_kind/1`.

## Wire and API surface

- New error codes: `match.full`, `match.locked`, `match.join_refused`. `match_full`
  previously came through as `ws.request_failed`.
- New field `joinable` on `match.joined` and every `match.list` entry. Additive;
  both protocol fixtures updated.
- New filter `joinable` on `match.list` and `GET /api/v1/matches/live`.
- New Lua namespaces `game.match` and `game.bots`.
- New presence message `{match_left, pid()}`.

The SDKs do not read `joinable` or branch on the new codes yet - worth a
`/sync-sdks` pass before this is announced.

## Verification

fmt, xref, dialyzer, ex_doc clean. 1730 eunit + 356 CT, zero failures.
Mutation testing on the changed lines: `asobi_match_server`,
`asobi_ws_handler`, `asobi_bot_spawner`, `asobi_match_lobby` at 100%,
`asobi_lua_match` at 97% (the survivor is a log call with no observable
effect). Its first run found three genuine gaps - the REST filter untested,
`bot_pids` only reached through a mock, loose refusal bounds - which is the
second commit.

eqwalizer is net zero against `main` (312 both sides). That standing count is
a pre-existing repo-wide condition across files this branch does not touch.

## Docs

`lua-scripting`, `lua-api`, `lua-bots`, `lobbies`, `matchmaking`, `rest-api`
and `websocket-protocol`, plus both protocol fixtures. `lobbies.md` gains a
"Joining a match already in progress" section and `matchmaking.md` states
plainly that the matchmaker never routes a queued player into a running match
- backfill is discovery, not a strategy.
