### PR TITLE
feat: release-level config-off switch for storage

### DIFF
--- a/guides/configuration.md
+++ b/guides/configuration.md
@@ -640,6 +640,23 @@ everyone out - see [Clustering](clustering.md) and
 [Operator console](console.md), which owns turning it on, signing in, what the
 screens show and the troubleshooting.
 
+## Storage
+
+Cloud saves and the generic key-value store, served at `/api/v1/saves*` and
+`/api/v1/storage*` and exposed to Lua as `game.storage.*`. On by default; set
+`storage` to `false` to switch the whole subsystem off - the opposite default
+to the console, which is off until asked for.
+
+```erlang
+{storage, false}
+```
+
+| Key | Default | Description |
+|-----|---------|-------------|
+| `storage` | `true` | Serve the storage subsystem. When `false` the seven `/saves` and `/storage` routes answer 404 and the `game.storage.*` Lua namespace is withheld at VM install |
+
+It has no environment variable; set it in `sys.config`.
+
 ## Vote templates
 
 Reusable vote configurations, merged with the per-vote config from your game

--- a/guides/rest-api.md
+++ b/guides/rest-api.md
@@ -368,6 +368,10 @@ PUT    /api/v1/storage/:collection/:key        Write object
 DELETE /api/v1/storage/:collection/:key        Delete object
 ```
 
+The whole subsystem is on by default and switches off with `{storage, false}`;
+off, all seven routes answer 404 - see
+[Configuration](configuration.md#storage).
+
 ## Ops
 
 ```

--- a/guides/self-hosting.md
+++ b/guides/self-hosting.md
@@ -381,6 +381,9 @@ that evaluates on a *running* node, and `asobi_lua_validate:cli/1` ends in
 
 - **The console is off** unless you turned it on. Leave it off if nobody needs
   it; if you turn it on, put it behind the proxy restriction above.
