### PR TITLE
fix(ci): approve before merging so dependabot auto-merge works under the ruleset

### DIFF
--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -2,7 +2,17 @@ name: Dependabot auto-merge
 
 # Merge a dependabot PR (github-actions + docker bumps) once CI is green.
 # Runs on CI completion rather than PR open, so the merge only happens after
-# checks pass. Self-contained: no branch protection or repo settings required.
+# checks pass.
+#
+# It approves before merging because main's ruleset requires one approving
+# review. Without that, the merge is refused with "the base branch policy
+# prohibits the merge" - and because nothing watches this workflow, dependabot
+# PRs then pile up green-but-unmerged with no signal anywhere. Three had been
+# sitting for a day when this was found.
+#
+# Automating the approval is defensible only because the job is already gated on
+# the author being dependabot AND CI having passed. Do not widen either
+# condition without revisiting that.
 
 on:
   workflow_run:
@@ -33,5 +43,9 @@ jobs:
             echo "No open PR for branch $HEAD; nothing to merge."
             exit 0
           fi
-          echo "Merging PR #$num (branch $HEAD)"
+          echo "Approving and merging PR #$num (branch $HEAD)"
+          # github-actions[bot] is a different actor from dependabot[bot], so
+          # this is not a self-approval and does satisfy the review rule.
+          gh pr review "$num" --repo "$REPO" --approve \
+            --body "Automated approval: dependabot bump, CI green."
           gh pr merge "$num" --repo "$REPO" --squash --delete-branch


### PR DESCRIPTION
## What was broken

`dependabot-automerge.yml` has failed on every run since main's "Protect main" ruleset was added:

```
X Pull request widgrensit/asobi#430 is not mergeable: the base branch policy prohibits the merge.
```

The workflow's own header said *"Self-contained: no branch protection or repo settings required"* — an assumption the ruleset (1 approving review) invalidated. Nothing watches this workflow, so the failure was silent and dependabot PRs simply accumulated: #428, #429 and #430 sat green-but-unmerged for a day, and only surfaced because I went looking for open PRs.

## Fix

Approve with `GITHUB_TOKEN` before merging. `github-actions[bot]` is a different actor from `dependabot[bot]`, so it is not a self-approval and it does satisfy the review rule.

The job was **already** gated on `actor.login == 'dependabot[bot]'` and `conclusion == 'success'`. Those two conditions are what make automating an approval defensible rather than reckless, so the comment now says they are load-bearing and must not be widened casually.

`--auto` was the other candidate and does not work here: `allow_auto_merge` is `false` on this repo, and the blocker is a *review* rather than a pending check, so auto-merge would queue forever waiting for something that never arrives.

## Scope note

This only fixes `asobi`. Any other repo with both this workflow and a review-requiring ruleset has the same silent failure — worth a sweep, but not in this PR.

The three backed-up PRs are already merged (admin override), so this is about the next one, not the current backlog.