### PR TITLE
fix: vote calls into a finished or malformed state no longer crash

### DIFF
--- a/src/matches/asobi_match_server.erl
+++ b/src/matches/asobi_match_server.erl
@@ -440,16 +440,20 @@ running(
         {reply, From, {ok, VotePid}}
     ]};
 running({call, From}, {cast_vote, PlayerId, VoteId, OptionId}, State) when
-    is_binary(PlayerId), is_binary(OptionId)
+    is_binary(PlayerId), (is_binary(OptionId) orelse is_list(OptionId))
 ->
-    Active = maps:get(active_votes, State, #{}),
-    case maps:get(VoteId, Active, undefined) of
-        undefined ->
-            {keep_state_and_data, [{reply, From, {error, vote_not_found}}]};
-        VotePid ->
-            Result = asobi_vote_server:cast_vote(VotePid, PlayerId, OptionId),
-            {keep_state_and_data, [{reply, From, Result}]}
-    end;
+    handle_cast_vote(From, PlayerId, VoteId, OptionId, State);
+%% asobi#462: a valid option_id is a binary (plurality/weighted) or a list of
+%% binaries (approval/ranked - see asobi_vote_server:validate_option/2). A
+%% vote.cast whose option_id is a JSON number, bool, null or object misses the
+%% guard above; running/3 has no catch-all, so without this fallback the
+%% function_clause crashes the whole match - every player in it - on one
+%% malformed frame. Degrade to the invalid_option asobi_vote_server already
+%% reports for a bad option, and never forward the junk value on. A list that
+%% carries a non-binary passes the guard and is rejected downstream by
+%% validate_option, also as invalid_option, with no crash.
+running({call, From}, {cast_vote, _PlayerId, _VoteId, _OptionId}, _State) ->
+    {keep_state_and_data, [{reply, From, {error, invalid_option}}]};
 running({call, From}, {use_veto, PlayerId, VoteId}, #{veto_tokens := Tokens} = State) when
     is_binary(PlayerId)
 ->
@@ -469,6 +473,12 @@ running({call, From}, {use_veto, PlayerId, VoteId}, #{veto_tokens := Tokens} = S
                     {keep_state_and_data, [{reply, From, Err}]}
             end
     end;
+%% asobi#462: mirrors the cast_vote fallback above - a use_veto that misses the
+%% is_binary(PlayerId) guard would otherwise crash the whole match on
+%% function_clause. PlayerId is always resolved server-side, so this is
+%% defence-in-depth, replying the same invalid_option rather than a crash.
+running({call, From}, {use_veto, _PlayerId, _VoteId}, _State) ->
+    {keep_state_and_data, [{reply, From, {error, invalid_option}}]};
 running(cast, {broadcast_event, Event, Payload}, State) ->
     broadcast_match_event(Event, Payload, State),
     keep_state_and_data;
@@ -610,6 +620,19 @@ finished({call, From}, {get_info, listing}, State) ->
 finished(cast, {broadcast_event, Event, Payload}, State) ->
     broadcast_match_event(Event, Payload, State),
     keep_state_and_data;
+%% asobi#462: a late vote.cast/vote.veto lands here while the finished match
+%% waits out its 5s cleanup timer, still holding the player's match_pid.
+%% Without an explicit reply the catch-all below swallows the {call, From} and
+%% the caller (asobi_ws_handler, an infinity gen_statem:call) blocks until this
+%% server stops at its cleanup timeout - a frozen socket that reads as a
+%% disconnect on mobile - then gets a misleading internal_error. Replying
+%% not_in_match returns immediately with the same registered 409 the
+%% dead/finished-fabric path in vote_call/1 uses, so "the match is over" is one
+%% code a client can branch on, not two that depend on a 5s race.
+finished({call, From}, {cast_vote, _PlayerId, _VoteId, _OptionId}, _State) ->
+    {keep_state_and_data, [{reply, From, {error, not_in_match}}]};
+finished({call, From}, {use_veto, _PlayerId, _VoteId}, _State) ->
+    {keep_state_and_data, [{reply, From, {error, not_in_match}}]};
 finished(_EventType, _Event, _State) ->
     keep_state_and_data.
 
@@ -924,6 +947,21 @@ listing_info(Info) ->
             Base#{phase => maps:with([status, phase, remaining_ms, start_condition], Phase)};
         _ ->
             Base
+    end.
+
+%% asobi#462: extracted from the running/3 cast_vote clause so OptionId is a
+%% plain term() here (a binary option or an approval/ranked list) rather than
+%% the guard-narrowed union, mirroring asobi_world_server:handle_cast_vote/5.
+%% asobi_vote_server:validate_option/2 is the one gate for whether the option
+%% is valid, list or scalar.
+handle_cast_vote(From, PlayerId, VoteId, OptionId, State) ->
+    Active = maps:get(active_votes, State, #{}),
+    case maps:get(VoteId, Active, undefined) of
+        undefined ->
+            {keep_state_and_data, [{reply, From, {error, vote_not_found}}]};
+        VotePid ->
+            Result = asobi_vote_server:cast_vote(VotePid, PlayerId, OptionId),
+            {keep_state_and_data, [{reply, From, Result}]}
     end.
 
 maybe_start_vote(Mod, #{game_state := GS} = State) ->

--- a/src/world/asobi_world_server.erl
+++ b/src/world/asobi_world_server.erl
@@ -372,10 +372,24 @@ running({call, From}, {get_info, listing}, State) ->
     {keep_state_and_data, [{reply, From, world_info(running, State, false)}]};
 running({call, From}, {start_vote, VoteConfig}, State) ->
     handle_start_vote(From, VoteConfig, State);
-running({call, From}, {cast_vote, PlayerId, VoteId, OptionId}, State) ->
+running({call, From}, {cast_vote, PlayerId, VoteId, OptionId}, State) when
+    is_binary(PlayerId), (is_binary(OptionId) orelse is_list(OptionId))
+->
     handle_cast_vote(From, PlayerId, VoteId, OptionId, State);
-running({call, From}, {use_veto, PlayerId, VoteId}, State) ->
+%% asobi#462: this path was guard-free and forwarded an unvalidated option
+%% straight to asobi_vote_server. A valid option_id is a binary
+%% (plurality/weighted) or a list of binaries (approval/ranked - see
+%% asobi_vote_server:validate_option/2); anything else (a JSON number, bool,
+%% null or object) hits this fallback and degrades to the invalid_option
+%% asobi_vote_server already reports for a bad option, never forwarding the
+%% junk. A list that carries a non-binary passes the guard and is rejected
+%% downstream by validate_option, also as invalid_option, with no crash.
+running({call, From}, {cast_vote, _PlayerId, _VoteId, _OptionId}, _State) ->
+    {keep_state_and_data, [{reply, From, {error, invalid_option}}]};
+running({call, From}, {use_veto, PlayerId, VoteId}, State) when is_binary(PlayerId) ->
     handle_use_veto(From, PlayerId, VoteId, State);
+running({call, From}, {use_veto, _PlayerId, _VoteId}, _State) ->
+    {keep_state_and_data, [{reply, From, {error, invalid_option}}]};
 running(
     cast,
     {spawn_at, TemplateId, {X, Y} = Pos, Overrides},
@@ -545,6 +559,19 @@ finished({call, From}, get_info, State) ->
     {keep_state_and_data, [{reply, From, world_info(finished, State)}]};
 finished({call, From}, {get_info, listing}, State) ->
     {keep_state_and_data, [{reply, From, world_info(finished, State, false)}]};
+%% asobi#462: as in asobi_match_server - a late vote.cast/vote.veto reaches a
+%% finished world during its 5s cleanup window while the session still holds
+%% world_pid. Without an explicit reply the catch-all below swallows the
+%% {call, From} and the caller (asobi_ws_handler, an infinity gen_statem:call)
+%% blocks until this server stops at its cleanup timeout - a frozen socket that
+%% reads as a disconnect on mobile - then gets a misleading internal_error.
+%% Replying not_in_match returns immediately with the same registered 409 the
+%% dead/finished-fabric path in vote_call/1 uses, so "the world is over" is one
+%% code a client can branch on, not two that depend on a 5s race.
+finished({call, From}, {cast_vote, _PlayerId, _VoteId, _OptionId}, _State) ->
+    {keep_state_and_data, [{reply, From, {error, not_in_match}}]};
+finished({call, From}, {use_veto, _PlayerId, _VoteId}, _State) ->
+    {keep_state_and_data, [{reply, From, {error, not_in_match}}]};
 finished(_EventType, _Event, _State) ->
     keep_state_and_data.
 

--- a/src/ws/asobi_ws_handler.erl
+++ b/src/ws/asobi_ws_handler.erl
@@ -642,9 +642,11 @@ handle_message(
                             VoteId = maps:get(~"vote_id", Payload),
                             OptionId = maps:get(~"option_id", Payload),
                             case
-                                asobi_world_server:cast_vote(
-                                    WorldPid, PlayerId, VoteId, OptionId
-                                )
+                                vote_call(fun() ->
+                                    asobi_world_server:cast_vote(
+                                        WorldPid, PlayerId, VoteId, OptionId
+                                    )
+                                end)
                             of
                                 ok ->
                                     Reply = encode_reply(Cid, ~"vote.cast_ok", #{success => true}),
@@ -657,7 +659,11 @@ handle_message(
                 MatchPid ->
                     VoteId = maps:get(~"vote_id", Payload),
                     OptionId = maps:get(~"option_id", Payload),
-                    case asobi_match_server:cast_vote(MatchPid, PlayerId, VoteId, OptionId) of
+                    case
+                        vote_call(fun() ->
+                            asobi_match_server:cast_vote(MatchPid, PlayerId, VoteId, OptionId)
+                        end)
+                    of
                         ok ->
                             Reply = encode_reply(Cid, ~"vote.cast_ok", #{success => true}),
                             {reply, {text, Reply}, State};
@@ -688,7 +694,11 @@ handle_message(
                             {reply, {text, Reply}, State};
                         WorldPid ->
                             VoteId = maps:get(~"vote_id", Payload),
-                            case asobi_world_server:use_veto(WorldPid, PlayerId, VoteId) of
+                            case
+                                vote_call(fun() ->
+                                    asobi_world_server:use_veto(WorldPid, PlayerId, VoteId)
+                                end)
+                            of
                                 ok ->
                                     Reply = encode_reply(Cid, ~"vote.veto_ok", #{success => true}),
                                     {reply, {text, Reply}, State};
@@ -699,7 +709,11 @@ handle_message(
                     end;
                 MatchPid ->
                     VoteId = maps:get(~"vote_id", Payload),
-                    case asobi_match_server:use_veto(MatchPid, PlayerId, VoteId) of
+                    case
+                        vote_call(fun() ->
+                            asobi_match_server:use_veto(MatchPid, PlayerId, VoteId)
+                        end)
+                    of
                         ok ->
                             Reply = encode_reply(Cid, ~"vote.veto_ok", #{success => true}),
                             {reply, {text, Reply}, State};
@@ -977,6 +991,29 @@ current_player_world(PlayerId) ->
     end.
 
 %% --- Internal ---
+
+%% asobi#462: a vote whose fabric is gone reaches asobi_vote_server via a
+%% gen_statem:call that exits. safe_handle_message/2 already catches any handler
+%% exit and returns an error frame, so this is never a crash-preventer - but
+%% that generic path logs a warning and answers internal_error, blaming asobi
+%% for a race the client cannot avoid. Catch only the process-gone exit shapes
+%% here and upgrade them to the clean, registered not_in_match: a finished
+%% fabric stops with normal (and a call that lost the race to its cleanup sees
+%% that stop), a dead one is noproc, and supervised teardown can surface
+%% shutdown or killed. Any other exit reason is a genuine vote-handler crash and
+%% falls through to safe_handle_message -> logged internal_error, which is
+%% intended - masking a real crash as not_in_match would hide it. The normal
+%% ok/{error, Reason} replies are untouched.
+-spec vote_call(fun(() -> ok | {error, term()})) -> ok | {error, term()}.
+vote_call(Call) ->
+    try
+        Call()
+    catch
+        exit:{noproc, _} -> {error, not_in_match};
+        exit:{normal, _} -> {error, not_in_match};
+        exit:{shutdown, _} -> {error, not_in_match};
+        exit:killed -> {error, not_in_match}
+    end.
 
 cancel_idle_auth_timer(#{idle_auth_timer := Ref} = State) when is_reference(Ref) ->
     _ = erlang:cancel_timer(Ref, [{async, true}, {info, false}]),

--- a/test/asobi_match_server_tests.erl
+++ b/test/asobi_match_server_tests.erl
@@ -989,6 +989,95 @@ broadcast_in_finished_is_not_swallowed_test() ->
     meck:unload(asobi_test_game),
     cleanup(ok).
 
+%% asobi#462: a vote.cast/vote.veto into a finished match landed on
+%% finished/3's catch-all, which swallowed the {call, From} with no reply, so
+%% the caller (an infinity gen_statem:call) blocked until the ~5s cleanup
+%% timeout. The finished-state vote clauses now reply immediately with
+%% not_in_match - the same registered code the dead-fabric path returns.
+vote_calls_into_finished_match_error_test() ->
+    setup(),
+    Pid = start_match(#{min_players => 2, max_players => 2}),
+    ok = asobi_match_server:join(Pid, ~"pf1"),
+    ok = asobi_match_server:join(Pid, ~"pf2"),
+    timer:sleep(50),
+    ?assertEqual(running, maps:get(status, asobi_match_server:get_info(Pid))),
+    asobi_match_server:cancel(Pid),
+    wait_for_status(Pid, finished, 60),
+    ?assertEqual(
+        {error, not_in_match},
+        gen_statem:call(Pid, {cast_vote, ~"pf1", ~"v1", ~"o1"}, 2000)
+    ),
+    ?assertEqual(
+        {error, not_in_match},
+        gen_statem:call(Pid, {use_veto, ~"pf1", ~"v1"}, 2000)
+    ),
+    ?assert(is_process_alive(Pid)),
+    gen_statem:stop(Pid),
+    cleanup(ok).
+
+%% asobi#462: a vote.cast with a non-binary option_id (a JSON number/null)
+%% missed running/3's is_binary guard and, with no catch-all there, crashed
+%% the whole match on function_clause - every player in it - on one malformed
+%% frame. It now degrades to {error, invalid_option} and the match survives.
+cast_vote_non_binary_option_does_not_crash_match_test() ->
+    setup(),
+    Pid = start_match(#{min_players => 2, max_players => 2}),
+    ok = asobi_match_server:join(Pid, ~"pnb1"),
+    ok = asobi_match_server:join(Pid, ~"pnb2"),
+    timer:sleep(50),
+    ?assertEqual(running, maps:get(status, asobi_match_server:get_info(Pid))),
+    ?assertEqual(
+        {error, invalid_option},
+        gen_statem:call(Pid, {cast_vote, ~"pnb1", ~"v1", 12345}, 2000)
+    ),
+    ?assert(is_process_alive(Pid)),
+    ?assertEqual(running, maps:get(status, asobi_match_server:get_info(Pid))),
+    stop(Pid),
+    cleanup(ok).
+
+%% asobi#462 regression guard: a valid option_id is a binary OR a list of
+%% binaries (approval/ranked - asobi_vote_server:cast_vote accepts
+%% binary() | [binary()]). An earlier is_binary(OptionId)-only guard rejected
+%% every list vote as invalid_option before it reached the vote server; the
+%% widened guard forwards a list through, and asobi_vote_server accepts a valid
+%% one and rejects a bad one - neither path crashes the match.
+cast_vote_list_option_reaches_vote_server_test() ->
+    setup(),
+    ensure_vote_sup(),
+    Pid = start_match(#{min_players => 2, max_players => 2}),
+    ok = asobi_match_server:join(Pid, ~"pl1"),
+    ok = asobi_match_server:join(Pid, ~"pl2"),
+    timer:sleep(50),
+    ?assertEqual(running, maps:get(status, asobi_match_server:get_info(Pid))),
+    {ok, VotePid} = asobi_match_server:start_vote(Pid, #{
+        vote_id => ~"v1",
+        method => approval,
+        options => [#{id => ~"a", label => ~"A"}, #{id => ~"b", label => ~"B"}],
+        window_ms => 60000
+    }),
+    ?assertEqual(ok, gen_statem:call(Pid, {cast_vote, ~"pl1", ~"v1", [~"a", ~"b"]}, 2000)),
+    ?assertEqual(
+        {error, invalid_option},
+        gen_statem:call(Pid, {cast_vote, ~"pl1", ~"v1", [~"a", 123]}, 2000)
+    ),
+    ?assertEqual(
+        {error, invalid_option},
+        gen_statem:call(Pid, {cast_vote, ~"pl1", ~"v1", 123}, 2000)
+    ),
+    ?assert(is_process_alive(Pid)),
+    gen_statem:stop(VotePid),
+    stop(Pid),
+    cleanup(ok).
+
+ensure_vote_sup() ->
+    case whereis(asobi_vote_sup) of
+        undefined ->
+            {ok, _} = asobi_vote_sup:start_link(),
+            ok;
+        _ ->
+            ok
+    end.
+
 empty_phases_does_not_finish_test() ->
     %% Inject phases/1 that returns []. Before the fix, the match would
     %% transition to `finished` on the first tick because asobi_phase:init([])

--- a/test/asobi_world_server_tests.erl
+++ b/test/asobi_world_server_tests.erl
@@ -101,7 +101,15 @@ world_server_test_() ->
         {"#304: oversized game.broadcast payload is not fanned out to players",
             fun broadcast_oversized_payload_is_rejected/0},
         {"#304: normal-size game.broadcast payload is still delivered",
-            fun broadcast_normal_payload_is_delivered/0}
+            fun broadcast_normal_payload_is_delivered/0},
+        {timeout, 15,
+            {"#462: vote calls into a finished world error rather than hang",
+                fun vote_calls_into_finished_world_error/0}},
+        {"#462: cast_vote with a non-binary option does not crash the world",
+            fun cast_vote_non_binary_option_does_not_crash_world/0},
+        {timeout, 15,
+            {"#462: cast_vote with a list option (approval/ranked) reaches the vote server",
+                fun cast_vote_list_option_reaches_vote_server/0}}
     ]}.
 
 starts_running() ->
@@ -638,4 +646,87 @@ flush_sent() ->
     receive
         {sent, _, _} = M -> [M | flush_sent()]
     after 0 -> []
+    end.
+
+%% asobi#462: a vote.cast/vote.veto into a finished world landed on
+%% finished/3's catch-all, which swallowed the {call, From} with no reply, so
+%% the caller (an infinity gen_statem:call) blocked until the ~5s cleanup
+%% timeout. The finished-state vote clauses now reply immediately with
+%% not_in_match - the same registered code the dead-fabric path returns.
+vote_calls_into_finished_world_error() ->
+    Ctx = #{world_pid := Pid} = start_world(),
+    asobi_world_server:cancel(Pid),
+    wait_for_world_status(Pid, finished, 60),
+    ?assertEqual(
+        {error, not_in_match},
+        gen_statem:call(Pid, {cast_vote, ~"pf1", ~"v1", ~"o1"}, 2000)
+    ),
+    ?assertEqual(
+        {error, not_in_match},
+        gen_statem:call(Pid, {use_veto, ~"pf1", ~"v1"}, 2000)
+    ),
+    ?assert(is_process_alive(Pid)),
+    stop_world(Ctx).
+
+%% asobi#462: the world cast_vote path was guard-free and forwarded an
+%% unvalidated non-binary option straight to asobi_vote_server. A vote.cast
+%% carrying a non-binary option_id (a JSON number/null) now degrades to
+%% {error, invalid_option} and the world survives, never forwarding the junk.
+cast_vote_non_binary_option_does_not_crash_world() ->
+    Ctx = #{world_pid := Pid} = start_world(),
+    ?assertEqual(
+        {error, invalid_option},
+        gen_statem:call(Pid, {cast_vote, ~"pnb1", ~"v1", 12345}, 2000)
+    ),
+    ?assert(is_process_alive(Pid)),
+    ?assertEqual(running, maps:get(status, asobi_world_server:get_info(Pid))),
+    stop_world(Ctx).
+
+wait_for_world_status(_Pid, _Status, 0) ->
+    error(timeout_waiting_for_status);
+wait_for_world_status(Pid, Status, N) ->
+    case maps:get(status, asobi_world_server:get_info(Pid), undefined) of
+        Status ->
+            ok;
+        _ ->
+            timer:sleep(20),
+            wait_for_world_status(Pid, Status, N - 1)
+    end.
+
+%% asobi#462 regression guard: the world cast_vote path was guard-free and
+%% forwarded any option straight to asobi_vote_server; the fix guards it with
+%% is_binary(OptionId) orelse is_list(OptionId). This proves a valid list
+%% option (approval/ranked) still reaches handle_cast_vote and is accepted,
+%% while a list carrying a non-binary and a bare non-binary scalar both degrade
+%% to invalid_option with no crash.
+cast_vote_list_option_reaches_vote_server() ->
+    ensure_vote_sup(),
+    Ctx = #{world_pid := Pid} = start_world(),
+    ok = asobi_world_server:join(Pid, ~"pl1"),
+    {ok, VotePid} = asobi_world_server:start_vote(Pid, #{
+        vote_id => ~"v1",
+        method => approval,
+        options => [#{id => ~"a", label => ~"A"}, #{id => ~"b", label => ~"B"}],
+        window_ms => 60000
+    }),
+    ?assertEqual(ok, gen_statem:call(Pid, {cast_vote, ~"pl1", ~"v1", [~"a", ~"b"]}, 2000)),
+    ?assertEqual(
+        {error, invalid_option},
+        gen_statem:call(Pid, {cast_vote, ~"pl1", ~"v1", [~"a", 123]}, 2000)
+    ),
+    ?assertEqual(
+        {error, invalid_option},
+        gen_statem:call(Pid, {cast_vote, ~"pl1", ~"v1", 123}, 2000)
+    ),
+    ?assert(is_process_alive(Pid)),
+    gen_statem:stop(VotePid),
+    stop_world(Ctx).
+
+ensure_vote_sup() ->
+    case whereis(asobi_vote_sup) of
+        undefined ->
+            {ok, _} = asobi_vote_sup:start_link(),
+            ok;
+        _ ->
+            ok
     end.

--- a/test/asobi_ws_vote_tests.erl
+++ b/test/asobi_ws_vote_tests.erl
@@ -18,7 +18,14 @@ vote_routing_test_() ->
         fun match_vote_veto_still_reaches_match_server/1,
         fun world_vote_cast_error_is_reported/1,
         fun world_vote_veto_error_is_reported/1,
-        fun no_fabric_vote_cast_is_not_in_match/1
+        fun no_fabric_vote_cast_is_not_in_match/1,
+        fun finished_match_vote_cast_reports_error/1,
+        fun finished_world_vote_veto_reports_error/1,
+        fun exiting_world_vote_cast_normal_degrades_to_error/1,
+        fun exiting_match_vote_veto_noproc_degrades_to_error/1,
+        fun exiting_world_vote_veto_shutdown_degrades_to_error/1,
+        fun exiting_match_vote_cast_killed_degrades_to_error/1,
+        fun genuine_vote_handler_crash_is_internal_error/1
     ]}.
 
 setup() ->
@@ -113,6 +120,87 @@ no_fabric_vote_cast_is_not_in_match(_) ->
         ?_assertEqual(0, meck:num_calls(asobi_world_server, cast_vote, '_')),
         ?_assertEqual(0, meck:num_calls(asobi_match_server, cast_vote, '_'))
     ].
+
+%% asobi#462: the finished fabric now replies not_in_match (unified with the
+%% dead-fabric path) rather than swallowing the call; the WS handler must
+%% surface that as a normal error frame.
+finished_match_vote_cast_reports_error(_) ->
+    mock_session(#{player_id => ~"p1", match_pid => self()}),
+    meck:expect(asobi_match_server, cast_vote, fun(_Pid, _PlayerId, _VoteId, _OptionId) ->
+        {error, not_in_match}
+    end),
+    Decoded = handle(~"vote.cast", ~"vf1", #{~"vote_id" => ~"v1", ~"option_id" => ~"a"}),
+    ?_assertMatch(
+        #{~"type" := ~"error", ~"payload" := #{~"reason" := ~"not_in_match"}}, Decoded
+    ).
+
+finished_world_vote_veto_reports_error(_) ->
+    mock_session(#{player_id => ~"p1", world_pid => self(), zone_pid => self()}),
+    meck:expect(asobi_world_server, use_veto, fun(_Pid, _PlayerId, _VoteId) ->
+        {error, not_in_match}
+    end),
+    Decoded = handle(~"vote.veto", ~"vf2", #{~"vote_id" => ~"v1"}),
+    ?_assertMatch(
+        #{~"type" := ~"error", ~"payload" := #{~"reason" := ~"not_in_match"}}, Decoded
+    ).
+
+%% asobi#462: a vote call whose fabric is gone exits. safe_handle_message/2 is
+%% the crash backstop, but vote_call/1 upgrades the process-gone exit shapes -
+%% normal (finished-fabric stop), noproc (dead), shutdown/killed (teardown) - to
+%% a clean not_in_match error frame instead of a logged internal_error.
+exiting_world_vote_cast_normal_degrades_to_error(_) ->
+    mock_session(#{player_id => ~"p1", world_pid => self(), zone_pid => self()}),
+    meck:expect(asobi_world_server, cast_vote, fun(_Pid, _PlayerId, _VoteId, _OptionId) ->
+        exit({normal, mocked})
+    end),
+    Decoded = handle(~"vote.cast", ~"ve1", #{~"vote_id" => ~"v1", ~"option_id" => ~"a"}),
+    ?_assertMatch(
+        #{~"type" := ~"error", ~"payload" := #{~"reason" := ~"not_in_match"}}, Decoded
+    ).
+
+exiting_match_vote_veto_noproc_degrades_to_error(_) ->
+    mock_session(#{player_id => ~"p1", match_pid => self()}),
+    meck:expect(asobi_match_server, use_veto, fun(_Pid, _PlayerId, _VoteId) ->
+        exit({noproc, mocked})
+    end),
+    Decoded = handle(~"vote.veto", ~"ve2", #{~"vote_id" => ~"v1"}),
+    ?_assertMatch(
+        #{~"type" := ~"error", ~"payload" := #{~"reason" := ~"not_in_match"}}, Decoded
+    ).
+
+exiting_world_vote_veto_shutdown_degrades_to_error(_) ->
+    mock_session(#{player_id => ~"p1", world_pid => self(), zone_pid => self()}),
+    meck:expect(asobi_world_server, use_veto, fun(_Pid, _PlayerId, _VoteId) ->
+        exit({shutdown, mocked})
+    end),
+    Decoded = handle(~"vote.veto", ~"ve3", #{~"vote_id" => ~"v1"}),
+    ?_assertMatch(
+        #{~"type" := ~"error", ~"payload" := #{~"reason" := ~"not_in_match"}}, Decoded
+    ).
+
+exiting_match_vote_cast_killed_degrades_to_error(_) ->
+    mock_session(#{player_id => ~"p1", match_pid => self()}),
+    meck:expect(asobi_match_server, cast_vote, fun(_Pid, _PlayerId, _VoteId, _OptionId) ->
+        exit(killed)
+    end),
+    Decoded = handle(~"vote.cast", ~"ve4", #{~"vote_id" => ~"v1", ~"option_id" => ~"a"}),
+    ?_assertMatch(
+        #{~"type" := ~"error", ~"payload" := #{~"reason" := ~"not_in_match"}}, Decoded
+    ).
+
+%% asobi#462: vote_call/1 must NOT swallow a genuine vote-handler crash - only
+%% the process-gone exit shapes. Any other exit reason falls through to
+%% safe_handle_message/2, which logs and answers internal_error. This keeps the
+%% real backstop visible rather than masking a bug as not_in_match.
+genuine_vote_handler_crash_is_internal_error(_) ->
+    mock_session(#{player_id => ~"p1", world_pid => self(), zone_pid => self()}),
+    meck:expect(asobi_world_server, cast_vote, fun(_Pid, _PlayerId, _VoteId, _OptionId) ->
+        exit({unexpected_bug, boom})
+    end),
+    Decoded = handle(~"vote.cast", ~"ve5", #{~"vote_id" => ~"v1", ~"option_id" => ~"a"}),
+    ?_assertMatch(
+        #{~"type" := ~"error", ~"payload" := #{~"reason" := ~"internal_error"}}, Decoded
+    ).
 
 mock_session(SState) ->
     meck:expect(asobi_player_session, get_state, fun(_Pid) -> SState end).


### PR DESCRIPTION
Closes #462. Both-fabric vote robustness (surfaced by the #447 review).

## Fixes
- **Match-wide DoS closed:** a `vote.cast` with a non-binary `option_id` (JSON number/null/etc.) `function_clause`-crashed the whole match — every player in it. Both servers gain `running`-state fallback clauses → `{error, invalid_option}`; the world path gained the missing `is_binary` guards.
- **Finished-fabric stall removed:** a vote into a `finished` match/world blocked the infinity `gen_statem:call` until the ~5s cleanup stop (a frozen socket that reads as a disconnect), then returned a misleading `internal_error`. `finished`-state clauses on both servers now reply immediately. (No connection *crash* was involved — `safe_handle_message/2` already backstops handler exits; the comments were corrected to say so.)
- **Consistent "over" code:** the finished reply is `not_in_match` (existing registered **409**), matching the dead-fabric path — so a client gets one branchable code regardless of the 5s alive/dead race (no more `ws.request_failed` 400 vs 409 flip).
- **`vote_call/1`** wraps the four fabric calls, catching the process-gone exits (`noproc`/`normal`/`shutdown`/`killed`) → clean `not_in_match`. Deliberately **not** `exit:_` — a genuine vote-handler crash still falls through to `safe_handle_message` and is logged (test-proven).

## Gate found a real regression, now fixed
The security review caught that the new `is_binary(OptionId)` guard **broke Approval/Ranked voting** — `asobi_vote_server` takes `binary() | [binary()]` (a list of option IDs), and the world path previously forwarded lists. The guard is widened to `is_binary(OptionId) orelse is_list(OptionId)` on both servers, with **new end-to-end list-vote tests** (valid list → `ok`; bad list / scalar → `invalid_option`).

## Gate
guardian (ACCEPT — both-fabric symmetry complete, corrected the connection-crash premise) + beam-security-reviewer (DoS fully closed; caught the approval/ranked regression) + erlang-code-reviewer (0 blockers). Local: eqwalize Δ0 (independently confirmed — CI skips it on PRs), dialyzer/xref/fmt/lint clean, full eunit 1931/0, frozen-wire guards 29/0, CT vote/ws/match/world 60 pass.