### PR TITLE
feat: match.find_or_create, the race-free route into a live match

### DIFF
--- a/guides/configuration.md
+++ b/guides/configuration.md
@@ -159,7 +159,7 @@ Shorthand (Erlang module only):
 | `skill_expand_rate` | `50` | Window expansion per 5 seconds (`skill_based` only) |
 | `bots` | `#{}` | Bot configuration - see [Bots](lua-bots.md) |
 | `listed` | `false` for matches, `true` for worlds | Whether instances appear in discovery (`match.list` / `world.list`). Matches are unlisted by default: a matchmaker-spawned match is already assigned to its players, so opt in explicitly |
-| `quick_play` | `true` | Whether `world.find_or_create` may place a player into an existing world of this mode. Read on the world entry path for whatever mode name it is handed, so setting it `false` on a match mode is protective rather than inert. Independent of `listed` - see [World server](world-server.md#visibility) |
+| `quick_play` | `true` for worlds, **`false` for matches** | Whether `world.find_or_create` / `match.find_or_create` may place a player into an existing instance of this mode. Match modes default closed so a mode written before `match.find_or_create` existed is not exposed on upgrade. Independent of `listed` - see [World server](world-server.md#visibility) |
 
 ### Operator modes and game-declared modes
 
@@ -672,7 +672,7 @@ module:
 }}
 ```
 
-## World capacity
+## Instance capacity
 
 Bounds on persistent world creation, enforced as a DoS backstop:
 
@@ -684,6 +684,18 @@ Bounds on persistent world creation, enforced as a DoS backstop:
 A player at the per-player cap gets `429 world.player_limit_reached`; once the
 global cap is reached further creates get `503 world.capacity_reached`. The
 global cap is checked first.
+
+Matches have a node-wide cap of their own:
+
+```erlang
+{match_max, 1000}            %% default 1000
+```
+
+It bounds `match.find_or_create`, and answers `match_capacity_reached`. The
+matchmaker used to bound match creation implicitly - forming one took
+`match_size` queued tickets - and that bound disappears once a single player can
+create a match. There is no per-player match cap: matches carry no owner, unlike
+worlds.
 
 ## Join rate
 

--- a/guides/lobbies.md
+++ b/guides/lobbies.md
@@ -25,9 +25,27 @@ A waiting match is the cheaper shape, but the row above that decides it is
 A match starts in the `waiting` state and transitions to `running` when
 `min_players` is reached. That waiting period is the lobby.
 
-**No client-facing call brings a match into existence.** The matchmaker is the
-only creator: it groups co-queued tickets and spawns. There is no `match.create`
-frame and no `POST /api/v1/matches`.
+**`match.find_or_create` is the client-facing route into a live match.** Send a
+mode; the server returns the first listed match of that mode with room that is
+still accepting players, and spawns one if there is none. The reply is
+`match.joined`, the same frame `match.join` answers with.
+
+```json
+{"type": "match.find_or_create", "cid": "1", "payload": {"mode": "arena"}}
+```
+
+Only `listed` modes participate. Matches are unlisted by default, so a ranked
+mode the matchmaker owns is never absorbed into this - the opt-in is the flag
+you already set to appear in `match.list`.
+
+Prefer it over `match.list` then `match.join`. Browsing and then joining is two
+round trips with a race in the middle: two clients that both read an empty list
+both create, and you get two half-empty matches that may each fail to reach
+`min_players`. `find_or_create` resolves server-side, serialized, so
+simultaneous callers land in the same match.
+
+There is still no bare `match.create`, and no `POST /api/v1/matches`. Creating a
+match without reusing one is what the matchmaker is for.
 
 But the waiting state is reachable from mode config. Declare a `min_players`
 higher than `match_size` and the matchmaker spawns on the group it formed while

--- a/guides/lobbies.md
+++ b/guides/lobbies.md
@@ -34,9 +34,14 @@ still accepting players, and spawns one if there is none. The reply is
 {"type": "match.find_or_create", "cid": "1", "payload": {"mode": "arena"}}
 ```
 
-Only `listed` modes participate. Matches are unlisted by default, so a ranked
-mode the matchmaker owns is never absorbed into this - the opt-in is the flag
-you already set to appear in `match.list`.
+Opt in with `quick_play = true`. It defaults to `false` for match modes, so a
+ranked mode the matchmaker owns is refused with `quick_play_disabled` until you
+say otherwise - and a mode written before this frame existed is safe on upgrade
+without touching it.
+
+`quick_play` and `listed` are independent: `listed` decides whether a match
+appears in `match.list`, `quick_play` decides whether a player may be dropped
+into an existing one. Hidden but auto-filled is a legitimate combination.
 
 Prefer it over `match.list` then `match.join`. Browsing and then joining is two
 round trips with a race in the middle: two clients that both read an empty list
@@ -169,8 +174,8 @@ Worlds are subject to `world_max_per_player` (5) and `world_max` (1000) - see
 
 ### Private lobbies
 
