### PR TITLE
feat: module.event named push envelope for extension server events

### DIFF
--- a/guides/websocket-protocol.md
+++ b/guides/websocket-protocol.md
@@ -355,6 +355,24 @@ raw, because it may be any scripting value (string, number, table).
 {"type": "module.message", "payload": {"module": "lua", "message": "you are player 3"}}
 ```
 
+### `module.event` (server push)
+
+A named, routable event an extension pushes to a player from its own Erlang
+code with `asobi_extensions:emit/4`. Unlike `module.message` (an unnamed dev
+message) this frame carries a routing key clients dispatch on. It is emitted as
+a single frame with no legacy alias.
+
+`module` is the emitter's registered short name. `event` is `<domain>.<name>`,
+where `domain` is an RPC prefix the extension owns. `data` is always an object.
+
+`module` may legitimately differ from the `event` domain, because an extension
+can own an RPC prefix that is not its own name - so a consumer should key off
+whichever of the two it actually means, deliberately.
+
+```json
+{"type": "module.event", "payload": {"module": "quests", "event": "quests.completed", "data": {"quest_id": "01j8x000000000000000000042", "reward": 250}}}
+```
+
 ### `game.error` / `game.message` (server push, deprecated)
 
 The pre-rename names for the two frames above. Deprecated. **New SDK code

--- a/priv/protocol/fixtures/module.event.json
+++ b/priv/protocol/fixtures/module.event.json
@@ -1,0 +1,1 @@
+{"type":"module.event","payload":{"module":"quests","event":"quests.completed","data":{"quest_id":"01j8x000000000000000000042","reward":250}}}

--- a/src/asobi_error.erl
+++ b/src/asobi_error.erl
@@ -88,6 +88,23 @@ working and a new one reads one place: see `legacy/2`.
     {~"rpc.unsupported_protocol", 400, ~"This server does not speak that RPC protocol version."},
     {~"rpc.invalid_params", 400, ~"`params` must be a JSON object."},
 
+    %% Extension event push. `asobi_extensions:emit/4` fails closed: an event
+    %% whose name is malformed, whose domain the emitter does not own, whose data
+    %% is not JSON-encodable, or whose encoded data is too large never reaches a
+    %% player.
+    {
+        ~"event.invalid_name",
+        400,
+        ~"An event name must be `<domain>.<name>` in [A-Za-z0-9_-], up to 64 bytes."
+    },
+    {
+        ~"event.unowned_domain",
+        403,
+        ~"The event's domain is not an RPC prefix this extension owns."
+    },
+    {~"event.invalid_data", 400, ~"The event data is not JSON-encodable."},
+    {~"event.payload_too_large", 413, ~"The event data is larger than the server accepts."},
+
     %% Accounts, providers, guests.
     {~"auth.registration_closed", 403, ~"This deployment is not accepting new players."},
     {

--- a/src/extensions/asobi_extension_reserved.erl
+++ b/src/extensions/asobi_extension_reserved.erl
@@ -14,10 +14,14 @@ cannot drift:
 - **tables** from every core `kura_schema` module's `table/0`, found the same
   way asobi finds an extension's schemas.
 - **queues** from every core `shigoto_worker` module's `queue/0`.
-- **rpc** from the domains of `asobi_error:core_codes/0`, plus the Lua
-  namespaces. An RPC prefix and an error domain are the same token by
-  construction (`{"code": "quests.name_taken"}`), so an extension owning the
-  `storage` prefix would mint codes inside core's closed code set.
+- **rpc** from the domains of `asobi_error:core_codes/0`, the Lua namespaces,
+  and `core_wire_prefixes/0`. An RPC prefix and an error domain are the same
+  token by construction (`{"code": "quests.name_taken"}`), so an extension
+  owning the `storage` prefix would mint codes inside core's closed code set.
+  `core_wire_prefixes/0` adds the wire frame families a code domain and a Lua
+  namespace between them miss - `session`, `presence` and `module` - so an
+  extension can neither mint a `session.*` code nor emit a `session.connected`
+  event under `asobi_extensions:emit/4`.
 
   `core_codes/0` rather than `codes/0` on purpose: `codes/0` includes the codes
   the installed extensions declare, and reserving those would tell an extension
@@ -57,7 +61,13 @@ rather than by two that can disagree.
 """.
 
 -export([
-    namespaces/0, kinds/0, route_prefixes/0, core_capabilities/0, schema_tables/1, worker_queues/1
+    namespaces/0,
+    kinds/0,
+    route_prefixes/0,
+    core_capabilities/0,
+    core_wire_prefixes/0,
+    schema_tables/1,
+    worker_queues/1
 ]).
 
 -type kind() :: tables | rpc | lua | queues | http.
@@ -77,7 +87,7 @@ namespaces() ->
         tables => schema_tables(Modules),
         queues => worker_queues(Modules),
         lua => Lua,
-        rpc => lists:usort(error_domains() ++ Lua),
+        rpc => lists:usort(error_domains() ++ Lua ++ core_wire_prefixes()),
         http => core_route_paths()
     }.
 
@@ -135,6 +145,31 @@ core_capabilities() ->
         presence,
         timers
     ].
+
+-doc """
+The core wire frame-family prefixes with no error domain and no Lua namespace.
+
+`error_domains/0` and `lua/0` between them cover most core wire frame families -
+`match.*`, `world.*`, `chat.*`, `matchmaker.*` and the rest all have an error
+code or a `game.*` namespace under the same prefix. Three do not:
+
+- `session` (`session.connected`, `session.heartbeat`),
+- `presence` (`presence.updated`),
+- `module` (`module.message`, `module.error`, `module.event`, the frames an
+  extension pushes - the last through `asobi_extensions:emit/4`).
+
+An RPC prefix, an error-code domain and an event domain are one token by
+construction, so without reserving these an extension could own `session` in
+`owns/0` and mint a `session.*` code or emit a `session.connected` event,
+colliding with a core frame family. This constant is a documented list rather
+than a derivation precisely because no core artefact names these prefixes -
+they exist only as wire type literals in `m:asobi_ws_handler`. Folded into the
+reserved `rpc` union, so the gap closes for error codes and the `module.event`
+event seam alike.
+""".
+-spec core_wire_prefixes() -> [asobi_extension:token(), ...].
+core_wire_prefixes() ->
+    [~"session", ~"presence", ~"module"].
 
 %% Every path any co-mounted application serves, prefixed as it is mounted.
 %% The compiled dispatch is `[nova, BootstrapApp | nova_apps]` (nova_sup),

--- a/src/extensions/asobi_extensions.erl
+++ b/src/extensions/asobi_extensions.erl
@@ -45,6 +45,7 @@ surfaces with Nova's crash context rather than a legible asobi error.
 
 -export([resolve/0, check/0, validate/1, describe/1, sup_specs/1, error_codes/0]).
 -export([rpc_methods/0, lua_bindings/0, ops_action/2, is_webhook_path/1]).
+-export([emit/4]).
 -ifdef(TEST).
 -export([reset/0]).
 -endif.
@@ -55,6 +56,11 @@ surfaces with Nova's crash context rather than a legible asobi error.
 -define(LUA_KEY, {?MODULE, lua_bindings}).
 -define(OPS_KEY, {?MODULE, ops_actions}).
 -define(WEBHOOK_KEY, {?MODULE, webhook_paths}).
+-define(MAX_EVENT_NAME_BYTES, 64).
+%% A `module.event` payload cap sized to the WS frame limit
+%% (asobi_ws_handler's ?WS_MAX_PAYLOAD_BYTES) so emit/4 refuses at the trust
+%% boundary what the socket would otherwise reject after the encode.
+-define(MAX_EVENT_DATA_BYTES, 65536).
 
 -doc "One resolved extension. `sup/0` is deliberately absent; see `sup_specs/1`.".
 -type extension() :: #{
@@ -195,6 +201,112 @@ pattern_matches([Pattern | PatternRest], [Segment | SegmentRest]) ->
         pattern_matches(PatternRest, SegmentRest);
 pattern_matches(_Pattern, _Segments) ->
     false.
+
+-doc """
+Push a named event to a player from an extension's own Erlang code.
+
+`Event` is `<domain>.<name>`: each half is `[A-Za-z0-9_-]` (the exact charset
+`asobi_ws_handler:is_event_name_char/1` allows, so an event name and a
+game.broadcast name are validated one way), a single dot separates them, and
+the whole is at most 64 bytes. `domain` must be an RPC prefix `Extension` owns -
+derived exactly as an error code's domain is (see `m:asobi_extension`). `Data`
+is always a JSON object; a non-map is a caller bug and fails the guard.
+
+The ownership check is namespace hygiene, not an authorization boundary: it
+stops an extension minting events in a namespace it does not own, the same
+anti-collision rule its error codes obey. Any first-party extension could call
+`asobi_presence:send/2` directly, so nothing downstream should treat a
+successful `emit/4` as proof of a privilege.
+
+On success the event reaches the player's live sessions as a `module.event`
+wire frame (`m:asobi_ws_handler`). This is an Erlang-only seam: only an
+extension's own code calls it, and it has no Lua binding.
+
+Returns `{error, asobi_error:object()}`, never a crash, for: an event name
+outside the charset/shape or over 64 bytes (`event.invalid_name`); a domain
+`Extension` does not own (`event.unowned_domain`); `Data` that is not
+JSON-encodable (`event.invalid_data`); or encoded `Data` at or over 64 KiB
+(`event.payload_too_large`). Validating encodability here - one extra encode off
+the per-tick hot path - is what keeps a bad term from reaching the socket and
+dropping every one of the player's sessions.
+""".
+-spec emit(atom(), binary(), binary(), map()) -> ok | {error, asobi_error:object()}.
+emit(Extension, PlayerId, Event, Data) when is_atom(Extension), is_binary(Event), is_map(Data) ->
+    case emit_problem(Extension, Event, Data) of
+        ok ->
+            asobi_presence:send(PlayerId, {extension_event, Extension, Event, Data}),
+            ok;
+        {error, _Object} = Error ->
+            Error
+    end.
+
+%% Each error code is a literal at its `asobi_error:object/2` call site: the
+%% shared-object contract test (`asobi_error_contract_tests`) refuses a code
+%% built from a variable, which is what stops a script- or client-supplied
+%% string ever becoming a code. Only the details map is factored out.
+emit_problem(Extension, Event, Data) ->
+    case event_domain(Event) of
+        {ok, Domain} ->
+            case emitter_owns_rpc_prefix(Extension, Domain) of
+                true ->
+                    data_problem(Data, Extension, Event);
+                false ->
+                    {error, asobi_error:object(~"event.unowned_domain", details(Extension, Event))}
+            end;
+        error ->
+            {error, asobi_error:object(~"event.invalid_name", details(Extension, Event))}
+    end.
+
+%% Prove Data encodable and within the frame cap here, at the trust boundary, so
+%% the author gets a synchronous error rather than a silent degrade on someone
+%% else's socket. The ws clause re-encodes the wrapper, so this encode is spent
+%% on validation alone - acceptable off the per-tick path for a frozen wire.
+data_problem(Data, Extension, Event) ->
+    try json:encode(Data) of
+        Encoded ->
+            case iolist_size(Encoded) >= ?MAX_EVENT_DATA_BYTES of
+                true ->
+                    {error,
+                        asobi_error:object(~"event.payload_too_large", details(Extension, Event))};
+                false ->
+                    ok
+            end
+    catch
+        _:_ -> {error, asobi_error:object(~"event.invalid_data", details(Extension, Event))}
+    end.
+
+details(Extension, Event) ->
+    #{module => atom_to_binary(Extension, utf8), event => Event}.
+
+%% `<domain>.<name>`, each half in the same charset the ws handler holds a
+%% game.broadcast name to (`asobi_ws_handler:is_event_name_char/1`), one dot,
+%% at most 64 bytes. The charset excludes `.`, so an all-charset domain and name
+%% also guarantee exactly one separator and reject non-ASCII / invalid-UTF-8
+%% bytes that would otherwise crash json:encode/1 in every subscriber's socket.
+event_domain(Event) ->
+    case is_dotted(Event) andalso byte_size(Event) =< ?MAX_EVENT_NAME_BYTES of
+        true ->
+            case binary:split(Event, ~".") of
+                [Domain, Name] ->
+                    case charset(Domain) andalso charset(Name) of
+                        true -> {ok, Domain};
+                        false -> error
+                    end;
+                _ ->
+                    error
+            end;
+        false ->
+            error
+    end.
+
+charset(Bin) ->
+    lists:all(fun asobi_ws_handler:is_event_name_char/1, binary_to_list(Bin)).
+
+emitter_owns_rpc_prefix(Extension, Domain) ->
+    case lists:search(fun(#{name := Name}) -> Name =:= Extension end, resolve()) of
+        {value, Resolved} -> lists:member(Domain, claims(Resolved, rpc));
+        false -> false
+    end.
 
 %% The codes term is written before the resolved term, so a concurrent second
 %% caller that sees ?KEY populated also sees the codes it implies.

--- a/src/social/asobi_presence.erl
+++ b/src/social/asobi_presence.erl
@@ -64,7 +64,10 @@ clauses against the same named type rather than an ad-hoc guess.
     | {dm_message, map()}
     | {notification, map()}
     | {game_message, term()}
-    | {script_error, map()}.
+    | {game_message, atom(), term()}
+    | {script_error, map()}
+    | {script_error, atom(), map()}
+    | {extension_event, atom(), binary(), map()}.
 
 -export_type([event_name/0, message/0]).
 

--- a/src/ws/asobi_ws_handler.erl
+++ b/src/ws/asobi_ws_handler.erl
@@ -8,7 +8,10 @@
 %% match./world. event stays inside the reserved namespace (#303), and so
 %% asobi_lua_api can reject a bad game.broadcast name against these same
 %% rules at the script's call site instead of re-stating them.
--export([reserved_event_names/0, event_name_binary/1]).
+%% `is_event_name_char/1` is the charset predicate itself, reused by
+%% `asobi_extensions:emit/4` to validate a `module.event` name's bytes against
+%% the same allowlist rather than forking a second charset notion.
+-export([reserved_event_names/0, event_name_binary/1, is_event_name_char/1]).
 
 -include_lib("kernel/include/logger.hrl").
 
@@ -283,6 +286,27 @@ websocket_info({asobi_message, {game_message, Extension, Payload}}, State) when
     %% breaking change.
     Body = #{~"module" => atom_to_binary(Extension), ~"message" => Payload},
     {reply, extension_frames(~"module.message", ~"game.message", Body), State};
+websocket_info({asobi_message, {extension_event, Extension, Event, Data}}, State) when
+    is_atom(Extension), is_binary(Event), is_map(Data)
+->
+    %% A named, routable server->client event an extension pushes from its own
+    %% Erlang code via asobi_extensions:emit/4. Distinct from module.message
+    %% (unnamed dev messages) and module.error (dev-mode only): the producer is
+    %% in `module`, the `<domain>.<name>` event in `event`, and `data` is always
+    %% an object. Emitted as a single frame - unlike module.message it has no
+    %% pre-S6 legacy alias, so it never routes through extension_frames/3.
+    %% emit/4 has already proven Data JSON-encodable, but the encode is still
+    %% wrapped like the script_error clause: a bad term reaching here must
+    %% degrade to an error frame, never crash this player's connection process
+    %% (send/2 fans out to every session pid, so a crash drops them all).
+    Payload = #{~"module" => atom_to_binary(Extension), ~"event" => Event, ~"data" => Data},
+    Reply =
+        try
+            encode_reply(undefined, ~"module.event", Payload)
+        catch
+            _:_ -> encode_error(undefined, ~"internal")
+        end,
+    {reply, {text, Reply}, State};
 websocket_info({asobi_message, {script_error, Payload}}, State) when is_map(Payload) ->
     websocket_info({asobi_message, {script_error, ?DEFAULT_EXTENSION, Payload}}, State);
 websocket_info({asobi_message, {script_error, Extension, Payload}}, State) when
@@ -1043,7 +1067,10 @@ event_name_binary(Event) when is_binary(Event) ->
     end.
 
 %% Deliberately excludes `.` — a script must not be able to mint a deeper
-%% `world.foo.bar` sub-namespace.
+%% `world.foo.bar` sub-namespace. Spec'd over `term()`, not `byte()`: it is a
+%% `lists:all/2` predicate and must stay `fun((term()) -> boolean())` for
+%% eqwalizer, which its `_ -> false` total clause honours for any term.
+-spec is_event_name_char(term()) -> boolean().
 is_event_name_char(C) when C >= $a, C =< $z -> true;
 is_event_name_char(C) when C >= $A, C =< $Z -> true;
 is_event_name_char(C) when C >= $0, C =< $9 -> true;

--- a/test/asobi_protocol_coverage_tests.erl
+++ b/test/asobi_protocol_coverage_tests.erl
@@ -260,6 +260,43 @@ scan_documented_reserved_names(Bin) ->
         nomatch -> []
     end.
 
+%% Every server->client frame family (the token before the first dot) must be a
+%% reserved RPC prefix. Most families are covered by an error domain or a Lua
+%% namespace; the ones that are neither (`session`, `presence`, `module`) are
+%% reserved via asobi_extension_reserved:core_wire_prefixes/0. Deriving the
+%% assertion from the emitted set means a FUTURE core frame family lacking both
+%% an error domain and a Lua namespace fails this test until it is added to the
+%% constant - the reserved_tests keep the explicit session/presence/module
+%% asserts, which catch removal from the constant.
+every_emitted_frame_family_prefix_is_reserved_test() ->
+    Emitted = enumerate_emitted_events(),
+    Prefixes = lists:usort(lists:append([wire_prefix(Type) || Type <- Emitted])),
+    #{rpc := Reserved} = asobi_extension_reserved:namespaces(),
+    Missing = Prefixes -- Reserved,
+    ?assertEqual(
+        [],
+        Missing,
+        lists:flatten(
+            io_lib:format(
+                "server->client frame family prefixes not reserved in "
+                "asobi_extension_reserved:namespaces() rpc set (add to "
+                "core_wire_prefixes/0 if the family has no error domain or Lua "
+                "namespace): ~p",
+                [Missing]
+            )
+        )
+    ).
+
+%% The bare `error` envelope has no family prefix; everything else contributes
+%% the token before its first dot.
+wire_prefix(~"error") ->
+    [];
+wire_prefix(Type) ->
+    case binary:split(Type, ~".") of
+        [Prefix, _] -> [Prefix];
+        _ -> []
+    end.
+
 match_or_world_suffix(<<"match.", Suffix/binary>>) -> {true, Suffix};
 match_or_world_suffix(<<"world.", Suffix/binary>>) -> {true, Suffix};
 match_or_world_suffix(_) -> false.

--- a/test/asobi_ws_handler_tests.erl
+++ b/test/asobi_ws_handler_tests.erl
@@ -218,6 +218,41 @@ script_error_unencodable_payload_degrades_test() ->
     ?assertEqual(~"internal", maps:get(~"code", maps:get(~"error", Payload))),
     ?assertEqual([~"error", ~"reason"], lists:sort(maps:keys(Payload))).
 
+%% module.event (asobi_extensions:emit/4): a named, routable server->client
+%% event, distinct from the unnamed module.message dev frame. Emitted as a
+%% single frame - it has no pre-S6 legacy alias, so unlike module.message it
+%% does not dual-emit through extension_frames/3. `data` is always an object.
+extension_event_encodes_the_named_push_envelope_test() ->
+    Data = #{~"quest_id" => ~"01j8", ~"reward" => 250},
+    Msg = {asobi_message, {extension_event, quests, ~"quests.completed", Data}},
+    {reply, {text, Frame}, _State1} = asobi_ws_handler:websocket_info(Msg, #{}),
+    ?assertEqual(
+        #{
+            ~"type" => ~"module.event",
+            ~"payload" => #{
+                ~"module" => ~"quests",
+                ~"event" => ~"quests.completed",
+                ~"data" => Data
+            }
+        },
+        decode(Frame)
+    ).
+
+extension_event_is_a_single_frame_test() ->
+    Msg = {asobi_message, {extension_event, quests, ~"quests.completed", #{}}},
+    ?assertMatch({reply, {text, _}, _}, asobi_ws_handler:websocket_info(Msg, #{})).
+
+%% The socket safety net: emit/4 normally rejects non-encodable data, but if a
+%% bad term reaches the ws clause the encode is wrapped so it degrades to an
+%% error frame rather than crashing this connection process - send/2 fans out
+%% to every one of the player's session pids, so a crash would drop them all.
+extension_event_unencodable_data_degrades_test() ->
+    Msg = {asobi_message, {extension_event, quests, ~"x.y", #{~"k" => self()}}},
+    {reply, {text, Frame}, _State1} = asobi_ws_handler:websocket_info(Msg, #{}),
+    Decoded = decode(Frame),
+    ?assertEqual(~"error", maps:get(~"type", Decoded)),
+    ?assertEqual(~"internal", maps:get(~"reason", maps:get(~"payload", Decoded))).
+
 type_of({text, Raw}) ->
     #{~"type" := Type} = decode(Raw),
     Type.

--- a/test/extensions/asobi_extension_reserved_tests.erl
+++ b/test/extensions/asobi_extension_reserved_tests.erl
@@ -98,6 +98,21 @@ rpc_prefixes_cover_error_domains_and_lua_test() ->
     [?assert(lists:member(N, Reserved)) || N <- Lua],
     ?assertNot(lists:member(~"quests", Reserved)).
 
+%% session.*, presence.* and module.* are core wire frame families with no
+%% error domain and no Lua namespace, so error_domains/0 and lua/0 miss their
+%% prefixes. core_wire_prefixes/0 folds them into the rpc union. Anti-drift:
+%% every prefix the constant names must land in the reserved rpc set, so a
+%% frame family added to the constant later cannot be silently unreserved.
+core_wire_prefixes_are_reserved_rpc_prefixes_test() ->
+    #{rpc := Reserved} = asobi_extension_reserved:namespaces(),
+    [
+        ?assert(lists:member(Prefix, Reserved))
+     || Prefix <- asobi_extension_reserved:core_wire_prefixes()
+    ],
+    ?assert(lists:member(~"session", Reserved)),
+    ?assert(lists:member(~"presence", Reserved)),
+    ?assert(lists:member(~"module", Reserved)).
+
 %% Deleting this env key silently removes `rebar3 asobi check` from every host.
 the_build_time_gate_is_declared_to_rebar3_test() ->
     _ = application:load(asobi),

--- a/test/extensions/asobi_extensions_tests.erl
+++ b/test/extensions/asobi_extensions_tests.erl
@@ -26,6 +26,7 @@ extensions_test_() ->
         fun reserved_core_table_refused/0,
         fun reserved_core_queue_refused/0,
         fun reserved_rpc_prefix_refused/0,
+        fun reserved_core_wire_prefix_refused/0,
         fun claiming_outside_the_owned_set_refused/0,
         fun a_queue_is_derived_from_the_worker_that_declares_it/0,
         fun a_table_is_derived_from_the_schema_that_declares_it/0,
@@ -65,6 +66,99 @@ extensions_test_() ->
         fun a_duplicated_requires_entry_reports_once/0,
         fun a_requires_must_be_a_list_of_atoms/0
     ]}.
+
+%% emit/4 needs the quests fixture resolved (for its owned `quests` RPC prefix).
+%% asobi_presence:send/2 is meck'd with a passthrough so the produced term is
+%% observable through meck's call history - a foreach test body runs in its own
+%% process, so message-passing to the setup process would never arrive.
+emit_test_() ->
+    {foreach, fun emit_setup/0, fun emit_cleanup/1, [
+        fun emit_reaches_the_player_under_an_owned_domain/0,
+        fun emit_under_an_unowned_domain_is_refused/0,
+        fun emit_with_a_malformed_event_is_refused/0,
+        fun emit_with_a_non_ascii_event_name_is_refused/0,
+        fun emit_with_non_encodable_data_is_refused/0,
+        fun emit_with_oversized_data_is_refused/0,
+        fun emit_rejects_non_map_data/0
+    ]}.
+
+emit_setup() ->
+    asobi_extensions:reset(),
+    meck:new(asobi_presence, [passthrough, no_link]),
+    meck:expect(asobi_presence, send, fun(_PlayerId, _Message) -> ok end),
+    install(?QUESTS).
+
+emit_cleanup(_) ->
+    asobi_fixture_app:uninstall(?QUESTS),
+    meck:unload(asobi_presence),
+    asobi_extensions:reset(),
+    ok.
+
+emit_reaches_the_player_under_an_owned_domain() ->
+    Data = #{~"quest_id" => ~"01j8", ~"reward" => 250},
+    ?assertEqual(ok, asobi_extensions:emit(quests, ~"p1", ~"quests.completed", Data)),
+    ?assert(
+        meck:called(
+            asobi_presence, send, [~"p1", {extension_event, quests, ~"quests.completed", Data}]
+        )
+    ).
+
+emit_under_an_unowned_domain_is_refused() ->
+    %% quests owns the `quests` RPC prefix, not `social`.
+    {error, Object} = asobi_extensions:emit(quests, ~"p1", ~"social.pinged", #{}),
+    ?assertEqual(~"event.unowned_domain", code_of(Object)),
+    ?assertEqual(0, meck:num_calls(asobi_presence, send, ['_', '_'])).
+
+emit_with_a_malformed_event_is_refused() ->
+    OwnedButTooLong = <<"quests.", (binary:copy(~"a", 58))/binary>>,
+    ?assertEqual(65, byte_size(OwnedButTooLong)),
+    Names = [~"nodot", ~"quests.", ~".completed", ~"", ~"quests.a.b", OwnedButTooLong],
+    [
+        begin
+            {error, Object} = asobi_extensions:emit(quests, ~"p1", Name, #{}),
+            ?assertEqual(~"event.invalid_name", code_of(Object))
+        end
+     || Name <- Names
+    ],
+    ?assertEqual(0, meck:num_calls(asobi_presence, send, ['_', '_'])).
+
+%% A non-ASCII / invalid-UTF-8 byte in the name is rejected before it can reach
+%% json:encode/1 and crash every subscriber's socket. The domain is owned, so
+%% only the charset check stands between it and the wire.
+emit_with_a_non_ascii_event_name_is_refused() ->
+    {error, Object} = asobi_extensions:emit(quests, ~"p1", <<"quests.", 16#FF>>, #{}),
+    ?assertEqual(~"event.invalid_name", code_of(Object)),
+    ?assertEqual(0, meck:num_calls(asobi_presence, send, ['_', '_'])).
+
+%% A pid (or any non-JSON term) in Data raises inside json:encode/1; emit/4
+%% catches it at the boundary and returns an error rather than crashing the
+%% socket clause. Owned domain + valid name, so only encodability stands here.
+emit_with_non_encodable_data_is_refused() ->
+    {error, Object} = asobi_extensions:emit(quests, ~"p1", ~"quests.completed", #{~"pid" => self()}),
+    ?assertEqual(~"event.invalid_data", code_of(Object)),
+    ?assertEqual(0, meck:num_calls(asobi_presence, send, ['_', '_'])).
+
+%% One byte of data blob per the 64 KiB cap, plus the JSON overhead, is over it.
+emit_with_oversized_data_is_refused() ->
+    Big = #{~"blob" => binary:copy(~"a", 65536)},
+    {error, Object} = asobi_extensions:emit(quests, ~"p1", ~"quests.completed", Big),
+    ?assertEqual(~"event.payload_too_large", code_of(Object)),
+    ?assertEqual(0, meck:num_calls(asobi_presence, send, ['_', '_'])).
+
+%% The `is_map(Data)` guard has no in-type value that fails it, so the non-map
+%% arguments travel through apply/3 - which eqwalizer does not arg-check - to
+%% reach the guard at runtime without a static type error.
+emit_rejects_non_map_data() ->
+    [
+        ?assertError(
+            function_clause,
+            erlang:apply(asobi_extensions, emit, [quests, ~"p1", ~"quests.completed", NotAMap])
+        )
+     || NotAMap <- [[], 7]
+    ].
+
+code_of(#{error := #{code := Code}}) ->
+    Code.
 
 setup() ->
     asobi_extensions:reset(),
@@ -198,6 +292,16 @@ reserved_core_queue_refused() ->
 reserved_rpc_prefix_refused() ->
     tunable(#{rpc => #{~"storage.get" => {tunable_rpc, get, 2}}}),
     ?assert(lists:member({reserved_namespace, rpc, ~"storage", ?TUNABLE}, check_problems())).
+
+%% `session` and `presence` are core wire frame families with no error domain
+%% and no Lua namespace, now reserved via core_wire_prefixes/0. An extension
+%% claiming either as an owns/0 RPC prefix is refused, so it cannot forge a
+%% frame in a core family or emit an event under it.
+reserved_core_wire_prefix_refused() ->
+    tunable(#{owns => #{rpc => [~"session"]}}),
+    ?assert(lists:member({reserved_namespace, rpc, ~"session", ?TUNABLE}, check_problems())),
+    retune(#{owns => #{rpc => [~"presence"]}}),
+    ?assert(lists:member({reserved_namespace, rpc, ~"presence", ?TUNABLE}, check_problems())).
 
 claiming_outside_the_owned_set_refused() ->
     tunable(#{


### PR DESCRIPTION
## Wave 0a — the deadline-bound wire seam

Adds `module.event`, a server->client wire frame letting first-party extension Erlang code push a **named, routable** event to a player. Frozen-at-1.0 wire, so the shape and reserved-set are locked in now.

### Frame
```json
{"type":"module.event","payload":{"module":"quests","event":"quests.completed","data":{"quest_id":"01j8","reward":250}}}
```
- `module` = emitter short name; `event` = `<domain>.<name>` (domain must be an owned `owns/0` rpc prefix); `data` always an object.

### Surface
- `asobi_extensions:emit/4` — the single Erlang-only entry point. Validates event-name shape+charset, ownership (domain in the emitter's resolved `owns/0` rpc set), then encodability + a 64 KiB size cap, all at the trust boundary so the author gets a synchronous `{error, asobi_error:object()}`.
- Reserved-set hardening: `core_wire_prefixes/0` = `[session, presence, module]` folded into the reserved rpc union, closing the gap where an extension could own a core wire frame family and forge e.g. `session.connected`.
- `asobi_presence:message/0` gains `{extension_event, ...}` and the two pre-existing 3-tuple drift variants.
- One ws-handler clause emits the single frame (no legacy alias).

### Crash-safety (gate blocker, fixed)
The gate (guardian + security, independently) found the encode could crash the target player's WS process on a non-encodable `Data` value or non-ASCII event name. Fixed on both sides: charset/encodability/size validation at `emit/4` + a try/catch degrade-to-error net at the ws clause (mirroring the `script_error` sibling). New codes `event.invalid_data` (400), `event.payload_too_large` (413).

### Docs + drift guard
- `guides/websocket-protocol.md` gains a `module.event` section (fixture JSON as the example).
- `asobi_protocol_coverage_tests` gains a derived test asserting every emitted frame-family prefix is a reserved rpc prefix (so a future core frame family can't silently reopen the gap).

Gate: asobi-architecture-guardian (accept-with-changes) + beam-security-reviewer (1 High, fixed) + erlang-code-reviewer (0 blockers) + adversarial re-verify of the crash-safety fix. Local: eqwalize delta 0, dialyzer/xref/fmt clean, 1872 eunit + 29 CT green.