### PR TITLE
fix: plumb broadcast_interval to the zone; document client-side prediction (#463)

### DIFF
--- a/guides/migrate-from-hathora.md
+++ b/guides/migrate-from-hathora.md
@@ -316,7 +316,12 @@ applies when you decide to move.
   `guest_auth` and the operator supplies a pepper of at least 32 bytes.
 - **No server-to-server token introspection route.** See Option A above.
 - **No automatic multi-region.** One container per region, deployed by you.
-- **No client-side prediction or rollback netcode primitives.**
+- **No rollback netcode or lag compensation.** No server-side replay, no hitbox
+  rewind; over TCP (above) asobi is not for twitch shooters. But the server half
+  of *client-side prediction* is available: a game stamps each input with a
+  sequence number, echoes the last-applied one back on the player's own entity,
+  and the client reconciles against it. See
+  [Client-side prediction](websocket-protocol.md#client-side-prediction).
 - **Pre-1.0 API.** Minor breaking changes are possible until 1.0.
 
 ## Do this today

--- a/guides/websocket-protocol.md
+++ b/guides/websocket-protocol.md
@@ -617,6 +617,9 @@ Join a specific world by id (e.g. one returned from `world.list`).
 Send game input to your zone. The `payload` IS the input map - there is
 no inner `data` wrapper. Field names are entirely up to your game; the
 server only forwards the map verbatim to your `handle_input/3` callback.
+Because it is verbatim, a client that wants prediction can add its own
+per-input field (a `seq`) and read the last-applied one back off `world.tick`;
+see [Client-side prediction](#client-side-prediction).
 
 ```json
 {"type": "world.input", "payload": {"kind": "move", "x": 600, "y": 480}}
@@ -661,6 +664,32 @@ handler before sending the join message or you miss it.
 | `"a"` | Added, full state | id + every field on the entity |
 | `"u"` | Updated, diff | id + only changed fields |
 | `"r"` | Removed | id only |
+
+### Client-side prediction
+
+asobi is server-authoritative, and server-side rollback, replay and lag
+compensation are out of scope (TCP transport - see
+[migrate-from-hathora](migrate-from-hathora.md)). The server half that
+*client-side* prediction needs - an ack telling a client which of its inputs
+the authoritative state already includes - works today with no special
+protocol support, because `world.input` is verbatim and a `world.tick` delta
+carries whatever fields your entity has:
+
+1. The client stamps each `world.input` with its own increasing `seq` and
+   applies the input locally right away (the prediction).
+2. Your `handle_input/3` writes that `seq` onto the acting player's entity,
+   e.g. `entity.last_seq = input.seq`.
+3. It rides back in the next `world.tick` delta for that entity. The client
+   drops every predicted input up to `last_seq` and replays the rest on top of
+   the authoritative state (the reconciliation).
+
+Set [`broadcast_interval`](world-server.md) to 1 so the ack returns every tick
+rather than every third.
+
+One cost to know: `last_seq` sits on the shared entity delta, so it reaches
+every subscriber in the zone, not just its owner - the ack's bandwidth scales
+with zone population. A per-connection ack frame that avoids that is tracked in
+asobi#463; the entity-field pattern is the answer today.
 
 ### `world.terrain` (server push)
 

--- a/guides/websocket-protocol.md
+++ b/guides/websocket-protocol.md
@@ -689,7 +689,7 @@ rather than every third.
 One cost to know: `last_seq` sits on the shared entity delta, so it reaches
 every subscriber in the zone, not just its owner - the ack's bandwidth scales
 with zone population. A per-connection ack frame that avoids that is tracked in
-asobi#463; the entity-field pattern is the answer today.
+asobi#474; the entity-field pattern is the answer today.
 
 ### `world.terrain` (server push)
 

--- a/guides/world-server.md
+++ b/guides/world-server.md
@@ -365,6 +365,7 @@ Register your world mode in `sys.config`:
 | `grid_size` | 10 | Zones per axis; total zones = `grid_size^2` |
 | `zone_size` | 200 | Units per zone side; world size = `grid_size * zone_size` |
 | `tick_rate` | 50 | Milliseconds between ticks (50 = 20 Hz) |
+| `broadcast_interval` | 3 | Simulation ticks per wire delta. Deltas go out every `tick_rate * broadcast_interval` ms (default 150 ms, ~6.7 Hz, even though the sim runs at `tick_rate`). Set to 1 for a delta every tick, which is what client-side prediction wants |
 | `view_radius` | 1 | Zones visible in each direction from the player's zone |
 | `max_players` | 500 | Concurrent players per world |
 | `persistent` | `false` | Keep the world alive with no players in it |

--- a/guides/world-server.md
+++ b/guides/world-server.md
@@ -365,7 +365,7 @@ Register your world mode in `sys.config`:
 | `grid_size` | 10 | Zones per axis; total zones = `grid_size^2` |
 | `zone_size` | 200 | Units per zone side; world size = `grid_size * zone_size` |
 | `tick_rate` | 50 | Milliseconds between ticks (50 = 20 Hz) |
-| `broadcast_interval` | 3 | Simulation ticks per wire delta. Deltas go out every `tick_rate * broadcast_interval` ms (default 150 ms, ~6.7 Hz, even though the sim runs at `tick_rate`). Set to 1 for a delta every tick, which is what client-side prediction wants |
+| `broadcast_interval` | 3 | Simulation ticks per wire delta; deltas go out every `tick_rate * broadcast_interval` ms. Set to 1 for a delta every tick, which client-side prediction wants |
 | `view_radius` | 1 | Zones visible in each direction from the player's zone |
 | `max_players` | 500 | Concurrent players per world |
 | `persistent` | `false` | Keep the world alive with no players in it |

--- a/src/asobi_game_modes.erl
+++ b/src/asobi_game_modes.erl
@@ -118,7 +118,10 @@ world_config(Mode) ->
                 listed => maps:get(listed, ModeConfig, true),
                 quick_play => maps:get(quick_play, ModeConfig, true)
             },
-            {ok, forward_optional(ModeConfig, [empty_grace_ms, player_ttl_ms, chat], Base)};
+            {ok,
+                forward_optional(
+                    ModeConfig, [empty_grace_ms, player_ttl_ms, chat, broadcast_interval], Base
+                )};
         {error, _} = Err ->
             Err
     end.

--- a/src/lua/asobi_lua_config.erl
+++ b/src/lua/asobi_lua_config.erl
@@ -317,6 +317,7 @@ read_match_globals(ScriptPath, St) ->
     GameType = read_global_string(~"game_type", St),
     StateStrategy = read_global_string(~"state_strategy", St),
     TickRate = read_global_int(~"tick_rate", St),
+    BroadcastInterval = read_global_int(~"broadcast_interval", St),
     GridSize = read_global_int(~"grid_size", St),
     ZoneSize = read_global_int(~"zone_size", St),
     ViewRadius = read_global_int(~"view_radius", St),
@@ -361,7 +362,8 @@ read_match_globals(ScriptPath, St) ->
             %% (asobi_matchmaker), worlds listed (asobi_game_modes:world_config/1).
             Config14 = maybe_add_bool(Config13, listed, Listed),
             Config15 = maybe_add_bool(Config14, quick_play, QuickPlay),
-            {ok, Config15};
+            Config16 = maybe_add_int(Config15, broadcast_interval, BroadcastInterval),
+            {ok, Config16};
         _ ->
             {error, {ScriptPath, ~"match_size must be a positive integer"}}
     end.

--- a/src/world/asobi_world_server.erl
+++ b/src/world/asobi_world_server.erl
@@ -611,6 +611,11 @@ configure_zone_manager(
         spawn_templates => Templates,
         persistence => Persistence,
         snapshot_interval => maps:get(snapshot_interval, Config, 600),
+        %% How many simulation ticks per wire delta. Default 3 (so at the 50ms
+        %% tick_rate deltas go out every 150ms); a mode sets `broadcast_interval`
+        %% to decimate less - 1 means every tick, which is what client-side
+        %% prediction wants for the tightest correction latency.
+        broadcast_interval => maps:get(broadcast_interval, Config, 3),
         zone_manager_pid => ZoneManagerPid,
         terrain_store_pid => TerrainStorePid,
         %% So a zone can decide crossings with the same clamped math - see

--- a/src/world/asobi_world_server.erl
+++ b/src/world/asobi_world_server.erl
@@ -611,10 +611,9 @@ configure_zone_manager(
         spawn_templates => Templates,
         persistence => Persistence,
         snapshot_interval => maps:get(snapshot_interval, Config, 600),
-        %% How many simulation ticks per wire delta. Default 3 (so at the 50ms
-        %% tick_rate deltas go out every 150ms); a mode sets `broadcast_interval`
-        %% to decimate less - 1 means every tick, which is what client-side
-        %% prediction wants for the tightest correction latency.
+        %% Default 3, so at the 50ms tick_rate deltas go out every 150ms even
+        %% though the sim runs at tick_rate; a mode sets `broadcast_interval` to
+        %% 1 for a delta every tick (tightest correction latency for prediction).
         broadcast_interval => maps:get(broadcast_interval, Config, 3),
         zone_manager_pid => ZoneManagerPid,
         terrain_store_pid => TerrainStorePid,

--- a/test/asobi_lua_config_tests.erl
+++ b/test/asobi_lua_config_tests.erl
@@ -693,6 +693,10 @@ world_dimension_globals_forwarded() ->
     ?assertEqual(1500, maps:get(zone_size, Mode)),
     ?assertEqual(0, maps:get(view_radius, Mode)),
     ?assertEqual(true, maps:get(persistent, Mode)),
+    %% broadcast_interval reaches the mode config too, so a world can decimate
+    %% the wire delta rate (asobi#463: it was read by asobi_zone but never
+    %% plumbed, so every zone was stuck on the default 3).
+    ?assertEqual(2, maps:get(broadcast_interval, Mode)),
     %% And world_config/1 must echo them through.
     {ok, WorldConfig} = asobi_game_modes:world_config(~"default"),
     ?assertEqual(100, maps:get(tick_rate, WorldConfig)),
@@ -700,6 +704,7 @@ world_dimension_globals_forwarded() ->
     ?assertEqual(1500, maps:get(zone_size, WorldConfig)),
     ?assertEqual(0, maps:get(view_radius, WorldConfig)),
     ?assertEqual(true, maps:get(persistent, WorldConfig)),
+    ?assertEqual(2, maps:get(broadcast_interval, WorldConfig)),
     cleanup_temp_dir(TmpDir).
 
 discovery_flags_forwarded() ->

--- a/test/asobi_world_zone_integration_tests.erl
+++ b/test/asobi_world_zone_integration_tests.erl
@@ -62,6 +62,10 @@ world_zone_integration_test_() ->
         {"multiple players share same zone process", fun shared_zone_process/0},
         {"get_active_zones correct after lazy joins", fun active_zones_after_joins/0},
         {"small grid backward compat", fun small_grid_backward_compat/0},
+        {"broadcast_interval override reaches the zone process (#463)",
+            fun broadcast_interval_reaches_the_zone/0},
+        {"broadcast_interval defaults to 3 when unset (#463)",
+            fun broadcast_interval_defaults_to_three/0},
         {"world.input crossing a zone boundary rehomes the player",
             fun world_input_rehomes_across_boundary/0},
         {"a binary-keyed (Lua-shaped) player entity rehomes across a boundary",
@@ -103,6 +107,22 @@ default_prespawns_all() ->
         end,
         [{X, Y} || X <- lists:seq(0, 2), Y <- lists:seq(0, 2)]
     ),
+    stop_world(Ctx).
+
+%% asobi#463: a mode-set broadcast_interval must reach the zone PROCESS, not just
+%% world_config/1. This is the hop that was missing - the value was read by
+%% asobi_zone but never placed into BaseZoneConfig.
+broadcast_interval_reaches_the_zone() ->
+    Ctx = #{zone_mgr := Mgr} = start_world(#{broadcast_interval => 1}),
+    {ok, ZonePid} = asobi_zone_manager:get_zone(Mgr, {0, 0}),
+    ?assertEqual(1, maps:get(broadcast_interval, sys:get_state(ZonePid))),
+    stop_world(Ctx).
+
+%% The default is unchanged: a world that sets nothing runs on 3.
+broadcast_interval_defaults_to_three() ->
+    Ctx = #{zone_mgr := Mgr} = start_world(),
+    {ok, ZonePid} = asobi_zone_manager:get_zone(Mgr, {0, 0}),
+    ?assertEqual(3, maps:get(broadcast_interval, sys:get_state(ZonePid))),
     stop_world(Ctx).
 
 %% lazy_zones=true means no zones spawned at startup

--- a/test/fixtures/lua/config_world_dimensions.lua
+++ b/test/fixtures/lua/config_world_dimensions.lua
@@ -1,14 +1,15 @@
 -- Exercises the world dimension globals: tick_rate, grid_size,
--- zone_size, view_radius, persistent. These flow through to the world
--- server via asobi_game_modes:world_config/1.
-match_size  = 1
-max_players = 4
-game_type   = "world"
-tick_rate   = 100
-grid_size   = 1
-zone_size   = 1500
-view_radius = 0
-persistent  = true
+-- zone_size, view_radius, persistent, broadcast_interval. These flow
+-- through to the world server via asobi_game_modes:world_config/1.
+match_size         = 1
+max_players        = 4
+game_type          = "world"
+tick_rate          = 100
+grid_size          = 1
+zone_size          = 1500
+view_radius        = 0
+persistent         = true
+broadcast_interval = 2
 
 function init(config) return {} end
 function spawn_position(player_id, state) return { x = 0, y = 0 } end


### PR DESCRIPTION
Resolves the two concrete halves of #463; the third (a first-class `world.ack` frame) is deferred as a design decision (see bottom).

## Part 1 — `broadcast_interval` was unreachable (bug)

`asobi_zone` reads `broadcast_interval` (default 3, gates broadcast cadence at `TickN rem BroadcastInterval`) but it was never placed into `BaseZoneConfig` in `asobi_world_server:configure_zone_manager/1`, so **every world was stuck at 3** — deltas every `tick_rate * 3` = 150ms (~6.7Hz) while the sim runs at 20Hz, with no way for a mode to change it.

Plumbed through, default unchanged (3):
- `asobi_lua_config` reads the `broadcast_interval` global
- `asobi_game_modes:world_config/1` forwards it
- `asobi_world_server` puts it in `BaseZoneConfig` (the load-bearing fix; the zone-manager already forwards the map verbatim)
- Documented as a settable option in `guides/world-server.md` (it was effectively an undocumented 5th "value you cannot set"). Set to **1** for a delta every tick — what prediction wants.

Test: extended `world_dimension_globals_forwarded` to assert `broadcast_interval` flows Lua global → mode config → `world_config/1`.

## Part 2 — client-side prediction, the answer for today

The Discord question that spawned #463 has a working answer **now, with no protocol change**: `world.input` is verbatim and `encode_delta/1` only injects `op`+`id`, so a game stamps each input with a `seq`, echoes `last_seq` onto the entity in `handle_input/3`, and reconciles off `world.tick`. Documented as a `### Client-side prediction` recipe in `guides/websocket-protocol.md`, and the `migrate-from-hathora` "no prediction" bullet is reframed (no rollback/lag-comp, but the ack half is available).

## Deferred: first-class `world.ack` frame

Not here, on purpose. Under the 1.0 wire freeze (ADR 0010) `world.` is the open-leaf carve-out, so minting `world.ack` is **break-weighted** (reserves the `ack` leaf, could retroactively ban a shipped game's own `world.ack` broadcast) and the ADR points at `module.event` instead; and it needs typed dispatch in **all 7 SDKs** (5/7 drop unknown frames). That's a design call (typed frame vs module.event vs stay-userland) + a multi-repo project, tracked for follow-up.

## Checks
Compile / fmt / `asobi_lua_config_tests` (49, 0 failures) green locally. No wire change; frozen-protocol guards untouched.