### PR TITLE
chore: scope code owner review to src, config, the Dockerfile and deploy

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,8 @@
-* @Taure
+# Review is for changes that can break a deployment or the runtime. A rule
+# matching every path blocked dependency bumps as hard as it blocked source
+# changes, and caught neither: the only owner cannot approve their own pull
+# request, so every one of them landed through an admin override. A gate that
+# is always overridden stops meaning anything the day it matters.
+
+/src/ @Taure
+/deploy/ @Taure

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -3,6 +3,15 @@
 # changes, and caught neither: the only owner cannot approve their own pull
 # request, so every one of them landed through an admin override. A gate that
 # is always overridden stops meaning anything the day it matters.
+#
+# `config` and the Dockerfile are here because they are where a deployment
+# actually breaks. minato 1.0.1 refused the address family that
+# `prod_sys.config.src` splices in from `ASOBI_DB_SOCKET_OPTS`, which the
+# Dockerfile defaults to `inet`, and the result was an environment that boots
+# and never becomes ready. Neither file is source, and both decide whether the
+# thing runs.
 
 /src/ @Taure
+/config/ @Taure
+/Dockerfile @Taure
 /deploy/ @Taure


### PR DESCRIPTION
`* @Taure` matched every path, so a lock-only dependency bump needed the same review as a change to the runtime. With a single owner that review can never be given - GitHub does not let you approve your own pull request - so every PR landed BLOCKED and went in through an admin override. Three did today alone. A gate that is always overridden stops meaning anything on the day it should have stopped something.

Scoped to the paths where a change can break a deployment or the runtime:

```
/src/ @Taure
/config/ @Taure
/Dockerfile @Taure
/deploy/ @Taure
```

`config` and the Dockerfile earn their place from today: minato 1.0.1 refused the address family that `config/prod_sys.config.src` splices in from `ASOBI_DB_SOCKET_OPTS`, which `Dockerfile` defaults to `inet`. Every environment would have booted with a pool answering `disconnected` and a readiness probe that never flips. Neither file is source, and both decide whether the thing runs.

`deploy/` does not exist in this repo yet; the entry is there for when it does.

What is deliberately not covered: `rebar.lock`, `guides/`, `test/`, `README.md`. Those are the ones that made the old rule noise.

Merging this needs one last admin override, since `.github/CODEOWNERS` is matched by the rule it replaces.