### PR TITLE
fix: refuse a match mode on world.create, and rate-limit both create frames

### DIFF
--- a/src/asobi_game_modes.erl
+++ b/src/asobi_game_modes.erl
@@ -99,10 +99,30 @@ lua_provider(Kind, Script) ->
             {error, lua_runtime_unavailable}
     end.
 
--doc "Build a world server config map from a mode's game_modes config.".
--spec world_config(binary()) -> {ok, map()} | {error, not_found | lua_runtime_unavailable}.
+-doc """
+Build a world server config map from a mode's game_modes config.
+
+`{error, wrong_mode_type}` means the mode exists but is a match mode. Only
+`resolve_game_module/1`'s first clause dispatches on `type`, so without this
+guard a match mode resolves to `asobi_lua_match` and a world is built around
+it - six processes come up and then the first join or tick raises `undef`,
+because `asobi_lua_match` exports neither `spawn_position/2` nor `post_tick/2`.
+A mode with no `type` is a match, which is the default, so the common way to
+hit this is forgetting `game_type = "world"` in a Lua config.
+""".
+-spec world_config(binary()) ->
+    {ok, map()} | {error, not_found | wrong_mode_type | lua_runtime_unavailable}.
 world_config(Mode) ->
     ModeConfig = mode_config(Mode),
+    case maps:get(type, ModeConfig, match) of
+        world -> world_config_1(Mode, ModeConfig);
+        _ when map_size(ModeConfig) =:= 0 -> {error, not_found};
+        _ -> {error, wrong_mode_type}
+    end.
+
+-spec world_config_1(binary(), map()) ->
+    {ok, map()} | {error, not_found | lua_runtime_unavailable}.
+world_config_1(Mode, ModeConfig) ->
     case resolve_game_module(Mode) of
         {ok, GameMod, ExtraConfig} ->
             Base = #{

--- a/src/ws/asobi_ws_handler.erl
+++ b/src/ws/asobi_ws_handler.erl
@@ -820,24 +820,42 @@ handle_message(
     #{player_id := PlayerId} = State
 ) ->
     Cid = maps:get(~"cid", Msg, undefined),
-    case asobi_world_lobby:create_world(Mode, PlayerId) of
-        {ok, WorldPid, _Info} ->
-            join_and_reply(Cid, WorldPid, PlayerId, State);
-        {error, Reason} ->
-            Reply = encode_error(Cid, Reason),
-            {reply, {text, Reply}, State}
+    %% asobi#480: both create frames spawn or resolve an instance and were the
+    %% only entry points not behind the join limiter, even though world.join
+    %% and match.join are. The pg caps bound how many worlds one player can
+    %% OWN, not how often they may ask.
+    case check_join_rate(PlayerId) of
+        denied ->
+            {reply, {text, encode_error(Cid, ~"join_rate_limited")}, State};
+        allowed ->
+            case asobi_world_lobby:create_world(Mode, PlayerId) of
+                {ok, WorldPid, _Info} ->
+                    join_and_reply(Cid, WorldPid, PlayerId, State);
+                {error, Reason} ->
+                    Reply = encode_error(Cid, Reason),
+                    {reply, {text, Reply}, State}
+            end
     end;
 handle_message(
     #{~"type" := ~"world.find_or_create", ~"payload" := #{~"mode" := Mode}} = Msg,
     #{player_id := PlayerId} = State
 ) ->
     Cid = maps:get(~"cid", Msg, undefined),
