### PR TITLE
feat: world.ack input-seq acknowledgement for client-side prediction (#474)

### DIFF
--- a/guides/websocket-protocol.md
+++ b/guides/websocket-protocol.md
@@ -69,10 +69,10 @@ The runtime validates the leaf name before it goes on the wire:
 
 <!-- BEGIN reserved-event-names (verified against asobi_ws_handler:reserved_event_names/0 by asobi_protocol_coverage_tests) -->
 ```
-finished            joined              left                list
-matched             matchmaker_expired  matchmaker_failed   phase_changed
-state               terrain             tick                vote_result
-vote_start          vote_tally          vote_vetoed
+ack                 finished            joined              left
+list                matched             matchmaker_expired  matchmaker_failed
+phase_changed       state               terrain             tick
+vote_result         vote_start          vote_tally          vote_vetoed
 ```
 <!-- END reserved-event-names -->
 
@@ -617,12 +617,15 @@ Join a specific world by id (e.g. one returned from `world.list`).
 Send game input to your zone. The `payload` IS the input map - there is
 no inner `data` wrapper. Field names are entirely up to your game; the
 server only forwards the map verbatim to your `handle_input/3` callback.
-Because it is verbatim, a client that wants prediction can add its own
-per-input field (a `seq`) and read the last-applied one back off `world.tick`;
-see [Client-side prediction](#client-side-prediction).
+
+For client-side prediction, add an optional `seq` *alongside* `payload` (a
+sibling, so "the payload IS the input map" stays true). The server echoes the
+highest consumed `seq` back as a [`world.ack`](#worldack-server-push); see
+[Client-side prediction](#client-side-prediction). A non-integer `seq` is
+ignored.
 
 ```json
-{"type": "world.input", "payload": {"kind": "move", "x": 600, "y": 480}}
+{"type": "world.input", "seq": 412, "payload": {"kind": "move", "x": 600, "y": 480}}
 ```
 
 The server routes the message to whichever zone owns your player
@@ -670,26 +673,40 @@ handler before sending the join message or you miss it.
 asobi is server-authoritative, and server-side rollback, replay and lag
 compensation are out of scope (TCP transport - see
 [migrate-from-hathora](migrate-from-hathora.md)). The server half that
-*client-side* prediction needs - an ack telling a client which of its inputs
-the authoritative state already includes - works today with no special
-protocol support, because `world.input` is verbatim and a `world.tick` delta
-carries whatever fields your entity has:
+*client-side* prediction needs - an ack telling a client which of its inputs the
+authoritative state already includes - is a first-class primitive:
 
-1. The client stamps each `world.input` with its own increasing `seq` and
-   applies the input locally right away (the prediction).
-2. Your `handle_input/3` writes that `seq` onto the acting player's entity,
-   e.g. `entity.last_seq = input.seq`.
-3. It rides back in the next `world.tick` delta for that entity. The client
-   drops every predicted input up to `last_seq` and replays the rest on top of
-   the authoritative state (the reconciliation).
+1. The client stamps each `world.input` with its own increasing `seq` (a sibling
+   of `payload`) and applies the input locally right away (the prediction).
+2. The server records the highest `seq` it consumed for that player - a rejected
+   input still counts, so a dropped input never strands the client - and sends it
+   back on the next broadcast as a per-connection
+   [`world.ack`](#worldack-server-push).
+3. The client discards every predicted input up to that `seq` and replays the
+   rest on top of the authoritative `world.tick` state (the reconciliation).
 
-Set [`broadcast_interval`](world-server.md) to 1 so the ack returns every tick
-rather than every third.
+Set [`broadcast_interval`](world-server.md) to 1 so the ack returns every tick.
 
-One cost to know: `last_seq` sits on the shared entity delta, so it reaches
-every subscriber in the zone, not just its owner - the ack's bandwidth scales
-with zone population. A per-connection ack frame that avoids that is tracked in
-asobi#474; the entity-field pattern is the answer today.
+The ack is per-connection: it is sent only to clients that opted in by stamping a
+`seq`, and never rides the shared `world.tick`, so one player's input stream is
+never broadcast to the rest of the zone.
+
+**If your SDK does not yet surface `world.ack`**, the same reconciliation works
+in userland: write the `seq` onto the player's entity in `handle_input/3`
+(`entity.last_seq = input.seq`) and read it back off the `world.tick` delta. The
+tradeoff is that `last_seq` then sits on the shared entity delta, so it reaches
+every subscriber in the zone - its bandwidth scales with zone population, which
+is exactly what the `world.ack` frame avoids.
+
+### `world.ack` (server push)
+
+Per-connection acknowledgement of the highest `world.input` `seq` the server has
+consumed for you as of `tick`. Sent only to clients that stamped a `seq` on their
+input; use it to reconcile prediction (above).
+
+```json
+{"type": "world.ack", "payload": {"tick": 42, "seq": 412}}
+```
 
 ### `world.terrain` (server push)
 

--- a/guides/websocket-protocol.md
+++ b/guides/websocket-protocol.md
@@ -621,8 +621,8 @@ server only forwards the map verbatim to your `handle_input/3` callback.
 For client-side prediction, add an optional `seq` *alongside* `payload` (a
 sibling, so "the payload IS the input map" stays true). The server echoes the
 highest consumed `seq` back as a [`world.ack`](#worldack-server-push); see
-[Client-side prediction](#client-side-prediction). A non-integer `seq` is
-ignored.
+[Client-side prediction](#client-side-prediction). A `seq` that is not a
+non-negative integer below 2^53 is ignored.
 
 ```json
 {"type": "world.input", "seq": 412, "payload": {"kind": "move", "x": 600, "y": 480}}

--- a/guides/world-server.md
+++ b/guides/world-server.md
@@ -598,7 +598,7 @@ World messages use the `world.*` namespace. See
 | `world.join` | `{"world_id": "..."}` | Join a specific world |
 | `world.list` | `{"mode": "...", "has_capacity": true}` | Browse listed worlds |
 | `world.leave` | `{}` | Leave the current world |
-| `world.input` | `{"action": "move", "x": 100, "y": 200}` | Send input to your zone |
+| `world.input` | `{"action": "move", "x": 100, "y": 200}`, optional top-level `seq` | Send input to your zone; a `seq` opts into `world.ack` |
 
 ### Server to client
 
@@ -607,6 +607,7 @@ World messages use the `world.*` namespace. See
 | `world.joined` | `{world_id, status, player_count, grid_size, ...}` | Join confirmed |
 | `world.left` | `{success: true}` | Leave confirmed |
 | `world.tick` | `{tick, updates: [{op, id, ...}]}` | Zone delta broadcast |
+| `world.ack` | `{tick, seq}` | Per-connection input ack for prediction; see [Client-side prediction](websocket-protocol.md#client-side-prediction) |
 | `world.phase_changed` | the phase info block | See [Phases](phases.md) |
 | `world.terrain` | `{coords, data}` | See [Large worlds](large-worlds.md) |
 | `world.finished` | `{world_id, result}` | World ended |

--- a/priv/protocol/fixtures/world.ack.json
+++ b/priv/protocol/fixtures/world.ack.json
@@ -1,0 +1,1 @@
+{"type":"world.ack","payload":{"tick":42,"seq":412}}

--- a/src/world/asobi_zone.erl
+++ b/src/world/asobi_zone.erl
@@ -8,7 +8,7 @@ via `asobi_spatial`. Zones are created and reaped lazily as players move.
 -behaviour(gen_server).
 
 -export([start_link/1, reap/1]).
--export([tick/2, player_input/3, add_entity/3, remove_entity/2]).
+-export([tick/2, player_input/3, player_input/4, add_entity/3, remove_entity/2]).
 -export([spawn_entity/3, spawn_entity/4, spawn_entities/2, despawn_entity/2]).
 -export([subscribe/2, unsubscribe/2]).
 -export([get_entities/1, get_subscriber_count/1, sync/1]).
@@ -54,7 +54,11 @@ tick(Pid, TickN) ->
 
 -spec player_input(pid(), binary(), map()) -> ok.
 player_input(Pid, PlayerId, Input) ->
-    gen_server:cast(Pid, {input, PlayerId, Input}).
+    player_input(Pid, PlayerId, Input, undefined).
+
+-spec player_input(pid(), binary(), map(), non_neg_integer() | undefined) -> ok.
+player_input(Pid, PlayerId, Input, Seq) ->
+    gen_server:cast(Pid, {input, PlayerId, Input, Seq}).
 
 -spec add_entity(pid(), binary(), map()) -> ok.
 add_entity(Pid, EntityId, EntityState) ->
@@ -209,6 +213,11 @@ init(Config) ->
             subscribers => #{},
             zone_state => ZoneState,
             input_queue => [],
+            %% asobi#474: highest input seq the server has consumed per player,
+            %% for clients that stamp world.input with a seq. Sent back as
+            %% world.ack so a client can reconcile its prediction; pruned to the
+            %% current subscribers each tick.
+            player_ack => #{},
             entity_timers => asobi_entity_timer:new(),
             spawner => Spawner,
             persistence => Persistence,
@@ -397,8 +406,8 @@ handle_cast({tick, TickN}, State) ->
             end,
             {noreply, State2}
     end;
-handle_cast({input, PlayerId, Input}, #{input_queue := Queue} = State) ->
-    {noreply, State#{input_queue => [{PlayerId, Input} | Queue]}};
+handle_cast({input, PlayerId, Input, Seq}, #{input_queue := Queue} = State) ->
+    {noreply, State#{input_queue => [{PlayerId, Seq, Input} | Queue]}};
 handle_cast(
     {add_entity, EntityId, EntityState}, #{entities := Entities, spatial_grid := Grid} = State
 ) ->
@@ -586,7 +595,8 @@ do_tick(
     %% this, a burst of moves arriving in one tick window collapses to the
     %% OLDEST input's state — every later move gets overwritten by the
     %% next-handle_input call walking the list head-first.
-    Entities2 = apply_inputs(GameMod, lists:reverse(Queue), Entities0),
+    {Entities2, TickAcks} = apply_inputs(GameMod, lists:reverse(Queue), Entities0),
+    PlayerAck1 = maps:fold(fun record_ack/3, maps:get(player_ack, State, #{}), TickAcks),
     Now = erlang:system_time(millisecond),
     {TimerEvents, ET1} = asobi_entity_timer:tick(Now, ET),
     Entities3 = apply_timer_events(TimerEvents, Entities2),
@@ -614,6 +624,7 @@ do_tick(
             0 ->
                 Deltas = compute_deltas(BroadcastEntities, Entities4),
                 broadcast_deltas(TickN, Deltas, Subs),
+                broadcast_acks(TickN, PlayerAck1, Subs),
                 State#{broadcast_entities => Entities4};
             _ ->
                 State
@@ -648,6 +659,9 @@ do_tick(
         prev_entities => Entities4,
         zone_state => ZoneState1,
         input_queue => [],
+        %% Bound player_ack to currently-subscribed players so it does not grow
+        %% with everyone who ever sent an input (asobi#474).
+        player_ack => maps:with(maps:keys(Subs), PlayerAck1),
         entity_timers => ET1,
         spawner => Spawner1,
         spatial_grid => Grid1,
@@ -667,19 +681,37 @@ apply_timer_events([{entity_timer_expired, EntityId, _TimerId, OnComplete} | Res
         end,
     apply_timer_events(Rest, Entities1).
 
-apply_inputs(_GameMod, [], Entities) ->
-    Entities;
-apply_inputs(GameMod, [{PlayerId, Input} | Rest], Entities) ->
+apply_inputs(GameMod, Queue, Entities) ->
+    apply_inputs(GameMod, Queue, Entities, #{}).
+
+apply_inputs(_GameMod, [], Entities, Acks) ->
+    {Entities, Acks};
+apply_inputs(GameMod, [{PlayerId, Seq, Input} | Rest], Entities, Acks) ->
+    %% A rejected input still advances the ack (asobi#474): the client asked the
+    %% server to consume this seq and it did, it just declined the effect.
+    %% Otherwise a client waits forever on an input the server chose to drop.
+    Acks1 = record_ack(PlayerId, Seq, Acks),
     case GameMod:handle_input(PlayerId, Input, Entities) of
         {ok, Entities1} ->
-            apply_inputs(GameMod, Rest, Entities1);
+            apply_inputs(GameMod, Rest, Entities1, Acks1);
         {error, Reason} ->
             logger:warning(#{
                 msg => ~"zone input rejected",
                 player_id => PlayerId,
                 reason => Reason
             }),
-            apply_inputs(GameMod, Rest, Entities)
+            apply_inputs(GameMod, Rest, Entities, Acks1)
+    end.
+
+%% Keep the highest seq per player. world.input carries a monotonic client seq;
+%% out-of-order or duplicate delivery must never regress the ack. Inputs with no
+%% seq (the client did not opt in) contribute nothing.
+record_ack(_PlayerId, undefined, Acks) ->
+    Acks;
+record_ack(PlayerId, Seq, Acks) when is_integer(Seq) ->
+    case Acks of
+        #{PlayerId := Prev} when Prev >= Seq -> Acks;
+        _ -> Acks#{PlayerId => Seq}
     end.
 
 -spec compute_deltas(map(), map()) -> [term()].
@@ -723,6 +755,24 @@ broadcast_deltas(TickN, Deltas, Subs) ->
     maps:foreach(
         fun(_PlayerId, {Pid, _MonRef}) -> Pid ! RawMsg end,
         Subs
+    ).
+
+%% asobi#474: per-connection input ack. Iterate the opted-in players (those with
+%% a recorded seq) and send world.ack only to the ones still subscribed. Kept
+%% off the shared world.tick binary so the ack never leaks one player's input
+%% stream to the rest of the zone.
+-spec broadcast_acks(non_neg_integer(), #{binary() => non_neg_integer()}, map()) -> ok.
+broadcast_acks(TickN, PlayerAck, Subs) ->
+    maps:foreach(
+        fun(PlayerId, Seq) ->
+            case Subs of
+                #{PlayerId := {Pid, _MonRef}} ->
+                    Pid ! {asobi_message, {world_ack, TickN, Seq}};
+                _ ->
+                    ok
+            end
+        end,
+        PlayerAck
     ).
 
 encode_deltas(Deltas) ->

--- a/src/world/asobi_zone.erl
+++ b/src/world/asobi_zone.erl
@@ -695,7 +695,7 @@ apply_inputs(GameMod, [{PlayerId, Seq, Input} | Rest], Entities, Acks) ->
         {ok, Entities1} ->
             apply_inputs(GameMod, Rest, Entities1, Acks1);
         {error, Reason} ->
-            logger:warning(#{
+            ?LOG_WARNING(#{
                 msg => ~"zone input rejected",
                 player_id => PlayerId,
                 reason => Reason
@@ -708,11 +708,15 @@ apply_inputs(GameMod, [{PlayerId, Seq, Input} | Rest], Entities, Acks) ->
 %% seq (the client did not opt in) contribute nothing.
 record_ack(_PlayerId, undefined, Acks) ->
     Acks;
-record_ack(PlayerId, Seq, Acks) when is_integer(Seq) ->
+record_ack(PlayerId, Seq, Acks) when is_integer(Seq), Seq >= 0 ->
     case Acks of
         #{PlayerId := Prev} when Prev >= Seq -> Acks;
         _ -> Acks#{PlayerId => Seq}
-    end.
+    end;
+%% Total over Seq: player_input/4 is exported, so a caller passing a
+%% spec-violating Seq must not function_clause-crash the shared zone process.
+record_ack(_PlayerId, _Seq, Acks) ->
+    Acks.
 
 -spec compute_deltas(map(), map()) -> [term()].
 compute_deltas(OldEntities, NewEntities) ->

--- a/src/ws/asobi_ws_handler.erl
+++ b/src/ws/asobi_ws_handler.erl
@@ -831,11 +831,13 @@ handle_message(
     #{session := SessionPid} = State
 ) when SessionPid =/= undefined ->
     %% asobi#474: an optional client input sequence number, a sibling of payload
-    %% (so "the payload IS the input map" stays true). Non-integers are ignored,
-    %% so a malformed seq degrades to no-ack instead of crashing the handler.
+    %% (so "the payload IS the input map" stays true). Bounded to a non-negative
+    %% JS-safe integer: the value is echoed back on every broadcast tick, so an
+    %% unbounded bignum here would be a per-tick json:encode amplifier. Anything
+    %% out of range degrades to no-ack rather than crashing the handler.
     Seq =
         case maps:get(~"seq", Msg, undefined) of
-            N when is_integer(N) -> N;
+            N when is_integer(N), N >= 0, N =< 16#1FFFFFFFFFFFFF -> N;
             _ -> undefined
         end,
     try asobi_player_session:get_state(SessionPid) of

--- a/src/ws/asobi_ws_handler.erl
+++ b/src/ws/asobi_ws_handler.erl
@@ -60,6 +60,7 @@
 -define(RESERVED_EVENT_NAMES, [
     ~"state",
     ~"tick",
+    ~"ack",
     ~"terrain",
     ~"list",
     ~"left",
@@ -232,6 +233,10 @@ websocket_info({asobi_message, {zone_delta_raw, PreEncoded}}, State) when is_bin
     {reply, {text, PreEncoded}, State};
 websocket_info({asobi_message, {zone_delta, TickN, Deltas}}, State) ->
     Reply = encode_reply(undefined, ~"world.tick", #{tick => TickN, updates => Deltas}),
+    {reply, {text, Reply}, State};
+websocket_info({asobi_message, {world_ack, TickN, Seq}}, State) ->
+    %% asobi#474: per-connection input ack, sent beside the shared world.tick.
+    Reply = encode_reply(undefined, ~"world.ack", #{tick => TickN, seq => Seq}),
     {reply, {text, Reply}, State};
 websocket_info({asobi_message, {terrain_chunk, {CX, CY}, Data}}, State) when is_binary(Data) ->
     Reply = encode_reply(undefined, ~"world.terrain", #{
@@ -822,9 +827,17 @@ handle_message(
             {reply, {text, Reply}, State}
     end;
 handle_message(
-    #{~"type" := ~"world.input", ~"payload" := Payload},
+    #{~"type" := ~"world.input", ~"payload" := Payload} = Msg,
     #{session := SessionPid} = State
 ) when SessionPid =/= undefined ->
+    %% asobi#474: an optional client input sequence number, a sibling of payload
+    %% (so "the payload IS the input map" stays true). Non-integers are ignored,
+    %% so a malformed seq degrades to no-ack instead of crashing the handler.
+    Seq =
+        case maps:get(~"seq", Msg, undefined) of
+            N when is_integer(N) -> N;
+            _ -> undefined
+        end,
     try asobi_player_session:get_state(SessionPid) of
         #{player_id := PlayerId} = SState ->
             case maps:get(zone_pid, SState, undefined) of
@@ -837,7 +850,7 @@ handle_message(
                             Other when is_map(Other) -> Other;
                             _ -> #{}
                         end,
-                    asobi_zone:player_input(ZonePid, PlayerId, InputData),
+                    asobi_zone:player_input(ZonePid, PlayerId, InputData, Seq),
                     {ok, State}
             end
     catch

--- a/test/asobi_zone_tests.erl
+++ b/test/asobi_zone_tests.erl
@@ -45,6 +45,12 @@ zone_test_() ->
         {"tick processes inputs and broadcasts deltas", fun tick_broadcasts/0},
         {"tick with no changes sends no deltas", fun tick_no_changes/0},
         {"tick acks to ticker", fun tick_acks/0},
+        {"world.input seq comes back as a world.ack (#474)", fun world_ack_returns_seq/0},
+        {"a rejected input still advances the world.ack (#474)",
+            fun world_ack_advances_on_reject/0},
+        {"world.input without a seq produces no world.ack (#474)",
+            fun world_ack_absent_without_seq/0},
+        {"world.ack keeps the highest seq (#474)", fun world_ack_keeps_highest_seq/0},
         {"queued inputs apply in arrival order", fun inputs_apply_in_arrival_order/0},
         {"subscriber DOWN cleans up", fun subscriber_down_cleanup/0},
         {"tick touches zone_manager when subscribers present", fun tick_touches_zone_manager/0},
@@ -197,6 +203,61 @@ subscribe_unsubscribe() ->
     timer:sleep(10),
     ?assertEqual(0, asobi_zone:get_subscriber_count(Pid)),
     gen_server:stop(Pid).
+
+%% asobi#474: a world.input carrying a client seq comes back to that connection
+%% as a world.ack, so the client can reconcile its prediction.
+world_ack_returns_seq() ->
+    Pid = start_zone(#{broadcast_interval => 1}),
+    asobi_zone:subscribe(Pid, {~"p1", self()}),
+    asobi_zone:add_entity(Pid, ~"p1", #{x => 0, y => 0, type => ~"player"}),
+    timer:sleep(10),
+    flush_messages(),
+    asobi_zone:player_input(Pid, ~"p1", #{~"action" => ~"move", ~"x" => 5, ~"y" => 5}, 412),
+    asobi_zone:tick(Pid, 1),
+    ?assertEqual(412, recv_ack()),
+    gen_server:stop(Pid).
+
+%% A rejected input still advances the ack: the server consumed the seq, it just
+%% declined the effect. With no p1 entity the move is rejected (not_found).
+world_ack_advances_on_reject() ->
+    Pid = start_zone(#{broadcast_interval => 1}),
+    asobi_zone:subscribe(Pid, {~"p1", self()}),
+    timer:sleep(10),
+    flush_messages(),
+    asobi_zone:player_input(Pid, ~"p1", #{~"action" => ~"move", ~"x" => 1, ~"y" => 1}, 7),
+    asobi_zone:tick(Pid, 1),
+    ?assertEqual(7, recv_ack()),
+    gen_server:stop(Pid).
+
+%% A client that never stamps a seq (did not opt in) gets no ack frames.
+world_ack_absent_without_seq() ->
+    Pid = start_zone(#{broadcast_interval => 1}),
+    asobi_zone:subscribe(Pid, {~"p1", self()}),
+    asobi_zone:add_entity(Pid, ~"p1", #{x => 0, y => 0, type => ~"player"}),
+    timer:sleep(10),
+    flush_messages(),
+    asobi_zone:player_input(Pid, ~"p1", #{~"action" => ~"move", ~"x" => 3, ~"y" => 3}),
+    asobi_zone:tick(Pid, 1),
+    ?assertEqual(no_ack, recv_ack()),
+    gen_server:stop(Pid).
+
+%% Out-of-order or duplicate seqs never regress the ack: the highest wins.
+world_ack_keeps_highest_seq() ->
+    Pid = start_zone(#{broadcast_interval => 1}),
+    asobi_zone:subscribe(Pid, {~"p1", self()}),
+    timer:sleep(10),
+    flush_messages(),
+    asobi_zone:player_input(Pid, ~"p1", #{}, 5),
+    asobi_zone:player_input(Pid, ~"p1", #{}, 3),
+    asobi_zone:tick(Pid, 1),
+    ?assertEqual(5, recv_ack()),
+    gen_server:stop(Pid).
+
+recv_ack() ->
+    receive
+        {asobi_message, {world_ack, _Tick, Seq}} -> Seq
+    after 300 -> no_ack
+    end.
 
 %% widgrensit/asobi#293: leaving a zone's interest ring must mirror joining
 %% it - subscribe_new/3 sends an `a` for every entity, so unsubscribe must

--- a/test/asobi_zone_tests.erl
+++ b/test/asobi_zone_tests.erl
@@ -51,6 +51,12 @@ zone_test_() ->
         {"world.input without a seq produces no world.ack (#474)",
             fun world_ack_absent_without_seq/0},
         {"world.ack keeps the highest seq (#474)", fun world_ack_keeps_highest_seq/0},
+        {"world.ack is per-connection - p1's ack never reaches p2 (#474)",
+            fun world_ack_is_per_connection/0},
+        {"a negative seq is ignored - no ack (#474 hardening)",
+            fun world_ack_ignores_negative_seq/0},
+        {"a non-integer seq via player_input/4 does not crash the zone (#474 hardening)",
+            fun world_ack_survives_non_integer_seq/0},
         {"queued inputs apply in arrival order", fun inputs_apply_in_arrival_order/0},
         {"subscriber DOWN cleans up", fun subscriber_down_cleanup/0},
         {"tick touches zone_manager when subscribers present", fun tick_touches_zone_manager/0},
@@ -251,6 +257,59 @@ world_ack_keeps_highest_seq() ->
     asobi_zone:player_input(Pid, ~"p1", #{}, 3),
     asobi_zone:tick(Pid, 1),
     ?assertEqual(5, recv_ack()),
+    gen_server:stop(Pid).
+
+%% asobi#474: the ack is per-connection - p1's seq reaches p1 only, never p2's
+%% connection. That isolation is the whole point of the frame over the shared
+%% entity-field ack.
+world_ack_is_per_connection() ->
+    Parent = self(),
+    Pid = start_zone(#{broadcast_interval => 1}),
+    P2 = spawn(fun() -> p2_ack_forwarder(Parent) end),
+    asobi_zone:subscribe(Pid, {~"p1", self()}),
+    asobi_zone:subscribe(Pid, {~"p2", P2}),
+    asobi_zone:add_entity(Pid, ~"p1", #{x => 0, y => 0, type => ~"player"}),
+    timer:sleep(10),
+    flush_messages(),
+    asobi_zone:player_input(Pid, ~"p1", #{~"action" => ~"move", ~"x" => 2, ~"y" => 2}, 99),
+    asobi_zone:tick(Pid, 1),
+    ?assertEqual(99, recv_ack()),
+    receive
+        {p2_saw_ack, S} ->
+            ?assert(false, "p2 received a world.ack for p1's seq: " ++ integer_to_list(S))
+    after 100 -> ok
+    end,
+    gen_server:stop(Pid).
+
+p2_ack_forwarder(Parent) ->
+    receive
+        {asobi_message, {world_ack, _T, S}} -> Parent ! {p2_saw_ack, S};
+        _ -> p2_ack_forwarder(Parent)
+    end.
+
+%% asobi#474 hardening: record_ack is total and rejects negatives, so a
+%% spec-violating seq reaching the exported player_input/4 neither acks nor
+%% crashes the shared zone process (which would DoS every player in it).
+world_ack_ignores_negative_seq() ->
+    Pid = start_zone(#{broadcast_interval => 1}),
+    asobi_zone:subscribe(Pid, {~"p1", self()}),
+    timer:sleep(10),
+    flush_messages(),
+    asobi_zone:player_input(Pid, ~"p1", #{}, -5),
+    asobi_zone:tick(Pid, 1),
+    ?assertEqual(no_ack, recv_ack()),
+    ?assert(is_process_alive(Pid)),
+    gen_server:stop(Pid).
+
+world_ack_survives_non_integer_seq() ->
+    Pid = start_zone(#{broadcast_interval => 1}),
+    asobi_zone:subscribe(Pid, {~"p1", self()}),
+    timer:sleep(10),
+    flush_messages(),
+    asobi_zone:player_input(Pid, ~"p1", #{}, ~"not-a-seq"),
+    asobi_zone:tick(Pid, 1),
+    ?assertEqual(no_ack, recv_ack()),
+    ?assert(is_process_alive(Pid)),
     gen_server:stop(Pid).
 
 recv_ack() ->


### PR DESCRIPTION
Builds the backend half of #474 (design ratified: typed `world.ack` frame, world-server only, opt-in per connection). SDK dispatch is per-SDK follow-up.

## What
- **`world.input` + optional `seq`** — a top-level sibling of `payload` (so "the payload IS the input map" holds). Non-integer `seq` is ignored (degrades to no-ack, never crashes the handler).
- **Zone tracks the highest consumed `seq` per player** — a *rejected* input still advances it, so a dropped input never strands a client. Sent as a per-connection **`world.ack` `{tick, seq}`** on each broadcast, only to opted-in clients.
- **Never on the shared `world.tick` binary** — the ack goes to the player's own connection, so one player's input stream is not broadcast to the zone (the bandwidth win over the userland `last_seq` pattern).
- **`player_ack` pruned to current subscribers each tick** — bounded memory.

## Frozen wire (ADR 0010)
Additive: `world.ack` is a new reserved `world.` leaf (`?RESERVED_EVENT_NAMES` + the guide's machine-verified reserved block + `priv/protocol/fixtures/world.ack.json`); the inbound `seq` is a plain additive field. Not added to `?FROZEN_WIRE_1_0`. `match.input` untouched.

## Security posture
`seq` is untrusted client input: integer-validated at the boundary; a malicious/huge/negative `seq` only affects that client's own ack (monotonic max, per-connection delivery — no cross-player leak); `player_ack` is bounded to subscriber count.

## Tests / checks
- New: 4 zone behavioural tests (seq→ack, rejected-still-acks, no-seq→no-ack, monotonic-highest-wins).
- Protocol coverage 9/9 (frozen-set guards untouched; fixture + reserved-name checks pass).
- Local: compile / fmt / xref / **dialyzer 0 warnings** / **eqwalize delta 0** (asobi_zone, asobi_ws_handler) / zone tests 38/38. (The lone integration-suite failure is the pre-existing `world_input_crossing_touches_only_ring_delta` module-isolation flake, green in full-suite CI.)

## Docs
`world.ack` frame + the `seq` field + a reworked "Client-side prediction" recipe that leads with `world.ack` and keeps the userland `last_seq` pattern as the no-SDK fallback.