### PR TITLE
fix: harden ws non-map payloads and world loading-state calls

### DIFF
--- a/guides/websocket-protocol.md
+++ b/guides/websocket-protocol.md
@@ -907,7 +907,8 @@ changing your vote more times than the vote's `max_revotes` allows (3 by
 default) is `rate_limited`. The refusals that come from the vote itself -
 `vote_not_found`, `vote_closed`, `not_eligible`, `invalid_option` - have no
 code of their own and arrive as `ws.request_failed` with the reason in
-`details`.
+`details`. A vote in a world that has not finished loading is
+`world_not_ready`, carried the same way.
 
 ### `vote.veto`
 
@@ -926,7 +927,8 @@ in match config and `veto_enabled` on the vote.
 
 An unknown vote is `vote_not_found`, a player out of tokens is
 `no_veto_tokens`, and a vote that did not enable vetoes is `veto_disabled`.
-None of the three has a code of its own either.
+None of the three has a code of its own either. A veto in a world that has not
+finished loading is `world_not_ready`, carried the same way.
 
 ### `match.vote_start` (server push)
 

--- a/src/world/asobi_world_server.erl
+++ b/src/world/asobi_world_server.erl
@@ -285,6 +285,10 @@ loading({call, _From}, {join, _PlayerId}, _State) ->
     %% Postpone join until we transition to running. Otherwise the call
     %% would crash with function_clause and the caller would time out.
     {keep_state_and_data, [postpone]};
+%% asobi#466: any other call during loading must reply, not function_clause -
+%% an unanswered {call, From} crashes the world and hangs the caller's call.
+loading({call, From}, _Request, _State) ->
+    {keep_state_and_data, [{reply, From, {error, world_not_ready}}]};
 %% A zone's post-tick crossing check (asobi_zone:resolve_zone_crossings/1)
 %% can fire on a pre-warmed zone recovered from a snapshot before the world
 %% has finished loading. Without this, that cast is a function_clause and

--- a/src/ws/asobi_ws_handler.erl
+++ b/src/ws/asobi_ws_handler.erl
@@ -898,6 +898,11 @@ safe_handle_message(Msg, State) ->
             reply_error(Msg, ~"invalid_payload", State);
         error:{case_clause, _}:_Stack ->
             reply_error(Msg, ~"invalid_payload", State);
+        %% asobi#465: a non-map payload reaches maps:get/2 and raises badmap.
+        %% Treat it as a client payload error, not an internal_error with a
+        %% warning-log line an authenticated player could spam.
+        error:{badmap, _}:_Stack ->
+            reply_error(Msg, ~"invalid_payload", State);
         Class:Reason:Stack ->
             logger:warning(#{
                 msg => ~"ws_handler_crash",

--- a/test/asobi_world_server_tests.erl
+++ b/test/asobi_world_server_tests.erl
@@ -109,7 +109,9 @@ world_server_test_() ->
             fun cast_vote_non_binary_option_does_not_crash_world/0},
         {timeout, 15,
             {"#462: cast_vote with a list option (approval/ranked) reaches the vote server",
-                fun cast_vote_list_option_reaches_vote_server/0}}
+                fun cast_vote_list_option_reaches_vote_server/0}},
+        {"#466: an unexpected call to a loading world replies world_not_ready, not crash",
+            fun loading_call_replies_world_not_ready/0}
     ]}.
 
 starts_running() ->
@@ -720,6 +722,26 @@ cast_vote_list_option_reaches_vote_server() ->
     ),
     ?assert(is_process_alive(Pid)),
     gen_statem:stop(VotePid),
