### PR TITLE
fix: audit rows for successful extension ops mutations

### DIFF
--- a/guides/rest-api.md
+++ b/guides/rest-api.md
@@ -790,12 +790,10 @@ cannot write on this plane without core recording who asked. Declaring a
 method other than `get` is what opts an action in; there is nothing to
 configure.
 
-That recording is currently incomplete. Only a failure returned without
-details reaches `ops_audit_entries`; a successful call, and a failure carrying
-details, raise inside the audit path and are logged at error level as
-`ops audit row not written`, carrying the action but not the row's own
-fields. The call itself still runs and still answers normally. Ship your logs
-and treat them as part of the audit trail until that is fixed.
+A successful call is stored as outcome `ok` with a succeeded count of one. A
+failure is stored as outcome `error` whether or not it carried details, and
+the row's `details` holds the returned code; the details map itself is the
+caller's diagnostic and is not stored.
 
 While the node is still running migrations the route answers **503**
 `not_ready`, before the extension's handler runs.

--- a/guides/rest-api.md
+++ b/guides/rest-api.md
@@ -793,7 +793,9 @@ configure.
 A successful call is stored as outcome `ok` with a succeeded count of one. A
 failure is stored as outcome `error` whether or not it carried details, and
 the row's `details` holds the returned code; the details map itself is the
-caller's diagnostic and is not stored.
+caller's diagnostic and is not stored. A handler that raises, or answers
+something outside the reply contract, is answered `internal` and still
+audited as an `error` outcome.
 
 While the node is still running migrations the route answers **503**
 `not_ready`, before the extension's handler runs.

--- a/src/ops/asobi_ops_audit.erl
+++ b/src/ops/asobi_ops_audit.erl
@@ -23,6 +23,12 @@ fully succeed" an index scan rather than a jsonb parse.
 `{error, Reason}` is the operation that never got as far as having subjects -
 a rejected parameter, a lost connection.
 
+An extension ops handler returns `t:asobi_rpc:reply/0` and is audited without
+translation: `{ok, Map}` is the single-subject success, and `{error, Code}`
+or `{error, Code, Details}` is an operation that failed as a whole. The
+stored reason is the code; `Details` is the caller's diagnostic and already
+went to the caller.
+
 ## When the audit write itself fails
 
 **The audit never fails the operation.** It runs after the mutation has
@@ -61,7 +67,7 @@ to hide one by exploding.
 
 -type subject() :: binary().
 -type failure() :: {subject(), term()}.
--type outcome() :: {ok, [subject()], [failure()]} | {error, term()}.
+-type outcome() :: {ok, [subject()], [failure()]} | {error, term()} | asobi_rpc:reply().
 -type target() :: {binary(), subject() | undefined} | undefined.
 
 -export_type([subject/0, failure/0, outcome/0, target/0]).
@@ -194,7 +200,9 @@ target({Type, Id}) -> #{target_type => Type, target_id => Id}.
 
 -spec counts(outcome()) -> {non_neg_integer(), non_neg_integer()}.
 counts({ok, Succeeded, Failed}) -> {length(Succeeded), length(Failed)};
-counts({error, _Reason}) -> {0, 0}.
+counts({ok, Result}) when is_map(Result) -> {1, 0};
+counts({error, _Reason}) -> {0, 0};
+counts({error, _Code, _Details}) -> {0, 0}.
 
 %% A bulk call where every subject failed is not a partial success. It is
 %% recorded as `error` so the "did not fully succeed" query and the "nothing
@@ -203,7 +211,9 @@ counts({error, _Reason}) -> {0, 0}.
 classify({ok, _Succeeded, []}) -> ~"ok";
 classify({ok, [], [_ | _]}) -> ~"error";
 classify({ok, [_ | _], [_ | _]}) -> ~"partial";
