### PR TITLE
fix: make world.input and world.ack match their documented contract

### DIFF
--- a/guides/migrate-from-hathora.md
+++ b/guides/migrate-from-hathora.md
@@ -320,8 +320,8 @@ applies when you decide to move.
   rewind; over TCP (above) asobi is not for twitch shooters. But the server half
   of *client-side prediction* is a first-class primitive: the client stamps each
   `world.input` with an increasing `seq`, and the server returns the highest one
-  it has consumed as a per-connection `world.ack` for the client to reconcile
-  against. See
+  it has consumed as a `world.ack` on that connection for the client to
+  reconcile against. See
   [Client-side prediction](websocket-protocol.md#client-side-prediction).
 - **Pre-1.0 API.** Minor breaking changes are possible until 1.0.
 

--- a/guides/observability.md
+++ b/guides/observability.md
@@ -120,12 +120,18 @@ asobi.session.connected          asobi.session.disconnected
 asobi.ws.connected               asobi.ws.disconnected
 asobi.ws.message_in              asobi.ws.message_out
 asobi.ws.connect_rate_limited    asobi.ws.idle_auth_timeout
-asobi.ws.origin_rejected
+asobi.ws.origin_rejected         asobi.ws.legacy_input_unwrap
 ```
 
 `asobi.ws.origin_rejected` and `asobi.ws.connect_rate_limited` are the two
 worth alerting on: a spike in either is either an attack or a client
 misconfiguration, and both are invisible in game metrics.
+
+`asobi.ws.legacy_input_unwrap` counts input frames sent in the deprecated
+sole-`data` shape (see [WebSocket protocol](websocket-protocol.md#worldinput)).
+It is not an error, and not worth an alert: it exists so the carve-out can be
+retired once the counter reaches zero for a release, instead of guessing which
+clients still depend on it.
 
 ### Matches and matchmaking
 

--- a/guides/websocket-protocol.md
+++ b/guides/websocket-protocol.md
@@ -616,7 +616,13 @@ Join a specific world by id (e.g. one returned from `world.list`).
 
 Send game input to your zone. The `payload` IS the input map - there is
 no inner `data` wrapper. Field names are entirely up to your game; the
-server only forwards the map verbatim to your `handle_input/3` callback.
+server forwards the map verbatim to your `handle_input/3` callback.
+
+One compatibility shape survives: a payload whose *only* key is `data`, mapped
+to an object, is unwrapped to that object, because an SDK sends input that way.
+A `data` key alongside any other key is not special, and neither is a `data`
+whose value is not an object - both reach `handle_input/3` untouched, with the
+rest of the payload intact.
 
 For client-side prediction, add an optional `seq` *alongside* `payload` (a
 sibling, so "the payload IS the input map" stays true). The server echoes the
@@ -680,16 +686,21 @@ authoritative state already includes - is a first-class primitive:
    of `payload`) and applies the input locally right away (the prediction).
 2. The server records the highest `seq` it consumed for that player - a rejected
    input still counts, so a dropped input never strands the client - and sends it
-   back on the next broadcast as a per-connection
-   [`world.ack`](#worldack-server-push).
+   back on the next broadcast as a [`world.ack`](#worldack-server-push)
+   addressed to that connection alone.
 3. The client discards every predicted input up to that `seq` and replays the
    rest on top of the authoritative `world.tick` state (the reconciliation).
 
 Set [`broadcast_interval`](world-server.md) to 1 so the ack returns every tick.
 
-The ack is per-connection: it is sent only to clients that opted in by stamping a
-`seq`, and never rides the shared `world.tick`, so one player's input stream is
-never broadcast to the rest of the zone.
+The ack is addressed to one connection: it is sent only to clients that opted in
+by stamping a `seq`, and never rides the shared `world.tick`, so one player's
+input stream is never broadcast to the rest of the zone.
+
+It is emitted by the zone that consumed the input, and a player is subscribed to
+their whole interest ring, so a zone stops acking you as soon as your entity
+leaves it. Crossing a boundary therefore hands the ack over from one zone to the
+next rather than leaving the old one to repeat a stale `seq`.
 
 **If your SDK does not yet surface `world.ack`**, the same reconciliation works
 in userland: write the `seq` onto the player's entity in `handle_input/3`
@@ -700,9 +711,10 @@ is exactly what the `world.ack` frame avoids.
 
 ### `world.ack` (server push)
 
-Per-connection acknowledgement of the highest `world.input` `seq` the server has
-consumed for you as of `tick`. Sent only to clients that stamped a `seq` on their
-input; use it to reconcile prediction (above).
+Acknowledgement of the highest `world.input` `seq` the zone holding your entity
+has consumed for you as of `tick`. Addressed to your connection alone, and sent
+only to clients that stamped a `seq` on their input; use it to reconcile
+prediction (above).
 
 ```json
 {"type": "world.ack", "payload": {"tick": 42, "seq": 412}}

--- a/guides/websocket-protocol.md
+++ b/guides/websocket-protocol.md
@@ -284,6 +284,17 @@ Send game input to the match server.
 {"type": "match.input", "payload": {"action": "move", "x": 10, "y": 5}}
 ```
 
+As with [`world.input`](#worldinput), the `payload` IS the input map. Two
+**deprecated** compatibility shapes survive here and will go at the next
+protocol break: a payload whose only key is `data` mapped to an object is
+unwrapped to that object, and one whose only key is `data` mapped to a JSON
+*string* is decoded and unwrapped. A malformed string, a decoded value that is
+not an object, or a `payload` that is not an object at all is answered with
+`error`, reason `invalid_payload`.
+
+When the connection is in a world rather than a match, `match.input` is routed
+to your zone, so the two frames reach the same `handle_input/3`.
+
 Input sent while not in a match or world is dropped. The first drop (at
 most one per 5 seconds per connection) is answered with an error event so
 the client can tell input is going nowhere:
@@ -614,15 +625,19 @@ Join a specific world by id (e.g. one returned from `world.list`).
 
 ### `world.input`
 
-Send game input to your zone. The `payload` IS the input map - there is
-no inner `data` wrapper. Field names are entirely up to your game; the
-server forwards the map verbatim to your `handle_input/3` callback.
+Send game input to your zone. The `payload` IS the input map; the server
+forwards it verbatim to your `handle_input/3` callback and field names are
+entirely up to your game.
 
-One compatibility shape survives: a payload whose *only* key is `data`, mapped
-to an object, is unwrapped to that object, because an SDK sends input that way.
-A `data` key alongside any other key is not special, and neither is a `data`
-whose value is not an object - both reach `handle_input/3` untouched, with the
-rest of the payload intact.
+One **deprecated** compatibility shape survives: a payload whose *only* key is
+`data`, mapped to an object, is unwrapped to that object. It exists for clients
+that predate this rule and will be removed at the next protocol break; do not
+send it. A `data` key alongside any other key is not special, and neither is a
+`data` whose value is not an object - both reach `handle_input/3` untouched,
+with the rest of the payload intact.
+
+A `payload` that is not an object at all is rejected with an `error` frame,
+reason `invalid_payload`. It is not silently treated as empty input.
 
 For client-side prediction, add an optional `seq` *alongside* `payload` (a
 sibling, so "the payload IS the input map" stays true). The server echoes the
@@ -697,10 +712,11 @@ The ack is addressed to one connection: it is sent only to clients that opted in
 by stamping a `seq`, and never rides the shared `world.tick`, so one player's
 input stream is never broadcast to the rest of the zone.
 
-It is emitted by the zone that consumed the input, and a player is subscribed to
-their whole interest ring, so a zone stops acking you as soon as your entity
-leaves it. Crossing a boundary therefore hands the ack over from one zone to the
-next rather than leaving the old one to repeat a stale `seq`.
+**`seq` never goes backwards on a connection.** The high-water mark is recorded
+per zone, and a player is subscribed to their whole interest ring, so during a
+crossing more than one zone can hold a mark for them. The connection drops any
+ack that does not advance the highest `seq` it has already sent you, so you can
+prune against the value you receive without tracking a maximum yourself.
 
 **If your SDK does not yet surface `world.ack`**, the same reconciliation works
 in userland: write the `seq` onto the player's entity in `handle_input/3`
@@ -711,10 +727,10 @@ is exactly what the `world.ack` frame avoids.
 
 ### `world.ack` (server push)
 
-Acknowledgement of the highest `world.input` `seq` the zone holding your entity
-has consumed for you as of `tick`. Addressed to your connection alone, and sent
-only to clients that stamped a `seq` on their input; use it to reconcile
-prediction (above).
+Acknowledgement of the highest `world.input` `seq` the server has consumed for
+you as of `tick`, and monotonic for the life of the connection. Addressed to your
+connection alone, and sent only to clients that stamped a `seq` on their input;
+use it to reconcile prediction (above).
 
 ```json
 {"type": "world.ack", "payload": {"tick": 42, "seq": 412}}

--- a/src/asobi_telemetry.erl
+++ b/src/asobi_telemetry.erl
@@ -23,7 +23,8 @@
     join_rate_limited/1,
     rehome_rate_limited/1,
     ws_idle_auth_timeout/0,
-    ws_origin_rejected/0
+    ws_origin_rejected/0,
+    ws_legacy_input_unwrap/0
 ]).
 -export([anticheat_violation/3]).
 -export([game_error/1, game_error/2]).
