### PR TITLE
feat: export_player/1 extension callback and export walker

### DIFF
--- a/guides/extensions.md
+++ b/guides/extensions.md
@@ -71,7 +71,7 @@ player-scoped, and no player ever holds an operator capability.
 ```erlang
 -module(asobi_quests_extension).
 -behaviour(asobi_extension).
--export([info/0, rpc/0, lua/0, sup/0, owns/0, codes/0, ops/0, erase_player/1]).
+-export([info/0, rpc/0, lua/0, sup/0, owns/0, codes/0, ops/0, erase_player/1, export_player/1]).
 
 info() -> #{name => quests, extension_version => 1}.
 
@@ -727,12 +727,17 @@ export_player(PlayerId) ->
 The map keys are your own section names, mirroring core's per-table sections.
 Apply the same rule core does: positive allowlists via `maps:with/2`, never
 subtractive filters - an extension carrying a token or secret column is one
-schema field away from exporting it otherwise.
+schema field away from exporting it otherwise. And every row you return must
+be one this player owns - core cannot check that for you. Where one column
+holds several players' data, lift out this player's part rather than exporting
+the column whole, the way core exports only the requester's own choice from
+`votes.votes_cast`.
 
 A missing callback is a marker; a failing one fails the export. Returning
-`{error, _}` or raising means data was promised and not delivered - exactly the
-silent incompleteness the marker exists to prevent - so the whole request
-answers `500 ops.export_incomplete` and no artefact is produced. There is no
+`{error, _}`, raising, or returning a section `json:encode/1` cannot encode
+means data was promised and not delivered - exactly the silent incompleteness
+the marker exists to prevent - so the whole request answers
+`500 ops.export_incomplete` and no artefact is produced. There is no
 transaction: core's export is a sequence of plain reads, and yours run in the
 same untransacted pass, after core's own sections.
 

--- a/guides/extensions.md
+++ b/guides/extensions.md
@@ -704,18 +704,37 @@ than merely discouraged: a database cascade fires below the transaction's
 control flow, so `erase_player/1` would never be called at all and the receipts
 would be destroyed silently.
 
-### There is no `export_player/1`
+### `export_player/1`
 
 Core exports a player - `GET /api/v1/ops/players/:id/export` - and the payload
-covers core's tables only. Extensions do not contribute to it, and that is a
-decision rather than a gap.
+names **every** installed extension under an `extensions` key: the data your
+`export_player/1` returned, or a `skipped` marker when you do not export one.
 
 `erase_player/1` earns its keep because the foreign key forces you to answer:
 skip it and the player row physically cannot be deleted. An export callback has
-no such forcing function, so an extension that skipped it would produce a
-silently incomplete export and nothing would fail - a worse contract than no
-contract. If one ever ships, core will have to name in the payload which
-installed extensions contributed and which did not.
+no such forcing function - an extension that skipped an unmarked one would
+produce a silently incomplete export and nothing would fail - so the artefact
+itself is the forcing function. A skipped extension is a visible marker in the
+export a data subject or auditor reads, not an absence nobody can detect.
+
+```erlang
+-spec export_player(binary()) -> {ok, #{binary() => term()}} | {error, term()}.
+export_player(PlayerId) ->
+    {ok, Rows} = asobi_repo:all(by_player(asobi_quest_progress, PlayerId)),
+    {ok, #{~"quest_progress" => [maps:with([quest_id, counter], Row) || Row <- Rows]}}.
+```
+
+The map keys are your own section names, mirroring core's per-table sections.
+Apply the same rule core does: positive allowlists via `maps:with/2`, never
+subtractive filters - an extension carrying a token or secret column is one
+schema field away from exporting it otherwise.
+
+A missing callback is a marker; a failing one fails the export. Returning
+`{error, _}` or raising means data was promised and not delivered - exactly the
+silent incompleteness the marker exists to prevent - so the whole request
+answers `500 ops.export_incomplete` and no artefact is produced. There is no
+transaction: core's export is a sequence of plain reads, and yours run in the
+same untransacted pass, after core's own sections.
 
 ## Counters
 

--- a/guides/rest-api.md
+++ b/guides/rest-api.md
@@ -857,6 +857,13 @@ row through a positive allowlist. Credentials are never in it: no
 bearer token. Class `player_data`, not `read` - a leaderboard view is one
 thing, and the whole of one identified person's record is another.
 
+The payload also names every installed extension under an `extensions` key:
+the data its `export_player/1` returned, or a `skipped` marker when the
+extension does not export one - a skipped extension is visible in the
+artefact, never silently absent. An extension that fails to export fails the
+whole request with `500 ops.export_incomplete`, and no partial artefact is
+returned. See [Extensions](extensions.md).
+
 `erase` deletes the player and every row core holds for them, in one
 transaction, and it cannot be undone. The body must echo the player's username
 and the server checks it against the row:

--- a/src/asobi_error.erl
+++ b/src/asobi_error.erl
@@ -195,6 +195,11 @@ working and a new one reads one place: see `legacy/2`.
         ~"The username in the request body is not this player's username."
     },
     {~"ops.erase_failed", 500, ~"The erasure was rolled back and nothing was deleted."},
+    {
+        ~"ops.export_incomplete",
+        500,
+        ~"An installed extension failed to export. No export was produced."
+    },
 
     %% Operator console. One 404 covers both "this node does not serve the
     %% console" and "no such asset", so a caller cannot tell a deployment that

--- a/src/extensions/asobi_extension.erl
+++ b/src/extensions/asobi_extension.erl
@@ -17,7 +17,7 @@ just modules. This behaviour covers only what core cannot infer.
 ```erlang
 -module(asobi_quests_extension).
 -behaviour(asobi_extension).
--export([info/0, rpc/0, lua/0, sup/0, owns/0, codes/0, erase_player/1]).
+-export([info/0, rpc/0, lua/0, sup/0, owns/0, codes/0, erase_player/1, export_player/1]).
 
 info() -> #{name => quests, extension_version => 1}.
 
@@ -41,6 +41,10 @@ owns() -> #{tables => [~"quests"], rpc => [~"quests"],
 erase_player(PlayerId) ->
     {ok, _} = asobi_repo:delete_all(by_player(asobi_quest_progress, PlayerId)),
     ok.
+
+export_player(PlayerId) ->
+    {ok, Rows} = asobi_repo:all(by_player(asobi_quest_progress, PlayerId)),
+    {ok, #{~"quest_progress" => [maps:with([quest_id, counter], Row) || Row <- Rows]}}.
 ```
 
 Only `info/0` is required. `rpc/0`, `lua/0`, `sup/0`, `owns/0`, `codes/0`,
@@ -307,14 +311,22 @@ not.
 
 Apply the same projection rule core does: positive allowlists via
 `maps:with/2`, never subtractive filters - an extension carrying a token or
-secret column is one schema field away from exporting it otherwise.
+secret column is one schema field away from exporting it otherwise. And every
+row you return must be one this player owns - core cannot check that for you.
+Where one column holds several players' data, lift out this player's part
+rather than exporting the column whole, the way core exports only the
+requester's own choice from `votes.votes_cast`.
 
 A missing callback is a marker; a failing one fails the export. Returning
 `{error, Reason}` or raising means data was promised and not delivered, which
 is exactly the silent incompleteness the marker exists to prevent, so the
-whole export fails and no artefact is produced. There is no transaction: the
-export is a sequence of plain reads, and this runs in the same untransacted
-pass, after core's own sections. `m:asobi_extension_export` is the seam.
+whole export fails and no artefact is produced. The sections must be
+JSON-encodable - the export is served as one JSON object, so a section
+`json:encode/1` refuses fails the export the same way, attributed to this
+extension rather than surfacing as an unattributed 500 after the payload left
+the controller. There is no transaction: the export is a sequence of plain
+reads, and this runs in the same untransacted pass, after core's own sections.
+`m:asobi_extension_export` is the seam.
 """.
 -callback export_player(PlayerId :: binary()) ->
     {ok, #{binary() => term()}} | {error, term()}.

--- a/src/extensions/asobi_extension.erl
+++ b/src/extensions/asobi_extension.erl
@@ -43,10 +43,10 @@ erase_player(PlayerId) ->
     ok.
 ```
 
-Only `info/0` is required. `rpc/0`, `lua/0`, `sup/0`, `owns/0`, `codes/0` and
-`erase_player/1` default to nothing, because several are frequently empty: an
-extension with no processes has no `sup/0`, and one whose rows cascade needs no
-`erase_player/1`.
+Only `info/0` is required. `rpc/0`, `lua/0`, `sup/0`, `owns/0`, `codes/0`,
+`erase_player/1` and `export_player/1` default to nothing, because several are
+frequently empty: an extension with no processes has no `sup/0`, and one whose
+rows cascade needs no `erase_player/1`.
 
 An extension declaring neither `rpc/0` nor `lua/0` is reachable by nobody:
 game logic calls `game.<ns>.*` from Lua, and clients call
@@ -290,6 +290,35 @@ the same reason the guide gives an extension author for not reaching for one.
 """.
 -callback erase_player(PlayerId :: binary()) -> ok | {error, term()}.
 
+-doc """
+Export everything this extension holds about one player, keyed by the
+extension's own section names - mirroring core's per-table sections.
+
+The read half of `c:erase_player/1`, and optional for a different reason.
+Erasure has a physical forcing function: skip it and the foreign key blocks
+the delete. An export callback has none, so for a long time there was
+deliberately no contract here - an extension that skipped it would have
+produced a silently incomplete export and nothing would have failed. What
+made one shippable is that the artefact itself now forces the answer: core's
+export names **every** installed extension, and one without this callback
+appears under a `skipped` marker rather than being silently absent, so a data
+subject or auditor can see exactly which extensions contributed and which did
+not.
+
+Apply the same projection rule core does: positive allowlists via
+`maps:with/2`, never subtractive filters - an extension carrying a token or
+secret column is one schema field away from exporting it otherwise.
+
+A missing callback is a marker; a failing one fails the export. Returning
+`{error, Reason}` or raising means data was promised and not delivered, which
+is exactly the silent incompleteness the marker exists to prevent, so the
+whole export fails and no artefact is produced. There is no transaction: the
+export is a sequence of plain reads, and this runs in the same untransacted
+pass, after core's own sections. `m:asobi_extension_export` is the seam.
+""".
+-callback export_player(PlayerId :: binary()) ->
+    {ok, #{binary() => term()}} | {error, term()}.
+
 -doc "One operator action, the last segment of `/api/v1/ops/ext/<name>/<action>`.".
 -type ops_action() :: binary().
 
@@ -359,4 +388,4 @@ callback for it here. See `guides/console-extensions.md`.
 -callback codes() -> codes().
 -callback ops() -> ops().
 
--optional_callbacks([rpc/0, lua/0, sup/0, owns/0, codes/0, ops/0, erase_player/1]).
+-optional_callbacks([rpc/0, lua/0, sup/0, owns/0, codes/0, ops/0, erase_player/1, export_player/1]).

--- a/src/extensions/asobi_extension_erase.erl
+++ b/src/extensions/asobi_extension_erase.erl
@@ -26,9 +26,18 @@ An extension that raises is caught rather than allowed to propagate, so the
 failure is attributed to a name before it becomes the caller's problem. Nothing
 runs after a catch: the Postgres transaction is already aborted at that point,
 and the only correct next statement is the caller's rollback.
+
+Failure reasons carry the shape of what came back - a tag and a size, a
+truncated formatted reason, the top stack frame without arguments - never the
+term itself. What an extension returns on this path can be the data subject's
+personal data, and the reason flows into the log line below and into the
+caller's badmatch; neither may hold it. `m:asobi_extension_export` applies the
+same rule.
 """.
 
 -include_lib("kernel/include/logger.hrl").
+
+-define(MAX_REASON_BYTES, 200).
 
 -export([run/1]).
 
@@ -65,8 +74,28 @@ erase_one(Module, PlayerId) ->
             try Module:erase_player(PlayerId) of
                 ok -> ok;
                 {error, Reason} -> {error, Reason};
-                Other -> {error, {bad_return, Other}}
+                Other -> {error, {bad_return, kind(Other)}}
             catch
-                Class:Reason:Stacktrace -> {error, {raised, Class, Reason, Stacktrace}}
+                Class:Reason:Stacktrace ->
+                    {error, {raised, Class, reason(Reason), top_frame(Stacktrace)}}
             end
     end.
+
+kind(Term) when is_tuple(Term), tuple_size(Term) > 0 -> {element(1, Term), tuple_size(Term)};
+kind(Term) when length(Term) >= 0 -> {list, length(Term)};
+kind(Term) when is_map(Term) -> {map, map_size(Term)};
+kind(_Term) -> other.
+
+reason(Reason) when is_binary(Reason) -> truncate(Reason);
+reason(Reason) when is_atom(Reason) -> atom_to_binary(Reason);
+reason(Reason) -> truncate(iolist_to_binary(io_lib:format("~0p", [Reason]))).
+
+truncate(Bin) when byte_size(Bin) =< ?MAX_REASON_BYTES -> Bin;
+truncate(Bin) -> <<(binary:part(Bin, 0, ?MAX_REASON_BYTES))/binary, "...">>.
+
+top_frame([{Module, Function, Arity, _Location} | _]) when is_integer(Arity) ->
+    {Module, Function, Arity};
+top_frame([{Module, Function, Args, _Location} | _]) when is_list(Args) ->
+    {Module, Function, length(Args)};
+top_frame(_Stacktrace) ->
+    undefined.

--- a/src/extensions/asobi_extension_export.erl
+++ b/src/extensions/asobi_extension_export.erl
@@ -15,16 +15,27 @@ A missing callback is a marker; a failing callback fails the export. An
 extension that exports the callback and then returns `{error, _}` or raises
 promised data and could not deliver it - exactly the silent incompleteness the
 marker exists to prevent - so the caller must produce no artefact. Fail loudly
-and retry beats a partial export presented as complete.
+and retry beats a partial export presented as complete. A section
+`json:encode/1` refuses is the same failure: the export is served as one JSON
+object, so an unencodable term would otherwise become an unattributed 500
+after the payload had already left the controller.
 
 No transaction: core's own export is a sequence of plain reads with no
 transaction around them, and wrapping only this walk in one would buy
 consistency with nothing. An extension that raises is caught rather than
 allowed to propagate, so the failure is attributed to a name before it becomes
 the caller's problem.
+
+Failure reasons carry the shape of what came back - a tag and a size, a
+truncated formatted reason, the top stack frame without arguments - never the
+term itself. What an extension returns on this path is the data subject's
+personal data, and a reason term flows into the log line below and into the
+caller's error; neither may hold what the export refused to produce.
 """.
 
 -include_lib("kernel/include/logger.hrl").
+
+-define(MAX_REASON_BYTES, 200).
 
 -export([run/1]).
 
@@ -62,10 +73,38 @@ export_one(Module, PlayerId) ->
             {ok, #{skipped => ~"export_player/1 not exported"}};
         true ->
             try Module:export_player(PlayerId) of
-                {ok, Data} when is_map(Data) -> {ok, #{data => Data}};
+                {ok, Data} when is_map(Data) -> encodable(Data);
                 {error, Reason} -> {error, Reason};
-                Other -> {error, {bad_return, Other}}
+                Other -> {error, {bad_return, kind(Other)}}
             catch
-                Class:Reason:Stacktrace -> {error, {raised, Class, Reason, Stacktrace}}
+                Class:Reason:Stacktrace ->
+                    {error, {raised, Class, reason(Reason), top_frame(Stacktrace)}}
             end
     end.
+
+encodable(Data) ->
+    try
+        _ = json:encode(Data),
+        {ok, #{data => Data}}
+    catch
+        error:Reason -> {error, {not_encodable, reason(Reason)}}
+    end.
+
+kind(Term) when is_tuple(Term), tuple_size(Term) > 0 -> {element(1, Term), tuple_size(Term)};
+kind(Term) when length(Term) >= 0 -> {list, length(Term)};
+kind(Term) when is_map(Term) -> {map, map_size(Term)};
+kind(_Term) -> other.
+
+reason(Reason) when is_binary(Reason) -> truncate(Reason);
+reason(Reason) when is_atom(Reason) -> atom_to_binary(Reason);
+reason(Reason) -> truncate(iolist_to_binary(io_lib:format("~0p", [Reason]))).
+
+truncate(Bin) when byte_size(Bin) =< ?MAX_REASON_BYTES -> Bin;
+truncate(Bin) -> <<(binary:part(Bin, 0, ?MAX_REASON_BYTES))/binary, "...">>.
+
+top_frame([{Module, Function, Arity, _Location} | _]) when is_integer(Arity) ->
+    {Module, Function, Arity};
+top_frame([{Module, Function, Args, _Location} | _]) when is_list(Args) ->
+    {Module, Function, length(Args)};
+top_frame(_Stacktrace) ->
+    undefined.

--- a/src/extensions/asobi_extension_export.erl
+++ b/src/extensions/asobi_extension_export.erl
@@ -1,0 +1,71 @@
+-module(asobi_extension_export).
+-moduledoc """
+Collects every installed extension's export section for one player.
+
+The read half of `m:asobi_extension_erase`, and shaped on it: walk
+`asobi_extensions:resolve/0`, call `export_player/1` on each extension that
+exports one, and stop at the first failure. The result names **every**
+installed extension - one without the callback contributes a `skipped` marker
+rather than nothing, so a skipped extension is visible in the artefact a data
+subject or auditor reads, not an absence nobody can detect. See
+`c:asobi_extension:export_player/1` for why the marker is the forcing function
+that let this callback ship at all.
+
+A missing callback is a marker; a failing callback fails the export. An
+extension that exports the callback and then returns `{error, _}` or raises
+promised data and could not deliver it - exactly the silent incompleteness the
+marker exists to prevent - so the caller must produce no artefact. Fail loudly
+and retry beats a partial export presented as complete.
+
+No transaction: core's own export is a sequence of plain reads with no
+transaction around them, and wrapping only this walk in one would buy
+consistency with nothing. An extension that raises is caught rather than
+allowed to propagate, so the failure is attributed to a name before it becomes
+the caller's problem.
+""".
+
+-include_lib("kernel/include/logger.hrl").
+
+-export([run/1]).
+
+-doc """
+Every installed extension by name: `#{data => ...}` from one that exported,
+`#{skipped => ...}` for one without the callback. Or the first extension to
+fail and why; nothing is retried and nothing after it is attempted.
+""".
+-spec run(binary()) ->
+    {ok, #{asobi_extension:name() => map()}}
+    | {error, {asobi_extension:name(), term()}}.
+run(PlayerId) ->
+    export_each(asobi_extensions:resolve(), PlayerId, #{}).
+
+export_each([], _PlayerId, Sections) ->
+    {ok, Sections};
+export_each([#{name := Name, module := Module} | Rest], PlayerId, Sections) ->
+    case export_one(Module, PlayerId) of
+        {ok, Section} ->
+            export_each(Rest, PlayerId, Sections#{Name => Section});
+        {error, Reason} ->
+            ?LOG_ERROR(#{
+                msg => ~"extension_export_failed",
+                extension => Name,
+                player_id => PlayerId,
+                reason => Reason,
+                detail => ~"no export was produced"
+            }),
+            {error, {Name, Reason}}
+    end.
+
+export_one(Module, PlayerId) ->
+    case erlang:function_exported(Module, export_player, 1) of
+        false ->
+            {ok, #{skipped => ~"export_player/1 not exported"}};
+        true ->
+            try Module:export_player(PlayerId) of
+                {ok, Data} when is_map(Data) -> {ok, #{data => Data}};
+                {error, Reason} -> {error, Reason};
+                Other -> {error, {bad_return, Other}}
+            catch
+                Class:Reason:Stacktrace -> {error, {raised, Class, Reason, Stacktrace}}
+            end
+    end.

--- a/src/ops/asobi_ops_controller.erl
+++ b/src/ops/asobi_ops_controller.erl
@@ -81,9 +81,6 @@ export_player(#{bindings := #{~"id" := Id}}) ->
         false -> {asobi_error, ~"ops.invalid_id"}
     end.
 
-%% The walker has already logged the failing extension and the reason, so this
-%% clause only states the outcome: fail loudly and retry beats a partial
-%% export presented as complete.
 -spec exported(
     {ok, map()} | {error, not_found | {extension_export, asobi_extension:name(), term()}}
 ) -> response().

--- a/src/ops/asobi_ops_controller.erl
+++ b/src/ops/asobi_ops_controller.erl
@@ -81,9 +81,15 @@ export_player(#{bindings := #{~"id" := Id}}) ->
         false -> {asobi_error, ~"ops.invalid_id"}
     end.
 
--spec exported({ok, map()} | {error, not_found}) -> response().
+%% The walker has already logged the failing extension and the reason, so this
+%% clause only states the outcome: fail loudly and retry beats a partial
+%% export presented as complete.
+-spec exported(
+    {ok, map()} | {error, not_found | {extension_export, asobi_extension:name(), term()}}
+) -> response().
 exported({ok, Payload}) -> {json, #{data => Payload}};
-exported({error, not_found}) -> {asobi_error, ~"ops.not_found"}.
+exported({error, not_found}) -> {asobi_error, ~"ops.not_found"};
+exported({error, {extension_export, _Name, _Reason}}) -> {asobi_error, ~"ops.export_incomplete"}.
 
 -spec confirmed_erase(binary(), binary() | undefined, asobi_ops_auth:actor()) -> response().
 confirmed_erase(_Id, undefined, _Actor) ->

--- a/src/players/asobi_player_export.erl
+++ b/src/players/asobi_player_export.erl
@@ -12,7 +12,9 @@ Every row goes through a `maps:with/2` projection, modelled on
 `asobi_ops_players:project/1`. `players` carries `hashed_password`, so a
 subtractive filter is one schema field away from exporting a credential;
 `player_tokens` carries live bearer tokens, so the export reports that a
-session existed and when, never the token itself.
+session existed and when, never the token itself. A guest identity's
+`provider_metadata` is the device-secret verifier, so only its `revoked` flag
+is exported.
 
 ## The two tables with no foreign key
 
@@ -128,21 +130,33 @@ player(Row) ->
         Row
     ).
 
+%% A guest identity's `provider_metadata` is the credential verifier itself -
+%% salt, key id, HMAC verifier, written by the guest controller - so only its
+%% `revoked` flag survives. Other providers' metadata is descriptive profile
+%% data and passes through.
 -spec identity(map()) -> map().
 identity(Row) ->
-    maps:with(
+    Projected = maps:with(
         [
             id,
             provider,
             provider_uid,
             provider_email,
             provider_display_name,
-            provider_metadata,
             inserted_at,
             updated_at
         ],
         Row
-    ).
+    ),
+    Metadata = identity_metadata(
+        maps:get(provider, Row, undefined), maps:get(provider_metadata, Row, #{})
+    ),
+    Projected#{provider_metadata => Metadata}.
+
+-spec identity_metadata(term(), term()) -> map().
+identity_metadata(~"guest", Metadata) when is_map(Metadata) -> maps:with([~"revoked"], Metadata);
+identity_metadata(_Provider, Metadata) when is_map(Metadata) -> Metadata;
+identity_metadata(_Provider, _Metadata) -> #{}.
 
 -spec stats(map()) -> map().
 stats(Row) ->

--- a/src/players/asobi_player_export.erl
+++ b/src/players/asobi_player_export.erl
@@ -32,15 +32,24 @@ bury one inside entity state, and there is no projection core could apply to it
 that would not either miss the data or export another player's. A game that
 puts personal data there owns exporting it, the same way it owns erasing it.
 
-## No extension callback
+## Extensions
 
-There is deliberately no `export_player/1` for extensions in this change.
-`c:asobi_extension:erase_player/1` earns its keep because the foreign key
-physically forces an author to answer it; an export callback has no forcing
-function, so an extension that skipped it would produce a silently incomplete
-export and nothing would fail. That is a worse contract than no contract. If
-one ever ships, the payload must name which installed extensions contributed
-and which did not.
+The payload's `extensions` key names **every** installed extension: the ones
+whose `c:asobi_extension:export_player/1` contributed data, and the ones
+without the callback under a `skipped` marker. The callback could only ship
+under that condition. `c:asobi_extension:erase_player/1` earns its keep
+because the foreign key physically forces an author to answer it; an export
+callback has no such forcing function, so the artefact itself is the forcing
+function - a skipped extension is a visible marker in the export a data
+subject or auditor reads, not an absence nobody can detect.
+
+A failing `export_player/1` fails the whole export -
+`{error, {extension_export, Name, Reason}}`, no artefact - because an
+extension that promised data and could not deliver it is exactly the silently
+incomplete export the marker exists to prevent. `m:asobi_extension_export` is
+the walker, and its reads run in the same untransacted pass as core's own
+sections: core's export takes no transaction, so wrapping only the extension
+walk in one would buy consistency with nothing.
 """.
 
 -include_lib("kura/include/kura.hrl").
@@ -48,19 +57,31 @@ and which did not.
 -export([run/1]).
 
 -doc """
-Every core row that names `PlayerId`, projected.
+Every core row that names `PlayerId`, projected, plus every installed
+extension's own sections.
 
 `{error, not_found}` when no such player exists - an empty export and a
 missing account are different answers to a data-subject request.
+`{error, {extension_export, Name, Reason}}` when an installed extension
+failed to export: no partial artefact is produced.
 """.
--spec run(binary()) -> {ok, map()} | {error, not_found}.
+-spec run(binary()) ->
+    {ok, map()} | {error, not_found | {extension_export, asobi_extension:name(), term()}}.
 run(PlayerId) when is_binary(PlayerId) ->
     case asobi_repo:get(asobi_player, PlayerId) of
-        {ok, Player} -> {ok, payload(PlayerId, Player)};
+        {ok, Player} -> with_extensions(PlayerId, payload(PlayerId, Player));
         {error, _Reason} -> {error, not_found}
     end.
 
 %% --- Internal ---
+
+-spec with_extensions(binary(), map()) ->
+    {ok, map()} | {error, {extension_export, asobi_extension:name(), term()}}.
+with_extensions(PlayerId, Payload) ->
+    case asobi_extension_export:run(PlayerId) of
+        {ok, Extensions} -> {ok, Payload#{extensions => Extensions}};
+        {error, {Name, Reason}} -> {error, {extension_export, Name, Reason}}
+    end.
 
 -spec payload(binary(), map()) -> map().
 payload(PlayerId, Player) ->

--- a/test/asobi_ops_tests.erl
+++ b/test/asobi_ops_tests.erl
@@ -650,7 +650,8 @@ erase_handler_test_() ->
         {"a refused capability answers forbidden", fun erase_forbidden/0},
         {"a rolled-back erasure is a 500 code", fun erase_failed/0},
         {"export projects and never 404s a live player", fun export_ok/0},
-        {"export of an unknown player is not_found", fun export_unknown/0}
+        {"export of an unknown player is not_found", fun export_unknown/0},
+        {"a failed extension export is export_incomplete", fun export_incomplete/0}
     ]}.
 
 -define(ERASE_ID, ~"01960000-0000-7000-8000-000000000009").
@@ -750,5 +751,16 @@ export_unknown() ->
     meck:expect(asobi_player_export, run, fun(?ERASE_ID) -> {error, not_found} end),
     ?assertEqual(
         {asobi_error, ~"ops.not_found"},
+        asobi_ops_controller:export_player(#{bindings => #{~"id" => ?ERASE_ID}})
+    ).
+
+%% Fail loudly and retry beats a partial export presented as complete: an
+%% extension failure is a 500 code, never a payload missing a section.
+export_incomplete() ->
+    meck:expect(asobi_player_export, run, fun(?ERASE_ID) ->
+        {error, {extension_export, quests, db_down}}
+    end),
+    ?assertEqual(
+        {asobi_error, ~"ops.export_incomplete"},
         asobi_ops_controller:export_player(#{bindings => #{~"id" => ?ERASE_ID}})
     ).

--- a/test/asobi_player_export_tests.erl
+++ b/test/asobi_player_export_tests.erl
@@ -14,16 +14,24 @@ export_test_() ->
         {"match records are matched by containment", fun match_records_by_containment/0},
         {"votes are matched by jsonb key existence", fun votes_by_key_existence/0},
         {"a vote exports this player's choice and nobody else's",
-            fun votes_do_not_leak_other_voters/0}
+            fun votes_do_not_leak_other_voters/0},
+        {"every installed extension is named, contributor or not",
+            fun extensions_are_named_contributor_or_not/0},
+        {"a failing extension export fails the whole export",
+            fun a_failing_extension_fails_the_export/0}
     ]}.
 
 setup() ->
     meck:new(asobi_repo, [no_link]),
     meck:expect(asobi_repo, get, fun(asobi_player, ?PLAYER) -> {ok, player_row()} end),
     meck:expect(asobi_repo, all, fun(#kura_query{from = Schema}) -> {ok, [row(Schema)]} end),
+    meck:new(asobi_extensions, [no_link, passthrough]),
+    meck:expect(asobi_extensions, resolve, fun() -> [] end),
     ok.
 
 cleanup(_) ->
+    _ = [catch meck:unload(M) || M <- [asobi_fake_quests, asobi_fake_seasons]],
+    meck:unload(asobi_extensions),
     meck:unload(asobi_repo),
     ok.
 
@@ -113,7 +121,8 @@ covers_the_same_tables() ->
         ]),
         Queried
     ),
