### PR TITLE
docs: refresh stale asobi dependency pins in guides and moduledocs

### DIFF
--- a/guides/console-extensions.md
+++ b/guides/console-extensions.md
@@ -320,7 +320,7 @@ Name it in `rebar.config`, which is where the build looks:
 {asobi, [{console_bundle_app, game_console}]}.
 
 {project_plugins, [
-    {asobi, {git, "https://github.com/widgrensit/asobi.git", {tag, "v0.75.0"}}}
+    {asobi, {git, "https://github.com/widgrensit/asobi.git", {tag, "v0.83.5"}}}
 ]}.
 ```
 

--- a/guides/extensions.md
+++ b/guides/extensions.md
@@ -34,7 +34,7 @@ failure and Hex rejects outright.
 Validate the set before you boot it:
 
 ```erlang
-{project_plugins, [{asobi, {git, "https://github.com/widgrensit/asobi.git", {tag, "v0.68.2"}}}]}.
+{project_plugins, [{asobi, {git, "https://github.com/widgrensit/asobi.git", {tag, "v0.83.5"}}}]}.
 ```
 
 ```sh
@@ -624,7 +624,7 @@ A bare list of names, never version ranges. The names are core subsystems
 `social`, `chat`, `iap`, `matches`, `world`, `votes`, `presence`, `timers`)
 and other installed extensions. Which versions work together is the
 dependency pin's job -
-`{asobi, "~> 0.79.0"}` in your `rebar.config`, and the bundle's lockstep for a
+`{asobi, "~> 0.83.0"}` in your `rebar.config`, and the bundle's lockstep for a
 first-party set - so `requires/0` says only *that* you call into a thing, never
 *which* of it.
 

--- a/src/extensions/asobi_extension.erl
+++ b/src/extensions/asobi_extension.erl
@@ -156,7 +156,7 @@ The subsystems and extensions this extension calls, by name.
 
 A bare list of names - core subsystems (`economy`, `leaderboards`, `world`,
 ...) and other installed extensions - never version ranges. Which versions are
-compatible is the dependency pin's job (`{asobi, "~> 0.79.0"}`, and the
+compatible is the dependency pin's job (`{asobi, "~> 0.83.0"}`, and the
 bundle's lockstep for a first-party set); this list says only *that* you call
 into a thing, never *which* of it. `requires => [economy]` says "I call into
 economy" and nothing about which economy.

--- a/src/extensions/rebar3_asobi_check.erl
+++ b/src/extensions/rebar3_asobi_check.erl
@@ -9,7 +9,7 @@ rebar3 asobi check     # 0 and a summary, or 1 and a report naming both claimant
 Add it to a host release's `rebar.config`:
 
 ```erlang
-{project_plugins, [{asobi, {git, "https://github.com/widgrensit/asobi.git", {tag, "v0.50.0"}}}]}.
+{project_plugins, [{asobi, {git, "https://github.com/widgrensit/asobi.git", {tag, "v0.83.5"}}}]}.
 ```
 
 This is the gate, not the backstop. asobi validates the same set again at


### PR DESCRIPTION
Bumps the stale asobi dependency pins in guides + moduledocs to the current release. The four `{tag, "v0.50.0"}` examples predated the extension machinery; `v0.68.2`/`v0.75.0`/`~> 0.79.0` had drifted. Now `{tag, "v0.83.5"}` and `~> 0.83.0`. Pure documentation (moduledoc example strings + guide snippets); `examples/*/rebar.config` (CI-built) left for a separate example refresh. No logic change.