### PR TITLE
ci: turn the ELP lint gate on, and record why eqwalize stays off

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ concurrency:
 
 jobs:
   ci:
-    uses: Taure/erlang-ci/.github/workflows/ci.yml@v2.1.5
+    uses: Taure/erlang-ci/.github/workflows/ci.yml@v2.1.7
     permissions:
       contents: write
       pull-requests: write
@@ -61,9 +61,9 @@ jobs:
       #   since fixed), and ELP does not need to run on 28.x. The real blocker
       #   for both ELP jobs was that Taure/erlang-ci's elp action mapped OTP
       #   majors to hardcoded asset names and stopped at 28, so on OTP 29 it
-      #   failed before downloading ELP at all - fixed in erlang-ci#71, which
-      #   also moved its compile step to `rebar3 as test compile` so
-      #   test-profile parse transforms (proper) resolve.
+      #   failed before downloading ELP at all. Fixed across erlang-ci#71, #72
+      #   and #73 (v2.1.7), which also moved its compile step to
+      #   `rebar3 as test compile` so test-profile parse transforms resolve.
       #
       # enable-mutate - needs the rebar3_mutate plugin, and a full-tree
       #   run over 134 modules is far too slow for per-PR CI. Wants

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ concurrency:
 
 jobs:
   ci:
-    uses: Taure/erlang-ci/.github/workflows/ci.yml@v2.1.4
+    uses: Taure/erlang-ci/.github/workflows/ci.yml@v2.1.5
     permissions:
       contents: write
       pull-requests: write
@@ -32,7 +32,8 @@ jobs:
       enable-audit: true
       enable-ct: true
       enable-coverage: true
-      # The four quality gates still off, and what each is waiting on:
+      enable-elp-lint: true
+      # The three quality gates still off, and what each is waiting on:
       #
       # enable-sbom / enable-sbom-scan - `rebar3 sbom` crashes on this repo
       #   with `badarg` in `unicode:characters_to_binary(git)`
@@ -44,21 +45,26 @@ jobs:
       #   without a human call, and the plugin should handle the atom anyway
       #   (filed upstream).
       #
-      # enable-elp-lint - the job fails on any error, and elp 1.1.0 reports
-      #   twelve on this tree, none of them an asobi defect:
-      #     - nine L0002 from an ELP internal crash
-      #       (`elp_lint:deprecated_function/5` case_clause {unsafe,possibly}),
-      #       spread across src/ and test/;
-      #     - three parse errors in src/ops/asobi_ops_params.erl, where ELP
-      #       cannot read `~"\\"` - an escaped backslash inside the OTP 27
-      #       sigil this codebase uses everywhere. It compiles fine.
-      #   Two more (`undefined function proper_transformer:parse_transform/2`
-      #   on test/prop_*.erl) appear only in CI, because Taure/erlang-ci's elp
-      #   action runs `rebar3 compile` and proper is a test-profile dep; they
-      #   go away under `rebar3 as test compile`.
-      # enable-elp-eqwalize - eqwalizer panics on OTP behaviour result
-      #   types under OTP 29; it has to run on 28.x. kura and shigoto pin
-      #   this false for the same reason.
+      # enable-elp-eqwalize - 312 eqwalizer errors on this tree (asobi#435),
+      #   so the job would fail on merge day. 310 of them are
+      #   `incompatible_types`, and 172 of those are a `term()` - out of
+      #   `maps:get/2`, `persistent_term:get/1`, ETS, or Luerl's `dynamic()` -
+      #   reaching a typed context with no narrowing clause. Weighted to
+      #   test/ (127) but present across src/console, src/lua, src/world and
+      #   src/ops. Cleaning it is a real project, tracked in the issue; the
+      #   tooling to run it is in place now, so it can go on per-area as the
+      #   count comes down.
+      #
+      #   Two reasons previously recorded here were wrong and cost time twice
+      #   over, so for the record: eqwalizer does NOT panic on OTP 29 (that
+      #   theory was superseded - the root cause was the `record()` builtin,
+      #   since fixed), and ELP does not need to run on 28.x. The real blocker
+      #   for both ELP jobs was that Taure/erlang-ci's elp action mapped OTP
+      #   majors to hardcoded asset names and stopped at 28, so on OTP 29 it
+      #   failed before downloading ELP at all - fixed in erlang-ci#71, which
+      #   also moved its compile step to `rebar3 as test compile` so
+      #   test-profile parse transforms (proper) resolve.
+      #
       # enable-mutate - needs the rebar3_mutate plugin, and a full-tree
       #   run over 134 modules is far too slow for per-PR CI. Wants
       #   mutate-diff (changed lines only) and a measured baseline first.

--- a/src/ops/asobi_ops_params.erl
+++ b/src/ops/asobi_ops_params.erl
@@ -159,9 +159,17 @@ like_pattern(Params, Key) ->
 %% unescaped search term changes what the query means - a lone `%` matches
 %% every row. Escape the backslash first, or the escapes added below get
 %% escaped in turn.
+%% The two backslash literals are `<<>>` rather than the `~""` sigil this
+%% codebase uses everywhere else, and have to stay that way: ELP's lexer does
+%% not terminate a `~"..."` whose content ends in an escaped backslash. It
+%% treats the closing quote as escaped, runs on into the following tokens and
+%% reports a syntax error several lines later. These three lines were the only
+%% ELP lint errors in the tree and the reason the lint job could not be turned
+%% on. Erlang itself parses either form; `~"%"` and `~"\\%"` are unaffected
+%% because they do not end in a backslash.
 -spec escape_like(binary()) -> binary().
 escape_like(Term) ->
