### PR TITLE
docs: cloud tenants set guest retention, so stop sending them to the client

### DIFF
--- a/guides/authentication.md
+++ b/guides/authentication.md
@@ -366,8 +366,9 @@ curl -X POST http://localhost:8084/api/v1/players/me/erase \
 
 It is the only erasure path that needs no operator credential at all - the
 player's own token is the authority. A cloud tenant reaches the ops erasure
-routes as well, through a console token minted for an `owner` or `admin`; what
-stays out of reach there is `guest_reap_after`, which is an operator key.
+routes as well, through a console token minted for an `owner` or `admin`, and
+sets `guest_reap_after` from the environment's **Guests** picker on the
+dashboard.
 
 **A device secret is now a destruction credential, not just an impersonation
 one.** Anyone holding it can resume the account and erase it, with no password

--- a/guides/cloud.md
+++ b/guides/cloud.md
@@ -354,18 +354,29 @@ all. This is the largest gap on the list. If your game needs platform sign-in
 or store receipt validation today, self-host.
 
 **Guest auth beyond the toggle.** The per-environment pepper is injected for
-you, so `guest_auth = true` in your Lua works. `guest_verifier_key_id`,
-`guest_unlinked_cap`, `guest_reap_after` and `guest_reap_interval_ms` are not
-settable, so unclaimed guests are never reaped automatically and only the
-default soft cap applies. Pepper rotation is not yours either. Two things still
-clear them: a client can shed accounts one at a time with
-`POST /api/v1/players/me/erase`
+you, so `guest_auth = true` in your Lua works. `guest_verifier_key_id` and
+`guest_reap_interval_ms` are not settable and only the default soft cap
+(`guest_unlinked_cap`) applies. Pepper rotation is not yours either.
+
+Retention **is** yours. The environment row on the dashboard carries a
+**Guests** picker - keep for ever, or delete after 7, 30, 90 or 365 days
+without a resume - which is `guest_reap_after` under another name. New
+environments keep guests for ever until you choose otherwise, because the
+reaper erases permanently and a retention period is not something to arrive at
+by default. Applying a change restarts the environment, since the engine reads
+the policy at boot.
+
+Two things clear guests besides the reaper: a client can shed accounts one at a
+time with `POST /api/v1/players/me/erase`
 ([REST API](rest-api.md#erasing-your-own-account)), and an operator can delete
-the abandoned cohort in bulk with
-[`POST /api/v1/ops/players/guests/purge`](rest-api.md#purging-abandoned-guests),
-which needs no server-side configuration. A client that mints a throwaway
-device pair per launch should still erase the account it abandons rather than
-leave the purge to clean up after it.
+the abandoned cohort in bulk from the console, or with
+[`POST /api/v1/ops/players/guests/purge`](rest-api.md#purging-abandoned-guests).
+
+Use the client route for a player who asks to be deleted, not for housekeeping.
+It is one request per account issued by a process that may be shutting down,
+and several engines bind the response callback to the object that made the
+call, so a quit or a teardown is where the reply gets dropped. Set a retention
+period instead and let the server do it.
 
 **Ops-plane shape.** `ops_secret`, `console_erasure`, `console_session_ttl`,
 `console_secure_cookie`, `console_api_base`, `console_label`,

--- a/guides/configuration.md
+++ b/guides/configuration.md
@@ -487,7 +487,7 @@ operator half.
 | `guest_verifier_pepper` | none | Key-id -> pepper map, or a single binary. Each pepper must be at least 32 bytes; a shorter one is treated as absent. Presence is the operator's on switch |
 | `guest_verifier_key_id` | `~"v1"` | Which pepper key id to use when minting new verifiers |
 | `guest_unlinked_cap` | `100000` | Soft ceiling on unclaimed guests, or `infinity`. Anything else falls back to the default and logs `invalid_guest_unlinked_cap` |
-| `guest_reap_after` | unset | Seconds of inactivity since the device last resumed; unset disables the reaper, so guests are permanent |
+| `guest_reap_after` | unset | Seconds of inactivity since the device last resumed; unset disables the reaper, so guests are permanent. On cloud this is the **Guests** picker on the environment row, not a key you write |
 
 The cap is a soft ceiling, not an exact one: the count comes from a short-TTL
 cache rather than a `COUNT` per create, so it can overshoot by roughly (TTL x
@@ -498,9 +498,14 @@ full deployment. Both log `guest_create_denied` with a `reason`; the cap denial
 also logs the `count` and `cap` it compared, which is what tells you whether
 the ceiling is anywhere near.
 
-Clients can shed guests themselves with `POST /api/v1/players/me/erase`
-(see [REST API](rest-api.md#erasing-your-own-account)), which is the only guest
-removal available when `guest_reap_after` is not settable.
+Clients can also shed guests themselves with `POST /api/v1/players/me/erase`
+(see [REST API](rest-api.md#erasing-your-own-account)). Reach for it when a
+player asks to be deleted, not as a way to do housekeeping: a client-side
+erasure is one HTTP request per account, issued by a process that may be on its
+way out. Several engines bind a response callback to the object that made the
+call, so the natural place to put it - a quit, a teardown, a screen closing -
+is exactly where the reply is dropped and the request may never land. Retention
+is the server's job; use this setting for it.
 
 Measured from the last resume, not from account creation. Under device auth a
 guest stays unclaimed for life - there is no password to set - so account age

--- a/guides/testing-multiple-players.md
+++ b/guides/testing-multiple-players.md
@@ -87,12 +87,17 @@ func _ready() -> void:
 ```
 <!-- /tabs -->
 
-Every run leaves another guest account on the node. That is harmless locally,
-and `guest_reap_after` clears unclaimed guests on a self-hosted deployment. On
-cloud that key is not yours to set, so a test client pointed at a cloud
-environment should call `POST /api/v1/players/me/erase`
-([REST API](rest-api.md#erasing-your-own-account)) when it shuts down. A crash
-still leaks one, so for anything you run repeatedly against cloud prefer
+Every run leaves another guest account on the node. That is harmless, and
+`guest_reap_after` clears unclaimed guests for you - self-hosted it is a
+config key, on cloud it is the **Guests** picker on the environment row. Set it
+on whatever environment you point test clients at and the debris cleans itself
+up.
+
+Do not try to erase the account on shutdown instead. It is the obvious move and
+it does not work: several engines bind an HTTP response callback to the object
+that made the call, so a request issued from a quit or a teardown has its reply
+dropped and often never lands at all. A crash leaks one regardless. For
+anything you run repeatedly prefer
 [stable test players](#stable-test-players-across-runs) below, which reuse one
 account per instance instead of minting a new one each launch. Ship
 `guest_device` in the build players actually install.


### PR DESCRIPTION
Third of three, with widgrensit/asobi_saas#282 (the picker) and widgrensit/asobi_engine#112 (reads it).

## What was wrong

`guides/configuration.md` said the client calling `POST /api/v1/players/me/erase` was *"the only guest removal available when `guest_reap_after` is not settable"*, and `guides/cloud.md` listed the key among those a cloud tenant cannot reach.

Both were accurate, and together they aimed studios at one HTTP request per account, issued from a process that is often on its way out. Several engines bind a response callback to the object that made the call, so the natural place for it - a quit, a teardown, a screen closing - is exactly where the reply is dropped and the request may never land. Defold is the one we have a report for (widgrensit/asobi-defold#60), but the shape is not Defold-specific, so the guides do not name an engine.

The result: a studio follows the documentation, guests accumulate anyway, and nothing tells them. That is how a live environment ended up on 254 unclaimed guests.

## Changed

- **cloud.md** - retention moves out of the cannot-configure list and gets its own paragraph: the **Guests** picker, what the default is and why, and that applying it restarts the environment.
- **configuration.md** - the client route is for a player asking to be deleted, not for housekeeping. The `guest_reap_after` table row notes it is a picker on cloud rather than a key you write.
- **authentication.md** - `guest_reap_after` no longer listed as out of a cloud tenant's reach.
- **testing-multiple-players.md** - this one told anyone testing against cloud to erase on shutdown, which is where the advice was most likely to be followed and least likely to work. Now: set retention on the environment you point test clients at.

## Note on the default

New environments keep guests for ever until a studio chooses otherwise. The reaper erases permanently and writes no audit row, so a retention period has to be chosen rather than arrived at - the guides say so rather than leaving a reader to infer it from an empty field.

## Checks

`rebar3 ex_doc` clean apart from the two pre-existing warnings (`.github/CODEOWNERS`, `asobi_ws_handler:encode_rpc/2`), both unrelated and present on `main`. No code touched.

`asobi_site` regen follows once this merges - `configuration`, `authentication` and `testing-multiple-players` are all generated pages.