@@ -80,6 +81,7 @@ events() ->
         [asobi, ws, connect_rate_limited],
         [asobi, ws, idle_auth_timeout],
         [asobi, ws, origin_rejected],
+        [asobi, ws, legacy_input_unwrap],
         [asobi, join, rate_limited],
         [asobi, rehome, rate_limited],
         [asobi, anticheat, violation],
@@ -329,6 +331,13 @@ ws_idle_auth_timeout() ->
 -spec ws_origin_rejected() -> ok.
 ws_origin_rejected() ->
     telemetry:execute([asobi, ws, origin_rejected], #{count => 1}, #{}).
+
+%% asobi#478: a client sent input wrapped as a sole `data` key, the deprecated
+%% compat shape. Counted so the carve-out's removal can be scheduled against real
+%% traffic instead of guesswork.
+-spec ws_legacy_input_unwrap() -> ok.
+ws_legacy_input_unwrap() ->
+    telemetry:execute([asobi, ws, legacy_input_unwrap], #{count => 1}, #{}).
 
 -spec anticheat_violation(binary(), atom(), map()) -> ok.
 anticheat_violation(PlayerId, Type, Details) ->

--- a/src/players/asobi_player_session.erl
+++ b/src/players/asobi_player_session.erl
@@ -41,6 +41,7 @@ init(#{player_id := PlayerId, ws_pid := WsPid}) ->
         player_id => PlayerId,
         ws_pid => WsPid,
         match_pid => undefined,
+        last_ack_seq => -1,
         channels => [],
         presence => #{status => ~"online"},
         connected_at => erlang:system_time(millisecond)
@@ -98,6 +99,28 @@ handle_info({asobi_message, {world_joined, WorldPid, ZonePid}}, State) ->
     {noreply, State#{world_pid => WorldPid, zone_pid => ZonePid}};
 handle_info({asobi_message, {world_zone_changed, ZonePid}}, State) ->
     {noreply, State#{zone_pid => ZonePid}};
+%% asobi#477: make world.ack monotonic per connection.
+%%
+%% The seq is the client's own counter, but the high-water mark is recorded per
+%% zone, and a player is subscribed to their whole interest ring - at the default
+%% view_radius of 1 a one-step crossing leaves them subscribed to the zone behind
+%% them. That zone keeps acking its own mark, and input still routed to it during
+%% the crossing re-arms the entry, so the client would see seq go backwards and a
+%% prune-and-replay reconciler would re-apply input the server had consumed.
+%%
+%% The session is per WebSocket and dies with it, so last_ack_seq resets exactly
+%% when the client's counter does. Dropping any ack that does not advance the mark
+%% makes the guarantee hold whichever zone emits the frame, and independently of
+%% cast ordering during a crossing.
+handle_info({asobi_message, {world_ack, _Tick, Seq}}, #{last_ack_seq := Last} = State) when
+    is_integer(Seq), Seq =< Last
+->
+    {noreply, State};
+handle_info(
+    {asobi_message, {world_ack, _Tick, Seq}} = Msg, #{ws_pid := WsPid} = State
+) when is_integer(Seq) ->
+    WsPid ! Msg,
+    {noreply, State#{last_ack_seq => Seq}};
 handle_info({asobi_message, _} = Msg, #{ws_pid := WsPid} = State) ->
     WsPid ! Msg,
     {noreply, State};

--- a/src/world/asobi_zone.erl
+++ b/src/world/asobi_zone.erl
@@ -415,7 +415,18 @@ handle_cast(
     {noreply, State#{entities => Entities#{EntityId => EntityState}, spatial_grid => Grid1}};
 handle_cast({remove_entity, EntityId}, #{entities := Entities, spatial_grid := Grid} = State) ->
     Grid1 = spatial_grid_remove(EntityId, Grid),
-    {noreply, State#{entities => maps:remove(EntityId, Entities), spatial_grid => Grid1}};
+    %% asobi#477: drop any input ack held for this entity. A crossing player
+    %% stays subscribed to the zone they left whenever it remains inside their
+    %% interest ring, so without this the old zone keeps acking them with a
+    %% frozen seq while the new zone advances - and the client sees world.ack
+    %% go backwards. Entity ids and player ids coincide for players; for an NPC
+    %% removal this is a no-op.
+    PlayerAck = maps:remove(EntityId, maps:get(player_ack, State, #{})),
+    {noreply, State#{
+        entities => maps:remove(EntityId, Entities),
+        spatial_grid => Grid1,
+        player_ack => PlayerAck
+    }};
 handle_cast(
     {subscribe, PlayerId, PlayerPid},
     #{subscribers := Subs} = State
@@ -761,8 +772,11 @@ broadcast_deltas(TickN, Deltas, Subs) ->
         Subs
     ).
 
-%% asobi#474: per-connection input ack. Iterate the opted-in players (those with
-%% a recorded seq) and send world.ack only to the ones still subscribed. Kept
+%% asobi#474: input ack, addressed to one connection. Iterate the opted-in
+%% players (those with a recorded seq) and send world.ack only to the ones still
+%% subscribed. asobi#477: an entry is dropped when the player's entity leaves
+%% this zone, so a subscriber whose entity has crossed into a neighbour is no
+%% longer acked here and never sees a stale seq from the zone behind them. Kept
 %% off the shared world.tick binary so the ack never leaks one player's input
 %% stream to the rest of the zone.
 -spec broadcast_acks(non_neg_integer(), #{binary() => non_neg_integer()}, map()) -> ok.

--- a/src/world/asobi_zone.erl
+++ b/src/world/asobi_zone.erl
@@ -415,18 +415,7 @@ handle_cast(
     {noreply, State#{entities => Entities#{EntityId => EntityState}, spatial_grid => Grid1}};
 handle_cast({remove_entity, EntityId}, #{entities := Entities, spatial_grid := Grid} = State) ->
     Grid1 = spatial_grid_remove(EntityId, Grid),
-    %% asobi#477: drop any input ack held for this entity. A crossing player
-    %% stays subscribed to the zone they left whenever it remains inside their
-    %% interest ring, so without this the old zone keeps acking them with a
-    %% frozen seq while the new zone advances - and the client sees world.ack
-    %% go backwards. Entity ids and player ids coincide for players; for an NPC
-    %% removal this is a no-op.
-    PlayerAck = maps:remove(EntityId, maps:get(player_ack, State, #{})),
-    {noreply, State#{
-        entities => maps:remove(EntityId, Entities),
-        spatial_grid => Grid1,
-        player_ack => PlayerAck
-    }};
+    {noreply, State#{entities => maps:remove(EntityId, Entities), spatial_grid => Grid1}};
 handle_cast(
     {subscribe, PlayerId, PlayerPid},
     #{subscribers := Subs} = State
@@ -774,9 +763,9 @@ broadcast_deltas(TickN, Deltas, Subs) ->
 
 %% asobi#474: input ack, addressed to one connection. Iterate the opted-in
 %% players (those with a recorded seq) and send world.ack only to the ones still
-%% subscribed. asobi#477: an entry is dropped when the player's entity leaves
-%% this zone, so a subscriber whose entity has crossed into a neighbour is no
-%% longer acked here and never sees a stale seq from the zone behind them. Kept
+%% subscribed. The mark is per zone, so a crossing player can be acked by both
+%% the zone they left and the one they entered; asobi_player_session drops any
+%% ack that does not advance, which is what makes the frame monotonic. Kept
 %% off the shared world.tick binary so the ack never leaks one player's input
 %% stream to the rest of the zone.
 -spec broadcast_acks(non_neg_integer(), #{binary() => non_neg_integer()}, map()) -> ok.

--- a/src/ws/asobi_ws_handler.erl
+++ b/src/ws/asobi_ws_handler.erl
@@ -4,6 +4,10 @@
 -export([init/1, websocket_init/1, websocket_handle/2, websocket_info/2, terminate/3]).
 %% Exported for tests (pure allowlist predicate), mirroring deployable/1.
 -export([origin_allowed/1]).
+
+-ifdef(TEST).
+-export([world_input_data/1]).
+-endif.
 %% Exported so asobi_protocol_coverage_tests can assert every emitted
 %% match./world. event stays inside the reserved namespace (#303), and so
 %% asobi_lua_api can reject a bad game.broadcast name against these same
@@ -118,6 +122,24 @@ websocket_init(State) ->
 %% may open the socket. A missing Origin header is a non-browser client
 %% (Defold/Unity native etc.) - it cannot be a CSWSH vector, so it always
 %% passes regardless of the allowlist.
+%% asobi#478: the payload IS the input map, which is what
+%% guides/websocket-protocol.md promises. `data` is unwrapped only when it is a
+%% map AND the sole key - the shape asobi-unreal sends - and everything else
+%% goes through verbatim.
+%%
+%% Before this, any `data` key was unwrapped, silently dropping its siblings, and
+%% a `data` that was not a map discarded the whole input as `#{}`. That second
+%% branch is how asobi-unity sent world input into a void for every release it
+%% ever shipped: it wrapped the payload as a JSON *string* under `data`, so
+%% handle_input/3 always received an empty map, with nothing logged either side.
+-spec world_input_data(term()) -> map().
+world_input_data(#{~"data" := Inner} = Payload) when is_map(Inner), map_size(Payload) =:= 1 ->
+    Inner;
+world_input_data(Payload) when is_map(Payload) ->
+    Payload;
+world_input_data(_) ->
+    #{}.
+
 -spec origin_allowed(binary() | undefined) -> boolean().
 origin_allowed(undefined) ->
     true;
@@ -846,12 +868,7 @@ handle_message(
                 undefined ->
                     {ok, State};
                 ZonePid ->
-                    InputData =
-                        case maps:get(~"data", Payload, undefined) of
-                            undefined when is_map(Payload) -> Payload;
-                            Other when is_map(Other) -> Other;
-                            _ -> #{}
-                        end,
+                    InputData = world_input_data(Payload),
                     asobi_zone:player_input(ZonePid, PlayerId, InputData, Seq),
                     {ok, State}
             end

--- a/src/ws/asobi_ws_handler.erl
+++ b/src/ws/asobi_ws_handler.erl
@@ -6,7 +6,7 @@
 -export([origin_allowed/1]).
 
 -ifdef(TEST).
--export([world_input_data/1]).
+-export([world_input_data/1, match_input_data/1]).
 -endif.
 %% Exported so asobi_protocol_coverage_tests can assert every emitted
 %% match./world. event stays inside the reserved namespace (#303), and so
@@ -122,24 +122,6 @@ websocket_init(State) ->
 %% may open the socket. A missing Origin header is a non-browser client
 %% (Defold/Unity native etc.) - it cannot be a CSWSH vector, so it always
 %% passes regardless of the allowlist.
-%% asobi#478: the payload IS the input map, which is what
-%% guides/websocket-protocol.md promises. `data` is unwrapped only when it is a
-%% map AND the sole key - the shape asobi-unreal sends - and everything else
-%% goes through verbatim.
-%%
-%% Before this, any `data` key was unwrapped, silently dropping its siblings, and
-%% a `data` that was not a map discarded the whole input as `#{}`. That second
-%% branch is how asobi-unity sent world input into a void for every release it
-%% ever shipped: it wrapped the payload as a JSON *string* under `data`, so
-%% handle_input/3 always received an empty map, with nothing logged either side.
--spec world_input_data(term()) -> map().
-world_input_data(#{~"data" := Inner} = Payload) when is_map(Inner), map_size(Payload) =:= 1 ->
-    Inner;
-world_input_data(Payload) when is_map(Payload) ->
-    Payload;
-world_input_data(_) ->
-    #{}.
-
 -spec origin_allowed(binary() | undefined) -> boolean().
 origin_allowed(undefined) ->
     true;
@@ -160,6 +142,69 @@ origin_allowed(Origin) when is_binary(Origin) ->
             end;
         {ok, Other} ->
             misconfigured_origins(Other)
+    end.
+
+%% asobi#478: the payload IS the input map, which is what
+%% guides/websocket-protocol.md promises.
+%%
+%% `legacy_unwrap` is a DEPRECATED compatibility shape: a payload whose sole key
+%% is `data`, mapped to an object. asobi-unreal still sends input that way. It is
+%% reported to telemetry so the removal can be scheduled once no SDK relies on
+%% it; remove this clause at the next protocol break.
+%%
+%% Everything else that is a map goes through verbatim. A payload that is not a
+%% map at all is `invalid` rather than an empty map: handing the game `#{}` is
+%% indistinguishable from a legitimate empty input, and the client - which sent a
+%% frame the protocol does not allow - would be told nothing.
+-spec world_input_data(term()) -> {ok, map()} | {legacy_unwrap, map()} | invalid.
+world_input_data(#{~"data" := Inner} = Payload) when is_map(Inner), map_size(Payload) =:= 1 ->
+    {legacy_unwrap, Inner};
+world_input_data(Payload) when is_map(Payload) ->
+    {ok, Payload};
+world_input_data(_) ->
+    invalid.
+
+%% match.input carries the same shapes plus one of its own: a sole `data` holding
+%% a JSON *string*, which predates world.input and is what asobi-unity's
+%% SendMatchInput sends. The decode is total - `json:decode/1` RAISES on malformed
+%% input, and an authenticated client can send 60 frames a second, so letting it
+%% reach safe_handle_message/2's catch-all hands one connection a warning-log
+%% amplifier that can exhaust the node's logger burst budget and blind every other
+%% log line. See asobi#465 for the same class closed on badmap.
+-spec match_input_data(term()) -> {ok, map()} | {legacy_unwrap, map()} | invalid.
+match_input_data(#{~"data" := Bin} = Payload) when is_binary(Bin), map_size(Payload) =:= 1 ->
+    try json:decode(Bin) of
+        Decoded when is_map(Decoded) -> {legacy_unwrap, Decoded};
+        _ -> invalid
+    catch
+        _:_ -> invalid
+    end;
+match_input_data(Payload) ->
+    world_input_data(Payload).
+
+%% Unwrap the extraction result, reporting the deprecated compat shape so its
+%% removal can be scheduled against real traffic rather than guesswork.
+-spec input_data({ok, map()} | {legacy_unwrap, map()}) -> map().
+input_data({ok, Input}) ->
+    Input;
+input_data({legacy_unwrap, Input}) ->
+    asobi_telemetry:ws_legacy_input_unwrap(),
+    Input.
+
+-spec match_input_route(map(), binary(), map(), map()) -> {ok, map()} | {reply, term(), map()}.
+match_input_route(SState, PlayerId, InputData, State) ->
+    case maps:get(match_pid, SState, undefined) of
+        undefined ->
+            case maps:get(zone_pid, SState, undefined) of
+                undefined ->
+                    not_in_match_hint(State);
+                ZonePid ->
+                    asobi_zone:player_input(ZonePid, PlayerId, InputData),
+                    {ok, State}
+            end;
+        MatchPid ->
+            asobi_match_server:handle_input(MatchPid, PlayerId, InputData),
+            {ok, State}
     end.
 
 -spec misconfigured_origins(term()) -> false.
@@ -441,36 +486,20 @@ handle_message(#{~"type" := ~"session.heartbeat"} = Msg, State) ->
     Reply = encode_reply(Cid, ~"session.heartbeat", #{ts => erlang:system_time(millisecond)}),
     {reply, {text, Reply}, State};
 handle_message(
-    #{~"type" := ~"match.input", ~"payload" := Payload}, #{session := SessionPid} = State
+    #{~"type" := ~"match.input", ~"payload" := Payload} = Msg,
+    #{session := SessionPid} = State
 ) when
     SessionPid =/= undefined
 ->
     try asobi_player_session:get_state(SessionPid) of
         #{player_id := PlayerId} = SState ->
-            InputData =
-                case maps:get(~"data", Payload, undefined) of
-                    undefined when is_map(Payload) -> Payload;
-                    Bin when is_binary(Bin) ->
-                        case json:decode(Bin) of
-                            M when is_map(M) -> M;
-                            _ -> #{}
-                        end;
-                    Other when is_map(Other) -> Other;
-                    _ ->
-                        #{}
-                end,
-            case maps:get(match_pid, SState, undefined) of
-                undefined ->
-                    case maps:get(zone_pid, SState, undefined) of
-                        undefined ->
-                            not_in_match_hint(State);
-                        ZonePid ->
-                            asobi_zone:player_input(ZonePid, PlayerId, InputData),
-                            {ok, State}
-                    end;
-                MatchPid ->
-                    asobi_match_server:handle_input(MatchPid, PlayerId, InputData),
-                    {ok, State}
+            case match_input_data(Payload) of
+                invalid ->
+                    Cid = maps:get(~"cid", Msg, undefined),
+                    {reply, {text, encode_error(Cid, ~"invalid_payload")}, State};
+                Extracted ->
+                    InputData = input_data(Extracted),
+                    match_input_route(SState, PlayerId, InputData, State)
             end
     catch
         exit:{noproc, _} ->
@@ -868,9 +897,15 @@ handle_message(
                 undefined ->
                     {ok, State};
                 ZonePid ->
-                    InputData = world_input_data(Payload),
-                    asobi_zone:player_input(ZonePid, PlayerId, InputData, Seq),
-                    {ok, State}
+                    case world_input_data(Payload) of
+                        invalid ->
+                            Cid = maps:get(~"cid", Msg, undefined),
+                            {reply, {text, encode_error(Cid, ~"invalid_payload")}, State};
+                        Extracted ->
+                            InputData = input_data(Extracted),
+                            asobi_zone:player_input(ZonePid, PlayerId, InputData, Seq),
+                            {ok, State}
+                    end
             end
     catch
         exit:{noproc, _} ->

--- a/test/asobi_player_session_tests.erl
+++ b/test/asobi_player_session_tests.erl
@@ -1,0 +1,72 @@
+-module(asobi_player_session_tests).
+
+-include_lib("eunit/include/eunit.hrl").
+
+%% asobi#477: world.ack must be monotonic per connection.
+%%
+%% The seq is the client's own counter, but the server records the high-water
+%% mark per zone, and a crossing player stays subscribed to the zone they left
+%% whenever it stays in their interest ring. That zone keeps emitting its own
+%% mark, so without a filter here the client sees seq go backwards and a
+%% prune-and-replay reconciler re-applies input the server already consumed.
+%%
+%% handle_info/2 is a plain function over a state map, so these drive it
+%% directly rather than standing up a session process.
+
+state() ->
+    #{player_id => ~"p1", ws_pid => self(), last_ack_seq => -1}.
+
+recv() ->
+    receive
+        {asobi_message, {world_ack, _Tick, Seq}} -> Seq
+    after 0 -> no_ack
+    end.
+
+an_advancing_ack_is_forwarded_and_recorded_test() ->
+    {noreply, S1} = asobi_player_session:handle_info(
+        {asobi_message, {world_ack, 1, 412}}, state()
+    ),
+    ?assertEqual(412, recv()),
+    ?assertEqual(412, maps:get(last_ack_seq, S1)).
+
+a_stale_ack_from_the_zone_left_behind_is_dropped_test() ->
+    %% The crossing: the new zone acks 500, then the old zone emits its frozen
+    %% 413 on the same broadcast tick. Only the first reaches the client.
+    {noreply, S1} = asobi_player_session:handle_info(
+        {asobi_message, {world_ack, 9, 500}}, state()
+    ),
+    ?assertEqual(500, recv()),
+    {noreply, S2} = asobi_player_session:handle_info(
+        {asobi_message, {world_ack, 9, 413}}, S1
+    ),
+    ?assertEqual(no_ack, recv()),
+    ?assertEqual(500, maps:get(last_ack_seq, S2)).
+
+a_repeated_ack_is_dropped_test() ->
+    %% A zone re-emits its unchanged mark every broadcast tick while the player
+    %% sends nothing. Forwarding those is pure noise on the socket.
+    {noreply, S1} = asobi_player_session:handle_info(
+        {asobi_message, {world_ack, 1, 77}}, state()
+    ),
+    ?assertEqual(77, recv()),
+    {noreply, _S2} = asobi_player_session:handle_info(
+        {asobi_message, {world_ack, 2, 77}}, S1
+    ),
+    ?assertEqual(no_ack, recv()).
+
+seq_zero_is_a_real_value_test() ->
+    %% last_ack_seq starts at -1 precisely so that seq 0 advances it.
+    {noreply, S1} = asobi_player_session:handle_info(
+        {asobi_message, {world_ack, 1, 0}}, state()
+    ),
+    ?assertEqual(0, recv()),
+    ?assertEqual(0, maps:get(last_ack_seq, S1)).
+
+other_messages_still_pass_through_test() ->
+    {noreply, _} = asobi_player_session:handle_info(
+        {asobi_message, {world_tick, 1}}, state()
+    ),
+    receive
+        {asobi_message, {world_tick, 1}} -> ok
+    after 0 -> ?assert(false, "world_tick was swallowed by the ack filter")
+    end.

--- a/test/asobi_ws_handler_tests.erl
+++ b/test/asobi_ws_handler_tests.erl
@@ -375,28 +375,56 @@ await_no_unhandled() ->
     end.
 
 %% asobi#478: `data` is not a general escape hatch on a world.input payload.
-%% The guide promises the payload IS the input map; these pin the three shapes
-%% that promise turns on.
+%% The guide promises the payload IS the input map; these pin the shapes that
+%% promise turns on, and the deprecated compat carve-out that survives it.
 
 world_input_data_forwards_the_payload_verbatim_test() ->
     Payload = #{~"kind" => ~"move", ~"x" => 600, ~"y" => 480},
-    ?assertEqual(Payload, asobi_ws_handler:world_input_data(Payload)).
+    ?assertEqual({ok, Payload}, asobi_ws_handler:world_input_data(Payload)).
 
 world_input_data_unwraps_a_sole_data_map_test() ->
-    %% asobi-unreal's shape: {"data": {...}} and nothing else.
+    %% asobi-unreal's shape: {"data": {...}} and nothing else. Deprecated.
     Inner = #{~"kind" => ~"move", ~"x" => 1},
-    ?assertEqual(Inner, asobi_ws_handler:world_input_data(#{~"data" => Inner})).
+    ?assertEqual({legacy_unwrap, Inner}, asobi_ws_handler:world_input_data(#{~"data" => Inner})).
 
 world_input_data_keeps_siblings_of_a_data_key_test() ->
     %% Was: unwrapped to the inner map, silently dropping `kind`.
     Payload = #{~"kind" => ~"fire", ~"data" => #{~"x" => 1}},
-    ?assertEqual(Payload, asobi_ws_handler:world_input_data(Payload)).
+    ?assertEqual({ok, Payload}, asobi_ws_handler:world_input_data(Payload)).
 
 world_input_data_keeps_a_non_map_data_value_test() ->
-    %% Was: #{} - the whole input discarded. This is the asobi-unity case.
+    %% Was: #{} - the whole input discarded.
     Payload = #{~"data" => ~"{\"kind\":\"move\"}"},
-    ?assertEqual(Payload, asobi_ws_handler:world_input_data(Payload)).
+    ?assertEqual({ok, Payload}, asobi_ws_handler:world_input_data(Payload)).
 
-world_input_data_on_a_non_map_payload_is_empty_test() ->
-    ?assertEqual(#{}, asobi_ws_handler:world_input_data(~"not a map")),
-    ?assertEqual(#{}, asobi_ws_handler:world_input_data([1, 2, 3])).
+world_input_data_on_a_non_map_payload_is_invalid_test() ->
+    %% Not #{}: an empty map is indistinguishable from a legitimate empty input,
+    %% so the client would be told nothing about a frame it got wrong.
+    ?assertEqual(invalid, asobi_ws_handler:world_input_data(~"not a map")),
+    ?assertEqual(invalid, asobi_ws_handler:world_input_data([1, 2, 3])).
+
+%% match.input carries world.input's shapes plus a sole `data` holding a JSON
+%% string. The decode must be total: json:decode/1 raises, and an authenticated
+%% client can send 60 frames a second.
+
+match_input_data_decodes_a_sole_data_string_test() ->
+    ?assertEqual(
+        {legacy_unwrap, #{~"kind" => ~"move"}},
+        asobi_ws_handler:match_input_data(#{~"data" => ~"{\"kind\":\"move\"}"})
+    ).
+
+match_input_data_on_malformed_json_is_invalid_not_a_crash_test() ->
+    %% asobi#465 class: reaching safe_handle_message/2's catch-all would log a
+    %% stacktrace per frame, and the logger burst budget is node-wide.
+    ?assertEqual(invalid, asobi_ws_handler:match_input_data(#{~"data" => ~"{not json"})),
+    ?assertEqual(invalid, asobi_ws_handler:match_input_data(#{~"data" => ~""})),
+    ?assertEqual(invalid, asobi_ws_handler:match_input_data(#{~"data" => ~"\xff\xfe"})).
+
+match_input_data_on_a_non_object_json_string_is_invalid_test() ->
+    ?assertEqual(invalid, asobi_ws_handler:match_input_data(#{~"data" => ~"[1,2,3]"})),
+    ?assertEqual(invalid, asobi_ws_handler:match_input_data(#{~"data" => ~"null"})).
+
+match_input_data_falls_back_to_the_world_shapes_test() ->
+    Payload = #{~"kind" => ~"fire"},
+    ?assertEqual({ok, Payload}, asobi_ws_handler:match_input_data(Payload)),
+    ?assertEqual(invalid, asobi_ws_handler:match_input_data(~"nope")).

--- a/test/asobi_ws_handler_tests.erl
+++ b/test/asobi_ws_handler_tests.erl
@@ -373,3 +373,30 @@ await_no_unhandled() ->
     after 200 ->
         no_log
     end.
+
+%% asobi#478: `data` is not a general escape hatch on a world.input payload.
+%% The guide promises the payload IS the input map; these pin the three shapes
+%% that promise turns on.
+
+world_input_data_forwards_the_payload_verbatim_test() ->
+    Payload = #{~"kind" => ~"move", ~"x" => 600, ~"y" => 480},
+    ?assertEqual(Payload, asobi_ws_handler:world_input_data(Payload)).
+
+world_input_data_unwraps_a_sole_data_map_test() ->
+    %% asobi-unreal's shape: {"data": {...}} and nothing else.
+    Inner = #{~"kind" => ~"move", ~"x" => 1},
+    ?assertEqual(Inner, asobi_ws_handler:world_input_data(#{~"data" => Inner})).
+
+world_input_data_keeps_siblings_of_a_data_key_test() ->
+    %% Was: unwrapped to the inner map, silently dropping `kind`.
+    Payload = #{~"kind" => ~"fire", ~"data" => #{~"x" => 1}},
+    ?assertEqual(Payload, asobi_ws_handler:world_input_data(Payload)).
+
+world_input_data_keeps_a_non_map_data_value_test() ->
+    %% Was: #{} - the whole input discarded. This is the asobi-unity case.
+    Payload = #{~"data" => ~"{\"kind\":\"move\"}"},
+    ?assertEqual(Payload, asobi_ws_handler:world_input_data(Payload)).
+
+world_input_data_on_a_non_map_payload_is_empty_test() ->
+    ?assertEqual(#{}, asobi_ws_handler:world_input_data(~"not a map")),
+    ?assertEqual(#{}, asobi_ws_handler:world_input_data([1, 2, 3])).

--- a/test/asobi_zone_tests.erl
+++ b/test/asobi_zone_tests.erl
@@ -53,6 +53,10 @@ zone_test_() ->
         {"world.ack keeps the highest seq (#474)", fun world_ack_keeps_highest_seq/0},
         {"world.ack is per-connection - p1's ack never reaches p2 (#474)",
             fun world_ack_is_per_connection/0},
+        {"removing a player's entity stops that zone acking them (#477)",
+            fun world_ack_stops_when_entity_leaves_the_zone/0},
+        {"removing an entity leaves other players' acks alone (#477)",
+            fun world_ack_entity_removal_is_scoped_to_that_player/0},
         {"a negative seq is ignored - no ack (#474 hardening)",
             fun world_ack_ignores_negative_seq/0},
         {"a non-integer seq via player_input/4 does not crash the zone (#474 hardening)",
@@ -286,6 +290,47 @@ p2_ack_forwarder(Parent) ->
         {asobi_message, {world_ack, _T, S}} -> Parent ! {p2_saw_ack, S};
         _ -> p2_ack_forwarder(Parent)
     end.
+
+%% asobi#477: a crossing player stays subscribed to the zone they left whenever
+%% it remains inside their interest ring, which at the default view_radius of 1
+%% is every one-step crossing. Without dropping the ack on remove_entity the old
+%% zone kept acking a frozen seq while the new zone advanced, so the client saw
+%% world.ack go backwards and a naive prune-and-replay re-applied consumed input.
+world_ack_stops_when_entity_leaves_the_zone() ->
+    Pid = start_zone(#{broadcast_interval => 1}),
+    asobi_zone:subscribe(Pid, {~"p1", self()}),
+    asobi_zone:add_entity(Pid, ~"p1", #{x => 0, y => 0, type => ~"player"}),
+    timer:sleep(10),
+    flush_messages(),
+    asobi_zone:player_input(Pid, ~"p1", #{~"action" => ~"move", ~"x" => 5, ~"y" => 5}, 412),
+    asobi_zone:tick(Pid, 1),
+    ?assertEqual(412, recv_ack()),
+    %% The crossing: the entity moves on, the subscription stays.
+    asobi_zone:remove_entity(Pid, ~"p1"),
+    timer:sleep(10),
+    flush_messages(),
+    asobi_zone:tick(Pid, 2),
+    ?assertEqual(no_ack, recv_ack()),
+    ?assert(asobi_zone:get_subscriber_count(Pid) > 0),
+    gen_server:stop(Pid).
+
+%% Removing one entity must not disturb anyone else's ack.
+world_ack_entity_removal_is_scoped_to_that_player() ->
+    Pid = start_zone(#{broadcast_interval => 1}),
+    asobi_zone:subscribe(Pid, {~"p1", self()}),
+    asobi_zone:add_entity(Pid, ~"p1", #{x => 0, y => 0, type => ~"player"}),
+    asobi_zone:add_entity(Pid, ~"p2", #{x => 1, y => 1, type => ~"player"}),
+    timer:sleep(10),
+    flush_messages(),
+    asobi_zone:player_input(Pid, ~"p1", #{~"action" => ~"move", ~"x" => 5, ~"y" => 5}, 77),
+    asobi_zone:tick(Pid, 1),
+    ?assertEqual(77, recv_ack()),
+    asobi_zone:remove_entity(Pid, ~"p2"),
+    timer:sleep(10),
+    flush_messages(),
+    asobi_zone:tick(Pid, 2),
+    ?assertEqual(77, recv_ack()),
+    gen_server:stop(Pid).
 
 %% asobi#474 hardening: record_ack is total and rejects negatives, so a
 %% spec-violating seq reaching the exported player_input/4 neither acks nor

--- a/test/asobi_zone_tests.erl
+++ b/test/asobi_zone_tests.erl
@@ -53,10 +53,8 @@ zone_test_() ->
         {"world.ack keeps the highest seq (#474)", fun world_ack_keeps_highest_seq/0},
         {"world.ack is per-connection - p1's ack never reaches p2 (#474)",
             fun world_ack_is_per_connection/0},
-        {"removing a player's entity stops that zone acking them (#477)",
-            fun world_ack_stops_when_entity_leaves_the_zone/0},
-        {"removing an entity leaves other players' acks alone (#477)",
-            fun world_ack_entity_removal_is_scoped_to_that_player/0},
+        {"a straggler input re-arms the zone's ack after the entity left (#477)",
+            fun world_ack_rearms_in_the_zone_left_behind/0},
         {"a negative seq is ignored - no ack (#474 hardening)",
             fun world_ack_ignores_negative_seq/0},
         {"a non-integer seq via player_input/4 does not crash the zone (#474 hardening)",
@@ -291,12 +289,15 @@ p2_ack_forwarder(Parent) ->
         _ -> p2_ack_forwarder(Parent)
     end.
 
-%% asobi#477: a crossing player stays subscribed to the zone they left whenever
-%% it remains inside their interest ring, which at the default view_radius of 1
-%% is every one-step crossing. Without dropping the ack on remove_entity the old
-%% zone kept acking a frozen seq while the new zone advanced, so the client saw
-%% world.ack go backwards and a naive prune-and-replay re-applied consumed input.
-world_ack_stops_when_entity_leaves_the_zone() ->
+%% asobi#477: this pins the zone-side behaviour the session-side filter exists to
+%% correct. A crossing player stays subscribed to the zone they left whenever it
+%% remains in their interest ring, and input still routed there during the
+%% crossing re-arms the ack, so the zone goes on emitting a mark that the zone
+%% they moved into has already passed. The zone cannot know that on its own -
+%% only the connection sees both streams - which is why asobi_player_session
+%% drops any ack that does not advance. If this test ever starts reporting
+%% no_ack, the zone has grown a guard and the session filter may be redundant.
+world_ack_rearms_in_the_zone_left_behind() ->
     Pid = start_zone(#{broadcast_interval => 1}),
     asobi_zone:subscribe(Pid, {~"p1", self()}),
     asobi_zone:add_entity(Pid, ~"p1", #{x => 0, y => 0, type => ~"player"}),
@@ -305,31 +306,14 @@ world_ack_stops_when_entity_leaves_the_zone() ->
     asobi_zone:player_input(Pid, ~"p1", #{~"action" => ~"move", ~"x" => 5, ~"y" => 5}, 412),
     asobi_zone:tick(Pid, 1),
     ?assertEqual(412, recv_ack()),
-    %% The crossing: the entity moves on, the subscription stays.
+    %% The straggler: cast before the crossing lands, drained on the next tick.
+    asobi_zone:player_input(Pid, ~"p1", #{~"action" => ~"move", ~"x" => 6, ~"y" => 6}, 413),
     asobi_zone:remove_entity(Pid, ~"p1"),
-    timer:sleep(10),
     flush_messages(),
     asobi_zone:tick(Pid, 2),
-    ?assertEqual(no_ack, recv_ack()),
-    ?assert(asobi_zone:get_subscriber_count(Pid) > 0),
-    gen_server:stop(Pid).
-
-%% Removing one entity must not disturb anyone else's ack.
-world_ack_entity_removal_is_scoped_to_that_player() ->
-    Pid = start_zone(#{broadcast_interval => 1}),
-    asobi_zone:subscribe(Pid, {~"p1", self()}),
-    asobi_zone:add_entity(Pid, ~"p1", #{x => 0, y => 0, type => ~"player"}),
-    asobi_zone:add_entity(Pid, ~"p2", #{x => 1, y => 1, type => ~"player"}),
-    timer:sleep(10),
-    flush_messages(),
-    asobi_zone:player_input(Pid, ~"p1", #{~"action" => ~"move", ~"x" => 5, ~"y" => 5}, 77),
-    asobi_zone:tick(Pid, 1),
-    ?assertEqual(77, recv_ack()),
-    asobi_zone:remove_entity(Pid, ~"p2"),
-    timer:sleep(10),
-    flush_messages(),
-    asobi_zone:tick(Pid, 2),
-    ?assertEqual(77, recv_ack()),
+    ?assertEqual(413, recv_ack()),
+    asobi_zone:tick(Pid, 3),
+    ?assertEqual(413, recv_ack()),
     gen_server:stop(Pid).
 
 %% asobi#474 hardening: record_ack is total and rejects negatives, so a


### PR DESCRIPTION
Closes #477. Closes #478.

Both found while documenting client-side prediction across the seven SDKs, and both are the same
shape: the handler does something `guides/websocket-protocol.md` does not describe.

**Reworked after review.** The first commit's approach to #477 did not work; architecture, security
and code review all independently reproduced it. Second commit fixes it properly. Both commits are
kept so the review thread still reads.

## #477 - `world.ack` was not monotonic

`player_ack` is per-zone state (`asobi_zone.erl:220`) and a player is subscribed to their whole
interest ring, so at `view_radius` 1 a one-step crossing leaves them subscribed to the zone behind
them. That zone kept emitting its own frozen mark while the destination advanced, so `payload.seq`
went **backwards** and the prune-and-replay recipe the guide teaches re-applied consumed input.

**What did not work.** Dropping the entry in `remove_entity`. `record_ack/3` runs unconditionally in
`apply_inputs/4`, so any input still queued for the departed zone re-creates it, and the tick prune
keeps it because the player is still subscribed. Reviewers reproduced the original symptom on the
branch in both orderings. The window is the common case: `remove_entity` is cast at
`asobi_world_server.erl:1209` but `world_zone_changed` only at `:1243`, and the session rebind is
async, so input routed to the old zone mid-crossing is expected - and only prediction clients receive
acks at all, which means they are sending every frame.

**What also would not have worked.** Guarding `broadcast_acks` on `is_map_key(PlayerId, Entities)`.
A player whose entity was removed by game logic - dead, awaiting respawn - is still connected and
still sending input, and would receive no acks at all while their prediction buffer grew.

**The fix.** `asobi_player_session` holds `last_ack_seq` and drops any `world.ack` that does not
advance it. The session is per WebSocket and dies with it, so the mark resets exactly when the
client's counter does. That holds whichever zone emits the frame and regardless of cast ordering.
The zone keeps recording, because only the zone knows the tick-to-state binding; only the
monotonicity claim moved.

`world.ack` is therefore monotonic per connection, the guide now says so, and **the seven SDKs can
drop the running-maximum workaround** they currently document. That follow-up is not in this PR.

## #478 - `data` was a reserved key on `world.input`

| payload | before | after |
|---|---|---|
| `{"kind":"move","x":600}` | verbatim | verbatim |
| `{"data":{"x":1}}` | `#{x}` | `#{x}`, deprecated + counted |
| `{"kind":"fire","data":{"x":1}}` | `#{x}`, `kind` **dropped** | verbatim |
| `{"kind":"fire","data":"blob"}` | `#{}`, **all dropped** | verbatim |
| `"not an object"` | `invalid_payload` (via badmap) | `invalid_payload` (explicit) |

That fourth row is why asobi-unity sent world input into a void. Note the fix for Unity is
widgrensit/asobi-unity#46, not this - here that shape now arrives as `#{~"data" => ~"..."}`, which is
merely honest rather than useful.

Review turned up two more:

- **A silent drop I introduced.** The first commit turned a non-map payload into `#{}`, which a game
  cannot distinguish from legitimate empty input, and told the client nothing. `world_input_data/1`
  now returns `{ok, _} | {legacy_unwrap, _} | invalid` and the caller answers `invalid_payload`.
- **A Medium in the sibling path.** `match.input`'s `json:decode` of a binary `data` was unguarded.
  `json:decode/1` raises, landing in `safe_handle_message/2`'s catch-all, which logs a stacktrace. At
  60 frames/sec/connection and 60 connects/sec/IP, roughly 9 sockets exhaust the logger's burst
  budget and blind every other log line on the node, auth failures included. Same class asobi#465
  closed for `badmap`. `match_input_data/1` makes it total, and gives `match.input` the same contract.

The sole-key unwrap is reported as `[asobi, ws, legacy_input_unwrap]` and documented as deprecated
with a removal condition, so it can be retired against real traffic rather than frozen into the spec
by being written down.

## Checks

`fmt`, `xref`, `dialyzer` (exit 0), `eunit` **1959 tests, 0 failures**. `elp eqwalize` on all four
changed modules is identical to main (`asobi_ws_handler` 2, `asobi_zone` 2, `asobi_player_session` 0,
`asobi_telemetry` 1). The telemetry coverage test caught the new event missing from the attach list,
which is the check working.

**Mutation-verified.** Removing the session filter fails 4 of the 5 new session tests; the survivor
is the pass-through test, correctly. `world_ack_rearms_in_the_zone_left_behind` pins the zone-side
behaviour the filter exists to correct, so if a future guard lands in the zone that test says so.
