### PR TITLE
docs: freeze the wire protocol at 1.0

### DIFF
--- a/docs/adr/0010-wire-protocol-frozen-at-1.0.md
+++ b/docs/adr/0010-wire-protocol-frozen-at-1.0.md
@@ -1,0 +1,137 @@
+# ADR 0010: The client wire protocol is frozen at 1.0
+
+Date: 2026-08-13
+
+## Status
+
+Accepted. Freezes the client-facing wire that the ecosystem's ADR 0003
+("RPC is the only extension wire seam") drew, now that both transports carry
+it and all seven SDKs speak it.
+
+This is a version on the **wire contract**, not on the asobi package. asobi is
+a 0.x library and keeps moving; the frame corpus and the RPC envelope below it
+do not. The two numbers are independent: the package can reach 1.0, or never,
+without touching this freeze, and this freeze can bump to 2.0 while the package
+stays 0.x. The number that moves here is the RPC protocol integer
+(`?PROTOCOL` in `m:asobi_rpc`), which is `1`.
+
+## Context
+
+The wire is complete. `module.event` and the HTTP RPC transport shipped, and
+all seven SDKs (JavaScript, Dart/Flame, Godot, Defold, LÖVE, Unity, Unreal)
+decode both. There is no frame type left to add before a client can be written
+against this server, so there is nothing left that a first release has to wait
+for.
+
+The SDKs do not depend on this server; they copy from it. Every SDK vendors the
+fixture corpus (`priv/protocol/fixtures/`) by copying the JSON into its own test
+tree, and the Godot and LÖVE SDKs are consumed by copying their source into a
+game project. There is no package manager between this repository and a shipped
+client, so there is no upgrade path but re-copying, which a shipped game does
+not do.
+
+That makes a quiet wire edit a silent client break. Additions are safe: five of
+the seven SDKs drop a frame type they do not recognise, so a new frame type or a
+new payload field reaches an old client as a no-op. A **rename** is not an
+addition. It is a new type the old client drops plus the removal of a type the
+old client dispatched on, and the client goes quiet with nothing on either end
+reporting it. Changing an existing payload's shape is the same failure a layer
+down: the client still dispatches, then reads a field that is no longer there.
+The corpus is vendored, so the break lands in every game already shipped against
+the old shape and cannot be pulled back.
+
+The same failure runs the other way. An SDK hard-codes the `type` it sends for
+each call, so the client -> server command frames are as fixed as the outbound
+ones even though they are not in the vendored corpus. Rename a handled inbound
+frame and the server answers `unknown_type` to every shipped client - the
+identical un-re-pullable break, on the sending side.
+
+This is why the wire freezes harder than the Erlang API. A library consumer of
+asobi upgrades a pin and recompiles; a game holding a vendored corpus cannot.
+The blast radius of a wire break is every shipped client, not every consumer who
+chooses to upgrade.
+
+## Decision
+
+**Freeze the client-facing wire contract at 1.0.** In scope of the freeze:
+
+- **The frame corpus, in both directions.**
+  - *Outbound (server -> client): the 40 frame types under
+    `priv/protocol/fixtures/` and the payload shape of each.* These are the
+    types a client dispatches on and the fields it reads; the SDKs vendor them
+    as their test corpus.
+  - *Inbound (client -> server): the 22 command frame types the socket
+    handles* - `chat.join`, `chat.leave`, `chat.send`, `dm.send`,
+    `match.input`, `match.join`, `match.leave`, `match.list`, `matchmaker.add`,
+    `matchmaker.remove`, `presence.update`, `rpc.call`, `session.connect`,
+    `session.heartbeat`, `vote.cast`, `vote.veto`, `world.create`,
+    `world.find_or_create`, `world.input`, `world.join`, `world.leave`,
+    `world.list`. These are not in the vendored corpus; they are hard-coded in
+    every SDK's call sites, so they cannot be re-pulled either. Renaming or
+    removing a handled inbound frame makes the server answer `unknown_type` to
+    every shipped client, the same blast radius as an outbound rename, from the
+    sending side.
+- **The envelope.** `{"type": ..., "payload": {...}}`, the frame every type
+  above rides in.
+- **The RPC contract.** `rpc.call` in, `rpc.ok` / `rpc.error` out; the
+  `{code, message, details}` error object; and the RPC protocol integer
+  (`?PROTOCOL = 1`), which versions the payload rather than the frame type.
+- **Both transports.** WebSocket and `POST /api/v1/rpc/<method>`. They diverge
+  in front of the dispatcher (auth, rate limit, size cap, where `protocol`
+  comes from) but share one envelope below it, so a single SDK decoder serves
+  both, and that shared envelope is frozen for both.
+
+Compat policy from here:
+
+- **Additive, with one carve-out.** A new frame type, and a new field on an
+  existing payload, are allowed, and clients tolerate both: an unknown type is
+  dropped and an unknown field is ignored. This is unconditionally safe in the
+  reserved namespaces (`session`, `presence`, `module`, `rpc`). It is NOT
+  unconditionally safe in the open `match.` / `world.` leaf space, which game
+  scripts share: adding a core `match.<leaf>` or `world.<leaf>` frame forces
+  adding `<leaf>` to `?RESERVED_EVENT_NAMES` (`m:asobi_ws_handler`), and the
+  validate path then silently drops that leaf server-side for any shipped game
+  already broadcasting it through `game.broadcast`. A core addition in the open
+  leaf space can therefore retroactively ban a shipped game's own event, so it
+  is weighed as a break there rather than waved through as additive.
+- **Rename or removal of a frozen frame type, or a change to an existing
+  payload's shape, is a breaking change.** It is not a silent edit. It requires
+  bumping the RPC protocol integer (1 -> 2) and carrying both versions under an
+  N / N-1 window, so a client on the old version keeps a server that answers it
+  while it migrates.
+
+## Consequences
+
+- **A wire break now costs a version bump and a compat window, deliberately.**
+  That is the point of the freeze, not a side effect of it. The cost is paid by
+  whoever breaks the wire, once, rather than by every shipped game, silently.
+- **The freeze is enforced by CI, not by discipline.** Two guards already hold
+  most of it, and this ADR adds the frozen-set guards:
+  - `scripts/protocol-sync.sh` and `.github/workflows/protocol-sync.yml` keep
+    all seven SDK vendored copies of the corpus in lockstep with this
+    repository, so no SDK carries a stale or forked fixture.
+  - `asobi_protocol_coverage_tests` enforces corpus integrity: every emitted
+    event has a fixture, no fixture is stale, every fixture is a valid envelope,
+    and the listing projections match their fixtures.
+  - The new frozen-set guards in that suite pin the frozen types by name in
+    both directions - the 40 outbound fixtures, and the 22 inbound command
+    frames scanned from `asobi_ws_handler`'s handled clauses - so removing or
+    renaming either fails the build and forces a conscious wire-version decision
+    rather than a green diff. Additions stay allowed; the coverage test above
+    already covers new outbound types.
+- **The frozen-set guards pin type NAMES, not payload shapes.** A field quietly
+  dropped or retyped on a frozen frame is not what they catch; that is held by
+  the other three mechanisms - the fixtures are the SDKs' vendored ground truth,
+  `protocol-sync` keeps every copy identical, and
+  `listing_fixtures_match_the_projection_test` pins the two listing payloads to
+  their projection function. Do not read the frozen-set tripwire as a shape
+  check.
+- **The HTTP RPC status mapping is frozen too.**
+  `POST /api/v1/rpc/<method>` returns the error object's own HTTP status
+  (`asobi_error:status/1`), so that code -> status map is part of this frozen
+  wire. The rest of the REST surface is out of scope here and is versioned
+  separately through its own `/api/v1/` path.
+- **The frozen sets are hand-maintained lists, not derived from the corpus or
+  the handler scan.** Deriving either would defeat it: a deletion would shrink
+  the derived list along with the thing it checks and pass, which is exactly the
+  change the guards exist to catch.

