### PR TITLE
feat: make min_players reachable from mode config

### DIFF
--- a/guides/lobbies.md
+++ b/guides/lobbies.md
@@ -25,17 +25,28 @@ A waiting match is the cheaper shape, but the row above that decides it is
 A match starts in the `waiting` state and transitions to `running` when
 `min_players` is reached. That waiting period is the lobby.
 
-**No client-facing call brings a waiting match into existence.**
-`asobi_match_sup:start_match/1` is the only thing that creates a match, and its
-only caller in the release is the matchmaker - which spawns a match with
-`min_players` already equal to the group it just formed, so the waiting state
-lasts as long as the join fan-out and no longer. There is no `match.create`
+**No client-facing call brings a match into existence.** The matchmaker is the
+only creator: it groups co-queued tickets and spawns. There is no `match.create`
 frame and no `POST /api/v1/matches`.
 
-So the waiting-match lobby is an **Erlang-only** route: it needs a module in
-your release that calls `asobi_match_sup:start_match/1` with a `min_players`
-higher than the number of players it seeds, and `listed => true` so clients can
-find it.
+But the waiting state is reachable from mode config. Declare a `min_players`
+higher than `match_size` and the matchmaker spawns on the group it formed while
+the match sits in `waiting` until backfill brings it up to the threshold:
+
+```lua
+match_size  = 2   -- the matchmaker forms and spawns on two
+min_players = 4   -- the loop does not start until four are in
+max_players = 8
+listed      = true
+```
+
+It gives up at `?WAITING_TIMEOUT` (60s) if the fourth never arrives.
+
+Before asobi v0.85.0 the matchmaker overwrote `min_players` with `match_size`,
+so declaring it was silently ignored and this was an Erlang-only route through
+`asobi_match_sup:start_match/1`. That call is still available to an operator
+shipping their own module, and is still the only way to create a match outside
+the matchmaker.
 
 ```erlang
 {ok, Pid} = asobi_match_sup:start_match(#{

--- a/src/lua/asobi_lua_config.erl
+++ b/src/lua/asobi_lua_config.erl
@@ -28,6 +28,8 @@ configure via `sys.config` are unaffected).
 ```lua
 match_size     = 4                          -- required, positive integer
 max_players    = 10                         -- optional, defaults to match_size
+min_players    = 4                          -- optional, defaults to match_size; higher than
+                                            -- match_size spawns a match that waits for backfill
 strategy       = "fill"                     -- optional, "fill" | "skill_based"
 bots           = { script = "bots/ai.lua", min_players = 4 } -- optional; min_players defaults to match_size, enabled defaults to true
 game_type      = "world"                    -- optional, "match" (default) or "world"
@@ -312,6 +314,7 @@ load_match_config(ScriptPath) ->
 read_match_globals(ScriptPath, St) ->
     MatchSize = read_global_int(~"match_size", St),
     MaxPlayers = read_global_int(~"max_players", St),
+    MinPlayers = read_global_int(~"min_players", St),
     Strategy = read_global_string(~"strategy", St),
     Bots = read_global_table(~"bots", St),
     GameType = read_global_string(~"game_type", St),
@@ -363,7 +366,11 @@ read_match_globals(ScriptPath, St) ->
             Config14 = maybe_add_bool(Config13, listed, Listed),
             Config15 = maybe_add_bool(Config14, quick_play, QuickPlay),
             Config16 = maybe_add_int(Config15, broadcast_interval, BroadcastInterval),
-            {ok, Config16};
+            %% asobi#481: asobi_match_server has always read and honoured
+            %% min_players; nothing could set it. Omitted here it defaults to
+            %% match_size downstream, so declaring nothing changes nothing.
+            Config17 = maybe_add_int(Config16, min_players, MinPlayers),
+            {ok, Config17};
         _ ->
             {error, {ScriptPath, ~"match_size must be a positive integer"}}
     end.

--- a/src/matches/asobi_matchmaker.erl
+++ b/src/matches/asobi_matchmaker.erl
@@ -495,13 +495,20 @@ spawn_matches([Group | Rest], Failed) ->
 spawn_match(Mode, ModeConfig, PlayerIds, Group, Rest, Failed) ->
     MatchSize = maps:get(match_size, ModeConfig, length(PlayerIds)),
     MaxPlayers = maps:get(max_players, ModeConfig, MatchSize),
+    %% asobi#481: min_players was hardcoded to MatchSize here, so the field
+    %% asobi_match_server already reads and honours was reachable only by an
+    %% Erlang caller of asobi_match_sup:start_match/1 - a mode declaring it got
+    %% silence. Defaulting to MatchSize keeps every existing mode identical;
+    %% declaring it higher spawns a match that genuinely waits for backfill and
+    %% gives up at ?WAITING_TIMEOUT.
+    MinPlayers = maps:get(min_players, ModeConfig, MatchSize),
     case asobi_game_modes:resolve_game_module(Mode) of
         {ok, GameMod, ExtraConfig} ->
             Config = #{
                 mode => Mode,
                 game_module => GameMod,
                 game_config => ExtraConfig,
