### PR TITLE
refactor: post-erase subsystem cleanup runs through a hook, not a direct call

### DIFF
--- a/src/players/asobi_player_erase.erl
+++ b/src/players/asobi_player_erase.erl
@@ -104,12 +104,27 @@ Evicting the player from `m:asobi_auth_cache` and from every live
 `m:asobi_leaderboard_server`, and killing the live session, run **after** the
 commit, because an ETS eviction and a process exit cannot roll back. All are
 idempotent, so a retry is safe. See `after_commit/1`.
+
+Those post-commit surfaces split two ways. Revoking the auth cache and killing
+the session are core's own session/identity teardown for the player it just
+deleted - kernel work erase owns and will always own. Taking the player off a
+running leaderboard is a *subsystem* cleaning up its own in-memory state, and
+core should not name a subsystem's internals at its own call site. So the
+leaderboard eviction runs through a registry, `post_erase_hooks/0`, one
+`{Module, Function}` per subsystem that needs post-commit cleanup, invoked
+best-effort in list order. When leaderboards extracts (Wave 2)
+`post_erase_hooks/0` is reimplemented to walk the installed subsystems - the
+same registry ratchet 3 introduces - rather than return this literal, so the
+leaderboard entry is no longer named here; nothing re-registers itself into a
+list. The registry stays core-internal until then, deliberately off the public
+`m:asobi_extension` behaviour, which is a separate contract decision.
 """.
 
 -include_lib("kernel/include/logger.hrl").
 -include_lib("kura/include/kura.hrl").
 
 -export([steps/1, after_commit/1, run/1, run/2, orphan_blocker/1, core_relations/0]).
+-export([post_erase_hooks/0]).
 
 -define(ACTION, ~"players.erase").
 -define(CLASS, erasure).
@@ -191,11 +206,13 @@ erase_player(PlayerId, Actor) ->
     try asobi_repo:transaction(fun() -> erase_txn(PlayerId, Actor) end) of
         {ok, Summary} when is_map(Summary) ->
             %% Not bare `after_commit(PlayerId)`: an exception raised in a
-            %% `try ... of` body escapes the `catch` below, so a gen_server
-            %% timeout in one of the three evictions would answer `{error, _}`
-            %% for an erasure that had already committed, and log nothing. The
-            %% rows are gone by this point, so a failed eviction is a thing to
-            %% log and retry by hand, never a reason to report failure.
+            %% `try ... of` body escapes the `catch` below. `after_commit/1`
+            %% isolates each post-commit hook, so a subsystem's failure is
+            %% already logged and swallowed there; wrapping the whole call is
+            %% the belt that keeps a raise from the orchestration itself off the
+            %% result of an erasure that had already committed. The rows are
+            %% gone by this point, so a failed hook is a thing to log and retry
+            %% by hand, never a reason to report failure.
             after_commit_best_effort(PlayerId),
             {ok, Summary};
         {error, _Reason} = Error ->
@@ -265,26 +282,93 @@ The in-memory surfaces the transaction cannot cover, run after it commits.
 
 An ETS eviction and a process exit cannot roll back, so none of these may run
 before the commit. `run/1,2` call this for you; a caller that holds its own
-transaction - `m:asobi_guest_reaper` - calls it once that transaction has
-committed.
+transaction - `m:asobi_guest_reaper` and `asobi_player_controller:erase_self/1`
+- calls it once that transaction has committed.
 
-* `m:asobi_auth_cache` - without it a deleted player's access token keeps
-  resolving for up to `auth_cache_ttl_ms` against a row that no longer exists,
-  which is the revocation SLA that module's moduledoc already states.
-* `m:asobi_leaderboard_server` - each board keeps its entries in ETS and reads
-  from there, hydrating from Postgres only at init. Deleting the rows does not
-  take an erased player off a board that is already running, and a score still
-  pending for them re-inserts against a foreign key that is now gone. See
-  `asobi_leaderboard_server:evict_player/1`.
-* The live session.
+Two kinds of work run here, and the split is deliberate:
 
-All three are idempotent, so a retried erasure is safe.
+* **Kernel teardown**, run directly. `m:asobi_auth_cache` - without it a
+  deleted player's access token keeps resolving for up to `auth_cache_ttl_ms`
+  against a row that no longer exists, which is the revocation SLA that
+  module's moduledoc already states. The live session, killed through
+  `m:asobi_presence`. Both are erase's own session/identity teardown for the
+  player it just deleted; neither is a subsystem's concern and neither will
+  ever extract, so core names them here rather than on the registry.
+* **Subsystem cleanup**, run through `post_erase_hooks/0`. Today that is
+  `m:asobi_leaderboard_server`: each board keeps its entries in ETS and reads
+  from there, hydrating from Postgres only at init, so deleting the rows does
+  not take an erased player off a board that is already running, and a score
+  still pending for them re-inserts against a foreign key that is now gone. It
+  is a subsystem cleaning up its own state, so it is a registered hook, not a
+  call core spells out here.
+
+Every step is idempotent, so a retried erasure is safe, and every step is
+best-effort in isolation: one that raises is logged, naming the step, and
+swallowed, so a wedged subsystem cannot stop another's cleanup or the kernel
+teardown, and a committed erasure always stands.
 """.
 -spec after_commit(binary()) -> ok.
 after_commit(PlayerId) ->
