### PR TITLE
fix(console): a minted token opens one session and then stops being a credential

### DIFF
--- a/src/console/asobi_console_controller.erl
+++ b/src/console/asobi_console_controller.erl
@@ -157,11 +157,26 @@ authenticate(#{body := Body} = Req) when is_binary(Body), Body =/= ~"" ->
 authenticate(_Req) ->
     {asobi_error, ~"missing_field"}.
 
+%% A minted token opens one session and then stops being a credential.
+%%
+%% Verifying it says only that it is authentic, never that it is unspent, so
+%% until `consume_token/2` existed an exchanged token stayed live for the rest
+%% of its fifteen minutes - usable here again, or as a bearer header on the ops
+%% plane. That is also what made this endpoint a session-fixation primitive:
+%% `SameSite` governs which requests carry a cookie, not which may set one.
+%%
+%% A spent token is refused exactly like an invalid one, so presenting one
+%% teaches nothing about whether it was ever real.
 minted(Token, Req, Reply) ->
     case asobi_ops_token:verify(Token) of
-        {ok, #{sub := Sub, caps := Caps, exp := Exp}} ->
-            {ok, Session} = asobi_console_session:create(Sub, Caps, Exp),
-            granted(Session, Req, Reply);
+        {ok, #{sub := Sub, caps := Caps, exp := Exp, id := TokenId}} ->
+            case asobi_console_session:consume_token(TokenId, Exp) of
+                ok ->
+                    {ok, Session} = asobi_console_session:create(Sub, Caps, Exp),
+                    granted(Session, Req, Reply);
+                {error, replayed} ->
+                    rejected(Req)
+            end;
         {error, _Reason} ->
             rejected(Req)
     end.

--- a/src/console/asobi_console_session.erl
+++ b/src/console/asobi_console_session.erl
@@ -39,12 +39,17 @@ while a tab sits open is the wrong default for a surface that bans players.
 -include_lib("kernel/include/logger.hrl").
 
 -export([start_link/0, create/1, create/3, resolve/2, delete/1, csrf/1, ttl_seconds/0]).
+-export([consume_token/2]).
 -export([init/1, handle_call/3, handle_cast/2, handle_info/2]).
 -ifdef(TEST).
 -export([expire/1, sweep/0]).
 -endif.
 
 -define(TABLE, ?MODULE).
+%% Minted tokens already spent on a session. Keyed by the token's MAC, valued
+%% by its own expiry, so a row costs nothing to reason about: it is needed for
+%% exactly as long as the token it refuses could still be presented.
+-define(SEEN_TABLE, asobi_console_session_seen).
 -define(SECRET_KEY, {?MODULE, secret}).
 -define(ID_BYTES, 32).
 -define(SECRET_BYTES, 32).
@@ -114,6 +119,38 @@ create(Label, Caps, NotAfter) ->
     gen_server:call(?MODULE, {create, label(Label), Caps, NotAfter}).
 
 -doc """
+Spend a minted token, so it can open exactly one session.
+
+`verify/1` proving a token authentic says nothing about whether it has already
+been used, and until this existed nothing did: exchanging a token at
+`/console/session` left it valid for the rest of its fifteen minutes, usable
+again there or directly as a bearer header on the ops plane. Anyone who read
+it in transit, out of a log, or off a shared machine had a live credential for
+as long as the person it was minted for did.
+
+It also closes the login-CSRF half of the same hole. `SameSite` governs which
+requests carry a cookie, not which may set one, so any origin could post a
+token it held to a victim's browser and land them in a session the attacker
+chose. There is no privilege gain - the token is env-scoped and role-derived -
+but every audit row the victim then wrote would name the attacker's `sub`, on
+the one plane whose rows are the only surviving evidence of an erasure.
+
+`{error, replayed}` is deliberately not distinguishable from a bad token by
+the caller's response: both answer 403 the same way, so presenting a spent
+token teaches nothing about whether it was ever real.
+""".
+-spec consume_token(binary(), integer()) -> ok | {error, replayed}.
+consume_token(TokenId, NotAfter) ->
+    %% Not a pass-through: `gen_server:call/2` is typed `term()`, and this is
+    %% the one call in this module whose answer decides whether a credential is
+    %% honoured. Narrowing it here means an unexpected reply crashes at the
+    %% boundary rather than being read as something it is not.
+    case gen_server:call(?MODULE, {consume_token, TokenId, NotAfter}) of
+        ok -> ok;
+        {error, replayed} -> {error, replayed}
+    end.
+
+-doc """
 Resolve a cookie and its CSRF token to a live session.
 
 Both halves are required. A cookie alone is not a credential here: that is
@@ -153,6 +190,7 @@ ttl_seconds() ->
 -spec init([]) -> {ok, #{}}.
 init([]) ->
     _ = ets:new(?TABLE, [named_table, protected, set, {read_concurrency, true}]),
+    _ = ets:new(?SEEN_TABLE, [named_table, protected, set, {read_concurrency, true}]),
     persistent_term:put(?SECRET_KEY, crypto:strong_rand_bytes(?SECRET_BYTES)),
     _ = erlang:send_after(?SWEEP_MS, self(), sweep),
     {ok, #{}}.
@@ -171,6 +209,14 @@ handle_call({create, Label, Caps, NotAfter}, _From, State) ->
             expires_at => ExpiresAt
         }},
         State};
+handle_call({consume_token, TokenId, NotAfter}, _From, State) ->
+    %% `insert_new` is the whole mechanism: the first exchange wins and every
+    %% later one loses, atomically, without a read-then-write the second
+    %% request could interleave with.
+    case ets:insert_new(?SEEN_TABLE, {TokenId, NotAfter}) of
+        true -> {reply, ok, State};
+        false -> {reply, {error, replayed}, State}
+    end;
 handle_call({delete, Id}, _From, State) ->
     true = ets:delete(?TABLE, Id),
     {reply, ok, State};
@@ -207,9 +253,15 @@ handle_info(_Message, State) ->
 %% so that running it cannot also schedule another one.
 -spec sweep_expired() -> ok.
 sweep_expired() ->
+    Now = erlang:system_time(second),
     Removed = ets:select_delete(?TABLE, [
-        {{'_', '$1', '_', '_'}, [{'<', '$1', erlang:system_time(second)}], [true]}
+        {{'_', '$1', '_', '_'}, [{'<', '$1', Now}], [true]}
     ]),
+    %% A spent token past its own expiry can no longer be presented, so
+    %% remembering it buys nothing. Not logged: this is bookkeeping about
+    %% credentials that already died of old age, and a count of it would only
+    %% dilute the session sweep line that operators actually read.
+    _ = ets:select_delete(?SEEN_TABLE, [{{'_', '$1'}, [{'<', '$1', Now}], [true]}]),
     log_sweep(Removed).
 
 -spec lookup(binary()) -> {ok, session()} | {error, reason()}.

--- a/src/ops/asobi_ops_token.erl
+++ b/src/ops/asobi_ops_token.erl
@@ -66,7 +66,11 @@ the lifetime is capped rather than merely checked.
     sub := binary(),
     caps := [asobi_ops_caps:class()],
     iat := integer(),
-    exp := integer()
+    exp := integer(),
+    %% Not signed into the payload - this is the token's own MAC, added by
+    %% `verify/1` so a caller can identify the token it just verified without
+    %% keeping the token itself.
+    id := binary()
 }.
 
 -export_type([claims/0]).
@@ -120,12 +124,19 @@ verify(Token, Key, EnvId) ->
         [?VERSION, Payload, Mac] ->
             Signed = <<?VERSION/binary, ".", Payload/binary>>,
             case authentic(Key, Signed, Mac) of
-                true -> claims(Payload, EnvId);
+                true -> with_id(claims(Payload, EnvId), Mac);
                 false -> {error, bad_signature}
             end;
         _ ->
             {error, malformed}
     end.
+
+%% The MAC identifies this token, and it is the MAC rather than the whole token
+%% so nothing downstream ends up holding a replayable credential in order to
+%% remember it. Distinct tokens have distinct MACs by construction; identical
+%% ones are the same token, which is the question being asked.
+with_id({ok, Claims}, Mac) -> {ok, Claims#{id => Mac}};
+with_id({error, _} = Err, _Mac) -> Err.
 
 %% Constant time, and over the decoded MAC rather than its text, so a token
 %% carrying differently-padded base64 of the right MAC is still the right MAC.
@@ -189,14 +200,24 @@ classes(Names, Known) ->
         false -> false
     end.
 
-claims_json(#{env := Env, sub := Sub, caps := Caps, iat := Iat, exp := Exp}) ->
-    #{
+%% `jti` is optional and passed through untouched. It is not read on this side
+%% at all - the token's own MAC is what identifies it for single-use - but a
+%% minter needs somewhere to put a nonce, because `iat` is only second-granular
+%% and two mints for the same person, environment and caps inside one second
+%% would otherwise be byte-identical, and a token spent once would refuse its
+%% own twin.
+claims_json(#{env := Env, sub := Sub, caps := Caps, iat := Iat, exp := Exp} = Claims) ->
+    Base = #{
         ~"env" => Env,
         ~"sub" => Sub,
         ~"caps" => [atom_to_binary(C, utf8) || C <- Caps],
         ~"iat" => Iat,
         ~"exp" => Exp
-    }.
+    },
+    case maps:get(jti, Claims, undefined) of
+        Jti when is_binary(Jti) -> Base#{~"jti" => Jti};
+        _None -> Base
+    end.
 
 %% Both halves or nothing: a node that knows its key but not which environment
 %% it is cannot check `env`, and answering "close enough" there is how a token

--- a/test/asobi_console_SUITE.erl
+++ b/test/asobi_console_SUITE.erl
@@ -33,6 +33,8 @@
     a_minted_session_carries_only_the_token_s_caps/1,
     a_minted_session_does_not_outlive_its_token/1,
     a_bad_minted_token_is_refused_like_a_bad_secret/1,
+    a_minted_token_opens_only_one_session/1,
+    cors_never_allows_credentials/1,
     a_form_post_redirects_into_the_console/1
 ]).
 
@@ -58,6 +60,8 @@ groups() ->
             a_minted_session_carries_only_the_token_s_caps,
             a_minted_session_does_not_outlive_its_token,
             a_bad_minted_token_is_refused_like_a_bad_secret,
+            a_minted_token_opens_only_one_session,
+            cors_never_allows_credentials,
             a_form_post_redirects_into_the_console,
             session_cookie_opens_the_ops_plane,
             cookie_without_csrf_is_refused,
@@ -87,6 +91,11 @@ init_per_group(_Group, Config) ->
     Config.
 
 %% A token the way asobi_saas mints one.
+%% Carries a `jti` because the control plane does: `iat` is only
+%% second-granular, so without a nonce two mints for the same person, env and
+%% caps inside one second are byte-identical - and a token that is spent once
+%% would refuse its own twin. Uniqueness is the minter's job; single-use here
+%% only holds if the minter does it.
 minted(Caps) ->
     Now = erlang:system_time(second),
     asobi_ops_token:sign(?SIGNING_SECRET, #{
@@ -94,7 +103,8 @@ minted(Caps) ->
         sub => ~"user-7",
         caps => Caps,
         iat => Now,
-        exp => Now + asobi_ops_token:max_ttl()
+        exp => Now + asobi_ops_token:max_ttl(),
+        jti => base64:encode(crypto:strong_rand_bytes(9), #{mode => urlsafe, padding => false})
     }).
 
 end_per_group(_Group, Config) ->
@@ -252,6 +262,22 @@ a_minted_token_opens_a_session(Config) ->
     ?assertMatch(#{~"data" := #{~"display" := ~"user-7"}}, nova_test:json(Resp)),
     Config.
 
+%% Exchanging a token spends it. It used to stay live for the rest of its
+%% fifteen minutes, usable here again or as a bearer header on the ops plane,
+%% so anyone who read it in transit or off a shared machine held a working
+%% credential for as long as its owner did. It is also what made this endpoint
+%% a session-fixation primitive: `SameSite` governs which requests carry a
+%% cookie, not which may set one.
+a_minted_token_opens_only_one_session(Config) ->
+    Token = minted([read]),
+    {ok, First} = nova_test:post("/console/session", #{json => #{~"token" => Token}}, Config),
+    ?assertStatus(200, First),
+    {ok, Second} = nova_test:post("/console/session", #{json => #{~"token" => Token}}, Config),
+    %% Refused exactly like an invalid token, so presenting a spent one teaches
+    %% nothing about whether it was ever real.
+    ?assertStatus(403, Second),
+    Config.
+
 %% The whole point of mapping roles to classes at mint time would be undone if
 %% the exchange widened them back out.
 a_minted_session_carries_only_the_token_s_caps(Config) ->
@@ -382,3 +408,29 @@ nonce(Resp) ->
     [_, Rest] = binary:split(Policy, ~"script-src 'nonce-"),
     [Nonce | _] = binary:split(Rest, ~"'"),
     Nonce.
+
+%% The engine serves the ops plane and the game API on one port, with
+%% `ASOBI_CORS_ORIGINS` defaulting to `*` on the grounds that the API is bearer
+%% authenticated and carries no ambient credentials. That stopped being the
+%% whole truth when `/console` shipped HttpOnly cookie sessions on the same
+%% origin.
+%%
+%% What keeps the wildcard harmless is that nothing emits
+%% `Access-Control-Allow-Credentials`, so a browser refuses to send a
+%% credentialed cross-origin request at all. That is a dependency's omission
+%% rather than a decision of ours, and if a Nova upgrade or an ingress ever
+%% added the header, `Access-Control-Allow-Origin: *` plus
+%% `Access-Control-Allow-Headers: *` would turn into a cross-origin CSRF on
+%% `POST /api/v1/ops/players/:id/erase` - the wildcard covers `x-csrf-token`,
+%% and a `Lax` cookie rides a top-level POST.
+%%
+%% So the property gets a test rather than a comment.
+cors_never_allows_credentials(Config) ->
+    {ok, Resp} = nova_test:request(options, "/api/v1/ops/players", #{}, Config),
+    Headers = [string:lowercase(K) || {K, _V} <- nova_test:headers(Resp)],
+    ?assertNot(lists:member("access-control-allow-credentials", Headers)),
+    %% And the wildcard this is protecting is really there, so the test fails
+    %% loudly if the CORS posture changes shape rather than silently passing
+    %% against a response that has no CORS headers at all.
+    ?assert(lists:member("access-control-allow-origin", Headers)),
+    Config.

--- a/test/asobi_console_session_tests.erl
+++ b/test/asobi_console_session_tests.erl
@@ -40,7 +40,10 @@ session_test_() ->
             {"the ttl is clamped", fun ttl/0},
             {"a browser session cannot erase by default", fun no_erasure_by_default/0},
             {"one config key opts the console in", fun erasure_opt_in/0},
-            {"a minted token's caps are inherited whole", fun minted_caps_are_untouched/0}
+            {"a minted token's caps are inherited whole", fun minted_caps_are_untouched/0},
+            {"a token opens one session and no more", fun token_is_single_use/0},
+            {"two distinct tokens both open one", fun distinct_tokens_both_spend/0},
+            {"a spent token stays spent until it expires", fun spent_survives_a_sweep/0}
         ]
     end).
 
@@ -184,3 +187,28 @@ restart_ends_every_session_test() ->
     after
         cleanup(Pid2)
     end.
+
+%% Verifying a token proves it authentic, never that it is unspent. Before
+%% this, exchanging one left it live for the rest of its fifteen minutes -
+%% usable again here, or as a bearer header on the ops plane - so anyone who
+%% read it in transit or off a shared machine held a working credential for as
+%% long as the person it was minted for.
+token_is_single_use() ->
+    NotAfter = erlang:system_time(second) + 900,
+    ?assertEqual(ok, asobi_console_session:consume_token(~"mac-1", NotAfter)),
+    ?assertEqual({error, replayed}, asobi_console_session:consume_token(~"mac-1", NotAfter)),
+    ?assertEqual({error, replayed}, asobi_console_session:consume_token(~"mac-1", NotAfter)).
+
+distinct_tokens_both_spend() ->
+    NotAfter = erlang:system_time(second) + 900,
+    ?assertEqual(ok, asobi_console_session:consume_token(~"mac-a", NotAfter)),
+    ?assertEqual(ok, asobi_console_session:consume_token(~"mac-b", NotAfter)).
+
+%% The sweep must not hand a token back. It drops rows past their own expiry,
+%% and a token that far gone can no longer be presented anyway - but a sweep
+%% that cleared live rows would silently restore replay.
+spent_survives_a_sweep() ->
+    NotAfter = erlang:system_time(second) + 900,
+    ?assertEqual(ok, asobi_console_session:consume_token(~"mac-sweep", NotAfter)),
+    ok = asobi_console_session:sweep(),
+    ?assertEqual({error, replayed}, asobi_console_session:consume_token(~"mac-sweep", NotAfter)).


### PR DESCRIPTION
From the security review. Two findings, one of which turned out to have a prerequisite nobody had noticed.

## Replay, and the fixation half of the same hole

`asobi_ops_token:verify/1` proves a token authentic. It says nothing about whether it has already been used, and until now nothing else did either — exchanging a token at `/console/session` left it valid for the rest of its fifteen minutes, usable there again or directly as a bearer header on `/api/v1/ops`. Anyone who read it in transit, out of a log, or off a shared machine held a working credential for as long as its owner did.

The same gap made this endpoint a session-fixation primitive. `SameSite` governs which requests *carry* a cookie, not which may *set* one, so any origin could post a token it held to a victim's browser and land them in a session the attacker chose. No privilege is gained — the token is env-scoped and role-derived — but every audit row the victim then wrote would name the attacker's `sub`, on the one plane whose rows are the only surviving evidence of an erasure.

`consume_token/2` spends a token by its own MAC via `ets:insert_new`, so the first exchange wins atomically with no read-then-write for a second request to interleave with. The table lives in the session server, which already sweeps on the same expiry logic, and a spent token is forgotten once it could no longer be presented anyway. **A replayed token is refused exactly like an invalid one**, so presenting a spent token teaches nothing about whether it was ever real.

## The prerequisite: tokens were not unique

Single-use only means something if two tokens are two tokens. `iat` is second-granular and there was no nonce, so **two mints for the same person, environment and caps inside one second are byte-identical** — and a token spent once would have refused its own twin. That would have shown up as a console login mysteriously 403ing on a double-submit.

`sign/2` now carries an optional `jti` through to the payload. Nothing on this side reads it — the MAC is the identity — it only has to reach the signature so the MAC differs. The control plane populating it is a separate change; until it does, the collision window stays one second wide and is self-healing on retry.

I found this because the CT suite went red: its helper builds tokens exactly the way the control plane does, so identical claims produced one token and every test after the first was "replayed". That is the bug reproducing itself, not a test artefact.

## The CORS invariant

`ASOBI_CORS_ORIGINS` defaults to `*` on the stated grounds that the API is bearer authenticated with no ambient credentials. That stopped being the whole truth when `/console` shipped `HttpOnly` cookie sessions on the same port.

What keeps the wildcard harmless is that nothing emits `Access-Control-Allow-Credentials` — a dependency's omission rather than a decision of ours. Add that header via a Nova upgrade or an ingress and `Allow-Origin: *` plus `Allow-Headers: *` becomes a cross-origin CSRF on `POST /api/v1/ops/players/:id/erase`: the wildcard covers `x-csrf-token` and a `Lax` cookie rides a top-level POST.

`cors_never_allows_credentials` now fails if it ever appears, and also asserts the wildcard is still there so it cannot pass vacuously against a response with no CORS headers at all.

## Checks

`fmt --check`, `xref`, `dialyzer`, `eunit` 2003 pass, `ct` on `asobi_console_SUITE` 22 (+2) and `asobi_guest_purge_SUITE` 8. `elp eqwalize` measured against a clean `origin/main` worktree: `asobi_ops_token` clean, `asobi_console_controller` 3 = baseline, `asobi_console_session` 10 = baseline — the first cut added one (`gen_server:call` typed `term()`) and it is narrowed rather than absorbed.