-                min_players => MatchSize,
+                min_players => MinPlayers,
                 max_players => MaxPlayers,
                 listed => maps:get(listed, ModeConfig, false)
             },

--- a/test/asobi_lua_config_tests.erl
+++ b/test/asobi_lua_config_tests.erl
@@ -74,6 +74,9 @@ config_test_() ->
             fun discovery_flags_forwarded/0},
         {"listed = true opts a match mode into the live-match browser",
             fun listed_match_global_forwarded/0},
+        {"min_players reaches the mode config (#481)", fun min_players_global_forwarded/0},
+        {"min_players absent leaves the key out so match_size still defaults it (#481)",
+            fun min_players_absent_keeps_match_size/0},
         {"absent listed/quick_play leave the per-kind defaults alone",
             fun discovery_flags_absent_keep_defaults/0},
         {"a non-boolean listed is ignored and warns rather than failing open",
@@ -726,6 +729,34 @@ discovery_flags_forwarded() ->
     {ok, WorldConfig} = asobi_game_modes:world_config(~"default"),
     ?assertEqual(false, maps:get(listed, WorldConfig)),
     ?assertEqual(false, maps:get(quick_play, WorldConfig)),
+    cleanup_temp_dir(TmpDir).
+
+min_players_global_forwarded() ->
+    %% asobi#481: asobi_match_server reads min_players at :219 and honours it in
+    %% maybe_start/2, but the matchmaker hardcoded it to match_size and the Lua
+    %% globals reader did not read it at all, so declaring it was silence.
+    TmpDir = make_temp_dir(),
+    {ok, Content} = file:read_file(fixture("config_min_players.lua")),
+    ok = file:write_file(filename:join(TmpDir, "match.lua"), Content),
+    application:set_env(asobi, game_dir, TmpDir),
+    ok = asobi_lua_config:maybe_load_game_config(),
+    Mode = maps:get(~"default", get_game_modes()),
+    ?assertEqual(4, maps:get(min_players, Mode)),
+    ?assertEqual(2, maps:get(match_size, Mode)),
+    cleanup_temp_dir(TmpDir).
+
+min_players_absent_keeps_match_size() ->
+    %% The compatibility case, and the reason the default lives downstream
+    %% rather than here: a script that never mentions min_players must produce
+    %% a mode map with no such key, so asobi_matchmaker keeps defaulting it to
+    %% match_size and no existing mode moves.
+    TmpDir = make_temp_dir(),
+    {ok, Content} = file:read_file(fixture("config_listed_match.lua")),
+    ok = file:write_file(filename:join(TmpDir, "match.lua"), Content),
+    application:set_env(asobi, game_dir, TmpDir),
+    ok = asobi_lua_config:maybe_load_game_config(),
+    Mode = maps:get(~"default", get_game_modes()),
+    ?assertNot(maps:is_key(min_players, Mode)),
     cleanup_temp_dir(TmpDir).
 
 listed_match_global_forwarded() ->

--- a/test/asobi_matchmaker_SUITE.erl
+++ b/test/asobi_matchmaker_SUITE.erl
@@ -13,6 +13,7 @@
     add_idempotent_same_player_mode/1,
     add_distinct_modes_new_ticket/1,
     add_distinct_players_new_ticket/1,
+    min_players_above_match_size_spawns_a_waiting_match/1,
     add_default_mode_idempotent/1,
     remove_then_readd_new_ticket/1,
     selfmatch_group_rejected/1,
@@ -45,7 +46,8 @@ all() ->
         expiry_emits_removed_telemetry,
         spawn_retry_bounded_then_gives_up,
         queue_snapshot_reports_waiting_by_mode,
-        queue_snapshot_never_waits_on_the_matchmaker
+        queue_snapshot_never_waits_on_the_matchmaker,
+        min_players_above_match_size_spawns_a_waiting_match
     ].
 
 init_per_suite(Config) ->
@@ -329,4 +331,54 @@ await_mode(Mode, Attempts) ->
         [] ->
             timer:sleep(200),
             await_mode(Mode, Attempts - 1)