-classify({error, _Reason}) -> ~"error".
+classify({ok, Result}) when is_map(Result) -> ~"ok";
+classify({error, _Reason}) -> ~"error";
+classify({error, _Code, _Details}) -> ~"error".
 
 -spec details(outcome()) -> map().
 details({ok, _Succeeded, []}) ->
@@ -217,8 +227,12 @@ details({ok, _Succeeded, Failed}) ->
         ],
         failures_omitted => length(Failed) - length(Shown)
     };
+details({ok, Result}) when is_map(Result) ->
+    #{};
 details({error, Reason}) ->
-    #{reason => reason(Reason)}.
+    #{reason => reason(Reason)};
+details({error, Code, _Details}) ->
+    #{reason => reason(Code)}.
 
 -spec reason(term()) -> binary().
 reason(Reason) when is_binary(Reason) ->

--- a/src/ops/asobi_ops_audit.erl
+++ b/src/ops/asobi_ops_audit.erl
@@ -27,7 +27,10 @@ An extension ops handler returns `t:asobi_rpc:reply/0` and is audited without
 translation: `{ok, Map}` is the single-subject success, and `{error, Code}`
 or `{error, Code, Details}` is an operation that failed as a whole. The
 stored reason is the code; `Details` is the caller's diagnostic and already
-went to the caller.
+went to the caller. A handler that raises arrives as the seam's own
+`{raised, Class, Reason, Stack}` value, and an off-contract return arrives as
+itself; both are audited as `error`. The row build is total: a shape the
+audit cannot describe must not become a mutation it does not record.
 
 ## When the audit write itself fails
 
@@ -67,7 +70,11 @@ to hide one by exploding.
 
 -type subject() :: binary().
 -type failure() :: {subject(), term()}.
--type outcome() :: {ok, [subject()], [failure()]} | {error, term()} | asobi_rpc:reply().
+-type outcome() ::
+    {ok, [subject()], [failure()]}
+    | {error, term()}
+    | asobi_rpc:reply()
+    | {raised, atom(), term(), erlang:stacktrace()}.
 -type target() :: {binary(), subject() | undefined} | undefined.
 
 -export_type([subject/0, failure/0, outcome/0, target/0]).
@@ -85,7 +92,7 @@ Run `Fun` and audit whatever it returns.
 Returns `Fun`'s own value unchanged, so wrapping a call site is a
 substitution rather than a rewrite.
 """.
--spec mutation(asobi_ops_auth:actor(), binary(), target(), fun(() -> outcome())) -> outcome().
+-spec mutation(asobi_ops_auth:actor(), binary(), target(), fun(() -> Outcome)) -> Outcome.
 mutation(Actor, Action, Target, Fun) ->
     try Fun() of
         Outcome ->
@@ -104,7 +111,7 @@ Prefer `mutation/4`. This exists for a call site that performs its own
 sequencing and genuinely holds the real outcome; it can still be handed a
 lie, which `mutation/4` cannot.
 """.
--spec record(asobi_ops_auth:actor(), binary(), target(), outcome()) -> ok.
+-spec record(asobi_ops_auth:actor(), binary(), target(), term()) -> ok.
 record(Actor, Action, Target, Outcome) ->
     %% Never let the audit path itself decide the fate of the operation it
     %% describes: a raise here - a lost connection, an unexpected reason term -
@@ -140,7 +147,7 @@ record_strict(Actor, Action, Target, Outcome) ->
         {error, Reason} -> {error, Reason}
     end.
 
