### PR TITLE
fix: route world votes to the world server

### DIFF
--- a/src/ws/asobi_ws_handler.erl
+++ b/src/ws/asobi_ws_handler.erl
@@ -626,10 +626,34 @@ handle_message(
     Cid = maps:get(~"cid", Msg, undefined),
     try asobi_player_session:get_state(SessionPid) of
         #{player_id := PlayerId} = SState ->
+            %% #447: a vote lives on the fabric the player is actually in. A
+            %% match player casts against their match_server; a world player
+            %% casts against their world_server, which owns the world's votes.
+            %% Resolving from the authenticated session's own state (never from
+            %% the payload) is what stops a player voting in a fabric they are
+            %% not in. Mirrors the match.input fallback shape.
             case maps:get(match_pid, SState, undefined) of
                 undefined ->
-                    Reply = encode_error(Cid, ~"not_in_match"),
-                    {reply, {text, Reply}, State};
+                    case maps:get(world_pid, SState, undefined) of
+                        undefined ->
+                            Reply = encode_error(Cid, ~"not_in_match"),
+                            {reply, {text, Reply}, State};
+                        WorldPid ->
+                            VoteId = maps:get(~"vote_id", Payload),
+                            OptionId = maps:get(~"option_id", Payload),
+                            case
+                                asobi_world_server:cast_vote(
+                                    WorldPid, PlayerId, VoteId, OptionId
+                                )
+                            of
+                                ok ->
+                                    Reply = encode_reply(Cid, ~"vote.cast_ok", #{success => true}),
+                                    {reply, {text, Reply}, State};
+                                {error, Reason} ->
+                                    Reply = encode_error(Cid, Reason),
+                                    {reply, {text, Reply}, State}
+                            end
+                    end;
                 MatchPid ->
                     VoteId = maps:get(~"vote_id", Payload),
                     OptionId = maps:get(~"option_id", Payload),
@@ -653,10 +677,26 @@ handle_message(
     Cid = maps:get(~"cid", Msg, undefined),
     try asobi_player_session:get_state(SessionPid) of
         #{player_id := PlayerId} = SState ->
+            %% #447: same fabric-aware routing as vote.cast - a world player's
+            %% veto reaches their world_server, a match player's their
+            %% match_server.
             case maps:get(match_pid, SState, undefined) of
                 undefined ->
-                    Reply = encode_error(Cid, ~"not_in_match"),
-                    {reply, {text, Reply}, State};
+                    case maps:get(world_pid, SState, undefined) of
+                        undefined ->
+                            Reply = encode_error(Cid, ~"not_in_match"),
+                            {reply, {text, Reply}, State};
+                        WorldPid ->
+                            VoteId = maps:get(~"vote_id", Payload),
+                            case asobi_world_server:use_veto(WorldPid, PlayerId, VoteId) of
+                                ok ->
+                                    Reply = encode_reply(Cid, ~"vote.veto_ok", #{success => true}),
+                                    {reply, {text, Reply}, State};
+                                {error, Reason} ->
+                                    Reply = encode_error(Cid, Reason),
+                                    {reply, {text, Reply}, State}
+                            end
+                    end;
                 MatchPid ->
                     VoteId = maps:get(~"vote_id", Payload),
                     case asobi_match_server:use_veto(MatchPid, PlayerId, VoteId) of

--- a/test/asobi_ws_vote_tests.erl
+++ b/test/asobi_ws_vote_tests.erl
@@ -1,0 +1,132 @@
+-module(asobi_ws_vote_tests).
+
+-include_lib("eunit/include/eunit.hrl").
+
+%% #447: world votes were unreachable from clients. asobi_ws_handler resolved
+%% vote.cast / vote.veto from the session's match_pid only, but a world join
+%% sets world_pid/zone_pid and never match_pid, so a world-mode script could
+%% start a vote that no client could ever cast or veto in. These tests drive
+%% the frozen vote.cast / vote.veto frames through websocket_handle/2 and prove
+%% a world-context session now reaches asobi_world_server while the
+%% match-context path still reaches asobi_match_server unchanged.
+
+vote_routing_test_() ->
+    {foreach, fun setup/0, fun cleanup/1, [
+        fun world_vote_cast_reaches_world_server/1,
+        fun world_vote_veto_reaches_world_server/1,
+        fun match_vote_cast_still_reaches_match_server/1,
+        fun match_vote_veto_still_reaches_match_server/1,
+        fun world_vote_cast_error_is_reported/1,
+        fun world_vote_veto_error_is_reported/1,
+        fun no_fabric_vote_cast_is_not_in_match/1
+    ]}.
+
+setup() ->
+    meck:new(asobi_player_session, [passthrough]),
+    meck:new(asobi_world_server, [passthrough]),
+    meck:new(asobi_match_server, [passthrough]),
+    meck:expect(asobi_world_server, cast_vote, fun(_Pid, _PlayerId, _VoteId, _OptionId) -> ok end),
+    meck:expect(asobi_world_server, use_veto, fun(_Pid, _PlayerId, _VoteId) -> ok end),
+    meck:expect(asobi_match_server, cast_vote, fun(_Pid, _PlayerId, _VoteId, _OptionId) -> ok end),
+    meck:expect(asobi_match_server, use_veto, fun(_Pid, _PlayerId, _VoteId) -> ok end),
+    ok.
+
+cleanup(_) ->
+    meck:unload(asobi_match_server),
+    meck:unload(asobi_world_server),
+    meck:unload(asobi_player_session),
+    ok.
+
+world_vote_cast_reaches_world_server(_) ->
+    mock_session(#{player_id => ~"p1", world_pid => self(), zone_pid => self()}),
+    Decoded = handle(~"vote.cast", ~"vc1", #{~"vote_id" => ~"v1", ~"option_id" => ~"a"}),
+    [
+        ?_assertMatch(
+            #{~"type" := ~"vote.cast_ok", ~"cid" := ~"vc1", ~"payload" := #{~"success" := true}},
+            Decoded
+        ),
+        %% '_' for the vote target pid: eunit runs a deferred ?_assert in a
+        %% different process than the one that recorded the meck call, so a
+        %% literal self() here would never match. The other three args pin the
+        %% authenticated player and the payload's vote/option ids.
+        ?_assertEqual(1, meck:num_calls(asobi_world_server, cast_vote, ['_', ~"p1", ~"v1", ~"a"])),
+        ?_assertEqual(0, meck:num_calls(asobi_match_server, cast_vote, '_'))
+    ].
+
+world_vote_veto_reaches_world_server(_) ->
+    mock_session(#{player_id => ~"p1", world_pid => self(), zone_pid => self()}),
+    Decoded = handle(~"vote.veto", ~"vv1", #{~"vote_id" => ~"v1"}),
+    [
+        ?_assertMatch(
+            #{~"type" := ~"vote.veto_ok", ~"cid" := ~"vv1", ~"payload" := #{~"success" := true}},
+            Decoded
+        ),
+        ?_assertEqual(1, meck:num_calls(asobi_world_server, use_veto, ['_', ~"p1", ~"v1"])),
+        ?_assertEqual(0, meck:num_calls(asobi_match_server, use_veto, '_'))
+    ].
+
+match_vote_cast_still_reaches_match_server(_) ->
+    mock_session(#{player_id => ~"p1", match_pid => self()}),
+    Decoded = handle(~"vote.cast", ~"vc2", #{~"vote_id" => ~"v1", ~"option_id" => ~"a"}),
+    [
+        ?_assertMatch(#{~"type" := ~"vote.cast_ok", ~"payload" := #{~"success" := true}}, Decoded),
+        ?_assertEqual(1, meck:num_calls(asobi_match_server, cast_vote, ['_', ~"p1", ~"v1", ~"a"])),
+        ?_assertEqual(0, meck:num_calls(asobi_world_server, cast_vote, '_'))
+    ].
+
+match_vote_veto_still_reaches_match_server(_) ->
+    mock_session(#{player_id => ~"p1", match_pid => self()}),
+    Decoded = handle(~"vote.veto", ~"vv2", #{~"vote_id" => ~"v1"}),
+    [
+        ?_assertMatch(#{~"type" := ~"vote.veto_ok", ~"payload" := #{~"success" := true}}, Decoded),
+        ?_assertEqual(1, meck:num_calls(asobi_match_server, use_veto, ['_', ~"p1", ~"v1"])),
+        ?_assertEqual(0, meck:num_calls(asobi_world_server, use_veto, '_'))
+    ].
+
+world_vote_cast_error_is_reported(_) ->
+    mock_session(#{player_id => ~"p1", world_pid => self(), zone_pid => self()}),
+    meck:expect(asobi_world_server, cast_vote, fun(_Pid, _PlayerId, _VoteId, _OptionId) ->
+        {error, vote_not_found}
+    end),
+    Decoded = handle(~"vote.cast", ~"vc3", #{~"vote_id" => ~"gone", ~"option_id" => ~"a"}),
+    ?_assertMatch(
+        #{~"type" := ~"error", ~"payload" := #{~"reason" := ~"vote_not_found"}}, Decoded
+    ).
+
+world_vote_veto_error_is_reported(_) ->
+    mock_session(#{player_id => ~"p1", world_pid => self(), zone_pid => self()}),
+    meck:expect(asobi_world_server, use_veto, fun(_Pid, _PlayerId, _VoteId) ->
+        {error, no_veto_tokens}
+    end),
+    Decoded = handle(~"vote.veto", ~"vv3", #{~"vote_id" => ~"v1"}),
+    ?_assertMatch(
+        #{~"type" := ~"error", ~"payload" := #{~"reason" := ~"no_veto_tokens"}}, Decoded
+    ).
+
+no_fabric_vote_cast_is_not_in_match(_) ->
+    mock_session(#{player_id => ~"p1"}),
+    Decoded = handle(~"vote.cast", ~"vc4", #{~"vote_id" => ~"v1", ~"option_id" => ~"a"}),
+    [
+        ?_assertMatch(
+            #{~"type" := ~"error", ~"payload" := #{~"reason" := ~"not_in_match"}}, Decoded
+        ),
+        ?_assertEqual(0, meck:num_calls(asobi_world_server, cast_vote, '_')),
+        ?_assertEqual(0, meck:num_calls(asobi_match_server, cast_vote, '_'))
+    ].
+
+mock_session(SState) ->
+    meck:expect(asobi_player_session, get_state, fun(_Pid) -> SState end).
+
+handle(Type, Cid, Payload) ->
+    Raw = iolist_to_binary(
+        json:encode(#{~"type" => Type, ~"cid" => Cid, ~"payload" => Payload})
+    ),
+    {reply, {text, Frame}, _State} = asobi_ws_handler:websocket_handle({text, Raw}, state()),
+    json:decode(iolist_to_binary(Frame)).
+
+state() ->
+    #{
+        session => self(),
+        ws_msg_count => 0,
+        ws_msg_window_start => erlang:system_time(millisecond)
+    }.


### PR DESCRIPTION
Closes #447.

`asobi_world_server:cast_vote/4` and `use_veto/3` had zero callers: the ws `vote.cast`/`vote.veto` clauses resolved the vote target from `match_pid` only, but world joins set `world_pid`/`zone_pid`. So world-mode votes could be broadcast by a script but no client could cast or veto.

- Made both vote clauses **fabric-aware**: `match_pid` set → `asobi_match_server` (unchanged); else `world_pid` set → `asobi_world_server`. Mirrors the existing `match.input` fallback shape. The vote target + `player_id` come only from the authenticated session, never the payload (no cross-fabric voting).
- The frozen `vote.cast`/`vote.veto` (in) and `vote.cast_ok`/`vote.veto_ok` (out) frames are untouched — server-side routing only.
- **Full sweep** of all 4 `match_pid` reads: `match.input` already fabric-aware; `match.leave` correctly match-only (leave is fabric-specific; a world player leaves via `world.leave`); the two vote clauses fixed. No other fabric-blind surface.
- Tests drive the real `websocket_handle/2`: world-context cast/veto now reach the world server (+ match server 0 calls), match-context unchanged (+ world server 0 calls), cast/veto error propagation, no-fabric → `not_in_match`.

## Gate
guardian (ACCEPT — fabric model correct, cross-fabric-voting safe, no warping) + erlang-code-reviewer (0 blockers). Local: eqwalize delta 0, dialyzer/xref/fmt/lint clean, vote eunit 17/0, full eunit 1915/0, ws/vote/world CT 45+32 pass.

Follow-up filed (guardian finding, pre-existing/symmetric): a vote into a *finished* match or world hangs the caller and crashes the WS connection (the `finished` catch-all swallows the call), plus vote payload-validation gaps — tracked separately as a both-fabric robustness fix.