### PR TITLE
fix: a Lua script can actually start a vote now

### DIFF
--- a/guides/voting.md
+++ b/guides/voting.md
@@ -75,22 +75,18 @@ end
 
 Clear whatever condition set `_vote`, or the next tick sets it again.
 
-### Known gap: a Lua config does not start a vote today
-
-Both triggers are called and both decode your table, but the decoded table
-reaches the vote server with **string keys**, and the vote server reads atom
-keys. It therefore fails to start and the failure is swallowed at both call
-sites, so the vote silently never happens: no `vote_start` frame, no log line
-naming your script.
-
-This is a defect, not a design. Until it is fixed, a vote has to be started
-from Erlang. If you are writing a Lua-only game and you need voting now, this
-is the one feature you cannot reach.
+Before asobi v0.87.0 neither trigger worked. The decoded table reached the vote
+server with string keys where it reads atom ones, so the vote failed to start
+and the failure was swallowed at both call sites - no `vote_start` frame, no log
+line naming the script. If you are on an older server, a vote has to be started
+from Erlang.
 
 ## Starting a vote from Erlang
 
-`asobi_match_server:start_vote/2` and `asobi_world_server:start_vote/2` take the
-session pid and a config map with **atom keys**. There is no Lua equivalent.
+A game module written in Erlang calls `asobi_match_server:start_vote/2` or
+`asobi_world_server:start_vote/2` directly, with the session pid and a config
+map. A Lua script does not need this - return the config from `vote_requested`
+instead, as above.
 
 ```erlang
 asobi_match_server:start_vote(MatchPid, #{

--- a/src/lua/asobi_lua_match.erl
+++ b/src/lua/asobi_lua_match.erl
@@ -306,16 +306,14 @@ vote_requested(#{lua_state := LuaSt, game_state := GS}) ->
 -define(VOTE_OPTION_KEYS, [id, label]).
 
 -spec normalise_vote_config(map()) -> map().
-normalise_vote_config(Config) when is_map(Config) ->
+normalise_vote_config(Config) ->
     Atomised = atomise_keys(?VOTE_CONFIG_KEYS, Config),
     case maps:get(options, Atomised, undefined) of
         Options when is_list(Options) ->
             Atomised#{options => [atomise_option(O) || O <- Options]};
         _ ->
             Atomised
-    end;
-normalise_vote_config(Other) ->
-    Other.
+    end.
 
 -spec atomise_option(term()) -> term().
 atomise_option(Option) when is_map(Option) ->

--- a/src/lua/asobi_lua_match.erl
+++ b/src/lua/asobi_lua_match.erl
@@ -42,6 +42,10 @@ function on_phase_ended(phase_name, state)   -- return updated state
 
 -export([init/1, join/2, join/3, leave/2, handle_input/3, tick/1, get_state/2]).
 -export([vote_requested/1, vote_resolved/3]).
+
+-ifdef(TEST).
+-export([normalise_vote_config/1]).
+-endif.
 -export([phases/1, on_phase_started/2, on_phase_ended/2]).
 
 %% A sandboxed Lua callback runs in a child process so the parent
@@ -258,13 +262,77 @@ vote_requested(#{lua_state := LuaSt, game_state := GS}) ->
         {ok, [false | _], _} ->
             none;
         {ok, [Config | _], LuaSt1} ->
-            Decoded = decode_to_map(Config, LuaSt1),
+            Decoded = normalise_vote_config(decode_to_map(Config, LuaSt1)),
             case map_size(Decoded) of
                 0 -> none;
                 _ -> {ok, Decoded}
             end;
         _ ->
             none
+    end.
+
+%% asobi#489: a Lua table decodes with binary keys, and asobi_vote_server reads
+%% atom ones - `maps:get(options, Merged)` has no default, so a binary-keyed
+%% config raised badkey, the vote server failed to start, and do_start_vote/3
+%% matched `{error, _} -> State`. The vote silently never happened: no
+%% vote_start frame, no log line naming the script. guides/voting.md called it
+%% "the one feature you cannot reach" from Lua.
+%%
+%% Translated against a fixed whitelist rather than binary_to_atom/2 on whatever
+%% the script wrote: script-supplied keys are untrusted input and converting
+%% them wholesale is an atom-table exhaustion vector. A key not on the list is
+%% left as the script wrote it, so it reaches the vote server as a binary key it
+%% ignores, which is the same outcome as not setting it.
+-define(VOTE_CONFIG_KEYS, [
+    template,
+    vote_id,
+    options,
+    window_ms,
+    method,
+    visibility,
+    tie_breaker,
+    veto_enabled,
+    max_revotes,
+    window_type,
+    min_window_ms,
+    supermajority,
+    require_supermajority,
+    quorum,
+    default_votes,
+    delegation,
+    spectator_weight
+]).
+
+-define(VOTE_OPTION_KEYS, [id, label]).
+
+-spec normalise_vote_config(map()) -> map().
+normalise_vote_config(Config) when is_map(Config) ->
+    Atomised = atomise_keys(?VOTE_CONFIG_KEYS, Config),
+    case maps:get(options, Atomised, undefined) of
+        Options when is_list(Options) ->
+            Atomised#{options => [atomise_option(O) || O <- Options]};
+        _ ->
+            Atomised
+    end;
+normalise_vote_config(Other) ->
+    Other.
+
+-spec atomise_option(term()) -> term().
+atomise_option(Option) when is_map(Option) ->
+    atomise_keys(?VOTE_OPTION_KEYS, Option);
+atomise_option(Other) ->
+    Other.
+
+-spec atomise_keys([atom()], map()) -> map().
+atomise_keys([], Map) ->
+    Map;
+atomise_keys([Key | Rest], Map) ->
+    Bin = atom_to_binary(Key, utf8),
+    case Map of
+        #{Bin := Value} ->
+            atomise_keys(Rest, maps:put(Key, Value, maps:remove(Bin, Map)));
+        _ ->
+            atomise_keys(Rest, Map)
     end.
 
 -spec vote_resolved(binary(), map(), map()) -> {ok, map()}.

--- a/test/asobi_lua_match_tests.erl
+++ b/test/asobi_lua_match_tests.erl
@@ -42,6 +42,8 @@ lua_match_test_() ->
         {"tick signals finished", fun tick_finishes/0},
         {"get_state returns player view", fun get_state_view/0},
         {"vote_requested returns config at right tick", fun vote_requested_ok/0},
+        {"an unknown vote-config key is left as the script wrote it (#489)",
+            fun vote_requested_leaves_unknown_keys_alone/0},
         {"vote_requested returns none normally", fun vote_requested_none/0},
         {"vote_resolved updates state", fun vote_resolved_ok/0},
         {"finish_immediately script", fun finish_immediately/0},
@@ -289,16 +291,42 @@ get_state_view() ->
     View = asobi_lua_match:get_state(~"player1", State1),
     ?assert(is_map(View)).
 
+%% asobi#489: this used to assert is_map/1 and tolerate `none`, so it passed
+%% while the feature was unreachable. The config a Lua script returns decodes
+%% with BINARY keys, and asobi_vote_server reads ATOM ones - maps:get(options,
+%% Merged) has no default, so it raised badkey, the vote server failed to start,
+%% and do_start_vote/3 swallowed it. Assert the exact reads the vote server
+%% performs instead.
 vote_requested_ok() ->
     {ok, State0} = init_match(),
     {ok, State1} = asobi_lua_match:join(~"player1", State0),
     State50 = tick_n(50, State1),
-    case asobi_lua_match:vote_requested(State50) of
-        {ok, VoteConfig} ->
-            ?assert(is_map(VoteConfig));
-        none ->
-            ok
-    end.
+    {ok, VoteConfig} = asobi_lua_match:vote_requested(State50),
+    %% Every read asobi_vote_server:init/1 does on a script-supplied key.
+    ?assertEqual(~"test_vote", maps:get(template, VoteConfig)),
+    ?assertEqual(~"plurality", maps:get(method, VoteConfig)),
+    ?assertEqual(5000, maps:get(window_ms, VoteConfig)),
+    Options = maps:get(options, VoteConfig),
+    ?assertEqual(2, length(Options)),
+    %% validate_option/2 comprehends on `#{id := Id}`, so a binary id key makes
+    %% every cast_vote fail to match its own option.
+    ?assertEqual(
+        [~"opt_a", ~"opt_b"],
+        lists:sort([maps:get(id, O) || O <- Options]),
+        "option ids must be reachable on the atom key the vote server matches"
+    ),
+    ?assertEqual(~"Option A", maps:get(label, hd(Options))),
+    %% A key the script did not write must not be invented.
+    ?assertNot(maps:is_key(veto_enabled, VoteConfig)).
+
+%% Keys outside the whitelist are left exactly as written. Translating whatever
+%% a script puts in the table would be binary_to_atom/2 on untrusted input.
+vote_requested_leaves_unknown_keys_alone() ->
+    Config = #{~"custom_thing" => 1, ~"template" => ~"t"},
+    Normalised = asobi_lua_match:normalise_vote_config(Config),
+    ?assertEqual(~"t", maps:get(template, Normalised)),
+    ?assertEqual(1, maps:get(~"custom_thing", Normalised)),
+    ?assertNot(maps:is_key(custom_thing, Normalised)).
 
 vote_requested_none() ->
     {ok, State0} = init_match(),