--- a/guides/websocket-protocol.md
+++ b/guides/websocket-protocol.md
@@ -1088,6 +1088,46 @@ reflected back. Codes core itself adds for this surface:
 | `unauthenticated` | The socket has not completed `session.connect` |
 | `not_ready` | The node is still running migrations. Retry |
 
+### HTTP transport
+
+The same RPC also answers over HTTP, for a client with no open socket:
+
+```
+POST /api/v1/rpc/quests.claim
+```
+
+- The method is the last path segment, so `quests.claim` here is the method the
+  socket names in its payload. The body carries only `params`:
+
+```json
+{"params": {"quest_id": "q-1"}}
+```
+
+- `protocol` is injected server-side, so an HTTP client never sends it, and
+  `rpc.unsupported_protocol` cannot fire here; the version lives in the
+  `/api/v1/` path instead.
+- There is no `cid`. An HTTP reply is self-correlating - it is the response to
+  this one request and nothing else.
+
+The reply is the **same envelope** the socket sends,
+`{"type": ..., "payload": ...}`, carrying the same `rpc.ok` or `rpc.error`
+below it, plus an HTTP status: `200` for `rpc.ok`, and the error object's own
+status otherwise (the status the [REST API](rest-api.md#errors) gives that
+code).
+
+```json
+200 OK
+{"type": "rpc.ok", "payload": {"result": {"reward": 100}}}
+```
+
+```json
+404 Not Found
+{"type": "rpc.error", "payload": {"error": {"code": "rpc.unknown_method", "message": "No installed extension serves this RPC method.", "details": {}}}}
+```
+
+Both transports share one envelope below the transport, so a single SDK decoder
+reads a reply whether it arrived on the socket or from this endpoint.
+
 ## Next steps
 
 - [REST API](rest-api.md) - the request/response surface alongside this socket protocol.

--- a/test/asobi_protocol_coverage_tests.erl
+++ b/test/asobi_protocol_coverage_tests.erl
@@ -15,6 +15,96 @@
     ?WORLD_SERVER
 ]).
 
