### PR TITLE
fix(docs): pin the console example to v0.75.0, the release that has it

### DIFF
--- a/examples/console-extension/rebar.config
+++ b/examples/console-extension/rebar.config
@@ -2,8 +2,12 @@
 
 {project_app_dirs, ["apps/*"]}.
 
+%% From git rather than Hex, and pinned to the same tag as the plugin below.
+%% The console source and `rebar3 asobi console` landed in v0.75.0, which is
+%% ahead of what is on Hex - releases there are cut by hand. Once a Hex release
+%% carries it, `{asobi, "~> 0.75"}` works here just as well.
 {deps, [
-    {asobi, "0.74.0"}
+    {asobi, {git, "https://github.com/widgrensit/asobi.git", {tag, "v0.75.0"}}}
 ]}.
 
 %% Where `rebar3 asobi console` writes the composed bundle. The same name goes
@@ -18,10 +22,10 @@
 %% the dependency's, and an exact match between the two is what keeps the
 %% provider and that surface from disagreeing.
 %%
-%% Both are 0.74.0 or newer: the console source only ships in the Hex package,
-%% and `rebar3 asobi console` only exists at all, from that release on.
+%% Both name v0.75.0: the console source ships, and `rebar3 asobi console`
+%% exists at all, only from that release on.
 {project_plugins, [
-    {asobi, {git, "https://github.com/widgrensit/asobi.git", {tag, "v0.74.0"}}}
+    {asobi, {git, "https://github.com/widgrensit/asobi.git", {tag, "v0.75.0"}}}
 ]}.
 
 {relx, [

--- a/guides/console-extensions.md
+++ b/guides/console-extensions.md
@@ -320,7 +320,7 @@ Name it in `rebar.config`, which is where the build looks:
 {asobi, [{console_bundle_app, game_console}]}.
 
 {project_plugins, [
-    {asobi, {git, "https://github.com/widgrensit/asobi.git", {tag, "v0.74.0"}}}
+    {asobi, {git, "https://github.com/widgrensit/asobi.git", {tag, "v0.75.0"}}}
 ]}.
 ```
 


### PR DESCRIPTION
The pins in `examples/console-extension/rebar.config` and
`guides/console-extensions.md` said v0.74.0, which was the next version when
#425 was written. #437 and #438 landed first and took 0.74.0 and 0.74.1, so the
console feature shipped as v0.75.0 and the example pointed at a real release
with no console provider in it - the same "unknown command" the branch set out
to fix, with a different number.

`git ls-tree v0.75.0` has `src/extensions/rebar3_asobi_console.erl`; v0.74.0
does not.

The dependency comes from git rather than Hex for now. Hex is at 0.72.6 and
releases there are cut by hand, so a 0.75.0 Hex pin would not resolve. Once a
Hex release carries it, `{asobi, "~> 0.75"}` works there just as well.