-    ok = asobi_auth_cache:revoke_player(PlayerId),
-    ok = asobi_leaderboard_server:evict_player(PlayerId),
-    ok = asobi_presence:disconnect(PlayerId, ~"erased").
+    %% Kernel teardown first, then the subsystem hooks, in list order - the
+    %% whole sequence is deterministic. Each step is isolated so one failure
+    %% never reaches the next.
+    best_effort_step(PlayerId, {asobi_auth_cache, revoke_player}, fun() ->
+        ok = asobi_auth_cache:revoke_player(PlayerId)
+    end),
+    best_effort_step(PlayerId, {asobi_presence, disconnect}, fun() ->
+        ok = asobi_presence:disconnect(PlayerId, ~"erased")
+    end),
+    _ = [run_hook(PlayerId, Hook) || Hook <- post_erase_hooks()],
+    ok.
+
+-spec run_hook(binary(), {module(), atom()}) -> ok.
+run_hook(PlayerId, {Module, Function} = Hook) ->
+    best_effort_step(PlayerId, Hook, fun() -> ok = Module:Function(PlayerId) end).
+
+-doc """
+The subsystem cleanups to run after a player-erase commits, in order.
+
+The seam. Each entry is one subsystem's post-commit cleanup of the player just
+erased, invoked as `Module:Function(PlayerId)` by `after_commit/1`. It exists so
+core does not name a subsystem's internals mid-`after_commit/1`: the one edge
+that used to reach straight into `asobi_leaderboard_server:evict_player/1` is
+now this single list entry. When leaderboards extracts (Wave 2) this function is
+reimplemented to walk the installed subsystems - the same registry ratchet 3
+introduces - rather than return a literal, so the leaderboard entry is no longer
+named here. There is no extension-facing hook-registration API today and this is
+not one; the registry is kept core-internal for now, off the public
+`m:asobi_extension` behaviour, which is a separate contract decision.
+
+Ordered and deterministic: hooks run top to bottom, after the kernel teardown.
+""".
+-spec post_erase_hooks() -> [{module(), atom()}].
+post_erase_hooks() ->
+    [
+        {asobi_leaderboard_server, evict_player}
+    ].
+
+%% One post-commit step, best-effort. A raise is logged, naming the step, and
+%% swallowed with `ok`, so the caller runs the next step regardless: the rows
+%% are already gone, and one subsystem's failure must not block another's
+%% cleanup or the kernel teardown. The `ok =` inside each step's fun still holds
+%% - a step that answers anything else raises a badmatch, which is caught here.
+-spec best_effort_step(binary(), {module(), atom()}, fun(() -> ok)) -> ok.
+best_effort_step(PlayerId, Step, Fun) ->
+    try
+        Fun(),
+        ok
+    catch
+        Class:Reason:Stacktrace ->
+            ?LOG_ERROR(#{
+                msg => ~"player erase committed but a post-commit step failed",
+                player_id => PlayerId,
+                step => Step,
+                class => Class,
+                reason => Reason,
+                stacktrace => Stacktrace
+            }),
+            ok
+    end.
 
 -spec after_commit_best_effort(binary()) -> ok.
 after_commit_best_effort(PlayerId) ->
@@ -293,7 +377,7 @@ after_commit_best_effort(PlayerId) ->
     catch
         Class:Reason:Stacktrace ->
             ?LOG_ERROR(#{
-                msg => ~"player erase committed but post-commit eviction failed",
+                msg => ~"player erase committed but post-commit orchestration failed",
                 player_id => PlayerId,
                 class => Class,
                 reason => Reason,

--- a/test/asobi_player_erase_tests.erl
+++ b/test/asobi_player_erase_tests.erl
@@ -29,7 +29,11 @@ erase_test_() ->
             fun failed_lookup_is_not_not_found/0},
         {"a failed lookup at the last step rolls back", fun failed_final_lookup_rolls_back/0},
         {"the auth cache is revoked after the commit", fun revokes_after_commit/0},
