### PR TITLE
fix(ci): detect new fixtures in protocol sync

### DIFF
--- a/.github/workflows/protocol-sync.yml
+++ b/.github/workflows/protocol-sync.yml
@@ -98,11 +98,16 @@ jobs:
         run: |
           scripts/protocol-sync.sh apply "${{ matrix.sdk }}" sdk
           cd sdk
-          if git diff --quiet; then
+          # `git diff` ignores untracked files, so a purely additive corpus
+          # change - a brand new <event>.json, the most common case - reads as
+          # "no change" and the PR step is skipped, silently. That is exactly
+          # how module.event reached only four of the seven SDKs. `git status
+          # --porcelain` lists untracked files too, so a new fixture counts.
+          if [ -z "$(git status --porcelain)" ]; then
             echo "changed=false" >> "$GITHUB_OUTPUT"
           else
             echo "changed=true" >> "$GITHUB_OUTPUT"
-            git diff --stat
+            git status --short
           fi
 
       - name: Open a PR


### PR DESCRIPTION
## The bug

The `protocol-sync` workflow decides whether to open/update a per-SDK PR with `git diff --quiet` — which **ignores untracked files**. So a purely additive corpus change (a brand-new `<event>.json`, the most common trigger) reads as "no change", the "Open a PR" step is skipped, and the run stays **green** while syncing nothing.

## Evidence

On the `module.event` merge (#455), the workflow reported success for all 7 SDKs, but `module.event.json` reached only 4 sync PRs (dart/defold/unity/unreal — which were also behind on a *modified* fixture, so `git diff` fired and swept the new file in). js, godot, and love2d — otherwise current — had only the new untracked file, so their gate returned false and they were silently left behind. The js job log confirms: token minted, repo checked out, `apply` reported "1 change(s) applied", yet no PR — the gate skipped it.

This is precisely the "a green run that did nothing is worse than a red one" failure the workflow was rebuilt (#387) to prevent, recurring for the additive case.

## The fix

Detect the change with `git status --porcelain`, which lists untracked files too, so a new fixture counts.

After merge I'll trigger the workflow (`workflow_dispatch`) to re-sync all seven and close the js/godot/love2d gap.