### PR TITLE
feat: name orphaned extracted-table rows on player erase

### DIFF
--- a/guides/extensions.md
+++ b/guides/extensions.md
@@ -799,6 +799,32 @@ than merely discouraged: a database cascade fires below the transaction's
 control flow, so `erase_player/1` would never be called at all and the receipts
 would be destroyed silently.
 
+### Removing the package, and the rows it leaves
+
+Uninstalling an extension does not drop its tables or delete its rows: a
+package removal is a code change, not a data migration, because destroying
+player progress stays a deliberate act. But the rows outlive the code that
+swept them. The foreign key into `players.id` is still `no_action`, and nothing
+runs the extension's `erase_player/1` any more, so the next erasure of a player
+those rows reference cannot delete the `players` row - and without the policy
+below that surfaces as a bare Postgres constraint error and leaves the player
+permanently un-eraseable.
+
+Core names the blocker instead. `asobi_player_erase` catches the
+`foreign_key_violation` and returns `{error, {orphaned_extension_rows, Table}}`,
+naming the referencing table the absent package owns; the ops route
+(`POST /api/v1/ops/players/:id/erase`) answers `ops.orphaned_extension_rows`
+(409) with that table in `details`, and the guest reaper logs it. The player is
+not erased and the transaction rolls back. There are two honest ways out:
+
+- **Keep the package installed.** Its `erase_player/1` stays on the erasure
+  path and keeps sweeping, so erasure never breaks in the first place.
+- **Purge its tables.** Delete the extension's rows deliberately -
+  `asobi ext remove` (asobi-cli) prints the per-table statements derived from
+  the package's `owns/0` table claims, run by the operator. Destroying player
+  progress stays a decision, never a side effect - but so does keeping GDPR
+  erase working.
+
 ### `export_player/1`
 
 Core exports a player - `GET /api/v1/ops/players/:id/export` - and the payload

--- a/src/asobi_error.erl
+++ b/src/asobi_error.erl
@@ -196,6 +196,11 @@ working and a new one reads one place: see `legacy/2`.
     },
     {~"ops.erase_failed", 500, ~"The erasure was rolled back and nothing was deleted."},
     {
+        ~"ops.orphaned_extension_rows",
+        409,
+        ~"A removed extension's rows still reference this player and block the erase. Reinstall the package so its erase sweep runs, or purge its tables."
+    },
+    {
         ~"ops.export_incomplete",
         500,
         ~"An installed extension failed to export. No export was produced."

--- a/src/asobi_guest_reaper.erl
+++ b/src/asobi_guest_reaper.erl
@@ -249,14 +249,24 @@ erase_guest(PlayerId) ->
             skipped
     catch
         Class:CReason:Stacktrace ->
-            ?LOG_WARNING(#{
-                event => guest_reap_cascade_error,
-                player_id => PlayerId,
-                class => Class,
-                reason => CReason,
-                stacktrace => Stacktrace
-            }),
-            skipped
+            case asobi_player_erase:orphan_blocker(CReason) of
+                {orphaned_extension_rows, Table} ->
+                    ?LOG_WARNING(#{
+                        event => guest_reap_orphaned_extension_rows,
+                        player_id => PlayerId,
+                        table => Table
+                    }),
+                    skipped;
+                not_orphaned ->
+                    ?LOG_WARNING(#{
+                        event => guest_reap_cascade_error,
+                        player_id => PlayerId,
+                        class => Class,
+                        reason => CReason,
+                        stacktrace => Stacktrace
+                    }),
+                    skipped
+            end
     end.
 
 -doc """

--- a/src/ops/asobi_ops_controller.erl
+++ b/src/ops/asobi_ops_controller.erl
@@ -106,9 +106,20 @@ erased({error, forbidden}, _Id) ->
     {asobi_error, ~"forbidden"};
 erased({error, not_found}, _Id) ->
     {asobi_error, ~"ops.not_found"};
+erased({error, {orphaned_extension_rows, Blocker}}, Id) ->
+    ?LOG_ERROR(#{
+        msg => ~"ops player erase blocked by orphaned extension rows",
+        player_id => Id,
+        table => Blocker
+    }),
+    {asobi_error, ~"ops.orphaned_extension_rows", #{table => blocker_detail(Blocker)}};
 erased({error, Reason}, Id) ->
     ?LOG_ERROR(#{msg => ~"ops player erase failed", player_id => Id, reason => Reason}),
     {asobi_error, ~"ops.erase_failed"}.
+
+-spec blocker_detail(term()) -> binary().
+blocker_detail(Table) when is_binary(Table) -> Table;
+blocker_detail(_Blocker) -> ~"unknown".
 
 %% `undefined` is "no confirmation sent", which is a different answer from a
 %% confirmation that did not match - an operator who typed the wrong name

--- a/src/players/asobi_player_controller.erl
+++ b/src/players/asobi_player_controller.erl
@@ -149,13 +149,24 @@ erase(PlayerId, ConfirmedHash) ->
             {asobi_error, ~"player.erase_failed"}
     catch
         Class:Reason:Stacktrace ->
-            ?LOG_ERROR(#{
-                event => player_self_erase_rolled_back,
-                player_id => PlayerId,
-                class => Class,
-                reason => Reason,
-                stacktrace => Stacktrace
-            }),
+            %% Log the named blocker for operators, but never put a table name
+            %% on a player-facing response - the wire answer stays generic.
+            case asobi_player_erase:orphan_blocker(Reason) of
+                {orphaned_extension_rows, Table} ->
+                    ?LOG_ERROR(#{
+                        event => player_self_erase_orphaned_extension_rows,
+                        player_id => PlayerId,
+                        table => Table
+                    });
+                not_orphaned ->
+                    ?LOG_ERROR(#{
+                        event => player_self_erase_rolled_back,
+                        player_id => PlayerId,
+                        class => Class,
+                        reason => Reason,
+                        stacktrace => Stacktrace
+                    })
+            end,
             {asobi_error, ~"player.erase_failed"}
     end.
 

--- a/src/players/asobi_player_erase.erl
+++ b/src/players/asobi_player_erase.erl
@@ -2,9 +2,17 @@
 -moduledoc """
 Delete one player and everything core holds about them, in one transaction.
 