+%% The frozen 1.0 wire (ADR 0010): the 40 frame types the corpus shipped when
+%% the wire froze. Every one must stay present as a fixture, because the SDKs
+%% vendor the corpus by copying it and cannot be upgraded in place - removing or
+%% renaming a frozen type breaks every client already shipped against it. So a
+%% removal has to fail CI and go through a protocol-version bump (1 -> 2) rather
+%% than pass as a green diff. Additions are NOT listed here: a new event is not
+%% frozen yet, and every_emitted_event_has_a_fixture_test already covers it.
+%%
+%% This list is hand-maintained, NOT derived from the corpus, and that is the
+%% whole point: deriving it would let a deletion shrink the list along with the
+%% fixtures and pass, which is exactly the regression this guard exists to catch.
+-define(FROZEN_WIRE_1_0, [
+    ~"chat.joined",
+    ~"chat.left",
+    ~"chat.message",
+    ~"dm.message",
+    ~"dm.sent",
+    ~"error",
+    ~"game.error",
+    ~"game.message",
+    ~"match.finished",
+    ~"match.joined",
+    ~"match.left",
+    ~"match.list",
+    ~"match.matched",
+    ~"match.matchmaker_expired",
+    ~"match.matchmaker_failed",
+    ~"match.state",
+    ~"match.vote_result",
+    ~"match.vote_start",
+    ~"match.vote_tally",
+    ~"match.vote_vetoed",
+    ~"matchmaker.queued",
+    ~"matchmaker.removed",
+    ~"module.error",
+    ~"module.event",
+    ~"module.message",
+    ~"notification.new",
+    ~"presence.updated",
+    ~"rpc.error",
+    ~"rpc.ok",
+    ~"session.connected",
+    ~"session.heartbeat",
+    ~"vote.cast_ok",
+    ~"vote.veto_ok",
+    ~"world.finished",
+    ~"world.joined",
+    ~"world.left",
+    ~"world.list",
+    ~"world.phase_changed",
+    ~"world.terrain",
+    ~"world.tick"
+]).
+
+%% The frozen 1.0 INBOUND wire (ADR 0010): the 22 client->server command frame
+%% types the socket handles. The client SENDS these; they are hard-coded in
+%% every SDK's call sites, NOT in the vendored fixture corpus, so they cannot be
+%% re-pulled either - renaming or removing a handled frame makes the server
+%% answer `unknown_type` to every shipped client, the same blast radius as an
+%% outbound rename. Each must stay handled by asobi_ws_handler.
+%%
+%% Hand-maintained, NOT derived from the handler scan, for the same reason the
+%% outbound list is not derived from the corpus: deriving it would let a
+%% deleted clause shrink the list along with the scanned set and pass, which is
+%% exactly the regression this guard exists to catch.
+-define(FROZEN_INBOUND_1_0, [
+    ~"chat.join",
+    ~"chat.leave",
+    ~"chat.send",
+    ~"dm.send",
+    ~"match.input",
+    ~"match.join",
+    ~"match.leave",
+    ~"match.list",
+    ~"matchmaker.add",
+    ~"matchmaker.remove",
+    ~"presence.update",
+    ~"rpc.call",
+    ~"session.connect",
+    ~"session.heartbeat",
+    ~"vote.cast",
+    ~"vote.veto",
+    ~"world.create",
+    ~"world.find_or_create",
+    ~"world.input",
+    ~"world.join",
+    ~"world.leave",
+    ~"world.list"
+]).
+
 %% Every event the asobi server emits must have a fixture file. SDKs use
 %% the fixtures as ground truth for dispatch tests; a missing fixture
 %% means a wire event that no SDK can dispatch-test against. This is the