-        {"live leaderboards drop the player after the commit", fun evicts_leaderboards/0}
+        {"live leaderboards drop the player after the commit", fun evicts_leaderboards/0},
+        {"a raising subsystem hook is logged, swallowed, and does not fail the erase",
+            fun a_raising_hook_is_swallowed/0},
+        {"a raising step does not stop the steps after it", fun a_raising_step_isolates/0},
+        {"the post-commit steps run in a deterministic order", fun post_commit_order_is_fixed/0}
     ]}.
 
 setup() ->
@@ -373,4 +377,90 @@ evicts_leaderboards() ->
         )
     after
         meck:unload(asobi_leaderboard_server)
+    end.
+
+%% --- The post-erase hook seam ---
+%%
+%% The leaderboard eviction is no longer a hardcoded call in `after_commit/1`;
+%% it is the one entry in `post_erase_hooks/0`, invoked best-effort in isolation
+%% next to the kernel teardown. These pin the three properties the seam keeps: a
+%% raising hook is swallowed and does not fail the erase, a raising step does
+%% not stop the ones after it, and the order is deterministic.
+
+%% The rows are already committed away, so a wedged board must be logged and
+%% dropped, never turned into a failure. The kernel teardown that shares
+%% `after_commit/1` is untouched by it.
+a_raising_hook_is_swallowed() ->
+    meck:new(asobi_presence, [no_link]),
+    meck:expect(asobi_presence, disconnect, fun(_PlayerId, _Reason) -> ok end),
+    meck:new(asobi_leaderboard_server, [no_link, passthrough]),
+    meck:expect(asobi_leaderboard_server, evict_player, fun(_PlayerId) -> error(board_is_wedged) end),
+    try
+        ?assertMatch({ok, _}, asobi_player_erase:run(?PLAYER)),
+        ?assertEqual(1, meck:num_calls(asobi_leaderboard_server, evict_player, [?PLAYER])),
+        ?assertEqual(1, meck:num_calls(asobi_auth_cache, revoke_player, [?PLAYER]))
+    after
+        meck:unload(asobi_leaderboard_server),
+        meck:unload(asobi_presence)
+    end.
+
+%% Isolation, proved from the front: the first step `after_commit/1` runs -
+%% revoking the auth cache - is made to raise, and the session teardown and the
+%% leaderboard hook after it must still run, with the erase still {ok, _}. One
+%% subsystem's failure blocking another's cleanup is exactly what the per-step
+%% guard exists to forbid.
+a_raising_step_isolates() ->
+    meck:expect(asobi_auth_cache, revoke_player, fun(_PlayerId) -> error(cache_is_down) end),
+    meck:new(asobi_presence, [no_link]),
+    meck:expect(asobi_presence, disconnect, fun(_PlayerId, _Reason) -> ok end),
+    meck:new(asobi_leaderboard_server, [no_link, passthrough]),
+    meck:expect(asobi_leaderboard_server, evict_player, fun(_PlayerId) -> ok end),
+    try
+        ?assertMatch({ok, _}, asobi_player_erase:run(?PLAYER)),
+        ?assertEqual(1, meck:num_calls(asobi_presence, disconnect, [?PLAYER, ~"erased"])),
+        ?assertEqual(1, meck:num_calls(asobi_leaderboard_server, evict_player, [?PLAYER]))
+    after
+        meck:unload(asobi_leaderboard_server),
+        meck:unload(asobi_presence)
+    end.
+
+%% Kernel teardown (auth cache, then session), then the subsystem hooks in
+%% `post_erase_hooks/0` order. A collector records each call as it happens, so
+%% the sequence itself is asserted, not just the registry's contents.
+post_commit_order_is_fixed() ->
+    Tester = self(),
+    meck:expect(asobi_auth_cache, revoke_player, fun(_PlayerId) ->
+        Tester ! {step, {asobi_auth_cache, revoke_player}},
+        ok
+    end),
+    meck:new(asobi_presence, [no_link]),
+    meck:expect(asobi_presence, disconnect, fun(_PlayerId, _Reason) ->
+        Tester ! {step, {asobi_presence, disconnect}},
+        ok
+    end),
+    meck:new(asobi_leaderboard_server, [no_link, passthrough]),
+    meck:expect(asobi_leaderboard_server, evict_player, fun(_PlayerId) ->
+        Tester ! {step, {asobi_leaderboard_server, evict_player}},
+        ok
+    end),
+    try
+        ?assertMatch({ok, _}, asobi_player_erase:run(?PLAYER)),
+        ?assertEqual(
+            [
+                {asobi_auth_cache, revoke_player},
+                {asobi_presence, disconnect},
+                {asobi_leaderboard_server, evict_player}
+            ],
+            drain_steps()
+        )
+    after
+        meck:unload(asobi_leaderboard_server),
+        meck:unload(asobi_presence)
+    end.
+
+drain_steps() ->
+    receive
+        {step, Step} -> [Step | drain_steps()]
+    after 0 ->
+        []
     end.


