### PR TITLE
docs: point the hathora migration guide at world.ack

### DIFF
--- a/guides/migrate-from-hathora.md
+++ b/guides/migrate-from-hathora.md
@@ -318,9 +318,10 @@ applies when you decide to move.
 - **No automatic multi-region.** One container per region, deployed by you.
 - **No rollback netcode or lag compensation.** No server-side replay, no hitbox
   rewind; over TCP (above) asobi is not for twitch shooters. But the server half
-  of *client-side prediction* is available: a game stamps each input with a
-  sequence number, echoes the last-applied one back on the player's own entity,
-  and the client reconciles against it. See
+  of *client-side prediction* is a first-class primitive: the client stamps each
+  `world.input` with an increasing `seq`, and the server returns the highest one
+  it has consumed as a per-connection `world.ack` for the client to reconcile
+  against. See
   [Client-side prediction](websocket-protocol.md#client-side-prediction).
 - **Pre-1.0 API.** Minor breaking changes are possible until 1.0.
 


### PR DESCRIPTION
Follow-up to #473/#475. The `Things asobi does not do` prediction bullet in `guides/migrate-from-hathora.md` was written in #473, one PR before #475 made the ack a first-class frame. It still teaches the userland recipe (stamp a seq, echo `last_seq` back on the player's own entity) that `websocket-protocol.md` itself now labels the fallback for SDKs that do not surface `world.ack`.

All seven client SDKs now dispatch `world.ack` (dart#41, js#29, godot#34, defold#56, love2d#23, unity#44, unreal#31), so the guide should lead with the first-class primitive and let the WebSocket guide carry the fallback.

Docs-only, one bullet. The anchor it links to (`websocket-protocol.md#client-side-prediction`, guides/websocket-protocol.md:671) is unchanged. `scripts/check-archived-refs.sh` passes; CI is `paths-ignore: ['**.md', ...]` so no build runs.

asobi.dev republishes this page from the guide; the site regen is a separate PR in asobi_site (ADR 0003).