### PR TITLE
docs: no match example ever set quick_play, so nobody could find it

### DIFF
--- a/guides/configuration.md
+++ b/guides/configuration.md
@@ -20,6 +20,8 @@ Declare settings as globals at the top of your match script:
 -- match.lua
 match_size = 4
 max_players = 10
+min_players = 4     -- defaults to match_size; higher makes the match wait for backfill
+quick_play = true   -- defaults to FALSE for matches: without it match.find_or_create refuses
 strategy = "fill"
 bots = { script = "bots/arena_bot.lua" }
 ```
@@ -28,11 +30,12 @@ bots = { script = "bots/arena_bot.lua" }
 |--------|----------|---------|-------------|
 | `match_size` | yes | none | Minimum players to start a match |
 | `max_players` | no | `match_size` | Maximum players per match |
+| `min_players` | no | `match_size` | Players needed before the loop starts. Higher than `match_size` spawns a match that waits for backfill, and gives up after 60s |
 | `strategy` | no | `"fill"` | `"fill"`, `"skill_based"`, or a custom module |
 | `bots` | no | none | `{ script = "path/to/bot.lua" }` - see [Bots](lua-bots.md) |
 | `game_type` | no | `"match"` | `"match"` or `"world"` |
 | `listed` | no | `false` for matches, `true` for worlds | Whether instances appear in discovery (`match.list` / `world.list`). Never gates joining |
-| `quick_play` | no | `true` | Whether `world.find_or_create` may place a player into an existing instance of this mode |
+| `quick_play` | no | `false` for matches, `true` for worlds | Whether `match.find_or_create` / `world.find_or_create` may place a player into an existing instance of this mode. A match mode that does not set it is refused with `quick_play_disabled`. Independent of `listed` |
 | `state_strategy` | no | none | `"shared"` selects the encode-once broadcast path |
 | `guest_auth` | no | `false` | Declares that this game offers anonymous play. The operator still has to supply a pepper |
 | `registration` | no | none | `"open"`, `"oauth_only"` or `"closed"`. The operator's `sys.config` wins when it sets one |

--- a/guides/lobbies.md
+++ b/guides/lobbies.md
@@ -67,25 +67,16 @@ listed      = true   -- so match.list can find it too
 It gives up at `?WAITING_TIMEOUT` (60s) if the fourth never arrives.
 
 Before asobi v0.85.0 the matchmaker overwrote `min_players` with `match_size`,
-so declaring it was silently ignored and this was an Erlang-only route through
-`asobi_match_sup:start_match/1`. That call is still available to an operator
-shipping their own module, and is still the only way to create a match outside
-the matchmaker.
+so declaring it was silently ignored and a waiting lobby needed an Erlang module
+in your release calling `asobi_match_sup:start_match/1`. That function still
+exists for an operator shipping their own module, but nothing about a lobby
+needs it any more.
 
-```erlang
-{ok, Pid} = asobi_match_sup:start_match(#{
-    mode         => ~"arena",
-    game_module  => my_arena,
-    game_config  => #{},
-    min_players  => 4,
-    max_players  => 4,
-    listed       => true
-}).
-```
-
-**If you are writing Lua, use a world instead.** A world is the only session a
-client can create, so it is the only lobby a Lua-only game can build. Skip to
-[Persistent world as a hub](#persistent-world-as-a-hub).
+**A match is a client-creatable session too.** That was not true before
+`match.find_or_create`, and this page used to send Lua readers to a world for
+that reason. A world is still the better hub when you want somewhere persistent
+that survives empty - see [Persistent world as a hub](#persistent-world-as-a-hub)
+- but it is a choice now, not the only option.
 
 ### Letting players find it
 

--- a/guides/lobbies.md
+++ b/guides/lobbies.md
@@ -60,7 +60,8 @@ the match sits in `waiting` until backfill brings it up to the threshold:
 match_size  = 2   -- the matchmaker forms and spawns on two
 min_players = 4   -- the loop does not start until four are in
 max_players = 8
-listed      = true
+quick_play  = true   -- so match.find_or_create can bring the other two in
+listed      = true   -- so match.list can find it too
 ```
 
 It gives up at `?WAITING_TIMEOUT` (60s) if the fourth never arrives.


### PR DESCRIPTION
Found by the owner reading the published docs, not by any check.

`quick_play` gates `match.find_or_create` and defaults to **false** for match modes. Across all of `guides/`, exactly one Lua example sets it - and that one is a **world** (`world-server.md:431`).

So a match developer reading the documentation never saw the flag, copied an example without it, and got `quick_play_disabled`. The feature was unreachable from the docs that introduced it.

## Three fixes

**The canonical `match.lua` example** (`configuration.md`) now sets `quick_play` and `min_players`, each with a comment. That example is the one people copy.

**The globals table there still said `quick_play` defaults `true`.** That is the world default. #482 made match modes default closed, and the *other* table in the same file was corrected then - this one was missed, so `configuration.md` contradicted itself two tables apart.

**`min_players` was never in that table**, though #481 made it reachable from mode config. It was documented in `lobbies.md` prose and nowhere a reader looking up globals would find it.

Plus the backfill example in `lobbies.md` set `listed` but not `quick_play`, on a page that recommends `match.find_or_create` over browse-then-join twenty lines earlier. Copying it produced a mode the recommended route refuses.

## Why this slipped

Every automated check passed. `check-generated-current.sh` compares the site views to the guides, so it verifies the docs are *published*, not that they are *right*. `check-error-drift.sh` verifies error codes against source. Nothing checks that an example in a guide would actually work against the feature the same guide documents - and #482's default-closed decision is exactly the kind of change that invalidates examples written before it.

Docs only. `check-error-drift.sh` passes.