-    ?assertEqual(18, map_size(Payload)).
+    ?assertEqual(19, map_size(Payload)),
+    ?assertEqual(#{}, maps:get(extensions, Payload)).
 
 %% `match_records.players` is a jsonb id list with no foreign key, so a match a
 %% player took part in is only reachable by containment.
@@ -163,3 +172,38 @@ asobi_player_export_probe(PlayerId) ->
     meck:expect(asobi_repo, get, fun(asobi_player, _) -> {ok, player_row()} end),
     {ok, #{votes := [Vote]}} = asobi_player_export:run(PlayerId),
     Vote.
+
+%% The payload names every installed extension, whether or not it contributed:
+%% a skipped callback is a visible marker in the artefact, never a silent
+%% absence.
+extensions_are_named_contributor_or_not() ->
+    meck:new(asobi_fake_quests, [non_strict, no_link]),
+    meck:expect(asobi_fake_quests, export_player, fun(?PLAYER) ->
+        {ok, #{~"quest_progress" => [#{~"quest_id" => ~"q-1"}]}}
+    end),
+    meck:new(asobi_fake_seasons, [non_strict, no_link]),
+    meck:expect(asobi_extensions, resolve, fun() ->
+        [
+            #{name => quests, module => asobi_fake_quests},
+            #{name => seasons, module => asobi_fake_seasons}
+        ]
+    end),
+    {ok, #{extensions := Extensions}} = asobi_player_export:run(?PLAYER),
+    ?assertEqual(
+        #{
+            quests => #{data => #{~"quest_progress" => [#{~"quest_id" => ~"q-1"}]}},
+            seasons => #{skipped => ~"export_player/1 not exported"}
+        },
+        Extensions
+    ).
+
+%% Fail-closed: an extension that promised data and could not deliver it is
+%% exactly the silent incompleteness the marker exists to prevent, so no
+%% artefact is produced at all.
+a_failing_extension_fails_the_export() ->
+    meck:new(asobi_fake_quests, [non_strict, no_link]),
+    meck:expect(asobi_fake_quests, export_player, fun(?PLAYER) -> {error, db_down} end),
+    meck:expect(asobi_extensions, resolve, fun() ->
+        [#{name => quests, module => asobi_fake_quests}]
+    end),
+    ?assertEqual({error, {extension_export, quests, db_down}}, asobi_player_export:run(?PLAYER)).

--- a/test/asobi_player_export_tests.erl
+++ b/test/asobi_player_export_tests.erl
@@ -15,6 +15,8 @@ export_test_() ->
         {"votes are matched by jsonb key existence", fun votes_by_key_existence/0},
         {"a vote exports this player's choice and nobody else's",
             fun votes_do_not_leak_other_voters/0},
+        {"a guest identity exports its revoked flag and never the verifier",
+            fun guest_identity_metadata_is_projected/0},
         {"every installed extension is named, contributor or not",
             fun extensions_are_named_contributor_or_not/0},
         {"a failing extension export fails the whole export",
@@ -172,6 +174,38 @@ asobi_player_export_probe(PlayerId) ->
     meck:expect(asobi_repo, get, fun(asobi_player, _) -> {ok, player_row()} end),
     {ok, #{votes := [Vote]}} = asobi_player_export:run(PlayerId),
     Vote.
+
+%% A guest identity's `provider_metadata` is the credential verifier itself -
+%% salt, key id, HMAC verifier - so exporting it whole would hand out the
+%% means to resume the session. Only `revoked` survives.
+guest_identity_metadata_is_projected() ->
+    meck:expect(asobi_repo, all, fun(#kura_query{from = Schema}) ->
+        case Schema of
+            asobi_player_identity -> {ok, [guest_identity_row()]};
+            _ -> {ok, []}
+        end
+    end),
+    {ok, #{identities := [Identity]}} = asobi_player_export:run(?PLAYER),
+    ?assertEqual(#{~"revoked" => false}, maps:get(provider_metadata, Identity)),
+    Flat = iolist_to_binary(io_lib:format("~p", [Identity])),
+    ?assertEqual(nomatch, binary:match(Flat, ~"a-base64-salt")),
+    ?assertEqual(nomatch, binary:match(Flat, ~"a-base64-verifier")).
+
+guest_identity_row() ->
+    #{
+        id => ~"i-1",
+        player_id => ?PLAYER,
+        provider => ~"guest",
+        provider_uid => ~"device-1",
+        provider_metadata => #{
+            ~"salt" => ~"a-base64-salt",
+            ~"key_id" => ~"k1",
+            ~"verifier" => ~"a-base64-verifier",
+            ~"revoked" => false
+        },
+        inserted_at => {{2026, 1, 1}, {0, 0, 0}},
+        updated_at => {{2026, 1, 1}, {0, 0, 0}}
+    }.
 
 %% The payload names every installed extension, whether or not it contributed:
 %% a skipped callback is a visible marker in the artefact, never a silent

--- a/test/extensions/asobi_extension_erase_tests.erl
+++ b/test/extensions/asobi_extension_erase_tests.erl
@@ -57,20 +57,26 @@ a_refusing_extension_stops_the_whole_deletion() ->
     ),
     ?assertEqual([{quests, ?PLAYER}], asobi_fixture_erase:calls()).
 
+%% The reason is sanitised - class, truncated text, top frame without
+%% arguments - because whatever the extension raised with can hold the
+%% subject's data, and the reason reaches the log and the caller's badmatch.
 a_raising_extension_is_attributed_not_propagated() ->
     install_both(),
     ok = asobi_fixture_erase:outcome(quests, {raise, boom}),
     ?assertMatch(
-        {error, {quests, {raised, error, boom, _}}}, asobi_extension_erase:run(?PLAYER)
+        {error, {quests, {raised, error, ~"boom", _}}}, asobi_extension_erase:run(?PLAYER)
     ),
     ?assertEqual([{quests, ?PLAYER}], asobi_fixture_erase:calls()).
 
+%% Only the shape of what came back survives - an atom carries no size, so it
+%% reports as `other` - for the same reason the raise path truncates.
 a_return_outside_the_contract_is_a_failure() ->
     install_both(),
     ok = asobi_fixture_erase:outcome(quests, deleted_i_think),
     ?assertEqual(
-        {error, {quests, {bad_return, deleted_i_think}}}, asobi_extension_erase:run(?PLAYER)
-    ).
+        {error, {quests, {bad_return, other}}}, asobi_extension_erase:run(?PLAYER)
+    ),
+    ?assertEqual([{quests, ?PLAYER}], asobi_fixture_erase:calls()).
 
 install_both() ->
     ok = asobi_fixture_app:install(?QUESTS, asobi_fixture_quests_extension, []),

--- a/test/extensions/asobi_extension_export_tests.erl
+++ b/test/extensions/asobi_extension_export_tests.erl
@@ -1,0 +1,86 @@
+-module(asobi_extension_export_tests).
+
+-include_lib("eunit/include/eunit.hrl").
+
+-define(QUESTS, asobi_fixture_quests).
+-define(CLANS, asobi_fixture_clans).
+-define(MINIMAL, asobi_fixture_minimal).
+-define(PLAYER, ~"01960000-0000-7000-8000-000000000001").
+
+export_test_() ->
+    {foreach, fun setup/0, fun cleanup/1, [
+        fun nothing_installed_is_an_empty_report/0,
+        fun an_extension_without_an_export_path_is_a_visible_marker/0,
+        fun every_extension_exports_in_dependency_order/0,
+        fun a_refusing_extension_fails_the_whole_export/0,
+        fun a_raising_extension_is_attributed_not_propagated/0,
+        fun a_return_outside_the_contract_is_a_failure/0
+    ]}.
+
+setup() ->
+    asobi_extensions:reset(),
+    asobi_fixture_export:reset(),
+    ok.
+
+cleanup(_) ->
+    _ = [asobi_fixture_app:uninstall(A) || A <- [?QUESTS, ?CLANS, ?MINIMAL]],
+    asobi_fixture_export:reset(),
+    asobi_extensions:reset(),
+    ok.
+
+nothing_installed_is_an_empty_report() ->
+    ?assertEqual({ok, #{}}, asobi_extension_export:run(?PLAYER)),
+    ?assertEqual([], asobi_fixture_export:calls()).
+
+%% The callback is optional, but an extension without one must be visible in
+%% the artefact rather than silently absent - the condition under which the
+%% callback could ship at all.
+an_extension_without_an_export_path_is_a_visible_marker() ->
+    ok = asobi_fixture_app:install(?MINIMAL, asobi_fixture_minimal_extension, []),
+    ?assertEqual(
+        {ok, #{minimal => #{skipped => ~"export_player/1 not exported"}}},
+        asobi_extension_export:run(?PLAYER)
+    ),
+    ?assertEqual([], asobi_fixture_export:calls()).
+
+%% clans sorts first alphabetically and depends on quests, so this order can
+%% only come from the resolved dependency order.
+every_extension_exports_in_dependency_order() ->
+    install_both(),
+    ?assertEqual(
+        {ok, #{
+            quests => #{data => #{~"rows" => [?PLAYER]}},
+            clans => #{data => #{~"rows" => [?PLAYER]}}
+        }},
+        asobi_extension_export:run(?PLAYER)
+    ),
+    ?assertEqual([{quests, ?PLAYER}, {clans, ?PLAYER}], asobi_fixture_export:calls()).
+
+%% Fail-closed, not best-effort: an extension that promised data and could not
+%% deliver it is the silent incompleteness the skipped marker exists to
+%% prevent, so the first failure names itself and nothing after it is
+%% attempted.
+a_refusing_extension_fails_the_whole_export() ->
+    install_both(),
+    ok = asobi_fixture_export:outcome(quests, {error, db_down}),
+    ?assertEqual({error, {quests, db_down}}, asobi_extension_export:run(?PLAYER)),
+    ?assertEqual([{quests, ?PLAYER}], asobi_fixture_export:calls()).
+
+a_raising_extension_is_attributed_not_propagated() ->
+    install_both(),
+    ok = asobi_fixture_export:outcome(quests, {raise, boom}),
+    ?assertMatch(
+        {error, {quests, {raised, error, boom, _}}}, asobi_extension_export:run(?PLAYER)
+    ),
+    ?assertEqual([{quests, ?PLAYER}], asobi_fixture_export:calls()).
+
+a_return_outside_the_contract_is_a_failure() ->
+    install_both(),
+    ok = asobi_fixture_export:outcome(quests, {ok, not_a_map}),
+    ?assertEqual(
+        {error, {quests, {bad_return, {ok, not_a_map}}}}, asobi_extension_export:run(?PLAYER)
+    ).
+
+install_both() ->
+    ok = asobi_fixture_app:install(?QUESTS, asobi_fixture_quests_extension, []),
+    ok = asobi_fixture_app:install(?CLANS, asobi_fixture_clans_extension, [?QUESTS]).

--- a/test/extensions/asobi_extension_export_tests.erl
+++ b/test/extensions/asobi_extension_export_tests.erl
@@ -14,7 +14,8 @@ export_test_() ->
         fun every_extension_exports_in_dependency_order/0,
         fun a_refusing_extension_fails_the_whole_export/0,
         fun a_raising_extension_is_attributed_not_propagated/0,
-        fun a_return_outside_the_contract_is_a_failure/0
+        fun a_return_outside_the_contract_is_a_failure/0,
+        fun a_section_that_cannot_be_encoded_fails_the_export/0
     ]}.
 
 setup() ->
@@ -66,20 +67,35 @@ a_refusing_extension_fails_the_whole_export() ->
     ?assertEqual({error, {quests, db_down}}, asobi_extension_export:run(?PLAYER)),
     ?assertEqual([{quests, ?PLAYER}], asobi_fixture_export:calls()).
 
+%% The reason is sanitised - class, truncated text, top frame without
+%% arguments - because whatever the extension raised with can hold the
+%% subject's data, and the reason reaches the log and the caller's error.
 a_raising_extension_is_attributed_not_propagated() ->
     install_both(),
     ok = asobi_fixture_export:outcome(quests, {raise, boom}),
     ?assertMatch(
-        {error, {quests, {raised, error, boom, _}}}, asobi_extension_export:run(?PLAYER)
+        {error, {quests, {raised, error, ~"boom", _}}}, asobi_extension_export:run(?PLAYER)
     ),
     ?assertEqual([{quests, ?PLAYER}], asobi_fixture_export:calls()).
 
+%% Only the shape of what came back - a tag and a size - survives, for the
+%% same reason the raise path truncates.
 a_return_outside_the_contract_is_a_failure() ->
     install_both(),
     ok = asobi_fixture_export:outcome(quests, {ok, not_a_map}),
     ?assertEqual(
-        {error, {quests, {bad_return, {ok, not_a_map}}}}, asobi_extension_export:run(?PLAYER)
-    ).
+        {error, {quests, {bad_return, {ok, 2}}}}, asobi_extension_export:run(?PLAYER)
+    ),
+    ?assertEqual([{quests, ?PLAYER}], asobi_fixture_export:calls()).
+
+%% The export is served as one JSON object, so a section json:encode/1
+%% refuses must fail here, attributed to its extension - not as an
+%% unattributed 500 after the payload has already left the controller.
+a_section_that_cannot_be_encoded_fails_the_export() ->
+    install_both(),
+    ok = asobi_fixture_export:outcome(quests, {ok, #{~"where" => {59.3, 18.1}}}),
+    ?assertMatch({error, {quests, _}}, asobi_extension_export:run(?PLAYER)),
+    ?assertEqual([{quests, ?PLAYER}], asobi_fixture_export:calls()).
 
 install_both() ->
     ok = asobi_fixture_app:install(?QUESTS, asobi_fixture_quests_extension, []),

--- a/test/extensions/asobi_fixture_clans_extension.erl
+++ b/test/extensions/asobi_fixture_clans_extension.erl
@@ -2,7 +2,7 @@
 -moduledoc "A second extension, whose application depends on the first, so ordering is observable.".
 -behaviour(asobi_extension).
 
--export([info/0, rpc/0, lua/0, sup/0, owns/0, erase_player/1]).
+-export([info/0, rpc/0, lua/0, sup/0, owns/0, erase_player/1, export_player/1]).
 
 -spec info() -> asobi_extension:info().
 info() ->
@@ -46,3 +46,7 @@ owns() ->
 -spec erase_player(binary()) -> ok | {error, term()}.
 erase_player(PlayerId) ->
     asobi_fixture_erase:run(clans, PlayerId).
+
+-spec export_player(binary()) -> {ok, #{binary() => term()}} | {error, term()}.
+export_player(PlayerId) ->
+    asobi_fixture_export:run(clans, PlayerId).

--- a/test/extensions/asobi_fixture_export.erl
+++ b/test/extensions/asobi_fixture_export.erl
@@ -1,0 +1,38 @@
+-module(asobi_fixture_export).
+-moduledoc """
+The export paths of the fixture extensions, and a record of what was called.
+
+The same shape as `m:asobi_fixture_erase`, for the same reason: two extensions
+must be observable in one run to pin ordering, and a manifest module has to be
+named after its own application, so the recording lives here and each
+fixture's `export_player/1` delegates to it.
+""".
+
+-export([reset/0, calls/0, outcome/2, run/2]).
+
+-define(CALLS, {?MODULE, calls}).
+-define(OUTCOMES, {?MODULE, outcomes}).
+
+-spec reset() -> ok.
+reset() ->
+    _ = persistent_term:erase(?CALLS),
+    _ = persistent_term:erase(?OUTCOMES),
+    ok.
+
+-doc "Every `export_player/1` call, in the order core made them.".
+-spec calls() -> [{atom(), binary()}].
+calls() ->
+    lists:reverse(persistent_term:get(?CALLS, [])).
+
+-doc "What this extension's export path does: `{ok, Data}`, `{error, R}` or `{raise, R}`.".
+-spec outcome(atom(), term()) -> ok.
+outcome(Name, Outcome) ->
+    persistent_term:put(?OUTCOMES, maps:put(Name, Outcome, persistent_term:get(?OUTCOMES, #{}))).
+
+-spec run(atom(), binary()) -> term().
+run(Name, PlayerId) ->
+    persistent_term:put(?CALLS, [{Name, PlayerId} | persistent_term:get(?CALLS, [])]),
+    case maps:get(Name, persistent_term:get(?OUTCOMES, #{}), {ok, #{~"rows" => [PlayerId]}}) of
+        {raise, Reason} -> error(Reason);
+        Outcome -> Outcome
+    end.

--- a/test/extensions/asobi_fixture_quests_extension.erl
+++ b/test/extensions/asobi_fixture_quests_extension.erl
@@ -2,7 +2,7 @@
 -moduledoc "A complete extension manifest, shaped exactly like the design's worked example.".
 -behaviour(asobi_extension).
 
--export([info/0, rpc/0, lua/0, sup/0, owns/0, codes/0, ops/0, erase_player/1]).
+-export([info/0, rpc/0, lua/0, sup/0, owns/0, codes/0, ops/0, erase_player/1, export_player/1]).
 
 -spec info() -> asobi_extension:info().
 info() ->
@@ -79,3 +79,7 @@ ops() ->
 -spec erase_player(binary()) -> ok | {error, term()}.
 erase_player(PlayerId) ->
     asobi_fixture_erase:run(quests, PlayerId).
+
+-spec export_player(binary()) -> {ok, #{binary() => term()}} | {error, term()}.
+export_player(PlayerId) ->
+    asobi_fixture_export:run(quests, PlayerId).


### PR DESCRIPTION
Implements the `export_player/1` extension callback from the reviewed design in kernel-and-extensions.md ("Lifecycle completeness: export, audit, releases"). The moduledoc's condition for shipping one is now met: the payload names which installed extensions contributed and which did not.

## What changed

- `asobi_extension`: new optional callback `export_player(PlayerId) -> {ok, #{binary() => term()}} | {error, term()}`, added to `-optional_callbacks`.
- `asobi_extension_export` (new): the read half of `asobi_extension_erase`. Walks `asobi_extensions:resolve()`, collects each extension's sections, stops at the first failure. No transaction, matching core's own untransacted export reads.
- `asobi_player_export`: the payload gains an `extensions` key naming every installed extension; `run/1` returns `{error, {extension_export, Name, Reason}}` when one fails. Moduledoc rewritten - the "no extension callback" rationale is replaced by the shipped contract.
- `asobi_error`: new `ops.export_incomplete` (500).
- `asobi_ops_controller`: one clause in `exported/1` mapping the new error to `ops.export_incomplete`. No new routes; the ops export path stays the sole caller.
- Guides: extensions.md ("There is no `export_player/1`" section replaced with the callback contract), rest-api.md export section.

Review-gate follow-ups (second commit):

- The walker rejects a section `json:encode/1` cannot encode, attributed to its extension - previously an unencodable term would have surfaced as an unattributed 500 after the controller had returned.
- Walker failure reasons are sanitised in both walkers - shape only for bad returns, truncated reason plus argument-free top stack frame for raises - because an extension's return value on these paths is the data subject's personal data; `asobi_extension_erase` had the same pattern and gets the identical fix.
- A guest identity's `provider_metadata` is the device-secret verifier (salt, key id, HMAC verifier), so the export now projects it per provider: guests keep only `revoked`, other providers pass through.

## Failure semantics

| Case | Outcome |
| --- | --- |
| Callback exported, returns `{ok, Data}` | `Name => #{data => Data}` in the payload |
| Callback not exported | `Name => #{skipped => "export_player/1 not exported"}` - visible in the artefact, never silent |
| Callback returns `{error, R}`, raises, or returns outside the contract | the whole export fails: `{error, {extension_export, Name, R}}`, HTTP 500 `ops.export_incomplete`, no artefact |
| Callback returns `{ok, Data}` that `json:encode/1` refuses | same as a failure: `{error, {extension_export, Name, {not_encodable, _}}}`, HTTP 500 `ops.export_incomplete` - attributed at the walker, never an unattributed 500 mid-response |

Fail-closed on purpose: the erase-side asymmetry does not apply here - a partial export presented as complete is exactly the silent incompleteness the design closes.

## Tests

- New `asobi_extension_export_tests` (eunit, mirrors the erase walker tests): empty set, skipped marker, dependency order, refusal stops the walk, raise attributed to a name, bad return is a failure, unencodable section fails the export.
- `asobi_player_export_tests`: extensions named contributor-or-not (data + skipped), a failing extension fails `run/1`, a guest identity exports `revoked` and never the verifier; existing payload assertions extended to the new key.
- `asobi_extension_erase_tests`: updated for the sanitised reason shapes.
- `asobi_ops_tests`: the `ops.export_incomplete` mapping.
- Fixtures: new `asobi_fixture_export` recorder; `export_player/1` on the quests and clans fixture extensions.

## Checks

| Check | Result |
| --- | --- |
| rebar3 fmt | pass |
| rebar3 xref | pass |
| rebar3 dialyzer | pass |
| elp eqwalize-all | pre-existing failure (asobi#435, gate off in CI): 322 errors on origin/main, 330 on this branch. The +8 are all in test fixtures/tests and are the `term()`-flow class the issue tracks - 5 of them in `asobi_fixture_export`, the exact errors its pre-existing twin `asobi_fixture_erase` carries. New src modules are eqwalizer-clean. |
| elp lint | pass (warnings only; the two new ones are the `catch meck:unload` cleanup pattern three existing test files already use) |
| rebar3 eunit | pass - 1788 tests, 0 failures |
| rebar3 ct | pass - full run, all 360 tests; the erase/export suites (asobi_guest_SUITE + asobi_player_erase_SUITE + asobi_player_erase_self_SUITE, 26 tests) re-run green after the review-gate commit |
| rebar3 ex_doc | pass (one pre-existing CODEOWNERS warning from CONTRIBUTING.md, untouched here) |
| rebar3 fmt --check | pass |
| rebar3 mutate | skipped - not configured in this repo (CI documents enable-mutate as off pending mutate-diff) |

Part of #446.
