### PR TITLE
docs: the match find_or_create doc still named the wrong flag

### DIFF
--- a/src/matches/asobi_match_lobby.erl
+++ b/src/matches/asobi_match_lobby.erl
@@ -121,9 +121,11 @@ Serialized through `asobi_world_lobby_server`, which already owns the shared
 listing cache for both worlds and matches. Calling `find_or_create_unsafe/2`
 directly is racy.
 
-Only `listed` modes participate, which is the opt-in and needs no new flag:
-matches are unlisted by default, so a ranked mode the matchmaker owns is
-unreachable here by construction.
+Eligibility is `quick_play`, which defaults to FALSE for match modes, so a
+ranked mode the matchmaker owns is refused with `quick_play_disabled` until it
+opts in. That is a separate axis from `listed`, which decides only whether a
+match appears in `match.list` - hidden but auto-filled is a legitimate
+combination.
 """.
 -spec find_or_create(binary(), binary() | undefined) -> {ok, pid(), map()} | {error, term()}.
 find_or_create(Mode, PlayerId) ->


### PR DESCRIPTION
Caught by an SDK verification agent reading the module to check what a client SDK should document.

`asobi_match_lobby`'s moduledoc for `find_or_create/2` still says:

    Only `listed` modes participate, which is the opt-in and needs no new flag

That was true of the first cut of #482. The guardian implementation review changed eligibility to `quick_play` before merge, the code has said `quick_play` ever since, and this paragraph was left behind - so the moduledoc and the function under it disagree, and hexdocs publishes the wrong one.

`listed` decides only whether a match appears in `match.list`. `quick_play` decides whether a player may be dropped into an existing match, defaults to `false` for match modes, and refuses with `quick_play_disabled`. They are deliberately independent, so hidden-but-auto-filled stays expressible.

Docs only. `fmt --check` and `ex_doc` clean (same 2 pre-existing warnings as main).