-This is the single place core deletes a player. `m:asobi_guest_reaper` is one
-caller of it, not the site itself, and the operator-facing route
-(`POST /api/v1/ops/players/:id/erase`) is another.
+This is the single place core deletes a player. `steps/1` is the delete
+sequence; three callers reach it, each wrapping its own transaction:
+
+* `run/1,2` here - the shell and the operator route
+  (`POST /api/v1/ops/players/:id/erase`);
+* `m:asobi_guest_reaper` - the retention sweep;
+* `asobi_player_controller:erase_self/1` - the data subject's own
+  `POST /api/v1/players/me/erase`.
+
+All three route a rolled-back erasure through `orphan_blocker/1` so a removed
+extension's rows are named rather than surfaced as a bare constraint error.
 
 ## Why the child list is written out here
 
@@ -62,6 +70,14 @@ erased, the transaction rolls back cleanly, and the operator learns which
 package to reinstall or purge instead of reading a constraint name off a
 stacktrace. `guides/extensions.md` documents the rule where it bites.
 
+The translation is **narrow**: only a 23503 naming a table *outside*
+`core_relations/0` - the set `steps/1` itself sweeps, plus `players` and the
+ops audit table - reads as extension residue. A 23503 naming a core-swept
+table, or one carrying no table name, is a core bug or a write-race, not a
+removed package; those keep the raw reason and surface as
+`ops.erase_failed` (500), which is the escalate signal, never the benign
+"reinstall the package" 409.
+
 ## Atomic, never best-effort
 
 One transaction, every result asserted, so a bare `{error, _}` becomes a
@@ -93,7 +109,7 @@ idempotent, so a retry is safe. See `after_commit/1`.
 -include_lib("kernel/include/logger.hrl").
 -include_lib("kura/include/kura.hrl").
 
--export([steps/1, after_commit/1, run/1, run/2, orphan_blocker/1]).
+-export([steps/1, after_commit/1, run/1, run/2, orphan_blocker/1, core_relations/0]).
 
 -define(ACTION, ~"players.erase").
 -define(CLASS, erasure).