@@ -48,6 +138,60 @@ no_stale_fixtures_test() ->
             io_lib:format(
                 "Fixtures exist for events with no emit site in src/ — stale or renamed: ~p",
                 [Stale]
+            )
+        )
+    ).
+
+%% ADR 0010: the 1.0 wire is frozen. Every frozen frame type must still ship a
+%% fixture; a missing one is a removal or rename that silently breaks every SDK
+%% that vendored the corpus, and must instead go through a protocol-version bump
+%% (?PROTOCOL 1 -> 2) with an N/N-1 window. Additions stay allowed - a type not
+%% in the frozen list is covered by every_emitted_event_has_a_fixture_test.
+frozen_1_0_wire_types_are_still_present_test() ->
+    Fixtures = list_fixture_event_names(),
+    Removed = lists:sort(?FROZEN_WIRE_1_0 -- Fixtures),
+    ?assertEqual(
+        [],
+        Removed,
+        lists:flatten(
+            io_lib:format(
+                "Frozen 1.0 wire frame types removed or renamed (ADR 0010) - breaking "
+                "the wire needs a protocol-version bump, not a fixture deletion: ~p",
+                [Removed]
+            )
+        )
+    ).
+
+%% ADR 0010: the 1.0 wire is frozen in BOTH directions. The client SENDS the 22
+%% command frames in ?FROZEN_INBOUND_1_0; each must still be handled by
+%% asobi_ws_handler, or a shipped client's call answers `unknown_type`. A
+%% removal/rename drops the frame from the scanned set and must instead go
+%% through a protocol-version bump (?PROTOCOL 1 -> 2) with an N/N-1 window.
+%%
+%% The handled set is scanned straight from source (mirroring
+%% scan_encode_reply_types/1 for the outbound direction), so the guard trips
+%% even when a refactor updates the behavioural suite in lockstep with the
+%% rename. Additions stay allowed: a new inbound frame is simply not frozen yet,
+%% so it enlarges the scanned set without tripping the ?FROZEN_INBOUND_1_0 diff.
+frozen_1_0_inbound_types_are_still_handled_test() ->
+    Handled = scan_handled_inbound_types(read_file(?WS_HANDLER)),
+    %% The scan is real, not vacuous, and not over-broad: it finds a genuine
+    %% inbound command, and does NOT pick up a pure server push (match.state)
+    %% nor an outbound reply literal (session.connected), so it is reading
+    %% handle_message clause heads rather than encode_reply calls or payloads.
+    ?assert(lists:member(~"session.connect", Handled)),
+    ?assertNot(lists:member(~"match.state", Handled)),
+    ?assertNot(lists:member(~"session.connected", Handled)),
+    Removed = lists:sort(?FROZEN_INBOUND_1_0 -- Handled),
+    ?assertEqual(
+        [],
+        Removed,
+        lists:flatten(
+            io_lib:format(
+                "Frozen 1.0 inbound command frames no longer handled by asobi_ws_handler "
+                "(ADR 0010) - breaking the wire needs a protocol-version bump, not a "
+                "handler-clause deletion: ~p",
+                [Removed]
             )
         )
     ).
