### PR TITLE
feat(ops): erase the unclaimed guest cohort from the console

### DIFF
--- a/guides/architecture.md
+++ b/guides/architecture.md
@@ -380,11 +380,12 @@ the detail.
 
 Every ops route carries a capability class - `read`, `player_data`, `config`
 or `erasure` (`src/ops/asobi_ops_caps.erl`) - and the class is the only thing
-that authorises the call. Core's routes are reads apart from two:
-`GET /api/v1/ops/players/:id/export` (`player_data`) and
-`POST /api/v1/ops/players/:id/erase` (`erasure`). The third mutating route is
-`/api/v1/ops/ext/:extension/:action`, whose behaviour comes from an installed
-extension.
+that authorises the call. Core's routes are reads apart from three:
+`GET /api/v1/ops/players/:id/export` (`player_data`),
+`POST /api/v1/ops/players/:id/erase` (`erasure`) and
+`POST /api/v1/ops/players/guests/purge` (`erasure`, the bulk form of the same
+action). The fourth mutating route is `/api/v1/ops/ext/:extension/:action`,
+whose behaviour comes from an installed extension.
 
 `erasure` is its own class because it is the only irreversible one, and a
 console session is granted every class but that one by default

--- a/guides/cloud.md
+++ b/guides/cloud.md
@@ -351,12 +351,16 @@ or store receipt validation today, self-host.
 **Guest auth beyond the toggle.** The per-environment pepper is injected for
 you, so `guest_auth = true` in your Lua works. `guest_verifier_key_id`,
 `guest_unlinked_cap`, `guest_reap_after` and `guest_reap_interval_ms` are not
