### PR TITLE
feat: requires/0 extension dependency declaration

### DIFF
--- a/guides/extensions.md
+++ b/guides/extensions.md
@@ -75,9 +75,12 @@ right answer and when `rpc/0` is.
 ```erlang
 -module(asobi_quests_extension).
 -behaviour(asobi_extension).
--export([info/0, rpc/0, lua/0, sup/0, owns/0, codes/0, ops/0, erase_player/1, export_player/1]).
+-export([info/0, requires/0, rpc/0, lua/0, sup/0, owns/0, codes/0, ops/0,
+         erase_player/1, export_player/1]).
 
 info() -> #{name => quests, extension_version => 1}.
+
+requires() -> [economy].
 
 rpc()  -> #{~"quests.list"  => {asobi_quests_rpc, list,  2},
             ~"quests.claim" => {asobi_quests_rpc, claim, 2}}.
@@ -112,6 +115,8 @@ extension.
 
 Only `info/0` is required. The rest default to nothing.
 
+- `requires/0` - the subsystems and extensions this one calls, by name. See
+  [Declaring dependencies](#declaring-dependencies).
 - `rpc/0` - core cannot guess that `quests.claim` is `{asobi_quests_rpc, claim, 2}`.
   The arity is always 2; see [Writing an RPC handler](#writing-an-rpc-handler).
 - `lua/0` - the `game.<ns>.*` surface a Lua game calls. See
@@ -605,6 +610,45 @@ Two failure modes are worth stating plainly:
   503. The alternative is every extension crash-looping into its own restart
   budget and going dark anyway. The marker is written once, before this
   supervisor exists, so it cannot flip later and there is nothing to retry.
+
+## Declaring dependencies
+
+`requires/0` names the subsystems and extensions this one calls:
+
+```erlang
+requires() -> [economy].
+```
+
+A bare list of names, never version ranges. The names are core subsystems
+(`economy`, `leaderboards`, `notifications`, `storage`, `tournaments`,
+`social`, `chat`, `iap`, `matches`, `world`, `votes`, `presence`, `timers`)
+and other installed extensions. Which versions work together is the
+dependency pin's job -
+`{asobi, "~> 0.79.0"}` in your `rebar.config`, and the bundle's lockstep for a
+first-party set - so `requires/0` says only *that* you call into a thing, never
+*which* of it.
+
+Two things read it, both through the one `rebar3 asobi check`:
+
+- **A name that resolves to nothing is refused.** If a required name is neither
+  a core subsystem nor an installed extension, the build fails and the boot
+  backstop refuses, naming your extension and the missing dependency - not an
+  `undef` the first time a client reaches the code that was never installed.
+- **It orders boot.** A requirement on another extension must be backed by an
+  ordinary OTP application dependency, so the resolver already starts the
+  provider first (the same dependency order your `sup/0` children rely on).
+  Declare `requires => [leaderboards]` and make your application depend on
+  `asobi_leaderboards`; the requirement without the application dependency is
+  refused, because nothing would guarantee the boot order. A requirement on an
+  always-present core subsystem imposes no ordering.
+
+The set a name resolves against is the union of core's subsystem names and the
+installed extensions' names, and that union is what keeps a `requires` correct
+when a core subsystem later ships as its own package: the name moves from the
+core side of the union to the extension side, and the requirement stays
+satisfied because the bundle installs the package. `economy` is a core
+subsystem you may depend on today and an extracted extension tomorrow, and
+`requires => [economy]` reads the same either way.
 
 ## Namespaces
 

--- a/src/extensions/asobi_extension.erl
+++ b/src/extensions/asobi_extension.erl
@@ -17,9 +17,11 @@ just modules. This behaviour covers only what core cannot infer.
 ```erlang
 -module(asobi_quests_extension).
 -behaviour(asobi_extension).
--export([info/0, rpc/0, lua/0, sup/0, owns/0, codes/0, erase_player/1, export_player/1]).
+-export([info/0, requires/0, rpc/0, lua/0, sup/0, owns/0, codes/0, erase_player/1, export_player/1]).
 
 info() -> #{name => quests, extension_version => 1}.
+
+requires() -> [economy].
 
 rpc()  -> #{~"quests.claim" => {asobi_quests_rpc, claim, 2}}.
 