--spec write(asobi_ops_auth:actor(), binary(), target(), outcome()) -> ok.
+-spec write(asobi_ops_auth:actor(), binary(), target(), term()) -> ok.
 write(Actor, Action, Target, Outcome) ->
     Params = params(Actor, Action, Target, Outcome),
     CS = kura_changeset:cast(
@@ -167,7 +174,7 @@ loggable(#{occurred_at := {{Y, Mo, D}, {H, Mi, S}}} = Params) ->
     ),
     Params#{occurred_at => Rendered}.
 
--spec params(asobi_ops_auth:actor(), binary(), target(), outcome()) -> map().
+-spec params(asobi_ops_auth:actor(), binary(), target(), term()) -> map().
 params(Actor, Action, Target, Outcome) ->
     #{
         id := ActorId,
@@ -198,27 +205,28 @@ target(undefined) -> #{};
 target({Type, undefined}) -> #{target_type => Type};
 target({Type, Id}) -> #{target_type => Type, target_id => Id}.
 
--spec counts(outcome()) -> {non_neg_integer(), non_neg_integer()}.
-counts({ok, Succeeded, Failed}) -> {length(Succeeded), length(Failed)};
-counts({ok, Result}) when is_map(Result) -> {1, 0};
-counts({error, _Reason}) -> {0, 0};
-counts({error, _Code, _Details}) -> {0, 0}.
+-spec counts(term()) -> {non_neg_integer(), non_neg_integer()}.
+counts({ok, Succeeded, Failed}) when is_list(Succeeded), is_list(Failed) ->
+    {length(Succeeded), length(Failed)};
+counts({ok, Result}) when is_map(Result) ->
+    {1, 0};
+counts(_Other) ->
+    {0, 0}.
 
 %% A bulk call where every subject failed is not a partial success. It is
 %% recorded as `error` so the "did not fully succeed" query and the "nothing
 %% happened" query are answerable separately.
--spec classify(outcome()) -> binary().
-classify({ok, _Succeeded, []}) -> ~"ok";
+-spec classify(term()) -> binary().
+classify({ok, Succeeded, []}) when is_list(Succeeded) -> ~"ok";
 classify({ok, [], [_ | _]}) -> ~"error";
 classify({ok, [_ | _], [_ | _]}) -> ~"partial";
 classify({ok, Result}) when is_map(Result) -> ~"ok";
-classify({error, _Reason}) -> ~"error";
-classify({error, _Code, _Details}) -> ~"error".
+classify(_Other) -> ~"error".
 
--spec details(outcome()) -> map().
+-spec details(term()) -> map().
 details({ok, _Succeeded, []}) ->
     #{};
-details({ok, _Succeeded, Failed}) ->
+details({ok, _Succeeded, Failed}) when is_list(Failed) ->
     Shown = lists:sublist(Failed, ?MAX_DETAIL_FAILURES),
     #{
         failures => [
@@ -227,12 +235,18 @@ details({ok, _Succeeded, Failed}) ->
         ],
         failures_omitted => length(Failed) - length(Shown)
     };
+%% A handler's own result can carry player data, so a success row stores none
+%% of it - the row is attribution, not a response cache.
 details({ok, Result}) when is_map(Result) ->
     #{};
 details({error, Reason}) ->
     #{reason => reason(Reason)};
-details({error, Code, _Details}) ->
-    #{reason => reason(Code)}.
+details({error, Code, Details}) when is_map(Details) ->
+    #{reason => reason(Code)};
+details({raised, Class, Reason, _Stack}) ->
+    #{reason => reason({Class, Reason})};
+details(Other) ->
+    #{reason => reason(Other)}.
 
 -spec reason(term()) -> binary().
 reason(Reason) when is_binary(Reason) ->

--- a/src/ops/asobi_ops_extension.erl
+++ b/src/ops/asobi_ops_extension.erl
@@ -101,6 +101,8 @@ dispatch(Extension, Action, Actor, Req) ->
 ctx(Extension, Action, Actor) ->
     #{actor => Actor, extension => Extension, action => Action}.
 
+-spec call({module(), atom(), 2}, map(), ctx()) ->
+    asobi_rpc:reply() | {raised, atom(), term(), erlang:stacktrace()}.
 call({M, F, 2}, Params, Ctx) ->
     try
         M:F(Params, Ctx)

--- a/test/asobi_ops_audit_SUITE.erl
+++ b/test/asobi_ops_audit_SUITE.erl
@@ -9,7 +9,8 @@
     half_failed_broadcast_is_stored_as_partial/1,
     row_carries_the_unattested_actor/1,
     successful_extension_mutation_is_stored_as_ok/1,
