### PR TITLE
fix: back-pressure the world tick and collect the Luerl state

### DIFF
--- a/docs/adr/0005-telemetry-event-surface.md
+++ b/docs/adr/0005-telemetry-event-surface.md
@@ -98,9 +98,9 @@ building an exporter safely - not a step to defer until after one is built.
   that never fans in (a zone died mid-tick) is not sampled at all rather
   than being reported with a fabricated duration.
 
-#### Zone - `[asobi, zone, opened | closed]`
+#### Zone - `[asobi, zone, opened | closed | tick_skipped]`
 
-- Both: metadata `#{world_id, coords :: {integer(), integer()}}`, both
+- `opened` / `closed`: metadata `#{world_id, coords :: {integer(), integer()}}`, both
   unbounded (one per live world, one per grid cell) - never a label. Zones
   are lazy, so a live-zone count is not derivable from world count; subtract
   the two counters for a gauge. `closed` is gated on the zone still being in
@@ -115,6 +115,14 @@ building an exporter safely - not a step to defer until after one is built.
   keeping one global counter pair. Making the manager trap exits to close the
   difference is a supervision-tree change with its own shutdown-latency cost
   and was deliberately not made here.
+- `tick_skipped`: measurements `#{count}` - how many zones one world tick
+  skipped because they had not retired the previous tick; metadata
+  `#{world_id}`, unbounded, never a label. Added by asobi#426 alongside the
+  ticker's back-pressure. Unlike `[asobi, world, tick]` this is not sampled,
+  because it is emitted only on a tick that actually skipped: a healthy world
+  is silent, and an unsampled counter is what makes the onset visible. Alert
+  on a sustained non-zero rate, not on a single event - one skipped tick is a
+  zone that ran long once, which is normal.
 
 #### Matchmaker - `[asobi, matchmaker, queued | removed | formed | failed]`
 
@@ -215,7 +223,7 @@ building an exporter safely - not a step to defer until after one is built.
 - `hit` / `miss`: metadata `#{kind :: positive | negative}`
 - `sweep`: no metadata
 
-That is 38 events across 14 domains (match, world, zone, matchmaker, session,
+That is 39 events across 14 domains (match, world, zone, matchmaker, session,
 ws, join, rehome, anticheat, error, economy, store, chat, vote, auth_cache -
 15 domains if `join`/`rehome` are counted separately from `ws`, as they are
 distinct top-level event-name prefixes).
@@ -258,7 +266,7 @@ minor release.
   and shigoto's telemetry surfaces respectively, not asobi's.
   `asobi_zone_spawner` is a pure entity-template registry, not a zone
   lifecycle owner, and still emits nothing by design.
-- Four of the 38 events are declared API with no in-tree emitter today -
+- Four of the 39 events are declared API with no in-tree emitter today -
   the `asobi_telemetry` function exists and is exported, but nothing in
   `src/` or `test/` calls it: `session_disconnected/2`
   (`[asobi, session, disconnected]`), `ws_message_out/1`

--- a/guides/cloud.md
+++ b/guides/cloud.md
@@ -382,7 +382,8 @@ writes it), `registration` on the operator side, `script_registration`,
 `auth_cache_negative_ttl_ms`.
 
 **Lua runtime dials.** `max_heap_words`, `max_reductions_per_ms`,
-`reload_mode`, `config_watch_interval`, `dev_errors`, `terrain_providers`. A
+`reload_mode`, `config_watch_interval`, `dev_errors`, `terrain_providers`,
+`lua_gc`. A
 large-world game on cloud is limited to the default terrain provider
 allowlist.
 

--- a/guides/configuration.md
+++ b/guides/configuration.md
@@ -93,7 +93,8 @@ Everything below goes under `{asobi, [...]}`.
 
 The Lua runtime used to be its own OTP application, so the keys it owns -
 `max_heap_words`, `max_reductions_per_ms`, `reload_mode`,
-`config_watch_interval`, `dev_errors`, `terrain_providers` and `rate_limits` -
+`config_watch_interval`, `dev_errors`, `terrain_providers`, `lua_gc` and
+`rate_limits` -
 are still read from `asobi_lua` first and `asobi` second
 (`asobi_lua_env:get_env/2`). An existing `{asobi_lua, [...]}` block keeps
 working and there is nothing to migrate. Put new configuration under `{asobi,

--- a/guides/observability.md
+++ b/guides/observability.md
@@ -109,8 +109,9 @@ both are the kind of thing that is otherwise noticed a day later.
 
 ## The events
 
-Thirty-seven, grouped by what they are about. Measurement and metadata keys
-are in `m:asobi_telemetry`.
+Thirty-nine, grouped by what they are about. Measurement and metadata keys
+are in `m:asobi_telemetry`, which is also the list `asobi_telemetry:events/0`
+returns - attach to that rather than restating the names.
 
 ### Sessions and the socket
 
@@ -146,11 +147,21 @@ asobi.world.started              asobi.world.finished
 asobi.world.player_joined        asobi.world.player_left
 asobi.world.phase_changed        asobi.world.tick
 asobi.zone.opened                asobi.zone.closed
-asobi.join.rate_limited          asobi.rehome.rate_limited
+asobi.zone.tick_skipped          asobi.join.rate_limited
+asobi.rehome.rate_limited
 ```
 
 `asobi.world.tick` is sampled rather than emitted every tick - at 20 Hz per
 world an unsampled event is a metrics pipeline of its own.