@@ -140,6 +284,15 @@ scan_encode_reply_types(Bin) ->
         {match, Matches} -> [B || [B] <- Matches];
         nomatch -> []
     end.
+
+%% The INBOUND counterpart to scan_encode_reply_types/1: pulls every handled
+%% command `type` literal from the `handle_message(#{~"type" := ~"X"...` clause
+%% heads. The catch-all `#{~"type" := _Type}` clause matches a variable, not a
+%% `~"..."` literal, so it is not captured - only frames the socket actually
+%% handles are.
+scan_handled_inbound_types(Bin) ->
+    Re = "~\"type\"\\s*:=\\s*~\"([a-z][a-z._]*)\"",
+    extract_captures(Bin, Re).
 
 %% S6: extension-produced frames go out through extension_frames/3, which
 %% names two wire types - the current one and the deprecated pre-rename


### PR DESCRIPTION
Records the 1.0 wire-protocol freeze (the consolidate decision) and adds CI guards so a future change cannot silently break it.

## What
- **ADR 0010** (`docs/adr/`): declares the client-facing wire frozen at 1.0 — the frame corpus (40 outbound + 22 inbound command frames), the `{type,payload}` envelope, the RPC contract (`rpc.call`/`rpc.ok`/`rpc.error` + `{code,message,details}` + `?PROTOCOL=1`), and both transports (WS + HTTP). Additive-only going forward; rename/removal/shape-change needs a `?PROTOCOL` bump under an N/N-1 window. Explicit that *wire* 1.0 ≠ asobi's 0.x package version.
- **Two frozen-set guards** in `asobi_protocol_coverage_tests`: `?FROZEN_WIRE_1_0` (40 outbound types, pinned against the fixture corpus) and `?FROZEN_INBOUND_1_0` (22 client→server command types, pinned by source-scanning the `asobi_ws_handler` clause heads). Removal/rename of any frozen frame fails CI; additions stay allowed. Both are hand-maintained-not-derived on purpose (a derived list would shrink with a deletion and pass).
- **Wire doc**: the HTTP transport (`POST /api/v1/rpc/<method>`) now documented in `guides/websocket-protocol.md`, so the frozen-contract reference covers both transports.

## Gate
guardian (ACCEPT — caught that the freeze was outbound-only; inbound now frozen + guarded) + erlang-code-reviewer (0 blockers). The additive-only policy carves out the open `match.`/`world.` leaf namespace (a new core frame there can retroactively ban a shipped game's `game.broadcast`), and the Consequences are honest that the guards pin type *names*, not payload shapes (shapes are held by fixtures-as-ground-truth + protocol-sync). The inbound guard was verified non-vacuous out-of-band (a rename trips it).

Local: eqwalize delta 0, fmt/xref/lint clean, full eunit 1899/0, ex_doc no new warnings. No runtime src change — ADR + doc + test guards only.