+- **Storage is on** unless you set `{storage, false}`. Off, the `/saves` and
+  `/storage` routes answer 404 and Lua's `game.storage.*` is withheld - see
+  [Configuration](configuration.md#storage).
 - **Guest auth is off** until the game declares `guest_auth = true` in its Lua
   *and* the operator configures a pepper of at least 32 bytes. Both halves are
   required (ADR 0004), and the operator half currently needs a `sys.config`:

--- a/src/asobi_error.erl
+++ b/src/asobi_error.erl
@@ -229,13 +229,20 @@ working and a new one reads one place: see `legacy/2`.
     {~"console.not_found", 404, ~"No console resource exists at this path."},
     {~"console.not_built", 503, ~"The console bundle is not built into this release."},
 
-    %% Cloud saves.
+    %% Cloud saves. save.not_found is also what the slot-keyed /saves routes
+    %% return when storage is switched off at the release level
+    %% (asobi_storage:enabled/0), so a disabled deployment reads the same as an
+    %% empty one - see asobi_storage_controller.
     {~"save.not_found", 404, ~"No cloud save exists in this slot."},
     {~"save.too_large", 413, ~"The save data is larger than the per-slot limit."},
     {~"save.version_conflict", 409, ~"The slot was written by another client."},
     {~"save.slot_limit_reached", 409, ~"The player has no free cloud-save slots."},
 
-    %% Generic storage.
+    %% Generic storage. storage.not_found is also what the /storage routes
+    %% return when storage is switched off (asobi_storage:enabled/0), the
+    %% collection/key counterpart to save.not_found for the /saves routes: each
+    %% family answers with its own genuine-miss code so the off-state cannot be
+    %% fingerprinted against an enabled but empty deployment.
     {~"storage.not_found", 404, ~"No object exists at this collection and key."},
     {~"storage.forbidden", 403, ~"The object's permissions do not allow this."},
     {~"storage.value_too_large", 413, ~"The value is larger than the per-object limit."},

--- a/src/controllers/asobi_storage_controller.erl
+++ b/src/controllers/asobi_storage_controller.erl
@@ -19,16 +19,46 @@
 %% other value made the row self-DoS unreachable. Whitelist + reject.
 -define(VALID_PERMS, [~"public", ~"owner"]).
 
+-type response() ::
+    {json, map()}
+    | {json, integer(), map(), map()}
+    | {asobi_error, asobi_error:code()}
+    | {asobi_error, asobi_error:code(), asobi_error:details()}.
+
+%% Storage can be switched off for the whole release (asobi_storage:enabled/0).
+%% When it is, each route short-circuits ahead of its DB and handler work and
+%% answers the 404 it would give for a genuine miss - save.not_found on the
+%% slot-keyed /saves routes, storage.not_found on the /storage routes - so the
+%% off-state cannot be told apart from an enabled but empty deployment. Auth is
+%% an upstream Nova plugin that has already run by the time a handler is
+%% reached, so the guard precedes the DB work, not the authentication. One
+%% guard serves all seven routes, given the family's miss-response - kept a
+%% literal at each call site so the error-code contract scanner sees it.
+-spec guarded(response(), fun(() -> response())) -> response().
+guarded(Disabled, Handler) ->
+    case asobi_storage:enabled() of
+        true -> Handler();
+        false -> Disabled
+    end.
+
 %% --- Cloud Saves ---
 
--spec list_saves(cowboy_req:req()) -> {json, map()}.
-list_saves(#{auth_data := #{player_id := PlayerId}} = _Req) ->
+-spec list_saves(cowboy_req:req()) -> response().
+list_saves(Req) ->
+    guarded({asobi_error, ~"save.not_found"}, fun() -> do_list_saves(Req) end).
+
+-spec do_list_saves(cowboy_req:req()) -> {json, map()}.
+do_list_saves(#{auth_data := #{player_id := PlayerId}} = _Req) ->
     Q = kura_query:where(kura_query:from(asobi_cloud_save), {player_id, PlayerId}),
     {ok, Saves} = asobi_repo:all(Q),
     {json, #{saves => [maps:with([slot, version, updated_at], S) || S <- Saves]}}.
 
--spec get_save(cowboy_req:req()) -> {json, map()} | {asobi_error, asobi_error:code()}.
-get_save(#{bindings := #{~"slot" := Slot}, auth_data := #{player_id := PlayerId}} = _Req) ->
+-spec get_save(cowboy_req:req()) -> response().
+get_save(Req) ->
+    guarded({asobi_error, ~"save.not_found"}, fun() -> do_get_save(Req) end).
+
+-spec do_get_save(cowboy_req:req()) -> {json, map()} | {asobi_error, asobi_error:code()}.
+do_get_save(#{bindings := #{~"slot" := Slot}, auth_data := #{player_id := PlayerId}} = _Req) ->
     Q = kura_query:where(
         kura_query:where(kura_query:from(asobi_cloud_save), {player_id, PlayerId}),
         {slot, Slot}
@@ -38,12 +68,16 @@ get_save(#{bindings := #{~"slot" := Slot}, auth_data := #{player_id := PlayerId}
         {ok, []} -> {asobi_error, ~"save.not_found"}
     end.
 
--spec put_save(cowboy_req:req()) ->
+-spec put_save(cowboy_req:req()) -> response().
+put_save(Req) ->
+    guarded({asobi_error, ~"save.not_found"}, fun() -> do_put_save(Req) end).
+
+-spec do_put_save(cowboy_req:req()) ->
     {json, map()}
     | {json, integer(), map(), map()}
     | {asobi_error, asobi_error:code()}
     | {asobi_error, asobi_error:code(), asobi_error:details()}.
-put_save(
+do_put_save(
     #{bindings := #{~"slot" := Slot}, json := Params, auth_data := #{player_id := PlayerId}} = _Req
 ) when is_map(Params), is_binary(PlayerId) ->
     Data = maps:get(~"data", Params, #{}),
@@ -105,8 +139,12 @@ put_save(
 %% row these ACL-based case clauses assume.
 -define(PLAYER_SCOPE, {player_id, is_not_nil}).
 
--spec get_storage(cowboy_req:req()) -> {json, map()} | {asobi_error, asobi_error:code()}.
-get_storage(
+-spec get_storage(cowboy_req:req()) -> response().
+get_storage(Req) ->
+    guarded({asobi_error, ~"storage.not_found"}, fun() -> do_get_storage(Req) end).
+
+-spec do_get_storage(cowboy_req:req()) -> {json, map()} | {asobi_error, asobi_error:code()}.
+do_get_storage(
     #{bindings := #{~"collection" := Col, ~"key" := Key}, auth_data := #{player_id := PlayerId}} =
         _Req
 ) ->
@@ -134,9 +172,13 @@ get_storage(
             {asobi_error, ~"storage.query_failed"}
     end.
 
--spec put_storage(cowboy_req:req()) ->
+-spec put_storage(cowboy_req:req()) -> response().
+put_storage(Req) ->
+    guarded({asobi_error, ~"storage.not_found"}, fun() -> do_put_storage(Req) end).
+
+-spec do_put_storage(cowboy_req:req()) ->
     {json, map()} | {json, integer(), map(), map()} | {asobi_error, asobi_error:code()}.
-put_storage(
+do_put_storage(
     #{
         bindings := #{~"collection" := Col, ~"key" := Key},
         json := Params,
@@ -157,7 +199,7 @@ put_storage(
         true ->
             put_storage_checked(Col, Key, PlayerId, Value, ReadPerm, WritePerm)
     end;
-put_storage(_Req) ->
+do_put_storage(_Req) ->
     {asobi_error, ~"storage.invalid_request"}.
 
 -spec put_storage_checked(
@@ -227,8 +269,12 @@ put_storage_checked(Col, Key, PlayerId, Value, ReadPerm, WritePerm) ->
             end
     end.
 
--spec delete_storage(cowboy_req:req()) -> {json, map()} | {asobi_error, asobi_error:code()}.
-delete_storage(
+-spec delete_storage(cowboy_req:req()) -> response().
+delete_storage(Req) ->
+    guarded({asobi_error, ~"storage.not_found"}, fun() -> do_delete_storage(Req) end).
+
+-spec do_delete_storage(cowboy_req:req()) -> {json, map()} | {asobi_error, asobi_error:code()}.
+do_delete_storage(
     #{bindings := #{~"collection" := Col, ~"key" := Key}, auth_data := #{player_id := PlayerId}} =
         _Req
 ) ->
@@ -258,8 +304,12 @@ delete_storage(
             {asobi_error, ~"storage.query_failed"}
     end.
 
--spec list_storage(cowboy_req:req()) -> {json, map()}.
-list_storage(
+-spec list_storage(cowboy_req:req()) -> response().
+list_storage(Req) ->
+    guarded({asobi_error, ~"storage.not_found"}, fun() -> do_list_storage(Req) end).
+
+-spec do_list_storage(cowboy_req:req()) -> {json, map()}.
+do_list_storage(
     #{bindings := #{~"collection" := Col}, qs := Qs, auth_data := #{player_id := PlayerId}} = _Req
 ) when is_binary(Qs), is_binary(PlayerId) ->
     Params = cow_qs:parse_qs(Qs),

--- a/src/lua/asobi_lua_api.erl
+++ b/src/lua/asobi_lua_api.erl
@@ -39,7 +39,7 @@ game.leaderboard.around(board_id, player_id, count)
 game.notify(player_id, type, subject, data)
 game.notify_many(player_ids, type, subject, data)
 
--- Key-Value Storage
+-- Key-Value Storage (withheld when storage is off; asobi_storage:enabled/0)
 game.storage.get(collection, key)
 game.storage.set(collection, key, value)
 game.storage.player_get(player_id, collection, key)
@@ -127,9 +127,21 @@ install_pure(Ctx, St0) ->
 %% installing `game.quests.progress` into a nil `game.quests` raises.
 create_tables(Ctx, St) ->
     create_namespaces(
-        asobi_lua_surface:reserved_namespaces() ++ extension_namespaces(Ctx),
+        [Ns || Ns <- asobi_lua_surface:reserved_namespaces(), storage_available(Ns)] ++
+            extension_namespaces(Ctx),
         St
     ).
+
+%% Storage is the one core namespace with a release-level off switch
+%% (asobi_storage:enabled/0). When it is off, neither the `game.storage` table
+%% nor its four bindings are installed - a script indexing `game.storage` then
+%% hits a nil-index Lua error, the twin of the HTTP 404 asobi_storage_controller
+%% answers. Gated here so install/2 and install_pure/2 (both build via
+%% create_tables and api_surface) withhold it together; the name stays reserved
+%% (asobi_lua_surface) whether or not it is installed.
+-spec storage_available([binary(), ...]) -> boolean().
+storage_available([~"game", ~"storage" | _]) -> asobi_storage:enabled();
+storage_available(_Path) -> true.
 
 create_namespaces([], St) ->
     St;
@@ -145,6 +157,13 @@ api_fns(Ctx, Mode) ->
 %% a resource; `none` only reads or computes.
 -spec api_surface(map()) -> [{[binary(), ...], asobi_lua_surface:effect(), function()}].
 api_surface(Ctx) ->
+    [
+        Entry
+     || {Path, _, _} = Entry <- core_surface(Ctx) ++ extension_surface(Ctx), storage_available(Path)
+    ].
+
+-spec core_surface(map()) -> [{[binary(), ...], asobi_lua_surface:effect(), function()}].
+core_surface(Ctx) ->
     [
         %% Core
         {[~"game", ~"id"], none, fun_id()},
@@ -188,7 +207,7 @@ api_surface(Ctx) ->
         %% Terrain
         {[~"game", ~"terrain", ~"get_chunk"], none, fun_terrain_get_chunk(Ctx)},
         {[~"game", ~"terrain", ~"preload"], terrain_effect(Ctx), fun_terrain_preload(Ctx)}
-    ] ++ extension_surface(Ctx).
+    ].
 
 %%--------------------------------------------------------------------
 %% Extension namespaces (asobi_extension:lua/0)

--- a/src/ops/asobi_ops_features.erl
+++ b/src/ops/asobi_ops_features.erl
@@ -113,6 +113,7 @@ capabilities() ->
             {~"matches", any_mode(fun is_match_mode/1)},
             {~"oidc", configured_collection(oidc_providers)},
             {~"steam", configured(steam_api_key)},
+            {~"storage", asobi_storage:enabled()},
             {~"worlds", any_mode(fun is_world_mode/1)}
         ])
     ].

--- a/src/storage/asobi_storage.erl
+++ b/src/storage/asobi_storage.erl
@@ -3,7 +3,15 @@
 
 -include_lib("kura/include/kura.hrl").
 
--export([table/0, fields/0, associations/0, indexes/0, generate_id/0]).
+-export([enabled/0, table/0, fields/0, associations/0, indexes/0, generate_id/0]).
+
+%% Storage is on unless a release explicitly sets `storage` to `false` - the
+%% opposite default to the console (m:asobi_console), which is off until asked
+%% for. When off the seven HTTP routes answer 404 and the game.storage.* Lua
+%% namespace is withheld at VM install.
+-spec enabled() -> boolean().
+enabled() ->
+    application:get_env(asobi, storage, true) =:= true.
 
 -spec table() -> binary().
 table() -> ~"storage".

--- a/test/asobi_lua_api_tests.erl
+++ b/test/asobi_lua_api_tests.erl
@@ -109,7 +109,12 @@ api_test_() ->
         {"probe ctx: game.storage.get still runs for real", fun probe_storage_get_live/0},
         {"probe ctx: game.chat.send is inert", fun probe_chat_send_inert/0},
         {"install creates exactly the reserved namespaces", fun install_creates_reserved/0},
-        {"probe install creates the same namespaces", fun probe_install_creates_reserved/0}
+        {"probe install creates the same namespaces", fun probe_install_creates_reserved/0},
+        {"storage on by default installs game.storage", fun storage_enabled_installs_namespace/0},
+        {"storage off withholds game.storage at install",
+            fun storage_disabled_withholds_namespace/0},
+        {"storage off withholds game.storage in a probe VM too",
+            fun storage_disabled_withholds_namespace_probe/0}
     ]}.
 
 setup() ->
@@ -962,6 +967,51 @@ probe_install_creates_reserved() ->
     Reserved = lists:sort(asobi_lua_surface:reserved_namespaces()),
     ?assertEqual(Reserved, lists:sort(namespace_tables(St))),
     ?assertEqual(Reserved, lists:sort(populated_namespaces(St))).
+
+%% --- Storage off switch (asobi_storage:enabled/0) ---
+%%
+%% When storage is disabled at the release level the `game.storage` table is
+%% not pre-created and its four bindings are not installed, so a script that
+%% indexes `game.storage` gets a nil-index error. Both install/2 and
+%% install_pure/2 honour the switch. The name stays reserved either way.
+
+storage_enabled_installs_namespace() ->
+    with_storage(true, fun() ->
+        St = install_api(),
+        ?assert(lists:member([~"game", ~"storage"], namespace_tables(St))),
+        ?assert(lists:member([~"game", ~"storage"], populated_namespaces(St))),
+        Code = "local r = game.storage.get('c', 'k')\nreturn r.error ~= nil",
+        {ok, [true | _], _} = eval(Code, St)
+    end).
+
+storage_disabled_withholds_namespace() ->
+    with_storage(false, fun() ->
+        St = install_api(),
+        ?assertNot(lists:member([~"game", ~"storage"], namespace_tables(St))),
+        ?assertNot(lists:member([~"game", ~"storage"], populated_namespaces(St))),
+        %% The rest of the surface is untouched.
+        ?assert(lists:member([~"game", ~"economy"], namespace_tables(St)))
+    end).
+
+storage_disabled_withholds_namespace_probe() ->
+    with_storage(false, fun() ->
+        St = install_api_probe(),
+        ?assertNot(lists:member([~"game", ~"storage"], namespace_tables(St))),
+        ?assertNot(lists:member([~"game", ~"storage"], populated_namespaces(St)))
+    end).
+
+-spec with_storage(boolean(), fun(() -> term())) -> term().
+with_storage(Value, Fun) ->
+    Was = application:get_env(asobi, storage),
+    try
+        application:set_env(asobi, storage, Value),
+        Fun()
+    after
+        case Was of
+            {ok, Prev} -> application:set_env(asobi, storage, Prev);
+            undefined -> application:unset_env(asobi, storage)
+        end
+    end.
 
 %% `game` itself plus every table-valued field on it.
 namespace_tables(St) ->

--- a/test/asobi_ops_tests.erl
+++ b/test/asobi_ops_tests.erl
@@ -629,6 +629,23 @@ features_capability_reflects_configuration_test() ->
         end
     end.
 
+%% Storage is on by default (asobi_storage:enabled/0), unlike the configured
+%% capabilities above which are off until set. `false` is the only value that
+%% reports it disabled.
+features_reports_the_storage_switch_test() ->
+    Original = application:get_env(asobi, storage),
+    try
+        application:unset_env(asobi, storage),
+        ?assertEqual(true, capability_enabled(~"storage")),
+        application:set_env(asobi, storage, false),
+        ?assertEqual(false, capability_enabled(~"storage"))
+    after
+        case Original of
+            {ok, Value} -> application:set_env(asobi, storage, Value);
+            undefined -> application:unset_env(asobi, storage)
+        end
+    end.
+
 capability_enabled(Name) ->
     [Enabled] = [
         E

--- a/test/asobi_storage_SUITE.erl
+++ b/test/asobi_storage_SUITE.erl
@@ -2,8 +2,10 @@
 
 -include_lib("nova_test/include/nova_test.hrl").
 
--export([all/0, groups/0, init_per_suite/1, end_per_suite/1]).
+-export([all/0, groups/0, init_per_suite/1, end_per_suite/1, end_per_testcase/2]).
 -export([
+    %% Config off switch
+    disabled_routes_answer_404/1,
     %% Cloud saves
     list_saves_empty/1,
     create_save/1,
@@ -22,7 +24,7 @@
     global_and_player_row_coexist_at_same_key/1
 ]).
 
-all() -> [{group, cloud_saves}, {group, generic_storage}].
+all() -> [{group, cloud_saves}, {group, generic_storage}, disabled_routes_answer_404].
 
 groups() ->
     [
@@ -68,6 +70,40 @@ init_per_suite(Config) ->
     ].
 
 end_per_suite(Config) ->
+    Config.
+
+%% The storage off switch (asobi_storage:enabled/0) proven through the real
+%% Nova HTTP stack, not just the controller fn: with `storage` set false the
+%% routes are still wired, but each family answers its own genuine-miss 404 -
+%% save.not_found on /saves, storage.not_found on /storage.
+disabled_routes_answer_404(Config) ->
+    ok = application:set_env(asobi, storage, false),
+    {ok, SaveResp} = nova_test:get(
+        "/api/v1/saves",
+        #{headers => auth(Config, player1)},
+        Config
+    ),
+    ?assertStatus(404, SaveResp),
+    ?assertMatch(
+        #{~"error" := #{~"code" := ~"save.not_found", ~"details" := #{}}},
+        nova_test:json(SaveResp)
+    ),
+    {ok, StorageResp} = nova_test:get(
+        "/api/v1/storage/settings/theme",
+        #{headers => auth(Config, player1)},
+        Config
+    ),
+    ?assertStatus(404, StorageResp),
+    ?assertMatch(
+        #{~"error" := #{~"code" := ~"storage.not_found", ~"details" := #{}}},
+        nova_test:json(StorageResp)
+    ),
+    Config.
+
+end_per_testcase(disabled_routes_answer_404, Config) ->
+    application:set_env(asobi, storage, true),
+    Config;
+end_per_testcase(_Case, Config) ->
     Config.
 
 auth(Config, Player) ->

--- a/test/asobi_storage_controller_tests.erl
+++ b/test/asobi_storage_controller_tests.erl
@@ -1,0 +1,126 @@
+-module(asobi_storage_controller_tests).
+
+-include_lib("eunit/include/eunit.hrl").
+
+%% The seven storage routes answer the same 404 an unknown route gets when
+%% storage is switched off (asobi_storage:enabled/0), before any auth or body
+%% work, and behave normally when it is on. asobi_repo is mocked so the enabled
+%% path needs no database.
+
+-define(PID, ~"11111111-1111-1111-1111-111111111111").
+
+controller_test_() ->
+    {foreach, fun setup/0, fun cleanup/1, [
+        fun each_route_answers_its_family_not_found_when_disabled/0,
+        fun routes_reach_their_handler_when_enabled/0
+    ]}.
+
+setup() ->
+    Was = application:get_env(asobi, storage),
+    meck:new(asobi_repo, [no_link]),
+    meck:expect(asobi_repo, all, fun(_) -> {ok, []} end),
+    meck:expect(asobi_repo, insert, fun(_) -> {ok, row()} end),
+    meck:expect(asobi_repo, update, fun(_) -> {ok, row()} end),
+    meck:expect(asobi_repo, delete, fun(_, _) -> {ok, row()} end),
+    Was.
+
+cleanup(Was) ->
+    meck:unload(asobi_repo),
+    case Was of
+        {ok, Value} -> application:set_env(asobi, storage, Value);
+        undefined -> application:unset_env(asobi, storage)
+    end.
+
+%% Disabled: each route answers the 404 code it gives for a genuine miss -
+%% save.not_found on /saves, storage.not_found on /storage - so the off-state
+%% is indistinguishable from an empty deployment per family. Both a full req
+%% and a bare req (no auth_data) short-circuit to that code, which locks the
+%% guard ahead of the head that would otherwise demand auth_data.
+each_route_answers_its_family_not_found_when_disabled() ->
+    application:set_env(asobi, storage, false),
+    [
+        begin
+            ?assertEqual({asobi_error, Code}, Fn(Req)),
+            ?assertEqual({asobi_error, Code}, Fn(#{}))
+        end
+     || {Fn, Req, Code} <- disabled_routes()
+    ].
+
+disabled_routes() ->
+    [
+        {fun asobi_storage_controller:list_saves/1, list_saves_req(), ~"save.not_found"},
+        {fun asobi_storage_controller:get_save/1, get_save_req(), ~"save.not_found"},
+        {fun asobi_storage_controller:put_save/1, put_save_req(), ~"save.not_found"},
+        {fun asobi_storage_controller:list_storage/1, list_storage_req(), ~"storage.not_found"},
+        {fun asobi_storage_controller:get_storage/1, get_storage_req(), ~"storage.not_found"},
+        {fun asobi_storage_controller:put_storage/1, put_storage_req(), ~"storage.not_found"},
+        {fun asobi_storage_controller:delete_storage/1, delete_storage_req(), ~"storage.not_found"}
+    ].
+
+routes_reach_their_handler_when_enabled() ->
+    application:set_env(asobi, storage, true),
+    %% Empty DB: the handler runs and lands on its own not-found / empty
+    %% result, which is a different code from the disabled 404.
+    ?assertMatch({json, _}, asobi_storage_controller:list_saves(list_saves_req())),
+    ?assertEqual(
+        {asobi_error, ~"save.not_found"}, asobi_storage_controller:get_save(get_save_req())
+    ),
+    ?assertMatch({json, 200, _, _}, asobi_storage_controller:put_save(put_save_req())),
+    ?assertMatch({json, _}, asobi_storage_controller:list_storage(list_storage_req())),
+    %% get/delete would themselves answer storage.not_found on an empty DB
+    %% (the object is genuinely absent), so seed a public row to prove the
+    %% handler ran rather than the guard.
+    meck:expect(asobi_repo, all, fun(_) -> {ok, [row()]} end),
+    ?assertMatch({json, _}, asobi_storage_controller:get_storage(get_storage_req())),
+    ?assertMatch({json, _}, asobi_storage_controller:put_storage(put_storage_req())),
+    ?assertMatch({json, _}, asobi_storage_controller:delete_storage(delete_storage_req())).
+
+list_saves_req() ->
+    #{auth_data => #{player_id => ?PID}}.
+
+get_save_req() ->
+    #{bindings => #{~"slot" => ~"slot1"}, auth_data => #{player_id => ?PID}}.
+
+put_save_req() ->
+    #{
+        bindings => #{~"slot" => ~"slot1"},
+        json => #{~"data" => #{}},
+        auth_data => #{player_id => ?PID}
+    }.
+
+list_storage_req() ->
+    #{bindings => #{~"collection" => ~"settings"}, qs => ~"", auth_data => #{player_id => ?PID}}.
+
+get_storage_req() ->
+    #{
+        bindings => #{~"collection" => ~"settings", ~"key" => ~"theme"},
+        auth_data => #{player_id => ?PID}
+    }.
+
+put_storage_req() ->
+    #{
+        bindings => #{~"collection" => ~"settings", ~"key" => ~"theme"},
+        json => #{~"value" => #{}},
+        auth_data => #{player_id => ?PID}
+    }.
+
+delete_storage_req() ->
+    #{
+        bindings => #{~"collection" => ~"settings", ~"key" => ~"theme"},
+        auth_data => #{player_id => ?PID}
+    }.
+
+%% A public row that satisfies the get/put/delete happy paths.
+row() ->
+    #{
+        id => ~"11111111-1111-1111-1111-111111111112",
+        slot => ~"slot1",
+        collection => ~"settings",
+        key => ~"theme",
+        player_id => ?PID,
+        value => #{},
+        version => 1,
+        read_perm => ~"public",
+        write_perm => ~"public",
+        updated_at => {{2024, 1, 1}, {0, 0, 0}}
+    }.

--- a/test/asobi_storage_tests.erl
+++ b/test/asobi_storage_tests.erl
@@ -1,0 +1,35 @@
+-module(asobi_storage_tests).
+
+-include_lib("eunit/include/eunit.hrl").
+
+%% The release-level off switch. Storage is on by default - the opposite of the
+%% console - so an absent env means enabled, and only `false` closes it.
+
+switch_test_() ->
+    {foreach, fun setup/0, fun cleanup/1, [
+        fun on_by_default/0,
+        fun false_turns_it_off/0,
+        fun true_keeps_it_on/0
+    ]}.
+
+setup() ->
+    Was = application:get_env(asobi, storage),
+    application:unset_env(asobi, storage),
+    Was.
+
+cleanup(Was) ->
+    case Was of
+        {ok, Value} -> application:set_env(asobi, storage, Value);
+        undefined -> application:unset_env(asobi, storage)
+    end.
+
+on_by_default() ->
+    ?assert(asobi_storage:enabled()).
+
+false_turns_it_off() ->
+    application:set_env(asobi, storage, false),
+    ?assertNot(asobi_storage:enabled()).
+
+true_keeps_it_on() ->
+    application:set_env(asobi, storage, true),
+    ?assert(asobi_storage:enabled()).


### PR DESCRIPTION
## Wave 1 — config-off instead of extraction

The architecture gate ruled `do-not-extract-yet` on storage (a read-only understand+plan workflow: extraction achieves ~zero client decoupling since all 7 SDKs bind the same paths/wire, incurs permanent migration residue, and `asobi_bundle` does not yet exist so it would break the default install). This ships the guardian's recommended terminus instead: a release-level on/off switch mirroring the `asobi_console` precedent.

### Behaviour
`asobi_storage:enabled/0` -> `application:get_env(asobi, storage, true)` (default **on**). When `false`:
- The 7 storage HTTP routes answer 404 via a `guarded/2` helper — per-family miss-code so the off-state is indistinguishable from a genuine miss (`save.not_found` on the slot-keyed `/saves*` routes, `storage.not_found` on `/storage*`).
- `game.storage.*` Lua namespace + its 4 bindings are withheld at install (via `storage_available/1` at the two shared chokepoints, honoured by both `install/2` and `install_pure/2`). `reserved_namespaces/0` is untouched — the name stays reserved.
- `asobi_ops_features:capabilities/0` reports `#{name => storage, enabled => false}`.

No module leaves the kernel, no wire break, no migration, fully reversible. `to_storage_value/1` (a generic Lua serializer despite its name) is untouched.

### Gate
asobi-architecture-guardian (conformance: accept-with-changes) + erlang-code-reviewer (0 blockers). Both independently flagged the original single-code reuse leaking the off-state on `/saves` — fixed to per-family codes. Config key documented in `configuration.md`/`self-hosting.md`/`rest-api.md`. Local: eqwalize delta 0, dialyzer/xref/fmt/ex_doc clean, full eunit + CT (incl. a new HTTP-stack disabled-route case) green.