### PR TITLE
fix(hex): ship the console source, which include_files never did

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -100,24 +100,12 @@
 {cover_export_enabled, true}.
 {covertool, [{coverdata_files, ["eunit.coverdata", "ct.coverdata"]}]}.
 
+%% Only `doc` belongs here. rebar3_hex reads the package's file list out of
+%% src/asobi.app.src, not out of this key, so an `include_files` written here
+%% is accepted by rebar3 and then ignored - which is how `console` came to be
+%% listed for a release and shipped in none. It lives in the .app.src now.
 {hex, [
-    {doc, #{provider => ex_doc}},
-    {include_files, [
-        <<"src">>,
-        <<"include">>,
-        <<"priv">>,
-        %% The console's *source*, not just the built bundle in priv. A host
-        %% whose extensions ship operator screens composes its own console out
-        %% of this tree with `rebar3 asobi console`, and a Hex consumer that
-        %% did not get the source could not. Roughly 30 KB; node_modules is
-        %% never in it.
-        <<"console">>,
-        <<"rebar.config">>,
-        <<"rebar.lock">>,
-        <<"README.md">>,
-        <<"guides">>,
-        <<"docs">>
-    ]}
+    {doc, #{provider => ex_doc}}
 ]}.
 
 {ex_doc, [

--- a/src/asobi.app.src
+++ b/src/asobi.app.src
@@ -24,6 +24,36 @@
     %% special name.
     {env, [{providers, [rebar3_asobi_check, rebar3_asobi_console]}]},
     {modules, []},
+    %% Added to the file set rebar3_hex ships, not a replacement for it:
+    %% `include_paths` merges over the defaults, which already carry src, priv,
+    %% include and the two rebar files.
+    %%
+    %% The console's *source*. A host whose extensions ship operator screens
+    %% composes its own bundle out of this tree with `rebar3 asobi console`,
+    %% and a consumer who installed from Hex without it gets
+    %% `no_console_source` from a command the guides tell them to run.
+    %%
+    %% Spelled out rather than `"console"`, and this is load-bearing:
+    %% `rebar3_hex_build:include_files/3` applies the excludes to the default
+    %% file set and only then merges the included paths over the result, so an
+    %% `exclude_paths` for `console/node_modules` would not be consulted. A
+    %% whole-directory include therefore ships whatever npm left in the tree of
+    %% whoever published - measured at 556 files. These four are what the
+    %% provider copies into its workspace (`?SOURCES`), and no wildcard can
+    %% reach node_modules.
+    %%
+    %% It has to be here rather than in rebar.config's `{hex, ...}`, which is
+    %% where it was first written: rebar3_hex reads the file list out of this
+    %% file's own terms, so the key is silently inert anywhere else.
+    %% `{hex, [{doc, ...}]}` in rebar.config is read, which is what made the
+    %% mistake look like it worked.
+    {include_paths, [
+        "console/src",
+        "console/package.json",
+        "console/package-lock.json",
+        "console/vite.config.js",
+        "console/README.md"
+    ]},
     {licenses, ["Apache-2.0"]},
     {links, [{"GitHub", "https://github.com/widgrensit/asobi"}]}
 ]}.


### PR DESCRIPTION
`console/` was listed in `rebar.config`'s `{hex, [{include_files, ...}]}` in #425 and has shipped in no release. rebar3_hex reads the package file list from the **.app.src**'s own terms (`rebar3_hex_build:include_files/3` takes it from `AppDetails`), so the key is accepted by rebar3 and then ignored anywhere else. `{hex, [{doc, ...}]}` in `rebar.config` *is* read, which is what made the mistake look like it worked.

Found by unpacking the built tarball rather than by reading the config. v0.75.1 ships:

```
LICENSE README.md include priv rebar.config rebar.lock src
```

So a consumer installing from Hex gets `{no_console_source, _}` from `rebar3 asobi console` - a command the guides tell them to run.

## Why the paths are spelled out

`include_files/3` filters the default set against the excludes and *then* merges the included paths over the result:

```erlang
FilterExcluded = lists:filter(..., AllFiles),
WithIncludes = lists:ukeymerge(2, FilterExcluded, IncludeFiles),
```

An `exclude_paths` for `console/node_modules` is therefore never consulted. A whole-directory `"console"` include ships whatever npm left in the publishing tree - measured at **556 files** before this was pinned down. The five listed paths are what the provider copies into its workspace (`?SOURCES`), and no wildcard can reach `node_modules`.

## Verified

```
console/README.md  console/package.json  console/package-lock.json
console/src/*      console/vite.config.js
node_modules entries: 0
```

Package grows ~35 KB. `application:load(asobi)` still returns `ok` and the `providers` env is intact, so the non-standard key is tolerated the way `licenses` and `links` already are.

`guides/` and `docs/` were in the same inert list and are deliberately not restored: they reach HexDocs through the docs tarball, which is built separately and already carries them.

Blocks the 0.75.2 Hex release.