### PR TITLE
feat: report matchmaker dedupe and ticket expiry

### DIFF
--- a/docs/adr/0005-telemetry-event-surface.md
+++ b/docs/adr/0005-telemetry-event-surface.md
@@ -45,12 +45,18 @@ building an exporter safely - not a step to defer until after one is built.
   Prometheus label. This is a per-key, per-event classification, not a
   blanket claim on a key name:
   - `mode` (`match/started`, `world/started`, `matchmaker/*`). Bounded
-    because every entry point rejects an unknown mode before it can be
-    queued, via `asobi_matchmaker:known_mode/1`
-    (`src/ws/asobi_ws_handler.erl:450`,
-    `src/controllers/asobi_matchmaker_controller.erl:10`), which caps it at
-    64 bytes and requires it to resolve to a configured game module.
-  - `reason` on `matchmaker/removed` - an `atom()` chosen by core.
+    because every shipped entry point rejects an unknown mode before it can
+    be queued, via `asobi_matchmaker:known_mode/1`
+    (`asobi_ws_handler:handle_message/2`, `asobi_matchmaker_controller:add/1`
+    - referenced by function, not line, so the citation cannot rot), which
+    caps it at 64 bytes and requires it to resolve to a configured game
+    module. The gate is at those ingresses rather than in
+    `asobi_matchmaker:add/2` itself, so this bound is a property of the
+    shipped edges, not of the API: an embedder writing its own controller
+    over `add/2` must call `known_mode/1` or it re-opens the cardinality
+    hole for every `matchmaker/*` event.
+  - `reason` on `matchmaker/removed` - an `atom()` chosen by core
+    (`cancelled | expired`).
   - `type` on `anticheat/violation` - an `atom()` chosen by core, never
     derived from client input. This does **not** extend to the `ws` `type`,
     which is a different key on a different event; see below.
@@ -124,9 +130,14 @@ building an exporter safely - not a step to defer until after one is built.
   on a sustained non-zero rate, not on a single event - one skipped tick is a
   zone that ran long once, which is normal.
 
-#### Matchmaker - `[asobi, matchmaker, queued | removed | formed | failed]`
+#### Matchmaker - `[asobi, matchmaker, queued | deduped | removed | formed | failed]`
 
 - `queued`: metadata `#{player_id, mode}`
+- `deduped`: metadata `#{player_id, mode}`. An `add` answered with the
+  caller's existing ticket instead of a new one, per the one-live-ticket-per
+  (player, mode) guard. `mode` is label-safe on the same grounds as `queued`
+  (rejected at the edge by `asobi_matchmaker:known_mode/1`); `player_id` is
+  unbounded and must never be a label.
 - `removed`: metadata `#{player_id, reason}`
 - `formed`: measurements `#{player_count, wait_ms, count}`; metadata `#{mode}`
 - `failed`: measurements `#{player_count, count}`; metadata `#{mode}`
@@ -223,7 +234,7 @@ building an exporter safely - not a step to defer until after one is built.
 - `hit` / `miss`: metadata `#{kind :: positive | negative}`
 - `sweep`: no metadata
 