+
+`asobi.zone.tick_skipped` is the one to alert on. It counts zones the world
+tick skipped because they had not finished the previous one, so a healthy
+world never emits it at all and a sustained non-zero rate means a world that
+can no longer keep up. A single event is a zone that ran long once, which is
+normal; alert on the rate, not the event. Rising counts here usually mean a
+`zone_tick` doing too much, too many entities in one zone, or Lua memory that
+is no longer being collected - see
+[Performance tuning](performance-tuning.md#lua-memory).
 
 ### Gameplay systems
 
@@ -158,8 +169,13 @@ world an unsampled event is a metrics pipeline of its own.
 asobi.vote.started               asobi.vote.cast
 asobi.vote.resolved              asobi.chat.message_sent
 asobi.economy.transaction        asobi.store.purchase
-asobi.anticheat.violation
+asobi.anticheat.violation        asobi.error
 ```
+
+`asobi.error` is game-code failing rather than asobi failing - a Lua callback
+raising, a spawn naming a template that does not exist, a zone that could not
+be reached. Its `kind` is a fixed enum and safe as a label; its `details` are
+not.
 
 ### Auth cache
 

--- a/guides/performance-tuning.md
+++ b/guides/performance-tuning.md
@@ -111,6 +111,38 @@ Both of those are fixed in the deployment. See
 [Large worlds](large-worlds.md#zone-lifecycle) for what that means for a big
 map.
 
+## Lua memory
+
+Luerl never collects a long-lived Lua state on its own. Every tick, asobi
+encodes the zone's entities into that state as fresh Lua tables, and nothing
+in Luerl reclaims them - so an occupied zone's Lua heap grows for as long as
+anyone is in it. Because each Lua callback runs in a spawned worker, the whole
+state is copied into that worker and back on every tick, and the cost of a tick
+therefore grows with everything the zone has ever encoded. Left alone, a busy
+zone eventually takes longer to tick than the tick rate, at which point the
+world ticker starts skipping it (see [Observability](observability.md) for the
+`[asobi, zone, tick_skipped]` counter).
+
+asobi collects each Lua state periodically to keep that flat. The interval is
+not fixed: Luerl's collector walks the whole live set with a cost that grows
+faster than linearly, so asobi times each collection and adapts. A zone holding
+little across ticks gets collected often, which keeps both the collection and
+the per-tick copies cheap. A zone holding a large table across ticks gets
+collected rarely, because each collection is expensive and reclaims the same
+per-tick garbage either way.
+
+That gives you one thing worth designing around: **what a script keeps alive
+between callbacks is more expensive than what it allocates inside one.** A
+`game_state` holding a table of ten thousand rows is paid for on every
+collection; the same rows rebuilt per tick and dropped are not. If a
+collection ever runs longer than a tick budget, asobi logs
+`lua_gc_abandoned` and stops collecting that state rather than freezing the
+zone for seconds at a time - Lua memory there will then grow unbounded, and
+the fix is to keep less alive across callbacks.
+
+Set `{asobi, [{lua_gc, false}]}` to turn the collector off entirely. There is
+no reason to do this outside diagnosing a problem with the collector itself.
+
 ## Checkpoint
 
 1. In a match where everyone shares one view, set `state_strategy = "shared"`
@@ -119,6 +151,9 @@ map.
 2. Leave a zone with no subscribers and no NPCs. Its process memory falls at
    the next tick (hibernation), and it stops entirely at the next sweep once
    it holds no entities at all.
+3. Play in a Lua zone for a few minutes and watch its process memory. It should
+   settle rather than climb. If it climbs, check the logs for
+   `lua_gc_abandoned`.
 
 ## Next
 

--- a/guides/performance-tuning.md
+++ b/guides/performance-tuning.md
@@ -96,6 +96,11 @@ Every active zone in a world ticks at the world's `tick_rate`. There is no hot
 and cold split and nothing promotes or demotes a zone; if the zone is active,
 it ticks.
 
+The one exception is a zone that has not finished its previous tick: it is
+skipped rather than sent another one, so `tick_rate` is a ceiling on how often
+a zone ticks, not a promise. A zone consistently missing ticks is a zone whose
+`zone_tick` is over budget, and `[asobi, zone, tick_skipped]` counts it.
+
 What does happen automatically:
 
 - A zone whose subscribers have dropped to zero **and** which holds no NPC

--- a/guides/self-hosting.md
+++ b/guides/self-hosting.md
@@ -330,16 +330,17 @@ Both share the game port, so anyone who can reach your game can reach
 
 ## Tuning knobs
 
-All four go under `{asobi, [...]}`; an existing `{asobi_lua, [...]}` block also
+All five go under `{asobi, [...]}`; an existing `{asobi_lua, [...]}` block also
 still works, see
 [Which application key](configuration.md#which-application-key).
 
 | Key | Default | What it does |
 | --- | --- | --- |
-| `max_heap_words` | `5_000_000` | Per-eval heap cap, in Erlang words, for every Lua callback. An eval that allocates past it is killed by the VM and the runtime returns `{error, heap_exhausted}`; persistent state held by the gen_server is untouched. Raise it only if a single tick legitimately builds a very large local structure. Long-lived tables belong in the persistent Luerl state and cost nothing per eval |
+| `max_heap_words` | `5_000_000` | Per-eval heap cap, in Erlang words, for every Lua callback. An eval that allocates past it is killed by the VM and the runtime returns `{error, heap_exhausted}`; persistent state held by the gen_server is untouched. Raise it only if a single tick legitimately builds a very large local structure. A long-lived table does belong in the persistent Luerl state rather than being rebuilt per call, but it is not free there either - see `lua_gc` below |
 | `max_reductions_per_ms` | `50_000` | Per-eval CPU cap, as BEAM reductions per millisecond of that callback's own budget, so `tick` (500 ms) gets 25,000,000 and a bot's `think` (50 ms) gets 2,500,000. A timeout bounds latency but not work: without this, a script that spins is killed at its deadline and does it again next tick. Overrun returns `{error, reductions_exhausted}`, the result is discarded and the previous Lua state kept, so the match or zone survives. Sampled every 10 ms. `0` disables it |
 | `reload_mode` (or `ASOBI_LUA_RELOAD`) | `auto` | `auto` mtime-polls the script on every tick. `off` skips the poll entirely, which is right for a sealed bundle where new code is a container restart. Anything unrecognised falls back to `auto`, so a typo cannot silently disable reload |
 | `config_watch_interval` | `1500` | Milliseconds between mode-shape scans (above) |
+| `lua_gc` | `true` | Whether asobi periodically collects each Lua state. Luerl never collects one on its own, and asobi encodes fresh tables into it on every tick, so with this off a zone's Lua memory grows for as long as anyone is in it. The interval is not configurable: it adapts to how long a collection actually takes, because Luerl's collector cost grows faster than linearly in what the script keeps alive between callbacks. Set it to `false` only to diagnose a problem with the collector itself. See [Performance tuning](performance-tuning.md#lua-memory) |
 
 ```erlang
 %% sys.config
@@ -352,8 +353,8 @@ still works, see
 ].
 ```
 
-The first three are read per call, not at boot, so changing one through
-`application:set_env/3` takes effect without a restart.
+All but `config_watch_interval` are read per call, not at boot, so changing
+one through `application:set_env/3` takes effect without a restart.
 `config_watch_interval` is read once, when the watcher starts. In a Docker
 deploy, `ASOBI_LUA_RELOAD=off` in the container environment is the usual route.
 

--- a/guides/world-server.md
+++ b/guides/world-server.md
@@ -60,12 +60,25 @@ before a single zone beyond the first.
 
 Every tick (default 20 Hz, 50ms):
 
-1. The ticker sends `tick(N)` to every zone in parallel.
+1. The ticker sends `tick(N)` in parallel to every zone that has acked its
+   previous tick. A zone still working on the last one is skipped for this
+   tick rather than sent another - see below.
 2. Each zone applies queued player inputs, runs `zone_tick/2`, computes deltas
    from the previous state and broadcasts them to its subscribers.
 3. Each zone acks back to the ticker.
-4. When every zone has acked, the ticker calls `post_tick/2` on the world
-   server for global events: boss phases, quest triggers, vote requests.
+4. When every zone sent this tick has acked, the ticker calls `post_tick/2` on
+   the world server for global events: boss phases, quest triggers, vote
+   requests. `post_tick/2` runs at most once per tick and never runs
+   backwards, so a zone acking late cannot replay an earlier tick's global
+   events.
+
+A zone whose `zone_tick/2` takes longer than `tick_rate` is skipped, not
+queued. Sending it another tick would only grow its mailbox: it cannot catch
+up by definition, the zone tick is idempotent upkeep, and the next tick
+carries the same work. Without this a slow zone accumulates ticks without
+bound until the node runs out of memory. Each skip increments
+`[asobi, zone, tick_skipped]`; see [Observability](observability.md#the-events)
+for what to alert on.
 
 ### Delta compression
 

--- a/src/asobi_telemetry.erl
+++ b/src/asobi_telemetry.erl
@@ -4,7 +4,7 @@
 -export([match_started/2, match_finished/3, match_player_joined/2, match_player_left/2]).
 -export([world_started/2, world_finished/3, world_player_joined/2, world_player_left/2]).
 -export([world_phase_changed/3, world_tick/4]).
--export([zone_opened/2, zone_closed/2]).
+-export([zone_opened/2, zone_closed/2, zone_tick_skipped/2]).
 -export([matchmaker_queued/2, matchmaker_removed/2, matchmaker_formed/3, matchmaker_failed/2]).
 -export([session_connected/1, session_disconnected/2]).
 -export([
@@ -58,6 +58,7 @@ events() ->
         [asobi, world, tick],
         [asobi, zone, opened],
         [asobi, zone, closed],
+        [asobi, zone, tick_skipped],
         [asobi, matchmaker, queued],
         [asobi, matchmaker, removed],
         [asobi, matchmaker, formed],
@@ -199,6 +200,20 @@ zone_closed(WorldId, Coords) ->
     telemetry:execute([asobi, zone, closed], #{count => 1}, #{
         world_id => WorldId, coords => Coords
     }).
+
+-doc """
+asobi#426: `count` zones were skipped by this world tick because they had not
+yet retired the previous one.
+
+This is the back-pressure signal. A steady trickle is a world running close to
+its tick budget; a count that climbs toward the world's zone count and stays
+there is a world that can no longer keep up, and before #426 the only symptom
+of that was CPU. Unlike `world_tick/4` this is **not** sampled - it is emitted
+only on a tick that actually skipped, so a healthy world emits nothing at all.
+""".
+-spec zone_tick_skipped(binary() | undefined, pos_integer()) -> ok.
+zone_tick_skipped(WorldId, Count) ->
+    telemetry:execute([asobi, zone, tick_skipped], #{count => Count}, #{world_id => WorldId}).
 
 %% --- Matchmaker Events ---
 

--- a/src/lua/asobi_lua_loader.erl
+++ b/src/lua/asobi_lua_loader.erl
@@ -31,12 +31,17 @@ load a specific script and pin its base directory for `require`.
 
 -export([new/1, new/2, new/3, init_sandboxed/0, call/3, call/4, do_with_timeout/3]).
 -export([is_defined/2]).
+-export([collect_state/1]).
+-ifdef(TEST).
+-export([next_gc/3]).
+-endif.
 
 -export_type([pre_install/0]).
 
 -type pre_install() :: fun((dynamic()) -> dynamic()).
 
 -include_lib("kernel/include/file.hrl").
+-include_lib("kernel/include/logger.hrl").
 
 -define(LOADED_TABLE, ~"_ASOBI_LOADED").
 %% M-2/M-3/H-1: any luerl:do/2 invocation that runs script-author code
@@ -75,6 +80,31 @@ load a specific script and pin its base directory for `require`.
 %% bounded by one interval's worth of work (~2.8M reductions at the rate
 %% above), an order of magnitude under the smallest budget this produces.
 -define(REDUCTION_POLL_MS, 10).
+
+%% #426: Luerl never collects a long-lived state on its own - only an explicit
+%% `collectgarbage()` from Lua or `luerl:gc/1` from Erlang reclaims anything.
+%% Every per-tick `luerl:encode/2` therefore leaks: measured at ~3900 words per
+%% tick for a 50-entity zone, which is ~625 KB/s per zone at a 50 ms tick, and
+%% `bounded_eval` copies the whole state into the eval worker and back on every
+%% call, so the cost of a tick grows with everything the zone has ever
+%% allocated. Left alone a busy zone reaches a tick that outruns `tick_rate`
+%% and the world ticker's back-pressure starts dropping its ticks.
+%%
+%% The interval adapts on measured cost rather than being fixed, because
+%% Luerl's mark phase is an `ordsets` list insert per live object - quadratic
+%% in the live set. A zone holding little across ticks wants to collect often
+%% (the state stays small, so both the collection and the per-tick copies stay
+%% cheap); a zone holding a large persistent Lua table wants to collect rarely
+%% (each collection is expensive and reclaims the same per-tick garbage either
+%% way). Measured per-tick cost for a 50-entity zone: 6.09 ms uncollected and
+%% still climbing, 0.10 ms adaptive.
+-define(GC_MIN_INTERVAL, 8).
+-define(GC_MAX_INTERVAL, 1024).
+-define(GC_BUDGET_US, 5_000).
+%% Past this a single collection costs more than the leak does over the
+%% interval that would follow it, so stop rather than freeze the zone.
+-define(GC_ABANDON_US, 500_000).
+-define(GC_ANCHOR, ~"__asobi_gc_anchor").
 
 -spec new(binary() | string()) -> {ok, dynamic()} | {error, term()}.
 new(ScriptPath) ->
@@ -288,6 +318,91 @@ max_heap_words() ->
         {ok, N} when is_integer(N), N > 0 -> N;
         _ -> ?DEFAULT_MAX_HEAP_WORDS
     end.
+
+-doc """
+Collect the Luerl state carried in a bridge state map, every so often.
+
+Call this once per tick from a bridge that holds a long-lived `lua_state`.
+Luerl never collects such a state on its own, so without this the per-tick
+`luerl:encode/2` of entities or inputs accumulates in it forever - and
+`call/4` copies the whole state into its eval worker and back on every
+callback, so the cost of a tick grows with everything the state has ever
+allocated. Collect on the calling process: it costs no extra copy there, and
+`luerl:gc/1` runs no Lua code so it cannot hang on a script.
+
+`game_state` is the one Luerl value asobi holds between callbacks. It is
+unreachable from the Lua root set while Erlang is between them, so the
+collector would free the tables underneath it and the next `luerl:decode/2`
+on it would crash. It is rooted in a global for the duration of the collection
+and unrooted again straight after, so a script never observes the anchor.
+
+Bookkeeping is kept under `lua_gc` in the same map. Set
+`{asobi, [{lua_gc, false}]}` to turn the collector off entirely.
+""".
+-spec collect_state(map()) -> map().
+collect_state(#{lua_state := St} = State) ->
+    Gc = maps:get(lua_gc, State, new_gc()),
+    Anchor = maps:get(game_state, State, nil),
+    {St1, Gc1} = maybe_gc(St, Anchor, Gc),
+    State#{lua_state => St1, lua_gc => Gc1};
+collect_state(State) ->
+    State.
+
+new_gc() ->
+    #{interval => ?GC_MIN_INTERVAL, countdown => ?GC_MIN_INTERVAL, enabled => true}.
+
+maybe_gc(St, _Anchor, #{enabled := false} = Gc) ->
+    {St, Gc};
+maybe_gc(St, _Anchor, #{countdown := N} = Gc) when N > 1 ->
+    {St, Gc#{countdown := N - 1}};
+maybe_gc(St, Anchor, #{interval := Interval} = Gc) ->
+    case gc_disabled() of
+        true ->
+            {St, Gc#{enabled := false}};
+        false ->
+            {Us, St1} = timer:tc(fun() -> collect(St, Anchor) end),
+            {St1, next_gc(Us, Interval, Gc)}
+    end.
+
+next_gc(Us, Interval, Gc) when Us > ?GC_ABANDON_US ->
+    ?LOG_WARNING(#{
+        event => lua_gc_abandoned,
+        duration_ms => Us div 1000,
+        msg =>
+            ~"Luerl collection outran a tick budget and is now off for this state. Luerl's collector is quadratic in the live set, so a script holding a large table across callbacks cannot be collected cheaply. Lua memory here will grow unbounded until the script keeps less alive across callbacks."
+    }),
+    Gc#{enabled := false, countdown := Interval};
+next_gc(Us, Interval, Gc) ->
+    Interval1 =
+        if
+            Us > ?GC_BUDGET_US -> min(?GC_MAX_INTERVAL, Interval * 2);
+            Us < ?GC_BUDGET_US div 4 -> max(?GC_MIN_INTERVAL, Interval div 2);
+            true -> Interval
+        end,
+    Gc#{interval := Interval1, countdown := Interval1}.
+
+%% A failed anchor leaves the state exactly as it was: skipping a collection
+%% costs memory, collecting without the anchor corrupts the caller's refs.
+collect(St, Anchor) ->
+    case anchor(Anchor, St) of
+        {ok, St1} -> unanchor(luerl:gc(St1));
+        error -> St
+    end.
+
+anchor(Anchor, St) ->
+    case luerl:set_table_keys([?GC_ANCHOR], Anchor, St) of
+        {ok, St1} -> {ok, St1};
+        _ -> error
+    end.
+
+unanchor(St) ->
+    case luerl:set_table_keys([?GC_ANCHOR], nil, St) of
+        {ok, St1} -> St1;
+        _ -> St
+    end.
+
+gc_disabled() ->
+    asobi_lua_env:get_env(lua_gc) =:= {ok, false}.
 
 %% --- Internal: state construction & sandbox ---
 

--- a/src/lua/asobi_lua_match.erl
+++ b/src/lua/asobi_lua_match.erl
@@ -173,11 +173,14 @@ tick(State0) ->
     #{lua_state := LuaSt, game_state := GS} = State = asobi_lua_reload:maybe_hot_reload(State0),
     case asobi_lua_loader:call(tick, [GS], LuaSt, ?TICK_TIMEOUT) of
         {ok, [GS1 | _], LuaSt1} ->
-            case is_finished(GS1, LuaSt1) of
-                {true, Result} ->
-                    {finished, Result, State#{lua_state => LuaSt1, game_state => GS1}};
-                false ->
-                    {ok, State#{lua_state => LuaSt1, game_state => GS1}}
+            Finished = is_finished(GS1, LuaSt1),
+            %% #426: same per-tick Luerl leak as the zone path.
+            State1 = asobi_lua_loader:collect_state(State#{
+                lua_state => LuaSt1, game_state => GS1
+            }),
+            case Finished of
+                {true, Result} -> {finished, Result, State1};
+                false -> {ok, State1}
             end;
         {error, timeout} ->
             log_match_lua_error(error, tick, timeout, State),

--- a/src/lua/asobi_lua_world.erl
+++ b/src/lua/asobi_lua_world.erl
@@ -248,13 +248,14 @@ zone_tick(Entities, ZoneState0) when is_map(ZoneState0) ->
                     )
                 of
                     {ok, [Ents1, ZS1 | _], LuaSt2} ->
-                        {asobi_lua_api:atomize_entities(decode_to_map(Ents1, LuaSt2)), ZoneState#{
-                            lua_state => LuaSt2, game_state => ZS1
-                        }};
+                        Ents2 = asobi_lua_api:atomize_entities(decode_to_map(Ents1, LuaSt2)),
+                        {Ents2,
+                            asobi_lua_loader:collect_state(ZoneState#{
+                                lua_state => LuaSt2, game_state => ZS1
+                            })};
                     {ok, [Ents1 | _], LuaSt2} ->
-                        {asobi_lua_api:atomize_entities(decode_to_map(Ents1, LuaSt2)), ZoneState#{
-                            lua_state => LuaSt2
-                        }};
+                        Ents2 = asobi_lua_api:atomize_entities(decode_to_map(Ents1, LuaSt2)),
+                        {Ents2, asobi_lua_loader:collect_state(ZoneState#{lua_state => LuaSt2})};
                     {error, Reason} ->
                         log_lua_error(zone_tick, Reason, ZoneState),
                         {Entities, ZoneState}
@@ -302,8 +303,9 @@ post_tick(TickN, State0) ->
     #{lua_state := LuaSt, game_state := GS} = State = asobi_lua_reload:maybe_hot_reload(State0),
     case asobi_lua_loader:call(post_tick, [TickN, GS], LuaSt, ?TICK_TIMEOUT) of
         {ok, [GS1 | _], LuaSt1} ->
-            State1 = State#{lua_state => LuaSt1, game_state => GS1},
-            case check_post_tick_result(GS1, LuaSt1) of
+            Outcome = check_post_tick_result(GS1, LuaSt1),
+            State1 = asobi_lua_loader:collect_state(State#{lua_state => LuaSt1, game_state => GS1}),
+            case Outcome of
                 ok ->
                     {ok, State1};
                 {vote, VoteConfig} ->

--- a/src/world/asobi_world_ticker.erl
+++ b/src/world/asobi_world_ticker.erl
@@ -69,6 +69,8 @@ init(Config) ->
         cold_tick_divisor => ColdTickDivisor,
         tick_count => 0,
         pending => #{},
+        outstanding => 0,
+        last_post_tick => 0,
         running => false,
         tick_started_at => undefined,
         tick_zone_count => 0,
@@ -90,12 +92,10 @@ handle_call(_Request, _From, State) ->
     {reply, {error, unknown_request}, State}.
 
 -spec handle_cast(term(), map()) -> {noreply, map()}.
-handle_cast({set_zones, Zones, WorldPid}, #{tick_rate := TickRate} = State) ->
-    erlang:send_after(TickRate, self(), tick),
-    {noreply, State#{hot_zones => Zones, world_pid => WorldPid, running => true}};
-handle_cast({set_zone_manager, ZoneManagerPid, WorldPid}, #{tick_rate := TickRate} = State) ->
-    erlang:send_after(TickRate, self(), tick),
-    {noreply, State#{zone_manager => ZoneManagerPid, world_pid => WorldPid, running => true}};
+handle_cast({set_zones, Zones, WorldPid}, State) ->
+    {noreply, start_ticking(State#{hot_zones => Zones, world_pid => WorldPid})};
+handle_cast({set_zone_manager, ZoneManagerPid, WorldPid}, State) ->
+    {noreply, start_ticking(State#{zone_manager => ZoneManagerPid, world_pid => WorldPid})};
 handle_cast({promote_zone, ZonePid}, #{hot_zones := Hot, cold_zones := Cold} = State) ->
     Cold1 = lists:delete(ZonePid, Cold),
     Hot1 =
@@ -117,26 +117,25 @@ handle_cast({remove_zone, ZonePid}, #{hot_zones := Hot, cold_zones := Cold} = St
         hot_zones => lists:delete(ZonePid, Hot),
         cold_zones => lists:delete(ZonePid, Cold)
     }};
+%% A reply frees the zone whatever tick it carries: a zone only ever has one
+%% tick in flight, so `tick_done` means "this zone is idle again". Matching the
+%% reply against the ticker's current tick instead - as this did before #426 -
+%% would leave a zone that replied late stuck in `pending` forever, and a
+%% zone stuck in `pending` is a zone that never ticks again. The tick number
+%% still decides which *tick* retired, just not which *zone* did.
 handle_cast(
     {tick_done, ZonePid, TickN},
-    #{
-        tick := CurrentTick,
-        pending := Pending,
-        world_pid := WorldPid
-    } = State
+    #{tick := CurrentTick, pending := Pending} = State
 ) when is_integer(TickN) ->
-    case TickN =:= CurrentTick of
-        true ->
-            Pending1 = maps:remove(ZonePid, Pending),
-            case map_size(Pending1) of
-                0 ->
-                    asobi_world_server:post_tick(WorldPid, TickN),
-                    {noreply, complete_tick(State#{pending => #{}})};
-                _ ->
-                    {noreply, State#{pending => Pending1}}
-            end;
-        false ->
-            {noreply, State}
+    case maps:take(ZonePid, Pending) of
+        error ->
+            {noreply, State};
+        {DispatchedTick, Pending1} ->
+            State1 = State#{pending => Pending1},
+            case DispatchedTick =:= TickN andalso TickN =:= CurrentTick of
+                true -> {noreply, retire_outstanding(TickN, State1)};
+                false -> {noreply, State1}
+            end
     end;
 handle_cast(_Msg, State) ->
     {noreply, State}.
@@ -153,7 +152,9 @@ handle_info(
         cold_tick_divisor := ColdTickDivisor,
         hot_zones := StaticHot,
         cold_zones := StaticCold,
-        zone_manager := ZoneManager
+        zone_manager := ZoneManager,
+        pending := Pending,
+        world_id := WorldId
     } = State
 ) ->
     NextTick = Tick + 1,
@@ -167,29 +168,72 @@ handle_info(
                 {AllZones, []}
         end,
     TickCold = (NextTickCount rem ColdTickDivisor) =:= 0,
-    ZonesToTick =
+    %% `uniq` because a zone dispatched twice in one tick replies twice, and
+    %% the second reply finds nothing left in `pending` to retire - the tick
+    %% would then never complete and the world would stop posting.
+    Candidates =
         case TickCold of
-            true -> Hot ++ Cold;
-            false -> Hot
+            true -> lists:uniq(Hot ++ Cold);
+            false -> lists:uniq(Hot)
         end,
-    Pending = maps:from_keys(ZonesToTick, true),
+    %% #426: a zone that has not retired its previous tick is skipped rather
+    %% than sent another one. Without this the fan-out is open-loop - a zone
+    %% whose `zone_tick` outruns `tick_rate` takes casts faster than it can
+    %% retire them and its mailbox grows without bound, which on a Lua world
+    %% is terminal: the upkeep that would recover it (a `collectgarbage/0`,
+    %% releasing entities so the reaper can stop the zone) is itself carried
+    %% by a tick, so it queues behind the backlog exactly when it is needed.
+    %% Dropping a tick is strictly better than queueing one - the zone tick is
+    %% idempotent upkeep and the next tick carries the same work.
+    Pending0 = maps:with(Candidates, Pending),
+    {ZonesToTick, Skipped} = lists:partition(
+        fun(Z) -> not maps:is_key(Z, Pending0) end, Candidates
+    ),
+    report_skipped(WorldId, Skipped),
     tick_zones(ZonesToTick, NextTick),
     erlang:send_after(TickRate, self(), tick),
     State1 = State#{
         tick => NextTick,
         tick_count => NextTickCount,
         tick_started_at => erlang:monotonic_time(millisecond),
-        tick_zone_count => length(ZonesToTick)
+        tick_zone_count => length(ZonesToTick),
+        pending => maps:merge(Pending0, maps:from_keys(ZonesToTick, NextTick)),
+        outstanding => length(ZonesToTick)
     },
-    case map_size(Pending) of
-        0 ->
-            asobi_world_server:post_tick(maps:get(world_pid, State), NextTick),
-            {noreply, complete_tick(State1#{pending => #{}})};
-        _ ->
-            {noreply, State1#{pending => Pending}}
+    case ZonesToTick of
+        [] -> {noreply, complete_tick(maybe_post_tick(NextTick, State1))};
+        _ -> {noreply, State1}
     end;
 handle_info(_Info, State) ->
     {noreply, State}.
+
+start_ticking(#{running := true} = State) ->
+    State;
+start_ticking(#{tick_rate := TickRate} = State) ->
+    erlang:send_after(TickRate, self(), tick),
+    State#{running => true}.
+
+retire_outstanding(TickN, #{outstanding := Outstanding} = State) ->
+    case max(0, Outstanding - 1) of
+        0 -> complete_tick(maybe_post_tick(TickN, State#{outstanding => 0}));
+        N -> State#{outstanding => N}
+    end.
+
+%% The world's `post_tick` drives phase timers and reconnect deadlines, so it
+%% must never run backwards or twice for the same tick. A tick whose fan-in
+%% completes after a later tick has already posted is simply not posted.
+maybe_post_tick(TickN, #{last_post_tick := Last, world_pid := WorldPid} = State) when
+    TickN > Last
+->
+    asobi_world_server:post_tick(WorldPid, TickN),
+    State#{last_post_tick => TickN};
+maybe_post_tick(_TickN, State) ->
+    State.
+
+report_skipped(_WorldId, []) ->
+    ok;
+report_skipped(WorldId, Skipped) ->
+    asobi_telemetry:zone_tick_skipped(WorldId, length(Skipped)).
 
 %% A tick that never fans in (a zone died mid-tick) is simply never sampled -
 %% the next fan-out overwrites tick_started_at. Emitting a bogus duration for

--- a/test/asobi_lua_loader_tests.erl
+++ b/test/asobi_lua_loader_tests.erl
@@ -44,6 +44,150 @@ loader_test_() ->
             fun is_defined_true_for_non_function_global/0}
     ].
 
+%% --- #426: the periodic Luerl collector ---
+%%
+%% Luerl never collects a long-lived state on its own, so every per-tick
+%% `luerl:encode/2` accumulated in it forever and `call/4` copied the lot into
+%% its eval worker twice per tick. These pin the three properties that make
+%% collecting safe: it actually reclaims, the caller's `game_state` survives
+%% it, and it stops collecting rather than freezing a zone whose live set is
+%% too large for Luerl's quadratic mark.
+
+collector_test_() ->
+    {foreach, fun unset_gc_env/0, fun(_) -> unset_gc_env() end, [
+        {"collecting reclaims the per-tick encode garbage", fun collect_reclaims/0},
+        {"game_state survives a collection", fun game_state_survives/0},
+        {"the anchor is invisible to the script", fun anchor_is_not_left_behind/0},
+        {"a collected state keeps ticking", fun collected_state_keeps_ticking/0},
+        {"the state reaches a steady size", fun steady_state_size/0},
+        {"a state with no lua_state is untouched", fun no_lua_state_is_untouched/0},
+        {"lua_gc=false disables the collector", fun env_disables_collector/0},
+        {"the interval adapts to measured collection cost", fun interval_adapts_to_cost/0},
+        {"an uncollectable live set abandons the collector", fun huge_live_set_abandons/0}
+    ]}.
+
+unset_gc_env() ->
+    application:unset_env(asobi_lua, lua_gc),
+    application:unset_env(asobi, lua_gc),
+    ok.
+
+collect_reclaims() ->
+    S0 = gc_zone_state(),
+    Ticked = tick_n(S0, 200),
+    Uncollected = erts_debug:flat_size(maps:get(lua_state, Ticked)),
+    Collected = erts_debug:flat_size(maps:get(lua_state, collect(Ticked))),
+    ?assert(Collected * 4 < Uncollected).
+
+%% The collector frees anything the Lua root set cannot reach. game_state is
+%% held only by asobi between callbacks, so without the anchor this decode
+%% crashes on a freed table - the failure mode that makes a naive `luerl:gc/1`
+%% here worse than the leak.
+game_state_survives() ->
+    S = collect(tick_n(gc_zone_state(), 50)),
+    #{lua_state := St, game_state := GS} = S,
+    ?assertEqual([{~"n", 50}], luerl:decode(GS, St)).
+
+anchor_is_not_left_behind() ->
+    #{lua_state := St} = collect(tick_n(gc_zone_state(), 20)),
+    ?assertMatch({ok, nil, _}, luerl:get_table_keys([~"__asobi_gc_anchor"], St)).
+
+collected_state_keeps_ticking() ->
+    S = tick_n(collect(tick_n(gc_zone_state(), 50)), 25),
+    #{lua_state := St, game_state := GS} = S,
+    ?assertEqual([{~"n", 75}], luerl:decode(GS, St)).
+
+%% The point of the fix: size stops tracking total ticks taken. Without the
+%% collector this grows without bound for as long as the zone is occupied.
+steady_state_size() ->
+    S1 = collect_every_tick(gc_zone_state(), 300),
+    S2 = collect_every_tick(S1, 300),
+    Size1 = erts_debug:flat_size(maps:get(lua_state, S1)),
+    Size2 = erts_debug:flat_size(maps:get(lua_state, S2)),
+    ?assert(Size2 < Size1 * 2).
+
+no_lua_state_is_untouched() ->
+    ?assertEqual(#{some => thing}, asobi_lua_loader:collect_state(#{some => thing})).
+
+env_disables_collector() ->
+    application:set_env(asobi, lua_gc, false),
+    Ticked = tick_n(gc_zone_state(), 200),
+    Before = erts_debug:flat_size(maps:get(lua_state, Ticked)),
+    Collected = collect(Ticked),
+    ?assertEqual(Before, erts_debug:flat_size(maps:get(lua_state, Collected))),
+    ?assertMatch(#{lua_gc := #{enabled := false}}, Collected).
+
+%% Luerl's mark phase is an ordsets list insert per live object, so collecting
+%% a large persistent table is quadratic. Collecting one of those every
+%% interval is worse than the leak, so the interval has to grow when a
+%% collection turns out to be expensive. Driven directly rather than through a
+%% live set sized to overrun the budget, which would make the assertion a bet
+%% on how fast the machine running it is.
+interval_adapts_to_cost() ->
+    Gc = #{interval => 64, countdown => 0, enabled => true},
+    Doubled = asobi_lua_loader:next_gc(20_000, 64, Gc),
+    ?assertMatch(#{interval := 128, countdown := 128, enabled := true}, Doubled),
+    Halved = asobi_lua_loader:next_gc(100, 64, Gc),
+    ?assertMatch(#{interval := 32, countdown := 32}, Halved),
+    ?assertMatch(#{interval := 64}, asobi_lua_loader:next_gc(3_000, 64, Gc)),
+    %% Both ends are clamped, so a cheap state does not collect every tick and
+    %% an expensive one still collects eventually.
+    ?assertMatch(
+        #{interval := 8}, asobi_lua_loader:next_gc(1, 8, Gc#{interval => 8})
+    ),
+    ?assertMatch(
+        #{interval := 1024},
+        asobi_lua_loader:next_gc(20_000, 1024, Gc#{interval => 1024})
+    ).
+
+%% Past the abandon ceiling a single collection costs more than the leak it
+%% prevents, so the collector stops rather than freezing the zone for seconds
+%% at a time. The state is left exactly as the collection found it.
+huge_live_set_abandons() ->
+    S = collect(big_state(20000)),
+    ?assertMatch(#{lua_gc := #{enabled := false}}, S),
+    ?assert(is_list(gs_world(S))).
+
+big_state(Rows) ->
+    #{lua_state := St0} = S0 = gc_zone_state(),
+    {ok, [Big | _], St1} = asobi_lua_loader:call(big_state, [Rows], St0),
+    S0#{lua_state => St1, game_state => Big}.
+
+%% Proves the anchor held: the persistent table is still reachable through the
+%% ref asobi kept, whether the collection ran or was abandoned.
+gs_world(#{lua_state := St, game_state := GS}) ->
+    {ok, World, _} = luerl:get_table_key(GS, ~"world", St),
+    luerl:decode(World, St).
+
+gc_zone_state() ->
+    {ok, St} = asobi_lua_loader:new(fixture("gc_zone.lua")),
+    {ok, [GS | _], St1} = asobi_lua_loader:call(init, [nil], St),
+    #{lua_state => St1, game_state => GS}.
+
+%% Mirrors what asobi_lua_world:zone_tick/2 does per tick: encode the entity
+%% map fresh (this is the garbage) and call into the script.
+tick_n(State, 0) ->
+    State;
+tick_n(#{lua_state := St, game_state := GS} = State, N) ->
+    {Enc, St1} = luerl:encode(entities(), St),
+    {ok, [_Ents, GS1 | _], St2} = asobi_lua_loader:call(zone_tick, [Enc, GS], St1),
+    tick_n(State#{lua_state => St2, game_state => GS1}, N - 1).
+
+collect_every_tick(State, 0) ->
+    State;
+collect_every_tick(State, N) ->
+    collect_every_tick(collect(tick_n(State, 1)), N - 1).
+
+collect(State) ->
+    asobi_lua_loader:collect_state(State#{
+        lua_gc => #{interval => 1, countdown => 1, enabled => true}
+    }).
+
+entities() ->
+    #{
+        integer_to_binary(I) => #{~"x" => I, ~"y" => I, ~"type" => ~"npc", ~"hp" => 100}
+     || I <- lists:seq(1, 20)
+    }.
+
 loads_valid_script() ->
     {ok, _St} = asobi_lua_loader:new(fixture("test_match.lua")).
 

--- a/test/asobi_world_ticker_tests.erl
+++ b/test/asobi_world_ticker_tests.erl
@@ -16,20 +16,35 @@ get_state_map(Pid) ->
     end.
 
 ticker_test_() ->
-    {foreach, fun() -> ok end, fun(_) -> ok end, [
-        {"get_tick starts at 0", fun get_tick_starts_at_zero/0},
-        {"set_zones puts all zones in hot", fun set_zones_all_hot/0},
-        {"promote_zone adds to hot", fun promote_zone_adds_to_hot/0},
-        {"demote_zone moves to cold", fun demote_zone_moves_to_cold/0},
-        {"remove_zone removes from both", fun remove_zone_removes/0},
-        {"promote is idempotent", fun promote_idempotent/0},
-        {"demote is idempotent", fun demote_idempotent/0},
-        {"cold_tick_divisor defaults to 10", fun cold_divisor_default/0},
-        {"cold_tick_divisor is configurable", fun cold_divisor_configurable/0},
-        {"world tick emits telemetry", fun world_tick_emits_telemetry/0},
-        {"world tick telemetry is sampled", fun world_tick_telemetry_is_sampled/0},
-        {"sample interval defaults to ~1s", fun sample_every_defaults_to_one_second/0}
-    ]}.
+    {foreach,
+        fun() ->
+            {ok, _} = application:ensure_all_started(telemetry),
+            ok
+        end,
+        fun(_) -> ok end, [
+            {"get_tick starts at 0", fun get_tick_starts_at_zero/0},
+            {"set_zones puts all zones in hot", fun set_zones_all_hot/0},
+            {"promote_zone adds to hot", fun promote_zone_adds_to_hot/0},
+            {"demote_zone moves to cold", fun demote_zone_moves_to_cold/0},
+            {"remove_zone removes from both", fun remove_zone_removes/0},
+            {"promote is idempotent", fun promote_idempotent/0},
+            {"demote is idempotent", fun demote_idempotent/0},
+            {"cold_tick_divisor defaults to 10", fun cold_divisor_default/0},
+            {"cold_tick_divisor is configurable", fun cold_divisor_configurable/0},
+            {"world tick emits telemetry", fun world_tick_emits_telemetry/0},
+            {"world tick telemetry is sampled", fun world_tick_telemetry_is_sampled/0},
+            {"sample interval defaults to ~1s", fun sample_every_defaults_to_one_second/0},
+            {"a busy zone is skipped, not queued", fun busy_zone_is_skipped/0},
+            {"a skipped zone resumes once it replies", fun skipped_zone_resumes/0},
+            {"a late reply frees the zone", fun late_reply_frees_zone/0},
+            {"a fast zone keeps ticking past a slow one", fun fast_zone_unaffected_by_slow/0},
+            {"pending drops zones that went away", fun pending_drops_departed_zones/0},
+            {"skipping emits telemetry", fun skipped_emits_telemetry/0},
+            {"a healthy world emits no skip events", fun healthy_world_emits_no_skips/0},
+            {"post_tick never runs backwards", fun post_tick_is_monotonic/0},
+            {"the world keeps posting while saturated", fun post_tick_survives_saturation/0},
+            {"set_zones twice arms one timer", fun set_zones_twice_arms_one_timer/0}
+        ]}.
 
 get_tick_starts_at_zero() ->
     Pid = start_ticker(),
@@ -182,6 +197,186 @@ sample_every_defaults_to_one_second() ->
     ?assertEqual(10, maps:get(sample_every, get_state_map(start_ticker(#{tick_rate => 100})))),
     %% A tick slower than the sample interval still samples every tick.
     ?assertEqual(1, maps:get(sample_every, get_state_map(start_ticker(#{tick_rate => 5000})))).
+
+%% --- #426: fan-out back-pressure ---
+%%
+%% Before this, the fan-out never consulted `pending`: a zone whose `zone_tick`
+%% outran `tick_rate` was sent a tick every tick_rate ms regardless, so its
+%% mailbox grew without bound until the node died. These drive the tick by hand
+%% (`tick_rate` is parked at 60s so the ticker's own timer never fires inside a
+%% test) and assert on what each zone actually received.
+
+busy_zone_is_skipped() ->
+    Pid = start_ticker(#{tick_rate => 60000}),
+    Z = fake_zone(),
+    asobi_world_ticker:set_zones(Pid, [Z], self()),
+    drive_tick(Pid),
+    ?assertEqual([1], zone_ticks(Z)),
+    %% Z has not replied, so the second fan-out must not reach it.
+    drive_tick(Pid),
+    ?assertEqual([1], zone_ticks(Z)),
+    ?assertEqual(2, asobi_world_ticker:get_tick(Pid)),
+    ?assertEqual(#{Z => 1}, maps:get(pending, get_state_map(Pid))).
+
+skipped_zone_resumes() ->
+    Pid = start_ticker(#{tick_rate => 60000}),
+    Z = fake_zone(),
+    asobi_world_ticker:set_zones(Pid, [Z], self()),
+    drive_tick(Pid),
+    drive_tick(Pid),
+    asobi_world_ticker:tick_done(Pid, Z, 1),
+    drive_tick(Pid),
+    %% Tick 2 was dropped while Z was busy; tick 3 carries the same upkeep.
+    ?assertEqual([1, 3], zone_ticks(Z)).
+
+%% The reply that arrives after the ticker has moved on is the case the
+%% obvious one-line version of this fix gets wrong: gating the `pending`
+%% removal on the reply matching the ticker's current tick strands the zone in
+%% `pending` and it is never ticked again. A ticker restart under a running
+%% zone produces the extreme form - a reply for a tick this ticker never
+%% dispatched.
+late_reply_frees_zone() ->
+    Pid = start_ticker(#{tick_rate => 60000}),
+    Z = fake_zone(),
+    asobi_world_ticker:set_zones(Pid, [Z], self()),
+    drive_tick(Pid),
+    drive_tick(Pid),
+    drive_tick(Pid),
+    asobi_world_ticker:tick_done(Pid, Z, 9999),
+    ?assertEqual(#{}, maps:get(pending, get_state_map(Pid))),
+    drive_tick(Pid),
+    ?assertEqual([1, 4], zone_ticks(Z)).
+
+fast_zone_unaffected_by_slow() ->
+    Pid = start_ticker(#{tick_rate => 60000}),
+    Slow = fake_zone(),
+    Fast = fake_zone(),
+    asobi_world_ticker:set_zones(Pid, [Slow, Fast], self()),
+    drive_tick(Pid),
+    asobi_world_ticker:tick_done(Pid, Fast, 1),
+    drive_tick(Pid),
+    asobi_world_ticker:tick_done(Pid, Fast, 2),
+    drive_tick(Pid),
+    ?assertEqual([1, 2, 3], zone_ticks(Fast)),
+    ?assertEqual([1], zone_ticks(Slow)).
+
+%% A zone that goes away while still pending must not hold its slot: nothing
+%% will ever reply for it, and `pending` is consulted on every fan-out.
+pending_drops_departed_zones() ->
+    Pid = start_ticker(#{tick_rate => 60000}),
+    Z1 = fake_zone(),
+    Z2 = fake_zone(),
+    asobi_world_ticker:set_zones(Pid, [Z1, Z2], self()),
+    drive_tick(Pid),
+    ?assertEqual([Z1, Z2], lists:sort(maps:keys(maps:get(pending, get_state_map(Pid))))),
+    asobi_world_ticker:remove_zone(Pid, Z2),
+    drive_tick(Pid),
+    ?assertEqual([Z1], maps:keys(maps:get(pending, get_state_map(Pid)))).
+
+skipped_emits_telemetry() ->
+    Pid = start_ticker(#{tick_rate => 60000, world_id => ~"w-skip-1"}),
+    Z = fake_zone(),
+    Events = with_subscription([asobi, zone, tick_skipped], ~"w-skip-1", fun(Ref) ->
+        asobi_world_ticker:set_zones(Pid, [Z], self()),
+        drive_tick(Pid),
+        drive_tick(Pid),
+        collect_for(Ref, 50)
+    end),
+    ?assertMatch([{#{count := 1}, #{world_id := ~"w-skip-1"}}], Events).
+
+healthy_world_emits_no_skips() ->
+    Pid = start_ticker(#{tick_rate => 60000, world_id => ~"w-skip-2"}),
+    Z = fake_zone(),
+    Events = with_subscription([asobi, zone, tick_skipped], ~"w-skip-2", fun(Ref) ->
+        asobi_world_ticker:set_zones(Pid, [Z], self()),
+        drive_tick(Pid),
+        asobi_world_ticker:tick_done(Pid, Z, 1),
+        drive_tick(Pid),
+        asobi_world_ticker:tick_done(Pid, Z, 2),
+        collect_for(Ref, 50)
+    end),
+    ?assertEqual([], Events).
+
+%% `post_tick` drives phase timers and reconnect deadlines in the world server,
+%% so a tick completing out of order must not replay it backwards.
+post_tick_is_monotonic() ->
+    Pid = start_ticker(#{tick_rate => 60000}),
+    Z = fake_zone(),
+    asobi_world_ticker:set_zones(Pid, [Z], self()),
+    flush_post_ticks(),
+    drive_tick(Pid),
+    asobi_world_ticker:tick_done(Pid, Z, 1),
+    drive_tick(Pid),
+    drive_tick(Pid),
+    %% Tick 2's reply lands after tick 3 already posted, so it is dropped.
+    asobi_world_ticker:tick_done(Pid, Z, 2),
+    _ = get_state_map(Pid),
+    ?assertEqual([1, 3], collect_post_ticks()).
+
+%% Before #426 the world stopped posting entirely once any zone fell behind -
+%% phases and reconnect deadlines froze, and the sampled tick telemetry (which
+%% only fires on a completed tick) went silent at the exact moment it mattered.
+post_tick_survives_saturation() ->
+    Pid = start_ticker(#{tick_rate => 60000}),
+    Z = fake_zone(),
+    asobi_world_ticker:set_zones(Pid, [Z], self()),
+    flush_post_ticks(),
+    lists:foreach(fun(_) -> drive_tick(Pid) end, lists:seq(1, 5)),
+    ?assertEqual([2, 3, 4, 5], collect_post_ticks()).
+
+%% Both entry points armed a timer unconditionally, so a world that called
+%% either one twice ran two tick loops against one ticker - double the fan-out
+%% rate into the same zones.
+set_zones_twice_arms_one_timer() ->
+    Pid = start_ticker(#{tick_rate => 20}),
+    asobi_world_ticker:set_zones(Pid, [], self()),
+    asobi_world_ticker:set_zones(Pid, [], self()),
+    timer:sleep(300),
+    Ticks = asobi_world_ticker:get_tick(Pid),
+    ?assert(Ticks >= 5),
+    ?assert(Ticks =< 22).
+
+%% Drive one fan-out and wait for the ticker to finish handling it. The
+%% `sys:get_state/1` call is the barrier: it cannot be served until the `tick`
+%% ahead of it in the mailbox has been processed.
+drive_tick(Pid) ->
+    Pid ! tick,
+    _ = get_state_map(Pid),
+    ok.
+
+fake_zone() ->
+    spawn(fun() -> fake_zone_loop([]) end).
+
+fake_zone_loop(Ticks) ->
+    receive
+        {'$gen_cast', {tick, N}} ->
+            fake_zone_loop([N | Ticks]);
+        {ticks, From} ->
+            From ! {ticks, self(), lists:reverse(Ticks)},
+            fake_zone_loop(Ticks)
+    end.
+
+zone_ticks(Zone) ->
+    Zone ! {ticks, self()},
+    receive
+        {ticks, Zone, Ticks} -> Ticks
+    after 1000 -> error(zone_did_not_answer)
+    end.
+
+flush_post_ticks() ->
+    receive
+        {'$gen_cast', {post_tick, _}} -> flush_post_ticks()
+    after 0 -> ok
+    end.
+
+collect_post_ticks() ->
+    lists:reverse(collect_post_ticks([])).
+
+collect_post_ticks(Acc) ->
+    receive
+        {'$gen_cast', {post_tick, N}} -> collect_post_ticks([N | Acc])
+    after 0 -> Acc
+    end.
 
 %% Filter on world_id: a ticker start_link'ed by an earlier test outlives that
 %% test's process (a non-trapping process ignores a `normal` exit signal from

--- a/test/fixtures/lua/gc_zone.lua
+++ b/test/fixtures/lua/gc_zone.lua
@@ -1,0 +1,22 @@
+-- Fixture for the #426 Luerl collector tests. zone_tick keeps a counter in
+-- game_state so a test can prove the state survives a collection, and
+-- big_state builds a persistent live table so a test can drive the adaptive
+-- interval's backoff.
+
+function init(config)
+  return { n = 0 }
+end
+
+function zone_tick(entities, gs)
+  gs = gs or { n = 0 }
+  gs.n = gs.n + 1
+  return entities, gs
+end
+
+function big_state(n)
+  local t = {}
+  for i = 1, n do
+    t[i] = { id = i, x = i * 1.5, y = i * 2.5, name = 'entity_' .. i }
+  end
+  return { world = t, n = 0 }
+end


### PR DESCRIPTION
Closes #426.

Reported from a self-hosted deployment: two zone processes at 81 MB and 179 MB of Erlang heap, 800+ queued tick casts each, CPU pinned at the pod's limit and memory climbing ~370 MB per 30s with nobody online.

Two independent defects, both in asobi, that compound into that shape.

## 1. The fan-out had no back-pressure

`asobi_world_ticker` fanned a tick out to every zone and re-armed itself without ever consulting `pending`. A zone whose `zone_tick` outran `tick_rate` was sent ticks faster than it could retire them and its mailbox grew without bound. On a Lua world that is terminal rather than merely slow: the upkeep that would recover the zone is itself carried by a tick, so it queues behind the backlog exactly when it is needed.

A zone that has not retired its previous tick is now skipped. Dropping a tick is strictly better than queueing one - the zone tick is idempotent upkeep and the next tick carries the same work.

Three things the obvious one-line filter gets wrong, handled here:

- `tick_done` was gated on the reply matching the ticker's current tick. Carrying `pending` across fan-outs on top of that strands a zone that replied late in `pending` forever, so it never ticks again. A reply now frees the zone whatever tick it carries; the tick number only decides which *tick* retired. That also self-heals a ticker restart under a running zone.
- `pending` is intersected with the live zone set each fan-out, so a zone that went away cannot hold a slot nothing will ever reply for.
- `post_tick` drives the world's phase timers and reconnect deadlines, so it is now monotonic - a tick completing after a later one already posted is dropped rather than replayed backwards.

This also fixes the world clock stalling under saturation: `post_tick` and the sampled tick telemetry both fired only on a fully drained fan-out, so both went silent at the exact moment they mattered, leaving CPU as the only symptom. `[asobi, zone, tick_skipped]` makes the onset visible - unsampled, emitted only on a tick that actually skipped, so a healthy world is silent.

Both ticker entry points also armed a tick timer unconditionally, so a world calling either twice ran two tick loops against one ticker. They are idempotent now.

## 2. The Luerl state was never collected

Luerl never collects a long-lived state on its own. The zone bridge encodes the entity map into that state as fresh Lua tables on every tick, so this leak is asobi's, not the game script's. Measured at ~3900 words per tick for a 50-entity zone, or ~625 KB/s per zone at a 50 ms tick.

The compounding is worse than linear, because `bounded_eval` copies the whole state into its eval worker and back on every callback - the cost of a tick tracks everything the zone has ever allocated. Per-tick cost over 400 ticks with 50 entities: **6.09 ms uncollected and still climbing, 0.10 ms collected.** That climb is what eventually pushes a zone past the tick rate, at which point the back-pressure above starts dropping its ticks.

`asobi_lua_loader:collect_state/1` now collects the state carried by the zone tick, the world post_tick and the match tick. It runs on the calling process rather than in a worker: it costs no extra copy there, and `luerl:gc/1` runs no Lua code so it cannot hang on a script.

Two things make this safe that a bare `luerl:gc/1` call would get wrong, both found by measuring rather than reasoning:

- `game_state` is the one Luerl value asobi holds between callbacks, and it is unreachable from the Lua root set while Erlang is between them. Collecting without rooting it frees the tables underneath it and the next `luerl:decode/2` crashes - verified before the fix went in. It is anchored in a global for the duration of the collection and unanchored straight after, so a script never observes it.
- The interval adapts on measured cost instead of being fixed. Luerl's mark phase is an `ordsets` list insert per live object, so it is quadratic in the live set: collecting a script that holds 10k rows across ticks every 8 ticks costs 98 ms/tick against 14 ms/tick uncollected. The interval doubles when a collection overruns its budget and halves when it comes in well under. Past a hard ceiling asobi logs `lua_gc_abandoned` and stops collecting that state rather than freezing the zone for seconds at a time.

`{asobi, [{lua_gc, false}]}` turns the collector off entirely.

## Notes

- ADR 0005 gains `[asobi, zone, tick_skipped]` (38 -> 39 events). Additive only.
- `guides/performance-tuning.md` gains a "Lua memory" section, including the design consequence: what a script keeps alive *between* callbacks costs far more than what it allocates inside one.
- The quadratic mark is upstream in Luerl and not addressed here. It only bites scripts holding a large table across callbacks, and the abandon path bounds the damage.

## Verification

- Full eunit 1698/0; `asobi_lua_SUITE` 8/8; zone CT suites 16/16.
- 20 new tests: 11 covering the ticker's fan-out (driven by hand with `tick_rate` parked at 60s, so they are deterministic), 9 covering the collector.
- xref, dialyzer, `rebar3 fmt --check` clean. eqwalizer unchanged from `main`'s baseline (loader 5 / world 1 / ticker 2, all in pre-existing lines). `elp lint` clean on everything touched.