### PR DESCRIPTION
Found while auditing asobi.dev for Erlang examples that should be Lua. This one could not be converted, because the Lua route did not work.

`guides/voting.md` documented it as a known defect, in as many words:

    This is a defect, not a design. Until it is fixed, a vote has to be started
    from Erlang. If you are writing a Lua-only game and you need voting now, this
    is the one feature you cannot reach.

## The bug

A Lua table decodes with **binary** keys. `asobi_vote_server` reads **atom** ones, and `maps:get(options, Merged)` at `src/votes/asobi_vote_server.erl:139` has no default - so a script-supplied config raised `badkey`, `asobi_vote_sup:start_vote/1` returned an error, and `do_start_vote/3` matched `{error, _} -> State`.

Both triggers fired. Both decoded the table. Nothing happened: no `vote_start` frame, no log line naming the script. A silent swallow on the one path a Lua game had.

## The fix

`vote_requested/1` translates the decoded config against a fixed whitelist of the keys `asobi_vote_server:init/1` actually reads, plus `id` and `label` on each option entry.

A whitelist rather than `binary_to_atom/2` over the table, deliberately: a script's keys are untrusted input, and converting them wholesale is an atom-table exhaustion vector. An unrecognised key is left exactly as the script wrote it, so it arrives as a binary key the vote server ignores - the same outcome as not setting it, which is the right failure mode for a typo.

## The test could not fail

`vote_requested_ok` asserted `is_map/1` and tolerated a `none` return, so it passed for as long as the feature was broken. It now asserts every read `asobi_vote_server:init/1` performs on a script-supplied key - `template`, `method`, `window_ms`, and the option `id`s that `validate_option/2` comprehends on via `#{id := Id}`. A binary `id` there makes every `cast_vote` fail to match its own option, so that one matters as much as the top level.

Mutation-verified: removing the translation fails it.

## Docs

`guides/voting.md` drops the known-gap section. The Lua trigger was already documented above it with a working example; the page just said it did not work. The Erlang route stays documented for game modules written in Erlang, without the "there is no Lua equivalent" line.

## Checks

`fmt`, `xref`, `dialyzer` (exit 0), `eunit` **1976 tests, 0 failures**. `elp eqwalize asobi_lua_match` clean, same as main.