@@ -47,10 +49,10 @@ export_player(PlayerId) ->
     {ok, #{~"quest_progress" => [maps:with([quest_id, counter], Row) || Row <- Rows]}}.
 ```
 
-Only `info/0` is required. `rpc/0`, `lua/0`, `sup/0`, `owns/0`, `codes/0`,
-`ops/0`, `routes/0`, `erase_player/1` and `export_player/1` default to
-nothing, because several are frequently empty: an extension with no processes
-has no `sup/0`, and one whose rows cascade needs no `erase_player/1`.
+Only `info/0` is required. `requires/0`, `rpc/0`, `lua/0`, `sup/0`, `owns/0`,
+`codes/0`, `ops/0`, `routes/0`, `erase_player/1` and `export_player/1` default
+to nothing, because several are frequently empty: an extension with no
+processes has no `sup/0`, and one whose rows cascade needs no `erase_player/1`.
 
 An extension declaring neither `rpc/0` nor `lua/0` is reachable by nobody:
 game logic calls `game.<ns>.*` from Lua, and clients call
@@ -148,6 +150,38 @@ The contract version, distinct from the package version: a minor release may
 change an experimental contract.
 """.
 -type info() :: #{name := name(), extension_version := pos_integer()}.
+
+-doc """
+The subsystems and extensions this extension calls, by name.
+
+A bare list of names - core subsystems (`economy`, `leaderboards`, `world`,
+...) and other installed extensions - never version ranges. Which versions are
+compatible is the dependency pin's job (`{asobi, "~> 0.79.0"}`, and the
+bundle's lockstep for a first-party set); this list says only *that* you call
+into a thing, never *which* of it. `requires => [economy]` says "I call into
+economy" and nothing about which economy.
+
+Two things read it, and both run the same `asobi_extensions:check/0`:
+
+- **Refusal.** `rebar3 asobi check` and the boot backstop reject a set where a
+  required name resolves to nothing - neither a core subsystem nor an
+  installed extension. A missing dependency is a build failure naming the
+  extension and the name, not an `undef` the first time a client reaches the
+  moved code.
+- **Boot order.** A requirement on another extension must be backed by an OTP
+  application dependency, so the resolver already lists the provider first
+  (`c:sup/0`'s start-order guarantee); a requirement whose provider is not
+  ordered before it is refused, because boot would otherwise start them out of
+  order. A requirement on an always-present core subsystem imposes no order.
+
+The resolution set is the union of core's subsystem names and the installed
+extensions' names, and that union is what keeps `requires/0` correct across an
+extraction: when a core subsystem later ships as its own package the name
+simply moves from the core side of the union to the extension side, and a
+`requires` on it stays satisfied - the bundle installs the package. This is
+the seam the Wave 3 tournaments->leaderboards dependency rides.
+""".
+-callback requires() -> [name()].
 
 -doc "An RPC method, `<prefix>.<method>`.".
 -type method() :: binary().
@@ -472,5 +506,14 @@ That trade is accepted - method behaviour follows HTTP rather than hiding.
 -callback ops() -> ops().
 
 -optional_callbacks([
-    rpc/0, lua/0, sup/0, owns/0, codes/0, ops/0, routes/0, erase_player/1, export_player/1
+    requires/0,
+    rpc/0,
+    lua/0,
+    sup/0,
+    owns/0,
+    codes/0,
+    ops/0,
+    routes/0,
+    erase_player/1,
+    export_player/1
 ]).

--- a/src/extensions/asobi_extension_reserved.erl
+++ b/src/extensions/asobi_extension_reserved.erl
@@ -39,6 +39,12 @@ extension route may sit anywhere under them, whatever it would resolve to.
 This is a policy list, not a derivation - which sub-paths of a plane are
 sensitive is a judgment the route table cannot express.
 
+`core_capabilities/0` answers the mirror-image question `owns/0` does not:
+not "what may an extension never claim" but "what may an extension depend on".
+A subsystem name here can be named in `requires/0` yet never in `owns/0` - you
+may call into `economy`, never claim its namespace - so the two roles sit in
+one module because both are the authority on core's own subsystem names.
+
 Deriving from modules costs one `code:ensure_loaded/1` sweep over core's
 module list. `asobi_extensions` only asks for it when at least one extension
 is installed, so a node with none pays nothing.
@@ -50,7 +56,9 @@ claims, so core's names and an extension's names are found by the same rule
 rather than by two that can disagree.
 """.
 
--export([namespaces/0, kinds/0, route_prefixes/0, schema_tables/1, worker_queues/1]).
+-export([
+    namespaces/0, kinds/0, route_prefixes/0, core_capabilities/0, schema_tables/1, worker_queues/1
+]).
 
 -type kind() :: tables | rpc | lua | queues | http.
 -export_type([kind/0]).
@@ -81,6 +89,52 @@ console or socket plane is refused whatever the path would resolve to.
 -spec route_prefixes() -> [asobi_extension:token(), ...].
 route_prefixes() ->
     [~"/api/v1/ops", ~"/api/v1/auth", ~"/api/v1/iap", ~"/console", ~"/ws"].
+
+-doc """
+The core subsystem names an extension may name in `requires/0`.
+
+A documented constant, not a derivation, and deliberately so. The names an
+extension depends on are the extraction-unit names - the one each subsystem
+carries out of core as its own package, so `asobi_leaderboards`'s
+`info().name` is `leaderboards` - and no single core artefact spells that set:
+the `game.*` Lua namespaces are singular and partial (`leaderboard`, no
+`world` or `tournaments` at all) and the error-code domains mix machinery in.
+So the set is written here, one atom per subsystem, tied to its `src/`
+directory and its extraction wave. It has two groups: the extraction-unit
+names, each of which becomes an extension of exactly that name; and the
+kernel-permanent runtime subsystems an extension may call into but that never
+leave core (`matches`, `world`, `votes`, `presence`, `timers`). Only the first
+group moves.
+
+The resolution set `asobi_extensions` validates a `requires/0` against is the
+union of this set and the installed extensions' own names, and that union is
+why the set stays correct across an extraction: when a subsystem leaves core
+its atom is deleted here and reappears as the extracted package's
+`info().name`, so a `requires` on it moves from the core side of the union to
+the extension side with the same answer - satisfied, because the bundle
+installs the package. Sub-parts are named by the unit that extracts, never
+separately: use `economy` for inventory, `chat` for dm, `matches` for the
+matchmaker or match-scoped zones, `world` for world zones and terrain.
+""".
+-spec core_capabilities() -> [asobi_extension:name(), ...].
+core_capabilities() ->
+    [
+        %% Extraction targets - each becomes an extension named exactly this.
+        storage,
+        iap,
+        notifications,
+        leaderboards,
+        economy,
+        tournaments,
+        social,
+        chat,
+        %% Kernel-permanent subsystems - callable, never extracted.
+        matches,
+        world,
+        votes,
+        presence,
+        timers
+    ].
 
 %% Every path any co-mounted application serves, prefixed as it is mounted.
 %% The compiled dispatch is `[nova, BootstrapApp | nova_apps]` (nova_sup),

--- a/src/extensions/asobi_extensions.erl
+++ b/src/extensions/asobi_extensions.erl
@@ -62,6 +62,7 @@ surfaces with Nova's crash context rather than a legible asobi error.
     module := module(),
     name := asobi_extension:name(),
     extension_version := pos_integer(),
+    requires := [asobi_extension:name()],
     rpc := asobi_extension:rpc(),
     ops := asobi_extension:ops(),
     lua := asobi_extension:lua(),
@@ -78,7 +79,10 @@ surfaces with Nova's crash context rather than a legible asobi error.
     | {undeclared_claim, asobi_extension_reserved:kind(), asobi_extension:token(), atom()}
     | {route_conflict, {asobi_extension:token(), atom()}, {asobi_extension:token(), atom()}}
     | {reserved_route, asobi_extension:token(), asobi_extension:token(), atom()}
-    | {reserved_prefix, asobi_extension:token(), asobi_extension:token(), atom()}.
+    | {reserved_prefix, asobi_extension:token(), asobi_extension:token(), atom()}
+    | {unsatisfied_requirement, atom(), asobi_extension:name()}
+    | {requirement_out_of_order, atom(), asobi_extension:name()}
+    | {self_requirement, atom(), asobi_extension:name()}.
 
 -doc "One `lua/0` binding with the namespace and function name it was declared under.".
 -type binding() :: #{
@@ -379,6 +383,7 @@ read_one(App, Module) ->
 read_manifest(App, Module) ->
     Reads = [
         {info, call(Module, info, undefined)},
+        {requires, call(Module, requires, [])},
         {rpc, call(Module, rpc, #{})},
         {lua, call(Module, lua, #{})},
         {owns, call(Module, owns, #{})},
@@ -410,6 +415,7 @@ call(Module, Function, Default) ->
 build(App, Module, Values) ->
     #{
         info := Info,
+        requires := Requires,
         rpc := Rpc,
         lua := Lua,
         owns := Owns,
@@ -418,7 +424,7 @@ build(App, Module, Values) ->
         routes := Routes,
         sup := Sup
     } = Values,
-    case shape_problems(Info, Rpc, Lua, Owns, Codes, Ops, Routes, Sup) of
+    case shape_problems(Info, Requires, Rpc, Lua, Owns, Codes, Ops, Routes, Sup) of
         [] ->
             #{name := Name, extension_version := Version} = Info,
             {ok, #{
@@ -426,6 +432,7 @@ build(App, Module, Values) ->
                 module => Module,
                 name => Name,
                 extension_version => Version,
+                requires => Requires,
                 rpc => Rpc,
                 lua => Lua,
                 owns => Owns,
@@ -437,8 +444,9 @@ build(App, Module, Values) ->
             {error, [{bad_manifest, App, Module, Detail} || Detail <- Details]}
     end.
 
-shape_problems(Info, Rpc, Lua, Owns, Codes, Ops, Routes, Sup) ->
+shape_problems(Info, Requires, Rpc, Lua, Owns, Codes, Ops, Routes, Sup) ->
     info_problems(Info) ++
+        requires_problems(Requires) ++
         rpc_problems(Rpc) ++
         lua_problems(Lua) ++
         owns_problems(Owns) ++
@@ -464,6 +472,14 @@ name_problems(Name) ->
         match -> [];
         nomatch -> [{info, ~"name must match ^[a-z][a-z0-9_]*$", Name}]
     end.
+
+%% Shape only. Whether each name resolves to something installed, and orders
+%% before the requirer, is a cross-set question `validate/1` answers - the
+%% same split rpc/lua/http claims make between their own shape and collision.
+requires_problems(Requires) when is_list(Requires) ->
+    [{requires, ~"must be a list of atoms", Name} || Name <- Requires, not is_atom(Name)];
+requires_problems(Requires) ->
+    [{requires, ~"must be a list of atoms", Requires}].
 
 rpc_problems(Rpc) when is_map(Rpc) ->
     [
@@ -809,6 +825,12 @@ derived. Naming a kind at all says "this is the complete set", and anything
 derived outside it is `undeclared_claim` - which is what turns a typo in
 `owns.queues` from an invisible no-op into a build failure. Nothing in
 `owns/0` is load-bearing for collision detection any more.
+
+`requires/0` is checked here too, against the union of core's subsystem names
+(`asobi_extension_reserved:core_capabilities/0`) and the installed extensions'
+own names. It reads `Extensions` in the order given, which is the resolver's
+dependency order, so the extension-ordering rule is a position check rather
+than a second sort.
 """.
 -spec validate([extension()]) -> ok | {error, [problem(), ...]}.
 validate([]) ->
@@ -820,7 +842,8 @@ validate(Extensions) ->
             lists:append([
                 kind_problems(Kind, Extensions, maps:get(Kind, Reserved, []))
              || Kind <- asobi_extension_reserved:kinds()
-            ]),
+            ]) ++
+            requirement_problems(Extensions),
     case Problems of
         [] -> ok;
         [_ | _] -> {error, Problems}
@@ -831,6 +854,52 @@ duplicate_names(Extensions) ->
         {duplicate_name, Name, A, B}
      || {Name, A, B} <- pairs([{Name, App} || #{name := Name, app := App} <- Extensions])
     ].
+
+%% `requires/0` resolves against the union of core's subsystem names and the
+%% installed extensions' own names. Each name is checked in a fixed order.
+%% Naming your own info-name is a `self_requirement` manifest bug, caught first
+%% so it is never mistaken for an ordering problem an application dependency
+%% could fix. Otherwise a name that hits an installed extension carries an
+%% order: the walk is front to back over the resolver's dependency order,
+%% carrying the names already resolved, so a required extension not yet resolved
+%% is one that resolves at or after the requirer - its `requires` is not backed
+%% by an OTP application dependency, and boot would start the two out of order
+%% against `c:asobi_extension:sup/0`'s guarantee. A core subsystem is always
+%% present and boots first, so it imposes no order. The installed case is tried
+%% before the capability case, so a name that is both - a core subsystem an
+%% installed extension has taken over - resolves to the extension and keeps its
+%% ordering, which is the transparency an extraction needs. The result is
+%% `usort`ed, so a name repeated in one `requires/0` reports once.
+requirement_problems(Extensions) ->
+    Installed = [Name || #{name := Name} <- Extensions],
+    Capabilities = asobi_extension_reserved:core_capabilities(),
+    lists:usort(requirement_problems(Extensions, Installed, Capabilities, [])).
+
+requirement_problems([], _Installed, _Capabilities, _Resolved) ->
+    [];
+requirement_problems([Extension | Rest], Installed, Capabilities, Resolved) ->
+    #{app := App, name := Name, requires := Requires} = Extension,
+    lists:append([requirement(App, Name, R, Installed, Resolved, Capabilities) || R <- Requires]) ++
+        requirement_problems(Rest, Installed, Capabilities, [Name | Resolved]).
+
+requirement(App, Owner, Owner, _Installed, _Resolved, _Capabilities) ->
+    [{self_requirement, App, Owner}];
+requirement(App, _Owner, Required, Installed, Resolved, Capabilities) ->
+    case lists:member(Required, Resolved) of
+        true ->
+            [];
+        false ->
+            case lists:member(Required, Installed) of
+                true -> [{requirement_out_of_order, App, Required}];
+                false -> capability_requirement(App, Required, Capabilities)
+            end
+    end.
+
+capability_requirement(App, Required, Capabilities) ->
+    case lists:member(Required, Capabilities) of
+        true -> [];
+        false -> [{unsatisfied_requirement, App, Required}]
+    end.
 
 kind_problems(http, Extensions, ReservedPaths) ->
     Claims = lists:usort([{Path, App} || #{app := App} = E <- Extensions, Path <- claims(E, http)]),
@@ -989,6 +1058,23 @@ describe_one({reserved_prefix, Path, Prefix, App}) ->
     line(
         "~s declares the route \"~s\" under \"~s\", which asobi reserves for its own plane.",
         [App, Path, Prefix]
+    );
+describe_one({unsatisfied_requirement, App, Name}) ->
+    line(
+        "~s requires \"~s\", which resolves to nothing: it is neither a core "
+        "subsystem nor an installed extension.",
+        [App, Name]
+    );
+describe_one({requirement_out_of_order, App, Name}) ->
+    line(
+        "~s requires the extension \"~s\", but \"~s\" resolves after it. Make ~s's "
+        "application depend on it so boot starts the provider first.",
+        [App, Name, Name, App]
+    );
+describe_one({self_requirement, App, Name}) ->
+    line(
+        "~s lists itself (\"~s\") in requires/0; an extension cannot depend on itself.",
+        [App, Name]
     ).
 
 line(Format, Args) ->

--- a/src/extensions/rebar3_asobi_check.erl
+++ b/src/extensions/rebar3_asobi_check.erl
@@ -191,14 +191,23 @@ summarise(#{
     name := Name,
     app := App,
     extension_version := Version,
+    requires := Requires,
     rpc := Rpc,
     lua := Lua,
     routes := Routes
 }) ->
     io_lib:format(
-        "~s (~s, contract v~b): ~b rpc method(s), ~b lua namespace(s), ~b route(s)",
-        [Name, App, Version, map_size(Rpc), map_size(Lua), length(Routes)]
+        "~s (~s, contract v~b): ~b rpc method(s), ~b lua namespace(s), ~b route(s)~ts",
+        [Name, App, Version, map_size(Rpc), map_size(Lua), length(Routes), requires_note(Requires)]
     ).
+
+%% The migration order the report already prints is the boot order a
+%% requirement rides, so naming what each extension needs makes an out-of-order
+%% or missing dependency legible against the list right above it.
+requires_note([]) ->
+    ~"";
+requires_note(Requires) ->
+    io_lib:format(", requires ~ts", [lists:join(~", ", [atom_to_binary(R, utf8) || R <- Requires])]).
 
 route_line(#{path := Path, method := Method, security := Security}) ->
     io_lib:format(

--- a/test/extensions/asobi_extensions_tests.erl
+++ b/test/extensions/asobi_extensions_tests.erl
@@ -54,7 +54,16 @@ extensions_test_() ->
         fun a_code_outside_the_owned_set_refused/0,
         fun one_code_domain_two_claimants/0,
         fun a_bare_code_refused/0,
-        fun a_malformed_code_spec_refused/0
+        fun a_malformed_code_spec_refused/0,
+        fun a_requires_on_a_core_subsystem_is_satisfied/0,
+        fun a_requires_on_an_installed_extension_resolves_it_first/0,
+        fun an_unsatisfiable_requires_is_refused/0,
+        fun a_requires_on_an_extension_that_sorts_after_is_caught/0,
+        fun an_installed_extension_wins_over_the_same_named_core_subsystem/0,
+        fun a_self_requirement_is_named_as_such/0,
+        fun a_requires_cycle_is_a_legible_problem_not_a_loop/0,
+        fun a_duplicated_requires_entry_reports_once/0,
+        fun a_requires_must_be_a_list_of_atoms/0
     ]}.
 
 setup() ->
@@ -515,6 +524,107 @@ a_malformed_code_spec_refused() ->
     ?assertMatch([{bad_manifest, ?TUNABLE, _, {codes, _, ~"tunable.nope"}}], check_problems()),
     retune(#{codes => #{~"tunable.nope" => #{status => 409}}}),
     ?assertMatch([{bad_manifest, ?TUNABLE, _, {codes, _, ~"tunable.nope"}}], check_problems()).
+
+%% --- Requirements ---
+
+%% A core subsystem is always present and boots first, so a requires on one is
+%% satisfied with no other extension in play and imposes no ordering. This is
+%% the quests-requires-economy shape the real fixture ships.
+a_requires_on_a_core_subsystem_is_satisfied() ->
+    tunable(#{requires => [economy]}),
+    ?assertMatch({ok, [_]}, asobi_extensions:check()).
+
+%% A requires on another installed extension is satisfied when that extension
+%% resolves first, which the resolver's dependency order guarantees exactly
+%% when the requirer's application depends on the provider's. The clans fixture
+%% requires quests; installing it with the application dependency puts quests
+%% first, so the requirement holds.
+a_requires_on_an_installed_extension_resolves_it_first() ->
+    install(?QUESTS),
+    ok = asobi_fixture_app:install(?CLANS, asobi_fixture_clans_extension, [?QUESTS]),
+    ?assertEqual([quests], asobi_fixture_clans_extension:requires()),
+    ?assertEqual([quests, clans], [Name || #{name := Name} <- asobi_extensions:resolve()]),
+    ?assertMatch({ok, [_, _]}, asobi_extensions:check()).
+
+%% A name that resolves to nothing - no core subsystem, no installed extension
+%% - is refused by the gate and raised through the boot backstop, with one line
+%% naming the extension and the missing dependency.
+an_unsatisfiable_requires_is_refused() ->
+    tunable(#{requires => [does_not_exist]}),
+    Problems = check_problems(),
+    ?assert(lists:member({unsatisfied_requirement, ?TUNABLE, does_not_exist}, Problems)),
+    Text = iolist_to_binary(lists:join(~" ", asobi_extensions:describe(Problems))),
+    ?assertNotEqual(nomatch, binary:match(Text, atom_to_binary(?TUNABLE, utf8))),
+    ?assertNotEqual(nomatch, binary:match(Text, ~"does_not_exist")),
+    ?assertError({asobi_extensions, _}, asobi_extensions:resolve()).
+
+%% The ordering half. clans requires quests, but installed without the
+%% application dependency the two are independent, so the resolver lists them
+%% alphabetically - clans before quests - and the provider lands after the
+%% requirer. That is refused: a requires not backed by an application
+%% dependency cannot promise the boot order it needs. The refusal hinges on the
+%% resolve order (the alphabetical tie-break clans < quests puts the provider
+%% last); a future change to that ordering would surface here as an edit to
+%% this assertion, which is intended.
+a_requires_on_an_extension_that_sorts_after_is_caught() ->
+    install(?QUESTS),
+    ok = asobi_fixture_app:install(?CLANS, asobi_fixture_clans_extension, []),
+    ?assert(lists:member({requirement_out_of_order, ?CLANS, quests}, check_problems())).
+
+%% The union-shadow rule, pinned. economy is a core subsystem, but here an
+%% installed extension is also named economy and sorts after quests, which
+%% requires it. The installed check runs before the capability free pass, so
+%% the requirement is out of order (the extension wins) rather than trivially
+%% satisfied by the capability - the transparency an extraction depends on.
+an_installed_extension_wins_over_the_same_named_core_subsystem() ->
+    install(?QUESTS),
+    tunable(#{info => #{name => economy, extension_version => 1}}),
+    Problems = check_problems(),
+    ?assert(lists:member({requirement_out_of_order, ?QUESTS, economy}, Problems)),
+    ?assertNot(lists:member({unsatisfied_requirement, ?QUESTS, economy}, Problems)).
+
+%% A requires entry equal to the extension's own name is a manifest bug, and
+%% naming it so beats the out-of-order line, whose "add an application
+%% dependency" fix is uncompletable for a self-reference. The self check runs
+%% before the capability free pass too: economy is a capability, but naming
+%% yourself economy is still self-reference.
+a_self_requirement_is_named_as_such() ->
+    tunable(#{info => #{name => economy, extension_version => 1}, requires => [economy]}),
+    Problems = check_problems(),
+    ?assert(lists:member({self_requirement, ?TUNABLE, economy}, Problems)),
+    ?assertNot(lists:member({requirement_out_of_order, ?TUNABLE, economy}, Problems)),
+    Text = iolist_to_binary(lists:join(~" ", asobi_extensions:describe(Problems))),
+    ?assertNotEqual(nomatch, binary:match(Text, ~"itself")).
+
+%% A two-cycle terminates with a legible problem, not a loop. clans requires
+%% quests; a second extension named quests requires clans back. The walk visits
+%% each once, so the cycle surfaces as one out-of-order problem - the provider
+%% that sorts last - never a non-terminating resolve.
+a_requires_cycle_is_a_legible_problem_not_a_loop() ->
+    ok = asobi_fixture_app:install(?CLANS, asobi_fixture_clans_extension, []),
+    tunable(#{info => #{name => quests, extension_version => 1}, requires => [clans]}),
+    ?assert(lists:member({requirement_out_of_order, ?CLANS, quests}, check_problems())).
+
+%% asobi#369-style dedup discipline: a name repeated in one requires/0 must not
+%% report the same problem twice.
+a_duplicated_requires_entry_reports_once() ->
+    tunable(#{requires => [does_not_exist, does_not_exist]}),
+    ?assertEqual(
+        [{unsatisfied_requirement, ?TUNABLE, does_not_exist}],
+        [P || {unsatisfied_requirement, _, does_not_exist} = P <- check_problems()]
+    ).
+
+a_requires_must_be_a_list_of_atoms() ->
+    tunable(#{requires => [~"economy"]}),
+    ?assertMatch(
+        [{bad_manifest, ?TUNABLE, _, {requires, ~"must be a list of atoms", ~"economy"}}],
+        check_problems()
+    ),
+    retune(#{requires => not_a_list}),
+    ?assertMatch(
+        [{bad_manifest, ?TUNABLE, _, {requires, ~"must be a list of atoms", not_a_list}}],
+        check_problems()
+    ).
 
 %% --- Helpers ---
 

--- a/test/extensions/asobi_fixture_clans_extension.erl
+++ b/test/extensions/asobi_fixture_clans_extension.erl
@@ -1,12 +1,23 @@
 -module(asobi_fixture_clans_extension).
--moduledoc "A second extension, whose application depends on the first, so ordering is observable.".
+-moduledoc """
+A second extension, whose application depends on the first, so ordering is
+observable, and whose `requires/0` names the first, so the requires
+provider-before-requirer rule is observable on the same install.
+""".
 -behaviour(asobi_extension).
 
--export([info/0, rpc/0, lua/0, sup/0, owns/0, erase_player/1, export_player/1]).
+-export([info/0, requires/0, rpc/0, lua/0, sup/0, owns/0, erase_player/1, export_player/1]).
 
 -spec info() -> asobi_extension:info().
 info() ->
     #{name => clans, extension_version => 2}.
+
+%% Depends on the quests extension by name. Satisfied when clans's application
+%% also depends on quests's (quests then resolves first); an out-of-order
+%% problem when it does not.
+-spec requires() -> [asobi_extension:name()].
+requires() ->
+    [quests].
 
 -spec rpc() -> asobi_extension:rpc().
 rpc() ->

--- a/test/extensions/asobi_fixture_quests_extension.erl
+++ b/test/extensions/asobi_fixture_quests_extension.erl
@@ -3,12 +3,29 @@
 -behaviour(asobi_extension).
 
 -export([
-    info/0, rpc/0, lua/0, sup/0, owns/0, codes/0, ops/0, routes/0, erase_player/1, export_player/1
+    info/0,
+    requires/0,
+    rpc/0,
+    lua/0,
+    sup/0,
+    owns/0,
+    codes/0,
+    ops/0,
+    routes/0,
+    erase_player/1,
+    export_player/1
 ]).
 
 -spec info() -> asobi_extension:info().
 info() ->
     #{name => quests, extension_version => 1}.
+
+%% Models quests' real asobi_economy:grant/4 call: it depends on economy, which
+%% is a core subsystem today and an extracted extension from Wave 2 on. Either
+%% way this stays satisfied, because the resolution set is their union.
+-spec requires() -> [asobi_extension:name()].
+requires() ->
+    [economy].
 
 -spec rpc() -> asobi_extension:rpc().
 rpc() ->

--- a/test/extensions/asobi_fixture_tunable_extension.erl
+++ b/test/extensions/asobi_fixture_tunable_extension.erl
@@ -5,7 +5,7 @@ and colliding shape instead of a file per case.
 """.
 -behaviour(asobi_extension).
 
--export([info/0, rpc/0, lua/0, sup/0, owns/0, codes/0, ops/0, routes/0]).
+-export([info/0, requires/0, rpc/0, lua/0, sup/0, owns/0, codes/0, ops/0, routes/0]).
 -export([set/1, clear/0]).
 
 -define(KEY, {?MODULE, manifest}).
@@ -22,6 +22,10 @@ clear() ->
 -spec info() -> asobi_extension:info().
 info() ->
     value(info, #{name => tunable, extension_version => 1}).
+
+-spec requires() -> [asobi_extension:name()].
+requires() ->
+    value(requires, []).
 
 -spec rpc() -> asobi_extension:rpc().
 rpc() ->


### PR DESCRIPTION
Adds `requires/0`, the extension dependency-declaration seam from the contract
v1 manifest (Wave 0b), and the Wave 3 gate under which tournaments requires
leaderboards. Additive and self-contained; the erase path is untouched.

## The seam

A new optional callback `requires() -> [atom()]`, default `[]`. A bare list of
names - core subsystems and other installed extensions - never version ranges:
which versions are compatible is the dependency pin's job (`{asobi, "~> 0.79.0"}`
and the bundle's lockstep), not this list's.

## Resolution set (core capabilities + installed extensions)

A required name resolves against the union of `asobi_extension_reserved:core_capabilities/0`
and the installed extensions' own `info().name`s. The capability set has two
groups: the extraction-unit names, each of which becomes an extension of that
name (`storage`, `iap`, `notifications`, `leaderboards`, `economy`,
`tournaments`, `social`, `chat`); and the kernel-permanent runtime subsystems an
extension may call into but that never leave core (`matches`, `world`, `votes`,
`presence`, `timers`). The union is what keeps a `requires` correct across an
extraction: when a subsystem later ships as its own package its name is deleted
from the capability list and reappears as the extracted extension's name, so a
`requires` on it moves from one side of the union to the other with the same
answer - satisfied, because the bundle installs the package. `economy` is a core
subsystem you may depend on today and an extracted extension tomorrow, and
`requires => [economy]` reads the same either way.

## Refusal, both places

Validation lands in `asobi_extensions:validate/1`, so it runs through the one
`asobi_extensions:check/0` that both `rebar3 asobi check` and the boot backstop
run - a missing dependency is a legible build failure and a raise from the
backstop, never a bare `undef`. Three problems, following the existing
owns/undeclared_claim/reserved_route pattern, each with a `describe/1` line
naming the extension and the name:

- `{unsatisfied_requirement, App, Name}` - the name is neither a core subsystem
  nor an installed extension.
- `{requirement_out_of_order, App, Name}` - the name is an installed extension
  that resolves at or after the requirer.
- `{self_requirement, App, Name}` - the name is the extension's own info-name,
  reported as the manifest bug it is rather than as an uncompletable ordering
  fix.

## Boot-ordering rule

The check walks the resolver's existing dependency order (no parallel sort): a
required extension is satisfied only if it has already resolved, i.e. it is
ordered before the requirer. That order is OTP application order, so the rule is
"a `requires` on another extension must be backed by an application dependency" -
without one the boot order is not guaranteed and the set is refused. A `requires`
on an always-present core subsystem imposes no ordering. The per-name check order
is self -> already-resolved -> installed-but-later -> core-capability -> nothing,
so a name that is both a core subsystem and an installed extension resolves to
the extension (the union-shadow transparency an extraction depends on). A
two-cycle terminates with one out-of-order problem, never a loop.

## Dogfood

The fixture quests extension declares `requires => [economy]`, modelling quests'
real `asobi_economy:grant/4` call, so the seam ships with a live first-party
consumer rather than only a Wave 3 promise. The fixture clans extension requires
quests, exercising the extension-to-extension provider-first ordering.

## Review findings addressed (this revision)

1. **Union-shadow test** - added a test where a name is both a core capability
   and an installed extension sorting after its requirer, asserting
   `requirement_out_of_order` (the extension wins) rather than the capability
   free pass. Pins the installed-before-capability check order.
2. **Self-requirement** - `A requires A` is now `{self_requirement, ...}` with a
   legible line ("lists itself in requires/0; an extension cannot depend on
   itself"), not a mislabelled out-of-order. Added a two-cycle regression
   proving it terminates with a legible problem, not a loop.
3. **presence + timers** - added to `core_capabilities/0` (kernel-permanent
   subsystems extensions genuinely call into), preventing a spurious Wave 2
   refusal of `requires => [presence]` when `asobi_notifications` extracts.
   Moduledoc updated to describe the two groups.
4. **Dedup** - `requirement_problems` now `lists:usort`s its output, so a name
   repeated in one `requires/0` reports once (matches the sibling claims
   discipline).
5. **Test comment** - the sorts-after test notes it hinges on the alphabetical
   resolve tie-break, so a future ordering change surfaces as an intentional
   test edit.

## Follow-ups (to file, not in this PR)

- The real `asobi_quests` declaring `requires => [economy]` is a follow-up in the
  `asobi_quests` repo.
- The union-transparency `undef` gap (a forgotten capability-list delete plus the
  extension left uninstalled) is Wave 2 extraction hygiene, already doc-mandated.

## Test coverage

Extends the manifest-validation eunit, mirroring the owns/routes patterns:

- a requires on a core subsystem passes `check/0`;
- a requires on an installed extension passes and the provider resolves first;
- an unsatisfiable requires is refused by `check/0` and raised through the boot
  backstop (`resolve/0`), with `describe/1` naming both;
- a requires naming an extension that sorts after the requirer is caught;
- an installed extension wins over a same-named core subsystem (union-shadow);
- a self-requirement is named as such, not mislabelled;
- a two-cycle is a legible problem, not a loop;
- a duplicated requires entry reports once;
- requires must be a list of atoms (shape).

## Checklist (re-run after the review fixes)

| Check | Result |
|---|---|
| rebar3 fmt / fmt --check | clean |
| xref | clean |
| dialyzer | clean (0 warnings) |
| elp eqwalize | per-module delta zero - new code clean (asobi_extension 0, reserved 1, asobi_extensions 6, check 1) |
| elp lint | parity - zero new diagnostics |
| eunit | extension modules 65 pass; full suite 1855 pass (pre-fix run) |
| ct | 17 pass (asobi_extension_routes, asobi_rpc, asobi_ops_audit) |
| ex_doc | clean (only the pre-existing CODEOWNERS warning) |
| mutate | not configured in this repo |

Part of #446