+    end.
+
+%% asobi#481: the matchmaker hardcoded min_players => MatchSize, so a mode
+%% declaring a higher one was silently ignored and the match started the moment
+%% the group landed. With it plumbed, a mode can spawn on a group of two and
+%% genuinely wait for backfill to reach four before the loop runs. This drives
+%% the real matchmaker tick rather than calling start_match directly, because
+%% the overwrite was in the matchmaker and start_match always honoured it.
+min_players_above_match_size_spawns_a_waiting_match(Config) ->
+    Prev = application:get_env(asobi, game_modes),
+    application:set_env(asobi, game_modes, #{
+        ~"waitmode" => #{
+            module => asobi_test_game,
+            match_size => 2,
+            min_players => 4,
+            max_players => 8,
+            listed => true
+        }
+    }),
+    try
+        {ok, _, _} = asobi_matchmaker:add(~"wp1", #{mode => ~"waitmode"}),
+        {ok, _, _} = asobi_matchmaker:add(~"wp2", #{mode => ~"waitmode"}),
+        Match = wait_for_listed_match(~"waitmode", 40),
+        %% Two players landed but min_players is 4, so the loop must NOT be
+        %% running. Before the fix the matchmaker overwrote min_players with
+        %% match_size and this read `running`.
+        ?assertMatch(#{status := waiting, player_count := 2}, Match),
+        {ok, Pid} = asobi_match_server:whereis(maps:get(match_id, Match)),
+        ok = asobi_match_server:join(Pid, ~"wp3"),
+        ?assertMatch(#{status := waiting, player_count := 3}, asobi_match_server:get_info(Pid)),
+        %% The fourth clears the threshold.
+        ok = asobi_match_server:join(Pid, ~"wp4"),
+        ?assertMatch(#{status := running, player_count := 4}, asobi_match_server:get_info(Pid))
+    after
+        case Prev of
+            {ok, P} -> application:set_env(asobi, game_modes, P);
+            undefined -> application:unset_env(asobi, game_modes)
+        end
+    end,
+    Config.
+
+wait_for_listed_match(_Mode, 0) ->
+    ct:fail("matchmaker never spawned a match for the mode");
+wait_for_listed_match(Mode, N) ->
+    case [M || M <- asobi_match_lobby:list_matches(#{mode => Mode}), is_map(M)] of
+        [M | _] ->
+            M;
+        [] ->
+            timer:sleep(100),
+            wait_for_listed_match(Mode, N - 1)
     end.

--- a/test/fixtures/lua/config_min_players.lua
+++ b/test/fixtures/lua/config_min_players.lua
@@ -1,0 +1,15 @@
+-- asobi#481: a match that spawns with the matchmaker's group and then waits
+-- for backfill to reach min_players before the loop starts. min_players was
+-- honoured by asobi_match_server all along but reachable from no config
+-- surface, so declaring it here used to be silently ignored.
+match_size  = 2
+max_players = 8
+min_players = 4
+listed      = true
+
+function init(config) return {} end
+function join(player_id, state) return state end
+function leave(player_id, state) return state end
+function handle_input(player_id, input, state) return state end
+function tick(state) return state end
+function get_state(player_id, state) return state end


### PR DESCRIPTION
Second of three from the architecture review. Independent of the `match.find_or_create` design question.

## Not a new knob - an unwired one

`asobi_match_server` reads `min_players` at `:219` and honours it in `maybe_start/2` at `:744`. The state machine has always been complete. Nothing in the release could set it:

- `asobi_matchmaker:spawn_match/6` hardcoded `min_players => MatchSize`, overwriting whatever the mode declared.
- The Lua globals reader had no `min_players` (only `bots.min_players`, an unrelated knob).
- A `min_players` key in a sys.config `game_modes` entry is read nowhere in `src/` and was silently dropped.

So writing `min_players` in `match.lua` or in `game_modes` produced silence, and the only way to reach a fully-supported field was an Erlang caller of `asobi_match_sup:start_match/1` - which is precisely why `guides/lobbies.md` called the waiting-match lobby an "Erlang-only route".

## Two independent reasons

It closes a silent-ignore DX defect. And it makes `min_players > match_size` reachable: a match that spawns on the group the matchmaker formed and genuinely sits in `waiting` until backfill reaches the threshold, expiring at `?WAITING_TIMEOUT` (60s) if the rest never arrive.

```lua
match_size  = 2   -- the matchmaker forms and spawns on two
min_players = 4   -- the loop does not start until four are in
max_players = 8
listed      = true
```

That is the guide's Erlang snippet made Lua-reachable, and the guide now shows it instead of the Erlang one. The `start_match/1` route stays documented for operators shipping their own module, since it remains the only way to create a match outside the matchmaker.

## Nothing existing moves

The default stays `match_size`, and it is applied **downstream in the matchmaker** rather than baked in at config load - so a script that never mentions `min_players` still produces a mode map with no such key, and every existing mode behaves identically. One of the two new config tests pins exactly that.

## Checks

`fmt`, `xref`, `dialyzer` (exit 0), `eunit` **1964 tests, 0 failures**, `asobi_matchmaker_SUITE` 20/20. `elp eqwalize` identical to main on both changed modules (`asobi_matchmaker` 3, `asobi_lua_config` 1).

**Mutation-verified.** Restoring the `MatchSize` overwrite fails the new CT case, which drives the real matchmaker tick rather than calling `start_match/1` directly - the overwrite was in the matchmaker, and `start_match/1` always honoured the field. It asserts the match stays `waiting` at two and three players and flips to `running` on the fourth.

Next: `match.find_or_create`.