### PR DESCRIPTION
## The edge

`asobi_player_erase:after_commit/1` ran three hardcoded post-commit calls. One
of them, `asobi_leaderboard_server:evict_player/1`, was a direct core -> subsystem
edge: core naming a subsystem's internals mid-teardown. That is the edge Wave 2
needs gone so leaderboards can extract without core referencing it.

## The seam

The leaderboard eviction moves out of the `after_commit/1` body and into a small
core-internal registry, `post_erase_hooks/0` - an ordered list of
`{Module, Function}`, one entry per subsystem that needs post-commit cleanup,
each invoked `Module:Function(PlayerId)` best-effort. The single current entry is
`{asobi_leaderboard_server, evict_player}`. When leaderboards extracts (Wave 2)
that one line becomes the extension's own registration and leaves core. It is
kept core-internal for now, deliberately off the public `asobi_extension`
behaviour - that is a separate contract decision, not this PR's.

## Preserved best-effort semantics

Unchanged and asserted end to end: still post-commit (ETS/process teardown
cannot roll back), still best-effort, a committed erase always returns
`{ok, Summary}` regardless of hook outcome. Each step now runs in isolation - a
step that raises is logged, naming the step, and swallowed, so one wedged
subsystem cannot stop another's cleanup or the kernel teardown. Ordering is
deterministic: kernel teardown, then hooks in list order. `after_commit_best_effort/1`
is kept as the outer belt for the `run/1,2` path.

The guest reaper and `erase_self` go through the same `after_commit/1`, so both
pick up the hook with no duplicated registry - CT covers the reaper path.

## Kernel-vs-subsystem split (decision)

The two kernel teardown calls stay direct, off the registry: auth-cache
revocation and session disconnect are erase's own session/identity teardown for
the player it just deleted, not a subsystem cleaning up its own state, and
neither will ever extract. Only subsystem cleanup goes on the hook. Justified in
the moduledoc and `post_erase_hooks/0`.

## Per-hook isolation (decision)

One hook's crash skips only itself; the rest still run. This matches best-effort
intent - a subsystem's failure must not block another's cleanup - and is what
the isolation tests pin.

## Wrapper-vs-direct (decision)

The registry names `asobi_leaderboard_server:evict_player/1` directly rather than
via a thin `asobi_leaderboards:after_erase/1` wrapper. `evict_player/1` is
already the purpose-built seam (its own comment reads "for
`asobi_player_erase:after_commit/1`"); a wrapper would add a second name and an
export without removing any coupling.

## Test coverage

`asobi_player_erase_tests` (eunit), mirroring the existing suite:
- a normal erase still evicts the live leaderboard entry after the commit (behaviour preserved);
- a raising subsystem hook is logged, swallowed, and does not fail the erase;
- a raising step does not stop the steps after it (isolation proved from the first step);
- the post-commit steps run in a deterministic order.

CT `asobi_player_erase_SUITE` + `asobi_guest_SUITE` prove the full erase and the
reaper path end to end.

## Checklist

| Check | Result |
| --- | --- |
| rebar3 fmt | clean (no changes) |
| xref | clean |
| dialyzer | clean |
| elp eqwalize-all | 329 (baseline), changed module clean, delta 0 |
| elp lint | parity, no new warnings in changed files |
| rebar3 eunit (full) | 1850 tests, 0 failures |
| rebar3 ct (erase + guest) | 19 tests, 0 failures |
| rebar3 ct (leaderboards) | 15 tests, 0 failures |
| rebar3 ex_doc | clean (one pre-existing CODEOWNERS warning) |
| rebar3 fmt --check | clean |
| mutate | not configured in this repo |

Part of #446
