### PR TITLE
fix: reply to unexpected calls in the finished state instead of swallowing them

### DIFF
--- a/src/matches/asobi_match_server.erl
+++ b/src/matches/asobi_match_server.erl
@@ -620,18 +620,16 @@ finished({call, From}, {get_info, listing}, State) ->
 finished(cast, {broadcast_event, Event, Payload}, State) ->
     broadcast_match_event(Event, Payload, State),
     keep_state_and_data;
-%% asobi#462: a late vote.cast/vote.veto lands here while the finished match
-%% waits out its 5s cleanup timer, still holding the player's match_pid.
-%% Without an explicit reply the catch-all below swallows the {call, From} and
-%% the caller (asobi_ws_handler, an infinity gen_statem:call) blocks until this
-%% server stops at its cleanup timeout - a frozen socket that reads as a
-%% disconnect on mobile - then gets a misleading internal_error. Replying
+%% asobi#469: any other call landing here while the finished match waits out
+%% its 5s cleanup timer (a late vote.cast/vote.veto while the session still
+%% holds match_pid, or any call added later) must reply - an unanswered
+%% {call, From} hangs the caller (asobi_ws_handler, an infinity
+%% gen_statem:call) until this server stops at its cleanup timeout. Replying
 %% not_in_match returns immediately with the same registered 409 the
 %% dead/finished-fabric path in vote_call/1 uses, so "the match is over" is one
-%% code a client can branch on, not two that depend on a 5s race.
-finished({call, From}, {cast_vote, _PlayerId, _VoteId, _OptionId}, _State) ->
-    {keep_state_and_data, [{reply, From, {error, not_in_match}}]};
-finished({call, From}, {use_veto, _PlayerId, _VoteId}, _State) ->
+%% code a client can branch on. Only non-call events reach the swallow
+%% catch-all below now.
+finished({call, From}, _Request, _State) ->
     {keep_state_and_data, [{reply, From, {error, not_in_match}}]};
 finished(_EventType, _Event, _State) ->
     keep_state_and_data.

--- a/src/world/asobi_world_server.erl
+++ b/src/world/asobi_world_server.erl
@@ -563,18 +563,15 @@ finished({call, From}, get_info, State) ->
     {keep_state_and_data, [{reply, From, world_info(finished, State)}]};
 finished({call, From}, {get_info, listing}, State) ->
     {keep_state_and_data, [{reply, From, world_info(finished, State, false)}]};
-%% asobi#462: as in asobi_match_server - a late vote.cast/vote.veto reaches a
-%% finished world during its 5s cleanup window while the session still holds
-%% world_pid. Without an explicit reply the catch-all below swallows the
-%% {call, From} and the caller (asobi_ws_handler, an infinity gen_statem:call)
-%% blocks until this server stops at its cleanup timeout - a frozen socket that
-%% reads as a disconnect on mobile - then gets a misleading internal_error.
-%% Replying not_in_match returns immediately with the same registered 409 the
-%% dead/finished-fabric path in vote_call/1 uses, so "the world is over" is one
-%% code a client can branch on, not two that depend on a 5s race.
-finished({call, From}, {cast_vote, _PlayerId, _VoteId, _OptionId}, _State) ->
-    {keep_state_and_data, [{reply, From, {error, not_in_match}}]};
-finished({call, From}, {use_veto, _PlayerId, _VoteId}, _State) ->
+%% asobi#469: any other call reaching a finished world during its 5s cleanup
+%% window (a late vote.cast/vote.veto while the session still holds world_pid,
+%% or any call added later) must reply - an unanswered {call, From} hangs the
+%% caller (asobi_ws_handler, an infinity gen_statem:call) until this server
+%% stops at its cleanup timeout. Replying not_in_match returns immediately with
+%% the same registered 409 the dead/finished-fabric path in vote_call/1 uses,
+%% so "the world is over" is one code a client can branch on. Only non-call
+%% events reach the swallow catch-all below now.
+finished({call, From}, _Request, _State) ->
     {keep_state_and_data, [{reply, From, {error, not_in_match}}]};
 finished(_EventType, _Event, _State) ->
     keep_state_and_data.

--- a/test/asobi_match_server_tests.erl
+++ b/test/asobi_match_server_tests.erl
@@ -1015,6 +1015,32 @@ vote_calls_into_finished_match_error_test() ->
     gen_statem:stop(Pid),
     cleanup(ok).
 