-    failed_extension_mutation_is_stored_as_error/1
+    failed_extension_mutation_is_stored_as_error/1,
+    raising_extension_mutation_is_stored_as_error/1
 ]).
 
 all() -> [{group, ops_audit}, {group, extension_ops}].
@@ -23,7 +24,8 @@ groups() ->
         ]},
         {extension_ops, [], [
             successful_extension_mutation_is_stored_as_ok,
-            failed_extension_mutation_is_stored_as_error
+            failed_extension_mutation_is_stored_as_error,
+            raising_extension_mutation_is_stored_as_error
         ]}
     ].
 
@@ -150,6 +152,27 @@ failed_extension_mutation_is_stored_as_error(Config) ->
     ?assertEqual(0, maps:get(succeeded_count, Row)),
     ?assertEqual(0, maps:get(failed_count, Row)),
     ?assertEqual(#{~"reason" => ~"quests.already_claimed"}, maps:get(details, Row)),
+    Config.
+
+%% The declared action is re-pointed at the raising fixture, mirroring the
+%% dispatch_mfa helper the unit tests use, so the raise travels the same seam a
+%% real call takes.
+raising_extension_mutation_is_stored_as_error(Config) ->
+    Display = label(?FUNCTION_NAME),
+    meck:new(asobi_extensions, [passthrough, no_link]),
+    meck:expect(asobi_extensions, ops_action, fun(_Extension, _Action) ->
+        #{method => post, mfa => {asobi_fixture_quests_ops, raises, 2}, class => config}
+    end),
+    try
+        {asobi_error, ~"internal"} = asobi_ops_extension:handle(ext_req(Display, #{}))
+    after
+        meck:unload(asobi_extensions)
+    end,
+    Row = row(Display),
+    ?assertEqual(~"error", maps:get(outcome, Row)),
+    ?assertEqual(0, maps:get(succeeded_count, Row)),
+    ?assertEqual(0, maps:get(failed_count, Row)),
+    ?assertEqual(#{~"reason" => ~"{error,deliberate}"}, maps:get(details, Row)),
     Config.
 
 ext_req(Display, Params) ->

--- a/test/asobi_ops_audit_SUITE.erl
+++ b/test/asobi_ops_audit_SUITE.erl
@@ -3,14 +3,16 @@
 -include_lib("nova_test/include/nova_test.hrl").
 -include_lib("kura/include/kura.hrl").
 
--export([all/0, groups/0, init_per_suite/1, end_per_suite/1]).
+-export([all/0, groups/0, init_per_suite/1, end_per_suite/1, init_per_group/2, end_per_group/2]).
 -export([
     clean_broadcast_is_stored_as_ok/1,
     half_failed_broadcast_is_stored_as_partial/1,
-    row_carries_the_unattested_actor/1
+    row_carries_the_unattested_actor/1,
+    successful_extension_mutation_is_stored_as_ok/1,
+    failed_extension_mutation_is_stored_as_error/1
 ]).
 
-all() -> [{group, ops_audit}].
+all() -> [{group, ops_audit}, {group, extension_ops}].
 
 groups() ->
     [
@@ -18,6 +20,10 @@ groups() ->
             clean_broadcast_is_stored_as_ok,
             half_failed_broadcast_is_stored_as_partial,
             row_carries_the_unattested_actor
+        ]},
+        {extension_ops, [], [
+            successful_extension_mutation_is_stored_as_ok,
+            failed_extension_mutation_is_stored_as_error
         ]}
     ].
 
@@ -33,6 +39,24 @@ init_per_suite(Config) ->
     [{player_id, PlayerId} | Config0].
 
 end_per_suite(Config) ->
+    Config.
+
+%% The registry is memoised at Nova's boot, so the fixture is installed and the
+%% memo cleared rather than the node restarted, exactly as asobi_rpc_SUITE does.
+init_per_group(extension_ops, Config) ->
+    ok = asobi_fixture_app:install(asobi_fixture_quests, asobi_fixture_quests_extension, []),
+    asobi_extensions:reset(),
+    _ = asobi_extensions:resolve(),
+    Config;
+init_per_group(_Group, Config) ->
+    Config.
+
+end_per_group(extension_ops, Config) ->
+    asobi_fixture_app:uninstall(asobi_fixture_quests),
+    asobi_extensions:reset(),
+    _ = asobi_extensions:resolve(),
+    Config;
+end_per_group(_Group, Config) ->
     Config.
 
 %% A display name unique to the calling test, so the row it wrote is the row
@@ -101,3 +125,36 @@ row_carries_the_unattested_actor(Config) ->
     ?assertEqual(false, maps:get(actor_attested, Row)),
     ?assertEqual(~"player", maps:get(target_type, Row)),
     Config.
+
+%% asobi#397 against the real write path: an extension handler answers the rpc
+%% reply shapes, and both a success and a failure carrying details used to
+%% raise inside the audit path and leave no row.
+successful_extension_mutation_is_stored_as_ok(Config) ->
+    Display = label(?FUNCTION_NAME),
+    {json, _} = asobi_ops_extension:handle(ext_req(Display, #{~"key" => ~"daily"})),
+    Row = row(Display),
+    ?assertEqual(~"ok", maps:get(outcome, Row)),
+    ?assertEqual(1, maps:get(succeeded_count, Row)),
+    ?assertEqual(0, maps:get(failed_count, Row)),
+    ?assertEqual(~"quests.define", maps:get(action, Row)),
+    ?assertEqual(~"extension", maps:get(target_type, Row)),
+    ?assertEqual(~"quests", maps:get(target_id, Row)),
+    Config.
+
+failed_extension_mutation_is_stored_as_error(Config) ->
+    Display = label(?FUNCTION_NAME),
+    {asobi_error, ~"quests.already_claimed", _} =
+        asobi_ops_extension:handle(ext_req(Display, #{~"key" => ~"conflict"})),
+    Row = row(Display),
+    ?assertEqual(~"error", maps:get(outcome, Row)),
+    ?assertEqual(0, maps:get(succeeded_count, Row)),
+    ?assertEqual(0, maps:get(failed_count, Row)),
+    ?assertEqual(#{~"reason" => ~"quests.already_claimed"}, maps:get(details, Row)),
+    Config.
+
+ext_req(Display, Params) ->
+    #{
+        bindings => #{~"extension" => ~"quests", ~"action" => ~"define"},
+        auth_data => #{ops_actor => actor(Display)},
+        json => Params
+    }.

--- a/test/asobi_ops_audit_tests.erl
+++ b/test/asobi_ops_audit_tests.erl
@@ -9,6 +9,8 @@ audit_test_() ->
         fun partial_outcome_is_not_a_success/0,
         fun total_failure_is_not_partial/0,
         fun error_outcome_records_its_reason/0,
+        fun extension_reply_success_is_a_single_subject_ok/0,
+        fun extension_reply_failure_records_its_code/0,
         fun unattested_actor_is_recorded_as_unattested/0,
         fun attested_actor_is_recorded_as_attested/0,
         fun target_is_recorded_when_there_is_one/0,
@@ -81,6 +83,23 @@ error_outcome_records_its_reason() ->
     Row = record({error, invalid_subject}),
     ?assertEqual(~"error", maps:get(outcome, Row)),
     ?assertEqual(#{reason => ~"invalid_subject"}, maps:get(details, Row)).
+
+%% The rpc reply shapes an extension ops handler returns (asobi#397). Before
+%% they were accepted, a successful extension mutation raised function_clause
+%% inside the audit path and wrote no row at all.
+extension_reply_success_is_a_single_subject_ok() ->
+    Row = record({ok, #{~"defined" => ~"daily"}}),
+    ?assertEqual(~"ok", maps:get(outcome, Row)),
+    ?assertEqual(1, maps:get(succeeded_count, Row)),
+    ?assertEqual(0, maps:get(failed_count, Row)),
+    ?assertEqual(#{}, maps:get(details, Row)).
+
+extension_reply_failure_records_its_code() ->
+    Row = record({error, ~"quests.not_found", #{~"hint" => ~"use another key"}}),
+    ?assertEqual(~"error", maps:get(outcome, Row)),
+    ?assertEqual(0, maps:get(succeeded_count, Row)),
+    ?assertEqual(0, maps:get(failed_count, Row)),
+    ?assertEqual(#{reason => ~"quests.not_found"}, maps:get(details, Row)).
 
 %% An actor named only by the `x-asobi-operator` label is self-declared. The
 %% row has to say so, or every stored name implies a verification that never

--- a/test/extensions/asobi_fixture_quests_ops.erl
+++ b/test/extensions/asobi_fixture_quests_ops.erl
@@ -9,6 +9,8 @@
 -spec define(map(), asobi_ops_extension:ctx()) -> asobi_rpc:reply().
 define(#{~"key" := ~"taken"}, _Ctx) ->
     {error, ~"quests.not_found"};
+define(#{~"key" := ~"conflict"}, _Ctx) ->
+    {error, ~"quests.already_claimed", #{~"existing" => ~"daily"}};
 define(Params, #{actor := #{id := ActorId}} = Ctx) ->
     record({define, Params, Ctx}),
     {ok, #{~"defined" => maps:get(~"key", Params, ~""), ~"by" => ActorId}}.

--- a/test/extensions/asobi_ops_extension_tests.erl
+++ b/test/extensions/asobi_ops_extension_tests.erl
@@ -40,7 +40,9 @@ extension_ops_test_() ->
 extension_audit_row_test_() ->
     {foreach, fun setup_rows/0, fun cleanup_rows/1, [
         fun a_successful_write_writes_an_ok_row/0,
-        fun a_failure_with_details_writes_an_error_row/0
+        fun a_failure_with_details_writes_an_error_row/0,
+        fun a_raising_handler_writes_an_error_row/0,
+        fun an_off_contract_return_writes_an_error_row/0
     ]}.
 
 setup() ->
@@ -160,6 +162,25 @@ a_failure_with_details_writes_an_error_row() ->
     ?assertEqual(0, maps:get(succeeded_count, Row)),
     ?assertEqual(0, maps:get(failed_count, Row)),
     ?assertEqual(#{reason => ~"quests.already_claimed"}, maps:get(details, Row)).
+
+%% A raise is caught by the seam and comes back as a `{raised, ...}` value, so
+%% the wrapper audits it like any other outcome - answered `internal`, recorded
+%% as an error.
+a_raising_handler_writes_an_error_row() ->
+    ?assertEqual({asobi_error, ~"internal"}, dispatch_mfa(raises)),
+    Row = row(),
+    ?assertEqual(~"error", maps:get(outcome, Row)),
+    ?assertEqual(0, maps:get(succeeded_count, Row)),
+    ?assertEqual(0, maps:get(failed_count, Row)),
+    ?assertEqual(#{reason => ~"{error,deliberate}"}, maps:get(details, Row)).
+
+an_off_contract_return_writes_an_error_row() ->
+    ?assertEqual({asobi_error, ~"internal"}, dispatch_mfa(off_contract)),
+    Row = row(),
+    ?assertEqual(~"error", maps:get(outcome, Row)),
+    ?assertEqual(0, maps:get(succeeded_count, Row)),
+    ?assertEqual(0, maps:get(failed_count, Row)),
+    ?assertEqual(#{reason => ~"surprise"}, maps:get(details, Row)).
 
 %% --- Readiness ---
 

--- a/test/extensions/asobi_ops_extension_tests.erl
+++ b/test/extensions/asobi_ops_extension_tests.erl
@@ -1,6 +1,7 @@
 -module(asobi_ops_extension_tests).
 
 -include_lib("eunit/include/eunit.hrl").
+-include_lib("kura/include/kura.hrl").
 
 -define(QUESTS, asobi_fixture_quests).
 -define(ACTOR, #{
@@ -32,22 +33,49 @@ extension_ops_test_() ->
         fun nothing_is_served_before_migrations/0
     ]}.
 
+%% The dispatch tests above stub `asobi_ops_audit` away, which is how asobi#397
+%% could hide: `mutation/4` was invoked but the row build raised on the reply
+%% shape. Here the real audit path runs down to the repo call, so these fail if
+%% a handler's reply cannot become a row.
+extension_audit_row_test_() ->
+    {foreach, fun setup_rows/0, fun cleanup_rows/1, [
+        fun a_successful_write_writes_an_ok_row/0,
+        fun a_failure_with_details_writes_an_error_row/0
+    ]}.
+
 setup() ->
-    asobi_extensions:reset(),
-    asobi_fixture_quests_ops:reset(),
-    ok = asobi_fixture_app:install(?QUESTS, asobi_fixture_quests_extension, []),
-    _ = asobi_extensions:resolve(),
-    asobi_readiness:mark_ready(),
     meck:new(asobi_ops_audit, [passthrough, no_link]),
     meck:expect(asobi_ops_audit, mutation, fun(_Actor, Action, Target, Fun) ->
         persistent_term:put({?MODULE, audited}, {Action, Target}),
         Fun()
     end),
+    install().
+
+setup_rows() ->
+    meck:new(asobi_repo, [passthrough, no_link]),
+    meck:expect(asobi_repo, insert, fun(_CS) -> {ok, #{}} end),
+    ok = install(),
+    meck:reset(asobi_repo),
+    ok.
+
+install() ->
+    asobi_extensions:reset(),
+    asobi_fixture_quests_ops:reset(),
+    ok = asobi_fixture_app:install(?QUESTS, asobi_fixture_quests_extension, []),
+    _ = asobi_extensions:resolve(),
+    asobi_readiness:mark_ready(),
     ok.
 
 cleanup(_) ->
     meck:unload(asobi_ops_audit),
     _ = persistent_term:erase({?MODULE, audited}),
+    uninstall().
+
+cleanup_rows(_) ->
+    meck:unload(asobi_repo),
+    uninstall().
+
+uninstall() ->
     asobi_fixture_app:uninstall(?QUESTS),
     asobi_extensions:reset(),
     asobi_fixture_quests_ops:reset(),
@@ -112,6 +140,27 @@ a_read_is_not_audited() ->
     _ = get(~"quests", ~"summary", ~""),
     ?assertEqual(undefined, persistent_term:get({?MODULE, audited}, undefined)).
 
+a_successful_write_writes_an_ok_row() ->
+    ?assertMatch({json, _}, post(~"quests", ~"define", #{~"key" => ~"daily"})),
+    Row = row(),
+    ?assertEqual(~"ok", maps:get(outcome, Row)),
+    ?assertEqual(1, maps:get(succeeded_count, Row)),
+    ?assertEqual(0, maps:get(failed_count, Row)),
+    ?assertEqual(~"quests.define", maps:get(action, Row)),
+    ?assertEqual(~"extension", maps:get(target_type, Row)),
+    ?assertEqual(~"quests", maps:get(target_id, Row)).
+
+a_failure_with_details_writes_an_error_row() ->
+    ?assertMatch(
+        {asobi_error, ~"quests.already_claimed", _},
+        post(~"quests", ~"define", #{~"key" => ~"conflict"})
+    ),
+    Row = row(),
+    ?assertEqual(~"error", maps:get(outcome, Row)),
+    ?assertEqual(0, maps:get(succeeded_count, Row)),
+    ?assertEqual(0, maps:get(failed_count, Row)),
+    ?assertEqual(#{reason => ~"quests.already_claimed"}, maps:get(details, Row)).
+
 %% --- Readiness ---
 
 %% The route table compiles before migrations run, so an action is reachable
@@ -129,6 +178,10 @@ nothing_is_served_before_migrations() ->
 
 post(Extension, Action, Params) ->
     asobi_ops_extension:handle(req(Extension, Action, #{json => Params})).
+
+row() ->
+    [{_, {asobi_repo, insert, [#kura_changeset{changes = Changes}]}, _}] = meck:history(asobi_repo),
+    Changes.
 
 get(Extension, Action, Qs) ->
     asobi_ops_extension:handle(req(Extension, Action, #{qs => Qs})).


### PR DESCRIPTION
`asobi_ops_extension:dispatch/4` wraps every non-get action in `asobi_ops_audit:mutation/4`, but `counts/1`, `classify/1` and `details/1` only accepted `{ok, Succeeded, Failed} | {error, Reason}`. An extension handler returns `t:asobi_rpc:reply/0`, so `{ok, Map}` and `{error, Code, Details}` hit `function_clause` inside `write/4`, were caught by `record/4`, and wrote no row - only a bare `{error, Code}` was recorded. The same held for a raising handler, whose raise `call/3` catches and returns as a `{raised, Class, Reason, Stack}` value the wrapper audits like any other outcome, and for an off-contract return. The one ops-plane mutation that exists audited nothing on success, inverting the ADR 0007 promise.

## Fix

The row build is now total over whatever the wrapped operation returned:

- `{ok, Map}` -> outcome `ok`, succeeded 1, failed 0; the handler's result may carry player data, so the success row stores none of it
- `{error, Code, Details}` -> outcome `error`, counts 0/0, stored reason is the code, mirroring bare `{error, Code}`; the details map is the caller's diagnostic and is not stored
- `{raised, Class, Reason, Stack}` -> outcome `error`, reason is the printed `{Class, Reason}` (bounded by the existing 200-byte truncation), stacktrace deliberately dropped
- anything off contract -> outcome `error`, reason is its printed form, bounded the same way

`outcome()` is widened with `asobi_rpc:reply()` and the raised tuple, `mutation/4` is parametric (it returns the fun's value unchanged), the row-build chain takes `term()`, and `asobi_ops_extension:call/3` gained the spec it was missing. Every previously accepted shape is unchanged. `guides/rest-api.md` now describes the fixed behaviour, including that a raising or off-contract handler is answered `internal` and still audited as an `error` outcome.

## Regression tests

- eunit, `asobi_ops_audit_tests`: both reply shapes through `record/4`
- eunit, `asobi_ops_extension_tests`: new `extension_audit_row_test_` runs dispatch with the real audit path down to the repo call (the earlier tests stub `asobi_ops_audit`, which is how this hid) and asserts the ok row, the coded-error row, the raised-handler row and the off-contract row
- CT, `asobi_ops_audit_SUITE` `extension_ops` group: a successful extension mutation, a `{error, Code, Details}` failure and a raising handler through `asobi_ops_extension:handle/1` against real Postgres, rows read back and asserted

## Checks

| Check | Result |
| --- | --- |
| rebar3 fmt | pass |
| rebar3 xref | pass |
| rebar3 dialyzer | pass, no warnings |
| elp eqwalize-all | 322 errors, identical to origin/main baseline; 0 new (the 3 in touched files pre-exist at shifted lines) |
| elp lint | no new warnings; findings in touched files pre-exist on main |
| rebar3 eunit | 1783 tests, 0 failures (final tree) |
| rebar3 ct | full run all 362 passed at the first commit; audit suite re-run on the final tree, all 6 passed (incl. the raises case) |
| rebar3 ex_doc | pass (pre-existing CODEOWNERS warning from CONTRIBUTING.md) |
| rebar3 mutate | skipped - not configured in this repo |
| rebar3 fmt --check | pass |

Closes #397
Part of #446