-That is 39 events across 14 domains (match, world, zone, matchmaker, session,
+That is 40 events across 14 domains (match, world, zone, matchmaker, session,
 ws, join, rehome, anticheat, error, economy, store, chat, vote, auth_cache -
 15 domains if `join`/`rehome` are counted separately from `ws`, as they are
 distinct top-level event-name prefixes).
@@ -266,7 +277,7 @@ minor release.
   and shigoto's telemetry surfaces respectively, not asobi's.
   `asobi_zone_spawner` is a pure entity-template registry, not a zone
   lifecycle owner, and still emits nothing by design.
-- Four of the 39 events are declared API with no in-tree emitter today -
+- Four of the 40 events are declared API with no in-tree emitter today -
   the `asobi_telemetry` function exists and is exported, but nothing in
   `src/` or `test/` calls it: `session_disconnected/2`
   (`[asobi, session, disconnected]`), `ws_message_out/1`

--- a/guides/matchmaking.md
+++ b/guides/matchmaking.md
@@ -46,10 +46,22 @@ curl -X POST http://localhost:8084/api/v1/matchmaker \
 <!-- /tabs -->
 
 The reply - the `matchmaker.queued` frame over WS, the JSON body over REST -
-carries `ticket_id`, `status: "pending"` and `players_needed`: the mode's
-`match_size`, or `null` if the mode declares none. Show it as "waiting for N
-players" so a queued client is not staring at silence. The `Meta` map in the
-Erlang return holds the same `players_needed`.
+carries `ticket_id`, `status: "pending"`, `players_needed` (the mode's
+`match_size`, or `null` if the mode declares none) and `already_queued`. Show
+`players_needed` as "waiting for N players" so a queued client is not staring
+at silence. The `Meta` map in the Erlang return holds the same fields.
+
+`already_queued` is `true` when you already had an open ticket for that mode
+and got it back rather than a new one. One live ticket per (player, mode) is
+deliberate, and it is what makes `add` safe to retry: a client that resumes a
+backgrounded socket can resubmit without minting a second ticket that would
+fill into a self-match.
+
+Use it to decide what your UI does with the reply. On `false`, start the wait
+from now. On `true`, you are re-attaching to a wait already in progress - keep
+the elapsed timer running rather than resetting it, since the ticket's
+`max_wait_seconds` is counted from its original submission, not from your
+resubmit.
 
 ### Testing solo
 
@@ -210,6 +222,14 @@ spawning a degenerate self-match, whatever a strategy returns.
     }}
 ]}
 ```
+
+`max_queue` also bounds the worst tick. Expiry is swept in one pass, and each
+expired ticket costs a `matchmaker.removed` telemetry emit plus a push to its
+player, all inside the tick - so if something stops matches forming entirely,
+one sweep can walk the whole queue while the matchmaker answers nothing else.
+The default is comfortable; if you raise it a long way, raise `tick_interval`
+with it and keep telemetry handlers on these events cheap (they run
+synchronously in the matchmaker's own process).
 
 `match_size`, `strategy` and the rest of a mode's shape are read into
 `game_modes` at boot, and a config watcher polls the manifest and each mode

--- a/guides/observability.md
+++ b/guides/observability.md
@@ -13,7 +13,7 @@ which is a different question with a different tool. See
 
 ## What you get
 
-- **37 telemetry events**, listed below. Stable names; the measurement and
+- **40 telemetry events**, listed below. Stable names; the measurement and
   metadata keys are documented per-event in `m:asobi_telemetry`.
 - **Structured JSON logs** on stdout, one object per line, via
   `nova_jsonlogger`. No configuration needed - a container log shipper reads
@@ -109,7 +109,7 @@ both are the kind of thing that is otherwise noticed a day later.
 
 ## The events
 
-Thirty-nine, grouped by what they are about. Measurement and metadata keys
+Forty, grouped by what they are about. Measurement and metadata keys
 are in `m:asobi_telemetry`, which is also the list `asobi_telemetry:events/0`
 returns - attach to that rather than restating the names.
 
@@ -133,12 +133,44 @@ misconfiguration, and both are invisible in game metrics.
 asobi.match.started              asobi.match.finished
 asobi.match.player_joined        asobi.match.player_left
 asobi.matchmaker.queued          asobi.matchmaker.removed
-asobi.matchmaker.formed          asobi.matchmaker.failed
+asobi.matchmaker.deduped         asobi.matchmaker.formed
+asobi.matchmaker.failed
 ```
 
 Queue depth is the number worth watching, and in a cluster it is per-node -
 each node's matchmaker holds its own tickets, so a fleet-wide total is a sum
 across nodes, not a reading from one. See [Clustering](clustering.md).