@@ -341,16 +357,18 @@ shell_actor() ->
 -doc """
 Classify an exception raised inside the erase transaction.
 
-`{orphaned_extension_rows, Table}` when the failure was a Postgres
-`foreign_key_violation` (SQLSTATE 23503): core clears every child it owns
-before deleting `players`, so a foreign key that still refuses the parent
-delete belongs to a table core does not know about - a removed extension's.
-`Table` is the referencing table read from the error, its constraint name when
-the table is absent, and `unknown` when neither is carried. Every other failure
-is `not_orphaned` and keeps its own path. Exported for the other callers of the
-delete sequence - `m:asobi_guest_reaper` - which wrap their own transaction.
+`{orphaned_extension_rows, Table}` only when the failure was a Postgres
+`foreign_key_violation` (SQLSTATE 23503) naming a table **outside**
+`core_relations/0`. Core clears every child it owns before deleting `players`,
+so a foreign key that still refuses the parent delete and names a table core
+does not sweep belongs to a removed extension. A 23503 naming a core-swept
+table (a bug or a write-race), or one carrying no table name, is `not_orphaned`
+and keeps its raw reason so it escalates rather than reads as a benign removed
+package. Every non-23503 failure is `not_orphaned` too. Exported for the other
+callers of the delete sequence - `m:asobi_guest_reaper` and
+`asobi_player_controller:erase_self/1` - which wrap their own transaction.
 """.
--spec orphan_blocker(term()) -> {orphaned_extension_rows, binary() | unknown} | not_orphaned.
+-spec orphan_blocker(term()) -> {orphaned_extension_rows, binary()} | not_orphaned.
 orphan_blocker({badmatch, Inner}) ->
     orphan_blocker(Inner);
 orphan_blocker({error, Inner}) ->
@@ -360,16 +378,53 @@ orphan_blocker({pgsql_error, Fields}) when is_map(Fields) ->
 orphan_blocker(_Other) ->
     not_orphaned.
 
