### PR TITLE
feat: routes/0 extension seam with http path claims

### DIFF
--- a/guides/extensions.md
+++ b/guides/extensions.md
@@ -397,17 +397,22 @@ a webhook" is an accepted answer.
 
 ```erlang
 routes() ->
-    [#{path => ~"/api/v1/saves", method => get,
-       mfa => {asobi_storage_controller, list_saves, 1}, security => player},
-     #{path => ~"/api/v1/iap/notifications/apple", method => post,
-       mfa => {asobi_iap_controller, notification, 1}, security => webhook}].
+    [#{path => ~"/api/v1/quests/board", method => get,
+       mfa => {asobi_quests_controller, board, 1}, security => player},
+     #{path => ~"/api/v1/quests/webhook/steam", method => post,
+       mfa => {asobi_quests_controller, steam_notification, 1}, security => webhook}].
 ```
 
+Routes live under your extension's own name, exactly like every other
+namespace you claim: `/api/v1/quests/...` for an extension named `quests`. A
+subsystem extracted out of core is the one exception - it keeps its historic
+core paths, and core's own table stops serving them in the same release.
+
 Declared, not mounted: core's router mounts every entry at boot, inside its
-global plugin chain - body cap, rate limiter, client gate, security headers -
-which an extension can neither replace nor reorder. The handler is a Nova
-controller, applied as `Module:Function(Req)`, so the arity is 1 - unlike the
-`rpc/0` and `ops/0` seams, whose handlers never see a request.
+global plugin chain - body cap, rate limiter, security headers - which an
+extension can neither replace nor reorder. The handler is a Nova controller,
+applied as `Module:Function(Req)`, so the arity is 1 - unlike the `rpc/0`
+and `ops/0` seams, whose handlers never see a request.
 
 `security` picks what stands in front of it:
 
@@ -416,30 +421,44 @@ controller, applied as `Module:Function(Req)`, so the arity is 1 - unlike the
   request is refused exactly as it is on a core route. The default choice.
 - `webhook` - no player check, for the server-to-server case. The handler
   must authenticate its caller itself - a signature, a shared secret -