+    stop_world(Ctx).
+
+%% asobi#466: the loading state had no call catch-all, so a call other than
+%% get_info/listing/join function_clause-crashed the whole world and hung the
+%% caller. A naturally started world transitions to running immediately, so
+%% sys:replace_state forces the state name back to loading deterministically;
+%% the large tick_rate keeps the ticker from casting post_tick (unhandled in
+%% loading) during the test.
+loading_call_replies_world_not_ready() ->
+    Ctx = #{world_pid := Pid} = start_world(#{tick_rate => 3600000}),
+    sys:replace_state(Pid, fun({_State, Data}) -> {loading, Data} end),
+    ?assertEqual(
+        {error, world_not_ready},
+        gen_statem:call(Pid, {cast_vote, ~"p1", ~"v1", ~"a"}, 2000)
+    ),
+    ?assertEqual(
+        {error, world_not_ready},
+        gen_statem:call(Pid, {use_veto, ~"p1", ~"v1"}, 2000)
+    ),
+    ?assert(is_process_alive(Pid)),
     stop_world(Ctx).
 
 ensure_vote_sup() ->

--- a/test/asobi_ws_vote_tests.erl
+++ b/test/asobi_ws_vote_tests.erl
@@ -25,7 +25,8 @@ vote_routing_test_() ->
         fun exiting_match_vote_veto_noproc_degrades_to_error/1,
         fun exiting_world_vote_veto_shutdown_degrades_to_error/1,
         fun exiting_match_vote_cast_killed_degrades_to_error/1,
-        fun genuine_vote_handler_crash_is_internal_error/1
+        fun genuine_vote_handler_crash_is_internal_error/1,
+        fun non_map_payload_is_invalid_payload_not_internal_error/1
     ]}.
 
 setup() ->
@@ -200,6 +201,17 @@ genuine_vote_handler_crash_is_internal_error(_) ->
     Decoded = handle(~"vote.cast", ~"ve5", #{~"vote_id" => ~"v1", ~"option_id" => ~"a"}),
     ?_assertMatch(
         #{~"type" := ~"error", ~"payload" := #{~"reason" := ~"internal_error"}}, Decoded
+    ).
+
+%% asobi#465: a non-map payload (here a number) reaches maps:get(~"vote_id", 42)
+%% and raises error:{badmap, 42}. The named catch clause degrades that to a clean
+%% invalid_payload error frame with no warning-log line, rather than the generic
+%% internal_error an authenticated player could otherwise spam.
+non_map_payload_is_invalid_payload_not_internal_error(_) ->
+    mock_session(#{player_id => ~"p1", world_pid => self(), zone_pid => self()}),
+    Decoded = handle(~"vote.cast", ~"nm1", 42),
+    ?_assertMatch(
+        #{~"type" := ~"error", ~"payload" := #{~"reason" := ~"invalid_payload"}}, Decoded
     ).
 
 mock_session(SState) ->


### PR DESCRIPTION
Closes #465, closes #466. Two Low, defence-in-depth hardening items surfaced by the #462 review.

- **#465** (`asobi_ws_handler:safe_handle_message/2`): a frame with a non-map `payload` reached `maps:get/2` -> `error:{badmap,_}`, which fell to the `internal_error` catch-all + a warning-log line an authenticated player could spam. New `error:{badmap, _} -> reply_error(Msg, ~"invalid_payload", State)` clause (mirrors the sibling `badmatch`/`case_clause` handling) -> a clean `invalid_payload` frame, no log noise.
- **#466** (`asobi_world_server` `loading` state): had no call catch-all, so an unexpected `{call, From}` (e.g. a vote) `function_clause`-crashed the world and hung the caller. New `loading({call, From}, _Request, _State) -> {keep_state_and_data, [{reply, From, {error, world_not_ready}}]}` catch-all — it **replies** (the #462 lesson), never swallows. `world_not_ready` is a bare reason atom degrading to `ws.request_failed` (no new code minted for an unreachable-today path); documented in `websocket-protocol.md`'s vote-refusal catalogue for wire-freeze completeness.

Both with non-vacuous regression tests (verified failing without the fix). Gate: guardian (ACCEPT) + code review (0 blockers; the one should-fix — documenting `world_not_ready` in the frozen guide — is included). Local: eqwalize Δ0 (both modules 2->2), dialyzer/xref/fmt/lint clean, full eunit 1933/0, frozen-wire/contract guards pass.

Follow-up: the `finished` world state carries the same latent swallow-a-call hang (guardian noted `asobi_world_server:579`) — tracked separately.