-settable, so unclaimed guests are never reaped and only the default soft cap
-applies. Pepper rotation is not yours either. Your client can still shed
-accounts one at a time with `POST /api/v1/players/me/erase`
-([REST API](rest-api.md#erasing-your-own-account)) - that is the whole of guest
-removal on cloud, so a client that mints a throwaway device pair per launch
-should erase the account it abandons.
+settable, so unclaimed guests are never reaped automatically and only the
+default soft cap applies. Pepper rotation is not yours either. Two things still
+clear them: a client can shed accounts one at a time with
+`POST /api/v1/players/me/erase`
+([REST API](rest-api.md#erasing-your-own-account)), and an operator can delete
+the abandoned cohort in bulk with
+[`POST /api/v1/ops/players/guests/purge`](rest-api.md#purging-abandoned-guests),
+which needs no server-side configuration. A client that mints a throwaway
+device pair per launch should still erase the account it abandons rather than
+leave the purge to clean up after it.
 
 **Ops-plane shape.** `ops_secret`, `console_erasure`, `console_session_ttl`,
 `console_secure_cookie`, `console_api_base`, `console_label`,

--- a/guides/console.md
+++ b/guides/console.md
@@ -164,20 +164,23 @@ What a reader arriving from another console will look for and not find:
   plane.
 - The players screen shows the ops projection only: `id`, `username`,
   `display_name`, `avatar_url`, `metadata`, `inserted_at`, `updated_at`. No
-  linked providers, no guest status, no device verifiers.
+  linked providers, no guest status, no device verifiers. The list can be
+  *narrowed* to unclaimed guests with `?guest=true`, but no row says which it
+  is; the filter is a set, not a column.
 - The matches screen is the **finished-match record**. Live matches are visible
   only through the player-facing `GET /api/v1/matches/live`.
 
 ## What it cannot do
 
-Core's ops routes are reads apart from two account-lifecycle routes:
+Core's ops routes are reads apart from three account-lifecycle routes:
 
 ```
 GET  /api/v1/ops/players/:id/export     Everything held about one player
 POST /api/v1/ops/players/:id/erase      Delete one player. Irreversible.
+POST /api/v1/ops/players/guests/purge   Delete abandoned guests. Irreversible.
 ```
 
-Both are covered in
+All three are covered in
 [Erasing and exporting a player](rest-api.md#erasing-and-exporting-a-player).
 They exist because an operator must be able to answer a deletion or access
 request without a database shell, and because an Apache-2 self-hoster

--- a/guides/rest-api.md
+++ b/guides/rest-api.md
@@ -944,13 +944,18 @@ no identity of any other provider - whose guest identity has not been touched
 since the cutoff. A player who claimed their guest account or linked an OAuth
 provider fails that predicate and is unreachable here.
 
-`inactive_for_seconds` has no default, and that is the confirmation. The single
-erase is guarded by echoing a username nobody can know without looking at the
-row; a cohort has no such handle, so what stands in for it is that an empty
-POST selects nothing and answers `400 ops.invalid_cutoff`. An unattended
-request is never sufficient.
+Two things have to be named before anything is deleted. `inactive_for_seconds`
+has no default, so an empty POST selects nothing and answers
+`400 ops.invalid_cutoff`. And `confirm_count` is required on any call that is
+not a dry run, so a request that names a cutoff but no count answers
+`400 ops.confirmation_required`. The single erase is guarded by echoing a
+username nobody can know without looking at the row; a cohort echoes its size
+instead, which nobody can know without running the preview. An unattended
+request is never sufficient, and the larger blast radius does not get the
+weaker guard.
 
-Preview first - it counts and deletes nothing:
+Preview first - it counts and deletes nothing, and it is where the
+`confirm_count` for the real call comes from:
 
 ```bash
 curl -X POST \
@@ -961,40 +966,56 @@ curl -X POST \
 ```
 
 ```json
-{"data": {"matched": 14032, "deleted": 0, "skipped": 0, "remaining": 14032, "dry_run": true}}
+{"data": {"matched": 14032, "deleted": 0, "skipped": 0, "failed": 0, "remaining": 14032, "dry_run": true}}
 ```
 
-Then delete. One call erases at most `limit` players (default 500, ceiling
-5000) so a request is never held open across an unbounded table, and
-`remaining` says whether to call again:
+Then delete, echoing that count back. One call erases at most `limit` players
+(default 500, ceiling 5000) so a request is never held open across an unbounded
+table:
 
 ```bash
 curl -X POST \
   -H "Authorization: Bearer $ASOBI_OPS_SECRET" \
   -H 'Content-Type: application/json' \
-  -d '{"inactive_for_seconds": 2592000, "limit": 500}' \
+  -d '{"inactive_for_seconds": 2592000, "confirm_count": 14032, "limit": 500}' \
   https://game.example.com/api/v1/ops/players/guests/purge
 ```
 
 ```json
-{"data": {"matched": 14032, "deleted": 500, "skipped": 0, "remaining": 13532, "dry_run": false}}
+{"data": {"matched": 14032, "deleted": 500, "skipped": 0, "failed": 0, "remaining": 13532, "dry_run": false}}
 ```
+
+**Loop while `deleted` is above zero, not until `remaining` reaches it.** A
+player who cannot be erased is still unclaimed, still matches the predicate,
+and is selected again by the next call, so they never leave `remaining` and a
+loop waiting for zero would not terminate. A call that deleted nothing and
+reports `failed` above zero is that cohort; the reason is in the server log and
+in the audit row.
+
+`confirm_count` refuses the call with `409 ops.purge_count_mismatch` unless the
+server counts exactly that many right now. A live game minting guests will move
+under it between the preview and the delete, which is the point: re-preview and
+re-confirm rather than deleting a set nobody has looked at.
 
 To clear **every** guest, including the one that signed in a second ago, pass
 `inactive_for_seconds: 0`. On a game whose onboarding is guest-first that is
 the entire player base, which is why it has to be typed rather than defaulted
-to.
-
-`confirm_count` is optional and refuses the call with `409
-ops.purge_count_mismatch` unless the server counts exactly that many right
-now. It is for an operator working from a preview; a live game minting guests
-will move under it, which is the point of offering it rather than requiring it.
+to - and why the count has to be echoed too.
 
 Each player is erased in its own transaction, through the same delete sequence
 and the same severed tables as the single erase, and the unclaimed check is
-re-run inside that transaction: a guest who calls `/auth/guest/upgrade` between
-the select and their own delete survives and is reported under `skipped`, not
-`deleted`. One audit row covers the batch, carrying every erased id.
+re-run inside that transaction. The two non-deleted outcomes are reported
+separately because they ask for opposite responses:
+
+* `skipped` - a guest who called `/auth/guest/upgrade` between the select and
+  their own delete. Nothing went wrong, the answer changed, and they have left
+  the set.
+* `failed` - the erasure did not commit, most often because an extension left
+  orphaned rows behind. Something is wrong, they are still in the set, and the
+  next call will select them again.
+
+One audit row covers the batch, carrying every erased id and, for each player
+that was not erased, the reason it actually had.
 
 This is the on-demand half of guest retention. The automatic half is
 `guest_reap_after`, a background sweep that never runs unless the server sets

--- a/guides/rest-api.md
+++ b/guides/rest-api.md
@@ -396,6 +396,8 @@ GET /api/v1/ops/notifications                Paginated sent notifications
 
 GET  /api/v1/ops/players/:id/export          Everything held about one player
 POST /api/v1/ops/players/:id/erase           Delete one player. Irreversible.
+POST /api/v1/ops/players/guests/purge        Delete abandoned guests in bulk.
+                                             Irreversible.
 
 GET|POST|PUT|DELETE
     /api/v1/ops/ext/:extension/:action       Dispatch to an installed extension
@@ -405,8 +407,9 @@ The game-operations plane, for a console rather than a game client. The lists
 differ from the ones above in three ways: they report a total, they accept a
 sort, and they page by offset.
 
-Everything here is a read except two account-lifecycle routes - see
-[Erasing and exporting a player](#erasing-and-exporting-a-player) - and
+Everything here is a read except three account-lifecycle routes - see
+[Erasing and exporting a player](#erasing-and-exporting-a-player) and
+[Purging abandoned guests](#purging-abandoned-guests) - and
 `/api/v1/ops/ext/:extension/:action`, whose behaviour comes from an installed
 extension.
 
@@ -548,7 +551,9 @@ subsequent `401` as "it worked", not as "sign in again".
 | `500`  | `player.erase_failed` | The transaction rolled back. Nothing was deleted | and matches
 
 `ops/players` sorts on `id`, `username`, `display_name`, `inserted_at`,
-`updated_at`, and searches username and display name. `ops/matches` sorts on
+`updated_at`, searches username and display name, and filters on `guest`
+(`true` narrows to unclaimed guests, `false` to everyone else - the same set
+[the purge](#purging-abandoned-guests) deletes from). `ops/matches` sorts on
 `id`, `mode`, `status`, `started_at`, `finished_at`, `inserted_at`, filters on
 `mode` and `status`, and searches mode. Both return the same fields as their
 public counterparts - no roster, no credentials.
@@ -916,10 +921,104 @@ remote shell can call the same function, and it is the same code path:
 {ok,#{player => #{...}, wallets => [...], ...}}
 ```
 
-There is no player-facing self-delete. Whether players may erase themselves is
-a support-load and abuse decision belonging to the game - it turns an account
-takeover into an account destruction - so asobi gives the operator the
-primitive and the game decides whether to expose it.
+The player-facing counterpart is
+[`POST /api/v1/players/me/erase`](#erasing-your-own-account), which runs the
+same deletion on the caller's own account. Whether a game puts a button on it
+is the game's decision - it turns an account takeover into an account
+destruction - so asobi ships both the operator primitive and the self-service
+route and leaves the product call to the game.
+
+### Purging abandoned guests
+
+```
+POST /api/v1/ops/players/guests/purge
+```
+
+The bulk form of the erasure above, for the deployment whose `players` table
+has filled up with devices that signed in once and never came back. Class
+`erasure`, the same as the single delete: a credential trusted to erase one
+player is trusted to erase a cohort.
+
+It selects **unclaimed guests** - no password, at least one `guest` identity,
+no identity of any other provider - whose guest identity has not been touched
+since the cutoff. A player who claimed their guest account or linked an OAuth
+provider fails that predicate and is unreachable here.
+
+`inactive_for_seconds` has no default, and that is the confirmation. The single
+erase is guarded by echoing a username nobody can know without looking at the
+row; a cohort has no such handle, so what stands in for it is that an empty
+POST selects nothing and answers `400 ops.invalid_cutoff`. An unattended
+request is never sufficient.
+
+Preview first - it counts and deletes nothing:
+
+```bash
+curl -X POST \
+  -H "Authorization: Bearer $ASOBI_OPS_SECRET" \
+  -H 'Content-Type: application/json' \
+  -d '{"inactive_for_seconds": 2592000, "dry_run": true}' \
+  https://game.example.com/api/v1/ops/players/guests/purge
+```
+
+```json
+{"data": {"matched": 14032, "deleted": 0, "skipped": 0, "remaining": 14032, "dry_run": true}}
+```
+
+Then delete. One call erases at most `limit` players (default 500, ceiling
+5000) so a request is never held open across an unbounded table, and
+`remaining` says whether to call again:
+
+```bash
+curl -X POST \
+  -H "Authorization: Bearer $ASOBI_OPS_SECRET" \
+  -H 'Content-Type: application/json' \
+  -d '{"inactive_for_seconds": 2592000, "limit": 500}' \
+  https://game.example.com/api/v1/ops/players/guests/purge
+```
+
+```json
+{"data": {"matched": 14032, "deleted": 500, "skipped": 0, "remaining": 13532, "dry_run": false}}
+```
+
+To clear **every** guest, including the one that signed in a second ago, pass
+`inactive_for_seconds: 0`. On a game whose onboarding is guest-first that is
+the entire player base, which is why it has to be typed rather than defaulted
+to.
+
+`confirm_count` is optional and refuses the call with `409
+ops.purge_count_mismatch` unless the server counts exactly that many right
+now. It is for an operator working from a preview; a live game minting guests
+will move under it, which is the point of offering it rather than requiring it.
+
+Each player is erased in its own transaction, through the same delete sequence
+and the same severed tables as the single erase, and the unclaimed check is
+re-run inside that transaction: a guest who calls `/auth/guest/upgrade` between
+the select and their own delete survives and is reported under `skipped`, not
+`deleted`. One audit row covers the batch, carrying every erased id.
+
+This is the on-demand half of guest retention. The automatic half is
+`guest_reap_after`, a background sweep that never runs unless the server sets
+it - see [Configuration](configuration.md). A deployment that sets neither
+keeps its guests forever.
+
+The same predicate narrows the player list, so an operator can look at the
+cohort before deleting it:
+
+```bash
+curl -H "Authorization: Bearer $ASOBI_OPS_SECRET" \
+  "https://game.example.com/api/v1/ops/players?guest=true&limit=20"
+```
+
+`?guest=false` is everyone else. The rows themselves still carry no guest
+column - the filter is a set, not a field.
+
+From a remote shell it is the same code path, with no HTTP involved:
+
+```erlang
+1> Cutoff = asobi_guest_purge:cutoff(2592000).
+2> asobi_guest_purge:count(Cutoff).
+{ok,14032}
+```
 
 ### Console session
 

--- a/src/asobi_error.erl
+++ b/src/asobi_error.erl
@@ -213,6 +213,17 @@ working and a new one reads one place: see `legacy/2`.
     },
     {~"ops.erase_failed", 500, ~"The erasure was rolled back and nothing was deleted."},
     {
+        ~"ops.invalid_cutoff",
+        400,
+        ~"A guest purge must name `inactive_for_seconds` as a whole number of seconds, 0 or more."
+    },
+    {
+        ~"ops.purge_count_mismatch",
+        409,
+        ~"The cohort is no longer the size the request confirmed. Nothing was deleted."
+    },
+    {~"ops.purge_failed", 500, ~"The cohort could not be selected. Nothing was deleted."},
+    {
         ~"ops.orphaned_extension_rows",
         409,
         ~"A removed extension's rows still reference this player and block the erase. Reinstall the package so its erase sweep runs, or purge its tables."

--- a/src/asobi_guest_purge.erl
+++ b/src/asobi_guest_purge.erl
@@ -1,0 +1,265 @@
+-module(asobi_guest_purge).
+-moduledoc """
+Operator-initiated bulk erasure of unclaimed guests.
+
+The automatic half of guest retention is `m:asobi_guest_reaper`: a background
+sweep that runs only when the server sets `guest_reap_after`. This is the half
+a person triggers, for the deployment that never configured retention and now
+has a table full of abandoned devices, or the one that wants them gone now
+rather than at the next tick.
+
+Same predicate, same erasure, different trigger - and therefore a different
+audit posture. A sweep writes no audit rows because it is the machine doing
+housekeeping on a policy someone already set; a purge writes one, because here
+a person asked. That is the split `m:asobi_player_erase` states, applied to the
+bulk case.
+
+## What counts as purgeable
+
+An **unclaimed guest**: a player with no password, at least one `guest`
+identity, and no identity of any other provider. Claiming a guest
+(`/auth/guest/upgrade`) sets a password and deletes the guest identity, so a
+claimed account fails the predicate twice over. Linking an OAuth provider fails
+it once. Neither is reachable by this module.
+
+The cutoff is read against the guest identity's `updated_at`, not the player's
+and not `inserted_at`: guest sign-in touches that row, so it means *last seen*.
+A cutoff of `0` seconds therefore means every unclaimed guest including the one
+that signed in a moment ago, which is what "clear all guest users" asks for and
+why the caller has to say it in so many words.
+
+## Why the predicate is SQL and not `asobi_guest_reaper:unclaimed_guest/1`
+
+The reaper answers that question one player at a time, which is right when it
+is walking a bounded batch. Counting 14 000 of them that way is 28 000 queries
+before a single row is deleted. `clause/1` is the same question as one
+`WHERE`, so the preview a caller runs before a destructive call costs one
+round trip.
+
+The per-player function is still the authority at the moment of deletion:
+`erase_one/1` re-checks it inside the transaction, so a guest that signs up for
+a real account between the select and its own delete survives. The SQL is how
+the set is chosen; the Erlang is how each member is confirmed.
+
+## Bounded per call
+
+`run/4` deletes at most `Limit` players and reports what is left, rather than
+holding one request open across an unbounded table. A caller that wants the
+whole set repeats the call until `remaining` reaches `0`.
+""".
+
+-include_lib("kernel/include/logger.hrl").
+-include_lib("kura/include/kura.hrl").
+
+-export([count/1, run/4, clause/1, cutoff/1]).
+-export([default_limit/0, max_limit/0]).
+
+-define(PROVIDER, ~"guest").
+-define(ACTION, ~"players.purge_guests").
+-define(TARGET_TYPE, ~"guest_cohort").
+-define(DEFAULT_LIMIT, 500).
+-define(MAX_LIMIT, 5000).
+
+-type cutoff() :: calendar:datetime().
+-type condition() :: {atom(), is_nil} | {fragment, binary(), [term()]}.
+-type predicate() :: {'and', [condition()]}.
+
+-export_type([cutoff/0, predicate/0]).
+
+-doc "Default number of players one `run/4` erases when the caller names none.".
+-spec default_limit() -> pos_integer().
+default_limit() -> ?DEFAULT_LIMIT.
+
+-doc "Ceiling on `Limit`, so one request cannot be asked to hold an unbounded delete.".
+-spec max_limit() -> pos_integer().
+max_limit() -> ?MAX_LIMIT.
+
+-doc """
+The cutoff `Seconds` of inactivity maps to, in UTC.
+
+`0` is now, which selects every unclaimed guest.
+""".
+-spec cutoff(non_neg_integer()) -> cutoff().
+cutoff(Seconds) when is_integer(Seconds), Seconds >= 0 ->
+    Now = calendar:datetime_to_gregorian_seconds(erlang:universaltime()),
+    calendar:gregorian_seconds_to_datetime(Now - Seconds).
+
+-doc """
+How many unclaimed guests are older than `Cutoff`.
+
+The number a preview reports, and the number a caller compares against before
+asking for the delete.
+""".
+-spec count(cutoff()) -> {ok, non_neg_integer()} | {error, term()}.
+count(Cutoff) ->
+    case asobi_repo:aggregate(matching(Cutoff), count) of
+        {ok, N} when is_integer(N), N >= 0 -> {ok, N};
+        {error, Reason} -> {error, Reason};
+        Other -> {error, Other}
+    end.
+
+-doc """
+Erase up to `Limit` unclaimed guests older than `Cutoff`, and audit the batch.
+
+Returns the counts, never the ids: an operator page reports how many went, and
+the ids that did are in the audit row for anyone who has to answer for it
+later. A player whose in-transaction re-check now says "claimed" is counted
+`skipped`, not `failed` - nothing went wrong, the answer changed.
+
+One audit row per call, carrying every erased id as a subject, so a purge is
+one entry an operator can point at rather than N entries they have to correlate.
+""".
+-spec run(cutoff(), pos_integer(), non_neg_integer(), asobi_ops_auth:actor()) ->
+    {ok, #{deleted := non_neg_integer(), skipped := non_neg_integer()}} | {error, term()}.
+run(Cutoff, Limit, Matched, Actor) when is_integer(Limit), Limit > 0 ->
+    case candidates(Cutoff, min(Limit, ?MAX_LIMIT)) of
+        {ok, Ids} ->
+            {Erased, Skipped} = erase_each(Ids),
+            audit(Erased, Skipped, Matched, Actor),
+            {ok, #{deleted => length(Erased), skipped => length(Skipped)}};
+        {error, Reason} ->
+            {error, Reason}
+    end.
+
+-spec matching(cutoff() | undefined) -> #kura_query{}.
+matching(Cutoff) ->
+    kura_query:where(kura_query:from(asobi_player), clause(Cutoff)).
+
+-doc """
+The `WHERE` condition selecting every unclaimed guest last seen before `Cutoff`.
+
+Exported because the ops player list narrows on the same definition, and two
+places answering "is this a guest" differently is how a purge deletes a row an
+operator was told was not in the set. `undefined` drops the cutoff and keeps
+the rest, which is what a list filter wants.
+
+Three conditions, and each one is load-bearing:
+
+* no password - a claimed account is not a guest, and `/auth/guest/upgrade`
+  sets one;
+* a `guest` identity older than the cutoff - the row guest sign-in touches, so
+  this reads as "not seen since", not "signed up before";
+* no identity of any other provider - a guest who linked an OAuth account still
+  has the guest identity, and deleting them would take a real account with it.
+
+The subqueries are literal SQL because the alternative is a join, and a join
+here is ambiguous: `kura` emits unqualified column names in `WHERE`, and both
+tables carry `id` and `updated_at`. Correlated `EXISTS` keeps every column
+unambiguous and keeps the row count at one row per player. The two table names
+are the only literals; `asobi_guest_purge_tests` fails if either schema module
+stops agreeing with them.
+""".
+-spec clause(cutoff() | undefined) -> predicate().
+clause(undefined) ->
+    {'and', [{hashed_password, is_nil}, guest_identity(), no_other_provider()]};
+clause(Cutoff) ->
+    {'and', [{hashed_password, is_nil}, guest_identity(Cutoff), no_other_provider()]}.
+
+-spec guest_identity() -> condition().
+guest_identity() ->
+    {fragment,
+        ~"EXISTS (SELECT 1 FROM \"player_identities\" WHERE \"player_identities\".\"player_id\" = \"players\".\"id\" AND \"player_identities\".\"provider\" = ?)",
+        [?PROVIDER]}.
+
+%% `<=`, not `<`, and the boundary is the whole point rather than a detail.
+%% `erlang:universaltime/0` is whole seconds, so with a strict `<` a cutoff of
+%% zero excludes every guest whose identity was written during the current
+%% second - which is to say "clear all guest users" quietly spares the ones who
+%% just arrived. Inclusive, the cutoff means "not seen since", and a row written
+%% after it was measured is out of the set because it was not in it when the
+%% set was measured, which is the honest answer.
+-spec guest_identity(cutoff()) -> condition().
+guest_identity(Cutoff) ->
+    {fragment,
+        ~"EXISTS (SELECT 1 FROM \"player_identities\" WHERE \"player_identities\".\"player_id\" = \"players\".\"id\" AND \"player_identities\".\"provider\" = ? AND \"player_identities\".\"updated_at\" <= ?)",
+        [?PROVIDER, Cutoff]}.
+
+-spec no_other_provider() -> condition().
+no_other_provider() ->
+    {fragment,
+        ~"NOT EXISTS (SELECT 1 FROM \"player_identities\" WHERE \"player_identities\".\"player_id\" = \"players\".\"id\" AND \"player_identities\".\"provider\" <> ?)",
+        [?PROVIDER]}.
+
+-spec candidates(cutoff(), pos_integer()) -> {ok, [binary()]} | {error, term()}.
+candidates(Cutoff, Limit) ->
+    Q = kura_query:limit(kura_query:select(matching(Cutoff), [id]), Limit),
+    case asobi_repo:all(Q) of
+        {ok, Rows} -> {ok, [Id || #{id := Id} <- Rows, is_binary(Id)]};
+        {error, Reason} -> {error, Reason}
+    end.
+
+-spec erase_each([binary()]) -> {[binary()], [binary()]}.
+erase_each(Ids) ->
+    Outcomes = [{Id, erase_one(Id)} || Id <- Ids],
+    {[Id || {Id, erased} <- Outcomes], [Id || {Id, skipped} <- Outcomes]}.
+
+%% One transaction per player, not one around the batch: a batch-wide
+%% transaction would roll 500 erasures back because the 501st hit an
+%% extension's orphaned rows, and it would hold write locks across the whole
+%% cohort while it did. The re-check lives inside each transaction for the
+%% reason `m:asobi_guest_reaper` gives - a concurrent upgrade must win.
+-spec erase_one(binary()) -> erased | skipped.
+erase_one(PlayerId) ->
+    Fun = fun() ->
+        case asobi_guest_reaper:unclaimed_guest(PlayerId) of
+            false -> {error, claimed_during_purge};
+            true -> asobi_player_erase:steps(PlayerId)
+        end
+    end,
+    try asobi_repo:transaction(Fun) of
+        ok ->
+            asobi_player_erase:after_commit(PlayerId),
+            erased;
+        {error, Reason} ->
+            ?LOG_DEBUG(#{event => guest_purge_skipped, player_id => PlayerId, reason => Reason}),
+            skipped;
+        Other ->
+            ?LOG_WARNING(#{event => guest_purge_unexpected, player_id => PlayerId, result => Other}),
+            skipped
+    catch
+        Class:Reason:Stacktrace ->
+            log_failure(PlayerId, Class, Reason, Stacktrace),
+            skipped
+    end.
+
+-spec log_failure(binary(), atom(), term(), erlang:stacktrace()) -> ok.
+log_failure(PlayerId, Class, Reason, Stacktrace) ->
+    case asobi_player_erase:orphan_blocker(Reason) of
+        {orphaned_extension_rows, Table} ->
+            ?LOG_WARNING(#{
+                event => guest_purge_orphaned_extension_rows,
+                player_id => PlayerId,
+                table => Table
+            });
+        not_orphaned ->
+            ?LOG_ERROR(#{
+                event => guest_purge_rolled_back,
+                player_id => PlayerId,
+                class => Class,
+                reason => Reason,
+                stacktrace => Stacktrace
+            })
+    end,
+    ok.
+
+%% `record/4`, not `record_strict/4`. The single-player erase is strict because
+%% it can still roll its own transaction back when the audit insert fails; here
+%% the deletes have committed one by one and there is nothing left to undo, so
+%% a strict failure would have no answer to give. The insert failing is loud in
+%% the log either way - see `m:asobi_ops_audit` on why that trade is stated
+%% rather than assumed.
+-spec audit([binary()], [binary()], non_neg_integer(), asobi_ops_auth:actor()) -> ok.
+audit(Erased, Skipped, Matched, Actor) ->
+    asobi_ops_audit:record(
+        Actor,
+        ?ACTION,
+        {?TARGET_TYPE, undefined},
+        {ok, Erased, [{Id, claimed_during_purge} || Id <- Skipped]}
+    ),
+    ?LOG_INFO(#{
+        event => guest_cohort_purged,
+        deleted => length(Erased),
+        skipped => length(Skipped),
+        matched => Matched
+    }),
+    ok.

--- a/src/asobi_guest_purge.erl
+++ b/src/asobi_guest_purge.erl
@@ -45,7 +45,9 @@ the set is chosen; the Erlang is how each member is confirmed.
 
 `run/4` deletes at most `Limit` players and reports what is left, rather than
 holding one request open across an unbounded table. A caller that wants the
-whole set repeats the call until `remaining` reaches `0`.
+whole set repeats the call while `deleted` is above zero - not until nothing is
+left, because a player that cannot be erased stays in the set and is selected
+again every time.
 """.
 
 -include_lib("kernel/include/logger.hrl").
@@ -103,20 +105,40 @@ Erase up to `Limit` unclaimed guests older than `Cutoff`, and audit the batch.
 
 Returns the counts, never the ids: an operator page reports how many went, and
 the ids that did are in the audit row for anyone who has to answer for it
-later. A player whose in-transaction re-check now says "claimed" is counted
-`skipped`, not `failed` - nothing went wrong, the answer changed.
+later.
+
+`skipped` and `failed` are separate counts because they ask for opposite
+responses. A player whose in-transaction re-check now says "claimed" is
+`skipped` - nothing went wrong, the answer changed, and they have left the set.
+A player whose erasure raised is `failed`: something is wrong, they are still
+in the set, and the next call will select them again. Collapsing the two would
+report a stuck cohort as a quiet success.
+
+That is also why a caller loops while `deleted` is above zero rather than until
+`remaining` reaches zero. A player who cannot be erased - orphaned extension
+rows are the case `m:asobi_player_erase` names - never leaves `remaining`, so
+"loop until empty" would not terminate.
 
 One audit row per call, carrying every erased id as a subject, so a purge is
 one entry an operator can point at rather than N entries they have to correlate.
 """.
 -spec run(cutoff(), pos_integer(), non_neg_integer(), asobi_ops_auth:actor()) ->
-    {ok, #{deleted := non_neg_integer(), skipped := non_neg_integer()}} | {error, term()}.
+    {ok, #{
+        deleted := non_neg_integer(),
+        skipped := non_neg_integer(),
+        failed := non_neg_integer()
+    }}
+    | {error, term()}.
 run(Cutoff, Limit, Matched, Actor) when is_integer(Limit), Limit > 0 ->
     case candidates(Cutoff, min(Limit, ?MAX_LIMIT)) of
         {ok, Ids} ->
-            {Erased, Skipped} = erase_each(Ids),
-            audit(Erased, Skipped, Matched, Actor),
-            {ok, #{deleted => length(Erased), skipped => length(Skipped)}};
+            {Erased, Skipped, Failed} = erase_each(Ids),
+            audit(Erased, Skipped, Failed, Matched, Actor),
+            {ok, #{
+                deleted => length(Erased),
+                skipped => length(Skipped),
+                failed => length(Failed)
+            }};
         {error, Reason} ->
             {error, Reason}
     end.
@@ -188,17 +210,26 @@ candidates(Cutoff, Limit) ->
         {error, Reason} -> {error, Reason}
     end.
 
--spec erase_each([binary()]) -> {[binary()], [binary()]}.
+-spec erase_each([binary()]) -> {[binary()], [{binary(), term()}], [{binary(), term()}]}.
 erase_each(Ids) ->
     Outcomes = [{Id, erase_one(Id)} || Id <- Ids],
-    {[Id || {Id, erased} <- Outcomes], [Id || {Id, skipped} <- Outcomes]}.
+    {
+        [Id || {Id, erased} <- Outcomes],
+        [{Id, Reason} || {Id, {skipped, Reason}} <- Outcomes],
+        [{Id, Reason} || {Id, {failed, Reason}} <- Outcomes]
+    }.
 
 %% One transaction per player, not one around the batch: a batch-wide
 %% transaction would roll 500 erasures back because the 501st hit an
 %% extension's orphaned rows, and it would hold write locks across the whole
 %% cohort while it did. The re-check lives inside each transaction for the
 %% reason `m:asobi_guest_reaper` gives - a concurrent upgrade must win.
--spec erase_one(binary()) -> erased | skipped.
+%% The re-check losing to a concurrent upgrade is the ONLY skip. Everything
+%% else - a rolled-back transaction, an unexpected return, a raise - is a
+%% failure, because the player is still unclaimed, still matches the predicate,
+%% and will be selected again by the next call. Reporting those as skips is how
+%% a cohort that cannot be erased reads as a cohort that did not need erasing.
+-spec erase_one(binary()) -> erased | {skipped, term()} | {failed, term()}.
 erase_one(PlayerId) ->
     Fun = fun() ->
         case asobi_guest_reaper:unclaimed_guest(PlayerId) of
@@ -210,19 +241,27 @@ erase_one(PlayerId) ->
         ok ->
             asobi_player_erase:after_commit(PlayerId),
             erased;
+        {error, claimed_during_purge} ->
+            ?LOG_DEBUG(#{
+                event => guest_purge_skipped,
+                player_id => PlayerId,
+                reason => claimed_during_purge
+            }),
+            {skipped, claimed_during_purge};
         {error, Reason} ->
-            ?LOG_DEBUG(#{event => guest_purge_skipped, player_id => PlayerId, reason => Reason}),
-            skipped;
+            ?LOG_WARNING(#{event => guest_purge_failed, player_id => PlayerId, reason => Reason}),
+            {failed, Reason};
         Other ->
             ?LOG_WARNING(#{event => guest_purge_unexpected, player_id => PlayerId, result => Other}),
-            skipped
+            {failed, unexpected_result}
     catch
         Class:Reason:Stacktrace ->
-            log_failure(PlayerId, Class, Reason, Stacktrace),
-            skipped
+            {failed, log_failure(PlayerId, Class, Reason, Stacktrace)}
     end.
 
--spec log_failure(binary(), atom(), term(), erlang:stacktrace()) -> ok.
+%% Returns the reason it logged, so the audit row records why this player
+%% survived rather than restating the caller's assumption about why.
+-spec log_failure(binary(), atom(), term(), erlang:stacktrace()) -> term().
 log_failure(PlayerId, Class, Reason, Stacktrace) ->
     case asobi_player_erase:orphan_blocker(Reason) of
         {orphaned_extension_rows, Table} ->
@@ -230,7 +269,8 @@ log_failure(PlayerId, Class, Reason, Stacktrace) ->
                 event => guest_purge_orphaned_extension_rows,
                 player_id => PlayerId,
                 table => Table
-            });
+            }),
+            {orphaned_extension_rows, Table};
         not_orphaned ->
             ?LOG_ERROR(#{
                 event => guest_purge_rolled_back,
@@ -238,9 +278,9 @@ log_failure(PlayerId, Class, Reason, Stacktrace) ->
                 class => Class,
                 reason => Reason,
                 stacktrace => Stacktrace
-            })
-    end,
-    ok.
+            }),
+            {Class, Reason}
+    end.
 
 %% `record/4`, not `record_strict/4`. The single-player erase is strict because
 %% it can still roll its own transaction back when the audit insert fails; here
@@ -248,18 +288,29 @@ log_failure(PlayerId, Class, Reason, Stacktrace) ->
 %% a strict failure would have no answer to give. The insert failing is loud in
 %% the log either way - see `m:asobi_ops_audit` on why that trade is stated
 %% rather than assumed.
--spec audit([binary()], [binary()], non_neg_integer(), asobi_ops_auth:actor()) -> ok.
-audit(Erased, Skipped, Matched, Actor) ->
+%%
+%% Each non-erased subject carries the reason it actually had. The row is the
+%% only evidence left of what this call did, so stamping one reason across
+%% every subject would make it evidence of something that did not happen.
+-spec audit(
+    [binary()],
+    [{binary(), term()}],
+    [{binary(), term()}],
+    non_neg_integer(),
+    asobi_ops_auth:actor()
+) -> ok.
+audit(Erased, Skipped, Failed, Matched, Actor) ->
     asobi_ops_audit:record(
         Actor,
         ?ACTION,
         {?TARGET_TYPE, undefined},
-        {ok, Erased, [{Id, claimed_during_purge} || Id <- Skipped]}
+        {ok, Erased, Skipped ++ Failed}
     ),
     ?LOG_INFO(#{
         event => guest_cohort_purged,
         deleted => length(Erased),
         skipped => length(Skipped),
+        failed => length(Failed),
         matched => Matched
     }),
     ok.

--- a/src/asobi_router.erl
+++ b/src/asobi_router.erl
@@ -264,6 +264,17 @@ ops_routes() ->
                 methods => [get, options]
             }},
             {~"/players/:id", fun asobi_ops_controller:player/1, #{methods => [get, options]}},
+            %% After every `:id` route, and that is the asobi#326 trap rather
+            %% than a style choice. routing_tree prepends on insert and returns
+            %% on the first *matching sibling* without backtracking, so the
+            %% `:id` binding happily matches the literal segment `guests` and
+            %% then fails to find `purge` beneath it. Declared last, the literal
+            %% is prepended ahead of the binding and is tried first.
+            %% `asobi_router_tests` resolves every declared route and fails if
+            %% this moves back up.
+            {~"/players/guests/purge", fun asobi_ops_controller:purge_guests/1, #{
+                methods => [post, options]
+            }},
             {~"/matches", fun asobi_ops_controller:matches/1, #{methods => [get, options]}},
             {~"/matches/:id", fun asobi_ops_controller:match/1, #{methods => [get, options]}},
             {~"/features", fun asobi_ops_controller:features/1, #{methods => [get, options]}},

--- a/src/ops/asobi_ops_caps.erl
+++ b/src/ops/asobi_ops_caps.erl
@@ -63,7 +63,13 @@ classes() ->
         %% Not `read`. `read` grants a leaderboard view; this grants
         %% everything the deployment holds about one identified person.
         {get, [~"players", '_', ~"export"], player_data},
-        {post, [~"players", '_', ~"erase"], erasure}
+        {post, [~"players", '_', ~"erase"], erasure},
+        %% Same class as the single erase, because it is the same action at a
+        %% different fan-out. A credential trusted to erase one player is
+        %% trusted to erase a cohort; one that is not, is not. Splitting it
+        %% would mint a "may erase, but only slowly" capability, which nothing
+        %% in the threat model asks for.
+        {post, [~"players", ~"guests", ~"purge"], erasure}
     ].
 
 -doc """

--- a/src/ops/asobi_ops_controller.erl
+++ b/src/ops/asobi_ops_controller.erl
@@ -138,14 +138,20 @@ out rather than defaulted to.
 
 Three optional keys tighten or widen it:
 
-* `dry_run: true` counts and deletes nothing. Free, and worth doing first.
-* `confirm_count: N` refuses the call unless the server counts exactly `N`
-  right now. For an operator working from a preview; a live game minting
-  guests will move under it, which is the point.
+* `dry_run: true` counts and deletes nothing. Free, and the way to obtain the
+  `confirm_count` the destructive call then requires.
+* `confirm_count: N` is **required** unless `dry_run` is set, and refuses the
+  call unless the server counts exactly `N` right now. Erasing one player has
+  to echo that player's username; erasing a cohort has to echo its size, or the
+  larger blast radius would carry the weaker guard. A live game minting guests
+  will move under it, which is the point.
 * `limit: N` caps this call at `N` deletions (default
-  `asobi_guest_purge:default_limit/0`, ceiling `max_limit/0`). The response
-  reports `remaining`, and a caller that wants the whole cohort repeats until
-  it reaches `0` - one request is never held open across an unbounded table.
+  `asobi_guest_purge:default_limit/0`, ceiling `max_limit/0`). A caller that
+  wants the whole cohort repeats **while `deleted` is above zero**, not until
+  `remaining` reaches it: a player who cannot be erased stays in the set and is
+  re-selected every call, so looping on `remaining` would never terminate.
+  `failed` above zero on a call that deleted nothing is that cohort, and the
+  reason is in the log and the audit row.
 """.
 -spec purge_guests(cowboy_req:req()) -> response().
 purge_guests(#{auth_data := #{ops_actor := Actor}} = Req) ->
@@ -157,47 +163,68 @@ purge_guests(#{auth_data := #{ops_actor := Actor}} = Req) ->
 -spec counted(asobi_guest_purge:cutoff(), cowboy_req:req(), asobi_ops_auth:actor()) -> response().
 counted(Cutoff, Req, Actor) ->
     case asobi_guest_purge:count(Cutoff) of
-        {ok, Matched} ->
-            case confirmed_count(Req, Matched) of
-                ok -> purge_or_preview(Cutoff, Matched, Req, Actor);
-                mismatch -> {asobi_error, ~"ops.purge_count_mismatch", #{matched => Matched}}
-            end;
-        {error, Reason} ->
-            error_response({query_failed, Reason})
+        {ok, Matched} -> purge_or_preview(Cutoff, Matched, Req, Actor);
+        {error, Reason} -> error_response({query_failed, Reason})
     end.
 
+%% The dry run is checked before the confirmation, not after: a preview is how
+%% a caller learns the count it is then required to echo, so demanding the echo
+%% to reach the preview would leave no way in.
 -spec purge_or_preview(
     asobi_guest_purge:cutoff(), non_neg_integer(), cowboy_req:req(), asobi_ops_auth:actor()
 ) -> response().
 purge_or_preview(Cutoff, Matched, Req, Actor) ->
     case dry_run(Req) of
         true ->
-            {json, #{data => summary(Matched, 0, 0, Matched, true)}};
+            {json, #{data => summary(Matched, 0, 0, 0, Matched, true)}};
         false ->
-            case asobi_guest_purge:run(Cutoff, purge_limit(Req), Matched, Actor) of
-                {ok, #{deleted := Deleted, skipped := Skipped}} ->
-                    {json, #{
-                        data => summary(Matched, Deleted, Skipped, Matched - Deleted, false)
-                    }};
-                {error, Reason} ->
-                    ?LOG_ERROR(#{msg => ~"ops guest purge failed", reason => Reason}),
-                    {asobi_error, ~"ops.purge_failed"}
+            case confirmed_count(Req, Matched) of
+                ok -> purged(Cutoff, Matched, Req, Actor);
+                mismatch -> {asobi_error, ~"ops.purge_count_mismatch", #{matched => Matched}};
+                missing -> {asobi_error, ~"ops.confirmation_required", #{matched => Matched}}
             end
     end.
 
-%% `remaining` is the count this call started from minus what it erased, not a
-%% second count: a re-count here would read a table other requests are still
-%% writing to and report a number that was never true of this call. It is what
-%% is left of the cohort this call measured, which is the question a caller
-%% looping on it is asking.
+-spec purged(
+    asobi_guest_purge:cutoff(), non_neg_integer(), cowboy_req:req(), asobi_ops_auth:actor()
+) -> response().
+purged(Cutoff, Matched, Req, Actor) ->
+    case asobi_guest_purge:run(Cutoff, purge_limit(Req), Matched, Actor) of
+        {ok, #{deleted := Deleted, skipped := Skipped, failed := Failed}} ->
+            {json, #{
+                data => summary(
+                    Matched, Deleted, Skipped, Failed, Matched - Deleted - Skipped, false
+                )
+            }};
+        {error, Reason} ->
+            ?LOG_ERROR(#{msg => ~"ops guest purge failed", reason => Reason}),
+            {asobi_error, ~"ops.purge_failed"}
+    end.
+
+%% `remaining` is the count this call started from minus the players that left
+%% the set, not a second count: a re-count here would read a table other
+%% requests are still writing to and report a number that was never true of this
+%% call.
+%%
+%% Erased and skipped both leave. A skipped player was claimed mid-purge, so
+%% they no longer satisfy the predicate and the next call will not see them. A
+%% FAILED player has not left - they are still unclaimed and still match - so
+%% they stay counted, and `remaining` is honest about a cohort that is not
+%% shrinking rather than counting down to a zero it will never reach.
 -spec summary(
-    non_neg_integer(), non_neg_integer(), non_neg_integer(), integer(), boolean()
+    non_neg_integer(),
+    non_neg_integer(),
+    non_neg_integer(),
+    non_neg_integer(),
+    integer(),
+    boolean()
 ) -> map().
-summary(Matched, Deleted, Skipped, Remaining, DryRun) ->
+summary(Matched, Deleted, Skipped, Failed, Remaining, DryRun) ->
     #{
         matched => Matched,
         deleted => Deleted,
         skipped => Skipped,
+        failed => Failed,
         remaining => max(0, Remaining),
         dry_run => DryRun
     }.
@@ -216,12 +243,17 @@ inactive_for(_Req) ->
 dry_run(#{json := #{~"dry_run" := true}}) -> true;
 dry_run(_Req) -> false.
 
--spec confirmed_count(cowboy_req:req(), non_neg_integer()) -> ok | mismatch.
+%% Absent is `missing`, not `ok`. An unattended POST that names only a cutoff
+%% must not be sufficient to erase a cohort when erasing one player already
+%% requires echoing that player's username. A non-integer is `missing` too: it
+%% confirms nothing, and the caller needs to be told to send a real count
+%% rather than that their count did not match.
+-spec confirmed_count(cowboy_req:req(), non_neg_integer()) -> ok | mismatch | missing.
 confirmed_count(#{json := #{~"confirm_count" := Matched}}, Matched) when is_integer(Matched) -> ok;
 confirmed_count(#{json := #{~"confirm_count" := Given}}, _Matched) when is_integer(Given) ->
     mismatch;
 confirmed_count(_Req, _Matched) ->
-    ok.
+    missing.
 
 %% Clamped rather than rejected: an oversized batch is a caller asking for more
 %% work in one request than this route will hold open, and the honest answer is

--- a/src/ops/asobi_ops_controller.erl
+++ b/src/ops/asobi_ops_controller.erl
@@ -24,7 +24,7 @@ transaction. See `m:asobi_player_erase`.
 -include_lib("kernel/include/logger.hrl").
 -include_lib("kura/include/kura.hrl").
 
--export([players/1, player/1, erase_player/1, export_player/1]).
+-export([players/1, player/1, erase_player/1, export_player/1, purge_guests/1]).
 -export([matches/1, match/1, features/1, stats/1]).
 -export([leaderboards/1, leaderboard_entries/1, matchmaker/1]).
 -export([economy_items/1, economy_item/1, economy_listings/1, economy_listing/1]).
@@ -120,6 +120,117 @@ erased({error, Reason}, Id) ->
 -spec blocker_detail(term()) -> binary().
 blocker_detail(Table) when is_binary(Table) -> Table;
 blocker_detail(_Blocker) -> ~"unknown".
+
+-doc """
+Erase the unclaimed guests nobody has signed in as since a cutoff.
+
+The bulk counterpart to `erase_player/1`, and it takes the same position on
+confirmation from a different angle. One player is confirmed by echoing
+something only a caller who looked at the row can know; a cohort has no such
+handle, so what stands in for it is that **`inactive_for_seconds` has no
+default**. An empty POST to this route selects nothing and answers 400, which
+is the property the username echo buys over there: an unattended request is
+never sufficient.
+
+`inactive_for_seconds: 0` means "every unclaimed guest, including the one that
+signed in a second ago". That is the "clear them all" case, and it is spelled
+out rather than defaulted to.
+
+Three optional keys tighten or widen it:
+
+* `dry_run: true` counts and deletes nothing. Free, and worth doing first.
+* `confirm_count: N` refuses the call unless the server counts exactly `N`
+  right now. For an operator working from a preview; a live game minting
+  guests will move under it, which is the point.
+* `limit: N` caps this call at `N` deletions (default
+  `asobi_guest_purge:default_limit/0`, ceiling `max_limit/0`). The response
+  reports `remaining`, and a caller that wants the whole cohort repeats until
+  it reaches `0` - one request is never held open across an unbounded table.
+""".
+-spec purge_guests(cowboy_req:req()) -> response().
+purge_guests(#{auth_data := #{ops_actor := Actor}} = Req) ->
+    case inactive_for(Req) of
+        {ok, Seconds} -> counted(asobi_guest_purge:cutoff(Seconds), Req, Actor);
+        error -> {asobi_error, ~"ops.invalid_cutoff"}
+    end.
+
+-spec counted(asobi_guest_purge:cutoff(), cowboy_req:req(), asobi_ops_auth:actor()) -> response().
+counted(Cutoff, Req, Actor) ->
+    case asobi_guest_purge:count(Cutoff) of
+        {ok, Matched} ->
+            case confirmed_count(Req, Matched) of
+                ok -> purge_or_preview(Cutoff, Matched, Req, Actor);
+                mismatch -> {asobi_error, ~"ops.purge_count_mismatch", #{matched => Matched}}
+            end;
+        {error, Reason} ->
+            error_response({query_failed, Reason})
+    end.
+
+-spec purge_or_preview(
+    asobi_guest_purge:cutoff(), non_neg_integer(), cowboy_req:req(), asobi_ops_auth:actor()
+) -> response().
+purge_or_preview(Cutoff, Matched, Req, Actor) ->
+    case dry_run(Req) of
+        true ->
+            {json, #{data => summary(Matched, 0, 0, Matched, true)}};
+        false ->
+            case asobi_guest_purge:run(Cutoff, purge_limit(Req), Matched, Actor) of
+                {ok, #{deleted := Deleted, skipped := Skipped}} ->
+                    {json, #{
+                        data => summary(Matched, Deleted, Skipped, Matched - Deleted, false)
+                    }};
+                {error, Reason} ->
+                    ?LOG_ERROR(#{msg => ~"ops guest purge failed", reason => Reason}),
+                    {asobi_error, ~"ops.purge_failed"}
+            end
+    end.
+
+%% `remaining` is the count this call started from minus what it erased, not a
+%% second count: a re-count here would read a table other requests are still
+%% writing to and report a number that was never true of this call. It is what
+%% is left of the cohort this call measured, which is the question a caller
+%% looping on it is asking.
+-spec summary(
+    non_neg_integer(), non_neg_integer(), non_neg_integer(), integer(), boolean()
+) -> map().
+summary(Matched, Deleted, Skipped, Remaining, DryRun) ->
+    #{
+        matched => Matched,
+        deleted => Deleted,
+        skipped => Skipped,
+        remaining => max(0, Remaining),
+        dry_run => DryRun
+    }.
+
+%% Absent, wrong-typed and negative are one answer, because none of them says
+%% which cohort to delete. A float is not "close enough" to a cutoff either.
+-spec inactive_for(cowboy_req:req()) -> {ok, non_neg_integer()} | error.
+inactive_for(#{json := #{~"inactive_for_seconds" := Seconds}}) when
+    is_integer(Seconds), Seconds >= 0
+->
+    {ok, Seconds};
+inactive_for(_Req) ->
+    error.
+
+-spec dry_run(cowboy_req:req()) -> boolean().
+dry_run(#{json := #{~"dry_run" := true}}) -> true;
+dry_run(_Req) -> false.
+
+-spec confirmed_count(cowboy_req:req(), non_neg_integer()) -> ok | mismatch.
+confirmed_count(#{json := #{~"confirm_count" := Matched}}, Matched) when is_integer(Matched) -> ok;
+confirmed_count(#{json := #{~"confirm_count" := Given}}, _Matched) when is_integer(Given) ->
+    mismatch;
+confirmed_count(_Req, _Matched) ->
+    ok.
+
+%% Clamped rather than rejected: an oversized batch is a caller asking for more
+%% work in one request than this route will hold open, and the honest answer is
+%% the batch it will do plus the `remaining` that says to call again.
+-spec purge_limit(cowboy_req:req()) -> pos_integer().
+purge_limit(#{json := #{~"limit" := Limit}}) when is_integer(Limit), Limit > 0 ->
+    min(Limit, asobi_guest_purge:max_limit());
+purge_limit(_Req) ->
+    asobi_guest_purge:default_limit().
 
 %% `undefined` is "no confirmation sent", which is a different answer from a
 %% confirmation that did not match - an operator who typed the wrong name

--- a/src/ops/asobi_ops_players.erl
+++ b/src/ops/asobi_ops_players.erl
@@ -5,6 +5,11 @@ Player list for the ops read plane: filter, search, sort, paginate.
 Search is `ILIKE` across `username` and `display_name`. The endpoints this
 replaces searched by exact equality on a single column, which meant an
 operator had to already know the username to find it.
+
+`?guest=true` narrows to unclaimed guests, and `?guest=false` to everyone
+else. The predicate is `asobi_guest_purge:clause/1`'s, not a second reading
+of it: this list is what an operator looks at before purging that cohort, and a
+list that disagrees with the purge is a list that promises the wrong deletion.
 """.
 
 -include_lib("kura/include/kura.hrl").
@@ -37,11 +42,23 @@ query(Params) ->
     case asobi_ops_params:sort(Params, ?SORTABLE, [{inserted_at, desc}]) of
         {ok, Orders} ->
             case asobi_ops_filters:build(kura_query:from(asobi_player), Params, ?FILTERS) of
-                {ok, Query} -> {ok, kura_query:order_by(Query, Orders)};
+                {ok, Query} -> {ok, kura_query:order_by(guest(Query, Params), Orders)};
                 {error, _} = Error -> Error
             end;
         {error, _} = Error ->
             Error
+    end.
+
+%% Not an `asobi_ops_filters` spec: those build one clause over one column of
+%% the table being listed, and "is an unclaimed guest" is a statement about two
+%% correlated subqueries and a column this endpoint refuses to project. An
+%% unparseable value narrows nothing, the same as every other absent filter.
+-spec guest(#kura_query{}, asobi_ops_params:params()) -> #kura_query{}.
+guest(Query, Params) ->
+    case asobi_ops_params:boolean(Params, ~"guest") of
+        {ok, true} -> kura_query:where(Query, asobi_guest_purge:clause(undefined));
+        {ok, false} -> kura_query:where(Query, {'not', asobi_guest_purge:clause(undefined)});
+        none -> Query
     end.
 
 -doc """

--- a/test/asobi_guest_purge_SUITE.erl
+++ b/test/asobi_guest_purge_SUITE.erl
@@ -1,0 +1,202 @@
+-module(asobi_guest_purge_SUITE).
+-moduledoc """
+The purge against a real database.
+
+`asobi_guest_purge_tests` asserts the SQL this module builds. Whether Postgres
+accepts it, and whether the set it selects is the set the guides promise, is
+only answerable here: the predicate is two correlated subqueries over a table
+`asobi_repo` never joins anywhere else, and a mecked repo would agree with
+whatever it was told.
+""".
+
+-include_lib("nova_test/include/nova_test.hrl").
+
+-export([all/0, init_per_suite/1, end_per_suite/1]).
+-export([
+    purges_an_abandoned_guest/1,
+    spares_a_guest_seen_since_the_cutoff/1,
+    spares_a_claimed_account/1,
+    zero_seconds_takes_every_unclaimed_guest/1,
+    count_agrees_with_what_run_deletes/1,
+    limit_bounds_one_call_and_remaining_says_so/1
+]).
+
+all() ->
+    [
+        purges_an_abandoned_guest,
+        spares_a_guest_seen_since_the_cutoff,
+        spares_a_claimed_account,
+        zero_seconds_takes_every_unclaimed_guest,
+        count_agrees_with_what_run_deletes,
+        limit_bounds_one_call_and_remaining_says_so
+    ].
+
+%% Guest auth is set after the app starts, for the reason `asobi_guest_SUITE`
+%% documents at length: booting with no game bundle writes `guest_auth = false`
+%% unconditionally, so anything set before the start is overwritten during it.
+%%
+%% `guest_reap_after` is deliberately NOT set. This is the on-demand half of
+%% retention, and it has to work on a deployment that never configured the
+%% automatic half - which is the deployment that accumulates the guests in the
+%% first place. A stray background sweep would also delete the fixtures out
+%% from under these tests and make them pass for the wrong reason.
+init_per_suite(Config0) ->
+    Config = asobi_test_helpers:start(Config0),
+    application:set_env(asobi, guest_auth, true),
+    application:set_env(asobi, guest_verifier_pepper, crypto:strong_rand_bytes(32)),
+    application:unset_env(asobi, guest_reap_after),
+    Config.
+
+end_per_suite(Config) ->
+    Config.
+
+%% --- Helpers ---
+
+secret() ->
+    base64:encode(crypto:strong_rand_bytes(32)).
+
+device_id() ->
+    base64:encode(crypto:strong_rand_bytes(16)).
+
+create(DeviceId, Secret, Config) ->
+    nova_test:post(
+        "/api/v1/auth/guest",
+        #{json => #{~"device_id" => DeviceId, ~"device_secret" => Secret}},
+        Config
+    ).
+
+guest(Config) ->
+    {ok, Response} = create(device_id(), secret(), Config),
+    ?assertStatus(200, Response),
+    #{~"player_id" := PlayerId} = nova_test:json(Response),
+    PlayerId.
+
+%% Age the identity rather than sleeping past the cutoff - the same wall-clock
+%% race `asobi_guest_SUITE:age_identity/1` exists to avoid.
+age_identity(PlayerId) ->
+    Ancient = {{2020, 1, 1}, {0, 0, 0}},
+    {ok, 1} = asobi_repo:update_all(
+        kura_query:where(kura_query:from(asobi_player_identity), {player_id, PlayerId}),
+        #{inserted_at => Ancient, updated_at => Ancient}
+    ),
+    ok.
+
+actor() ->
+    asobi_ops_auth:subject_actor(~"suite").
+
+purge(Seconds, Limit) ->
+    asobi_guest_purge:run(asobi_guest_purge:cutoff(Seconds), Limit, 0, actor()).
+
+exists(PlayerId) ->
+    case asobi_repo:get(asobi_player, PlayerId) of
+        {ok, _} -> true;
+        {error, not_found} -> false
+    end.
+
+%% --- Tests ---
+
+%% The whole point: a device that signed in once and never came back.
+purges_an_abandoned_guest(Config) ->
+    PlayerId = guest(Config),
+    age_identity(PlayerId),
+    {ok, #{deleted := Deleted}} = purge(3600, 100),
+    ?assert(Deleted >= 1),
+    ?assertNot(exists(PlayerId)),
+    %% The identity goes with the player, which is why the next presentation of
+    %% the same device pair mints a new account rather than resuming this one.
+    ?assertEqual(
+        {ok, 0},
+        asobi_repo:aggregate(
+            kura_query:where(kura_query:from(asobi_player_identity), {player_id, PlayerId}), count
+        )
+    ),
+    Config.
+
+%% The cutoff reads last-seen, so a guest who is still playing survives however
+%% long ago they first launched. Keyed on `inserted_at` instead, this deletes
+%% an active player.
+spares_a_guest_seen_since_the_cutoff(Config) ->
+    Dev = device_id(),
+    Secret = secret(),
+    {ok, R1} = create(Dev, Secret, Config),
+    ?assertStatus(200, R1),
+    #{~"player_id" := PlayerId} = nova_test:json(R1),
+    age_identity(PlayerId),
+
+    %% Same device, same secret: a resume, which touches the identity row.
+    {ok, R2} = create(Dev, Secret, Config),
+    ?assertStatus(200, R2),
+    ?assertEqual(#{~"player_id" => PlayerId}, maps:with([~"player_id"], nova_test:json(R2))),
+
+    {ok, _} = purge(3600, 100),
+    ?assert(exists(PlayerId)),
+
+    %% And the purge still works on the same row once it does fall idle, so
+    %% this cannot pass by the purge being broken outright.
+    age_identity(PlayerId),
+    {ok, _} = purge(3600, 100),
+    ?assertNot(exists(PlayerId)),
+    Config.
+
+%% A guest who claimed their account has a password and no guest identity. Both
+%% halves of the predicate reject them, and deleting one would be silent loss
+%% of a real account.
+spares_a_claimed_account(Config) ->
+    Dev = device_id(),
+    Secret = secret(),
+    {ok, R1} = create(Dev, Secret, Config),
+    #{~"player_id" := PlayerId, ~"access_token" := Token} = nova_test:json(R1),
+    age_identity(PlayerId),
+
+    {ok, R2} = nova_test:post(
+        "/api/v1/auth/guest/upgrade",
+        #{
+            json => #{~"username" => asobi_id:rand_suffix(12), ~"password" => ~"pass12345"},
+            headers => [{~"authorization", <<"Bearer ", Token/binary>>}]
+        },
+        Config
+    ),
+    ?assertStatus(200, R2),
+
+    {ok, _} = purge(0, 100),
+    ?assert(exists(PlayerId)),
+    Config.
+
+%% "Clear all guest users": no cutoff at all, including the one that signed in
+%% a moment ago and was never aged.
+zero_seconds_takes_every_unclaimed_guest(Config) ->
+    Fresh = guest(Config),
+    Old = guest(Config),
+    age_identity(Old),
+    {ok, _} = purge(0, 1000),
+    ?assertNot(exists(Fresh)),
+    ?assertNot(exists(Old)),
+    Config.
+
+%% The preview has to describe the delete, or an operator confirms a number
+%% that means nothing.
+count_agrees_with_what_run_deletes(Config) ->
+    {ok, _} = purge(0, 1000),
+    Ids = [guest(Config) || _ <- lists:seq(1, 3)],
+    [age_identity(Id) || Id <- Ids],
+
+    Cutoff = asobi_guest_purge:cutoff(3600),
+    ?assertEqual({ok, 3}, asobi_guest_purge:count(Cutoff)),
+    {ok, #{deleted := 3, skipped := 0}} = asobi_guest_purge:run(Cutoff, 1000, 3, actor()),
+    ?assertEqual({ok, 0}, asobi_guest_purge:count(Cutoff)),
+    Config.
+
+%% One call is bounded, and what is left is the caller's cue to call again
+%% rather than a request held open across the whole table.
+limit_bounds_one_call_and_remaining_says_so(Config) ->
+    {ok, _} = purge(0, 1000),
+    Ids = [guest(Config) || _ <- lists:seq(1, 4)],
+    [age_identity(Id) || Id <- Ids],
+
+    Cutoff = asobi_guest_purge:cutoff(3600),
+    ?assertEqual({ok, 4}, asobi_guest_purge:count(Cutoff)),
+    {ok, #{deleted := 2}} = asobi_guest_purge:run(Cutoff, 2, 4, actor()),
+    ?assertEqual({ok, 2}, asobi_guest_purge:count(Cutoff)),
+    {ok, #{deleted := 2}} = asobi_guest_purge:run(Cutoff, 2, 2, actor()),
+    ?assertEqual({ok, 0}, asobi_guest_purge:count(Cutoff)),
+    Config.

--- a/test/asobi_guest_purge_SUITE.erl
+++ b/test/asobi_guest_purge_SUITE.erl
@@ -18,7 +18,9 @@ whatever it was told.
     spares_a_claimed_account/1,
     zero_seconds_takes_every_unclaimed_guest/1,
     count_agrees_with_what_run_deletes/1,
-    limit_bounds_one_call_and_remaining_says_so/1
+    limit_bounds_one_call_and_remaining_says_so/1,
+    a_blocked_erase_is_failed_not_skipped/1,
+    the_cohort_size_has_to_be_echoed_back/1
 ]).
 
 all() ->
@@ -28,7 +30,9 @@ all() ->
         spares_a_claimed_account,
         zero_seconds_takes_every_unclaimed_guest,
         count_agrees_with_what_run_deletes,
-        limit_bounds_one_call_and_remaining_says_so
+        limit_bounds_one_call_and_remaining_says_so,
+        a_blocked_erase_is_failed_not_skipped,
+        the_cohort_size_has_to_be_echoed_back
     ].
 
 %% Guest auth is set after the app starts, for the reason `asobi_guest_SUITE`
@@ -200,3 +204,95 @@ limit_bounds_one_call_and_remaining_says_so(Config) ->
     {ok, #{deleted := 2}} = asobi_guest_purge:run(Cutoff, 2, 2, actor()),
     ?assertEqual({ok, 0}, asobi_guest_purge:count(Cutoff)),
     Config.
+
+%% A guest the erase cannot delete is `failed`, and the distinction is the
+%% whole reason the two counts are separate. Collapsed into `skipped`, a cohort
+%% that CANNOT be erased reads exactly like a cohort that did not need erasing,
+%% and the caller loops forever: the player never leaves the set, so `remaining`
+%% never falls, so "repeat until remaining reaches 0" does not terminate.
+a_blocked_erase_is_failed_not_skipped(Config) ->
+    {ok, _} = purge(0, 1000),
+    Blocked = guest(Config),
+    Clear = guest(Config),
+    age_identity(Blocked),
+    age_identity(Clear),
+    blocking_table(Blocked),
+
+    Cutoff = asobi_guest_purge:cutoff(3600),
+    ?assertEqual({ok, 2}, asobi_guest_purge:count(Cutoff)),
+    ?assertMatch(
+        {ok, #{deleted := 1, skipped := 0, failed := 1}},
+        asobi_guest_purge:run(Cutoff, 100, 2, actor())
+    ),
+    ?assert(exists(Blocked)),
+    ?assertNot(exists(Clear)),
+
+    %% Still in the set, and a second call makes no progress on it. This is the
+    %% loop that used to have no exit, so the contract is "call again while
+    %% `deleted` is above zero", not "until nothing is left".
+    ?assertEqual({ok, 1}, asobi_guest_purge:count(Cutoff)),
+    ?assertMatch(
+        {ok, #{deleted := 0, skipped := 0, failed := 1}},
+        asobi_guest_purge:run(Cutoff, 100, 1, actor())
+    ),
+
+    unblock(),
+    Config.
+
+%% An extension-owned table core knows nothing about, holding a row that
+%% references the player without `ON DELETE CASCADE` - the orphaned-rows case
+%% `asobi_player_erase:orphan_blocker/1` classifies, reproduced rather than
+%% simulated so the failure arrives through the same 23503 the real one does.
+blocking_table(PlayerId) ->
+    _ = kura_db:query(
+        asobi_repo,
+        ~"CREATE TABLE IF NOT EXISTS purge_suite_ext_rows (player_id UUID PRIMARY KEY REFERENCES players (id))",
+        []
+    ),
+    _ = kura_db:query(
+        asobi_repo, ~"INSERT INTO purge_suite_ext_rows (player_id) VALUES ($1)", [PlayerId]
+    ),
+    ok.
+
+unblock() ->
+    _ = kura_db:query(asobi_repo, ~"DROP TABLE IF EXISTS purge_suite_ext_rows", []),
+    ok.
+
+%% Erasing one player has to echo that player's username. Erasing a cohort has
+%% to echo its size, or the call with the larger blast radius would be the one
+%% an unattended POST could make.
+the_cohort_size_has_to_be_echoed_back(Config) ->
+    {ok, _} = purge(0, 1000),
+    Id = guest(Config),
+    age_identity(Id),
+    Cutoff = #{~"inactive_for_seconds" => 3600},
+
+    ?assertMatch(
+        {asobi_error, ~"ops.confirmation_required", _},
+        asobi_ops_controller:purge_guests(req(Cutoff))
+    ),
+    ?assert(exists(Id)),
+
+    %% The dry run is exempt, because it is where the count comes from.
+    ?assertMatch(
+        {json, #{data := #{matched := 1, deleted := 0, dry_run := true}}},
+        asobi_ops_controller:purge_guests(req(Cutoff#{~"dry_run" => true}))
+    ),
+    ?assert(exists(Id)),
+
+    %% A wrong count is a mismatch, which is a different answer from sending none.
+    ?assertMatch(
+        {asobi_error, ~"ops.purge_count_mismatch", _},
+        asobi_ops_controller:purge_guests(req(Cutoff#{~"confirm_count" => 99}))
+    ),
+    ?assert(exists(Id)),
+
+    ?assertMatch(
+        {json, #{data := #{deleted := 1, skipped := 0, failed := 0, remaining := 0}}},
+        asobi_ops_controller:purge_guests(req(Cutoff#{~"confirm_count" => 1}))
+    ),
+    ?assertNot(exists(Id)),
+    Config.
+
+req(Json) ->
+    #{auth_data => #{ops_actor => actor()}, json => Json}.

--- a/test/asobi_guest_purge_tests.erl
+++ b/test/asobi_guest_purge_tests.erl
@@ -1,0 +1,114 @@
+-module(asobi_guest_purge_tests).
+
+-include_lib("eunit/include/eunit.hrl").
+
+sql(Cutoff) ->
+    Q = kura_query:where(kura_query:from(asobi_player), asobi_guest_purge:clause(Cutoff)),
+    {SQL, Params, _} = kura_dialect_pg:to_sql_from(Q, 1),
+    {iolist_to_binary(SQL), Params}.
+
+contains(Haystack, Needle) ->
+    binary:match(Haystack, Needle) =/= nomatch.
+
+%%--------------------------------------------------------------------
+%% The literal table names in the subqueries
+%%--------------------------------------------------------------------
+
+%% `clause/1` names both tables as literal SQL because a join would be
+%% ambiguous. That is only safe while the schema modules still agree, so a
+%% rename has to fail here rather than at 3am against a table that no longer
+%% exists.
+players_table_is_still_called_players_test() ->
+    ?assertEqual(~"players", asobi_player:table()).
+
+identities_table_is_still_called_player_identities_test() ->
+    ?assertEqual(~"player_identities", asobi_player_identity:table()).
+
+%%--------------------------------------------------------------------
+%% The predicate
+%%--------------------------------------------------------------------
+
+clause_has_three_conditions_test() ->
+    {'and', Conditions} = asobi_guest_purge:clause(undefined),
+    ?assertEqual(3, length(Conditions)).
+
+%% A claimed guest has a password, so the erasure can never reach one.
+clause_requires_no_password_test() ->
+    {'and', Conditions} = asobi_guest_purge:clause(undefined),
+    ?assert(lists:member({hashed_password, is_nil}, Conditions)).
+
+clause_requires_a_guest_identity_test() ->
+    {SQL, _Params} = sql(undefined),
+    ?assert(contains(SQL, ~"EXISTS (SELECT 1 FROM \"player_identities\"")).
+
+%% The one that stops a guest who linked an OAuth account from being swept up
+%% with the abandoned devices.
+clause_excludes_any_other_provider_test() ->
+    {SQL, _Params} = sql(undefined),
+    ?assert(contains(SQL, ~"NOT EXISTS (SELECT 1 FROM \"player_identities\"")).
+
+clause_correlates_to_the_outer_player_test() ->
+    {SQL, _Params} = sql(undefined),
+    ?assert(contains(SQL, ~"\"player_identities\".\"player_id\" = \"players\".\"id\"")).
+
+%% Every value is bound, none interpolated: the provider name reaches Postgres
+%% as a parameter, and the SQL text never carries it.
+clause_binds_the_provider_test() ->
+    {SQL, Params} = sql(undefined),
+    ?assertEqual([~"guest", ~"guest"], Params),
+    ?assertNot(contains(SQL, ~"'guest'")).
+
+%%--------------------------------------------------------------------
+%% The cutoff
+%%--------------------------------------------------------------------
+
+cutoff_reads_last_seen_not_signup_test() ->
+    {SQL, _Params} = sql({{2026, 1, 1}, {0, 0, 0}}),
+    ?assert(contains(SQL, ~"\"player_identities\".\"updated_at\" <=")),
+    ?assertNot(contains(SQL, ~"inserted_at")).
+
+%% The boundary is inclusive on purpose, and a strict `<` here is a real bug
+%% rather than an off-by-one: `erlang:universaltime/0` has whole-second
+%% resolution, so `inactive_for_seconds: 0` would spare every guest whose
+%% identity was written during the current second - "clear all guest users"
+%% silently keeping the ones who just arrived. Caught by
+%% `asobi_guest_purge_SUITE:zero_seconds_takes_every_unclaimed_guest/1` against
+%% a real database; pinned here so it fails in eunit first.
+cutoff_boundary_is_inclusive_test() ->
+    {SQL, _Params} = sql({{2026, 1, 1}, {0, 0, 0}}),
+    ?assert(contains(SQL, ~"\"updated_at\" <= ")),
+    ?assertNot(contains(SQL, ~"\"updated_at\" < $")).
+
+cutoff_is_bound_alongside_the_provider_test() ->
+    Cutoff = {{2026, 1, 1}, {0, 0, 0}},
+    {_SQL, Params} = sql(Cutoff),
+    ?assertEqual([~"guest", Cutoff, ~"guest"], Params).
+
+undefined_cutoff_drops_only_the_cutoff_test() ->
+    {SQL, _Params} = sql(undefined),
+    ?assertNot(contains(SQL, ~"\"updated_at\" <")),
+    ?assert(contains(SQL, ~"\"player_identities\".\"provider\"")).
+
+%% Zero seconds is "everyone, including the guest who signed in a moment ago",
+%% which is the whole point of making the caller name it.
+zero_seconds_is_now_test() ->
+    Before = erlang:universaltime(),
+    Cutoff = asobi_guest_purge:cutoff(0),
+    After = erlang:universaltime(),
+    ?assert(Cutoff >= Before andalso Cutoff =< After).
+
+cutoff_subtracts_the_seconds_test() ->
+    Now = calendar:datetime_to_gregorian_seconds(asobi_guest_purge:cutoff(0)),
+    Hour = calendar:datetime_to_gregorian_seconds(asobi_guest_purge:cutoff(3600)),
+    ?assert(Now - Hour >= 3600 andalso Now - Hour =< 3601).
+
+%%--------------------------------------------------------------------
+%% Batch bounds
+%%--------------------------------------------------------------------
+
+default_limit_is_below_the_ceiling_test() ->
+    ?assert(asobi_guest_purge:default_limit() =< asobi_guest_purge:max_limit()).
+
+limits_are_positive_test() ->
+    ?assert(asobi_guest_purge:default_limit() > 0),
+    ?assert(asobi_guest_purge:max_limit() > 0).

--- a/test/asobi_ops_auth_tests.erl
+++ b/test/asobi_ops_auth_tests.erl
@@ -64,6 +64,25 @@ class_is_undefined_for_a_method_the_route_does_not_carry_test() ->
     ?assertEqual(undefined, asobi_ops_caps:class(~"POST", ~"/api/v1/ops/players")),
     ?assertEqual(undefined, asobi_ops_caps:class(~"OPTIONS", ~"/api/v1/ops/players")).
 
+%% Same class as the single erase: a credential trusted to erase one player is
+%% trusted to erase a cohort. A separate class would be a "may erase, but only
+%% slowly" capability, which is not a thing the threat model asks for.
+guest_purge_carries_the_erasure_class_test() ->
+    ?assertEqual(
+        erasure, asobi_ops_caps:class(~"POST", ~"/api/v1/ops/players/guests/purge")
+    ).
+
+%% The route table matches `guests` as a literal, so a player whose id happened
+%% to be the string "guests" could not reach the purge through the erase route
+%% or the other way about.
+guest_purge_does_not_collide_with_the_single_erase_test() ->
+    ?assertEqual(
+        erasure, asobi_ops_caps:class(~"POST", ~"/api/v1/ops/players/guests/erase")
+    ),
+    ?assertEqual(
+        undefined, asobi_ops_caps:class(~"GET", ~"/api/v1/ops/players/guests/purge")
+    ).
+
 class_is_undefined_outside_the_ops_prefix_test() ->
     [
         ?assertEqual(undefined, asobi_ops_caps:class(~"GET", Path))

--- a/test/asobi_ops_tests.erl
+++ b/test/asobi_ops_tests.erl
@@ -191,6 +191,45 @@ players_no_search_no_filter_test() ->
     {ok, #kura_query{wheres = Wheres}} = asobi_ops_players:query(#{}),
     ?assertEqual([], Wheres).
 
+%% The list an operator reads before purging that cohort has to agree with the
+%% purge itself, so it narrows on the purge's own predicate rather than a
+%% second reading of "is this a guest".
+players_guest_filter_uses_the_purge_predicate_test() ->
+    {ok, #kura_query{wheres = Wheres}} = asobi_ops_players:query(#{~"guest" => ~"true"}),
+    ?assertEqual([asobi_guest_purge:clause(undefined)], Wheres).
+
+players_guest_false_negates_the_same_predicate_test() ->
+    {ok, #kura_query{wheres = Wheres}} = asobi_ops_players:query(#{~"guest" => ~"false"}),
+    ?assertEqual([{'not', asobi_guest_purge:clause(undefined)}], Wheres).
+
+%% An absent or unparseable value narrows nothing, the same as every other
+%% filter on this plane: a caller gets a superset and the rows to prove it.
+players_guest_filter_absent_narrows_nothing_test() ->
+    {ok, #kura_query{wheres = None}} = asobi_ops_players:query(#{}),
+    {ok, #kura_query{wheres = Junk}} = asobi_ops_players:query(#{~"guest" => ~"maybe"}),
+    ?assertEqual([], None),
+    ?assertEqual([], Junk).
+
+%% The list filter must not carry a cutoff. A purge deletes only guests older
+%% than one; a list that quietly applied the same cutoff would hide the guests
+%% an operator is about to be told are in the set.
+players_guest_filter_has_no_cutoff_test() ->
+    {ok, #kura_query{wheres = [Clause]}} = asobi_ops_players:query(#{~"guest" => ~"true"}),
+    ?assertEqual(asobi_guest_purge:clause(undefined), Clause),
+    ?assertNotEqual(asobi_guest_purge:clause({{2026, 1, 1}, {0, 0, 0}}), Clause).
+
+players_guest_filter_composes_with_search_test() ->
+    {ok, #kura_query{wheres = Wheres}} = asobi_ops_players:query(
+        #{~"q" => ~"kai", ~"guest" => ~"true"}
+    ),
+    ?assertEqual(
+        [
+            {'or', [{username, ilike, ~"%kai%"}, {display_name, ilike, ~"%kai%"}]},
+            asobi_guest_purge:clause(undefined)
+        ],
+        Wheres
+    ).
+
 %% The projection is a positive allowlist, so a credential column cannot leak
 %% even if a future schema change adds one.
 players_projection_drops_credentials_test() ->
@@ -299,31 +338,37 @@ ops_routes_are_mounted_behind_the_operator_check_test() ->
      || {Path, _Handler, Opts} <- Routes, not extension_route(Path)
     ].
 
-%% One route on core's plane answers a write method, and it is stated here so a
-%% second cannot appear without editing this line.
+%% The two routes on core's plane that answer a write method, stated here so a
+%% third cannot appear without editing these lines.
 expected_methods(~"/players/:id/erase") -> [post, options];
+expected_methods(~"/players/guests/purge") -> [post, options];
 expected_methods(_Path) -> [get, options].
 
-%% Core's plane is a read plane plus exactly two account-lifecycle routes, and
+%% Core's plane is a read plane plus account-lifecycle routes, and
 %% `asobi_ops_notifications:broadcast/5` is still deliberately not a route at
 %% all. Anything else non-read is a write surface that grew by accident.
 %%
 %% `erasure` is its own class rather than `player_data` because it is the only
 %% irreversible action here; `export` is `player_data` rather than `read`
-%% because it returns everything about one identified person.
+%% because it returns everything about one identified person. The guest purge
+%% shares `erasure` with the single erase on purpose: same action, wider
+%% fan-out, and a capability that separated them would read as "may erase, but
+%% only slowly".
 core_ops_non_read_classes_are_only_account_lifecycle_test() ->
     ?assertEqual(
         [
             {get, [~"players", '_', ~"export"], player_data},
-            {post, [~"players", '_', ~"erase"], erasure}
+            {post, [~"players", '_', ~"erase"], erasure},
+            {post, [~"players", ~"guests", ~"purge"], erasure}
         ],
         [Route || {_M, _S, Class} = Route <- asobi_ops_caps:classes(), Class =/= read]
     ).
 
-%% Stated once so it cannot widen quietly: two routes carry a write method, the
-%% erasure and the extension dispatch. Neither is an exception to the audit -
-%% the extension dispatch runs inside `asobi_ops_audit:mutation/4`, and the
-%% erasure writes its row inside its own transaction.
+%% Stated once so it cannot widen quietly: three routes carry a write method,
+%% the two erasures and the extension dispatch. None is an exception to the
+%% audit - the extension dispatch runs inside `asobi_ops_audit:mutation/4`, the
+%% single erasure writes its row inside its own transaction, and the guest
+%% purge writes one row for the batch once the deletes have committed.
 ops_routes_carrying_a_write_method_test() ->
     #{routes := Routes} = ops_group(),
     Writing = [
@@ -331,7 +376,9 @@ ops_routes_carrying_a_write_method_test() ->
      || {Path, _Handler, Opts} <- Routes,
         [] =/= [M || M <- maps:get(methods, Opts), M =/= get, M =/= options]
     ],
-    ?assertEqual([~"/players/:id/erase", ~"/ext/:extension/:action"], Writing).
+    ?assertEqual(
+        [~"/players/:id/erase", ~"/players/guests/purge", ~"/ext/:extension/:action"], Writing
+    ).
 
 %% asobi#326: routing_tree returns on the first matching sibling and a binding
 %% matches any segment, so `/players/:id` declared first would not swallow a
@@ -342,6 +389,17 @@ erase_and_export_are_declared_before_the_player_binding_test() ->
     Paths = [Path || {Path, _Handler, _Opts} <- Routes],
     ?assert(index_of(~"/players/:id/erase", Paths) < index_of(~"/players/:id", Paths)),
     ?assert(index_of(~"/players/:id/export", Paths) < index_of(~"/players/:id", Paths)).
+
+%% The other half of asobi#326, and the direction that actually bites: a
+%% *literal* segment where a sibling route has a binding must be declared
+%% AFTER it, because prepend-on-insert then puts the literal in front and it is
+%% tried first. Declared before, `:id` matches "guests", the lookup commits to
+%% that subtree, finds no "purge" under it and 404s a route that exists.
+guest_purge_is_declared_after_the_player_binding_test() ->
+    #{routes := Routes} = ops_group(),
+    Paths = [Path || {Path, _Handler, _Opts} <- Routes],
+    ?assert(index_of(~"/players/guests/purge", Paths) > index_of(~"/players/:id", Paths)),
+    ?assert(index_of(~"/players/guests/purge", Paths) > index_of(~"/players/:id/erase", Paths)).
 
 index_of(Needle, List) ->
     length(lists:takewhile(fun(Item) -> Item =/= Needle end, List)).


### PR DESCRIPTION
## Why

An operator running a deployment that never configured `guest_reap_after` ends up with a table full of abandoned devices and no way to clear them. `m:asobi_guest_reaper` only sweeps when retention is set, and `POST /ops/players/:id/erase` is one row per call.

Reported from a community forum thread: a guest cohort that would not go away, alongside a client log line that reads as a failed erase. The client-side half of that confusion was the Defold doc fix; this is the server-side half - the missing bulk erasure.

## What

`POST /ops/players/guests/purge`, the operator-triggered half of the same erasure the reaper performs automatically.

- **`inactive_for_seconds` has no default.** An empty POST selects nothing and answers 400. A cohort has no handle to echo back the way a single erase echoes a username, so the confirmation is that the caller has to name the cutoff in so many words.
- **`inactive_for_seconds: 0`** means every unclaimed guest, including one that signed in a moment ago. That is the "clear them all" case, spelled out rather than defaulted to.
- **`dry_run: true`** counts and deletes nothing.
- **`confirm_count: N`** refuses unless the server counts exactly `N` right now.
- **`limit: N`** caps the call (default 500, ceiling 5000) and the response reports `remaining`, so a caller loops rather than holding one request open across an unbounded table.

`?guest=true|false` on the ops player list narrows on `asobi_guest_purge:clause/1` - the same predicate, not a second reading of it. A list that disagrees with the purge is a list that promises the wrong deletion.

## Decisions worth reviewing

- **Same capability class as the single erase** (`erasure`), not a new one. A credential trusted to erase one player is trusted to erase a cohort; splitting it would mint a "may erase, but only slowly" capability nothing in the threat model asks for.
- **The cutoff is inclusive.** `erlang:universaltime/0` is whole seconds, so a strict `<` would make `inactive_for_seconds: 0` spare every guest whose identity row was written during the current second. Found by the CT suite against a real database, pinned in eunit so it fails there first.
- **One transaction per player, not one around the batch.** A batch-wide transaction would roll 500 erasures back because the 501st hit an extension's orphaned rows, and hold write locks across the cohort while it did. The per-player re-check runs inside each transaction, so a guest who claims their account mid-purge survives and is counted `skipped`.
- **`record/4`, not `record_strict/4`** for the audit row. The deletes have already committed one by one; a strict failure would have nothing left to undo.
- **The predicate is SQL, not `asobi_guest_reaper:unclaimed_guest/1` per row.** Counting 14 000 guests one at a time is 28 000 queries before a single delete. The per-player function is still the authority at the moment of deletion.
- **Correlated `EXISTS` rather than a join**, because `kura` emits unqualified column names in `WHERE` and both tables carry `id` and `updated_at`. The two table names are the only literals, and `asobi_guest_purge_tests` fails if either schema module stops agreeing with them.
- **The route is declared after `/players/:id`** - the asobi#326 trap. `routing_tree` prepends on insert and returns on the first matching sibling without backtracking, so the binding would otherwise swallow the literal `guests` segment.

## Checks

`fmt` · `xref` · `dialyzer` · `eqwalize` (new modules clean) · `elp lint` (new files clean) · `eunit` 2000/0 · `ct` 384/384 · `fmt --check`. `rebar3_mutate` is not a plugin here, so mutation testing does not apply.