--spec orphan_from_fields(map()) -> {orphaned_extension_rows, binary() | unknown} | not_orphaned.
-orphan_from_fields(#{code := ~"23503"} = Fields) ->
-    {orphaned_extension_rows, blocker_name(Fields)};
+-spec orphan_from_fields(map()) -> {orphaned_extension_rows, binary()} | not_orphaned.
+orphan_from_fields(#{code := ~"23503", table := Table}) when is_binary(Table), Table =/= ~"" ->
+    case is_core_relation(Table) of
+        true -> not_orphaned;
+        false -> {orphaned_extension_rows, Table}
+    end;
 orphan_from_fields(_Fields) ->
     not_orphaned.
 
--spec blocker_name(map()) -> binary() | unknown.
-blocker_name(#{table := Table}) when is_binary(Table), Table =/= ~"" ->
-    Table;
-blocker_name(#{constraint := Constraint}) when is_binary(Constraint), Constraint =/= ~"" ->
-    Constraint;
-blocker_name(_Fields) ->
-    unknown.
+-spec is_core_relation(binary()) -> boolean().
+is_core_relation(Table) ->
+    lists:member(Table, core_relations()).
+
+-doc """
+The Postgres relations `steps/1` clears, by their real table names.
+
+The escalation boundary for `orphan_blocker/1`: a 23503 naming one of these is
+a core defect or a write-race, not a removed extension. Derived from the schema
+modules `steps/1` sweeps (`asobi_player:table/0` and friends give the real
+relation name, which differs from the module name), plus the ops audit table
+`asobi_ops_audit:record_strict/4` writes inside the same transaction. `players`
+is already in the swept set. `asobi_player_erase_tests` fails if `steps/1` gains
+a schema whose table is not covered here.
+""".
+-spec core_relations() -> [binary()].
+core_relations() ->
+    [Schema:table() || Schema <- swept_schemas()] ++ [asobi_ops_audit_entry:table()].
+
+%% The schemas `steps/1` sweeps a player out of. Single source of truth for
+%% `core_relations/0`; keep in step with `steps/1`.
+-spec swept_schemas() -> [module()].
+swept_schemas() ->
+    [
+        asobi_iap_transaction,
+        asobi_group,
+        asobi_transaction,
+        asobi_wallet,
+        asobi_player_item,
+        asobi_storage,
+        asobi_cloud_save,
+        asobi_notification,
+        asobi_leaderboard_entry,
+        asobi_chat_message,
+        asobi_group_member,
+        asobi_friendship,
+        asobi_player_stats,
+        asobi_player_token,
+        asobi_player_identity,
+        asobi_player
+    ].

--- a/src/players/asobi_player_erase.erl
+++ b/src/players/asobi_player_erase.erl
@@ -48,6 +48,20 @@ that argument rather than by oversight:
   puts personal data in it owns erasing it, which is what
   `c:asobi_extension:erase_player/1` is for.
 
+## Rows a removed extension leaves behind
+
+Core clears its own children and each *installed* extension's `erase_player/1`
+clears the extension's. A package that has been **removed** runs neither: its
+tables and rows survive the uninstall, its foreign key into `players.id` is
+still `no_action`, and the parent delete this function ends on raises against
+them. Rather than surface that as a bare `{badmatch, {pgsql_error, ...}}`, the
+delete sequence is wrapped so a `foreign_key_violation` (SQLSTATE 23503)
+becomes `{error, {orphaned_extension_rows, Table}}` - `Table` is the referencing
+table the absent package owns, read from the Postgres error. The player is not
+erased, the transaction rolls back cleanly, and the operator learns which
+package to reinstall or purge instead of reading a constraint name off a
+stacktrace. `guides/extensions.md` documents the rule where it bites.
+
 ## Atomic, never best-effort
 
 One transaction, every result asserted, so a bare `{error, _}` becomes a
@@ -79,7 +93,7 @@ idempotent, so a retry is safe. See `after_commit/1`.
 -include_lib("kernel/include/logger.hrl").
 -include_lib("kura/include/kura.hrl").
 
--export([steps/1, after_commit/1, run/1, run/2]).
+-export([steps/1, after_commit/1, run/1, run/2, orphan_blocker/1]).
 
 -define(ACTION, ~"players.erase").
 -define(CLASS, erasure).
@@ -159,7 +173,7 @@ run(PlayerId, #{caps := Caps} = Actor) when is_binary(PlayerId) ->
 -spec erase_player(binary(), asobi_ops_auth:actor()) -> {ok, map()} | {error, term()}.
 erase_player(PlayerId, Actor) ->
     try asobi_repo:transaction(fun() -> erase_txn(PlayerId, Actor) end) of
-        {ok, Summary} ->
+        {ok, Summary} when is_map(Summary) ->
             %% Not bare `after_commit(PlayerId)`: an exception raised in a
             %% `try ... of` body escapes the `catch` below, so a gen_server
             %% timeout in one of the three evictions would answer `{error, _}`
@@ -179,6 +193,23 @@ erase_player(PlayerId, Actor) ->
             {error, {unexpected, Other}}
     catch
         Class:Reason:Stacktrace ->
+            rolled_back(PlayerId, Class, Reason, Stacktrace)
+    end.
+
+%% A foreign_key_violation that survives the whole delete sequence is a table
+%% core does not sweep - a removed extension's rows. Name it; everything else
+%% keeps the raw class/reason.
+-spec rolled_back(binary(), atom(), term(), list()) -> {error, term()}.
+rolled_back(PlayerId, Class, Reason, Stacktrace) ->
+    case orphan_blocker(Reason) of
+        {orphaned_extension_rows, Table} = Orphaned ->
+            ?LOG_ERROR(#{
+                msg => ~"player erase blocked by orphaned extension rows",
+                player_id => PlayerId,
+                table => Table
+            }),
+            {error, Orphaned};
+        not_orphaned ->
             ?LOG_ERROR(#{
                 msg => ~"player erase rolled back",
                 player_id => PlayerId,
@@ -306,3 +337,39 @@ shell_actor() ->
         caps => asobi_ops_caps:class_names(),
         attested => false
     }.
+
+-doc """
+Classify an exception raised inside the erase transaction.
+
+`{orphaned_extension_rows, Table}` when the failure was a Postgres
+`foreign_key_violation` (SQLSTATE 23503): core clears every child it owns
+before deleting `players`, so a foreign key that still refuses the parent
+delete belongs to a table core does not know about - a removed extension's.
+`Table` is the referencing table read from the error, its constraint name when
+the table is absent, and `unknown` when neither is carried. Every other failure
+is `not_orphaned` and keeps its own path. Exported for the other callers of the
+delete sequence - `m:asobi_guest_reaper` - which wrap their own transaction.
+""".
+-spec orphan_blocker(term()) -> {orphaned_extension_rows, binary() | unknown} | not_orphaned.
+orphan_blocker({badmatch, Inner}) ->
+    orphan_blocker(Inner);
+orphan_blocker({error, Inner}) ->
+    orphan_blocker(Inner);
+orphan_blocker({pgsql_error, Fields}) when is_map(Fields) ->
+    orphan_from_fields(Fields);
+orphan_blocker(_Other) ->
+    not_orphaned.
+
+-spec orphan_from_fields(map()) -> {orphaned_extension_rows, binary() | unknown} | not_orphaned.
+orphan_from_fields(#{code := ~"23503"} = Fields) ->
+    {orphaned_extension_rows, blocker_name(Fields)};
+orphan_from_fields(_Fields) ->
+    not_orphaned.
+
+-spec blocker_name(map()) -> binary() | unknown.
+blocker_name(#{table := Table}) when is_binary(Table), Table =/= ~"" ->
+    Table;
+blocker_name(#{constraint := Constraint}) when is_binary(Constraint), Constraint =/= ~"" ->
+    Constraint;
+blocker_name(_Fields) ->
+    unknown.

--- a/test/asobi_player_erase_SUITE.erl
+++ b/test/asobi_player_erase_SUITE.erl
@@ -20,24 +20,29 @@
 -export([
     erases_a_player_with_a_row_in_every_child_table/1,
     severs_rather_than_deletes_the_purchase_record/1,
-    leaves_a_group_standing_when_its_creator_is_erased/1
+    leaves_a_group_standing_when_its_creator_is_erased/1,
+    names_the_orphaned_table_and_rolls_back_when_a_removed_extension_blocks_erase/1
 ]).
 
 -include_lib("common_test/include/ct.hrl").
 -include_lib("stdlib/include/assert.hrl").
 -include_lib("kura/include/kura.hrl").
 
+-define(ORPHAN_TABLE, ~"orphan_ext_saves").
+
 all() ->
     [
         erases_a_player_with_a_row_in_every_child_table,
         severs_rather_than_deletes_the_purchase_record,
-        leaves_a_group_standing_when_its_creator_is_erased
+        leaves_a_group_standing_when_its_creator_is_erased,
+        names_the_orphaned_table_and_rolls_back_when_a_removed_extension_blocks_erase
     ].
 
 init_per_suite(Config) ->
     asobi_test_helpers:start(Config).
 
 end_per_suite(_Config) ->
+    drop_orphan_table(),
     ok.
 
 %%--------------------------------------------------------------------
@@ -94,6 +99,34 @@ leaves_a_group_standing_when_its_creator_is_erased(_Config) ->
 
     {ok, Standing} = asobi_repo:get(asobi_group, GroupId),
     ?assertEqual(undefined, maps:get(creator_id, Standing, undefined)),
+    ok.
+
+%% A table extracted out of core and then removed with its package keeps its
+%% rows and its `ON DELETE NO ACTION` foreign key into `players.id`, and nothing
+%% sweeps them. The parent delete then raises. Erase must name the blocking
+%% table rather than surface a bare constraint error, and roll the whole
+%% sequence back so nothing is half-deleted.
+names_the_orphaned_table_and_rolls_back_when_a_removed_extension_blocks_erase(_Config) ->
+    PlayerId = a_player(),
+    %% Core child rows that steps/1 deletes before the parent: they prove the
+    %% rollback covered the deletes already issued when the FK raised.
+    {ok, _} = insert(asobi_player_stats, #{player_id => PlayerId, matches_played => 1}),
+    {ok, _} = insert(asobi_wallet, #{player_id => PlayerId, currency => ~"coins", balance => 5}),
+
+    ok = create_orphan_table(),
+    ok = orphan_row(PlayerId),
+
+    Result = asobi_player_erase:run(PlayerId),
+    ?assertMatch({error, {orphaned_extension_rows, _}}, Result),
+    {error, {orphaned_extension_rows, Blocker}} = Result,
+    ct:pal("orphaned_extension_rows blocker = ~p", [Blocker]),
+    ?assertEqual(?ORPHAN_TABLE, Blocker),
+
+    %% The player survives ...
+    ?assertMatch({ok, _}, asobi_repo:get(asobi_player, PlayerId)),
+    %% ... and so does every core child row: the transaction rolled back whole.
+    ?assertMatch({ok, [_]}, asobi_repo:all(by(asobi_player_stats, player_id, PlayerId))),
+    ?assertMatch({ok, [_]}, asobi_repo:all(by(asobi_wallet, player_id, PlayerId))),
     ok.
 
 %%--------------------------------------------------------------------
@@ -173,6 +206,28 @@ a_row_in_every_child_table(PlayerId) ->
         player_id => PlayerId,
         score => 1
     }),
+    ok.
+
+%% A stand-in for an extracted table whose package has been removed: raw DDL,
+%% never a real migration in src/, so nothing teaches core to sweep it. The
+%% foreign key is `ON DELETE NO ACTION`, matching every core key into players.
+create_orphan_table() ->
+    drop_orphan_table(),
+    #{} = kura_db:query(
+        asobi_repo,
+        ~"CREATE TABLE orphan_ext_saves (id bigserial PRIMARY KEY, player_id uuid NOT NULL REFERENCES players(id) ON DELETE NO ACTION)",
+        []
+    ),
+    ok.
+
+orphan_row(PlayerId) ->
+    #{} = kura_db:query(
+        asobi_repo, ~"INSERT INTO orphan_ext_saves (player_id) VALUES ($1::uuid)", [PlayerId]
+    ),
+    ok.
+
+drop_orphan_table() ->
+    _ = kura_db:query(asobi_repo, ~"DROP TABLE IF EXISTS orphan_ext_saves", []),
     ok.
 
 %% The repo takes a changeset, not a bare struct - `kura_changeset:cast/4` is

--- a/test/asobi_player_erase_tests.erl
+++ b/test/asobi_player_erase_tests.erl
@@ -249,6 +249,102 @@ failed_final_lookup_rolls_back() ->
     %% is the outcome this test exists to forbid.
     ?assertEqual(0, meck:num_calls(asobi_repo, delete, [asobi_player, '_'])).
 
+%% --- orphan_blocker/1: pure classification, no database ---
+%%
+%% The 409 "reinstall the package" answer is only ever right for a foreign key
+%% core does not own. These pin that only a 23503 naming a table outside the
+%% swept set classifies; a core-table, no-table, or non-FK failure stays
+%% `not_orphaned` and escalates as a 500.
+
+orphan_blocker_test_() ->
+    [
+        {"an extension table on a badmatch-wrapped 23503 is named",
+            fun orphan_names_extension_table/0},
+        {"a 23503 with only a constraint, no table, does not classify",
+            fun orphan_no_table_is_not_orphaned/0},
+        {"a 23503 naming a core-swept table does not classify",
+            fun orphan_core_table_is_not_orphaned/0},
+        {"a non-23503 pgsql error does not classify", fun orphan_non_fk_is_not_orphaned/0},
+        {"a plain {error,{pgsql_error,_}} without the badmatch layer still classifies",
+            fun orphan_plain_error_unwraps/0},
+        {"an unrelated reason does not classify", fun orphan_unrelated_is_not_orphaned/0},
+        {"steps/1 touches no relation missing from core_relations/0",
+            fun steps_touch_only_core_relations/0}
+    ].
+
+orphan_names_extension_table() ->
+    Reason =
+        {badmatch,
+            {error,
+                {pgsql_error, #{
+                    code => ~"23503",
+                    table => ~"orphan_ext_saves",
+                    constraint => ~"orphan_ext_saves_player_id_fkey"
+                }}}},
+    ?assertEqual(
+        {orphaned_extension_rows, ~"orphan_ext_saves"}, asobi_player_erase:orphan_blocker(Reason)
+    ).
+
+orphan_no_table_is_not_orphaned() ->
+    Reason = {badmatch, {error, {pgsql_error, #{code => ~"23503", constraint => ~"some_fkey"}}}},
+    ?assertEqual(not_orphaned, asobi_player_erase:orphan_blocker(Reason)).
+
+orphan_core_table_is_not_orphaned() ->
+    CoreTable = asobi_wallet:table(),
+    Reason = {badmatch, {error, {pgsql_error, #{code => ~"23503", table => CoreTable}}}},
+    ?assertEqual(not_orphaned, asobi_player_erase:orphan_blocker(Reason)).
+
+orphan_non_fk_is_not_orphaned() ->
+    Reason = {badmatch, {error, {pgsql_error, #{code => ~"23505", table => ~"orphan_ext_saves"}}}},
+    ?assertEqual(not_orphaned, asobi_player_erase:orphan_blocker(Reason)).
+
+orphan_plain_error_unwraps() ->
+    Reason = {error, {pgsql_error, #{code => ~"23503", table => ~"orphan_ext_saves"}}},
+    ?assertEqual(
+        {orphaned_extension_rows, ~"orphan_ext_saves"}, asobi_player_erase:orphan_blocker(Reason)
+    ).
+
+orphan_unrelated_is_not_orphaned() ->
+    ?assertEqual(
+        not_orphaned, asobi_player_erase:orphan_blocker({lookup_failed, statement_timeout})
+    ),
+    ?assertEqual(not_orphaned, asobi_player_erase:orphan_blocker(not_found)).
+
+%% The anti-drift guard for FIX 1: every kura schema the erase logic references
+%% must have its real table name in core_relations/0. Add a table to steps/1
+%% without adding its schema to swept_schemas/0 and this fails - so a new core
+%% child can never silently start reading as extension residue.
+steps_touch_only_core_relations() ->
+    Core = asobi_player_erase:core_relations(),
+    Missing = [S || S <- erase_logic_schemas(), not lists:member(S:table(), Core)],
+    ?assertEqual([], Missing).
+
+%% The kura schema modules referenced anywhere in the erase logic, read from the
+%% compiled abstract code. swept_schemas/0 and core_relations/0 are excluded:
+%% they are the declaration under test, not part of the sweep.
+erase_logic_schemas() ->
+    Logic = [
+        F
+     || {function, _, Name, _Arity, _Clauses} = F <- forms(asobi_player_erase),
+        not lists:member(Name, [swept_schemas, core_relations])
+    ],
+    lists:usort([A || A <- atoms(Logic), is_kura_schema(A)]).
+
+atoms(Term) when is_tuple(Term) -> lists:append([atoms(E) || E <- tuple_to_list(Term)]);
+atoms(List) when is_list(List) -> lists:append([atoms(E) || E <- List]);
+atoms(A) when is_atom(A) -> [A];
+atoms(_Other) -> [].
+
+is_kura_schema(A) ->
+    _ = code:ensure_loaded(A),
+    erlang:function_exported(A, table, 0).
+
+forms(Module) ->
+    {Module, Beam, _Path} = code:get_object_code(Module),
+    {ok, {Module, [{abstract_code, {raw_abstract_v1, Forms}}]}} =
+        beam_lib:chunks(Beam, [abstract_code]),
+    Forms.
+
 %% asobi#215's revocation SLA: without this a deleted player's access token
 %% keeps resolving from the cache for up to auth_cache_ttl_ms against a row
 %% that no longer exists.


### PR DESCRIPTION
Wave 1 gate: this must ship before storage/iap can be extracted. After an extraction the deletes move into the package's `erase_player/1`, but the tables and their `on_delete = no_action` foreign keys stay in core (the seasons precedent). An operator who **removes** the extracted package keeps its tables **and rows**, and those rows refuse the parent delete - today that surfaces as a bare Postgres constraint error and leaves the player permanently un-eraseable.

Delivers the two core obligations from `kernel-and-extensions.md` "Extraction residue and erase". The third - `asobi ext remove` printing the per-table purge - is asobi-cli (a separate Go repo) and is a follow-up.

## The failure mode

`asobi_player_erase:steps/1` clears every core child, then deletes `players`. An orphaned extracted table still referencing `players.id` makes that final delete raise `foreign_key_violation` (SQLSTATE 23503). The `{ok, _} =` assertion turns it into a badmatch, minato rolls the transaction back and re-raises.

## The translation (narrowed for the extraction gate)

The erase is wrapped so a 23503 is caught and classified. The classifier is deliberately **narrow**: it returns `{error, {orphaned_extension_rows, Table}}` **only** when the 23503 names a table *outside* `core_relations/0` - the set `steps/1` itself sweeps, plus `players` and the ops audit table. A 23503 naming a core-swept table, or one carrying no table name, is a core bug or a write-race, **not** a removed package; it keeps the raw reason and surfaces as `ops.erase_failed` (500) - the escalate signal - never the benign "reinstall the package" 409.

`core_relations/0` is derived from the schema modules `steps/1` sweeps (each `table/0` gives the real relation name, which differs from the module name), not a hardcoded literal list. A unit test fails if `steps/1` gains a schema whose relation is not covered, so the set cannot silently drift from the sweep.

`Table` is read from `{pgsql_error, #{code := ~"23503", table := ...}}`; for a parent delete PG sets `table` to the referencing/child relation via `errtableconstraint(fk_rel, ...)`.

Wired through **all three** callers of the delete sequence:
- Operator route `POST /api/v1/ops/players/:id/erase` -> `ops.orphaned_extension_rows` (409) carrying the table in `details`.
- Guest reaper -> logs `guest_reap_orphaned_extension_rows` with the named table.
- Self-erase `POST /api/v1/players/me/erase` -> logs `player_self_erase_orphaned_extension_rows` server-side for operator alerting, but keeps the generic `player.erase_failed` (500) on the wire - a data subject never sees a deployment-internal table name.

The `asobi_player_erase` moduledoc now names all three callers accurately.

## Rollback guarantee

The player is **not** erased and the whole delete sequence rolls back - no partial deletion. The CT test inserts core child rows (wallet, player_stats) plus a stand-in orphaned table, attempts the erase, and asserts the named error, the surviving player, and the surviving core child rows.

## The doc rule, where it bites

`asobi_player_erase` moduledoc and `guides/extensions.md` state it: removing an extension without purging its data leaves rows that block player erase. Either keep the package installed (its `erase_player/1` keeps sweeping) or run the purge (`asobi ext remove`, coming in asobi-cli).

## Test coverage

- CT (real Postgres): orphaned table blocks erase -> `{error, {orphaned_extension_rows, <<"orphan_ext_saves">>}}`, player survives, core child rows survive (rollback verified). Stand-in table created with raw SQL in the suite, not a migration.
- eunit (pure, no DB) for `orphan_blocker/1`: extension-table path, constraint-only -> not_orphaned, **core-swept table -> not_orphaned**, non-23503 -> not_orphaned, plain `{error,{pgsql_error,_}}` unwrap without the badmatch layer, unrelated reason -> not_orphaned.
- eunit anti-drift guard: fails if `steps/1` references a relation missing from `core_relations/0`.
- Normal erase (no orphan) still succeeds unchanged.

## Checklist

| Step | Result |
|---|---|
| rebar3 fmt / fmt --check | clean |
| xref | clean |
| dialyzer | clean |
| elp eqwalize-all | 329 (baseline 330); every touched module clean, 0 new |
| elp lint | parity (only pre-existing unused-include warnings) |
| rebar3 eunit | 1847 tests, 0 failures |
| rebar3 ct (erase + guest suites) | 4/4 + 15/15 |
| rebar3 ex_doc | clean (pre-existing CODEOWNERS warning only) |
| mutate | not configured in this repo |

Part of #446