-    Backslashes = binary:replace(Term, ~"\\", ~"\\\\", [global]),
+    Backslashes = binary:replace(Term, <<"\\">>, <<"\\\\">>, [global]),
     Percents = binary:replace(Backslashes, ~"%", ~"\\%", [global]),
     binary:replace(Percents, ~"_", ~"\\_", [global]).
 

--- a/test/asobi_ops_params_tests.erl
+++ b/test/asobi_ops_params_tests.erl
@@ -239,6 +239,18 @@ like_pattern_escapes_wildcards_test() ->
 like_pattern_escapes_backslash_first_test() ->
     ?assertEqual({ok, ~"%\\\\\\%%"}, asobi_ops_params:like_pattern(#{~"q" => ~"\\%"}, ~"q")).
 
+%% A backslash with no wildcard after it still doubles. Pins the two literals
+%% that had to move off the `~""` sigil to keep ELP's lexer able to read this
+%% module - see escape_like/1.
+%% Every sigil here deliberately ends in something other than a backslash;
+%% one that ends in a backslash is unreadable to ELP and would put this module
+%% back on the lint job's error list.
+like_pattern_escapes_lone_backslash_test() ->
+    ?assertEqual({ok, ~"%a\\\\b%"}, asobi_ops_params:like_pattern(#{~"q" => ~"a\\b"}, ~"q")),
+    ?assertEqual(
+        {ok, ~"%a\\\\\\\\b%"}, asobi_ops_params:like_pattern(#{~"q" => ~"a\\\\b"}, ~"q")
+    ).
+
 %%--------------------------------------------------------------------
 %% Cursors
 %%--------------------------------------------------------------------


### PR DESCRIPTION
Follow-up to #434, where the ELP jobs showing `skipping` turned out to be hiding a stack of wrong diagnoses.

## The ELP jobs were not skipping because of this repo

`Taure/erlang-ci`'s elp action mapped an OTP major to a hardcoded asset name and stopped at 28, so on OTP 29 it failed with `ELP does not provide binaries for OTP 29` before downloading ELP at all. Both jobs default to off, so this never went red - it showed up as the gates being left off with reasons in `ci.yml` that had quietly stopped being true.

Fixed upstream in Taure/erlang-ci#71 (released v2.1.5, pin bumped here). For the record, since these cost time twice:

- **"eqwalizer panics on OTP behaviour result types under OTP 29; it has to run on 28.x"** - no. That theory was superseded; the root cause was the `record()` builtin resolving to `{type,_,record,[]}`, since fixed. `eqwalize-all` completes on OTP 29 with zero panics.
- **"nine L0002 from an ELP internal crash"** - gone with current ELP.
- **"ELP cannot read `~"\\"`"** - wrong construct, see below.

## The real lint blocker: a sigil ending in a backslash

Three errors, all in `escape_like/1`. ELP's lexer does not terminate a `~"..."` whose content **ends** in an escaped backslash - it reads the closing quote as escaped, runs on into the following tokens and reports the syntax error two lines later. Isolated:

```
~"\\"      in isolation  -> "OK" (only because the run-on hits EOF)
{~"\\", ~"x"}           -> 2 errors   <- sigil ending in backslash, then anything
{~"x", ~"\\\\"}         -> OK
{~"%", ~"\\%"}          -> OK         <- ends in %, unaffected
{~B"\\", ~B"\%"}        -> 2 errors   <- verbatim sigils too
{<<"\\">>, ~"x"}        -> OK
```

So the two backslash literals move to `<<>>`, against the house `~""` style, with a comment saying why they cannot move back. Erlang parses either form; behaviour is identical. The existing `like_pattern_escapes_backslash_first_test` still pins the escaping order, and a lone-backslash case is added because that is the literal that moved.

Worth reporting upstream to ELP - happy to file it if you want.

## The thirteen CI-only errors

`proper_transformer:parse_transform/2` on `test/prop_*.erl` was the action compiling the default profile, so test-only deps were never fetched. erlang-ci#71 moves it to `rebar3 as test compile`. Confirmed on a fresh checkout: 16 errors before a test-profile compile, 3 after, 0 after this change.

## Result

`enable-elp-lint: true`, tree at **zero** ELP lint errors.

`enable-elp-eqwalize` stays off: **312 errors**, broken down in #435 with a staged plan. 310 are `incompatible_types` and 172 of those are a `term()` reaching a typed context with no narrowing clause; 127 of the 312 are in `test/`. Each fix is a real behaviour change across ~60 modules of a live product, so it is not one PR. #435 also raises the two decisions that would let the gate come on sooner: excluding `test/`, or a changed-modules-only `eqwalize-diff`.

## Verification

Full eunit 1699/0, xref, dialyzer, `rebar3 fmt --check` clean. `elp lint` 0 errors. `elp eqwalize asobi_ops_params` unchanged from baseline (1 pre-existing error at line 101, untouched by this change).

## One thing worth deciding separately

Consumers pin the reusable workflow (`ci.yml@v2.1.5`) but that workflow references its inner actions as `Taure/erlang-ci/elp@main`. The fix reached this repo the moment it hit erlang-ci `main`, pin or no pin - convenient here, but it means the version pin does not pin what actually runs.