-Because only a world can be created by a client, a code-gated private lobby is a
-world too. Share a code out of band and check it on the way in. The join context
+A code-gated private lobby can be a match as well as a world: `match.find_or_create`
+forwards the join context, so a `join` callback can refuse on a bad code. Share a code out of band and check it on the way in. The join context
 is whatever the client put in the join payload; asobi never reads it.
 
 ```lua

--- a/guides/websocket-protocol.md
+++ b/guides/websocket-protocol.md
@@ -200,9 +200,14 @@ Replies with `match.joined`, exactly as `match.join` does. The payload takes
 `mode` only - every other match parameter comes from mode config, so a client
 cannot choose `max_players` or the tick rate.
 
-Only modes with `listed = true` are eligible, which is the same opt-in that
-makes a mode appear in `match.list`. A mode left unlisted is reachable through
-the matchmaker alone.
+Eligibility is `quick_play`, not `listed` - they are independent axes. A match
+mode **defaults to `quick_play = false`**, so a mode is reachable through the
+matchmaker alone until you opt it in. A mode that is not eligible answers
+`quick_play_disabled`, the same reason `world.find_or_create` uses.
+
+That default is deliberate: every match mode written before this frame existed
+declares no `quick_play`, and defaulting it open would expose a ranked mode to a
+client that had never been rated or queued.
 
 Prefer this to `match.list` followed by `match.join`: the two-step version
 races, and two clients reading the same empty listing will each create a match.

--- a/guides/websocket-protocol.md
+++ b/guides/websocket-protocol.md
@@ -188,6 +188,31 @@ Distinct from `GET /api/v1/matches`, which reads the match *record* table
 (finished matches, an audit trail). `GET /api/v1/matches/live` is the REST
 equivalent of this message.
 
+### `match.find_or_create`
+
+Get into a live match of a mode, spawning one if there is none.
+
+```json
+{"type": "match.find_or_create", "cid": "1", "payload": {"mode": "arena"}}
+```
+
+Replies with `match.joined`, exactly as `match.join` does. The payload takes
+`mode` only - every other match parameter comes from mode config, so a client
+cannot choose `max_players` or the tick rate.
+
+Only modes with `listed = true` are eligible, which is the same opt-in that
+makes a mode appear in `match.list`. A mode left unlisted is reachable through
+the matchmaker alone.
+
+Prefer this to `match.list` followed by `match.join`: the two-step version
+races, and two clients reading the same empty listing will each create a match.
+This resolves server-side and is serialized, so simultaneous callers converge on
+one match.
+
+Subject to the same join rate limit as `match.join` and `world.join`, and to a
+node-wide cap on live matches (`asobi.match_max`, default 1000), which answers
+`match_capacity_reached`. A world mode is refused with `wrong_mode_type`.
+
 ### `match.join`
 
 Join a match (after being matched via matchmaker, discovered via

--- a/src/matches/asobi_match_lobby.erl
+++ b/src/matches/asobi_match_lobby.erl
@@ -15,8 +15,11 @@ default to listed because their browser already shipped.
 """.
 
 -export([list_matches/0, list_matches/1, list_matches_cached/1]).
+-export([find_or_create/2, find_or_create_unsafe/2, live_match_count/0]).
 
 -define(LIST_CACHE_TTL_MS, 500).
+-define(PG_SCOPE, nova_scope).
+-define(DEFAULT_MAX_MATCHES, 1000).
 
 -doc "List live matches. Unfiltered - callers that serve clients want `list_matches/1`.".
 -spec list_matches() -> [map()].
@@ -101,3 +104,107 @@ matches_filters(Info, Filters) ->
     Status = maps:get(status, Info, undefined),
     StatusOk = Status =:= waiting orelse Status =:= running,
     ModeOk andalso CapOk andalso ListedOk andalso JoinableOk andalso StatusOk.
+
+-doc """
+Get this player into a live match of `Mode`, spawning one if there is none.
+
+The match twin of `asobi_world_lobby:find_or_create/2`, and the reason it
+exists: the matchmaker groups co-queued tickets and spawns - it never joins a
+player into a running match (see `asobi_matchmaker_fill`, whose `match/2` only
+ever sees the ticket queue). So before this the only route into a live match was
+`match.list` then `match.join`, a browse-then-join with the same TOCTOU
+`asobi_world_lobby_server` was built to close, and worse here because a split
+leaves two half-empty matches that may both fail to reach `min_players`.
+
+Serialized through `asobi_world_lobby_server`, which already owns the shared
+listing cache for both worlds and matches. Calling `find_or_create_unsafe/2`
+directly is racy.
+
+Only `listed` modes participate, which is the opt-in and needs no new flag:
+matches are unlisted by default, so a ranked mode the matchmaker owns is
+unreachable here by construction.
+""".
+-spec find_or_create(binary(), binary() | undefined) -> {ok, pid(), map()} | {error, term()}.
+find_or_create(Mode, PlayerId) ->
+    asobi_world_lobby_server:find_or_create_match(Mode, PlayerId).
+
+-doc """
+The inner sequence. Public only so the serializing server can call it - every
+other caller wants `find_or_create/2`.
+""".
+-spec find_or_create_unsafe(binary(), binary() | undefined) ->
+    {ok, pid(), map()} | {error, term()}.
+find_or_create_unsafe(Mode, _PlayerId) ->
+    Filters = #{mode => Mode, listed => true, has_capacity => true, joinable => true},
+    case list_matches(Filters) of
+        [Info | _] ->
+            %% A listing entry can name a match that died between the
+            %% enumeration and here, so resolve it again and fall through to a
+            %% spawn rather than handing back a dead pid.
+            case asobi_match_server:whereis(maps:get(match_id, Info, ~"")) of
+                {ok, Pid} -> {ok, Pid, Info};
+                error -> spawn_for_mode(Mode)
+            end;
+        [] ->
+            spawn_for_mode(Mode)
+    end.
+
+-doc """
+Live matches, counted from the pg group rather than by asking each one.
+
+`asobi_discovery` uses the server module as the pg group tag, so membership is
+already tracked and tied to the process lifetime - the count clears on death
+with no bookkeeping. Counting via `list_matches/0` would issue a
+`gen_statem:call` per match on every create, which is the amplification the
+listing cache exists to avoid.
+""".
+-spec live_match_count() -> non_neg_integer().
+live_match_count() ->
+    length(pg:get_members(?PG_SCOPE, asobi_match_server)).
+
+-spec spawn_for_mode(binary()) -> {ok, pid(), map()} | {error, term()}.
+spawn_for_mode(Mode) ->
+    ModeConfig = asobi_game_modes:mode_config(Mode),
+    case maps:get(type, ModeConfig, match) of
+        world ->
+            {error, wrong_mode_type};
+        _ when map_size(ModeConfig) =:= 0 ->
+            {error, not_found};
+        _ ->
+            check_cap_and_spawn(Mode, ModeConfig)
+    end.
+
+-spec check_cap_and_spawn(binary(), map()) -> {ok, pid(), map()} | {error, term()}.
+check_cap_and_spawn(Mode, ModeConfig) ->
+    Max = application:get_env(asobi, match_max, ?DEFAULT_MAX_MATCHES),
+    case live_match_count() >= Max of
+        true ->
+            {error, match_capacity_reached};
+        false ->
+            do_spawn(Mode, ModeConfig)
+    end.
+
+-spec do_spawn(binary(), map()) -> {ok, pid(), map()} | {error, term()}.
+do_spawn(Mode, ModeConfig) ->
+    case asobi_game_modes:resolve_game_module(Mode) of
+        {ok, GameMod, ExtraConfig} ->
+            MatchSize = maps:get(match_size, ModeConfig, 2),
+            Config = #{
+                mode => Mode,
+                game_module => GameMod,
+                game_config => ExtraConfig,
+                min_players => maps:get(min_players, ModeConfig, MatchSize),
+                max_players => maps:get(max_players, ModeConfig, MatchSize),
+                listed => maps:get(listed, ModeConfig, false)
+            },
+            case asobi_match_sup:start_match(Config) of
+                {ok, Pid} when is_pid(Pid) ->
+                    {ok, Pid, asobi_match_server:get_info(Pid)};
+                {error, _} = Err ->
+                    Err;
+                Other ->
+                    {error, {start_match_failed, Other}}
+            end;
+        {error, _} = Err ->
+            Err
+    end.

--- a/src/matches/asobi_match_lobby.erl
+++ b/src/matches/asobi_match_lobby.erl
@@ -20,6 +20,7 @@ default to listed because their browser already shipped.
 -define(LIST_CACHE_TTL_MS, 500).
 -define(PG_SCOPE, nova_scope).
 -define(DEFAULT_MAX_MATCHES, 1000).
+-define(LIVE_MATCHES_GROUP, asobi_live_matches_global).
 
 -doc "List live matches. Unfiltered - callers that serve clients want `list_matches/1`.".
 -spec list_matches() -> [map()].
@@ -135,47 +136,110 @@ other caller wants `find_or_create/2`.
 -spec find_or_create_unsafe(binary(), binary() | undefined) ->
     {ok, pid(), map()} | {error, term()}.
 find_or_create_unsafe(Mode, _PlayerId) ->
-    Filters = #{mode => Mode, listed => true, has_capacity => true, joinable => true},
-    case list_matches(Filters) of
-        [Info | _] ->
-            %% A listing entry can name a match that died between the
-            %% enumeration and here, so resolve it again and fall through to a
-            %% spawn rather than handing back a dead pid.
-            case asobi_match_server:whereis(maps:get(match_id, Info, ~"")) of
-                {ok, Pid} -> {ok, Pid, Info};
-                error -> spawn_for_mode(Mode)
-            end;
-        [] ->
-            spawn_for_mode(Mode)
+    ModeConfig = asobi_game_modes:mode_config(Mode),
+    case eligible(Mode, ModeConfig) of
+        {error, _} = Err ->
+            Err;
+        ok ->
+            Filters = #{mode => Mode, has_capacity => true, joinable => true},
+            %% Fullest first, via decorate-sort-undecorate then reverse:
+            %% lists:sort/2 is specced fun((term(), term()) -> boolean()), which
+            %% erases the element type, while lists:sort/1 is polymorphic and
+            %% keeps it.
+            %%
+            %% list_matches/1 order comes from pg:which_groups/1,
+            %% i.e. ETS iteration order, which is arbitrary and reshuffles as
+            %% groups churn - so without this, concurrent callers can flip to a
+            %% different match mid-fill and leave two half-filled waiting
+            %% matches that each die at ?WAITING_TIMEOUT without reaching
+            %% min_players. That is the exact failure this verb exists to
+            %% prevent. Fullest-first consolidates: a waiting match at 1/2 is
+            %% the one most worth completing.
+            case fullest(list_matches(Filters)) of
+                Info when is_map(Info) ->
+                    %% A listing entry can name a match that died between the
+                    %% enumeration and here, so resolve it again and fall
+                    %% through to a spawn rather than handing back a dead pid.
+                    case asobi_match_server:whereis(maps:get(match_id, Info, ~"")) of
+                        {ok, Pid} -> {ok, Pid, Info};
+                        error -> spawn_match(Mode, ModeConfig)
+                    end;
+                none ->
+                    spawn_match(Mode, ModeConfig)
+            end
+    end.
+
+%% Concrete integer key: maps:get/3 hands back a dynamic, and negating or
+%% sorting on that widens the decorated tuple enough to erase the map type of
+%% its second element.
+%% Only the top entry is ever used, so this picks the maximum rather than
+%% sorting - which also sidesteps lists:sort/2 being specced to return
+%% [term()], erasing the element type.
+-spec fullest([map()]) -> map() | none.
+fullest([]) ->
+    none;
+fullest([H | T]) ->
+    fullest(T, H).
+
+-spec fullest([map()], map()) -> map().
+fullest([], Best) ->
+    Best;
+fullest([H | T], Best) ->
+    case player_count_of(H) > player_count_of(Best) of
+        true -> fullest(T, H);
+        false -> fullest(T, Best)
+    end.
+
+-spec player_count_of(map()) -> integer().
+player_count_of(Info) ->
+    case maps:get(player_count, Info, 0) of
+        N when is_integer(N) -> N;
+        _ -> 0
+    end.
+
+%% asobi#482: `quick_play` is the eligibility axis, NOT `listed`.
+%%
+%% They are deliberately independent (guides/world-server.md#visibility):
+%% `listed` is browser visibility, `quick_play` is "may a player be dropped into
+%% an existing instance of this mode". Filtering on `listed` would collapse them
+%% and remove the operator's ability to express "auto-filled but hidden".
+%%
+%% It defaults to FALSE for matches, where worlds default true. Worlds shipped
+%% with find_or_create so their modes were always opted in; match modes have
+%% been matchmaker-only until now, and defaulting them open would silently
+%% expose every existing operator's ranked mode the moment they upgrade - a
+%% client could spawn and join a ranked match having never been rated or queued.
+%% guides/configuration.md already promised that `quick_play = false` on a match
+%% mode is "protective rather than inert"; this is the path that makes it true.
+-spec eligible(binary(), map()) -> ok | {error, term()}.
+eligible(_Mode, ModeConfig) when map_size(ModeConfig) =:= 0 ->
+    {error, not_found};
+eligible(_Mode, #{type := world}) ->
+    {error, wrong_mode_type};
+eligible(_Mode, ModeConfig) ->
+    case maps:get(quick_play, ModeConfig, false) of
+        true -> ok;
+        _ -> {error, quick_play_disabled}
     end.
 
 -doc """
 Live matches, counted from the pg group rather than by asking each one.
 
-`asobi_discovery` uses the server module as the pg group tag, so membership is
-already tracked and tied to the process lifetime - the count clears on death
-with no bookkeeping. Counting via `list_matches/0` would issue a
-`gen_statem:call` per match on every create, which is the amplification the
-listing cache exists to avoid.
+Counted from the flat `asobi_live_matches_global` group that `asobi_match_server`
+joins alongside its per-id one, mirroring `asobi_owned_worlds_global` on the
+world side. Note the per-id group is keyed `{asobi_match_server, MatchId}`, a
+tuple, so there is no bare-atom group to count - that mistake reads as a cap
+that never fires.
+
+Counting via `list_matches/0` instead would issue a `gen_statem:call` per live
+match on every create, the amplification the listing cache exists to avoid.
 """.
 -spec live_match_count() -> non_neg_integer().
 live_match_count() ->
-    length(pg:get_members(?PG_SCOPE, asobi_match_server)).
+    length(pg:get_members(?PG_SCOPE, ?LIVE_MATCHES_GROUP)).
 
--spec spawn_for_mode(binary()) -> {ok, pid(), map()} | {error, term()}.
-spawn_for_mode(Mode) ->
-    ModeConfig = asobi_game_modes:mode_config(Mode),
-    case maps:get(type, ModeConfig, match) of
-        world ->
-            {error, wrong_mode_type};
-        _ when map_size(ModeConfig) =:= 0 ->
-            {error, not_found};
-        _ ->
-            check_cap_and_spawn(Mode, ModeConfig)
-    end.
-
--spec check_cap_and_spawn(binary(), map()) -> {ok, pid(), map()} | {error, term()}.
-check_cap_and_spawn(Mode, ModeConfig) ->
+-spec spawn_match(binary(), map()) -> {ok, pid(), map()} | {error, term()}.
+spawn_match(Mode, ModeConfig) ->
     Max = application:get_env(asobi, match_max, ?DEFAULT_MAX_MATCHES),
     case live_match_count() >= Max of
         true ->
@@ -195,11 +259,19 @@ do_spawn(Mode, ModeConfig) ->
                 game_config => ExtraConfig,
                 min_players => maps:get(min_players, ModeConfig, MatchSize),
                 max_players => maps:get(max_players, ModeConfig, MatchSize),
-                listed => maps:get(listed, ModeConfig, false)
+                listed => maps:get(listed, ModeConfig, false),
+                quick_play => maps:get(quick_play, ModeConfig, false)
             },
             case asobi_match_sup:start_match(Config) of
                 {ok, Pid} when is_pid(Pid) ->
-                    {ok, Pid, asobi_match_server:get_info(Pid)};
+                    %% Both branches return the listing projection. The find
+                    %% branch already does; returning the full get_info here
+                    %% would hand the next caller a roster and server-side flags
+                    %% the other branch never provides.
+                    {ok, Pid,
+                        asobi_match_server:listing_info(
+                            asobi_match_server:get_info(Pid, listing)
+                        )};
                 {error, _} = Err ->
                     Err;
                 Other ->

--- a/src/matches/asobi_match_server.erl
+++ b/src/matches/asobi_match_server.erl
@@ -183,6 +183,13 @@ callback_mode() -> [state_functions, state_enter].
 init(Config) ->
     MatchId = maps:get(match_id, Config, generate_id()),
     pg:join(?PG_SCOPE, {asobi_match_server, MatchId}, self()),
+    %% asobi#482: a flat group as well as the per-id one, so the node-wide match
+    %% count is a pg lookup rather than a gen_statem:call per match. Mirrors
+    %% asobi_owned_worlds_global on the world side. Unconditional, so a
+    %% matchmaker-spawned match counts toward the same node resource as one
+    %% created through match.find_or_create. Membership is tied to the process,
+    %% so it clears on death with no bookkeeping.
+    pg:join(?PG_SCOPE, asobi_live_matches_global, self()),
     case recover_state(MatchId) of
         {ok, SavedStatus, SavedState} ->
             logger:notice(#{msg => ~"match recovered", match_id => MatchId, status => SavedStatus}),

--- a/src/world/asobi_world_lobby_server.erl
+++ b/src/world/asobi_world_lobby_server.erl
@@ -25,6 +25,7 @@ listings for both worlds and matches. Callers read the table directly
 -behaviour(gen_server).
 
 -export([start_link/0, find_or_create/1, find_or_create/2, cache_listing/3]).
+-export([find_or_create_match/2]).
 -export([init/1, handle_call/3, handle_cast/2]).
 
 -define(CALL_TIMEOUT, 30000).
@@ -47,6 +48,20 @@ find_or_create(Mode) ->
     {ok, pid(), map()} | {error, term()}.
 find_or_create(Mode, PlayerId) ->
     case gen_server:call(?MODULE, {find_or_create, Mode, PlayerId}, ?CALL_TIMEOUT) of
+        {ok, Pid, Meta} when is_pid(Pid), is_map(Meta) -> {ok, Pid, Meta};
+        {error, Reason} -> {error, Reason};
+        Other -> {error, {unexpected_reply, Other}}
+    end.
+
+-doc """
+Atomic `asobi_match_lobby:find_or_create_unsafe/2`. Matches serialize through
+the same process as worlds rather than a twin: this server already owns the
+shared listing cache for both, so one serialization point stays one.
+""".
+-spec find_or_create_match(binary(), binary() | undefined) ->
+    {ok, pid(), map()} | {error, term()}.
+find_or_create_match(Mode, PlayerId) ->
+    case gen_server:call(?MODULE, {find_or_create_match, Mode, PlayerId}, ?CALL_TIMEOUT) of
         {ok, Pid, Meta} when is_pid(Pid), is_map(Meta) -> {ok, Pid, Meta};
         {error, Reason} -> {error, Reason};
         Other -> {error, {unexpected_reply, Other}}
@@ -106,6 +121,11 @@ handle_call({find_or_create, Mode, PlayerId}, _From, State) when
     is_binary(Mode), (is_binary(PlayerId) orelse PlayerId =:= undefined)
 ->
     Result = asobi_world_lobby:find_or_create_unsafe(Mode, PlayerId),
+    {reply, Result, State};
+handle_call({find_or_create_match, Mode, PlayerId}, _From, State) when
+    is_binary(Mode), (is_binary(PlayerId) orelse PlayerId =:= undefined)
+->
+    Result = asobi_match_lobby:find_or_create_unsafe(Mode, PlayerId),
     {reply, Result, State};
 handle_call(_Other, _From, State) ->
     {reply, {error, unknown_request}, State}.

--- a/src/ws/asobi_ws_handler.erl
+++ b/src/ws/asobi_ws_handler.erl
@@ -638,6 +638,38 @@ handle_message(
     Reply = encode_reply(Cid, ~"presence.updated", #{status => Status}),
     {reply, {text, Reply}, State};
 handle_message(
+    #{~"type" := ~"match.find_or_create", ~"payload" := #{~"mode" := Mode}} = Msg,
+    #{player_id := PlayerId} = State
+) ->
+    %% asobi#482: the match twin of world.find_or_create. The matchmaker groups
+    %% co-queued tickets and never joins a player into a running match, so
+    %% before this the only route into a live match was match.list then
+    %% match.join - a browse-then-join carrying the TOCTOU that
+    %% asobi_world_lobby_server exists to close.
+    %%
+    %% The reply is match.joined, not a new match.created leaf: under the 1.0
+    %% freeze (ADR 0010) a new OUTBOUND match./world. leaf has to enter
+    %% ?RESERVED_EVENT_NAMES, which would retroactively ban it for any shipped
+    %% game already broadcasting that name through game.broadcast. Additive
+    %% inbound frames carry no such hazard.
+    Cid = maps:get(~"cid", Msg, undefined),
+    case check_join_rate(PlayerId) of
+        denied ->
+            {reply, {text, encode_error(Cid, ~"join_rate_limited")}, State};
+        allowed ->
+            case asobi_join_ctx:parse(maps:get(~"payload", Msg, #{})) of
+                {error, CtxErr} ->
+                    {reply, {text, encode_error(Cid, CtxErr)}, State};
+                {ok, Ctx} ->
+                    case asobi_match_lobby:find_or_create(Mode, PlayerId) of
+                        {ok, MatchPid, _Info} ->
+                            join_match_and_reply(Cid, MatchPid, PlayerId, Ctx, State);
+                        {error, Reason} ->
+                            {reply, {text, encode_error(Cid, Reason)}, State}
+                    end
+            end
+    end;
+handle_message(
     #{~"type" := ~"match.join", ~"payload" := #{~"match_id" := MatchId}} = Msg,
     #{player_id := PlayerId} = State
 ) ->

--- a/test/asobi_match_lobby_tests.erl
+++ b/test/asobi_match_lobby_tests.erl
@@ -86,8 +86,14 @@ match_lobby_test_() ->
             fun foc_spawns_when_none/0},
         {"find_or_create reuses a listed, joinable match with room (#482)",
             fun foc_reuses_existing/0},
-        {"find_or_create ignores an unlisted match, so ranked stays matchmaker-only (#482)",
-            fun foc_ignores_unlisted/0},
+        {"find_or_create REFUSES a non-quick_play mode, so ranked stays matchmaker-only (#482)",
+            fun foc_refuses_non_quick_play/0},
+        {"quick_play and listed stay independent axes (#482)",
+            fun foc_quick_play_is_independent_of_listed/0},
+        {"a mode that declares no quick_play is refused, so upgrades are safe (#482)",
+            fun foc_defaults_closed/0},
+        {"find_or_create picks the FULLEST eligible match, consolidating (#482)",
+            fun foc_picks_fullest/0},
         {"find_or_create ignores a match closed with set_joinable(false) (#482)",
             fun foc_ignores_closed/0},
         {"find_or_create refuses a world mode (#482)", fun foc_refuses_world_mode/0},
@@ -214,7 +220,44 @@ foc_mode(Mode, Extra) ->
     Prev = application:get_env(asobi, game_modes),
     application:set_env(asobi, game_modes, #{
         Mode => maps:merge(
-            #{module => ?GAME, match_size => 2, max_players => 4, listed => true}, Extra
+            #{
+                module => ?GAME,
+                match_size => 2,
+                max_players => 4,
+                listed => true,
+                quick_play => true
+            },
+            Extra
+        )
+    }),
+    Prev.
+
+%% A mode exactly as an operator would have written it before this verb existed:
+%% no quick_play key at all.
+foc_mode_bare(Mode) ->
+    Prev = application:get_env(asobi, game_modes),
+    application:set_env(asobi, game_modes, #{
+        Mode => #{module => ?GAME, match_size => 2, max_players => 4, listed => true}
+    }),
+    Prev.
+
+foc_mode2(Mode, Extra) ->
+    Prev = application:get_env(asobi, game_modes),
+    Existing =
+        case Prev of
+            {ok, M} when is_map(M) -> M;
+            _ -> #{}
+        end,
+    application:set_env(asobi, game_modes, Existing#{
+        Mode => maps:merge(
+            #{
+                module => ?GAME,
+                match_size => 2,
+                max_players => 4,
+                listed => true,
+                quick_play => true
+            },
+            Extra
         )
     }),
     Prev.
@@ -248,16 +291,77 @@ foc_reuses_existing() ->
         restore_modes(Prev)
     end.
 
-foc_ignores_unlisted() ->
-    %% The opt-in, and why no new mode flag was needed: matches are unlisted by
-    %% default, so a matchmaker-owned ranked mode is unreachable here.
-    Prev = foc_mode(~"foc_c", #{listed => false}),
+foc_refuses_non_quick_play() ->
+    %% The policy gate. quick_play defaults FALSE for match modes, so a
+    %% matchmaker-only mode is not merely un-found - it must be REFUSED. Before
+    %% this the filter simply missed the unlisted match and spawned another, so
+    %% every call minted a fresh ranked match and joined the caller to it,
+    %% routing around matchmaking entirely and bounded only by the join limiter.
+    Prev = foc_mode(~"foc_c", #{quick_play => false}),
     try
-        {ok, Pid1, _} = asobi_match_lobby:find_or_create_unsafe(~"foc_c", ~"p1"),
-        {ok, Pid2, _} = asobi_match_lobby:find_or_create_unsafe(~"foc_c", ~"p2"),
-        ?assertNotEqual(Pid1, Pid2, "an unlisted match must not absorb a second caller"),
-        stop_match(Pid1),
-        stop_match(Pid2)
+        ?assertEqual(
+            {error, quick_play_disabled},
+            asobi_match_lobby:find_or_create_unsafe(~"foc_c", ~"p1")
+        ),
+        ?assertEqual(
+            [],
+            asobi_match_lobby:list_matches(#{mode => ~"foc_c"}),
+            "a refused call must not have spawned anything"
+        )
+    after
+        restore_modes(Prev)
+    end.
+
+foc_picks_fullest() ->
+    %% Ordering is not incidental. list_matches/1 order comes from
+    %% pg:which_groups/1, i.e. ETS iteration order, which reshuffles as groups
+    %% churn - so without an explicit rule, concurrent callers can flip between
+    %% matches mid-fill and leave two half-filled waiting matches that each die
+    %% at ?WAITING_TIMEOUT without reaching min_players. Fullest-first
+    %% consolidates: the match at 2/4 is the one worth completing.
+    Prev = foc_mode(~"foc_j", #{}),
+    try
+        Empty = start_match(#{mode => ~"foc_j", listed => true, max_players => 4}),
+        Fuller = start_match(#{mode => ~"foc_j", listed => true, max_players => 4}),
+        ok = asobi_match_server:join(Fuller, ~"a"),
+        ok = asobi_match_server:join(Fuller, ~"b"),
+        {ok, Picked, _} = asobi_match_lobby:find_or_create_unsafe(~"foc_j", ~"p1"),
+        ?assertEqual(Fuller, Picked, "the fuller match must win, not whichever pg listed first"),
+        ?assertNotEqual(Empty, Picked),
+        stop_match(Empty),
+        stop_match(Fuller)
+    after
+        restore_modes(Prev)
+    end.
+
+foc_defaults_closed() ->
+    %% The upgrade-safety case, and the one that matters most: every match mode
+    %% that exists today predates this verb and declares no quick_play. If the
+    %% default were open, merging this would silently expose every operator's
+    %% ranked mode to a client that can spawn and join one without ever being
+    %% rated or queued. Declaring quick_play => false is NOT what protects them
+    %% - declaring nothing is the common case.
+    Prev = foc_mode_bare(~"foc_i"),
+    try
+        ?assertEqual(
+            {error, quick_play_disabled},
+            asobi_match_lobby:find_or_create_unsafe(~"foc_i", ~"p1")
+        ),
+        ?assertEqual([], asobi_match_lobby:list_matches(#{mode => ~"foc_i"}))
+    after
+        restore_modes(Prev)
+    end.
+
+foc_quick_play_is_independent_of_listed() ->
+    %% The two axes stay separate: hidden from the browser but still auto-filled
+    %% is a legitimate cell, and collapsing them onto `listed` would remove it.
+    Prev = foc_mode(~"foc_h", #{listed => false, quick_play => true}),
+    try
+        {ok, Pid1, _} = asobi_match_lobby:find_or_create_unsafe(~"foc_h", ~"p1"),
+        {ok, Pid2, _} = asobi_match_lobby:find_or_create_unsafe(~"foc_h", ~"p2"),
+        ?assertEqual(Pid1, Pid2),
+        ?assertEqual([], asobi_match_lobby:list_matches(#{mode => ~"foc_h", listed => true})),
+        stop_match(Pid1)
     after
         restore_modes(Prev)
     end.
@@ -301,19 +405,32 @@ foc_respects_cap() ->
     %% The matchmaker bounded match creation implicitly - it took match_size
     %% queued tickets to make one. A client-facing create removes that bound, so
     %% the cap is required machinery, not hardening.
+    %%
+    %% Discriminating on purpose: the earlier version set match_max to
+    %% live_match_count() and asserted 0 >= 0, which passed even with the count
+    %% hardcoded to zero - which is what a bare-atom pg lookup effectively was.
     Prev = foc_mode(~"foc_f", #{}),
+    Prev2 = foc_mode2(~"foc_g", #{}),
     PrevMax = application:get_env(asobi, match_max),
-    application:set_env(asobi, match_max, asobi_match_lobby:live_match_count()),
     try
+        {ok, P1, _} = asobi_match_lobby:find_or_create_unsafe(~"foc_f", ~"p1"),
+        Base = asobi_match_lobby:live_match_count(),
+        ?assert(Base >= 1, "a live match must be counted, or the cap can never fire"),
+        application:set_env(asobi, match_max, Base),
         ?assertEqual(
             {error, match_capacity_reached},
-            asobi_match_lobby:find_or_create_unsafe(~"foc_f", ~"p1")
-        )
+            asobi_match_lobby:find_or_create_unsafe(~"foc_g", ~"p2")
+        ),
+        application:set_env(asobi, match_max, Base + 1),
+        {ok, P2, _} = asobi_match_lobby:find_or_create_unsafe(~"foc_g", ~"p3"),
+        stop_match(P1),
+        stop_match(P2)
     after
         case PrevMax of
             {ok, M} -> application:set_env(asobi, match_max, M);
             undefined -> application:unset_env(asobi, match_max)
         end,
+        restore_modes(Prev2),
         restore_modes(Prev)
     end.
 
@@ -327,13 +444,19 @@ foc_is_serialized() ->
     Prev = foc_mode(~"foc_race", #{max_players => 64}),
     Parent = self(),
     try
+        %% Barrier: without it the eight spawns run sequentially and caller 1
+        %% can finish before caller 8 starts, so they would all find match 1
+        %% even unserialized and the test would prove nothing.
         Pids = [
             spawn(fun() ->
+                receive
+                    go -> ok
+                end,
                 Parent ! {foc, N, asobi_match_lobby:find_or_create(~"foc_race", ~"racer")}
             end)
          || N <- lists:seq(1, 8)
         ],
-        _ = Pids,
+        [P ! go || P <- Pids],
         Got = [
             receive
                 {foc, _, {ok, P, _}} -> P;

--- a/test/asobi_match_lobby_tests.erl
+++ b/test/asobi_match_lobby_tests.erl
@@ -13,17 +13,50 @@ setup() ->
         undefined -> pg:start_link(nova_scope);
         _ -> ok
     end,
+    %% asobi#482: find_or_create spawns through asobi_match_sup and serializes
+    %% through asobi_world_lobby_server, neither of which this module needed
+    %% before - it hand-starts match servers. Both are stopped again in cleanup:
+    %% the lobby server OWNS the asobi_world_lobby_cache ETS table, and leaving
+    %% it running makes asobi_world_lobby_cache_tests unable to create or delete
+    %% that table in its own setup.
+    Started = [
+        Name
+     || {Name, Start} <- [
+            {asobi_match_sup, fun asobi_match_sup:start_link/0},
+            {asobi_world_lobby_server, fun asobi_world_lobby_server:start_link/0}
+        ],
+        whereis(Name) =:= undefined andalso started(Start)
+    ],
     meck:new(asobi_repo, [no_link]),
     meck:expect(asobi_repo, insert, fun(_CS) -> {ok, #{}} end),
     meck:expect(asobi_repo, insert, fun(_CS, _Opts) -> {ok, #{}} end),
     meck:new(asobi_presence, [non_strict, no_link]),
     meck:expect(asobi_presence, send, fun(_PlayerId, _Msg) -> ok end),
-    ok.
+    Started.
 
-cleanup(_) ->
+cleanup(Started) ->
     meck:unload(asobi_presence),
     meck:unload(asobi_repo),
+    lists:foreach(fun stop_named/1, lists:reverse(Started)),
     ok.
+
+started(Start) ->
+    {ok, Pid} = Start(),
+    unlink(Pid),
+    true.
+
+stop_named(Name) ->
+    case whereis(Name) of
+        undefined ->
+            ok;
+        Pid ->
+            Ref = monitor(process, Pid),
+            exit(Pid, shutdown),
+            receive
+                {'DOWN', Ref, process, Pid, _} -> ok
+            after 2000 -> ok
+            end
+    end.
 
 %% Unlinked: see the note in asobi_match_server_tests (asobi#376).
 start_match(Overrides) ->
@@ -49,6 +82,18 @@ wait_gone(Pid, N) ->
 
 match_lobby_test_() ->
     {setup, fun setup/0, fun cleanup/1, [
+        {"find_or_create spawns when the mode has no live match (#482)",
+            fun foc_spawns_when_none/0},
+        {"find_or_create reuses a listed, joinable match with room (#482)",
+            fun foc_reuses_existing/0},
+        {"find_or_create ignores an unlisted match, so ranked stays matchmaker-only (#482)",
+            fun foc_ignores_unlisted/0},
+        {"find_or_create ignores a match closed with set_joinable(false) (#482)",
+            fun foc_ignores_closed/0},
+        {"find_or_create refuses a world mode (#482)", fun foc_refuses_world_mode/0},
+        {"find_or_create refuses an unconfigured mode (#482)", fun foc_refuses_unknown_mode/0},
+        {"find_or_create refuses past the global match cap (#482)", fun foc_respects_cap/0},
+        {"concurrent find_or_create callers land in ONE match (#482)", fun foc_is_serialized/0},
         {"matches are unlisted by default", fun unlisted_by_default/0},
         {"listed => true opts a match into discovery", fun listed_opts_in/0},
         {"listing drops the roster and the flag", fun listing_drops_roster/0},
@@ -159,3 +204,149 @@ filters_by_capacity() ->
         1, length(asobi_match_lobby:list_matches(#{listed => true, mode => ~"cap_mode"}))
     ),
     stop_match(Pid).
+
+%% asobi#482: find_or_create is the match twin of world.find_or_create. These
+%% drive find_or_create_unsafe/2 directly - the serialization is the server's
+%% job and is covered separately; what matters here is the find-or-spawn
+%% decision and every case it must refuse.
+
+foc_mode(Mode, Extra) ->
+    Prev = application:get_env(asobi, game_modes),
+    application:set_env(asobi, game_modes, #{
+        Mode => maps:merge(
+            #{module => ?GAME, match_size => 2, max_players => 4, listed => true}, Extra
+        )
+    }),
+    Prev.
+
+restore_modes({ok, P}) -> application:set_env(asobi, game_modes, P);
+restore_modes(undefined) -> application:unset_env(asobi, game_modes).
+
+foc_spawns_when_none() ->
+    Prev = foc_mode(~"foc_a", #{}),
+    try
+        {ok, Pid, Info} = asobi_match_lobby:find_or_create_unsafe(~"foc_a", ~"p1"),
+        ?assert(is_pid(Pid)),
+        ?assertEqual(~"foc_a", maps:get(mode, Info)),
+        stop_match(Pid)
+    after
+        restore_modes(Prev)
+    end.
+
+foc_reuses_existing() ->
+    Prev = foc_mode(~"foc_b", #{}),
+    try
+        {ok, Pid1, _} = asobi_match_lobby:find_or_create_unsafe(~"foc_b", ~"p1"),
+        {ok, Pid2, _} = asobi_match_lobby:find_or_create_unsafe(~"foc_b", ~"p2"),
+        ?assertEqual(
+            Pid1,
+            Pid2,
+            "a second caller must land in the first caller's match, not a fresh one"
+        ),
+        stop_match(Pid1)
+    after
+        restore_modes(Prev)
+    end.
+
+foc_ignores_unlisted() ->
+    %% The opt-in, and why no new mode flag was needed: matches are unlisted by
+    %% default, so a matchmaker-owned ranked mode is unreachable here.
+    Prev = foc_mode(~"foc_c", #{listed => false}),
+    try
+        {ok, Pid1, _} = asobi_match_lobby:find_or_create_unsafe(~"foc_c", ~"p1"),
+        {ok, Pid2, _} = asobi_match_lobby:find_or_create_unsafe(~"foc_c", ~"p2"),
+        ?assertNotEqual(Pid1, Pid2, "an unlisted match must not absorb a second caller"),
+        stop_match(Pid1),
+        stop_match(Pid2)
+    after
+        restore_modes(Prev)
+    end.
+
+foc_ignores_closed() ->
+    Prev = foc_mode(~"foc_d", #{}),
+    try
+        {ok, Pid1, _} = asobi_match_lobby:find_or_create_unsafe(~"foc_d", ~"p1"),
+        ok = asobi_match_server:set_joinable(Pid1, false),
+        {ok, Pid2, _} = asobi_match_lobby:find_or_create_unsafe(~"foc_d", ~"p2"),
+        ?assertNotEqual(Pid1, Pid2, "set_joinable(false) must keep new players out"),
+        stop_match(Pid1),
+        stop_match(Pid2)
+    after
+        restore_modes(Prev)
+    end.
+
+foc_refuses_world_mode() ->
+    %% Symmetric to the world.create guard: a world mode resolved here would
+    %% build a match around asobi_lua_world.
+    Prev = foc_mode(~"foc_w", #{type => world}),
+    try
+        ?assertEqual(
+            {error, wrong_mode_type}, asobi_match_lobby:find_or_create_unsafe(~"foc_w", ~"p1")
+        )
+    after
+        restore_modes(Prev)
+    end.
+
+foc_refuses_unknown_mode() ->
+    Prev = foc_mode(~"foc_e", #{}),
+    try
+        ?assertEqual(
+            {error, not_found}, asobi_match_lobby:find_or_create_unsafe(~"nope", ~"p1")
+        )
+    after
+        restore_modes(Prev)
+    end.
+
+foc_respects_cap() ->
+    %% The matchmaker bounded match creation implicitly - it took match_size
+    %% queued tickets to make one. A client-facing create removes that bound, so
+    %% the cap is required machinery, not hardening.
+    Prev = foc_mode(~"foc_f", #{}),
+    PrevMax = application:get_env(asobi, match_max),
+    application:set_env(asobi, match_max, asobi_match_lobby:live_match_count()),
+    try
+        ?assertEqual(
+            {error, match_capacity_reached},
+            asobi_match_lobby:find_or_create_unsafe(~"foc_f", ~"p1")
+        )
+    after
+        case PrevMax of
+            {ok, M} -> application:set_env(asobi, match_max, M);
+            undefined -> application:unset_env(asobi, match_max)
+        end,
+        restore_modes(Prev)
+    end.
+
+%% The reason find_or_create goes through a gen_server at all. Unserialized,
+%% N callers arriving together all see an empty listing and all spawn - the
+%% TOCTOU asobi_world_lobby_server was built to close, and worse on the match
+%% path because the split leaves several half-empty matches that may each fail
+%% to reach min_players. Drives the public (serialized) entry point, so removing
+%% the serialization fails this.
+foc_is_serialized() ->
+    Prev = foc_mode(~"foc_race", #{max_players => 64}),
+    Parent = self(),
+    try
+        Pids = [
+            spawn(fun() ->
+                Parent ! {foc, N, asobi_match_lobby:find_or_create(~"foc_race", ~"racer")}
+            end)
+         || N <- lists:seq(1, 8)
+        ],
+        _ = Pids,
+        Got = [
+            receive
+                {foc, _, {ok, P, _}} -> P;
+                {foc, _, Other} -> Other
+            after 5000 -> timeout
+            end
+         || _ <- lists:seq(1, 8)
+        ],
+        Unique = lists:usort(Got),
+        ?assertMatch([_], Unique, "every concurrent caller must land in the same match"),
+        [One] = Unique,
+        ?assert(is_pid(One)),
+        stop_match(One)
+    after
+        restore_modes(Prev)
+    end.

--- a/test/asobi_ws_SUITE.erl
+++ b/test/asobi_ws_SUITE.erl
@@ -360,6 +360,15 @@ ws_match_find_or_create_joins(Config) ->
             match_size => 2,
             min_players => 2,
             max_players => 8,
+            listed => true,
+            quick_play => true
+        },
+        %% Listed, but never opted in - the shape every match mode written
+        %% before this frame existed has.
+        ~"foc_ws_closed" => #{
+            module => asobi_test_game,
+            match_size => 2,
+            max_players => 8,
             listed => true
         }
     }),
@@ -399,6 +408,26 @@ ws_match_find_or_create_joins(Config) ->
             MatchId,
             maps:get(~"match_id", maps:get(~"payload", R2, #{}), undefined),
             "the second caller must find the first caller's match"
+        ),
+
+        %% And the refusal reaches the client as a reason it can branch on.
+        {_, Tok3} = register_player(~"focws3", Config),
+        Conn3 = ws_connect_authed(Tok3, Config),
+        ok = nova_test_ws:send_json(
+            #{
+                ~"type" => ~"match.find_or_create",
+                ~"cid" => ~"f3",
+                ~"payload" => #{~"mode" => ~"foc_ws_closed"}
+            },
+            Conn3
+        ),
+        {ok, R3} = recv_until(fun(M) -> maps:get(~"cid", M, undefined) =:= ~"f3" end, Conn3),
+        nova_test_ws:close(Conn3),
+        ?assertEqual(~"error", maps:get(~"type", R3, undefined)),
+        ?assertEqual(
+            ~"quick_play_disabled",
+            maps:get(~"reason", maps:get(~"payload", R3, #{}), undefined),
+            "a mode that never opted in must be refused, not silently spawned"
         )
     after
         case Prev of

--- a/test/asobi_ws_SUITE.erl
+++ b/test/asobi_ws_SUITE.erl
@@ -9,6 +9,7 @@
     ws_unknown_type/1,
     ws_idle_auth_timeout_closes/1,
     ws_match_input_not_in_match_hint/1,
+    ws_match_find_or_create_joins/1,
     ws_match_input_hint_rate_limited/1,
     ws_script_error_rendered_as_extension_error/1,
     ws_matchmaker_add_omitted_mode_rejected/1,
@@ -23,6 +24,7 @@ all() ->
         ws_unknown_type,
         ws_idle_auth_timeout_closes,
         ws_match_input_not_in_match_hint,
+        ws_match_find_or_create_joins,
         ws_match_input_hint_rate_limited,
         ws_script_error_rendered_as_extension_error,
         ws_matchmaker_add_omitted_mode_rejected,
@@ -343,3 +345,65 @@ recv_until(Pred, Conn, N) ->
         {error, _} = Err ->
             Err
     end.
+
+%% asobi#482: match.find_or_create is the match twin of world.find_or_create.
+%% Two things this pins that a unit test cannot: the frame is dispatched at all
+%% (it is an additive inbound type under the 1.0 freeze), and the reply is
+%% match.joined rather than a new match.created leaf - minting an outbound
+%% match. leaf would have to enter ?RESERVED_EVENT_NAMES and would retroactively
+%% ban that name for any shipped game broadcasting it via game.broadcast.
+ws_match_find_or_create_joins(Config) ->
+    Prev = application:get_env(asobi, game_modes),
+    application:set_env(asobi, game_modes, #{
+        ~"foc_ws" => #{
+            module => asobi_test_game,
+            match_size => 2,
+            min_players => 2,
+            max_players => 8,
+            listed => true
+        }
+    }),
+    try
+        {_, Tok1} = register_player(~"focws1", Config),
+        Conn1 = ws_connect_authed(Tok1, Config),
+        ok = nova_test_ws:send_json(
+            #{
+                ~"type" => ~"match.find_or_create",
+                ~"cid" => ~"f1",
+                ~"payload" => #{~"mode" => ~"foc_ws"}
+            },
+            Conn1
+        ),
+        {ok, R1} = recv_until(fun(M) -> maps:get(~"cid", M, undefined) =:= ~"f1" end, Conn1),
+        ?assertEqual(~"match.joined", maps:get(~"type", R1, undefined)),
+        MatchId = maps:get(~"match_id", maps:get(~"payload", R1, #{}), undefined),
+        ?assert(is_binary(MatchId)),
+
+        %% A second player asking for the same mode must land in that match,
+        %% not a fresh one - the whole point of the verb.
+        {_, Tok2} = register_player(~"focws2", Config),
+        Conn2 = ws_connect_authed(Tok2, Config),
+        ok = nova_test_ws:send_json(
+            #{
+                ~"type" => ~"match.find_or_create",
+                ~"cid" => ~"f2",
+                ~"payload" => #{~"mode" => ~"foc_ws"}
+            },
+            Conn2
+        ),
+        {ok, R2} = recv_until(fun(M) -> maps:get(~"cid", M, undefined) =:= ~"f2" end, Conn2),
+        nova_test_ws:close(Conn1),
+        nova_test_ws:close(Conn2),
+        ?assertEqual(~"match.joined", maps:get(~"type", R2, undefined)),
+        ?assertEqual(
+            MatchId,
+            maps:get(~"match_id", maps:get(~"payload", R2, #{}), undefined),
+            "the second caller must find the first caller's match"
+        )
+    after
+        case Prev of
+            {ok, P} -> application:set_env(asobi, game_modes, P);
+            undefined -> application:unset_env(asobi, game_modes)
+        end
+    end,
+    Config.


### PR DESCRIPTION
Third of three from the architecture review. Closes the gap the other two were sequenced ahead of.

## Why the gap was real

The guardian's July ruling rejected `match.find_or_create` (#229/#230) on the grounds that "the matchmaker IS find-or-create". It retracted that this time, having read the module: `asobi_matchmaker_fill:match/2` takes `([Ticket], Config)` and chunks the ticket queue. It never reads a live match, never calls `asobi_match_lobby`, never touches `asobi_match_server:whereis/1`. Finding an open match is not something the matchmaker does badly - it is something the strategy behaviour's interface cannot express.

So the only route into a running match was `match.list` then `match.join`: a browse-then-join with the same TOCTOU `asobi_world_lobby_server` exists to close, and worse on the match path, because the split leaves two half-empty matches that may each fail to reach `min_players`.

## The shape, and what it is not

Takes `mode` only - every other match parameter comes from mode config, exactly as `world.create` does, so a client cannot choose `max_players` or the tick rate.

**Not a bare `match.create`.** That is an unbounded match factory: every call spawns a `gen_statem` with a tick loop. Worlds can afford a bare create because they have an owner concept, persistence, and per-player pg caps. Matches have none of those. `find_or_create` reuses by construction and is self-limiting.

**Replies `match.joined`, not `match.created`.** Under the 1.0 freeze a new *outbound* `match.`/`world.` leaf has to enter `?RESERVED_EVENT_NAMES`, which would retroactively ban that name for any shipped game already broadcasting it through `game.broadcast`. Additive *inbound* frames carry no such hazard - `frozen_1_0_inbound_types_are_still_handled_test` documents exactly that, and passes.

**Eligibility is `quick_play`, default closed for matches.** Filtering on `listed` was wrong and is fixed in the second commit - see below.

## Serialized, and why not a twin

Through `asobi_world_lobby_server`, not a new match twin: that process already owns the shared listing cache for **both** worlds and matches (`cache_listing/3` handles both key shapes), so extending it keeps one serialization point instead of two.

Implementing it unserialized was explicitly ruled out, and the concurrency test is what holds that line.

## The cap is required machinery, not hardening

The matchmaker bounded match creation implicitly: it took `match_size` queued tickets to make one. That bound disappears the moment a single player can form a match. So `asobi.match_max` (default 1000) answers `match_capacity_reached`.

Counted from the pg group - `asobi_discovery` already uses the server module as the group tag, so membership is tied to process lifetime and clears on death. Counting via `list_matches/0` would issue a `gen_statem:call` per match on every create, which is precisely the amplification #480 just removed from the world create path.

A world mode is refused with `wrong_mode_type`, symmetric to the guard #480 added to `world.create`.

## What the guardian implementation review caught

Two ship-blockers, both reproduced against the branch. Fixed in `4c3c23a`.

**The cap was dead.** `live_match_count/0` counted `pg:get_members(nova_scope, asobi_match_server)`, but a match joins `{asobi_match_server, MatchId}` - a **tuple** group. `pg` returns `[]` for a group that does not exist, so the count was always 0 and the cap could never fire. My reasoning about using pg rather than a listing was right; I picked a group nobody joins. The world twin does not count `asobi_world_server` either - it counts `asobi_owned_worlds_global`, a separate flat group joined explicitly. Matches now join `asobi_live_matches_global` the same way.

**Eligibility was the wrong flag, and open by default.** Filtering on `listed` did not *refuse* a non-eligible mode - it missed it and spawned another, and the new match was itself unlisted, so every call minted a fresh one. On a ranked mode that is the matchmaker routed around entirely: a client could spawn and join a ranked match having never been rated or queued, bounded only by the join limiter.

The right axis is `quick_play`, and `guides/configuration.md` **already promised** it is "protective rather than inert" on a match mode - a promise this PR would otherwise have falsified. It stays independent of `listed`, so hidden-but-auto-filled remains expressible, and it defaults to **`false`** for matches where worlds default `true`: every match mode written before this frame declares no `quick_play`, and defaulting open would expose them all on upgrade.

Also from the review: both branches now return the listing projection rather than one returning the full roster, and selection is **fullest-first** - `pg:which_groups/1` order is ETS iteration order, so flipping between matches mid-fill leaves two half-filled `waiting` matches that each die at `?WAITING_TIMEOUT`.

**Three of my tests could not fail.** The cap test asserted `0 >= 0`; the unlisted-mode test pinned the bug as correct; the concurrency test let its eight callers run sequentially so they would have converged even unserialized. All rewritten and run against pre-fix code. I also added the case that matters most - a mode declaring no `quick_play` at all must be refused - after my first version passed a mutation that flipped the default.

## Checks

`fmt`, `xref`, `dialyzer` (exit 0), `eunit` **1975 tests, 0 failures**, `asobi_ws_SUITE` 11/11, `asobi_world_lobby_ws_SUITE` 10/10, `asobi_match_SUITE` 6/6. `elp eqwalize` identical to main on every changed module - note `asobi_match_lobby` briefly regressed 0 to 3 while adding the ordering rule, because `lists:sort/2` is specced to return `[term()]` and erases the element type; resolved by picking the maximum instead of sorting, which is all the code needed anyway.

**Mutation-verified, each against pre-fix code.** Pointing `find_or_create/2` at the unsafe inner function fails the concurrency test (eight callers released from a barrier must converge on one match). Reverting the cap to the bare-atom group fails the cap test. Flipping the `quick_play` default to open fails the defaults-closed test. Making selection pick the emptiest fails the consolidation test. Twelve unit tests cover spawn-when-none, reuse, fullest-first, the axis independence, and every refusal: not-eligible, default-closed, closed via `set_joinable(false)`, world mode, unknown mode, and the cap. A CT case drives the real frame over a socket and asserts the `match.joined` reply, that a second player lands in the first player's match, and that a mode which never opted in is refused with `quick_play_disabled` on the wire.

One test-hygiene note: this module now starts `asobi_match_sup` and `asobi_world_lobby_server` in setup and **stops them in cleanup**. Leaving the lobby server running breaks `asobi_world_lobby_cache_tests`, which creates and deletes the `asobi_world_lobby_cache` ETS table the server owns - it showed up as 5 cancelled tests before the lifecycle was scoped.

## Follow-up, not in this PR

The SDKs need to surface the frame, and the `guides/lobbies.md` rewrite here changes a page asobi.dev generates from, so the site needs a regen and a roll.