-    case asobi_world_lobby:find_or_create(Mode, PlayerId) of
-        {ok, WorldPid, _Info} ->
-            join_and_reply(Cid, WorldPid, PlayerId, State);
-        {error, Reason} ->
-            Reply = encode_error(Cid, Reason),
-            {reply, {text, Reply}, State}
+    %% asobi#480: the find branch consumes no pg cap at all - it returns an
+    %% existing world - so before this nothing bounded how often one connection
+    %% could drive a gen_server:call into the single lobby server, each one
+    %% fanning an uncached get_info out to every live world.
+    case check_join_rate(PlayerId) of
+        denied ->
+            {reply, {text, encode_error(Cid, ~"join_rate_limited")}, State};
+        allowed ->
+            case asobi_world_lobby:find_or_create(Mode, PlayerId) of
+                {ok, WorldPid, _Info} ->
+                    join_and_reply(Cid, WorldPid, PlayerId, State);
+                {error, Reason} ->
+                    Reply = encode_error(Cid, Reason),
+                    {reply, {text, Reply}, State}
+            end
     end;
 handle_message(
     #{~"type" := ~"world.join", ~"payload" := #{~"world_id" := WorldId}} = Msg,

--- a/test/asobi_game_modes_tests.erl
+++ b/test/asobi_game_modes_tests.erl
@@ -9,7 +9,11 @@ world_config_test_() ->
     {setup, fun setup/0, fun cleanup/1, [
         {"chat config reaches the world server config", fun chat_forwarded/0},
         {"a mode without chat config forwards no chat key", fun chat_absent/0},
-        {"declared global channel names are the union across modes", fun global_union/0}
+        {"declared global channel names are the union across modes", fun global_union/0},
+        {"a match mode is refused, not built into a world (#480)", fun match_mode_refused/0},
+        {"a mode with no type is a match, so it is refused too (#480)", fun untyped_mode_refused/0},
+        {"an unknown mode is still not_found, not wrong_mode_type (#480)",
+            fun unknown_mode_still_not_found/0}
     ]}.
 
 setup() ->
@@ -21,7 +25,9 @@ setup() ->
             chat => #{global => [~"general"], world => true}
         },
         ~"arena" => #{type => world, module => some_game, chat => #{global => [~"trade"]}},
-        ~"quiet" => #{type => world, module => some_game}
+        ~"quiet" => #{type => world, module => some_game},
+        ~"duel" => #{type => match, module => some_game},
+        ~"untyped" => #{module => some_game}
     }),
     Prev.
 
@@ -117,3 +123,21 @@ erlang_module_unaffected() ->
 
 world_config_without_provider() ->
     ?assertEqual({error, lua_runtime_unavailable}, asobi_game_modes:world_config(~"galaxy")).
+
+%% asobi#480: resolve_game_module/1 dispatches on `type` in its FIRST clause
+%% only, so a match mode fell through to asobi_lua_match and world_config/1
+%% built a world config around it. asobi_world_instance_sup then brought up six
+%% processes and the first join raised undef on spawn_position/2. Refuse it up
+%% front instead.
+match_mode_refused() ->
+    ?assertEqual({error, wrong_mode_type}, asobi_game_modes:world_config(~"duel")).
+
+%% `match` is the default, so the common way in is forgetting game_type.
+untyped_mode_refused() ->
+    ?assertEqual({error, wrong_mode_type}, asobi_game_modes:world_config(~"untyped")).
+
+%% The new clause must not swallow the pre-existing not_found case: a mode that
+%% is not configured at all is still not_found, so a client asking for a typo'd
+%% mode gets the same answer it always did.
+unknown_mode_still_not_found() ->
+    ?assertEqual({error, not_found}, asobi_game_modes:world_config(~"no_such_mode")).

--- a/test/asobi_world_lobby_ws_SUITE.erl
+++ b/test/asobi_world_lobby_ws_SUITE.erl
@@ -21,7 +21,8 @@ identity returned to the client.
     join_rejects_when_player_already_in_other_world/1,
     observer_sees_movers_input_via_world_tick/1,
     world_tick_diff_is_partial/1,
-    move_burst_collapses_to_latest_in_each_broadcast/1
+    move_burst_collapses_to_latest_in_each_broadcast/1,
+    find_or_create_is_join_rate_limited/1
 ]).
 
 -define(MODE_HUB, ~"test_ws_hub").
@@ -38,7 +39,8 @@ all() ->
         join_rejects_when_player_already_in_other_world,
         observer_sees_movers_input_via_world_tick,
         world_tick_diff_is_partial,
-        move_burst_collapses_to_latest_in_each_broadcast
+        move_burst_collapses_to_latest_in_each_broadcast,
+        find_or_create_is_join_rate_limited
     ].
 
 init_per_suite(Config) ->
@@ -470,3 +472,41 @@ cleanup_worlds() ->
             timer:sleep(20),
             ok
     end.