-  because nothing else will.
+  because nothing else will. Webhook paths run in the dedicated `webhook`
+  rate-limit bucket (10/s per caller, the same shape as iap) rather than
+  the general 300/s api bucket: a webhook handler does signature crypto on
+  every request, so the api budget would make it a CPU amplifier.
+
+One path carries exactly one security class - declaring the same path under
+both is a build failure, not a coin-flip on which chain OPTIONS lands in.
 
 Every declared path is a derived `http` claim (see
 [Namespaces](#namespaces)), and the comparison is structural: two paths
-collide when some request could match both, so `/saves/:slot` and
-`/saves/:id` are one claim, and a literal under another table's binding is
-caught too. A collision with another extension, or with any path core's own
-table serves, is a build failure at `rebar3 asobi check` and a refusal at
-boot - a route can never be silently shadowed first-compiled-wins, and
-declaration order never matters. The other side of that coin is the 404
-discipline: a path whose extension is not installed is simply absent from the
-table, indistinguishable from a path that never meant anything.
+collide when the routing tree cannot serve both - some request matches both
+patterns (`/saves/:slot` and `/saves/:id` are one claim), or one pattern
+diverges from the other at a binding at any depth, the shape that lets one
+route swallow lookups meant for the other. A collision with another
+extension, with any path a co-mounted application serves (core's own table,
+and `nova_apps` like nova_resilience's `/health`), or with a privileged
+plane prefix (`/api/v1/ops`, `/api/v1/auth`, `/api/v1/iap`, `/console`,
+`/ws`) is a build failure at `rebar3 asobi check` and a refusal at boot - a
+route can never be silently shadowed first-compiled-wins, and declaration
+order never matters. The other side of that coin is the 404 discipline: a
+path whose extension is not installed is simply absent from the table,
+answering 404 like any path that never meant anything. That discipline is
+path-level only - a mounted path answers a wrong-method request with 405
+plus an allow header, exactly as core routes do, so the methods on declared
+paths are enumerable; that trade is accepted.
 
 Each of these is a build failure, like the `ops/0` list above:
 
-- `path` is `/`-rooted, with non-empty segments that are literals (no
-  `: . ? # %`) or `:name` bindings
+- `path` is `/`-rooted, with non-empty segments that are literals
+  (`[A-Za-z0-9_~-]`) or `:name` bindings
 - `method` is `get`, `post`, `put` or `delete`
-- `mfa` is `{Module, Function, 1}`
-- `security` is `player` or `webhook`
+- `mfa` is `{Module, Function, 1}`, and it names an exported function - a
+  missing handler is refused here, not discovered as a 500
+- `security` is `player` or `webhook`, and one path carries one class
 - no two entries in one manifest serve the same path and method, and no two
-  declare patterns that match the same requests - the same path under several
-  methods is fine
-- with `owns().http` named, every declared path is listed in it, verbatim
+  declare patterns that collide - the same path under several methods is fine
+- with `owns().http` named, every declared path is listed in it, verbatim,
+  and every listed token is itself a `/`-rooted path
 
 ## Writing a Lua binding
 
@@ -612,13 +631,18 @@ build failure - which is what catches a worker on `quests` under an `owns/0`
 saying `quest`.
 
 `http` alone compares structurally rather than by name: two paths are one
-claim when some request could match both. An `owns().http` entry with no
-route behind it is a plain reservation, and reserves with the same
-exclusivity.
+claim when the routing tree cannot serve both - a request matches both, or
+they diverge at a binding at any depth. An `owns().http` entry with no route
+behind it is a plain reservation, and reserves with the same exclusivity.
 
 Core's reserved names derive from core itself by the same rules: Lua namespaces
 from `asobi_lua_surface:reserved_namespaces/0`, tables from core's schemas,
-queues from core's shigoto workers, route paths from core's own route table.
+queues from core's shigoto workers, route paths from every co-mounted
+application's route table - core's own plus `nova_apps`, so
+nova_resilience's `/health`, `/ready` and `/live` are as unclaimable as
+`/api/v1/matches`. Five plane prefixes (`/api/v1/ops`, `/api/v1/auth`,
+`/api/v1/iap`, `/console`, `/ws`) are reserved whole: nothing mounts under
+them, whatever it would resolve to.
 
 Reserved RPC prefixes are the domains of `asobi_error:core_codes/0` plus every
 core Lua namespace, because an RPC prefix and an error-code domain are the same

--- a/guides/extensions.md
+++ b/guides/extensions.md
@@ -60,11 +60,15 @@ extension means building your own release from the Hex package.
 | Game logic, in-match, server-side | `game.quests.progress(player_id, 1)` | "player killed something, +1" |
 | Game client, over the network | an `rpc.call` frame - `ws.rpc(...)` in JS, `rpc_call(...)` in Godot, `realtime:rpc(...)` in Defold and LÖVE | "give me my reward" |
 | An operator, on the ops plane | `POST /api/v1/ops/ext/quests/define` | "add a daily quest" |
+| An HTTP caller, on a declared route | `GET /api/v1/quests/board` via `routes/0` | a preserved REST surface, or a store's webhook |
 
 An extension with only the wire cannot observe gameplay; one with only Lua
 cannot be triggered by a player action from the client. The third is a
 different audience, not a third way to reach the same one: `rpc/0` is
-player-scoped, and no player ever holds an operator capability.
+player-scoped, and no player ever holds an operator capability. The fourth is
+deliberately narrow - see
+[Declaring an HTTP route](#declaring-an-http-route) for when a route is the
+right answer and when `rpc/0` is.
 
 ## What you declare
 
@@ -119,6 +123,8 @@ Only `info/0` is required. The rest default to nothing.
   [Error codes](#error-codes).
 - `ops/0` - operator actions, reached on the ops plane rather than by a player.
   See [Writing an operator action](#writing-an-operator-action).
+- `routes/0` - HTTP routes, for preserved REST surfaces and webhooks. See
+  [Declaring an HTTP route](#declaring-an-http-route).
 - `erase_player/1` - how to erase one player, when your rows do not cascade.
   See [Deleting a player](#deleting-a-player).
 - `info/0` - `name` is the extension's identity and the root of everything it
@@ -300,10 +306,10 @@ GET  /api/v1/ops/ext/quests/summary?filter=active
 
 `/api/v1/ops/ext/:extension/:action` is the extension seam on the ops plane,
 and this is what puts something behind it. Core's own routes there are reads
-apart from erasing and exporting a player. You still declare no routes: core
-owns `/ext/:extension/:action` and dispatches every declared action behind it,
-the same way it owns one WebSocket frame type and dispatches `rpc/0` behind
-that.
+apart from erasing and exporting a player. You declare no operator routes -
+`routes/0` mounts player and webhook surfaces, never this plane: core owns
+`/ext/:extension/:action` and dispatches every declared action behind it, the
+same way it owns one WebSocket frame type and dispatches `rpc/0` behind that.
 
 Know what gates it. On a stock deployment there is no `ops_secret`, so every
 bearer request is denied 403 and none of this is reachable. Once a secret is
@@ -375,6 +381,65 @@ Each of these is a build failure at `rebar3 asobi check`, and again at boot:
 - `method` is `get`, `post`, `put` or `delete`
 - `class` is `read`, `player_data` or `config`
 - `mfa` is `{Module, Function, 2}`
+
+## Declaring an HTTP route
+
+`routes/0` exists for two callers, and it is worth being blunt about which
+before showing the shape. It preserves REST surfaces - a subsystem extracted
+out of core keeps serving the exact paths every vendored SDK already calls -
+and it receives server-to-server webhooks, where the sender is a store's
+backend that could never hold a player token. A **new client-facing feature
+should use `rpc/0` instead**: one `rpc(method, params)` symbol reaches every
+SDK with zero per-extension SDK work, while a new REST route has no SDK
+surface at all. That is a listing guideline, not a mechanical ban - the
+catalogue review asks "why is this a route and not an rpc method", and "it is
+a webhook" is an accepted answer.
+
+```erlang
+routes() ->
+    [#{path => ~"/api/v1/saves", method => get,
+       mfa => {asobi_storage_controller, list_saves, 1}, security => player},
+     #{path => ~"/api/v1/iap/notifications/apple", method => post,
+       mfa => {asobi_iap_controller, notification, 1}, security => webhook}].
+```
+
+Declared, not mounted: core's router mounts every entry at boot, inside its
+global plugin chain - body cap, rate limiter, client gate, security headers -
+which an extension can neither replace nor reorder. The handler is a Nova
+controller, applied as `Module:Function(Req)`, so the arity is 1 - unlike the
+`rpc/0` and `ops/0` seams, whose handlers never see a request.
+
+`security` picks what stands in front of it:
+
+- `player` - the authenticated player-token check every core `/api/v1` route
+  carries. `Req` arrives with `auth_data` holding `player_id`, and a bare
+  request is refused exactly as it is on a core route. The default choice.
+- `webhook` - no player check, for the server-to-server case. The handler
+  must authenticate its caller itself - a signature, a shared secret -
+  because nothing else will.
+
+Every declared path is a derived `http` claim (see
+[Namespaces](#namespaces)), and the comparison is structural: two paths
+collide when some request could match both, so `/saves/:slot` and
+`/saves/:id` are one claim, and a literal under another table's binding is
+caught too. A collision with another extension, or with any path core's own
+table serves, is a build failure at `rebar3 asobi check` and a refusal at
+boot - a route can never be silently shadowed first-compiled-wins, and
+declaration order never matters. The other side of that coin is the 404
+discipline: a path whose extension is not installed is simply absent from the
+table, indistinguishable from a path that never meant anything.
+
+Each of these is a build failure, like the `ops/0` list above:
+
+- `path` is `/`-rooted, with non-empty segments that are literals (no
+  `: . ? # %`) or `:name` bindings
+- `method` is `get`, `post`, `put` or `delete`
+- `mfa` is `{Module, Function, 1}`
+- `security` is `player` or `webhook`
+- no two entries in one manifest serve the same path and method, and no two
+  declare patterns that match the same requests - the same path under several
+  methods is fine
+- with `owns().http` named, every declared path is listed in it, verbatim
 
 ## Writing a Lua binding
 
@@ -537,6 +602,7 @@ kind derives:
 | `lua` | the namespaces in `lua/0` |
 | `tables` | `table/0` on your `kura_schema` modules |
 | `queues` | `queue/0` on your `shigoto_worker` modules |
+| `http` | the paths in `routes/0` |
 
 So a collision is caught even before either extension has bothered with
 `owns/0`, and a queue you actually run is claimed whether or not you remembered
@@ -545,9 +611,14 @@ kind at all says "this is the whole set", so anything derived outside it is a
 build failure - which is what catches a worker on `quests` under an `owns/0`
 saying `quest`.
 
+`http` alone compares structurally rather than by name: two paths are one
+claim when some request could match both. An `owns().http` entry with no
+route behind it is a plain reservation, and reserves with the same
+exclusivity.
+
 Core's reserved names derive from core itself by the same rules: Lua namespaces
 from `asobi_lua_surface:reserved_namespaces/0`, tables from core's schemas,
-queues from core's shigoto workers.
+queues from core's shigoto workers, route paths from core's own route table.
 
 Reserved RPC prefixes are the domains of `asobi_error:core_codes/0` plus every
 core Lua namespace, because an RPC prefix and an error-code domain are the same
@@ -773,9 +844,17 @@ A fixture extension needs no `.app` file and no separate build.
 `asobi_fixture_app:install/3` hands `application:load/1` an application spec
 directly, with your manifest module in its `modules` list - exactly what
 discovery reads. `asobi_fixture_quests_extension` declares all of `rpc/0`,
-`lua/0`, `ops/0`, `codes/0` and `owns/0`; `asobi_fixture_minimal_extension` is
-the `info/0`-only case; `asobi_fixture_clans_extension` is a second extension
-whose application depends on the first, so start order is observable.
+`lua/0`, `ops/0`, `codes/0`, `routes/0` and `owns/0`;
+`asobi_fixture_minimal_extension` is the `info/0`-only case;
+`asobi_fixture_clans_extension` is a second extension whose application
+depends on the first, so start order is observable.
+
+A declared route only exists in a table compiled after the extension was
+installed, so `asobi_extension_routes_SUITE` installs its fixture and then
+restarts the node - there is no memo to clear after the fact, unlike the RPC
+registry. Route validation and mounting need no server at all:
+`asobi_extension_routes_tests` checks the compiled table with
+`nova_router:compile/1`, the same way `asobi_router_tests` does.
 
 Exercise `rpc/0` without a socket by calling the dispatcher directly.
 `asobi_rpc:handle(Cid, Payload, Caller)` takes the payload map and a caller of

--- a/rebar.config
+++ b/rebar.config
@@ -351,6 +351,7 @@
 %% rebar3 is the one running it.
 {xref_ignores, [
     {providers, create, 1},
+    {rebar_api, debug, 2},
     {rebar_api, error, 2},
     {rebar_api, info, 2},
     {rebar_api, warn, 2},

--- a/src/asobi_router.erl
+++ b/src/asobi_router.erl
@@ -359,16 +359,22 @@ ws_routes() ->
 extension_routes(Extensions) ->
     lists:append([extension_groups(Routes) || #{routes := Routes} <- Extensions]).
 
+%% The classifier is total over the validated shape, so a route that somehow
+%% lost its security key crashes the compile loudly instead of vanishing
+%% from the table - or worse, mounting under the wrong chain.
 extension_groups(Routes) ->
     [
         Group
      || Security <- [player, webhook],
-        Group <- security_group(Security, [E || #{security := S} = E <- Routes, S =:= Security])
+        Group <- security_group(Security, [E || E <- Routes, security(E) =:= Security])
     ].
+
+security(#{security := Security}) -> Security.
 
 %% `player` is the same chain `api_routes/0` carries; `webhook` mounts open,
 %% like `auth_routes/0`, for a server-to-server caller that cannot hold a
-%% player token - the handler authenticates its caller itself.
+%% player token - the handler authenticates its caller itself, and the rate
+%% limiter puts it in the dedicated webhook bucket rather than the api one.
 security_group(_Security, []) ->
     [];
 security_group(player, Entries) ->
@@ -377,7 +383,9 @@ security_group(webhook, Entries) ->
     [#{prefix => ~"", security => false, routes => mounted(Entries)}].
 
 mounted(Entries) ->
-    [
-        {Path, erlang:make_fun(Module, Function, 1), #{methods => [Method, options]}}
-     || #{path := Path, method := Method, mfa := {Module, Function, 1}} <- Entries
-    ].
+    [mount(Entry) || Entry <- Entries].
+
+%% Total on purpose: a malformed entry cannot exist after validation, and if
+%% one ever does, a function_clause here beats a route silently not mounted.
+mount(#{path := Path, method := Method, mfa := {Module, Function, 1}}) ->
+    {Path, fun Module:Function/1, #{methods => [Method, options]}}.

--- a/src/asobi_router.erl
+++ b/src/asobi_router.erl
@@ -1,7 +1,7 @@
 -module(asobi_router).
 -behaviour(nova_router).
 
--export([routes/1]).
+-export([routes/1, core_routes/0]).
 
 %% Every route accepts its real method plus OPTIONS. Nova's middleware chain
 %% runs `nova_router` before `nova_cors_plugin`, so a route that doesn't
@@ -13,11 +13,20 @@
 %% memoised function rather than a process: nova is in asobi's `applications`
 %% list, so nova_sup:init/1 compiles this route table before asobi_app:start/2
 %% has run and before any asobi process exists. Resolving here validates the
-%% installed set at the earliest possible moment. Extensions contribute no
-%% routes at all; core owns the whole table.
+%% installed set at the earliest possible moment. Core owns the whole table:
+%% an extension declares entries in its manifest's `routes/0`, and this is the
+%% one place they are mounted.
 -spec routes(atom()) -> [map()].
 routes(_Environment) ->
-    _ = asobi_extensions:resolve(),
+    Extensions = asobi_extensions:resolve(),
+    core_routes() ++ extension_routes(Extensions).
+
+%% Core's own groups, without resolving extensions. `asobi_extension_reserved`
+%% derives the reserved http claims from this - it is called from inside
+%% `asobi_extensions:resolve/0`, where reading `routes/1` would re-enter the
+%% resolver before its term exists.
+-spec core_routes() -> [map()].
+core_routes() ->
     [
         auth_routes(),
         iap_routes(),
@@ -284,12 +293,13 @@ ops_routes() ->
             {~"/notifications", fun asobi_ops_controller:notifications/1, #{
                 methods => [get, options]
             }},
-            %% The one route core owns on behalf of extensions. Extensions
-            %% contribute no routes at all; this dispatches every action an
-            %% installed manifest declares, exactly as one WebSocket frame type
-            %% dispatches `rpc/0`. Its class is per action and comes from that
-            %% manifest, so it is deliberately absent from
-            %% `asobi_ops_caps:classes/0` - see `m:asobi_ops_extension`.
+            %% The one ops-plane route core owns on behalf of extensions -
+            %% `routes/0` mounts player and webhook surfaces, never operator
+            %% ones. This dispatches every action an installed manifest
+            %% declares, exactly as one WebSocket frame type dispatches
+            %% `rpc/0`. Its class is per action and comes from that manifest,
+            %% so it is deliberately absent from `asobi_ops_caps:classes/0` -
+            %% see `m:asobi_ops_extension`.
             {~"/ext/:extension/:action", fun asobi_ops_extension:handle/1, #{
                 methods => [get, post, put, delete, options]
             }}
@@ -336,3 +346,38 @@ ws_routes() ->
             {~"/ws", asobi_ws_handler, #{protocol => ws}}
         ]
     }.
+
+%% The declared route seam. Each manifest's `routes/0` entries mount here,
+%% under core's global plugin chain: the groups declare no `plugins` key, so
+%% Nova applies the chain from its own env - a group naming `plugins` would
+%% replace it, which is the Nova-apps hazard this seam exists to close.
+%% Ordering against core's groups is irrelevant by construction:
+%% `asobi_extensions:validate/1` refused any two patterns that could match
+%% one request, so the asobi#326 declaration-order trap cannot arise, and an
+%% uninstalled extension's paths are simply absent - an unknown route, not a
+%% reserved-looking one.
+extension_routes(Extensions) ->
+    lists:append([extension_groups(Routes) || #{routes := Routes} <- Extensions]).
+
+extension_groups(Routes) ->
+    [
+        Group
+     || Security <- [player, webhook],
+        Group <- security_group(Security, [E || #{security := S} = E <- Routes, S =:= Security])
+    ].
+
+%% `player` is the same chain `api_routes/0` carries; `webhook` mounts open,
+%% like `auth_routes/0`, for a server-to-server caller that cannot hold a
+%% player token - the handler authenticates its caller itself.
+security_group(_Security, []) ->
+    [];
+security_group(player, Entries) ->
+    [#{prefix => ~"", security => fun asobi_auth_plugin:verify/1, routes => mounted(Entries)}];
+security_group(webhook, Entries) ->
+    [#{prefix => ~"", security => false, routes => mounted(Entries)}].
+
+mounted(Entries) ->
+    [
+        {Path, erlang:make_fun(Module, Function, 1), #{methods => [Method, options]}}
+     || #{path := Path, method := Method, mfa := {Module, Function, 1}} <- Entries
+    ].

--- a/src/asobi_sup.erl
+++ b/src/asobi_sup.erl
@@ -250,6 +250,13 @@ register_limiters() ->
         %% number because the honest frequency is lower.
         erase => #{algorithm => sliding_window, limit => 3, window => 60000},
         iap => #{algorithm => sliding_window, limit => 10, window => 1000},
+        %% Extension routes mounted with `security => webhook` (see
+        %% asobi_extension:routes/0). A webhook handler authenticates its
+        %% caller itself - signature crypto on every request - so letting
+        %% tokenless traffic ride the 300/s api bucket makes each request a
+        %% CPU amplifier. Same shape and size as iap, which is the known
+        %% webhook case the seam exists for.
+        webhook => #{algorithm => sliding_window, limit => 10, window => 1000},
         api => #{algorithm => sliding_window, limit => 300, window => 1000},
         ws_connect => #{algorithm => sliding_window, limit => 60, window => 1000},
         %% Per-player bound on world/match joins (asobi#193). Joining is how a
@@ -315,6 +322,7 @@ register_limiters() ->
 limiter_name(auth) -> asobi_auth_limiter;
 limiter_name(register) -> asobi_register_limiter;
 limiter_name(iap) -> asobi_iap_limiter;
+limiter_name(webhook) -> asobi_webhook_limiter;
 limiter_name(api) -> asobi_api_limiter;
 limiter_name(ws_connect) -> asobi_ws_connect_limiter;
 limiter_name(join) -> asobi_join_limiter;

--- a/src/extensions/asobi_extension.erl
+++ b/src/extensions/asobi_extension.erl
@@ -399,9 +399,12 @@ callback for it here. See `guides/console-extensions.md`.
 One HTTP route this extension serves, mounted by core's router.
 
 `path` is absolute and `/`-rooted, made of non-empty segments that are either
-literals or `:name` bindings. `mfa` is a Nova controller - applied as
-`Module:Function(Req)`, so the arity is always 1, unlike the `rpc/0` and
-`ops/0` seams whose handlers never see a request.
+literals (`[A-Za-z0-9_~-]` - RFC 3986 unreserved minus the dot, which
+routing_tree does not normalise) or `:name` bindings. `mfa` is a Nova
+controller - applied as `Module:Function(Req)`, so the arity is always 1,
+unlike the `rpc/0` and `ops/0` seams whose handlers never see a request -
+and it must name an exported function, checked at build time rather than
+discovered as a 500.
 
 `security` picks the chain in front of the handler:
 
@@ -411,11 +414,16 @@ literals or `:name` bindings. `mfa` is a Nova controller - applied as
   choice, and the only right one for anything a client calls.
 - `webhook` - no player check, for a server-to-server caller that cannot hold
   a token (a store's receipt notification). The handler must authenticate its
-  caller itself - a signature, a shared secret - because nothing else will.
+  caller itself - a signature, a shared secret - because nothing else will,
+  and the rate limiter puts the path in the dedicated `webhook` bucket
+  (10/s per caller, iap's shape) rather than the general api one, because
+  per-request signature crypto on the api bucket's budget is a CPU
+  amplifier.
 
 Either way the route mounts inside core's global plugin chain - body cap,
-rate limiter, client gate, security headers - which an extension can neither
-replace nor reorder.
+rate limiter, security headers - which an extension can neither replace nor
+reorder. One path carries exactly one security class: declaring it under
+both is refused at build time.
 """.
 -type route() :: #{
     path := binary(),
@@ -436,13 +444,22 @@ guideline, not a mechanical ban - "it is a webhook" is an accepted answer.
 
 Every declared path is a derived `http` claim, validated like tables, rpc,
 lua and queues - but the comparison is structural rather than token equality:
-two paths collide when some request could match both, so `/saves/:slot` and
-`/saves/:id` are one claim, and a literal sitting under another table's
-binding is caught too. A collision with another extension or with a path
-core's own table serves refuses boot; a declared route can never be silently
-shadowed first-compiled-wins. An unmounted route - the extension absent, the
-path never declared - is indistinguishable from any other unknown route: 404,
-never a hint that the path means something when installed.
+two paths collide when the routing tree cannot serve both, so `/saves/:slot`
+and `/saves/:id` are one claim, a literal sitting under another table's
+binding is caught, and so is a pattern that diverges from an existing route
+at a binding at any depth - the shape that lets one route swallow another's
+lookups. A collision with another extension, with a path any co-mounted
+application serves (core's own table, Nova's, `nova_apps` such as
+nova_resilience's `/health`), or with a privileged plane prefix
+(`/api/v1/ops`, `/api/v1/auth`, `/api/v1/iap`, `/console`, `/ws`) refuses
+boot; a declared route can never be silently shadowed first-compiled-wins.
+
+An unmounted route - the extension absent, the path never declared - is
+absent from the table: 404, indistinguishable at the path level from a path
+that never meant anything. This discipline is path-level only: a mounted
+path answers a wrong-method request with 405 and an allow header, as every
+core route does, so which methods a declared path serves is enumerable.
+That trade is accepted - method behaviour follows HTTP rather than hiding.
 """.
 -callback routes() -> [route()].
 

--- a/src/extensions/asobi_extension.erl
+++ b/src/extensions/asobi_extension.erl
@@ -48,9 +48,9 @@ export_player(PlayerId) ->
 ```
 
 Only `info/0` is required. `rpc/0`, `lua/0`, `sup/0`, `owns/0`, `codes/0`,
-`erase_player/1` and `export_player/1` default to nothing, because several are
-frequently empty: an extension with no processes has no `sup/0`, and one whose
-rows cascade needs no `erase_player/1`.
+`ops/0`, `routes/0`, `erase_player/1` and `export_player/1` default to
+nothing, because several are frequently empty: an extension with no processes
+has no `sup/0`, and one whose rows cascade needs no `erase_player/1`.
 
 An extension declaring neither `rpc/0` nor `lua/0` is reachable by nobody:
 game logic calls `game.<ns>.*` from Lua, and clients call
@@ -136,7 +136,8 @@ second consumer has said what it is missing.
     codes/0,
     ops/0,
     ops_action/0,
-    ops_entry/0
+    ops_entry/0,
+    route/0
 ]).
 
 -doc "The extension's short name, and the root of everything it owns.".
@@ -196,7 +197,8 @@ table at all, so the binding would install nothing.
     tables => [token()],
     rpc => [token()],
     lua => [token()],
-    queues => [token()]
+    queues => [token()],
+    http => [token()]
 }.
 
 -doc "The HTTP status and human-readable message one code carries.".
@@ -373,7 +375,8 @@ vocabulary no player ever holds. So an extension with an admin surface - the
 first one hit it immediately with `quests.define` - had nowhere to put it.
 This is that home.
 
-Extensions still contribute **no routes** of their own. Core owns one route,
+Extensions contribute **no operator routes** - `routes/0` mounts player and
+webhook surfaces, never this plane. Core owns one route,
 `/api/v1/ops/ext/:extension/:action`, and dispatches it here exactly as it owns
 one WebSocket frame type and dispatches `rpc/0` behind it. An action is
 therefore reachable at:
@@ -392,6 +395,57 @@ callback for it here. See `guides/console-extensions.md`.
 """.
 -type ops() :: #{ops_action() => ops_entry()}.
 
+-doc """
+One HTTP route this extension serves, mounted by core's router.
+
+`path` is absolute and `/`-rooted, made of non-empty segments that are either
+literals or `:name` bindings. `mfa` is a Nova controller - applied as
+`Module:Function(Req)`, so the arity is always 1, unlike the `rpc/0` and
+`ops/0` seams whose handlers never see a request.
+
+`security` picks the chain in front of the handler:
+
+- `player` - the same authenticated player-token check every core `/api/v1`
+  route carries. The handler's `Req` arrives with `auth_data` holding
+  `player_id`, exactly as a core controller's does. This is the default
+  choice, and the only right one for anything a client calls.
+- `webhook` - no player check, for a server-to-server caller that cannot hold
+  a token (a store's receipt notification). The handler must authenticate its
+  caller itself - a signature, a shared secret - because nothing else will.
+
+Either way the route mounts inside core's global plugin chain - body cap,
+rate limiter, client gate, security headers - which an extension can neither
+replace nor reorder.
+""".
+-type route() :: #{
+    path := binary(),
+    method := get | post | put | delete,
+    mfa := mfa(),
+    security := player | webhook
+}.
+
+-doc """
+The HTTP routes this extension serves. Core's router mounts them at boot;
+extensions never mount anything themselves.
+
+This exists to preserve extracted REST surfaces and to receive server-to-server
+webhooks. A new client-facing feature should use `rpc/0` instead: one
+`rpc(method, params)` symbol reaches every SDK with zero per-extension SDK
+work, while a new REST route has no SDK surface at all. That is a listing
+guideline, not a mechanical ban - "it is a webhook" is an accepted answer.
+
+Every declared path is a derived `http` claim, validated like tables, rpc,
+lua and queues - but the comparison is structural rather than token equality:
+two paths collide when some request could match both, so `/saves/:slot` and
+`/saves/:id` are one claim, and a literal sitting under another table's
+binding is caught too. A collision with another extension or with a path
+core's own table serves refuses boot; a declared route can never be silently
+shadowed first-compiled-wins. An unmounted route - the extension absent, the
+path never declared - is indistinguishable from any other unknown route: 404,
+never a hint that the path means something when installed.
+""".
+-callback routes() -> [route()].
+
 -callback info() -> info().
 -callback rpc() -> rpc().
 -callback lua() -> lua().
@@ -400,4 +454,6 @@ callback for it here. See `guides/console-extensions.md`.
 -callback codes() -> codes().
 -callback ops() -> ops().
 
--optional_callbacks([rpc/0, lua/0, sup/0, owns/0, codes/0, ops/0, erase_player/1, export_player/1]).
+-optional_callbacks([
+    rpc/0, lua/0, sup/0, owns/0, codes/0, ops/0, routes/0, erase_player/1, export_player/1
+]).

--- a/src/extensions/asobi_extension_reserved.erl
+++ b/src/extensions/asobi_extension_reserved.erl
@@ -22,11 +22,22 @@ cannot drift:
   `core_codes/0` rather than `codes/0` on purpose: `codes/0` includes the codes
   the installed extensions declare, and reserving those would tell an extension
   it may not claim the namespace it just claimed.
-- **http** from core's own route table, via `asobi_router:core_routes/0` -
-  the core groups without the extension mounts, because this runs inside
-  `asobi_extensions:resolve/0` and reading the full table there would re-enter
-  the resolver before its term exists. A path core serves can never be
-  re-served, or shadowed under a binding, by an extension.
+- **http** from the route tables of every co-mounted application - the same
+  list Nova compiles, `[nova, asobi | nova_apps]` - so `/health`, `/ready`
+  and `/live` (served by `nova_resilience` in both shipped configs) are as
+  unclaimable as core's own paths. asobi's table comes from
+  `asobi_router:core_routes/0`, the groups without the extension mounts,
+  because this runs inside `asobi_extensions:resolve/0` and reading the full
+  table there would re-enter the resolver before its term exists; every
+  other app's comes from its `<app>_router:routes/1`. A path any co-mounted
+  app serves can never be re-served, or shadowed under a binding, by an
+  extension.
+
+On top of the derived set, `route_prefixes/0` names the privileged plane
+roots (`/api/v1/ops`, `/api/v1/auth`, `/api/v1/iap`, `/console`, `/ws`): no
+extension route may sit anywhere under them, whatever it would resolve to.
+This is a policy list, not a derivation - which sub-paths of a plane are
+sensitive is a judgment the route table cannot express.
 
 Deriving from modules costs one `code:ensure_loaded/1` sweep over core's
 module list. `asobi_extensions` only asks for it when at least one extension
@@ -39,7 +50,7 @@ claims, so core's names and an extension's names are found by the same rule
 rather than by two that can disagree.
 """.
 
--export([namespaces/0, kinds/0, schema_tables/1, worker_queues/1]).
+-export([namespaces/0, kinds/0, route_prefixes/0, schema_tables/1, worker_queues/1]).
 
 -type kind() :: tables | rpc | lua | queues | http.
 -export_type([kind/0]).
@@ -62,14 +73,81 @@ namespaces() ->
         http => core_route_paths()
     }.
 
-%% Every path core's own table serves, prefixed as it is mounted. The one
-%% protocol route (`/ws`) carries no methods key and is still a path claim.
+-doc """
+The privileged plane roots. No extension route may sit anywhere under one -
+mounting an open webhook handler inside the operator, auth, purchase,
+console or socket plane is refused whatever the path would resolve to.
+""".
+-spec route_prefixes() -> [asobi_extension:token(), ...].
+route_prefixes() ->
+    [~"/api/v1/ops", ~"/api/v1/auth", ~"/api/v1/iap", ~"/console", ~"/ws"].
+
+%% Every path any co-mounted application serves, prefixed as it is mounted.
+%% The compiled dispatch is `[nova, BootstrapApp | nova_apps]` (nova_sup),
+%% and in routing_tree the FIRST insert of a path wins, so an extension claim
+%% on a later app's path (nova_resilience's /health) would silently hijack
+%% it. `nova:get_env/2` reads the bootstrap application's env, which is
+%% exactly where nova_sup reads `nova_apps` from.
 core_route_paths() ->
     lists:usort([
-        <<Prefix/binary, Path/binary>>
-     || #{prefix := Prefix, routes := Routes} <- asobi_router:core_routes(),
-        {Path, _Handler, _Options} <- Routes
+        Path
+     || App <- co_mounted_apps(),
+        Group <- app_route_groups(App),
+        Path <- group_paths(Group)
     ]).
+
+co_mounted_apps() ->
+    NovaApps =
+        case nova:get_env(nova_apps, []) of
+            Apps when is_list(Apps) -> [App || App <- Apps, is_atom(App)];
+            _ -> []
+        end,
+    [nova, asobi | NovaApps].
+
+%% asobi through `core_routes/0` - its full `routes/1` resolves extensions,
+%% and this runs inside the resolver. Everything else through its Nova router
+%% module, found by name in the app's own module list (the manifest-module
+%% rule, so no atom is ever created from config data) and called exactly as
+%% `nova_router:compile/3` calls it.
+app_route_groups(asobi) ->
+    asobi_router:core_routes();
+app_route_groups(App) ->
+    _ = application:load(App),
+    Name = atom_to_list(App) ++ "_router",
+    lists:append([
+        Module:routes(nova:get_environment())
+     || Module <- app_modules(App),
+        atom_to_list(Module) =:= Name,
+        code:ensure_loaded(Module) =:= {module, Module},
+        erlang:function_exported(Module, routes, 1)
+    ]).
+
+app_modules(App) ->
+    case application:get_key(App, modules) of
+        {ok, Modules} -> Modules;
+        undefined -> []
+    end.
+
+%% Total over every route shape Nova compiles: a path entry is a claim, a
+%% status-code entry claims nothing, and anything else - a static-file
+%% 2-tuple, a non-binary prefix - raises rather than silently reserving
+%% nothing. A hole here is a hijackable path, so unrecognised means loud.
+group_paths(#{routes := Routes} = Group) ->
+    case maps:get(prefix, Group, ~"") of
+        Prefix when is_binary(Prefix) ->
+            lists:append([entry_paths(Prefix, Entry) || Entry <- Routes]);
+        _ ->
+            error({asobi_unrecognised_core_route_group, Group})
+    end;
+group_paths(Group) ->
+    error({asobi_unrecognised_core_route_group, Group}).
+
+entry_paths(Prefix, {Path, _Handler, _Options}) when is_binary(Path) ->
+    [<<Prefix/binary, Path/binary>>];
+entry_paths(_Prefix, {Status, _Handler, _Options}) when is_integer(Status) ->
+    [];
+entry_paths(Prefix, Entry) ->
+    error({asobi_unrecognised_core_route, Prefix, Entry}).
 
 -doc "Every table declared by a `kura_schema` module in this list.".
 -spec schema_tables([module()]) -> [asobi_extension:token()].

--- a/src/extensions/asobi_extension_reserved.erl
+++ b/src/extensions/asobi_extension_reserved.erl
@@ -22,6 +22,11 @@ cannot drift:
   `core_codes/0` rather than `codes/0` on purpose: `codes/0` includes the codes
   the installed extensions declare, and reserving those would tell an extension
   it may not claim the namespace it just claimed.
+- **http** from core's own route table, via `asobi_router:core_routes/0` -
+  the core groups without the extension mounts, because this runs inside
+  `asobi_extensions:resolve/0` and reading the full table there would re-enter
+  the resolver before its term exists. A path core serves can never be
+  re-served, or shadowed under a binding, by an extension.
 
 Deriving from modules costs one `code:ensure_loaded/1` sweep over core's
 module list. `asobi_extensions` only asks for it when at least one extension
@@ -36,13 +41,13 @@ rather than by two that can disagree.
 
 -export([namespaces/0, kinds/0, schema_tables/1, worker_queues/1]).
 
--type kind() :: tables | rpc | lua | queues.
+-type kind() :: tables | rpc | lua | queues | http.
 -export_type([kind/0]).
 
 -doc "The namespace kinds an extension may claim in `owns/0`.".
 -spec kinds() -> [kind(), ...].
 kinds() ->
-    [tables, rpc, lua, queues].
+    [tables, rpc, lua, queues, http].
 
 -doc "Core's reserved token set, per namespace kind.".
 -spec namespaces() -> #{kind() := [asobi_extension:token()]}.
@@ -53,8 +58,18 @@ namespaces() ->
         tables => schema_tables(Modules),
         queues => worker_queues(Modules),
         lua => Lua,
-        rpc => lists:usort(error_domains() ++ Lua)
+        rpc => lists:usort(error_domains() ++ Lua),
+        http => core_route_paths()
     }.
+
+%% Every path core's own table serves, prefixed as it is mounted. The one
+%% protocol route (`/ws`) carries no methods key and is still a path claim.
+core_route_paths() ->
+    lists:usort([
+        <<Prefix/binary, Path/binary>>
+     || #{prefix := Prefix, routes := Routes} <- asobi_router:core_routes(),
+        {Path, _Handler, _Options} <- Routes
+    ]).
 
 -doc "Every table declared by a `kura_schema` module in this list.".
 -spec schema_tables([module()]) -> [asobi_extension:token()].

--- a/src/extensions/asobi_extensions.erl
+++ b/src/extensions/asobi_extensions.erl
@@ -44,7 +44,7 @@ surfaces with Nova's crash context rather than a legible asobi error.
 -include_lib("kernel/include/logger.hrl").
 
 -export([resolve/0, check/0, validate/1, describe/1, sup_specs/1, error_codes/0]).
--export([rpc_methods/0, lua_bindings/0, ops_action/2]).
+-export([rpc_methods/0, lua_bindings/0, ops_action/2, is_webhook_path/1]).
 -ifdef(TEST).
 -export([reset/0]).
 -endif.
@@ -54,6 +54,7 @@ surfaces with Nova's crash context rather than a legible asobi error.
 -define(RPC_KEY, {?MODULE, rpc_methods}).
 -define(LUA_KEY, {?MODULE, lua_bindings}).
 -define(OPS_KEY, {?MODULE, ops_actions}).
+-define(WEBHOOK_KEY, {?MODULE, webhook_paths}).
 
 -doc "One resolved extension. `sup/0` is deliberately absent; see `sup_specs/1`.".
 -type extension() :: #{
@@ -76,7 +77,8 @@ surfaces with Nova's crash context rather than a legible asobi error.
     | {reserved_namespace, asobi_extension_reserved:kind(), asobi_extension:token(), atom()}
     | {undeclared_claim, asobi_extension_reserved:kind(), asobi_extension:token(), atom()}
     | {route_conflict, {asobi_extension:token(), atom()}, {asobi_extension:token(), atom()}}
-    | {reserved_route, asobi_extension:token(), asobi_extension:token(), atom()}.
+    | {reserved_route, asobi_extension:token(), asobi_extension:token(), atom()}
+    | {reserved_prefix, asobi_extension:token(), asobi_extension:token(), atom()}.
 
 -doc "One `lua/0` binding with the namespace and function name it was declared under.".
 -type binding() :: #{
@@ -106,6 +108,7 @@ resolve() ->
             persistent_term:put(?RPC_KEY, rpc_table(Extensions)),
             persistent_term:put(?LUA_KEY, lua_table(Extensions)),
             persistent_term:put(?OPS_KEY, ops_table(Extensions)),
+            persistent_term:put(?WEBHOOK_KEY, webhook_table(Extensions)),
             persistent_term:put(?KEY, Extensions),
             Extensions;
         Extensions ->
@@ -164,6 +167,31 @@ because they are one outcome: nothing to route to, and nothing to authorise.
 ops_action(Extension, Action) ->
     maps:get({Extension, Action}, persistent_term:get(?OPS_KEY, #{}), undefined).
 
+-doc """
+Whether a request path (as normalised segments, `trim_all`) is served by a
+mounted `security => webhook` route.
+
+Read by `m:asobi_rate_limit_plugin` to pick the webhook bucket, so like
+`rpc_methods/0` it reads the memoised table and never triggers discovery.
+Before `resolve/0` has run there are no webhook routes and no traffic.
+""".
+-spec is_webhook_path([binary()]) -> boolean().
+is_webhook_path(Segments) ->
+    case persistent_term:get(?WEBHOOK_KEY, []) of
+        Patterns when is_list(Patterns) ->
+            lists:any(fun(Pattern) -> pattern_matches(Pattern, Segments) end, Patterns);
+        _ ->
+            false
+    end.
+
+pattern_matches([], []) ->
+    true;
+pattern_matches([Pattern | PatternRest], [Segment | SegmentRest]) ->
+    (Pattern =:= Segment orelse is_binding_segment(Pattern)) andalso
+        pattern_matches(PatternRest, SegmentRest);
+pattern_matches(_Pattern, _Segments) ->
+    false.
+
 %% The codes term is written before the resolved term, so a concurrent second
 %% caller that sees ?KEY populated also sees the codes it implies.
 error_code_table(Extensions) ->
@@ -188,6 +216,15 @@ lua_table(Extensions) ->
      || #{lua := Lua} <- Extensions,
         Namespace := Functions <- Lua,
         Function := Binding <- Functions
+    ].
+
+%% Pre-split with trim_all, the same normalisation the limiter applies to a
+%% request path, so the two can never disagree about slash variants.
+webhook_table(Extensions) ->
+    [
+        binary:split(Path, ~"/", [global, trim_all])
+     || #{routes := Routes} <- Extensions,
+        #{security := webhook, path := Path} <- Routes
     ].
 
 %% Two concurrent first callers both compute and both write. The computation
@@ -246,6 +283,7 @@ reset() ->
     _ = persistent_term:erase(?CODES_KEY),
     _ = persistent_term:erase(?RPC_KEY),
     _ = persistent_term:erase(?LUA_KEY),
+    _ = persistent_term:erase(?WEBHOOK_KEY),
     ok.
 -endif.
 
@@ -442,7 +480,13 @@ ops_problems(Ops) when is_map(Ops) ->
     [
         {ops, ~"action must map to #{method, mfa => {Module, Function, 2}, class}", Action}
      || Action := Entry <- Ops, not is_ops_entry(Action, Entry)
-    ];
+    ] ++
+        [
+            {ops, ~"mfa does not name an exported function", Action}
+         || Action := #{mfa := {M, F, 2}} = Entry <- Ops,
+            is_ops_entry(Action, Entry),
+            not is_exported_handler(M, F, 2)
+        ];
 ops_problems(Ops) ->
     [{ops, ~"must be a map", Ops}].
 
@@ -468,7 +512,7 @@ is_segment(_Action) ->
 %% its own shape has nothing meaningful to compare against.
 routes_problems(Routes) when is_list(Routes) ->
     case [Entry || Entry <- Routes, not is_route_entry(Entry)] of
-        [] -> route_set_problems(Routes);
+        [] -> route_handler_problems(Routes) ++ route_set_problems(Routes);
         Malformed -> [{routes, route_problem(Entry), route_offender(Entry)} || Entry <- Malformed]
     end;
 routes_problems(Routes) ->
@@ -485,15 +529,19 @@ is_route_entry(#{path := Path, method := Method, mfa := {M, F, 1}, security := S
 is_route_entry(_Entry) ->
     false.
 
-is_route_path(<<"/", Rest/binary>>) when Rest =/= <<>> ->
+is_route_path(<<"/", Rest/binary>>) when Rest =/= ~"" ->
     lists:all(fun is_route_segment/1, binary:split(Rest, ~"/", [global]));
 is_route_path(_Path) ->
     false.
 
+%% dollar_endonly on both: a bare `$` also matches before a final newline, so
+%% without it `:id\n` is a valid binding. Literals are RFC 3986 unreserved
+%% minus the dot (routing_tree does no dot-segment normalisation), so a
+%% segment no client can send never mounts.
 is_route_segment(<<":", Name/binary>>) ->
-    re:run(Name, ~"^[a-z][a-z0-9_]*$", [{capture, none}]) =:= match;
+    re:run(Name, ~"^[a-z][a-z0-9_]*$", [{capture, none}, dollar_endonly]) =:= match;
 is_route_segment(Segment) ->
-    is_segment(Segment) andalso binary:match(Segment, ~":") =:= nomatch.
+    re:run(Segment, ~"^[A-Za-z0-9_~-]+$", [{capture, none}, dollar_endonly]) =:= match.
 
 route_problem(#{path := Path} = Entry) when is_binary(Path) ->
     case is_route_path(Path) of
@@ -513,38 +561,88 @@ route_entry_problem(_Entry) ->
 route_offender(#{path := Path}) when is_binary(Path) -> Path;
 route_offender(Entry) -> Entry.
 
+%% A handler that is not exported is a 500 on the first request; refusing it
+%% here makes it a build failure naming the path instead.
+route_handler_problems(Routes) ->
+    [
+        {routes, ~"mfa does not name an exported function", Path}
+     || #{path := Path, mfa := {M, F, 1}} <- Routes,
+        not is_exported_handler(M, F, 1)
+    ].
+
+is_exported_handler(M, F, A) ->
+    code:ensure_loaded(M) =:= {module, M} andalso erlang:function_exported(M, F, A).
+
 %% Within one manifest the same path may carry several methods - core's own
 %% table does - but the same path and method twice would be resolved by
-%% insertion order, and two overlapping patterns would shadow one another the
-%% same way. Refusing both is what makes declaration order irrelevant.
+%% insertion order, two colliding patterns would shadow one another the same
+%% way, and one path under two security classes would route OPTIONS by
+%% declaration order. Refusing all three is what makes order irrelevant.
 route_set_problems(Routes) ->
-    Indexed = lists:enumerate([{Path, Method} || #{path := Path, method := Method} <- Routes]),
+    Indexed = lists:enumerate([
+        {Path, Method, Security}
+     || #{path := Path, method := Method, security := Security} <- Routes
+    ]),
     [
         {routes, ~"two entries serve the same path and method", PathA}
-     || {I, {PathA, Method}} <- Indexed,
-        {J, {PathB, MethodB}} <- Indexed,
+     || {I, {PathA, Method, _}} <- Indexed,
+        {J, {PathB, MethodB, _}} <- Indexed,
         I < J,
         PathA =:= PathB,
         Method =:= MethodB
     ] ++
         [
-            {routes, ~"two entries declare paths that match the same requests", {PathA, PathB}}
-         || {I, {PathA, _}} <- Indexed,
-            {J, {PathB, _}} <- Indexed,
+            {routes, ~"one path must carry exactly one security class", PathA}
+         || {I, {PathA, Method, SecurityA}} <- Indexed,
+            {J, {PathB, MethodB, SecurityB}} <- Indexed,
+            I < J,
+            PathA =:= PathB,
+            Method =/= MethodB,
+            SecurityA =/= SecurityB
+        ] ++
+        [
+            {routes, ~"two entries declare paths that collide in the route table", {PathA, PathB}}
+         || {I, {PathA, _, _}} <- Indexed,
+            {J, {PathB, _, _}} <- Indexed,
             I < J,
             PathA =/= PathB,
-            paths_overlap(PathA, PathB)
+            paths_collide(PathA, PathB)
         ].
 
-%% Two patterns collide when some concrete request path matches both: same
-%% segment count, and at every position the literals agree or either side is
-%% a binding. This is what makes `/saves/:slot` and `/saves/:id` one claim,
-%% and catches a literal hiding under somebody else's binding.
+%% Two patterns collide when the routing tree cannot serve both: either some
+%% concrete request path matches both (same segment count, every position a
+%% matching literal or a binding on either side - `/saves/:slot` and
+%% `/saves/:id` are one claim), or they interfere below a diverging binding.
+%% routing_tree keys nodes by segment text and lookup commits to the first
+%% matching sibling without backtracking, so `/players/:someone/detail`
+%% swallows lookups meant for `/players/:id` and `/players/me/erase` at any
+%% depth - equal-length comparison alone misses every such shape. Diverging
+%% at two distinct literals is safe; a shared segment (including a binding
+%% reused by its exact name) descends into the same node and is safe too.
+paths_collide(PathA, PathB) ->
+    paths_overlap(PathA, PathB) orelse
+        interfere(path_segments(PathA), path_segments(PathB)).
+
 paths_overlap(PathA, PathB) ->
-    SegmentsA = binary:split(PathA, ~"/", [global]),
-    SegmentsB = binary:split(PathB, ~"/", [global]),
+    SegmentsA = path_segments(PathA),
+    SegmentsB = path_segments(PathB),
     length(SegmentsA) =:= length(SegmentsB) andalso
         lists:all(fun segments_compatible/1, lists:zip(SegmentsA, SegmentsB)).
+
+interfere([Segment | RestA], [Segment | RestB]) ->
+    interfere(RestA, RestB);
+interfere([], _Segments) ->
+    false;
+interfere(_Segments, []) ->
+    false;
+interfere([SegmentA | _], [SegmentB | _]) ->
+    is_binding_segment(SegmentA) orelse is_binding_segment(SegmentB).
+
+path_segments(Path) ->
+    binary:split(Path, ~"/", [global]).
+
+is_binding_segment(<<":", _/binary>>) -> true;
+is_binding_segment(_Segment) -> false.
 
 segments_compatible({<<":", _/binary>>, _Segment}) -> true;
 segments_compatible({_Segment, <<":", _/binary>>}) -> true;
@@ -614,6 +712,15 @@ owns_problems(Owns) when is_map(Owns) ->
         [
             {owns, ~"tokens must be a list of non-empty binaries", Kind}
          || Kind := Tokens <- Owns, lists:member(Kind, Kinds), not is_token_list(Tokens)
+        ] ++
+        %% A bare token in owns().http reserves nothing: claims compare as
+        %% paths, and a token that is not one can never collide with one.
+        [
+            {owns, ~"http tokens must be /-rooted route paths", Token}
+         || Tokens <- [maps:get(http, Owns, [])],
+            is_token_list(Tokens),
+            Token <- Tokens,
+            not is_route_path(Token)
         ];
 owns_problems(Owns) ->
     [{owns, ~"must be a map", Owns}].
@@ -676,11 +783,15 @@ So two extensions installing the same `game.quests`, or the same job queue,
 collide before either has bothered with `owns/0`.
 
 The `http` kind alone compares structurally rather than by token equality:
-two paths conflict when some request could match both, so `/saves/:slot` and
-`/saves/:id` are one claim and a literal under another table's binding is a
-collision too. Its reserved set is core's own route table, via
-`asobi_router:core_routes/0` - the same derive-don't-restate rule the other
-kinds follow.
+two paths collide when the routing tree cannot serve both - some request
+matches both patterns, or the patterns diverge at a binding at any depth, in
+which case routing_tree's commit-to-first-sibling lookup lets one swallow
+requests meant for the other (see `paths_collide/2`). Its reserved set is
+every co-mounted app's route table - core's own via
+`asobi_router:core_routes/0`, plus nova's and every app in `nova_apps`, which
+is what keeps `/health` and its siblings unclaimable - and a claim under a
+privileged plane prefix (`asobi_extension_reserved:route_prefixes/0`) is
+refused outright, whatever it would resolve to.
 
 Tables and queues derive through `asobi_extension_reserved`, the same rule
 that finds core's own tables and queues, so a name core reserves and a name an
@@ -722,7 +833,13 @@ kind_problems(http, Extensions, ReservedPaths) ->
             {reserved_route, Path, CorePath, App}
          || {Path, App} <- Claims,
             CorePath <- ReservedPaths,
-            paths_overlap(Path, CorePath)
+            paths_collide(Path, CorePath)
+        ] ++
+        [
+            {reserved_prefix, Path, Prefix, App}
+         || {Path, App} <- Claims,
+            Prefix <- asobi_extension_reserved:route_prefixes(),
+            under_prefix(Path, Prefix)
         ] ++
         undeclared(http, Extensions);
 kind_problems(Kind, Extensions, ReservedTokens) ->
@@ -736,7 +853,7 @@ kind_problems(Kind, Extensions, ReservedTokens) ->
 
 %% Structural, so `pairs/1` cannot serve: two different tokens can still be
 %% one claim. Same-app pairs are skipped - a manifest's own set was already
-%% checked for internal overlap, and a reservation in `owns/0` next to the
+%% checked for internal collision, and a reservation in `owns/0` next to the
 %% route it reserves is the well-formed case, not a conflict.
 route_conflicts(Claims) ->
     Indexed = lists:enumerate(Claims),
@@ -746,8 +863,21 @@ route_conflicts(Claims) ->
         {J, {PathB, AppB}} <- Indexed,
         I < J,
         AppA =/= AppB,
-        paths_overlap(PathA, PathB)
+        paths_collide(PathA, PathB)
     ].
+
+%% Binding-aware: `/api/:v/ops/x` sits under `/api/v1/ops` because the
+%% binding matches the prefix's literal on a real request.
+under_prefix(Path, Prefix) ->
+    prefixed(path_segments(Path), path_segments(Prefix)).
+
+prefixed(_Segments, []) ->
+    true;
+prefixed([], [_ | _]) ->
+    false;
+prefixed([Segment | Rest], [PrefixSegment | PrefixRest]) ->
+    (Segment =:= PrefixSegment orelse is_binding_segment(Segment)) andalso
+        prefixed(Rest, PrefixRest).
 
 %% `owns/0` is the closed statement of what an extension claims. Once it names
 %% a kind at all, anything the manifest derives for that kind and the owned set
@@ -839,15 +969,20 @@ describe_one({route_conflict, {Path, A}, {Path, B}}) ->
     line("~s and ~s both declare the route \"~s\". Routes are exclusive; move one.", [A, B, Path]);
 describe_one({route_conflict, {PathA, A}, {PathB, B}}) ->
     line(
-        "~s declares the route \"~s\" and ~s declares \"~s\"; the two match the same requests.",
+        "~s declares the route \"~s\" and ~s declares \"~s\"; the two collide in the route table.",
         [A, PathA, B, PathB]
     );
 describe_one({reserved_route, Path, Path, App}) ->
     line("~s declares the route \"~s\", which asobi's own table serves.", [App, Path]);
 describe_one({reserved_route, Path, CorePath, App}) ->
     line(
-        "~s declares the route \"~s\", which matches requests asobi's own \"~s\" serves.",
+        "~s declares the route \"~s\", which would break asobi's own \"~s\".",
         [App, Path, CorePath]
+    );
+describe_one({reserved_prefix, Path, Prefix, App}) ->
+    line(
+        "~s declares the route \"~s\" under \"~s\", which asobi reserves for its own plane.",
+        [App, Path, Prefix]
     ).
 
 line(Format, Args) ->

--- a/src/extensions/asobi_extensions.erl
+++ b/src/extensions/asobi_extensions.erl
@@ -65,7 +65,8 @@ surfaces with Nova's crash context rather than a legible asobi error.
     ops := asobi_extension:ops(),
     lua := asobi_extension:lua(),
     owns := asobi_extension:owns(),
-    codes := asobi_extension:codes()
+    codes := asobi_extension:codes(),
+    routes := [asobi_extension:route()]
 }.
 
 -type problem() ::
@@ -73,7 +74,9 @@ surfaces with Nova's crash context rather than a legible asobi error.
     | {duplicate_name, asobi_extension:name(), atom(), atom()}
     | {namespace_conflict, asobi_extension_reserved:kind(), asobi_extension:token(), atom(), atom()}
     | {reserved_namespace, asobi_extension_reserved:kind(), asobi_extension:token(), atom()}
-    | {undeclared_claim, asobi_extension_reserved:kind(), asobi_extension:token(), atom()}.
+    | {undeclared_claim, asobi_extension_reserved:kind(), asobi_extension:token(), atom()}
+    | {route_conflict, {asobi_extension:token(), atom()}, {asobi_extension:token(), atom()}}
+    | {reserved_route, asobi_extension:token(), asobi_extension:token(), atom()}.
 
 -doc "One `lua/0` binding with the namespace and function name it was declared under.".
 -type binding() :: #{
@@ -337,6 +340,7 @@ read_manifest(App, Module) ->
         {owns, call(Module, owns, #{})},
         {codes, call(Module, codes, #{})},
         {ops, call(Module, ops, #{})},
+        {routes, call(Module, routes, [])},
         {sup, call(Module, sup, [])}
     ],
     case [{Key, Detail} || {Key, {error, Detail}} <- Reads] of
@@ -367,9 +371,10 @@ build(App, Module, Values) ->
         owns := Owns,
         codes := Codes,
         ops := Ops,
+        routes := Routes,
         sup := Sup
     } = Values,
-    case shape_problems(Info, Rpc, Lua, Owns, Codes, Ops, Sup) of
+    case shape_problems(Info, Rpc, Lua, Owns, Codes, Ops, Routes, Sup) of
         [] ->
             #{name := Name, extension_version := Version} = Info,
             {ok, #{
@@ -381,19 +386,21 @@ build(App, Module, Values) ->
                 lua => Lua,
                 owns => Owns,
                 codes => Codes,
-                ops => Ops
+                ops => Ops,
+                routes => Routes
             }};
         Details ->
             {error, [{bad_manifest, App, Module, Detail} || Detail <- Details]}
     end.
 
-shape_problems(Info, Rpc, Lua, Owns, Codes, Ops, Sup) ->
+shape_problems(Info, Rpc, Lua, Owns, Codes, Ops, Routes, Sup) ->
     info_problems(Info) ++
         rpc_problems(Rpc) ++
         lua_problems(Lua) ++
         owns_problems(Owns) ++
         codes_problems(Codes) ++
         ops_problems(Ops) ++
+        routes_problems(Routes) ++
         sup_problems(Sup).
 
 info_problems(#{name := Name, extension_version := Version}) when
@@ -456,6 +463,93 @@ is_segment(Action) when is_binary(Action), Action =/= ~"" ->
     binary:match(Action, [~"/", ~".", ~"?", ~"#", ~"%"]) =:= nomatch;
 is_segment(_Action) ->
     false.
+
+%% Cross-entry checks only run over a well-formed list: an entry that failed
+%% its own shape has nothing meaningful to compare against.
+routes_problems(Routes) when is_list(Routes) ->
+    case [Entry || Entry <- Routes, not is_route_entry(Entry)] of
+        [] -> route_set_problems(Routes);
+        Malformed -> [{routes, route_problem(Entry), route_offender(Entry)} || Entry <- Malformed]
+    end;
+routes_problems(Routes) ->
+    [{routes, ~"must be a list of route entries", Routes}].
+
+%% Arity 1, not the seams' usual 2: a route handler is a Nova controller and
+%% is applied as `Module:Function(Req)` by nova_handler, never by core.
+is_route_entry(#{path := Path, method := Method, mfa := {M, F, 1}, security := Security}) when
+    is_atom(M), is_atom(F)
+->
+    is_route_path(Path) andalso
+        lists:member(Method, [get, post, put, delete]) andalso
+        lists:member(Security, [player, webhook]);
+is_route_entry(_Entry) ->
+    false.
+
+is_route_path(<<"/", Rest/binary>>) when Rest =/= <<>> ->
+    lists:all(fun is_route_segment/1, binary:split(Rest, ~"/", [global]));
+is_route_path(_Path) ->
+    false.
+
+is_route_segment(<<":", Name/binary>>) ->
+    re:run(Name, ~"^[a-z][a-z0-9_]*$", [{capture, none}]) =:= match;
+is_route_segment(Segment) ->
+    is_segment(Segment) andalso binary:match(Segment, ~":") =:= nomatch.
+
+route_problem(#{path := Path} = Entry) when is_binary(Path) ->
+    case is_route_path(Path) of
+        false ->
+            ~"path must be /-rooted with non-empty literal or :binding segments";
+        true ->
+            route_entry_problem(Entry)
+    end;
+route_problem(_Entry) ->
+    ~"entry must be #{path, method, mfa => {Module, Function, 1}, security => player | webhook}".
+
+route_entry_problem(#{mfa := {M, F, A}}) when is_atom(M), is_atom(F), A =/= 1 ->
+    ~"a route handler is a Nova controller: mfa must be {Module, Function, 1}";
+route_entry_problem(_Entry) ->
+    ~"entry must be #{path, method, mfa => {Module, Function, 1}, security => player | webhook}".
+
+route_offender(#{path := Path}) when is_binary(Path) -> Path;
+route_offender(Entry) -> Entry.
+
+%% Within one manifest the same path may carry several methods - core's own
+%% table does - but the same path and method twice would be resolved by
+%% insertion order, and two overlapping patterns would shadow one another the
+%% same way. Refusing both is what makes declaration order irrelevant.
+route_set_problems(Routes) ->
+    Indexed = lists:enumerate([{Path, Method} || #{path := Path, method := Method} <- Routes]),
+    [
+        {routes, ~"two entries serve the same path and method", PathA}
+     || {I, {PathA, Method}} <- Indexed,
+        {J, {PathB, MethodB}} <- Indexed,
+        I < J,
+        PathA =:= PathB,
+        Method =:= MethodB
+    ] ++
+        [
+            {routes, ~"two entries declare paths that match the same requests", {PathA, PathB}}
+         || {I, {PathA, _}} <- Indexed,
+            {J, {PathB, _}} <- Indexed,
+            I < J,
+            PathA =/= PathB,
+            paths_overlap(PathA, PathB)
+        ].
+
+%% Two patterns collide when some concrete request path matches both: same
+%% segment count, and at every position the literals agree or either side is
+%% a binding. This is what makes `/saves/:slot` and `/saves/:id` one claim,
+%% and catches a literal hiding under somebody else's binding.
+paths_overlap(PathA, PathB) ->
+    SegmentsA = binary:split(PathA, ~"/", [global]),
+    SegmentsB = binary:split(PathB, ~"/", [global]),
+    length(SegmentsA) =:= length(SegmentsB) andalso
+        lists:all(fun segments_compatible/1, lists:zip(SegmentsA, SegmentsB)).
+
+segments_compatible({<<":", _/binary>>, _Segment}) -> true;
+segments_compatible({_Segment, <<":", _/binary>>}) -> true;
+segments_compatible({Segment, Segment}) -> true;
+segments_compatible({_SegmentA, _SegmentB}) -> false.
 
 is_dotted(Method) when is_binary(Method) ->
     case binary:split(Method, ~".") of
@@ -576,12 +670,20 @@ already implies, and every kind derives:
 | `lua` | the namespaces in `lua/0` |
 | `tables` | `table/0` on the extension's `kura_schema` modules |
 | `queues` | `queue/0` on the extension's `shigoto_worker` modules |
+| `http` | the paths in `routes/0` |
 
 So two extensions installing the same `game.quests`, or the same job queue,
 collide before either has bothered with `owns/0`.
 
-The last two derive through `asobi_extension_reserved`, the same rule that
-finds core's own tables and queues, so a name core reserves and a name an
+The `http` kind alone compares structurally rather than by token equality:
+two paths conflict when some request could match both, so `/saves/:slot` and
+`/saves/:id` are one claim and a literal under another table's binding is a
+collision too. Its reserved set is core's own route table, via
+`asobi_router:core_routes/0` - the same derive-don't-restate rule the other
+kinds follow.
+
+Tables and queues derive through `asobi_extension_reserved`, the same rule
+that finds core's own tables and queues, so a name core reserves and a name an
 extension claims can never be found two different ways.
 
 That leaves `owns/0` doing one job, and it is worth stating because it is no
@@ -613,6 +715,16 @@ duplicate_names(Extensions) ->
      || {Name, A, B} <- pairs([{Name, App} || #{name := Name, app := App} <- Extensions])
     ].
 
+kind_problems(http, Extensions, ReservedPaths) ->
+    Claims = lists:usort([{Path, App} || #{app := App} = E <- Extensions, Path <- claims(E, http)]),
+    route_conflicts(Claims) ++
+        [
+            {reserved_route, Path, CorePath, App}
+         || {Path, App} <- Claims,
+            CorePath <- ReservedPaths,
+            paths_overlap(Path, CorePath)
+        ] ++
+        undeclared(http, Extensions);
 kind_problems(Kind, Extensions, ReservedTokens) ->
     Claims = [{Token, App} || #{app := App} = E <- Extensions, Token <- claims(E, Kind)],
     [{namespace_conflict, Kind, Token, A, B} || {Token, A, B} <- pairs(Claims)] ++
@@ -621,6 +733,21 @@ kind_problems(Kind, Extensions, ReservedTokens) ->
          || {Token, App} <- lists:usort(Claims), lists:member(Token, ReservedTokens)
         ] ++
         undeclared(Kind, Extensions).
+
+%% Structural, so `pairs/1` cannot serve: two different tokens can still be
+%% one claim. Same-app pairs are skipped - a manifest's own set was already
+%% checked for internal overlap, and a reservation in `owns/0` next to the
+%% route it reserves is the well-formed case, not a conflict.
+route_conflicts(Claims) ->
+    Indexed = lists:enumerate(Claims),
+    [
+        {route_conflict, {PathA, AppA}, {PathB, AppB}}
+     || {I, {PathA, AppA}} <- Indexed,
+        {J, {PathB, AppB}} <- Indexed,
+        I < J,
+        AppA =/= AppB,
+        paths_overlap(PathA, PathB)
+    ].
 
 %% `owns/0` is the closed statement of what an extension claims. Once it names
 %% a kind at all, anything the manifest derives for that kind and the owned set
@@ -650,6 +777,8 @@ derived(#{rpc := Rpc, codes := Codes}, rpc) ->
     );
 derived(#{lua := Lua}, lua) ->
     lists:usort(maps:keys(Lua));
+derived(#{routes := Routes}, http) ->
+    lists:usort([Path || #{path := Path} <- Routes]);
 %% A shigoto queue is only ever what the worker's own `queue/0` returns -
 %% nothing reads `owns.queues` at runtime - so deriving it here is what makes
 %% the claim enforceable at all. Same for a table and its schema.
@@ -705,6 +834,20 @@ describe_one({undeclared_claim, Kind, Token, App}) ->
     line(
         "~s uses the ~s \"~s\" but does not list it in owns().~s.",
         [App, singular(Kind), Token, Kind]
+    );
+describe_one({route_conflict, {Path, A}, {Path, B}}) ->
+    line("~s and ~s both declare the route \"~s\". Routes are exclusive; move one.", [A, B, Path]);
+describe_one({route_conflict, {PathA, A}, {PathB, B}}) ->
+    line(
+        "~s declares the route \"~s\" and ~s declares \"~s\"; the two match the same requests.",
+        [A, PathA, B, PathB]
+    );
+describe_one({reserved_route, Path, Path, App}) ->
+    line("~s declares the route \"~s\", which asobi's own table serves.", [App, Path]);
+describe_one({reserved_route, Path, CorePath, App}) ->
+    line(
+        "~s declares the route \"~s\", which matches requests asobi's own \"~s\" serves.",
+        [App, Path, CorePath]
     ).
 
 line(Format, Args) ->
@@ -713,4 +856,5 @@ line(Format, Args) ->
 singular(tables) -> ~"table";
 singular(rpc) -> ~"RPC prefix";
 singular(lua) -> ~"Lua namespace";
-singular(queues) -> ~"queue".
+singular(queues) -> ~"queue";
+singular(http) -> ~"route".

--- a/src/extensions/asobi_extensions.erl
+++ b/src/extensions/asobi_extensions.erl
@@ -246,7 +246,13 @@ resolve_now() ->
 Discover, read and validate without memoising.
 
 The build-time gate (`rebar3 asobi check`) and the boot backstop run exactly
-this, so the two can never disagree.
+this, so the two can never disagree on anything derived from the loaded
+application set. The one env-dependent input is the co-mounted `http` reserved
+set, which reads `nova_apps`: the `m:rebar3_asobi_check` plugin sets it from
+the host's release sys_config before calling this, so the gate matches boot,
+and falls back to reserving nothing extra only when that config cannot be
+read - in which case boot, which does load sys.config, remains the backstop
+that refuses.
 """.
 -spec check() -> {ok, [extension()]} | {error, [problem(), ...]}.
 check() ->

--- a/src/extensions/rebar3_asobi_check.erl
+++ b/src/extensions/rebar3_asobi_check.erl
@@ -127,15 +127,17 @@ route_line(#{path := Path, method := Method, security := Security}) ->
 
 %% Not an error: it is a legal state halfway through writing an extension.
 %% But an extension with no seam at all is reachable by nobody - game logic
-%% calls game.<ns>.*, clients call rpc or a declared route - so saying
-%% nothing would be worse.
-is_unreachable(#{rpc := Rpc, lua := Lua, routes := Routes}) ->
-    map_size(Rpc) =:= 0 andalso map_size(Lua) =:= 0 andalso Routes =:= [].
+%% calls game.<ns>.*, clients call rpc or a declared route, operators call
+%% ops actions - so saying nothing would be worse.
+is_unreachable(#{rpc := Rpc, lua := Lua, ops := Ops, routes := Routes}) ->
+    map_size(Rpc) =:= 0 andalso map_size(Lua) =:= 0 andalso map_size(Ops) =:= 0 andalso
+        Routes =:= [].
 
 unreachable(#{app := App}) ->
     io_lib:format(
-        "~s declares neither rpc/0, lua/0 nor routes/0, so nothing can call it: "
-        "game logic reaches an extension through game.<ns>.*, clients through "
-        "rpc, HTTP callers through a declared route",
+        "~s declares none of rpc/0, lua/0, ops/0 or routes/0, so nothing can "
+        "call it: game logic reaches an extension through game.<ns>.*, clients "
+        "through rpc, operators through ops actions, HTTP callers through a "
+        "declared route",
         [App]
     ).

--- a/src/extensions/rebar3_asobi_check.erl
+++ b/src/extensions/rebar3_asobi_check.erl
@@ -29,6 +29,9 @@ version in `project_plugins`. Pin it to the same tag as the dependency.
 -behaviour(provider).
 
 -export([init/1, do/1, format_error/1]).
+-ifdef(TEST).
+-export([co_mounted_from_config/1]).
+-endif.
 
 -define(PROVIDER, check).
 -define(NAMESPACE, asobi).
@@ -60,6 +63,7 @@ init(State) ->
 -spec do(term()) -> {ok, term()} | {error, string()}.
 do(State) ->
     ok = load_apps(rebar_state:project_apps(State) ++ rebar_state:all_deps(State)),
+    ok = reserve_co_mounted_apps(State),
     case asobi_extensions:check() of
         {ok, []} ->
             rebar_api:info("asobi: no extensions installed", []),
@@ -94,6 +98,83 @@ load_app(AppInfo) ->
     _ = code:add_pathz(rebar_app_info:ebin_dir(AppInfo)),
     _ = application:load(binary_to_atom(rebar_app_info:name(AppInfo), utf8)),
     ok.
+
+%% The boot path reserves every co-mounted application's routes - nova plus
+%% the bootstrap app's `nova_apps` - so `/health` and its siblings cannot be
+%% claimed. This VM never loads sys.config, so without this the gate would
+%% see no `nova_apps`, pass a `/health` claim the node refuses at boot, and
+%% make `check/0`'s "build gate and boot backstop can never disagree" a lie.
+%% Read the same two keys the boot path reads out of the release sys_config
+%% and set them for the check. Defensive by design: an unreadable or
+%% templated (`.src`) config falls back to reserving nothing extra - which is
+%% also the correct answer for a project that declares no `nova_apps` - and
+%% never crashes the build.
+reserve_co_mounted_apps(State) ->
+    try
+        case sys_config(State) of
+            {ok, Config} ->
+                apply_co_mounted(co_mounted_from_config(Config));
+            none ->
+                ok
+        end
+    catch
+        Class:Reason ->
+            rebar_api:debug("asobi: could not read nova_apps from config (~p:~p)", [Class, Reason]),
+            ok
+    end.
+
+apply_co_mounted({ok, Bootstrap, NovaApps}) ->
+    %% Set nova's env last so `application:load(nova)` cannot reset it from
+    %% the .app, and set it at all because `nova:get_env/2` - the boot path's
+    %% own read - keys `nova_apps` off nova's `bootstrap_application`.
+    _ = application:load(nova),
+    ok = application:set_env(Bootstrap, nova_apps, NovaApps),
+    ok = application:set_env(nova, bootstrap_application, Bootstrap);
+apply_co_mounted(none) ->
+    ok.
+
+%% The release sys_config, from relx config in the host's rebar.config. A
+%% plain `.config` consults; a `.src` with templating does not, and falls
+%% through to the next candidate or to `none`.
+sys_config(State) ->
+    Relx = rebar_state:get(State, relx, []),
+    Paths = [P || {sys_config, P} <- Relx] ++ [P || {sys_config_src, P} <- Relx],
+    first_consultable(Paths).
+
+first_consultable([]) ->
+    none;
+first_consultable([Path | Rest]) ->
+    case filelib:is_regular(Path) andalso file:consult(Path) of
+        {ok, [Config]} when is_list(Config) -> {ok, Config};
+        _ -> first_consultable(Rest)
+    end.
+
+-doc """
+`nova`'s `bootstrap_application` and that app's `nova_apps`, the two keys
+`nova_sup` uses to build the compiled dispatch, or `none` when the config
+names no bootstrap app or an empty `nova_apps`. Pure, so the parse is tested
+without a rebar state.
+""".
+-spec co_mounted_from_config([{atom(), [{atom(), term()}]}]) ->
+    {ok, atom(), [atom()]} | none.
+co_mounted_from_config(Config) ->
+    case proplists:get_value(bootstrap_application, env(nova, Config)) of
+        Bootstrap when is_atom(Bootstrap), Bootstrap =/= undefined ->
+            case proplists:get_value(nova_apps, env(Bootstrap, Config)) of
+                [_ | _] = NovaApps -> {ok, Bootstrap, [App || App <- NovaApps, is_atom(App)]};
+                _ -> none
+            end;
+        _ ->
+            none
+    end.
+
+%% One app's env from a sys_config, or `[]` - narrowed to a list so the
+%% proplist reads above stay well-typed against an untyped config term.
+env(App, Config) ->
+    case proplists:get_value(App, Config, []) of
+        KVs when is_list(KVs) -> KVs;
+        _ -> []
+    end.
 
 report(Extensions) ->
     rebar_api:info("asobi: ~b extension(s), in migration order", [length(Extensions)]),

--- a/src/extensions/rebar3_asobi_check.erl
+++ b/src/extensions/rebar3_asobi_check.erl
@@ -50,8 +50,10 @@ init(State) ->
         {desc,
             "Discovers every application exporting an <app>_extension module, reads "
             "each manifest and checks that no two extensions claim the same table, "
-            "RPC prefix, Lua namespace or job queue, and that none claims a name "
-            "asobi reserves. Exits non-zero with both claimants named."}
+            "RPC prefix, Lua namespace, job queue or HTTP route, and that none "
+            "claims a name asobi reserves - for routes that includes any pattern a "
+            "request core's own table serves could match. Exits non-zero with both "
+            "claimants named."}
     ]),
     {ok, rebar_state:add_provider(State, Provider)}.
 
@@ -95,25 +97,45 @@ load_app(AppInfo) ->
 
 report(Extensions) ->
     rebar_api:info("asobi: ~b extension(s), in migration order", [length(Extensions)]),
-    _ = [rebar_api:info("  ~ts", [summarise(E)]) || E <- Extensions],
+    _ = [rebar_api:info("  ~ts", [Line]) || E <- Extensions, Line <- lines(E)],
     _ = [rebar_api:warn("asobi: ~ts", [unreachable(E)]) || E <- Extensions, is_unreachable(E)],
     ok.
 
-summarise(#{name := Name, app := App, extension_version := Version, rpc := Rpc, lua := Lua}) ->
+%% The route lines are the mount preview: exactly what `asobi_router` will
+%% put in the table, path by path, with the chain each one sits behind.
+lines(#{routes := Routes} = Extension) ->
+    [summarise(Extension) | [["  ", route_line(Route)] || Route <- Routes]].
+
+summarise(#{
+    name := Name,
+    app := App,
+    extension_version := Version,
+    rpc := Rpc,
+    lua := Lua,
+    routes := Routes
+}) ->
     io_lib:format(
-        "~s (~s, contract v~b): ~b rpc method(s), ~b lua namespace(s)",
-        [Name, App, Version, map_size(Rpc), map_size(Lua)]
+        "~s (~s, contract v~b): ~b rpc method(s), ~b lua namespace(s), ~b route(s)",
+        [Name, App, Version, map_size(Rpc), map_size(Lua), length(Routes)]
+    ).
+
+route_line(#{path := Path, method := Method, security := Security}) ->
+    io_lib:format(
+        "~ts ~ts (~s)",
+        [string:uppercase(atom_to_binary(Method, utf8)), Path, Security]
     ).
 
 %% Not an error: it is a legal state halfway through writing an extension.
-%% But an extension with neither seam is reachable by nobody - game logic
-%% calls game.<ns>.*, clients call rpc - so saying nothing would be worse.
-is_unreachable(#{rpc := Rpc, lua := Lua}) ->
-    map_size(Rpc) =:= 0 andalso map_size(Lua) =:= 0.
+%% But an extension with no seam at all is reachable by nobody - game logic
+%% calls game.<ns>.*, clients call rpc or a declared route - so saying
+%% nothing would be worse.
+is_unreachable(#{rpc := Rpc, lua := Lua, routes := Routes}) ->
+    map_size(Rpc) =:= 0 andalso map_size(Lua) =:= 0 andalso Routes =:= [].
 
 unreachable(#{app := App}) ->
     io_lib:format(
-        "~s declares neither rpc/0 nor lua/0, so nothing can call it: "
-        "game logic reaches an extension through game.<ns>.*, clients through rpc",
+        "~s declares neither rpc/0, lua/0 nor routes/0, so nothing can call it: "
+        "game logic reaches an extension through game.<ns>.*, clients through "
+        "rpc, HTTP callers through a declared route",
         [App]
     ).

--- a/src/ops/asobi_ops_extension.erl
+++ b/src/ops/asobi_ops_extension.erl
@@ -6,9 +6,11 @@ The ops plane's one extension seam: `/api/v1/ops/ext/:extension/:action`.
 action - `quests.define` was the first - had nowhere to put it. `ops/0` is
 that home, and this module is what makes it reachable.
 
-Extensions contribute no routes of their own. Core owns this one and dispatches
-every declared action behind it, exactly as it owns one WebSocket frame type
-and dispatches `rpc/0` behind that. The route table stays core's.
+Extensions contribute no routes of their own on this plane - `routes/0`
+declares player and webhook surfaces, never operator ones. Core owns this one
+route and dispatches every declared action behind it, exactly as it owns one
+WebSocket frame type and dispatches `rpc/0` behind that. The route table stays
+core's.
 
 ## What authorises
 

--- a/src/plugins/asobi_rate_limit_plugin.erl
+++ b/src/plugins/asobi_rate_limit_plugin.erl
@@ -79,17 +79,30 @@ select_limiter(Req) ->
     %% before the handler. register runs the password KDF and gets its own
     %% tighter bucket (asobi#157); it must match before the /auth/ prefix.
     case binary:split(cowboy_req:path(Req), ~"/", [global, trim_all]) of
-        [~"api", ~"v1", ~"auth", ~"register"] -> asobi_register_limiter;
+        [~"api", ~"v1", ~"auth", ~"register"] ->
+            asobi_register_limiter;
         %% Account erasure runs the KDF too, on a path nothing else serves.
-        [~"api", ~"v1", ~"players", ~"me", ~"erase"] -> asobi_erase_limiter;
-        [~"api", ~"v1", ~"auth" | _] -> asobi_auth_limiter;
-        [~"api", ~"v1", ~"iap" | _] -> asobi_iap_limiter;
+        [~"api", ~"v1", ~"players", ~"me", ~"erase"] ->
+            asobi_erase_limiter;
+        [~"api", ~"v1", ~"auth" | _] ->
+            asobi_auth_limiter;
+        [~"api", ~"v1", ~"iap" | _] ->
+            asobi_iap_limiter;
         %% The console login trades a shared secret for a session, so it is
         %% the one place in the deployment where guessing pays. It shares the
         %% auth bucket rather than getting its own: same threat, same shape,
         %% one fewer knob to leave unset.
-        [~"console", ~"session"] -> asobi_auth_limiter;
-        _ -> asobi_api_limiter
+        [~"console", ~"session"] ->
+            asobi_auth_limiter;
+        %% An extension route mounted `security => webhook` does signature
+        %% crypto per request instead of a token check, so tokenless traffic
+        %% there must not ride the 300/s api bucket. Reads the memoised
+        %% webhook path set - never triggers discovery on a request path.
+        Segments ->
+            case asobi_extensions:is_webhook_path(Segments) of
+                true -> asobi_webhook_limiter;
+                false -> asobi_api_limiter
+            end
     end.
 
 -ifdef(TEST).
@@ -143,6 +156,35 @@ select_limiter_test_() ->
             asobi_register_limiter, select_limiter(fake_req(#{path => ~"//api/v1/auth/register"}))
         )
     ].
+
+%% The webhook bucket only exists for mounted extension webhook routes, so
+%% this resolves a real fixture rather than faking the path table.
+webhook_limiter_test_() ->
+    {setup, fun install_webhook_fixture/0, fun uninstall_webhook_fixture/1, [
+        ?_assertEqual(
+            asobi_webhook_limiter, select_limiter(fake_req(#{path => ~"/api/v1/quests/webhook"}))
+        ),
+        %% The same extension's player route stays in the api bucket.
+        ?_assertEqual(
+            asobi_api_limiter, select_limiter(fake_req(#{path => ~"/api/v1/quests/board"}))
+        ),
+        %% Slash variants normalise onto the webhook bucket, like register's.
+        ?_assertEqual(
+            asobi_webhook_limiter,
+            select_limiter(fake_req(#{path => ~"/api/v1//quests/webhook/"}))
+        )
+    ]}.
+
+install_webhook_fixture() ->
+    asobi_extensions:reset(),
+    ok = asobi_fixture_app:install(asobi_fixture_quests, asobi_fixture_quests_extension, []),
+    _ = asobi_extensions:resolve(),
+    ok.
+
+uninstall_webhook_fixture(_) ->
+    asobi_fixture_app:uninstall(asobi_fixture_quests),
+    asobi_extensions:reset(),
+    ok.
 
 -define(PEER_IP, ~"198.51.100.7").
 

--- a/test/asobi_extension_routes_SUITE.erl
+++ b/test/asobi_extension_routes_SUITE.erl
@@ -18,7 +18,7 @@ list or a security callback goes wrong without any unit test noticing.
     the_global_plugin_chain_applies/1,
     an_unauthenticated_request_gets_the_core_refusal/1,
     a_webhook_route_needs_no_player_token/1,
-    an_absent_extension_route_is_an_unknown_route/1
+    the_404_discipline_is_path_level/1
 ]).
 
 -define(QUESTS, asobi_fixture_quests).
@@ -29,19 +29,28 @@ all() ->
         the_global_plugin_chain_applies,
         an_unauthenticated_request_gets_the_core_refusal,
         a_webhook_route_needs_no_player_token,
-        an_absent_extension_route_is_an_unknown_route
+        the_404_discipline_is_path_level
     ].
 
 %% The route table compiles inside Nova's boot, so unlike the RPC suite the
 %% fixture must be installed before the node starts - there is no memo to
 %% clear afterwards, a route either was mounted or was not. Another suite may
 %% have booted the node already; restarting nova is what recompiles the table
-%% (nova_app:prep_stop/1 closes the listener, so the port is free again).
+%% (nova_app:prep_stop/1 closes the listener, so the port is free again). If
+%% the boot then fails, the fixture must not stay loaded for whichever suite
+%% runs next.
 init_per_suite(Config) ->
     restart([
         fun() -> ok = asobi_fixture_app:install(?QUESTS, asobi_fixture_quests_extension, []) end
     ]),
-    asobi_test_helpers:start(Config).
+    try
+        asobi_test_helpers:start(Config)
+    catch
+        Class:Reason:Stack ->
+            asobi_fixture_app:uninstall(?QUESTS),
+            asobi_extensions:reset(),
+            erlang:raise(Class, Reason, Stack)
+    end.
 
 %% Restarted without the fixture so later suites compile a clean table.
 end_per_suite(Config) ->
@@ -108,17 +117,29 @@ a_webhook_route_needs_no_player_token(Config) ->
     ),
     ?assertEqual(200, nova_test:status(Resp)),
     ?assertEqual(#{~"received" => #{~"receipt" => ~"abc-123"}}, nova_test:json(Resp)),
+    %% The dedicated webhook bucket (limit 10), not the 300/s api one: the
+    %% remaining budget after one request gives the bucket away.
+    Remaining =
+        case nova_test:header("x-ratelimit-remaining", Resp) of
+            undefined -> ct:fail(missing_rate_limit_header);
+            Value -> list_to_integer(Value)
+        end,
+    ?assert(Remaining < 10),
     Config.
 
-%% The 404 discipline: a path the installed set never declared answers
-%% exactly as a path that has never meant anything - no status, header or
-%% body difference an outsider could use to map what is installed.
-an_absent_extension_route_is_an_unknown_route(Config) ->
+%% The 404 discipline is path-level: a path the installed set never declared
+%% answers 404 exactly as a path that never meant anything, while a
+%% wrong-method probe on a mounted path answers 405 with an allow header,
+%% as on any core route - method enumeration on declared paths is the
+%% accepted trade, not a leak this suite pretends is closed.
+the_404_discipline_is_path_level(Config) ->
     {ok, Resp} = nova_test:get("/api/v1/quests/undeclared", Config),
-    {ok, UnknownResp} = nova_test:get("/api/v1/never_a_route", Config),
     ?assertEqual(404, nova_test:status(Resp)),
-    ?assertEqual(nova_test:status(UnknownResp), nova_test:status(Resp)),
-    ?assertEqual(nova_test:body(UnknownResp), nova_test:body(Resp)),
+    {ok, WrongMethod} = nova_test:delete("/api/v1/quests/board", Config),
+    ?assertEqual(405, nova_test:status(WrongMethod)),
+    ?assertNotEqual(undefined, nova_test:header("allow", WrongMethod)),
+    {ok, CoreWrongMethod} = nova_test:delete("/api/v1/matches", Config),
+    ?assertEqual(nova_test:status(CoreWrongMethod), nova_test:status(WrongMethod)),
     Config.
 
 %% --- helpers (mirrors asobi_rpc_SUITE) ---

--- a/test/asobi_extension_routes_SUITE.erl
+++ b/test/asobi_extension_routes_SUITE.erl
@@ -1,0 +1,134 @@
+-module(asobi_extension_routes_SUITE).
+-moduledoc """
+The declared route seam, over a real server.
+
+Unit tests prove declaration, validation and the compiled table. This proves
+the wiring: a fixture extension's route serving through the running node, the
+player-token chain refusing exactly as it refuses on a core route, a webhook
+route open to a caller with no token, and an uninstalled extension's path
+answering as any unknown route does - which is where a route group, a plugin
+list or a security callback goes wrong without any unit test noticing.
+""".
+
+-include_lib("nova_test/include/nova_test.hrl").
+
+-export([all/0, init_per_suite/1, end_per_suite/1]).
+-export([
+    a_mounted_route_serves_authenticated_traffic/1,
+    the_global_plugin_chain_applies/1,
+    an_unauthenticated_request_gets_the_core_refusal/1,
+    a_webhook_route_needs_no_player_token/1,
+    an_absent_extension_route_is_an_unknown_route/1
+]).
+
+-define(QUESTS, asobi_fixture_quests).
+
+all() ->
+    [
+        a_mounted_route_serves_authenticated_traffic,
+        the_global_plugin_chain_applies,
+        an_unauthenticated_request_gets_the_core_refusal,
+        a_webhook_route_needs_no_player_token,
+        an_absent_extension_route_is_an_unknown_route
+    ].
+
+%% The route table compiles inside Nova's boot, so unlike the RPC suite the
+%% fixture must be installed before the node starts - there is no memo to
+%% clear afterwards, a route either was mounted or was not. Another suite may
+%% have booted the node already; restarting nova is what recompiles the table
+%% (nova_app:prep_stop/1 closes the listener, so the port is free again).
+init_per_suite(Config) ->
+    restart([
+        fun() -> ok = asobi_fixture_app:install(?QUESTS, asobi_fixture_quests_extension, []) end
+    ]),
+    asobi_test_helpers:start(Config).
+
+%% Restarted without the fixture so later suites compile a clean table.
+end_per_suite(Config) ->
+    restart([fun() -> asobi_fixture_app:uninstall(?QUESTS) end]),
+    _ = asobi_test_helpers:start(Config),
+    Config.
+
+%% The telemetry handler survives an application stop - telemetry itself
+%% keeps running - and `asobi_telemetry:setup/0` refuses a duplicate id, so
+%% a restart in the same VM must detach it first (ensure_all_started because
+%% this suite may also be the first boot, with no telemetry to ask). Only
+%% this suite restarts.
+restart(Steps) ->
+    _ = application:stop(asobi),
+    _ = application:stop(nova),
+    {ok, _} = application:ensure_all_started(telemetry),
+    _ = telemetry:detach(~"asobi-metrics-logger"),
+    _ = [Step() || Step <- Steps],
+    asobi_extensions:reset(),
+    ok.
+
+a_mounted_route_serves_authenticated_traffic(Config) ->
+    {PlayerId, Token} = register_player(~"extroute", Config),
+    {ok, Resp} = nova_test:get(
+        "/api/v1/quests/board",
+        #{headers => [{~"authorization", <<"Bearer ", Token/binary>>}]},
+        Config
+    ),
+    ?assertEqual(200, nova_test:status(Resp)),
+    ?assertEqual(#{~"player_id" => PlayerId, ~"quests" => []}, nova_test:json(Resp)),
+    Config.
+
+%% The mount sits inside core's global plugin chain and lists `options` on
+%% every entry, exactly as core routes do: a tokenless CORS preflight is
+%% intercepted by the global plugin and answers 2xx with the CORS headers,
+%% never 401 from the security callback or 405 from the router.
+the_global_plugin_chain_applies(Config) ->
+    Opts = #{
+        headers => [
+            {~"origin", ~"http://localhost:3000"},
+            {~"access-control-request-method", ~"GET"}
+        ]
+    },
+    {ok, Resp} = nova_test:request(options, "/api/v1/quests/board", Opts, Config),
+    Status = nova_test:status(Resp),
+    ?assert(Status >= 200 andalso Status < 300),
+    ?assertNotEqual(undefined, nova_test:header("access-control-allow-origin", Resp)),
+    Config.
+
+%% `security => player` is core's own chain, not one shaped like it: a bare
+%% request is refused with the same status a core route gives it.
+an_unauthenticated_request_gets_the_core_refusal(Config) ->
+    {ok, Resp} = nova_test:get("/api/v1/quests/board", Config),
+    {ok, CoreResp} = nova_test:get("/api/v1/matches", Config),
+    ?assertEqual(nova_test:status(CoreResp), nova_test:status(Resp)),
+    ?assertEqual(401, nova_test:status(Resp)),
+    Config.
+
+a_webhook_route_needs_no_player_token(Config) ->
+    {ok, Resp} = nova_test:post(
+        "/api/v1/quests/webhook",
+        #{json => #{~"receipt" => ~"abc-123"}},
+        Config
+    ),
+    ?assertEqual(200, nova_test:status(Resp)),
+    ?assertEqual(#{~"received" => #{~"receipt" => ~"abc-123"}}, nova_test:json(Resp)),
+    Config.
+
+%% The 404 discipline: a path the installed set never declared answers
+%% exactly as a path that has never meant anything - no status, header or
+%% body difference an outsider could use to map what is installed.
+an_absent_extension_route_is_an_unknown_route(Config) ->
+    {ok, Resp} = nova_test:get("/api/v1/quests/undeclared", Config),
+    {ok, UnknownResp} = nova_test:get("/api/v1/never_a_route", Config),
+    ?assertEqual(404, nova_test:status(Resp)),
+    ?assertEqual(nova_test:status(UnknownResp), nova_test:status(Resp)),
+    ?assertEqual(nova_test:body(UnknownResp), nova_test:body(Resp)),
+    Config.
+
+%% --- helpers (mirrors asobi_rpc_SUITE) ---
+
+register_player(Suffix, Config) ->
+    Username = <<"extr_", Suffix/binary, "_", (asobi_id:rand_suffix(4))/binary>>,
+    {ok, Resp} = nova_test:post(
+        "/api/v1/auth/register",
+        #{json => #{~"username" => Username, ~"password" => ~"testpass123"}},
+        Config
+    ),
+    #{~"player_id" := PlayerId, ~"access_token" := Token} = nova_test:json(Resp),
+    {PlayerId, Token}.

--- a/test/extensions/asobi_extension_reserved_tests.erl
+++ b/test/extensions/asobi_extension_reserved_tests.erl
@@ -59,6 +59,36 @@ http_paths_come_from_the_core_route_table_test() ->
     ],
     ?assertNot(lists:member(~"/api/v1/quests/board", Reserved)).
 
+%% The compiled dispatch is [nova, asobi | nova_apps] and the first insert of
+%% a path wins, so a co-mounted app's paths - nova_resilience answers the
+%% k8s probes in both shipped configs - must be as unclaimable as core's own.
+http_paths_cover_every_co_mounted_app_test() ->
+    application:set_env(nova, bootstrap_application, asobi),
+    application:set_env(asobi, nova_apps, [nova_resilience]),
+    try
+        #{http := Reserved} = asobi_extension_reserved:namespaces(),
+        [?assert(lists:member(P, Reserved)) || P <- [~"/health", ~"/ready", ~"/live"]],
+        %% nova_resilience mounts under its configured prefix, and the
+        %% reserved set derives through the same routes/1 call, so the two
+        %% cannot disagree about where the probes live.
+        application:set_env(nova_resilience, health_prefix, ~"/probes"),
+        #{http := Prefixed} = asobi_extension_reserved:namespaces(),
+        ?assert(lists:member(~"/probes/health", Prefixed)),
+        ?assertNot(lists:member(~"/health", Prefixed))
+    after
+        application:unset_env(nova_resilience, health_prefix),
+        application:unset_env(asobi, nova_apps),
+        application:unset_env(nova, bootstrap_application)
+    end.
+
+%% A policy list, not a derivation: which plane roots are closed to
+%% extensions outright is a judgment the route table cannot express.
+the_privileged_plane_prefixes_test() ->
+    ?assertEqual(
+        [~"/api/v1/ops", ~"/api/v1/auth", ~"/api/v1/iap", ~"/console", ~"/ws"],
+        asobi_extension_reserved:route_prefixes()
+    ).
+
 %% An RPC prefix and an error-code domain are the same token by construction,
 %% so core's closed code set reserves the prefixes too.
 rpc_prefixes_cover_error_domains_and_lua_test() ->

--- a/test/extensions/asobi_extension_reserved_tests.erl
+++ b/test/extensions/asobi_extension_reserved_tests.erl
@@ -2,8 +2,8 @@
 
 -include_lib("eunit/include/eunit.hrl").
 
-kinds_are_the_four_namespaces_owns_declares_test() ->
-    ?assertEqual([lua, queues, rpc, tables], lists:sort(asobi_extension_reserved:kinds())).
+kinds_are_the_five_namespaces_owns_declares_test() ->
+    ?assertEqual([http, lua, queues, rpc, tables], lists:sort(asobi_extension_reserved:kinds())).
 
 %% Derived from asobi_lua_surface, the one place the `game.*` vocabulary is
 %% written down, so adding a core namespace there reserves it here with no
@@ -40,6 +40,24 @@ seasons_is_no_longer_reserved_test() ->
 queues_come_from_core_shigoto_workers_test() ->
     #{queues := Reserved} = asobi_extension_reserved:namespaces(),
     ?assertEqual([asobi_broadcast_worker:queue()], Reserved).
+
+%% Derived from core's own route table - `asobi_router:core_routes/0`, the
+%% groups without the extension mounts - so a route core gains is reserved
+%% here with no second edit, and resolving inside Nova's boot cannot re-enter
+%% the resolver to read it.
+http_paths_come_from_the_core_route_table_test() ->
+    #{http := Reserved} = asobi_extension_reserved:namespaces(),
+    [
+        ?assert(lists:member(Path, Reserved))
+     || Path <- [
+            ~"/api/v1/matches/:id",
+            ~"/api/v1/auth/register",
+            ~"/api/v1/ops/ext/:extension/:action",
+            ~"/console",
+            ~"/ws"
+        ]
+    ],
+    ?assertNot(lists:member(~"/api/v1/quests/board", Reserved)).
 
 %% An RPC prefix and an error-code domain are the same token by construction,
 %% so core's closed code set reserves the prefixes too.

--- a/test/extensions/asobi_extension_routes_tests.erl
+++ b/test/extensions/asobi_extension_routes_tests.erl
@@ -17,10 +17,15 @@ routes_test_() ->
         fun a_core_path_is_refused/0,
         fun a_binding_over_a_core_binding_is_refused/0,
         fun a_literal_under_a_core_binding_is_refused/0,
+        fun a_binding_diverging_inside_a_core_namespace_is_refused/0,
+        fun a_same_named_binding_extension_is_not_interference/0,
+        fun a_privileged_plane_prefix_is_refused/0,
+        fun a_co_mounted_apps_route_is_refused/0,
         fun the_ws_and_console_paths_are_core_owned/0,
         fun resolve_raises_on_a_route_collision/0,
         fun resolve_raises_on_a_core_path_claim/0,
         fun a_route_handler_must_have_arity_one/0,
+        fun a_route_handler_must_exist/0,
         fun a_route_must_carry_a_real_method/0,
         fun a_route_must_carry_a_real_security/0,
         fun a_path_must_be_rooted/0,
@@ -29,10 +34,14 @@ routes_test_() ->
         fun a_binding_must_be_an_identifier/0,
         fun one_path_may_carry_several_methods/0,
         fun the_same_path_and_method_twice_is_refused/0,
+        fun mixed_security_on_one_path_is_refused/0,
         fun overlapping_paths_in_one_manifest_are_refused/0,
+        fun an_owned_http_token_must_be_a_path/0,
+        fun the_guide_example_passes_check/0,
         fun routes_must_be_a_list/0,
         fun a_player_route_mounts_under_the_player_chain/0,
         fun a_webhook_route_mounts_without_the_player_chain/0,
+        fun one_path_serves_each_declared_method/0,
         fun an_absent_extensions_routes_are_not_in_the_table/0
     ]}.
 
@@ -123,6 +132,94 @@ a_literal_under_a_core_binding_is_refused() ->
     Text = describe_text(Problems),
     ?assertNotEqual(nomatch, binary:match(Text, ~"/api/v1/matches/:id")).
 
+%% The three empirically verified attack shapes: a pattern diverging from
+%% core's table at a binding at ANY depth breaks core routes, because
+%% routing_tree keys nodes by segment text, prepends on insert and commits
+%% to the first matching sibling without backtracking - so equal-length
+%% overlap alone would let `/players/:someone/detail` swallow lookups meant
+%% for `/players/:id` and `/players/me/erase`.
+a_binding_diverging_inside_a_core_namespace_is_refused() ->
+    tunable(#{routes => [route(~"/api/v1/players/:someone/detail")]}),
+    Problems = check_problems(),
+    ?assert(
+        lists:member(
+            {reserved_route, ~"/api/v1/players/:someone/detail", ~"/api/v1/players/:id", ?TUNABLE},
+            Problems
+        )
+    ),
+    ?assert(
+        lists:member(
+            {reserved_route, ~"/api/v1/players/:someone/detail", ~"/api/v1/players/me/erase",
+                ?TUNABLE},
+            Problems
+        )
+    ),
+    retune(#{routes => [route(~"/api/v1/matches/:anything/extra")]}),
+    ?assert(
+        lists:member(
+            {reserved_route, ~"/api/v1/matches/:anything/extra", ~"/api/v1/matches/live", ?TUNABLE},
+            check_problems()
+        )
+    ).
+
+%% A pattern extending a core route through the binding's exact name descends
+%% into the same tree node and breaks nothing: refusing it would ban safe
+%% shapes for no gain.
+a_same_named_binding_extension_is_not_interference() ->
+    tunable(#{routes => [route(~"/api/v1/saves/:slot/meta")]}),
+    ?assertMatch({ok, [_]}, asobi_extensions:check()).
+
+%% The plane prefixes refuse whole subtrees: an open webhook inside the
+%% operator, console or auth plane is refused whatever it resolves to, and
+%% separately from any route it would collide with.
+a_privileged_plane_prefix_is_refused() ->
+    tunable(#{routes => [route(~"/api/v1/ops/players/:someone/notes")]}),
+    ?assert(
+        lists:member(
+            {reserved_prefix, ~"/api/v1/ops/players/:someone/notes", ~"/api/v1/ops", ?TUNABLE},
+            check_problems()
+        )
+    ),
+    retune(#{
+        routes => [
+            route(~"/console/hook", #{
+                method => post,
+                security => webhook,
+                mfa => {asobi_fixture_quests_controller, webhook, 1}
+            })
+        ]
+    }),
+    ?assert(
+        lists:member({reserved_prefix, ~"/console/hook", ~"/console", ?TUNABLE}, check_problems())
+    ),
+    retune(#{routes => [route(~"/api/v1/auth/sso")]}),
+    ?assert(
+        lists:member(
+            {reserved_prefix, ~"/api/v1/auth/sso", ~"/api/v1/auth", ?TUNABLE}, check_problems()
+        )
+    ).
+
+%% The compiled dispatch is [nova, asobi | nova_apps], both shipped configs
+%% co-mount nova_resilience, and in routing_tree the first insert of a path
+%% wins - so a claim on /health would silently hijack the k8s probes. The
+%% reserved set derives from every co-mounted table, not only asobi's.
+a_co_mounted_apps_route_is_refused() ->
+    application:set_env(nova, bootstrap_application, asobi),
+    application:set_env(asobi, nova_apps, [nova_resilience]),
+    try
+        tunable(#{routes => [route(~"/health")]}),
+        ?assert(
+            lists:member({reserved_route, ~"/health", ~"/health", ?TUNABLE}, check_problems())
+        ),
+        retune(#{routes => [route(~"/:anything")]}),
+        ?assert(
+            lists:member({reserved_route, ~"/:anything", ~"/health", ?TUNABLE}, check_problems())
+        )
+    after
+        application:unset_env(asobi, nova_apps),
+        application:unset_env(nova, bootstrap_application)
+    end.
+
 the_ws_and_console_paths_are_core_owned() ->
     tunable(#{routes => [route(~"/ws"), route(~"/console")]}),
     Problems = check_problems(),
@@ -154,6 +251,34 @@ a_route_handler_must_have_arity_one() ->
         ],
         check_problems()
     ).
+
+%% A handler that does not exist is a 500 on first request unless refused
+%% here: both the missing module and the missing export.
+a_route_handler_must_exist() ->
+    tunable(#{
+        routes => [route(~"/api/v1/tunable/a", #{mfa => {asobi_no_such_module, board, 1}})]
+    }),
+    ?assertMatch(
+        [
+            {bad_manifest, ?TUNABLE, _,
+                {routes, ~"mfa does not name an exported function", ~"/api/v1/tunable/a"}}
+        ],
+        check_problems()
+    ),
+    retune(#{
+        routes => [
+            route(~"/api/v1/tunable/a", #{mfa => {asobi_fixture_quests_controller, nope, 1}})
+        ]
+    }),
+    ?assertMatch(
+        [
+            {bad_manifest, ?TUNABLE, _,
+                {routes, ~"mfa does not name an exported function", ~"/api/v1/tunable/a"}}
+        ],
+        check_problems()
+    ),
+    retune(#{routes => [route(~"/api/v1/tunable/a")]}),
+    ?assertMatch({ok, [_]}, asobi_extensions:check()).
 
 a_route_must_carry_a_real_method() ->
     tunable(#{routes => [route(~"/api/v1/tunable/a", #{method => patch})]}),
@@ -204,9 +329,9 @@ a_path_must_have_no_empty_segments() ->
      || Path <- [~"/api//tunable", ~"/api/v1/tunable/"]
     ].
 
-%% routing_tree does no dot-segment normalisation, so this table declares no
-%% route form that could carry one - the console group's own rule, held here
-%% for every extension.
+%% Literals are RFC 3986 unreserved minus the dot (routing_tree does no
+%% dot-segment normalisation - the console group's own rule, held here for
+%% every extension), so a segment no client can send never mounts.
 a_path_segment_must_be_clean() ->
     tunable(#{}),
     [
@@ -217,7 +342,17 @@ a_path_segment_must_be_clean() ->
                 check_problems()
             )
         end
-     || Path <- [~"/api/v1/../tunable", ~"/api/v1/tun?able", ~"/api/v1/tun#able", ~"/a/b%20c"]
+     || Path <- [
+            ~"/api/v1/../tunable",
+            ~"/api/v1/tun?able",
+            ~"/api/v1/tun#able",
+            ~"/a/b%20c",
+            ~"/api/v1/tuna ble",
+            ~"/api/v1/tuna\tble",
+            ~"/api/v1/tunable/*",
+            ~"/api/v1/[abc]",
+            ~"/api/v1/tunabl\né"
+        ]
     ].
 
 a_binding_must_be_an_identifier() ->
@@ -230,7 +365,14 @@ a_binding_must_be_an_identifier() ->
                 check_problems()
             )
         end
-     || Path <- [~"/api/v1/tunable/:", ~"/api/v1/tunable/:1st", ~"/api/v1/tunable/x:y"]
+     || Path <- [
+            ~"/api/v1/tunable/:",
+            ~"/api/v1/tunable/:1st",
+            ~"/api/v1/tunable/x:y",
+            %% `$` alone matches before a trailing newline, so without
+            %% dollar_endonly `:id\n` is a valid binding name.
+            ~"/api/v1/tunable/:id\n"
+        ]
     ].
 
 one_path_may_carry_several_methods() ->
@@ -245,8 +387,8 @@ one_path_may_carry_several_methods() ->
 the_same_path_and_method_twice_is_refused() ->
     tunable(#{
         routes => [
-            route(~"/api/v1/tunable/a", #{mfa => {tunable_controller, a, 1}}),
-            route(~"/api/v1/tunable/a", #{mfa => {tunable_controller, b, 1}})
+            route(~"/api/v1/tunable/a", #{mfa => {asobi_fixture_quests_controller, board, 1}}),
+            route(~"/api/v1/tunable/a", #{mfa => {asobi_fixture_quests_controller, webhook, 1}})
         ]
     }),
     ?assertMatch(
@@ -257,7 +399,28 @@ the_same_path_and_method_twice_is_refused() ->
         check_problems()
     ).
 
-%% Refusing in-manifest overlap is what makes declaration order irrelevant:
+%% A path under two chains would route OPTIONS to whichever entry mounted
+%% first; a path has exactly one security class instead.
+mixed_security_on_one_path_is_refused() ->
+    tunable(#{
+        routes => [
+            route(~"/api/v1/tunable/a", #{method => get, security => player}),
+            route(~"/api/v1/tunable/a", #{
+                method => post,
+                security => webhook,
+                mfa => {asobi_fixture_quests_controller, webhook, 1}
+            })
+        ]
+    }),
+    ?assertMatch(
+        [
+            {bad_manifest, ?TUNABLE, _,
+                {routes, ~"one path must carry exactly one security class", ~"/api/v1/tunable/a"}}
+        ],
+        check_problems()
+    ).
+
+%% Refusing in-manifest collision is what makes declaration order irrelevant:
 %% the asobi#326 literal-behind-binding trap cannot be declared at all.
 overlapping_paths_in_one_manifest_are_refused() ->
     tunable(#{
@@ -269,12 +432,61 @@ overlapping_paths_in_one_manifest_are_refused() ->
     ?assertMatch(
         [
             {bad_manifest, ?TUNABLE, _,
-                {routes, ~"two entries declare paths that match the same requests", {
+                {routes, ~"two entries declare paths that collide in the route table", {
                     ~"/api/v1/tunable/:key", ~"/api/v1/tunable/live"
                 }}}
         ],
         check_problems()
+    ),
+    %% Divergence at a binding at a deeper level is the same trap.
+    retune(#{
+        routes => [
+            route(~"/api/v1/tunable/:key"),
+            route(~"/api/v1/tunable/live/summary", #{
+                mfa => {asobi_fixture_quests_controller, webhook, 1}
+            })
+        ]
+    }),
+    ?assertMatch(
+        [
+            {bad_manifest, ?TUNABLE, _,
+                {routes, ~"two entries declare paths that collide in the route table", _}}
+        ],
+        check_problems()
     ).
+
+%% A token-style entry in owns().http reserves nothing - claims compare as
+%% paths - so it is a typo, not a reservation.
+an_owned_http_token_must_be_a_path() ->
+    tunable(#{owns => #{http => [~"quests"]}}),
+    ?assertMatch(
+        [
+            {bad_manifest, ?TUNABLE, _,
+                {owns, ~"http tokens must be /-rooted route paths", ~"quests"}}
+        ],
+        check_problems()
+    ).
+
+%% The worked example in guides/extensions.md, verbatim: documentation the
+%% validator refuses is worse than no documentation.
+the_guide_example_passes_check() ->
+    tunable(#{
+        routes => [
+            #{
+                path => ~"/api/v1/quests/board",
+                method => get,
+                mfa => {asobi_quests_controller, board, 1},
+                security => player
+            },
+            #{
+                path => ~"/api/v1/quests/webhook/steam",
+                method => post,
+                mfa => {asobi_quests_controller, steam_notification, 1},
+                security => webhook
+            }
+        ]
+    }),
+    ?assertMatch({ok, [_]}, asobi_extensions:check()).
 
 routes_must_be_a_list() ->
     tunable(#{routes => #{~"/api/v1/tunable" => get}}),
@@ -309,8 +521,32 @@ a_webhook_route_mounts_without_the_player_chain() ->
     ?assertEqual(false, maps:get(security, Group)),
     ?assertNot(is_map_key(plugins, Group)).
 
-%% The 404 discipline: an uninstalled extension's paths are simply not in the
-%% table, indistinguishable from paths that never meant anything.
+%% One path under several methods is core's own pattern; each method must
+%% dispatch to its own declared handler through the compiled table.
+one_path_serves_each_declared_method() ->
+    tunable(#{
+        routes => [
+            route(~"/api/v1/tunable/a", #{method => get}),
+            route(~"/api/v1/tunable/a", #{
+                method => put, mfa => {asobi_fixture_quests_controller, webhook, 1}
+            })
+        ]
+    }),
+    _ = asobi_extensions:resolve(),
+    Dispatch = nova_router:compile([asobi]),
+    ?assertEqual(
+        {ok, #{}, fun asobi_fixture_quests_controller:board/1},
+        resolve_route(Dispatch, ~"/api/v1/tunable/a", ~"GET")
+    ),
+    ?assertEqual(
+        {ok, #{}, fun asobi_fixture_quests_controller:webhook/1},
+        resolve_route(Dispatch, ~"/api/v1/tunable/a", ~"PUT")
+    ).
+
+%% The 404 discipline is path-level: an uninstalled extension's paths are
+%% simply not in the table. Method behaviour on mounted paths follows HTTP
+%% (405 + allow) and is asserted where a real server runs, in
+%% asobi_extension_routes_SUITE.
 an_absent_extensions_routes_are_not_in_the_table() ->
     _ = asobi_extensions:resolve(),
     Dispatch = nova_router:compile([asobi]),
@@ -334,9 +570,16 @@ retune(Manifest) ->
 route(Path) ->
     route(Path, #{}).
 
+%% A real exported handler: routes are handler-existence-checked, so a fake
+%% module would fail validation before the property under test runs.
 route(Path, Overrides) ->
     maps:merge(
-        #{path => Path, method => get, mfa => {tunable_controller, a, 1}, security => player},
+        #{
+            path => Path,
+            method => get,
+            mfa => {asobi_fixture_quests_controller, board, 1},
+            security => player
+        },
         Overrides
     ).
 

--- a/test/extensions/asobi_extension_routes_tests.erl
+++ b/test/extensions/asobi_extension_routes_tests.erl
@@ -1,0 +1,380 @@
+-module(asobi_extension_routes_tests).
+
+-include_lib("eunit/include/eunit.hrl").
+-include_lib("nova/include/nova_router.hrl").
+
+-define(QUESTS, asobi_fixture_quests).
+-define(TUNABLE, asobi_fixture_tunable).
+
+routes_test_() ->
+    {foreach, fun setup/0, fun cleanup/1, [
+        fun a_declared_route_is_derived_as_an_http_claim/0,
+        fun a_route_outside_the_owned_set_is_refused/0,
+        fun a_reservation_without_a_route_is_legal/0,
+        fun two_extensions_one_path/0,
+        fun two_extensions_overlapping_bindings/0,
+        fun a_reservation_collides_like_a_route/0,
+        fun a_core_path_is_refused/0,
+        fun a_binding_over_a_core_binding_is_refused/0,
+        fun a_literal_under_a_core_binding_is_refused/0,
+        fun the_ws_and_console_paths_are_core_owned/0,
+        fun resolve_raises_on_a_route_collision/0,
+        fun resolve_raises_on_a_core_path_claim/0,
+        fun a_route_handler_must_have_arity_one/0,
+        fun a_route_must_carry_a_real_method/0,
+        fun a_route_must_carry_a_real_security/0,
+        fun a_path_must_be_rooted/0,
+        fun a_path_must_have_no_empty_segments/0,
+        fun a_path_segment_must_be_clean/0,
+        fun a_binding_must_be_an_identifier/0,
+        fun one_path_may_carry_several_methods/0,
+        fun the_same_path_and_method_twice_is_refused/0,
+        fun overlapping_paths_in_one_manifest_are_refused/0,
+        fun routes_must_be_a_list/0,
+        fun a_player_route_mounts_under_the_player_chain/0,
+        fun a_webhook_route_mounts_without_the_player_chain/0,
+        fun an_absent_extensions_routes_are_not_in_the_table/0
+    ]}.
+
+setup() ->
+    asobi_extensions:reset(),
+    asobi_fixture_tunable_extension:clear(),
+    ok.
+
+cleanup(_) ->
+    _ = [asobi_fixture_app:uninstall(A) || A <- [?QUESTS, ?TUNABLE]],
+    asobi_fixture_tunable_extension:clear(),
+    asobi_extensions:reset(),
+    ok.
+
+%% --- Claims and the owned set ---
+
+a_declared_route_is_derived_as_an_http_claim() ->
+    install_quests(),
+    {ok, [Extension]} = asobi_extensions:check(),
+    ?assertMatch(#{routes := [_, _]}, Extension).
+
+%% owns().http is the closed-set assertion, exactly as owns().queues is: name
+%% the kind and anything declared outside it is a typo or a land grab.
+a_route_outside_the_owned_set_is_refused() ->
+    tunable(#{
+        owns => #{http => [~"/api/v1/tunable/a"]},
+        routes => [route(~"/api/v1/tunable/b")]
+    }),
+    ?assert(
+        lists:member({undeclared_claim, http, ~"/api/v1/tunable/b", ?TUNABLE}, check_problems())
+    ).
+
+a_reservation_without_a_route_is_legal() ->
+    tunable(#{owns => #{http => [~"/api/v1/tunable/coming_soon"]}}),
+    ?assertMatch({ok, [_]}, asobi_extensions:check()).
+
+%% --- Collisions between extensions ---
+
+two_extensions_one_path() ->
+    install_quests(),
+    tunable(#{routes => [route(~"/api/v1/quests/board")]}),
+    assert_route_conflict(~"/api/v1/quests/board", ~"/api/v1/quests/board").
+
+%% The comparison is structural: a binding and a literal are different tokens
+%% and one claim, so token equality can never be the mechanism here.
+two_extensions_overlapping_bindings() ->
+    install_quests(),
+    tunable(#{routes => [route(~"/api/v1/quests/:anything")]}),
+    assert_route_conflict(~"/api/v1/quests/board", ~"/api/v1/quests/:anything").
+
+%% A path in owns().http with no route behind it still reserves: exclusivity
+%% is the point of a reservation.
+a_reservation_collides_like_a_route() ->
+    install_quests(),
+    tunable(#{owns => #{http => [~"/api/v1/quests/webhook"]}}),
+    assert_route_conflict(~"/api/v1/quests/webhook", ~"/api/v1/quests/webhook").
+
+%% --- Core's own table ---
+
+a_core_path_is_refused() ->
+    tunable(#{routes => [route(~"/api/v1/matches")]}),
+    ?assert(
+        lists:member(
+            {reserved_route, ~"/api/v1/matches", ~"/api/v1/matches", ?TUNABLE}, check_problems()
+        )
+    ).
+
+a_binding_over_a_core_binding_is_refused() ->
+    tunable(#{routes => [route(~"/api/v1/matches/:anything")]}),
+    ?assert(
+        lists:member(
+            {reserved_route, ~"/api/v1/matches/:anything", ~"/api/v1/matches/:id", ?TUNABLE},
+            check_problems()
+        )
+    ).
+
+%% The shadowing case token equality can never see: a literal that some
+%% request to a core binding would have reached.
+a_literal_under_a_core_binding_is_refused() ->
+    tunable(#{routes => [route(~"/api/v1/matches/anything")]}),
+    Problems = check_problems(),
+    ?assert(
+        lists:member(
+            {reserved_route, ~"/api/v1/matches/anything", ~"/api/v1/matches/:id", ?TUNABLE},
+            Problems
+        )
+    ),
+    Text = describe_text(Problems),
+    ?assertNotEqual(nomatch, binary:match(Text, ~"/api/v1/matches/:id")).
+
+the_ws_and_console_paths_are_core_owned() ->
+    tunable(#{routes => [route(~"/ws"), route(~"/console")]}),
+    Problems = check_problems(),
+    ?assert(lists:member({reserved_route, ~"/ws", ~"/ws", ?TUNABLE}, Problems)),
+    ?assert(lists:member({reserved_route, ~"/console", ~"/console", ?TUNABLE}, Problems)).
+
+%% --- Boot refusal: the backstop raises exactly as the other kinds do ---
+
+resolve_raises_on_a_route_collision() ->
+    install_quests(),
+    tunable(#{routes => [route(~"/api/v1/quests/board")]}),
+    ?assertError({asobi_extensions, _}, asobi_extensions:resolve()).
+
+resolve_raises_on_a_core_path_claim() ->
+    tunable(#{routes => [route(~"/api/v1/players/:someone")]}),
+    ?assertError({asobi_extensions, _}, asobi_extensions:resolve()).
+
+%% --- Manifest shape ---
+
+%% A route handler is a Nova controller, applied as Module:Function(Req) -
+%% arity 1, unlike the rpc/ops seams' 2.
+a_route_handler_must_have_arity_one() ->
+    tunable(#{routes => [route(~"/api/v1/tunable/a", #{mfa => {tunable_controller, a, 2}})]}),
+    ?assertMatch(
+        [
+            {bad_manifest, ?TUNABLE, _,
+                {routes, ~"a route handler is a Nova controller: mfa must be {Module, Function, 1}",
+                    ~"/api/v1/tunable/a"}}
+        ],
+        check_problems()
+    ).
+
+a_route_must_carry_a_real_method() ->
+    tunable(#{routes => [route(~"/api/v1/tunable/a", #{method => patch})]}),
+    ?assertMatch(
+        [{bad_manifest, ?TUNABLE, _, {routes, _, ~"/api/v1/tunable/a"}}],
+        check_problems()
+    ).
+
+a_route_must_carry_a_real_security() ->
+    tunable(#{routes => [route(~"/api/v1/tunable/a", #{security => admin})]}),
+    ?assertMatch(
+        [{bad_manifest, ?TUNABLE, _, {routes, _, ~"/api/v1/tunable/a"}}],
+        check_problems()
+    ),
+    retune(#{routes => [route(~"/api/v1/tunable/a", #{security => webhook})]}),
+    ?assertMatch({ok, [_]}, asobi_extensions:check()).
+
+a_path_must_be_rooted() ->
+    tunable(#{}),
+    [
+        begin
+            retune(#{routes => [route(Path)]}),
+            ?assertMatch(
+                [
+                    {bad_manifest, ?TUNABLE, _,
+                        {routes,
+                            ~"path must be /-rooted with non-empty literal or :binding segments",
+                            Path}}
+                ],
+                check_problems()
+            )
+        end
+     || Path <- [~"api/v1/tunable", ~"", ~"/"]
+    ],
+    retune(#{routes => [route(~"/api/v1/tunable/a")]}),
+    ?assertMatch({ok, [_]}, asobi_extensions:check()).
+
+a_path_must_have_no_empty_segments() ->
+    tunable(#{}),
+    [
+        begin
+            retune(#{routes => [route(Path)]}),
+            ?assertMatch(
+                [{bad_manifest, ?TUNABLE, _, {routes, _, Path}}],
+                check_problems()
+            )
+        end
+     || Path <- [~"/api//tunable", ~"/api/v1/tunable/"]
+    ].
+
+%% routing_tree does no dot-segment normalisation, so this table declares no
+%% route form that could carry one - the console group's own rule, held here
+%% for every extension.
+a_path_segment_must_be_clean() ->
+    tunable(#{}),
+    [
+        begin
+            retune(#{routes => [route(Path)]}),
+            ?assertMatch(
+                [{bad_manifest, ?TUNABLE, _, {routes, _, Path}}],
+                check_problems()
+            )
+        end
+     || Path <- [~"/api/v1/../tunable", ~"/api/v1/tun?able", ~"/api/v1/tun#able", ~"/a/b%20c"]
+    ].
+
+a_binding_must_be_an_identifier() ->
+    tunable(#{}),
+    [
+        begin
+            retune(#{routes => [route(Path)]}),
+            ?assertMatch(
+                [{bad_manifest, ?TUNABLE, _, {routes, _, Path}}],
+                check_problems()
+            )
+        end
+     || Path <- [~"/api/v1/tunable/:", ~"/api/v1/tunable/:1st", ~"/api/v1/tunable/x:y"]
+    ].
+
+one_path_may_carry_several_methods() ->
+    tunable(#{
+        routes => [
+            route(~"/api/v1/tunable/a", #{method => get}),
+            route(~"/api/v1/tunable/a", #{method => put})
+        ]
+    }),
+    ?assertMatch({ok, [_]}, asobi_extensions:check()).
+
+the_same_path_and_method_twice_is_refused() ->
+    tunable(#{
+        routes => [
+            route(~"/api/v1/tunable/a", #{mfa => {tunable_controller, a, 1}}),
+            route(~"/api/v1/tunable/a", #{mfa => {tunable_controller, b, 1}})
+        ]
+    }),
+    ?assertMatch(
+        [
+            {bad_manifest, ?TUNABLE, _,
+                {routes, ~"two entries serve the same path and method", ~"/api/v1/tunable/a"}}
+        ],
+        check_problems()
+    ).
+
+%% Refusing in-manifest overlap is what makes declaration order irrelevant:
+%% the asobi#326 literal-behind-binding trap cannot be declared at all.
+overlapping_paths_in_one_manifest_are_refused() ->
+    tunable(#{
+        routes => [
+            route(~"/api/v1/tunable/:key"),
+            route(~"/api/v1/tunable/live")
+        ]
+    }),
+    ?assertMatch(
+        [
+            {bad_manifest, ?TUNABLE, _,
+                {routes, ~"two entries declare paths that match the same requests", {
+                    ~"/api/v1/tunable/:key", ~"/api/v1/tunable/live"
+                }}}
+        ],
+        check_problems()
+    ).
+
+routes_must_be_a_list() ->
+    tunable(#{routes => #{~"/api/v1/tunable" => get}}),
+    ?assertMatch(
+        [{bad_manifest, ?TUNABLE, _, {routes, ~"must be a list of route entries", _}}],
+        check_problems()
+    ).
+
+%% --- Mounting ---
+
+a_player_route_mounts_under_the_player_chain() ->
+    install_quests(),
+    _ = asobi_extensions:resolve(),
+    Dispatch = nova_router:compile([asobi]),
+    ?assertEqual(
+        {ok, #{}, fun asobi_fixture_quests_controller:board/1},
+        resolve_route(Dispatch, ~"/api/v1/quests/board", ~"GET")
+    ),
+    [Group] = groups_serving(~"/api/v1/quests/board"),
+    ?assertEqual(fun asobi_auth_plugin:verify/1, maps:get(security, Group)),
+    ?assertNot(is_map_key(plugins, Group)).
+
+a_webhook_route_mounts_without_the_player_chain() ->
+    install_quests(),
+    _ = asobi_extensions:resolve(),
+    Dispatch = nova_router:compile([asobi]),
+    ?assertEqual(
+        {ok, #{}, fun asobi_fixture_quests_controller:webhook/1},
+        resolve_route(Dispatch, ~"/api/v1/quests/webhook", ~"POST")
+    ),
+    [Group] = groups_serving(~"/api/v1/quests/webhook"),
+    ?assertEqual(false, maps:get(security, Group)),
+    ?assertNot(is_map_key(plugins, Group)).
+
+%% The 404 discipline: an uninstalled extension's paths are simply not in the
+%% table, indistinguishable from paths that never meant anything.
+an_absent_extensions_routes_are_not_in_the_table() ->
+    _ = asobi_extensions:resolve(),
+    Dispatch = nova_router:compile([asobi]),
+    ?assertNotMatch(
+        {ok, _, _},
+        resolve_route(Dispatch, ~"/api/v1/quests/board", ~"GET")
+    ).
+
+%% --- Helpers ---
+
+install_quests() ->
+    ok = asobi_fixture_app:install(?QUESTS, asobi_fixture_quests_extension, []).
+
+tunable(Manifest) ->
+    ok = asobi_fixture_tunable_extension:set(Manifest),
+    ok = asobi_fixture_app:install(?TUNABLE, [asobi_fixture_tunable_extension], []).
+
+retune(Manifest) ->
+    ok = asobi_fixture_tunable_extension:set(Manifest).
+
+route(Path) ->
+    route(Path, #{}).
+
+route(Path, Overrides) ->
+    maps:merge(
+        #{path => Path, method => get, mfa => {tunable_controller, a, 1}, security => player},
+        Overrides
+    ).
+
+check_problems() ->
+    case asobi_extensions:check() of
+        {error, Problems} -> Problems;
+        {ok, Resolved} -> erlang:error({expected_problems, [N || #{name := N} <- Resolved]})
+    end.
+
+%% Both claimants and both paths, in the message a human reads. Which side
+%% comes first is claim sort order, which no test should care about.
+assert_route_conflict(QuestsPath, TunablePath) ->
+    Problems = check_problems(),
+    ?assert(
+        lists:member(
+            {route_conflict, {QuestsPath, ?QUESTS}, {TunablePath, ?TUNABLE}}, Problems
+        ) orelse
+            lists:member(
+                {route_conflict, {TunablePath, ?TUNABLE}, {QuestsPath, ?QUESTS}}, Problems
+            )
+    ),
+    Text = describe_text(Problems),
+    ?assertNotEqual(nomatch, binary:match(Text, atom_to_binary(?QUESTS, utf8))),
+    ?assertNotEqual(nomatch, binary:match(Text, atom_to_binary(?TUNABLE, utf8))),
+    ?assertNotEqual(nomatch, binary:match(Text, TunablePath)).
+
+describe_text(Problems) ->
+    iolist_to_binary([[~" ", Line] || Line <- asobi_extensions:describe(Problems)]).
+
+resolve_route(Dispatch, Path, Method) ->
+    case routing_tree:lookup('_', Path, Method, Dispatch) of
+        {ok, Bindings, #nova_handler_value{callback = Callback}} -> {ok, Bindings, Callback};
+        Other -> Other
+    end.
+
+groups_serving(Path) ->
+    [
+        Group
+     || #{routes := Routes} = Group <- asobi_router:routes(dev),
+        lists:any(fun({RoutePath, _, _}) -> RoutePath =:= Path end, Routes)
+    ].

--- a/test/extensions/asobi_extensions_tests.erl
+++ b/test/extensions/asobi_extensions_tests.erl
@@ -43,6 +43,7 @@ extensions_test_() ->
         fun an_rpc_handler_must_have_arity_two/0,
         fun a_bot_binding_is_refused_not_ignored/0,
         fun an_ops_handler_must_have_arity_two/0,
+        fun an_ops_handler_must_exist/0,
         fun an_ops_action_must_carry_a_real_class/0,
         fun an_ops_action_must_be_one_path_segment/0,
         fun a_declared_ops_action_is_reachable_by_its_class/0,
@@ -420,11 +421,29 @@ a_declared_ops_action_is_reachable_by_its_class() ->
         asobi_ops_caps:class(~"POST", ~"/api/v1/ops/ext/tunable/other")
     ).
 
+%% A real exported handler: ops entries are handler-existence-checked, so a
+%% fake module would fail validation before the property under test runs.
 ops_entry(Overrides) ->
     maps:merge(
-        #{method => post, mfa => {tunable_ops, thing, 2}, class => config},
+        #{method => post, mfa => {asobi_fixture_quests_ops, summary, 2}, class => config},
         Overrides
     ).
+
+%% The missing-handler refusal itself: shape-perfect entries whose module or
+%% function does not exist must fail the build, not 500 on first call.
+an_ops_handler_must_exist() ->
+    tunable(#{ops => #{~"thing" => ops_entry(#{mfa => {asobi_no_such_module, thing, 2}})}}),
+    ?assertMatch(
+        [{bad_manifest, ?TUNABLE, _, {ops, ~"mfa does not name an exported function", ~"thing"}}],
+        check_problems()
+    ),
+    retune(#{ops => #{~"thing" => ops_entry(#{mfa => {asobi_fixture_quests_ops, nope, 2}})}}),
+    ?assertMatch(
+        [{bad_manifest, ?TUNABLE, _, {ops, ~"mfa does not name an exported function", ~"thing"}}],
+        check_problems()
+    ),
+    retune(#{ops => #{~"thing" => ops_entry(#{})}}),
+    ?assertMatch({ok, [_]}, asobi_extensions:check()).
 
 %% --- Error codes ---
 

--- a/test/extensions/asobi_fixture_quests_controller.erl
+++ b/test/extensions/asobi_fixture_quests_controller.erl
@@ -1,0 +1,19 @@
+-module(asobi_fixture_quests_controller).
+-moduledoc """
+Nova controllers behind the quests fixture's declared routes: arity 1, `Req`
+in, ordinary Nova return out - exactly what an extracted core controller is.
+""".
+
+-export([board/1, webhook/1]).
+
+-spec board(cowboy_req:req()) -> {json, map()}.
+board(#{auth_data := #{player_id := PlayerId}}) ->
+    {json, #{~"player_id" => PlayerId, ~"quests" => []}}.
+
+%% Explicit 200: nova's default for a bare `{json, _}` on POST is 201, and a
+%% webhook sender retries on anything it does not recognise as acknowledged.
+-spec webhook(cowboy_req:req()) -> {json, 200, map(), map()}.
+webhook(#{json := Body}) when is_map(Body) ->
+    {json, 200, #{}, #{~"received" => Body}};
+webhook(_Req) ->
+    {json, 200, #{}, #{~"received" => #{}}}.

--- a/test/extensions/asobi_fixture_quests_extension.erl
+++ b/test/extensions/asobi_fixture_quests_extension.erl
@@ -2,7 +2,9 @@
 -moduledoc "A complete extension manifest, shaped exactly like the design's worked example.".
 -behaviour(asobi_extension).
 
--export([info/0, rpc/0, lua/0, sup/0, owns/0, codes/0, ops/0, erase_player/1, export_player/1]).
+-export([
+    info/0, rpc/0, lua/0, sup/0, owns/0, codes/0, ops/0, routes/0, erase_player/1, export_player/1
+]).
 
 -spec info() -> asobi_extension:info().
 info() ->
@@ -58,7 +60,8 @@ owns() ->
         tables => [~"quests", ~"quest_progress"],
         rpc => [~"quests"],
         lua => [~"quests"],
-        queues => [~"quests"]
+        queues => [~"quests"],
+        http => [~"/api/v1/quests/board", ~"/api/v1/quests/webhook"]
     }.
 
 -spec ops() -> asobi_extension:ops().
@@ -75,6 +78,23 @@ ops() ->
             class => read
         }
     }.
+
+-spec routes() -> [asobi_extension:route()].
+routes() ->
+    [
+        #{
+            path => ~"/api/v1/quests/board",
+            method => get,
+            mfa => {asobi_fixture_quests_controller, board, 1},
+            security => player
+        },
+        #{
+            path => ~"/api/v1/quests/webhook",
+            method => post,
+            mfa => {asobi_fixture_quests_controller, webhook, 1},
+            security => webhook
+        }
+    ].
 
 -spec erase_player(binary()) -> ok | {error, term()}.
 erase_player(PlayerId) ->

--- a/test/extensions/asobi_fixture_tunable_extension.erl
+++ b/test/extensions/asobi_fixture_tunable_extension.erl
@@ -5,7 +5,7 @@ and colliding shape instead of a file per case.
 """.
 -behaviour(asobi_extension).
 
--export([info/0, rpc/0, lua/0, sup/0, owns/0, codes/0, ops/0]).
+-export([info/0, rpc/0, lua/0, sup/0, owns/0, codes/0, ops/0, routes/0]).
 -export([set/1, clear/0]).
 
 -define(KEY, {?MODULE, manifest}).
@@ -30,6 +30,10 @@ rpc() ->
 -spec ops() -> asobi_extension:ops().
 ops() ->
     value(ops, #{}).
+
+-spec routes() -> [asobi_extension:route()].
+routes() ->
+    value(routes, []).
 
 -spec lua() -> asobi_extension:lua().
 lua() ->

--- a/test/extensions/asobi_quests_controller.erl
+++ b/test/extensions/asobi_quests_controller.erl
@@ -1,0 +1,17 @@
+-module(asobi_quests_controller).
+-moduledoc """
+The controller the extensions guide's `routes/0` example names, exported for
+real so the guide's exact declarations pass `asobi_extensions:check/0` - the
+handler-existence check makes a documented example with a fictional module a
+documented build failure.
+""".
+
+-export([board/1, steam_notification/1]).
+
+-spec board(cowboy_req:req()) -> {json, map()}.
+board(#{auth_data := #{player_id := PlayerId}}) ->
+    {json, #{~"player_id" => PlayerId, ~"quests" => []}}.
+
+-spec steam_notification(cowboy_req:req()) -> {json, 200, map(), map()}.
+steam_notification(_Req) ->
+    {json, 200, #{}, #{~"received" => true}}.

--- a/test/extensions/rebar3_asobi_check_tests.erl
+++ b/test/extensions/rebar3_asobi_check_tests.erl
@@ -1,0 +1,36 @@
+-module(rebar3_asobi_check_tests).
+
+-include_lib("eunit/include/eunit.hrl").
+
+%% The parse the plugin runs over a host's release sys_config to give the
+%% build gate the same `nova_apps` the boot path sees. Pure, so it is pinned
+%% without standing up a rebar state.
+
+reads_bootstrap_and_nova_apps_test() ->
+    Config = [
+        {nova, [{bootstrap_application, my_game}]},
+        {my_game, [{nova_apps, [nova_resilience]}]}
+    ],
+    ?assertEqual(
+        {ok, my_game, [nova_resilience]},
+        rebar3_asobi_check:co_mounted_from_config(Config)
+    ).
+
+no_bootstrap_application_is_none_test() ->
+    ?assertEqual(
+        none,
+        rebar3_asobi_check:co_mounted_from_config([{my_game, [{nova_apps, [nova_resilience]}]}])
+    ).
+
+empty_nova_apps_is_none_test() ->
+    Config = [
+        {nova, [{bootstrap_application, my_game}]},
+        {my_game, [{nova_apps, []}]}
+    ],
+    ?assertEqual(none, rebar3_asobi_check:co_mounted_from_config(Config)).
+
+%% A project that simply declares no nova_apps reserves nothing extra, which
+%% is the correct answer rather than a failure.
+no_nova_apps_key_is_none_test() ->
+    Config = [{nova, [{bootstrap_application, my_game}]}, {my_game, []}],
+    ?assertEqual(none, rebar3_asobi_check:co_mounted_from_config(Config)).


### PR DESCRIPTION
The extension HTTP route seam from the kernel-and-extensions design: manifest-declared, core-mounted, validated as a namespace claim. The second commit applies the review gate's verified security findings.

## The seam

- New optional callback `routes/0` on `asobi_extension`, returning entries of `#{path, method, mfa => {Module, Function, 1}, security => player | webhook}`. Arity 1 because the handler is a Nova controller, unlike the rpc/ops seams' 2, and the mfa must name an exported function - a missing handler is a build failure, not a 500.
- `asobi_router` stays the whole table: `routes/1` is now `core_routes() ++ extension_routes(resolve())`. Extension entries mount as groups with no `plugins` key, so Nova's global chain (body cap, rate limiter, CORS, security headers) applies unchanged, and every entry gets `options` added exactly as core routes do.
- Mounting happens at router-compile time, before `asobi_app:start/2`, through the same memoised `asobi_extensions:resolve/0` the router already calls - no new pre-boot machinery.

## Security chains

`security => player` mounts under `asobi_auth_plugin:verify/1`, the same chain as core's `/api/v1` group - an unauthenticated request gets the identical refusal. `security => webhook` mounts open, like the auth group, for a server-to-server caller that cannot hold a player token; the handler authenticates its caller itself, and webhook paths run in a dedicated `webhook` rate-limit bucket (sliding window, 10/s, iap's shape) rather than the 300/s api bucket - per-request signature crypto on the api budget is a CPU amplifier. One path carries exactly one security class; declaring both is refused, so OPTIONS can never route by declaration order.

## The http claim

New `http` kind in `owns/0`, derived from `routes/0` (never trusted). The comparison is structural, in two layers:

- **overlap**: equal-length patterns where some request matches both (`/saves/:slot` and `/saves/:id` are one claim, a literal under a binding is caught);
- **interference**: patterns diverging at a binding at any depth. routing_tree keys nodes by segment text, prepends on insert and commits to the first matching sibling without backtracking, so `/api/v1/players/:someone/detail` would swallow lookups meant for `/players/:id` and `/players/me/erase` - shapes that pass an equal-length check. Verified attack shapes against the players, matches and ops namespaces are all refused; extending a route through the binding's exact name (`/api/v1/saves/:slot/meta`) stays legal.

Refusal cases, all failing `rebar3 asobi check` and raising at boot with both claimants named:

- collision between two extensions (`route_conflict`, reservations included);
- any claim colliding with a path a co-mounted application serves (`reserved_route`, naming the path it would break). The reserved set derives from every app in the compiled dispatch - `[nova, asobi | nova_apps]` - not only asobi's table, so nova_resilience's `/health` `/ready` `/live` (the k8s probes, first-insert-wins hijackable otherwise) are as unclaimable as `/api/v1/matches`, honouring `health_prefix`. The derivation is total over Nova's route shapes: an unrecognised shape raises rather than silently reserving nothing. The build gate reads the same input as boot: `rebar3 asobi check` runs in a VM that does not load sys.config, so the plugin reads `nova_apps` (and the bootstrap application) from the host's release sys_config and sets them before `check/0`, keeping the gate and the boot backstop in agreement; an unreadable or `.src`-templated config falls back to reserving nothing extra, with boot (which does load sys.config) remaining the enforcing backstop;
- any claim under a privileged plane prefix (`reserved_prefix`): `/api/v1/ops`, `/api/v1/auth`, `/api/v1/iap`, `/console`, `/ws` are closed whole, so an open webhook can never mount inside the operator, auth, purchase, console or socket plane.

Within one manifest: several methods on one path are fine, the same path and method twice is refused, colliding patterns are refused - so declaration order never matters and the asobi#326 trap cannot be declared. Path grammar: literals are RFC 3986 unreserved minus the dot (`[A-Za-z0-9_~-]`), bindings are `:[a-z][a-z0-9_]*` with `dollar_endonly` so a trailing newline is not a valid binding, and `owns().http` entries must themselves be `/`-rooted paths.

`rebar3 asobi check` validates all of it through the shared `check/0`, and its report prints each extension's route count plus a per-route mount preview (`GET /api/v1/quests/board (player)`).

## 404 discipline and doctrine

An uninstalled extension's paths are absent from the table: 404, indistinguishable at the path level from a path that never meant anything. The discipline is path-level only - a mounted path answers a wrong-method probe with 405 plus an allow header, as core routes do; method enumeration on declared paths is the accepted trade, stated in the docs rather than pretended closed.

`guides/extensions.md` gains the routes section: `routes/0` preserves extracted REST surfaces and receives webhooks; a new client-facing feature should use rpc - a listing guideline, not a mechanical ban. The worked example uses the extension's own namespace and passes `check/0` verbatim, asserted by a test.

## Tests

- eunit (`asobi_extension_routes_tests`, 35 cases): claim derivation, owns().http closed set and path-shape rule, reservation semantics, the verified interference attacks (players/matches/ops shapes), the safe same-named-binding reuse, plane-prefix refusal, co-mounted-app refusal (`/health`, and a root binding), boot refusal via `resolve/0`, the full path/method/arity/security/handler-existence shape matrix (including the `:id\n` binding), mixed-security refusal, per-method mounting, and the compiled table (player chain, webhook chain, absent-extension lookup). Reserved-set tests cover the co-mounted derivation with `health_prefix` and the prefix list; the rate-limit plugin's tests cover webhook bucket selection with slash-variant normalisation; `asobi_extensions_tests` covers the ops handler-existence gap fixed alongside.
- CT (`asobi_extension_routes_SUITE`): a fixture route serving 200 end to end; a tokenless request refused with the same status as a core route; a webhook route reachable without a token and counted in the webhook bucket; CORS preflight through the global chain; 404 for undeclared paths and 405+allow for wrong-method probes, matching core.

## Checklist

| Check | Result |
|---|---|
| rebar3 fmt / fmt --check (last) | clean |
| rebar3 xref | clean |
| rebar3 dialyzer | clean |
| elp eqwalize-all | 330 errors = origin/main baseline (asobi#435); delta 0, new modules clean |
| elp lint | warning parity with origin/main (196) |
| rebar3 eunit | 1840 tests, 0 failures |
| rebar3 ct | 368 tests, 0 failures |
| rebar3 ex_doc | exit 0; one pre-existing CODEOWNERS warning (CONTRIBUTING.md, untouched) |
| mutate | not configured in this repo |

The `rebar3_asobi_check` plugin module carries a cluster of elp `W0017` "undefined function" warnings for the rebar3 API it calls (`rebar_api:*`, `rebar_state:*`, `providers:create` - elp analyses the plugin without rebar3 in scope); the build-gate fix adds two more of that same benign class (`rebar_api:debug/2`, `rebar_state:get/3`, the latter already in `xref_ignores`). Both calls are correct and unavoidable; they are not suppressed, matching the eleven existing unsuppressed ones on that module.

Part of #446.