+%% asobi#469: the finished state enumerated a couple of call clauses and then
+%% swallowed every other {call, From} on the catch-all, so a call the finished
+%% state did not name (here a reconnect) hung the caller until the ~5s cleanup
+%% timeout. A single general call catch-all now replies not_in_match to any
+%% unexpected call, and votes into a finished match still return not_in_match.
+unexpected_call_to_finished_match_replies_not_in_match_test() ->
+    setup(),
+    Pid = start_match(#{min_players => 2, max_players => 2}),
+    ok = asobi_match_server:join(Pid, ~"pf1"),
+    ok = asobi_match_server:join(Pid, ~"pf2"),
+    timer:sleep(50),
+    ?assertEqual(running, maps:get(status, asobi_match_server:get_info(Pid))),
+    asobi_match_server:cancel(Pid),
+    wait_for_status(Pid, finished, 60),
+    ?assertEqual(
+        {error, not_in_match},
+        gen_statem:call(Pid, {reconnect, ~"pf1"}, 2000)
+    ),
+    ?assertEqual(
+        {error, not_in_match},
+        gen_statem:call(Pid, {cast_vote, ~"pf1", ~"v1", ~"o1"}, 2000)
+    ),
+    ?assert(is_process_alive(Pid)),
+    gen_statem:stop(Pid),
+    cleanup(ok).
+
 %% asobi#462: a vote.cast with a non-binary option_id (a JSON number/null)
 %% missed running/3's is_binary guard and, with no catch-all there, crashed
 %% the whole match on function_clause - every player in it - on one malformed

--- a/test/asobi_world_server_tests.erl
+++ b/test/asobi_world_server_tests.erl
@@ -111,7 +111,10 @@ world_server_test_() ->
             {"#462: cast_vote with a list option (approval/ranked) reaches the vote server",
                 fun cast_vote_list_option_reaches_vote_server/0}},
         {"#466: an unexpected call to a loading world replies world_not_ready, not crash",
-            fun loading_call_replies_world_not_ready/0}
+            fun loading_call_replies_world_not_ready/0},
+        {timeout, 15,
+            {"#469: an unexpected call to a finished world replies not_in_match, not hang",
+                fun unexpected_call_to_finished_world_replies_not_in_match/0}}
     ]}.
 
 starts_running() ->
@@ -666,6 +669,26 @@ vote_calls_into_finished_world_error() ->
     ?assertEqual(
         {error, not_in_match},
         gen_statem:call(Pid, {use_veto, ~"pf1", ~"v1"}, 2000)
+    ),
+    ?assert(is_process_alive(Pid)),
+    stop_world(Ctx).
+
+%% asobi#469: the finished state enumerated a couple of call clauses and then
+%% swallowed every other {call, From} on the catch-all, so a call the finished
+%% state did not name (here a reconnect) hung the caller until the ~5s cleanup
+%% timeout. A single general call catch-all now replies not_in_match to any
+%% unexpected call, and votes into a finished world still return not_in_match.
+unexpected_call_to_finished_world_replies_not_in_match() ->
+    Ctx = #{world_pid := Pid} = start_world(),
+    asobi_world_server:cancel(Pid),
+    wait_for_world_status(Pid, finished, 60),
+    ?assertEqual(
+        {error, not_in_match},
+        gen_statem:call(Pid, {reconnect, ~"pf1"}, 2000)
+    ),
+    ?assertEqual(
+        {error, not_in_match},
+        gen_statem:call(Pid, {cast_vote, ~"pf1", ~"v1", ~"o1"}, 2000)
     ),
     ?assert(is_process_alive(Pid)),
     stop_world(Ctx).


### PR DESCRIPTION
Closes #469. The `finished`-state twin of #466.

Both `asobi_world_server` and `asobi_match_server` `finished` states enumerated a few calls (get_info/listing + the #462 cast_vote/use_veto) then swallowed every other `{call, From}` on the `finished(_EventType,...)` catch-all — an unanswered `gen_statem:call` (the ws handler's infinity vote call) hung the caller until the ~5s cleanup stop.

Fix: collapse the #462 vote-specific finished clauses into one general `finished({call, From}, _Request, _State) -> {keep_state_and_data, [{reply, From, {error, not_in_match}}]}` catch-all (after get_info/listing, before the non-call swallow catch-all). Modelled on `asobi_match_server`'s existing `paused` catch-all and the `loading` fix (#466). Votes to a finished fabric still get `not_in_match`; any other unexpected call now gets a clean 409 instead of hanging.

Gate: guardian (ACCEPT — behaviour-preserving, symmetric) + code review (0 blockers; the lone full-eunit failure is a **verified pre-existing** `rebar3_asobi_console_tests` /tmp-pollution flake — 16/16 in isolation, unrelated). Local: eqwalize Δ0 (world 2->2, match 4->4), dialyzer/xref/fmt/lint clean, world/match eunit 99/0, contract guard 20/0. Frozen wire untouched (`not_in_match` is the existing reply).