+
+%% asobi#480: world.create and world.find_or_create were the only instance-entry
+%% frames not behind the join limiter, even though world.join and match.join
+%% both are. The pg caps do not cover it: the FIND branch returns an existing
+%% world and consumes no cap at all, so nothing bounded how often one connection
+%% could drive a gen_server:call into the single lobby server, each fanning an
+%% uncached get_info out to every live world.
+%%
+%% The default bucket is 10 per 60s (asobi_sup). The 11th call must be refused.
+find_or_create_is_join_rate_limited(Config) ->
+    {_P, Tok} = register_player(~"rl1", Config),
+    Conn = ws_connect_authed(Tok, Config),
+    %% Ten reuse the same world and consume the bucket.
+    _ = [
+        ws_find_or_create(?MODE_HUB, integer_to_binary(N), Conn)
+     || N <- lists:seq(1, 10)
+    ],
+    ok = nova_test_ws:send_json(
+        #{
+            ~"type" => ~"world.find_or_create",
+            ~"cid" => ~"rl-over",
+            ~"payload" => #{~"mode" => ?MODE_HUB}
+        },
+        Conn
+    ),
+    {ok, Err} = recv_until(
+        fun(M) -> maps:get(~"cid", M, undefined) =:= ~"rl-over" end,
+        Conn
+    ),
+    nova_test_ws:close(Conn),
+    ?assertEqual(
+        ~"error",
+        maps:get(~"type", Err, undefined),
+        "an unrated find_or_create lets one connection saturate the lobby server"
+    ),
+    ?assertEqual(
+        ~"join_rate_limited", maps:get(~"reason", maps:get(~"payload", Err, #{}), undefined)
+    ).


### PR DESCRIPTION
First of three, from the architecture review of why matches have no client-facing create. Independent of that design question - both defects are true today.

## A match mode builds a world, then crashes

`resolve_game_module/1` dispatches on `type` in its **first clause only**. A match mode misses it, falls through to `asobi_lua_match`, and `world_config/1` builds a world config around it without ever inspecting `type` - the only two type-dispatching sites in `src/` are that clause and `asobi_matchmaker:spawn_matches/2`, and the client-facing world path is the unguarded one.

`asobi_world_instance_sup:start_world/1` then brings up six processes, and the first join raises `undef` on `spawn_position/2` - `asobi_lua_match` exports neither that nor `post_tick/2`, both of which `asobi_world_server` calls bare at `:767` and `:343` (it wraps the *optional* callbacks in `function_exported/3`, but not the mandatory ones).

No `wrong_mode_type` error existed anywhere. And `match` is the default type, so the ordinary way in is forgetting `game_type = \"world\"` in a Lua config: a Lua-authored typo answered with an obscure crash and six orphaned processes. Now refused up front. An unconfigured mode is still `not_found`, which the third new test pins.

## Neither create frame was rate-limited

`check_join_rate/1` guards `match.join` (`:650`) and `world.join` (`:852`) and neither `world.create` nor `world.find_or_create`.

The pg caps are not a substitute. They bound how many worlds a player may **own**, and `find_or_create`'s *find* branch returns an existing world and consumes no cap at all - so on any mode where a world already exists the path was completely unbounded. It is a `gen_server:call` into the single `asobi_world_lobby_server` (30s timeout, so every player queues behind every other), and inside it calls the **uncached** `list_worlds/1`, fanning a `get_info` out to every live world. The `world.list` handler at `:796` deliberately uses `list_worlds_cached/1` with a comment saying the cached variant exists so a flood "cannot stall every world's mailbox"; the strictly more expensive sibling was left open.

Severity is amplification, not an unbounded flood: `?WS_MSG_LIMIT` is 60/s per connection. But the join bucket is the control that belongs here.

## Deliberately not done

**Switching `do_find_or_create/2` to the cached listing.** It was suggested and it is unsafe. `list_worlds_cached/1` has a 500ms TTL and nothing invalidates it on create, so a stale **miss** would let two callers a moment apart both spawn - reintroducing the exact TOCTOU `asobi_world_lobby_server` exists to close, inside the serializer meant to close it. The `whereis` re-check only covers a stale *hit*. It also filters on `listed` where `do_find_or_create` filters on `quick_play`. Caching there needs invalidation-on-create first, which is its own change.

## Checks

`fmt`, `xref`, `dialyzer` (exit 0), `eunit` **1962 tests, 0 failures**, `asobi_world_lobby_ws_SUITE` 10/10. `elp eqwalize` identical to main on both changed modules (`asobi_game_modes` 1, `asobi_ws_handler` 2).

**Mutation-verified.** Removing the type guard fails 2 of the 3 new `asobi_game_modes_tests` (the `not_found` one correctly survives). Removing the limiter from `find_or_create` fails the new end-to-end CT case, which drives 10 real `world.find_or_create` frames over a socket and asserts the 11th comes back `join_rate_limited`.

Next: `min_players` reachable from config, then `match.find_or_create`.