+
+**The alert worth having is `removed{reason=expired}` rising while `formed`
+stays flat.** That pair says exactly one thing, with no interpretation needed:
+players waited the full `max_wait_seconds` and got nothing. Removals carry
+`reason` - `cancelled` when a client withdraws, `expired` when the ticket times
+out - and only `expired` means the matchmaker failed to do its job.
+
+`deduped` fires when a player asks to queue for a mode they already have an
+open ticket on and gets that ticket back. (The client-facing field on the reply
+is named `already_queued`; the metric keeps the mechanism's name.) Some of it
+is routine: a double-tapped *find match*, and reconnect resubmits, which are
+idempotent by design. It is a hint, not a diagnosis. A sustained rate is worth looking at -
+one cause is several clients authenticated as the same player, which no amount
+of waiting will fix because one player cannot fill a two-player match - but a
+bored player re-tapping in an empty queue produces the same shape.
+
+Note what this view **cannot** tell you. Distinguishing "one player re-tapping"
+from "several clients sharing one identity" needs a distinct-player count, and
+`player_id` is unbounded so an exporter must never make it a label (see
+[ADR 0005](https://github.com/widgrensit/asobi/blob/main/docs/adr/0005-telemetry-event-surface.md)).
+`queued` and `deduped` are counters of events, not a live-ticket count - queue
+depth is the snapshot gauge described above. To separate those two cases you
+need the node's queue snapshot or its logs, not Prometheus.
+
+Handlers run **synchronously in the process that emitted the event**, so a
+handler attached to a matchmaker event runs inside the matchmaker's own message
+loop. Never call `asobi_matchmaker:get_queue_stats/0` from one - that is a
+`gen_server:call` to the process currently executing your handler, so it
+deadlocks until the call times out and stalls matchmaking for every player
+meanwhile. Read `asobi_matchmaker:snapshot/0` instead: it reads ETS and never
+messages the matchmaker.
 
 ### Worlds and zones
 

--- a/guides/websocket-protocol.md
+++ b/guides/websocket-protocol.md
@@ -442,7 +442,7 @@ Submit a matchmaking ticket.
 #### `matchmaker.queued` (reply)
 
 ```json
-{"type": "matchmaker.queued", "cid": "q-1", "payload": {"ticket_id": "...", "status": "pending", "players_needed": 4}}
+{"type": "matchmaker.queued", "cid": "q-1", "payload": {"ticket_id": "...", "status": "pending", "players_needed": 4, "already_queued": false}}
 ```
 
 `players_needed` is the mode's configured `match_size`, or `null` when the
@@ -452,7 +452,13 @@ reported.
 A mode that resolves to no game module is `unknown_mode`
 (`matchmaker.unknown_mode`); a full queue is `queue_full`
 (`matchmaker.queue_full`). Re-adding for a mode you already have an open
-ticket for returns that same ticket rather than a second one.
+ticket for returns that same ticket rather than a second one, and sets
+`already_queued` to `true`.
+
+`already_queued` exists so a reconnecting client can tell "my resubmit was
+absorbed, my original wait still stands" from "freshly queued". Keep the
+elapsed timer running on `true` - `max_wait_seconds` counts from the ticket's
+original submission, not from the resubmit.
 
 ### `matchmaker.remove`
 

--- a/priv/protocol/fixtures/matchmaker.queued.json
+++ b/priv/protocol/fixtures/matchmaker.queued.json
@@ -1,1 +1,1 @@
-{"type":"matchmaker.queued","cid":"5","payload":{"ticket_id":"01j8x000000000000000000003","status":"pending"}}
+{"type":"matchmaker.queued","cid":"5","payload":{"ticket_id":"01j8x000000000000000000003","status":"pending","players_needed":2,"already_queued":false}}

--- a/src/asobi_telemetry.erl
+++ b/src/asobi_telemetry.erl
@@ -1,11 +1,18 @@
 -module(asobi_telemetry).
+-include_lib("kernel/include/logger.hrl").
 
 -export([setup/0]).
 -export([match_started/2, match_finished/3, match_player_joined/2, match_player_left/2]).
 -export([world_started/2, world_finished/3, world_player_joined/2, world_player_left/2]).
 -export([world_phase_changed/3, world_tick/4]).
 -export([zone_opened/2, zone_closed/2, zone_tick_skipped/2]).
--export([matchmaker_queued/2, matchmaker_removed/2, matchmaker_formed/3, matchmaker_failed/2]).
+-export([
+    matchmaker_queued/2,
+    matchmaker_deduped/2,
+    matchmaker_removed/2,
+    matchmaker_formed/3,
+    matchmaker_failed/2
+]).
 -export([session_connected/1, session_disconnected/2]).
 -export([
     ws_connected/0,
@@ -60,6 +67,7 @@ events() ->
         [asobi, zone, closed],
         [asobi, zone, tick_skipped],
         [asobi, matchmaker, queued],
+        [asobi, matchmaker, deduped],
         [asobi, matchmaker, removed],
         [asobi, matchmaker, formed],
         [asobi, matchmaker, failed],
@@ -220,6 +228,17 @@ zone_tick_skipped(WorldId, Count) ->
 -spec matchmaker_queued(binary(), binary() | undefined) -> ok.
 matchmaker_queued(PlayerId, Mode) ->
     telemetry:execute([asobi, matchmaker, queued], #{count => 1}, #{
+        player_id => PlayerId, mode => Mode
+    }).
+
+%% An `add' that returned the caller's existing ticket instead of minting one,
+%% per the (player, mode) self-match guard (asobi#230). That branch emitted
+%% nothing before, so a queue that never paired looked identical to an idle one.
+%% A hint rather than a diagnosis - a double-tapped "find match" dedupes exactly
+%% like two clients sharing an identity.
+-spec matchmaker_deduped(binary(), binary()) -> ok.
+matchmaker_deduped(PlayerId, Mode) ->
+    telemetry:execute([asobi, matchmaker, deduped], #{count => 1}, #{
         player_id => PlayerId, mode => Mode
     }).
 
@@ -412,7 +431,10 @@ auth_cache_sweep() ->
     telemetry:handler_config()
 ) -> ok.
 handle_event(EventName, Measurements, Metadata, _Config) ->
-    logger:debug(#{
+    %% Macro, not logger:debug/1: the macro's logger:allow/2 guard skips building
+    %% this report entirely when debug is off. This runs synchronously inside the
+    %% emitting process, which for the matchmaker events is its message loop.
+    ?LOG_DEBUG(#{
         msg => ~"telemetry_event",
         event => EventName,
         measurements => Measurements,

--- a/src/lua/bots/asobi_bot_spawner.erl
+++ b/src/lua/bots/asobi_bot_spawner.erl
@@ -110,22 +110,36 @@ clamp_fill_target(Target) ->
 %% lists:seq(1, Target - Count) up front) and stops as soon as the
 %% matchmaker reports its queue is full, instead of discarding that error
 %% and letting ?CHECK_INTERVAL retry the same unreachable target forever.
+%% The name index restarts at 1 each cycle, so low-numbered bots get re-offered
+%% while still queued from the last one; `add' hands back their existing ticket
+%% and nobody joins. Counting those as progress left the queue permanently short
+%% of Target. Skip them and keep walking.
+%%
+%% At most `Count' of the ids probed can already be queued, so probing
+%% Needed + Count of them always reaches Needed free ones. Bounding on Needed
+%% alone is what made the original bug: with three bots live and one slot to
+%% fill, the walk gives up on the two taken ids before reaching a free one.
 fill_until(Mode, Count, Target, Names) ->
-    fill_until_loop(Mode, 1, Target - Count, Names).
+    Needed = Target - Count,
+    fill_until_loop(Mode, 1, 0, Needed + min(Count, ?MAX_BOT_FILL), Needed, Names).
 
-fill_until_loop(_Mode, N, Needed, _Names) when N > Needed ->
+fill_until_loop(_Mode, _Index, Added, _Limit, Needed, _Names) when Added >= Needed ->
     ok;
-fill_until_loop(Mode, N, Needed, Names) ->
-    BotId = bot_name(N, Names),
+fill_until_loop(_Mode, Index, _Added, Limit, _Needed, _Names) when Index > Limit ->
+    ok;
+fill_until_loop(Mode, Index, Added, Limit, Needed, Names) ->
+    BotId = bot_name(Index, Names),
     case asobi_matchmaker:add(BotId, #{mode => Mode}) of
         {error, queue_full} ->
             ?LOG_WARNING(#{
                 msg => ~"bot fill stopped: matchmaker queue full",
                 mode => Mode,
-                bots_added => N - 1
+                bots_added => Added
             });
+        {ok, _TicketId, #{already_queued := true}} ->
+            fill_until_loop(Mode, Index + 1, Added, Limit, Needed, Names);
         _ ->
-            fill_until_loop(Mode, N + 1, Needed, Names)
+            fill_until_loop(Mode, Index + 1, Added + 1, Limit, Needed, Names)
     end.
 
 %% --- Match Scanning ---

--- a/src/matches/asobi_matchmaker.erl
+++ b/src/matches/asobi_matchmaker.erl
@@ -11,7 +11,7 @@ spawns a match, and pushes `match.matched` to each player. A single
 -export([known_mode/1, snapshot/0]).
 -export([init/1, handle_call/3, handle_cast/2, handle_info/2, terminate/2]).
 -ifdef(TEST).
--export([next_spawn_attempt/1, join_matched_players/3, tally/1, render/3]).
+-export([next_spawn_attempt/1, join_matched_players/3, tally/1, render/3, notify_expired/1]).
 -endif.
 
 -export_type([snapshot/0, mode_queue/0]).
@@ -74,11 +74,21 @@ known_mode(_) ->
 %% match_size (null if the mode declares none). players_waiting (a count of
 %% others queued) is deliberately not exposed by default - it is a per-mode
 %% opt-in, tracked in asobi#232's follow-up.
--spec queue_meta(binary()) -> map().
-queue_meta(Mode) ->
+%%
+%% `already_queued' says whether this reply carries a ticket the caller already
+%% held rather than a new one. `add' is idempotent per (player, mode) precisely
+%% so a reconnect resubmit is safe (asobi#230); without this flag a client
+%% resuming a backgrounded socket cannot tell "my resubmit was absorbed and my
+%% original wait still stands" from "freshly queued", so it restarts its wait
+%% UI. Named for what the client observes, not for the server mechanism - the
+%% telemetry event keeps the mechanism name. Additive field: clients that ignore
+%% it behave exactly as before.
+-spec queue_meta(binary(), boolean()) -> map().
+queue_meta(Mode, AlreadyQueued) ->
+    Meta = #{already_queued => AlreadyQueued},
     case maps:get(match_size, asobi_game_modes:mode_config(Mode), undefined) of
-        N when is_integer(N) -> #{players_needed => N};
-        _ -> #{players_needed => null}
+        N when is_integer(N) -> Meta#{players_needed => N};
+        _ -> Meta#{players_needed => null}
     end.
 
 -spec remove(binary(), binary()) -> ok | {error, not_found | not_owner}.
@@ -248,7 +258,8 @@ handle_call({add, PlayerId, Params}, _From, #{tickets := Tickets} = State) when
     %% self-match (asobi#230). A full queue is rejected before minting.
     case find_player_ticket(PlayerId, Mode, Tickets) of
         {ok, ExistingId} ->
-            {reply, {ok, ExistingId, queue_meta(Mode)}, State};
+            asobi_telemetry:matchmaker_deduped(PlayerId, Mode),
+            {reply, {ok, ExistingId, queue_meta(Mode, true)}, State};
         error when map_size(Tickets) >= MaxQueue ->
             {reply, {error, queue_full}, State};
         error ->
@@ -263,7 +274,7 @@ handle_call({add, PlayerId, Params}, _From, #{tickets := Tickets} = State) when
                 attempts => 0
             },
             asobi_telemetry:matchmaker_queued(PlayerId, Mode),
-            {reply, {ok, TicketId, queue_meta(Mode)}, State#{
+            {reply, {ok, TicketId, queue_meta(Mode, false)}, State#{
                 tickets => Tickets#{TicketId => Ticket}
             }}
     end;
@@ -717,6 +728,11 @@ notify_matchmaker_failed(PlayerIds, Reason) ->
 notify_expired([]) ->
     ok;
 notify_expired([#{player_id := PlayerId, id := TicketId} | Rest]) ->
+    %% Only `cancelled' was ever reported here, so removed{reason=expired} read
+    %% as zero and an operator's removal rate looked complete while omitting
+    %% every timeout. Expiry against flat `formed' is the unambiguous form of
+    %% "players waited the full max_wait and got nothing".
+    asobi_telemetry:matchmaker_removed(PlayerId, expired),
     asobi_presence:send(PlayerId, {match_event, matchmaker_expired, #{ticket_id => TicketId}}),
     notify_expired(Rest).
 

--- a/test/asobi_bot_spawner_tests.erl
+++ b/test/asobi_bot_spawner_tests.erl
@@ -29,7 +29,11 @@ fill_mode_test_() ->
         {"fill stops incrementally as soon as the matchmaker reports queue_full",
             fun fill_stops_on_queue_full/0},
         {"fill_mode returns cleanly (no crash) when the very first add hits queue_full",
-            fun fill_stops_on_queue_full_immediately/0}
+            fun fill_stops_on_queue_full_immediately/0},
+        {"fill walks past bot ids that are still queued from the last cycle",
+            fun fill_skips_already_queued_bots/0},
+        {"fill gives up rather than spinning when every id comes back already queued",
+            fun fill_gives_up_when_all_ids_taken/0}
     ]}.
 
 setup() ->
@@ -129,3 +133,53 @@ fill_stops_on_queue_full_immediately() ->
     meck:expect(asobi_matchmaker, add, fun(_BotId, _Opts) -> {error, queue_full} end),
     ?assertEqual(ok, asobi_bot_spawner:fill_mode(~"arena", 1)),
     ?assertEqual(1, meck:num_calls(asobi_matchmaker, add, '_')).
+
+%% The incident: the name index restarts at 1 each cycle, so low-numbered bots
+%% are re-offered while still queued from the last one. `add' is idempotent per
+%% (player, mode), so those re-offers hand back the existing ticket and nobody
+%% joins. Counting them as progress left the queue permanently short.
+%%
+%% Three queued (one human, bot_Spark, bot_Blitz) against a target of 4 is the
+%% case that bounding the walk on `Needed' alone gets wrong: it probes the two
+%% taken ids and gives up before reaching a free one, adding nobody, forever.
+fill_skips_already_queued_bots() ->
+    application:set_env(asobi, game_modes, #{
+        ~"arena" => #{
+            match_size => 4,
+            max_players => 10,
+            bots => #{enabled => true, min_players => 4}
+        }
+    }),
+    meck:expect(asobi_matchmaker, add, fun(BotId, _Opts) ->
+        Taken = lists:member(BotId, [~"bot_Spark", ~"bot_Blitz"]),
+        {ok, ~"ticket", #{already_queued => Taken}}
+    end),
+    asobi_bot_spawner:fill_mode(~"arena", 3),
+    ?assertEqual(3, meck:num_calls(asobi_matchmaker, add, '_')),
+    ?assertEqual(1, length(added_bots())).
+
+%% If every id it can reach is already queued the walk must terminate, not spin
+%% until the next tick.
+fill_gives_up_when_all_ids_taken() ->
+    application:set_env(asobi, game_modes, #{
+        ~"arena" => #{
+            match_size => 4,
+            max_players => 10,
+            bots => #{enabled => true, min_players => 4}
+        }
+    }),
+    meck:expect(asobi_matchmaker, add, fun(_BotId, _Opts) ->
+        {ok, ~"ticket", #{already_queued => true}}
+    end),
+    %% Needed 3 + Count 1 probes, then it stops rather than walking forever.
+    ?assertEqual(ok, asobi_bot_spawner:fill_mode(~"arena", 1)),
+    ?assertEqual(4, meck:num_calls(asobi_matchmaker, add, '_')),
+    ?assertEqual(0, length(added_bots())).
+
+added_bots() ->
+    [
+        BotId
+     || {_, {_, add, [BotId, _]}, {ok, _, #{already_queued := false}}} <- meck:history(
+            asobi_matchmaker
+        )
+    ].

--- a/test/asobi_matchmaker_SUITE.erl
+++ b/test/asobi_matchmaker_SUITE.erl
@@ -17,6 +17,9 @@
     remove_then_readd_new_ticket/1,
     selfmatch_group_rejected/1,
     add_reply_reports_players_needed/1,
+    add_reply_reports_already_queued/1,
+    dedup_emits_telemetry/1,
+    expiry_emits_removed_telemetry/1,
     spawn_retry_bounded_then_gives_up/1,
     queue_snapshot_reports_waiting_by_mode/1,
     queue_snapshot_never_waits_on_the_matchmaker/1
@@ -37,6 +40,9 @@ all() ->
         remove_then_readd_new_ticket,
         selfmatch_group_rejected,
         add_reply_reports_players_needed,
+        add_reply_reports_already_queued,
+        dedup_emits_telemetry,
+        expiry_emits_removed_telemetry,
         spawn_retry_bounded_then_gives_up,
         queue_snapshot_reports_waiting_by_mode,
         queue_snapshot_never_waits_on_the_matchmaker
@@ -160,6 +166,83 @@ selfmatch_group_rejected(Config) ->
             {ok, V} -> application:set_env(asobi, game_modes, V);
             undefined -> application:unset_env(asobi, game_modes)
         end
+    end,
+    Config.
+
+%% A reconnecting client resubmits, and must be able to tell that its resubmit
+%% was absorbed into the wait already running rather than starting a new one.
+add_reply_reports_already_queued(Config) ->
+    {ok, T1, Meta1} = asobi_matchmaker:add(~"player_dedup_meta", #{mode => ~"ranked"}),
+    ?assertEqual(false, maps:get(already_queued, Meta1)),
+    {ok, T2, Meta2} = asobi_matchmaker:add(~"player_dedup_meta", #{mode => ~"ranked"}),
+    ?assertEqual(T1, T2),
+    ?assertEqual(true, maps:get(already_queued, Meta2)),
+    %% A different player in the same mode is a fresh ticket, not a dedupe.
+    {ok, T3, Meta3} = asobi_matchmaker:add(~"player_dedup_other", #{mode => ~"ranked"}),
+    ?assertEqual(false, maps:get(already_queued, Meta3)),
+    asobi_matchmaker:remove(~"player_dedup_meta", T1),
+    asobi_matchmaker:remove(~"player_dedup_other", T3),
+    Config.
+
+%% The dedupe branch used to emit nothing at all, so "players are queueing and
+%% nothing is pairing" produced no signal anywhere on the node.
+dedup_emits_telemetry(Config) ->
+    Self = self(),
+    Ref = make_ref(),
+    Handler = {?MODULE, Ref},
+    ok = telemetry:attach(
+        Handler,
+        [asobi, matchmaker, deduped],
+        fun(_Event, Measurements, Meta, _) -> Self ! {Ref, Measurements, Meta} end,
+        undefined
+    ),
+    try
+        {ok, T1, _} = asobi_matchmaker:add(~"player_dedup_tel", #{mode => ~"ranked"}),
+        %% A fresh enqueue must NOT emit it.
+        receive
+            {Ref, _, #{player_id := ~"player_dedup_tel"}} ->
+                ct:fail(dedup_emitted_for_fresh_ticket)
+        after 200 -> ok
+        end,
+        {ok, T1, _} = asobi_matchmaker:add(~"player_dedup_tel", #{mode => ~"ranked"}),
+        receive
+            {Ref, Measurements, #{player_id := ~"player_dedup_tel"} = Meta} ->
+                ?assertEqual(1, maps:get(count, Measurements)),
+                ?assertEqual(~"ranked", maps:get(mode, Meta))
+        after 2000 -> ct:fail(no_dedup_telemetry)
+        end,
+        asobi_matchmaker:remove(~"player_dedup_tel", T1)
+    after
+        telemetry:detach(Handler)
+    end,
+    Config.
+
+%% Expiry used to notify only the player. `removed' therefore reported
+%% `cancelled' alone, so an operator's removal rate looked complete while
+%% silently omitting every timeout - and "everyone waited the full max_wait and
+%% got nothing" is the one unambiguous symptom of a matchmaker that is not
+%% pairing.
+expiry_emits_removed_telemetry(Config) ->
+    Self = self(),
+    Ref = make_ref(),
+    Handler = {?MODULE, Ref},
+    ok = telemetry:attach(
+        Handler,
+        [asobi, matchmaker, removed],
+        fun(_Event, _Measurements, Meta, _) -> Self ! {Ref, Meta} end,
+        undefined
+    ),
+    try
+        asobi_matchmaker:notify_expired([
+            #{player_id => ~"player_expiry_tel", id => ~"ticket-expired"}
+        ]),
+        receive
+            {Ref, #{player_id := ~"player_expiry_tel"} = Meta} ->
+                ?assertEqual(expired, maps:get(reason, Meta))
+        after 2000 -> ct:fail(no_expiry_telemetry)
+        end
+    after
+        telemetry:detach(Handler)
     end,
     Config.
 

--- a/test/asobi_matchmaker_api_SUITE.erl
+++ b/test/asobi_matchmaker_api_SUITE.erl
@@ -5,6 +5,7 @@
 -export([all/0, init_per_suite/1, end_per_suite/1]).
 -export([
     add_ticket/1,
+    add_ticket_reports_already_queued/1,
     add_ticket_omitted_mode_rejected/1,
     get_ticket/1,
     get_ticket_not_found/1,
@@ -17,6 +18,7 @@
 all() ->
     [
         add_ticket,
+        add_ticket_reports_already_queued,
         add_ticket_omitted_mode_rejected,
         get_ticket,
         get_ticket_not_found,
@@ -103,6 +105,33 @@ add_ticket(Config) ->
     ?assertMatch(#{~"ticket_id" := _, ~"status" := ~"pending"}, Body),
     #{~"ticket_id" := TicketId} = Body,
     true = is_binary(TicketId),
+    _ = nova_test:delete(
+        "/api/v1/matchmaker/" ++ binary_to_list(TicketId),
+        #{headers => auth(Config)},
+        Config
+    ),
+    Config.
+
+%% The reply metadata has to survive the controller's JSON projection, not just
+%% asobi_matchmaker:add/2's return map - and `already_queued' has to encode as a
+%% JSON boolean rather than a string. Asserted at the edge a client actually
+%% talks to.
+add_ticket_reports_already_queued(Config) ->
+    Post = fun() ->
+        {ok, Resp} = nova_test:post(
+            "/api/v1/matchmaker",
+            #{headers => auth(Config), json => #{~"mode" => ~"ranked"}},
+            Config
+        ),
+        ?assertStatus(200, Resp),
+        nova_test:json(Resp)
+    end,
+    Body1 = Post(),
+    ?assertMatch(#{~"already_queued" := false}, Body1),
+    Body2 = Post(),
+    ?assertMatch(#{~"already_queued" := true}, Body2),
+    #{~"ticket_id" := TicketId} = Body1,
+    ?assertEqual(TicketId, maps:get(~"ticket_id", Body2)),
     _ = nova_test:delete(
         "/api/v1/matchmaker/" ++ binary_to_list(TicketId),
         #{headers => auth(Config)},


### PR DESCRIPTION
Two players queued, both were handed the same `ticket_id`, no match could ever fill, and the node reported nothing unusual. That was a client-side bug — a Defold SDK defect signed every HTML5 browser in as one guest, fixed in [asobi-defold v1.13.1](https://github.com/widgrensit/asobi-defold/pull/50) — but it went **two weeks unnoticed** because the server had no way to say what was happening.

Two blind spots, both here.

## 1. The idempotent re-add branch was silent

`asobi_matchmaker.erl` returned the caller's existing ticket with no telemetry and a reply indistinguishable from a fresh enqueue. Now emits `[asobi, matchmaker, deduped]` and reports `already_queued` on the reply.

## 2. Ticket expiry emitted nothing at all

This is the bigger half, and I missed it on the first pass. `removed` only ever reported `cancelled`, so an operator's removal rate looked complete while silently omitting **every timeout**.

`removed{reason=expired}` rising against flat `formed` says exactly one thing with no interpretation: players waited the full `max_wait_seconds` and got nothing. That is now the headline alert in the guide.

`deduped` is deliberately documented as a *hint*, not a diagnosis — a double-tapped *find match* dedupes identically to two clients sharing an identity, and telling those apart needs a distinct-player count that an exporter can't compute (`player_id` is unbounded, so it must never be a label). The guide says what the metric cannot prove.

## The wire field

`already_queued` is named for what the client observes; the metric keeps the mechanism's name. `add` is idempotent per (player, mode) *precisely so a reconnect resubmit is safe* (asobi#230) — without the flag, a client resuming a backgrounded socket cannot tell an absorbed resubmit from a fresh queue and restarts its wait UI. Additive: clients that ignore it are unaffected. Flows to both the WS frame and the REST body unchanged, since both merge `Meta`.

## Bot-fill defect this exposed

Checking whether bots would pollute the new metric turned up a real bug. `fill_until_loop/4` restarts its name index at 1 each cycle, so low-numbered bots are re-offered while still queued; `add` hands back their existing ticket, the loop counts that as progress, and the queue stays permanently short of target — repeating every `?CHECK_INTERVAL` until the bots expire together.

Fixed by skipping taken ids, bounded by `Needed + min(Count, ?MAX_BOT_FILL)`: at most `Count` of the ids probed can be queued, so that always reaches `Needed` free ones. My first attempt bounded on `Needed * 2` and **reproduced the exact bug its own comment described** (three bots live, one slot needed → probes two taken ids, gives up, adds nobody). Caught in review; the test now fails against that bound.

## Contract

ADR 0005 updated: 39 → 40 events, `deduped` metadata classified for label safety, `reason` documented as `cancelled | expired`, and the mode-bound citations moved off line numbers onto function references (two of the three had already rotted to unrelated code).

## Verification

`fmt --check`, `xref`, `dialyzer`, `eunit` (1701), `asobi_matchmaker_SUITE` (19), `asobi_matchmaker_api_SUITE` (9). `elp lint` unchanged at 168 lines, so no new findings. eqwalizer stays off per 7c19e51.

New coverage: reply flag at the API edge (asserts it survives the controller's JSON projection as a boolean, not just `add/2`'s return map), `deduped` emitted on dedupe and *not* on fresh enqueue, `expired` emitted on sweep, and both bot-fill scenarios. Telemetry `receive`s are filtered by `player_id` so an unrelated dedupe elsewhere in the VM can't decide the result.

## Reviews

Architecture guardian (ACCEPT WITH CHANGES, all addressed), Erlang code reviewer (2 blockers, both fixed), BEAM security reviewer (0 High, 1 Medium, 3 Low — nothing blocking; Lows addressed).

Security review verified two things I'd asked it to break, and both held: `already_queued` is no oracle (`player_id` is never caller-influenced on either edge, there is no group-add API, and the branch already returned the existing ticket id), and the bot-fill bound is sound — exhaustively checked over every reachable `(Count, Target)`, where `Limit` collapses to `Target` ≤ 64 so `?MAX_BOT_FILL` is intact.

## Follow-ups, not in this PR

- **`matchmaker.add` has no dedicated rate limiter** (security review, Medium). It reaches a single global gen_server at 60/s per WS socket or 300/s over REST, where `match.join` gets its own 10-per-60s bucket. Pre-existing and not worsened in ceiling — `remove/2` already emitted per request — but this change makes the dedupe branch the one an accidental client retry loop hits, and the guide now invites operators to attach handlers to it. Adding a bucket is a client-visible behaviour change and deserves its own review.
- `find_player_ticket/3` materialises the whole ticket map per add (up to `max_queue`). A `{PlayerId, Mode}` index makes it a lookup. Wants a bench first.
- `opentelemetry_asobi` and `asobi_engine_metrics` carry their own stale event lists and won't see `deduped` until they move to `events/0`.

Merging fans out seven SDK fixture PRs via `protocol-sync.yml`. I confirmed `SDK_SYNC_APP_ID` (variable) and `SDK_SYNC_APP_PRIVATE_KEY` (secret) are both set, so it will actually fire this time.