### PR TITLE
feat: HTTP RPC transport (POST /api/v1/rpc/:method)

### DIFF
--- a/src/asobi_router.erl
+++ b/src/asobi_router.erl
@@ -227,7 +227,16 @@ api_routes() ->
             }},
             {~"/storage/:collection/:key", fun asobi_storage_controller:delete_storage/1, #{
                 methods => [delete, options]
-            }}
+            }},
+
+            %% Extension RPC over HTTP. The same dispatcher the socket
+            %% `rpc.call` frame reaches (`asobi_rpc:dispatch/2`), in the
+            %% player-scoped chain so the body cap, CORS and rate limiter apply
+            %% and a tokenless caller is refused before the controller - which
+            %% matches dispatch's own `unauthenticated` branch. The `/api/v1/rpc`
+            %% prefix is reserved in `asobi_extension_reserved:route_prefixes/0`
+            %% so no extension can claim this frozen core route.
+            {~"/rpc/:method", fun asobi_rpc_controller:call/1, #{methods => [post, options]}}
         ]
     }.
 

--- a/src/controllers/asobi_rpc_controller.erl
+++ b/src/controllers/asobi_rpc_controller.erl
@@ -1,0 +1,50 @@
+-module(asobi_rpc_controller).
+-moduledoc """
+The HTTP transport for the extension RPC dispatcher.
+
+`POST /api/v1/rpc/<method>` is `rpc.call` over HTTP: the method comes from the
+path, `params` from the JSON body (`{"params": {...}}`), and the caller from
+the authenticated player the route group's `asobi_auth_plugin:verify/1`
+resolved. It hands both to `asobi_rpc:dispatch/2` - the same transport-free
+core the socket `rpc.call` frame uses - and encodes the outcome through
+`asobi_rpc:envelope/1`, so a call answers byte-identically on either transport
+below the transport itself.
+
+The HTTP status is 200 for a result and the error object's own status
+(`asobi_error:status/1`) otherwise. The `rpc.ok` / `rpc.error` envelope is the
+body in both cases, never the bare `{asobi_error, ...}` shape the other
+controllers return: the envelope is the frozen wire contract this surface owes
+its clients, and it must read the same as a socket reply.
+
+`protocol` is injected server-side (`asobi_rpc:protocol/0`); an HTTP client
+sends only `params`. The caller is tagged `transport => http`, so a handler
+reads `Ctx.transport` to know its `session` is this request process - alive
+only for the one call - rather than a durable socket pid; one that must reach
+the player after it returns keys on `player_id` through presence (the
+`module.event` path), never on the session pid.
+""".
+
+-export([call/1]).
+
+-spec call(cowboy_req:req()) -> {json, pos_integer(), map(), map()}.
+call(#{bindings := #{~"method" := Method}, auth_data := #{player_id := PlayerId}} = Req) when
+    is_binary(PlayerId)
+->
+    Payload = #{
+        ~"protocol" => asobi_rpc:protocol(),
+        ~"method" => Method,
+        ~"params" => params(Req)
+    },
+    Caller = #{player_id => PlayerId, session => self(), transport => http},
+    Outcome = asobi_rpc:dispatch(Payload, Caller),
+    {Type, Body} = asobi_rpc:envelope(Outcome),
+    {json, http_status(Outcome), #{}, #{~"type" => Type, ~"payload" => Body}}.
+
+%% The dispatcher validates `params`: a missing key or a non-map body reaches
+%% it as `undefined` and comes back `rpc.invalid_params`, exactly as it does on
+%% the socket. So no shape is enforced here beyond guarding the body-map read.
+params(#{json := Json}) when is_map(Json) -> maps:get(~"params", Json, undefined);
+params(_Req) -> undefined.
+
+http_status({ok, _Result}) -> 200;
+http_status({error, #{error := #{code := Code}}}) -> asobi_error:status(Code).

--- a/src/extensions/asobi_extension_reserved.erl
+++ b/src/extensions/asobi_extension_reserved.erl
@@ -38,10 +38,10 @@ cannot drift:
   extension.
 
 On top of the derived set, `route_prefixes/0` names the privileged plane
-roots (`/api/v1/ops`, `/api/v1/auth`, `/api/v1/iap`, `/console`, `/ws`): no
-extension route may sit anywhere under them, whatever it would resolve to.
-This is a policy list, not a derivation - which sub-paths of a plane are
-sensitive is a judgment the route table cannot express.
+roots (`/api/v1/ops`, `/api/v1/auth`, `/api/v1/iap`, `/api/v1/rpc`, `/console`,
+`/ws`): no extension route may sit anywhere under them, whatever it would
+resolve to. This is a policy list, not a derivation - which sub-paths of a
+plane are sensitive is a judgment the route table cannot express.
 
 `core_capabilities/0` answers the mirror-image question `owns/0` does not:
 not "what may an extension never claim" but "what may an extension depend on".
@@ -94,11 +94,14 @@ namespaces() ->
 -doc """
 The privileged plane roots. No extension route may sit anywhere under one -
 mounting an open webhook handler inside the operator, auth, purchase,
-console or socket plane is refused whatever the path would resolve to.
+extension-rpc, console or socket plane is refused whatever the path would
+resolve to. `/api/v1/rpc` is the core rpc dispatcher's own HTTP route
+(`m:asobi_rpc_controller`), reserved so an extension cannot shadow the frozen
+`POST /api/v1/rpc/<method>` surface through its `routes/0`.
 """.
 -spec route_prefixes() -> [asobi_extension:token(), ...].
 route_prefixes() ->
-    [~"/api/v1/ops", ~"/api/v1/auth", ~"/api/v1/iap", ~"/console", ~"/ws"].
+    [~"/api/v1/ops", ~"/api/v1/auth", ~"/api/v1/iap", ~"/api/v1/rpc", ~"/console", ~"/ws"].
 
 -doc """
 The core subsystem names an extension may name in `requires/0`.

--- a/src/extensions/asobi_rpc.erl
+++ b/src/extensions/asobi_rpc.erl
@@ -53,8 +53,16 @@ and would put object construction in every extension. It is also the dialect
 core's own controllers already speak (`{asobi_error, Code, Details}`), so
 there is one shape to learn rather than two.
 
-`Ctx` is `#{player_id, session, method}` and may gain keys. Match the ones
-you need with `:=`; never match it exhaustively.
+`Ctx` is `#{player_id, session, method, transport}` and may gain keys. Match
+the ones you need with `:=`; never match it exhaustively.
+
+`Ctx.session` is a process, but which process depends on `Ctx.transport`. Over
+`ws` it is the durable player-session pid. Over `http`
+(`POST /api/v1/rpc/<method>`, `m:asobi_rpc_controller`) it is the request
+process, alive only for the one call. A handler that must reach the player
+after it returns checks `transport =:= ws` before touching `session`, and
+otherwise keys on `player_id` through presence (the `module.event` path) -
+never the session pid, which over HTTP is dead the moment the reply is sent.
 
 An extension error surfaces as **its own code**, provided the extension
 declared it in `codes/0`. A handler that raises, returns outside the contract,
@@ -83,11 +91,32 @@ every caller this dispatcher has - another declaration nothing can reach.
 The reachable home for an operator-only extension method is the ops plane,
 which is read-only today by assertion, so opening it is a decision about that
 plane rather than about this manifest.
+
+## Transports
+
+Two transports reach this dispatcher and share `dispatch/2` and `envelope/1`,
+so the reply envelope is byte-identical between them. What they do NOT share is
+everything in front of the dispatcher, and these divergences are frozen:
+
+- **The dispatcher enforces no auth, no rate limit and no size cap.** Each
+  transport enforces its own, separately, before calling in. A `ws` frame is
+  gated by socket auth, a per-connection 60/s message cap and a 64 KiB frame
+  cap; an `http` `POST` is gated by `asobi_auth_plugin` (401), the api rate
+  limiter (300/s per client IP) and the 1 MiB `asobi_body_cap_plugin`. A third
+  transport must supply its own; it must not assume the dispatcher does.
+- **The request-size caps differ and do not converge** - 64 KiB over `ws`,
+  1 MiB over `http`. The accepted request size is a property of the transport;
+  only the reply envelope is shared.
+- **Protocol versioning differs.** The `ws` payload carries a `protocol`
+  field, so a foreign version answers `rpc.unsupported_protocol`. The HTTP
+  controller injects `protocol` server-side and versions through the URL
+  (`/api/v1/...`) instead, so `rpc.unsupported_protocol` cannot fire over
+  `http` by design.
 """.
 
 -include_lib("kernel/include/logger.hrl").
 
--export([handle/3, protocol/0]).
+-export([handle/3, dispatch/2, envelope/1, protocol/0]).
 
 -define(PROTOCOL, 1).
 -define(MAX_CID_BYTES, 64).
@@ -96,7 +125,9 @@ plane rather than about this manifest.
 -type params() :: #{binary() => term()}.
 
 -doc "What a handler is told about its caller. Additive; never match it exhaustively.".
--type ctx() :: #{player_id := binary(), session := pid(), method := binary()}.
+-type ctx() :: #{
+    player_id := binary(), session := pid(), method := binary(), transport := ws | http
+}.
 
 -doc "What a handler returns.".
 -type reply() ::
@@ -104,8 +135,15 @@ plane rather than about this manifest.
     | {error, asobi_error:code()}
     | {error, asobi_error:code(), asobi_error:details()}.
 
--doc "The authenticated player behind the socket, or `unauthenticated`.".
--type caller() :: #{player_id := binary(), session := pid()} | unauthenticated.
+-doc """
+The authenticated player behind the transport, or `unauthenticated`.
+
+`transport` marks which one so a handler can branch on `Ctx.transport`; it is
+optional here and defaults to `ws` in `invoke/5`, so a caller built without it
+stays safe.
+""".
+-type caller() ::
+    #{player_id := binary(), session := pid(), transport => ws | http} | unauthenticated.
 
 -export_type([params/0, ctx/0, reply/0, caller/0]).
 
@@ -124,21 +162,46 @@ rejected - and the outcome to encode.
     {binary() | undefined, {ok, map()} | {error, asobi_error:object()}}.
 handle(Cid, Payload, Caller) ->
     case cid(Cid) of
-        {ok, Valid} -> {Valid, outcome(Payload, Caller)};
+        {ok, Valid} -> {Valid, dispatch(Payload, Caller)};
         error -> {undefined, {error, asobi_error:object(~"rpc.invalid_cid")}}
     end.
 
-%%====================================================================
-%% Internal
-%%====================================================================
+-doc """
+Dispatch one call, without a transport.
 
-outcome(_Payload, unauthenticated) ->
+`handle/3` is this behind the socket's `cid` validation;
+`m:asobi_rpc_controller` is this behind HTTP request parsing. Both hand the
+same `#{"protocol", "method", "params"}` payload and the same `caller()`, and
+both encode the outcome through `envelope/1`, so a given call answers
+byte-identically on either transport below the transport itself.
+""".
+-spec dispatch(term(), caller()) -> {ok, map()} | {error, asobi_error:object()}.
+dispatch(_Payload, unauthenticated) ->
     {error, asobi_error:object(~"unauthenticated")};
-outcome(Payload, Caller) ->
+dispatch(Payload, Caller) ->
     case asobi_readiness:guard() of
         ok -> ready(Payload, Caller);
         {error, Object} -> {error, Object}
     end.
+
+-doc """
+The `rpc.ok` / `rpc.error` wire payload for a dispatch outcome.
+
+The single source of truth for the pair, shared by the socket encoder
+(`asobi_ws_handler:encode_rpc/2`) and the HTTP controller so a frozen payload
+cannot drift between them: `{ok, Result}` becomes
+`{~"rpc.ok", #{~"result" => Result}}`, and `{error, Object}` becomes
+`{~"rpc.error", Object}` - the error object alone, never wrapped again.
+""".
+-spec envelope({ok, map()} | {error, asobi_error:object()}) -> {binary(), map()}.
+envelope({ok, Result}) ->
+    {~"rpc.ok", #{~"result" => Result}};
+envelope({error, Object}) ->
+    {~"rpc.error", Object}.
+
+%%====================================================================
+%% Internal
+%%====================================================================
 
 ready(Payload, _Caller) when not is_map(Payload) ->
     {error, asobi_error:object(~"invalid_payload")};
@@ -176,8 +239,13 @@ bad_arity(Method, Target) ->
     }),
     {error, asobi_error:object(~"internal")}.
 
-invoke(Module, Function, Method, Params, #{player_id := PlayerId, session := Session}) ->
-    Ctx = #{player_id => PlayerId, session => Session, method => Method},
+invoke(Module, Function, Method, Params, #{player_id := PlayerId, session := Session} = Caller) ->
+    Ctx = #{
+        player_id => PlayerId,
+        session => Session,
+        method => Method,
+        transport => maps:get(transport, Caller, ws)
+    },
     try Module:Function(Params, Ctx) of
         Reply -> reply(Reply, Method)
     catch
@@ -218,7 +286,7 @@ reply(Other, Method) ->
 failure(Code, Details, Method) ->
     case asobi_error:defined(Code) of
         true ->
-            {error, asobi_error:object(Code, Details)};
+            encodable_error(asobi_error:object(Code, Details), Method);
         false ->
             ?LOG_ERROR(#{event => undefined_error_code, code => Code, method => Method}),
             {error, asobi_error:object(~"internal")}
@@ -236,6 +304,28 @@ encodable(Result, Method) ->
         Class:Reason ->
             ?LOG_ERROR(#{
                 event => rpc_result_not_encodable,
+                method => Method,
+                class => Class,
+                reason => Reason
+            }),
+            {error, asobi_error:object(~"internal")}
+    end.
+
+%% Symmetric with encodable/2 on the ok path: a handler's `Details` is a runtime
+%% term and may hold a pid, ref or tuple that no reply encoder can serialise.
+%% Both transports encode this object, so an unencodable one would raise in the
+%% encoder - uncaught on the socket, uncaught in the controller. Encoding it
+%% here, where the method is known, degrades that to `internal` rather than a
+%% crash. `params` is always JSON-decoded, so this is an author footgun, not an
+%% attacker one.
+encodable_error(Object, Method) ->
+    try
+        _ = json:encode(Object),
+        {error, Object}
+    catch
+        Class:Reason ->
+            ?LOG_ERROR(#{
+                event => rpc_error_not_encodable,
                 method => Method,
                 class => Class,
                 reason => Reason

--- a/src/ws/asobi_ws_handler.erl
+++ b/src/ws/asobi_ws_handler.erl
@@ -816,18 +816,19 @@ handle_message(_Msg, State) ->
 rpc_caller(#{session := SessionPid, player_id := PlayerId}) when
     is_pid(SessionPid), is_binary(PlayerId)
 ->
-    #{player_id => PlayerId, session => SessionPid};
+    #{player_id => PlayerId, session => SessionPid, transport => ws};
 rpc_caller(_State) ->
     unauthenticated.
 
 %% `rpc.error` carries the error object alone. The `reason` half of the older
 %% `error` frame is not repeated here: nothing has ever shipped against this
 %% frame, so there is no client to keep working, and one dialect on a new
-%% surface is the point of the object.
-encode_rpc(Cid, {ok, Result}) ->
-    encode_reply(Cid, ~"rpc.ok", #{~"result" => Result});
-encode_rpc(Cid, {error, Object}) ->
-    encode_reply(Cid, ~"rpc.error", Object).
+%% surface is the point of the object. The `{type, payload}` pair comes from
+%% `asobi_rpc:envelope/1`, the one place it is built, so the HTTP transport
+%% (`m:asobi_rpc_controller`) puts the same payload on the wire.
+encode_rpc(Cid, Outcome) ->
+    {Type, Payload} = asobi_rpc:envelope(Outcome),
+    encode_reply(Cid, Type, Payload).
 
 %% --- Safe Message Dispatch ---
 

--- a/test/asobi_protocol_coverage_tests.erl
+++ b/test/asobi_protocol_coverage_tests.erl
@@ -4,6 +4,7 @@
 
 -define(FIXTURE_DIR, "priv/protocol/fixtures").
 -define(WS_HANDLER, "src/ws/asobi_ws_handler.erl").
+-define(RPC, "src/extensions/asobi_rpc.erl").
 -define(WS_GUIDE, "guides/websocket-protocol.md").
 -define(MATCH_SERVER, "src/matches/asobi_match_server.erl").
 -define(WORLD_SERVER, "src/world/asobi_world_server.erl").
@@ -86,7 +87,10 @@ list_fixture_event_names() ->
 
 enumerate_emitted_events() ->
     WsHandler = read_file(?WS_HANDLER),
-    Static = scan_encode_reply_types(WsHandler) ++ scan_extension_frame_types(WsHandler),
+    Static =
+        scan_encode_reply_types(WsHandler) ++
+            scan_extension_frame_types(WsHandler) ++
+            scan_envelope_types(read_file(?RPC)),
     MatchAtoms = collect_match_emit_atoms(),
     WorldAtoms = collect_world_emit_atoms(),
     lists:usort(
@@ -148,6 +152,17 @@ scan_extension_frame_types(Bin) ->
         {match, Matches} -> lists:append(Matches);
         nomatch -> []
     end.
+
+%% The rpc.ok / rpc.error wire types are built in asobi_rpc:envelope/1, the one
+%% place the pair lives now that both transports share it - so encode_rpc/2
+%% takes a variable type the encode_reply scan cannot see (mirrors
+%% scan_extension_frame_types). Anchored to the `envelope(...) -> {~"rpc.X", ...`
+%% clause head so only the code is scanned: the `-doc` prose shows the same
+%% literals, and matching it would let a deleted clause with a lingering doc
+%% example still "discover" the type and mask a now-stale fixture.
+scan_envelope_types(Bin) ->
+    Re = "envelope\\([^)]*\\)\\s*->\\s*\\{~\"(rpc\\.[a-z]+)\"",
+    extract_captures(Bin, Re).
 
 %% Pulls the atom out of `{match_event, foo, _}` / `{world_event, foo, _}`
 %% literals. Atoms in Erlang start with [a-z]; this keeps us from

--- a/test/asobi_rpc_controller_tests.erl
+++ b/test/asobi_rpc_controller_tests.erl
@@ -1,0 +1,151 @@
+-module(asobi_rpc_controller_tests).
+
+-include_lib("eunit/include/eunit.hrl").
+
+%% The HTTP transport for the extension RPC dispatcher, without a socket or a
+%% database. The quests fixture is installed and resolved the way asobi_rpc's
+%% own unit tests do it, so `call/1` runs a real dispatch; a fake Nova req map
+%% (bindings + json + auth_data, exactly the keys the plugins set) stands in for
+%% the request. The real Nova stack - auth, routing, the body cap - is exercised
+%% end to end in asobi_rpc_http_SUITE.
+
+-define(QUESTS, asobi_fixture_quests).
+-define(PLAYER, ~"p-1").
+
+controller_test_() ->
+    {foreach, fun setup/0, fun cleanup/1, [
+        fun a_known_method_answers_200_and_an_rpc_ok_envelope/0,
+        fun an_unknown_method_answers_404_and_an_rpc_error_envelope/0,
+        fun an_extension_error_carries_its_own_code_and_status/0,
+        fun non_map_params_answer_400_and_rpc_invalid_params/0,
+        fun absent_params_answer_400_and_rpc_invalid_params/0,
+        fun the_controller_marks_the_ctx_transport_http/0,
+        fun one_envelope_feeds_both_transports/0
+    ]}.
+
+setup() ->
+    asobi_extensions:reset(),
+    ok = asobi_fixture_app:install(?QUESTS, asobi_fixture_quests_extension, []),
+    _ = asobi_extensions:resolve(),
+    asobi_readiness:mark_ready(),
+    ok.
+
+cleanup(_) ->
+    asobi_readiness:reset(),
+    asobi_fixture_app:uninstall(?QUESTS),
+    asobi_extensions:reset(),
+    ok.
+
+a_known_method_answers_200_and_an_rpc_ok_envelope() ->
+    {json, Status, _Headers, Body} =
+        asobi_rpc_controller:call(req(~"quests.list", #{~"echo" => ~"pong"})),
+    ?assertEqual(200, Status),
+    ?assertMatch(#{~"type" := ~"rpc.ok", ~"payload" := #{~"result" := _}}, Body),
+    #{~"payload" := #{~"result" := Result}} = Body,
+    ?assertEqual(
+        #{~"player_id" => ?PLAYER, ~"method" => ~"quests.list", ~"echo" => ~"pong"},
+        Result
+    ).
+
+%% The error object is `asobi_error:object/1`, which keys with atoms - the same
+%% term the socket encoder hands `json:encode` - so the in-memory payload here
+%% carries atom keys, byte-identical to the WS path once serialised.
+an_unknown_method_answers_404_and_an_rpc_error_envelope() ->
+    {json, Status, _Headers, Body} = asobi_rpc_controller:call(req(~"quests.nope", #{})),
+    ?assertEqual(404, Status),
+    ?assertMatch(
+        #{~"type" := ~"rpc.error", ~"payload" := #{error := #{code := ~"rpc.unknown_method"}}},
+        Body
+    ).
+
+%% The status is the extension's own (409 for quests.already_claimed), routed
+%% through asobi_error:status/1 exactly as the socket surfaces the code.
+an_extension_error_carries_its_own_code_and_status() ->
+    {json, Status, _Headers, Body} =
+        asobi_rpc_controller:call(req(~"quests.claim", #{~"behaviour" => ~"declared_code"})),
+    ?assertEqual(409, Status),
+    ?assertMatch(
+        #{~"type" := ~"rpc.error", ~"payload" := #{error := #{code := ~"quests.already_claimed"}}},
+        Body
+    ).
+
+non_map_params_answer_400_and_rpc_invalid_params() ->
+    {json, Status, _Headers, Body} = asobi_rpc_controller:call(req(~"quests.claim", [1, 2, 3])),
+    ?assertEqual(400, Status),
+    ?assertMatch(#{~"payload" := #{error := #{code := ~"rpc.invalid_params"}}}, Body).
+
+%% Neither a `params` key nor a body at all reaches the dispatcher as
+%% `undefined`, which it rejects the same way it rejects a non-object. The req
+%% maps live in unspecced helpers so eqwalizer reads them as `dynamic()` and
+%% accepts them against `cowboy_req:req()`, the pattern asobi_storage_controller_tests
+%% uses (an inline literal req gets its precise shape inferred and rejected).
+absent_params_answer_400_and_rpc_invalid_params() ->
+    ?assertMatch(
+        {json, 400, _, #{~"payload" := #{error := #{code := ~"rpc.invalid_params"}}}},
+        asobi_rpc_controller:call(no_params_req())
+    ),
+    ?assertMatch(
+        {json, 400, _, #{~"payload" := #{error := #{code := ~"rpc.invalid_params"}}}},
+        asobi_rpc_controller:call(no_body_req())
+    ).
+
+%% The controller tags its caller `transport => http`, so a handler reading
+%% Ctx.transport sees `http` (handle/3's `ws` default is asserted in
+%% asobi_rpc_tests).
+the_controller_marks_the_ctx_transport_http() ->
+    {json, 200, _Headers, Body} =
+        asobi_rpc_controller:call(req(~"quests.claim", #{~"behaviour" => ~"ctx_transport"})),
+    ?assertMatch(
+        #{~"type" := ~"rpc.ok", ~"payload" := #{~"result" := #{~"transport" := ~"http"}}},
+        Body
+    ).
+
+%% The controller body's {type, payload} is asobi_rpc:envelope/1 applied to the
+%% dispatch outcome, and the socket encoder (asobi_ws_handler:encode_rpc/2)
+%% builds its frame from the same envelope/1 - so one outcome maps to one wire
+%% payload on both transports. Pin envelope/1 against the shipped fixtures the
+%% WS CT and every SDK dispatch-test against, closing the loop.
+one_envelope_feeds_both_transports() ->
+    Params = #{~"echo" => ~"pong"},
+    Payload = #{
+        ~"protocol" => asobi_rpc:protocol(),
+        ~"method" => ~"quests.list",
+        ~"params" => Params
+    },
+    Outcome = asobi_rpc:dispatch(Payload, #{player_id => ?PLAYER, session => self()}),
+    {Type, Wire} = asobi_rpc:envelope(Outcome),
+    {json, 200, _Headers, Body} = asobi_rpc_controller:call(req(~"quests.list", Params)),
+    ?assertEqual(#{~"type" => Type, ~"payload" => Wire}, Body),
+    assert_matches_fixture("rpc.ok", asobi_rpc:envelope({ok, #{~"reward" => 100}})),
+    assert_matches_fixture(
+        "rpc.error", asobi_rpc:envelope({error, asobi_error:object(~"quests.already_claimed")})
+    ).
+
+%% --- helpers ---
+
+req(Method, Params) ->
+    #{
+        bindings => #{~"method" => Method},
+        json => #{~"params" => Params},
+        auth_data => #{player_id => ?PLAYER}
+    }.
+
+no_params_req() ->
+    #{
+        bindings => #{~"method" => ~"quests.claim"},
+        json => #{},
+        auth_data => #{player_id => ?PLAYER}
+    }.
+
+no_body_req() ->
+    #{bindings => #{~"method" => ~"quests.claim"}, auth_data => #{player_id => ?PLAYER}}.
+
+%% The fixture is the wire ground truth minus the transport's own `cid`, so
+%% compare type and payload after a JSON round-trip that normalises the object's
+%% atom keys to the binary keys the fixture carries.
+assert_matches_fixture(Name, {Type, Wire}) ->
+    {ok, Bin} = file:read_file("priv/protocol/fixtures/" ++ Name ++ ".json"),
+    #{~"type" := FixtureType, ~"payload" := FixturePayload} = json:decode(Bin),
+    Encoded = iolist_to_binary(json:encode(#{~"type" => Type, ~"payload" => Wire})),
+    RoundTripped = json:decode(Encoded),
+    ?assertEqual(#{~"type" => FixtureType, ~"payload" => FixturePayload}, RoundTripped).

--- a/test/asobi_rpc_http_SUITE.erl
+++ b/test/asobi_rpc_http_SUITE.erl
@@ -1,0 +1,143 @@
+-module(asobi_rpc_http_SUITE).
+-moduledoc """
+The extension RPC wire over HTTP.
+
+`POST /api/v1/rpc/<method>` reaching the same dispatcher the socket `rpc.call`
+frame does, through the real Nova stack - the player-token security callback,
+the global plugin chain, `asobi_rpc_controller`. The socket path is proved in
+asobi_rpc_SUITE; this proves the HTTP transport answers with the same
+`rpc.ok` / `rpc.error` envelope and the code's own HTTP status, and that the
+group refuses a tokenless request before the controller.
+""".
+
+-include_lib("nova_test/include/nova_test.hrl").
+
+-export([all/0, init_per_suite/1, end_per_suite/1]).
+-export([
+    rpc_call_reaches_the_extension/1,
+    rpc_error_carries_the_extensions_own_code/1,
+    rpc_unknown_method/1,
+    rpc_requires_an_authenticated_request/1,
+    rpc_rejects_non_object_params/1
+]).
+
+-define(QUESTS, asobi_fixture_quests).
+
+all() ->
+    [
+        rpc_call_reaches_the_extension,
+        rpc_error_carries_the_extensions_own_code,
+        rpc_unknown_method,
+        rpc_requires_an_authenticated_request,
+        rpc_rejects_non_object_params
+    ].
+
+%% The rpc route is core-owned and always in the compiled table, so unlike the
+%% extension-routes suite no restart is needed: the fixture is installed and the
+%% memoised registry re-resolved, exactly as asobi_rpc_SUITE does for the
+%% socket path.
+init_per_suite(Config) ->
+    Config1 = asobi_test_helpers:start(Config),
+    ok = asobi_fixture_app:install(?QUESTS, asobi_fixture_quests_extension, []),
+    asobi_extensions:reset(),
+    _ = asobi_extensions:resolve(),
+    Config1.
+
+end_per_suite(Config) ->
+    asobi_fixture_app:uninstall(?QUESTS),
+    asobi_extensions:reset(),
+    _ = asobi_extensions:resolve(),
+    Config.
+
+rpc_call_reaches_the_extension(Config) ->
+    {PlayerId, Token} = register_player(~"ok", Config),
+    {ok, Resp} = rpc_post(~"quests.list", #{~"echo" => ~"pong"}, Token, Config),
+    ?assertEqual(200, nova_test:status(Resp)),
+    ?assertMatch(#{~"type" := ~"rpc.ok", ~"payload" := #{~"result" := _}}, nova_test:json(Resp)),
+    #{~"payload" := #{~"result" := Result}} = nova_test:json(Resp),
+    ?assertEqual(
+        #{~"player_id" => PlayerId, ~"method" => ~"quests.list", ~"echo" => ~"pong"},
+        Result
+    ),
+    Config.
+
+%% #364 gave an extension its own code domain. The HTTP status is that code's
+%% own (409), not a flattened 400/500.
+rpc_error_carries_the_extensions_own_code(Config) ->
+    {_, Token} = register_player(~"err", Config),
+    {ok, Resp} = rpc_post(~"quests.claim", #{~"behaviour" => ~"declared_code"}, Token, Config),
+    ?assertEqual(409, nova_test:status(Resp)),
+    ?assertMatch(
+        #{
+            ~"type" := ~"rpc.error",
+            ~"payload" := #{
+                ~"error" := #{
+                    ~"code" := ~"quests.already_claimed",
+                    ~"message" := ~"This quest was already claimed.",
+                    ~"details" := #{}
+                }
+            }
+        },
+        nova_test:json(Resp)
+    ),
+    Config.
+
+rpc_unknown_method(Config) ->
+    {_, Token} = register_player(~"unk", Config),
+    {ok, Resp} = rpc_post(~"quests.nothing_here", #{}, Token, Config),
+    ?assertEqual(404, nova_test:status(Resp)),
+    ?assertMatch(
+        #{
+            ~"type" := ~"rpc.error",
+            ~"payload" := #{~"error" := #{~"code" := ~"rpc.unknown_method"}}
+        },
+        nova_test:json(Resp)
+    ),
+    Config.
+
+%% The group security refuses a tokenless request before the controller, the
+%% same 401 a core route in this group gives - consistent with dispatch's own
+%% unauthenticated branch always erroring.
+rpc_requires_an_authenticated_request(Config) ->
+    {ok, Resp} = nova_test:post(
+        "/api/v1/rpc/quests.claim",
+        #{json => #{~"params" => #{}}},
+        Config
+    ),
+    ?assertEqual(401, nova_test:status(Resp)),
+    Config.
+
+rpc_rejects_non_object_params(Config) ->
+    {_, Token} = register_player(~"param", Config),
+    {ok, Resp} = rpc_post(~"quests.claim", [1, 2, 3], Token, Config),
+    ?assertEqual(400, nova_test:status(Resp)),
+    ?assertMatch(
+        #{
+            ~"type" := ~"rpc.error",
+            ~"payload" := #{~"error" := #{~"code" := ~"rpc.invalid_params"}}
+        },
+        nova_test:json(Resp)
+    ),
+    Config.
+
+%% --- helpers (mirrors asobi_rpc_SUITE) ---
+
+rpc_post(Method, Params, Token, Config) ->
+    nova_test:post(
+        binary_to_list(<<"/api/v1/rpc/", Method/binary>>),
+        #{
+            json => #{~"params" => Params},
+            headers => [{~"authorization", <<"Bearer ", Token/binary>>}]
+        },
+        Config
+    ).
+
+register_player(Suffix, Config) ->
+    Username = <<"rpch_", Suffix/binary, "_", (asobi_id:rand_suffix(4))/binary>>,
+    {ok, Resp} = nova_test:post(
+        "/api/v1/auth/register",
+        #{json => #{~"username" => Username, ~"password" => ~"testpass123"}},
+        Config
+    ),
+    #{~"player_id" := PlayerId, ~"access_token" := Token} = nova_test:json(Resp),
+    {PlayerId, Token}.

--- a/test/extensions/asobi_extension_reserved_tests.erl
+++ b/test/extensions/asobi_extension_reserved_tests.erl
@@ -85,7 +85,7 @@ http_paths_cover_every_co_mounted_app_test() ->
 %% extensions outright is a judgment the route table cannot express.
 the_privileged_plane_prefixes_test() ->
     ?assertEqual(
-        [~"/api/v1/ops", ~"/api/v1/auth", ~"/api/v1/iap", ~"/console", ~"/ws"],
+        [~"/api/v1/ops", ~"/api/v1/auth", ~"/api/v1/iap", ~"/api/v1/rpc", ~"/console", ~"/ws"],
         asobi_extension_reserved:route_prefixes()
     ).
 

--- a/test/extensions/asobi_extension_routes_tests.erl
+++ b/test/extensions/asobi_extension_routes_tests.erl
@@ -197,6 +197,14 @@ a_privileged_plane_prefix_is_refused() ->
         lists:member(
             {reserved_prefix, ~"/api/v1/auth/sso", ~"/api/v1/auth", ?TUNABLE}, check_problems()
         )
+    ),
+    %% The frozen core rpc route `POST /api/v1/rpc/:method` lives under this
+    %% plane; no extension may mount anywhere beneath it through routes/0.
+    retune(#{routes => [route(~"/api/v1/rpc/custom")]}),
+    ?assert(
+        lists:member(
+            {reserved_prefix, ~"/api/v1/rpc/custom", ~"/api/v1/rpc", ?TUNABLE}, check_problems()
+        )
     ).
 
 %% The compiled dispatch is [nova, asobi | nova_apps], both shipped configs

--- a/test/extensions/asobi_fixture_quests_rpc.erl
+++ b/test/extensions/asobi_fixture_quests_rpc.erl
@@ -4,9 +4,11 @@ The RPC handlers `asobi_fixture_quests_extension:rpc/0` declares.
 
 Every branch of the handler contract, in one place: an ok result, an
 extension-declared code, an extension code with details, a code nobody
-declared, a return outside the contract, a raise, and a result that cannot be
-JSON-encoded. Which branch runs is chosen by `params`, so one fixture covers
-the whole mapping without seven manifest entries.
+declared, an extension code whose details cannot be JSON-encoded, a return
+outside the contract, a raise, and a result that cannot be JSON-encoded. It
+also echoes `Ctx.transport` so a test can see which transport dispatched it.
+Which branch runs is chosen by `params`, so one fixture covers the whole
+mapping without a manifest entry each.
 """.
 
 -export([list/2, claim/2]).
@@ -24,6 +26,10 @@ claim(#{~"behaviour" := ~"declared_code"}, _Ctx) ->
     {error, ~"quests.already_claimed"};
 claim(#{~"behaviour" := ~"declared_code_details"}, _Ctx) ->
     {error, ~"quests.not_found", #{~"quest_id" => ~"q-404"}};
+claim(#{~"behaviour" := ~"unencodable_error"}, _Ctx) ->
+    {error, ~"quests.not_found", #{~"pid" => self()}};
+claim(#{~"behaviour" := ~"ctx_transport"}, #{transport := Transport}) ->
+    {ok, #{~"transport" => atom_to_binary(Transport)}};
 claim(#{~"behaviour" := ~"undeclared_code"}, _Ctx) ->
     {error, ~"quests.never_declared"};
 claim(#{~"behaviour" := ~"bad_return"}, _Ctx) ->

--- a/test/extensions/asobi_rpc_tests.erl
+++ b/test/extensions/asobi_rpc_tests.erl
@@ -23,7 +23,16 @@ rpc_test_() ->
         fun the_protocol_version_is_checked/0,
         fun params_must_be_an_object/0,
         fun the_cid_is_validated_and_echoed/0,
-        fun a_rejected_cid_is_not_echoed_back/0
+        fun a_rejected_cid_is_not_echoed_back/0,
+        fun dispatch_returns_an_ok_result/0,
+        fun dispatch_reports_an_unknown_method/0,
+        fun dispatch_refuses_an_unauthenticated_caller/0,
+        fun dispatch_rejects_non_map_params/0,
+        fun dispatch_rejects_an_unsupported_protocol/0,
+        fun an_error_with_unencodable_details_is_internal/0,
+        fun the_ctx_carries_the_transport/0,
+        fun envelope_wraps_an_ok_result/0,
+        fun envelope_passes_an_error_object_through/0
     ]}.
 
 setup() ->
@@ -167,10 +176,78 @@ a_rejected_cid_is_not_echoed_back() ->
     ],
     ?assertMatch({~"ok-cid", _}, call(~"ok-cid", ~"quests.claim", #{})).
 
+%% --- dispatch/2: the transport-free core ---
+%%
+%% handle/3 is dispatch/2 behind cid validation, and asobi_rpc_controller is
+%% dispatch/2 behind HTTP request parsing. These pin the outcomes both
+%% transports share, and that each equals what handle/3 returns as its second
+%% element for the same call.
+
+dispatch_returns_an_ok_result() ->
+    Outcome = dispatched(~"quests.claim", #{}),
+    ?assertEqual({ok, #{~"claimed_by" => ?PLAYER, ~"reward" => 100}}, Outcome),
+    {_Cid, HandleOutcome} = call(~"c-1", ~"quests.claim", #{}),
+    ?assertEqual(HandleOutcome, Outcome).
+
+dispatch_reports_an_unknown_method() ->
+    ?assertEqual(~"rpc.unknown_method", code(dispatched(~"quests.nope", #{}))).
+
+dispatch_refuses_an_unauthenticated_caller() ->
+    ?assertEqual(
+        {error, asobi_error:object(~"unauthenticated")},
+        asobi_rpc:dispatch(payload(~"quests.claim", #{}), unauthenticated)
+    ).
+
+dispatch_rejects_non_map_params() ->
+    Outcome = asobi_rpc:dispatch(
+        #{~"protocol" => 1, ~"method" => ~"quests.claim", ~"params" => [1, 2, 3]},
+        caller()
+    ),
+    ?assertEqual(~"rpc.invalid_params", code(Outcome)).
+
+dispatch_rejects_an_unsupported_protocol() ->
+    Outcome = asobi_rpc:dispatch(
+        #{~"protocol" => 99, ~"method" => ~"quests.claim", ~"params" => #{}},
+        caller()
+    ),
+    ?assertEqual(~"rpc.unsupported_protocol", code(Outcome)),
+    ?assertEqual(#{supported => [1]}, details(Outcome)).
+
+%% Symmetric with the ok path: an extension code whose Details holds a pid
+%% cannot be JSON-encoded, and the dispatcher degrades that to `internal`
+%% rather than letting the reply encoder raise on either transport.
+an_error_with_unencodable_details_is_internal() ->
+    ?assertEqual(
+        ~"internal",
+        code(call(~"c-ue", ~"quests.claim", #{~"behaviour" => ~"unencodable_error"}))
+    ).
+
+%% invoke/5 defaults a caller with no transport key to `ws`, so a handler
+%% dispatched through handle/3 sees `ws`. The controller path (`http`) is
+%% asserted in asobi_rpc_controller_tests.
+the_ctx_carries_the_transport() ->
+    {_Cid, {ok, Result}} = call(~"c-tr", ~"quests.claim", #{~"behaviour" => ~"ctx_transport"}),
+    ?assertEqual(~"ws", maps:get(~"transport", Result)).
+
+%% --- envelope/1: the one rpc.ok / rpc.error payload ---
+
+envelope_wraps_an_ok_result() ->
+    ?assertEqual(
+        {~"rpc.ok", #{~"result" => #{~"reward" => 100}}},
+        asobi_rpc:envelope({ok, #{~"reward" => 100}})
+    ).
+
+envelope_passes_an_error_object_through() ->
+    Object = asobi_error:object(~"rpc.unknown_method"),
+    ?assertEqual({~"rpc.error", Object}, asobi_rpc:envelope({error, Object})).
+
 %% --- helpers ---
 
 call(Cid, Method, Params) ->
     asobi_rpc:handle(Cid, payload(Method, Params), caller()).
+
+dispatched(Method, Params) ->
+    asobi_rpc:dispatch(payload(Method, Params), caller()).
 
 payload(Method, Params) ->
     #{~"protocol" => asobi_rpc:protocol(), ~"method" => Method, ~"params" => Params}.


### PR DESCRIPTION
## Wave 0a — the second RPC transport (ecosystem ADR 0003)

Adds `POST /api/v1/rpc/<method>` dispatching to the SAME dispatcher the WS `rpc.call` path uses, so one server encoder and one per-SDK decoder serve both transports. Frozen-at-1.0 wire.

### Shape
- Request: `POST /api/v1/rpc/<method>` with body `{"params": {...}}`. Method in the URL, `protocol` injected server-side.
- Response: the same `rpc.ok`/`rpc.error` envelope below the transport (`#{type, payload}`), plus an HTTP status (200 for ok, the error object's status otherwise). No `cid` — an HTTP reply is self-correlating.

### Design
- `asobi_rpc` gains public `dispatch/2` (cid-free, the old internal `outcome/2`) + `envelope/1` (the single rpc.ok/rpc.error payload source). `handle/3` (WS) wraps `dispatch/2` unchanged; `asobi_ws_handler:encode_rpc/2` delegates to `envelope/1` — one source of truth, WS byte-identical.
- New `asobi_rpc_controller:call/1` in the authenticated `/api/v1` group (401 for tokenless via the group security; inherits the 1 MiB body cap, CORS, and the 300/s-per-IP api limiter).
- `/api/v1/rpc` reserved in `route_prefixes/0` (two-layer: exact-path + prefix) so no extension can claim the frozen route via `routes/0`.
- `Ctx` gains `transport => ws | http` so a handler can tell a durable socket session from an ephemeral HTTP request process (nothing in core reads `session`).

### Gate (frozen-wire, full)
guardian (ACCEPT) + beam-security-reviewer (0 blockers; `http_status/1` proven exhaustive, rate-limiting parity confirmed) + erlang-code-reviewer (0 blockers/0 should-fix). Consolidated round fixed a caught eqwalize delta-0 regression (test req literals → unspecced helpers) and added, for the freeze: an encodability guard on the error-details path (symmetric with the ok path; a strict improvement for WS too), the per-transport-divergence docs at the dispatcher, and the `transport` ctx key.

Local: eqwalize 331 (delta 0, independently re-measured), dialyzer/xref/fmt clean, 1897 eunit + 16 CT green.

Follow-ups (deferred, out of scope): a dedicated rpc rate-limit bucket if expensive third-party handlers appear; the pre-existing `W0032` in `lookup/3`.