### PR TITLE
feat: world.tick carries its zone and sequence, and world.resync repairs a gap

### DIFF
--- a/priv/protocol/fixtures/world.tick.json
+++ b/priv/protocol/fixtures/world.tick.json
@@ -1,1 +1,1 @@
-{"type":"world.tick","payload":{"tick":42,"updates":[{"id":"01j8x000000000000000000000","op":"a","x":120,"y":80}]}}
+{"type":"world.tick","payload":{"zone":[0,0],"frame_seq":17,"kf":false,"tick":42,"updates":[{"id":"01j8x000000000000000000000","op":"a","x":120,"y":80}]}}

--- a/src/asobi_sup.erl
+++ b/src/asobi_sup.erl
@@ -296,7 +296,26 @@ register_limiters() ->
         %% own 5/sec budget scales that blocking load linearly with attacker
         %% count. Same reasoning as guest_global. Size from your real
         %% concurrent-player target; this default is a placeholder.
-        rehome_global => #{algorithm => sliding_window, limit => 200, window => 1000}
+        rehome_global => #{algorithm => sliding_window, limit => 200, window => 1000},
+        %% world.resync is the one inbound frame whose response is orders of
+        %% magnitude larger than the request: a ~120-byte ask produces a full
+        %% zone keyframe, measured at ~50 KB of JSON for a 400-entity zone, so
+        %% roughly 400x. Two limiters because one cannot cover both shapes of
+        %% abuse. Per player bounds a single client looping the request; the
+        %% global bucket bounds the aggregate, because per-player alone lets N
+        %% players cost N times the egress and the node's uplink does not care
+        %% whose request it was.
+        %%
+        %% Keyed on player_id rather than IP on purpose. The frame is only
+        %% reachable on an authenticated session, and IP keying would starve
+        %% every player behind one carrier-grade NAT - the same reasoning
+        %% asobi_sup already applies to the rehome pair.
+        %%
+        %% An honest client needs this once per detected gap, and a gap on a TCP
+        %% wire should be impossible, so 2 per 10 s is generous. A client hitting
+        %% the limit is already broken and backing it off is the correct answer.
+        resync => #{algorithm => sliding_window, limit => 2, window => 10000},
+        resync_global => #{algorithm => sliding_window, limit => 20, window => 1000}
     },
     Configured =
         case application:get_env(asobi, rate_limits, #{}) of
@@ -330,7 +349,9 @@ limiter_name(erase) -> asobi_erase_limiter;
 limiter_name(guest_global) -> asobi_guest_global_limiter;
 limiter_name(script_log) -> asobi_script_log_limiter;
 limiter_name(rehome) -> asobi_rehome_limiter;
-limiter_name(rehome_global) -> asobi_rehome_global_limiter.
+limiter_name(rehome_global) -> asobi_rehome_global_limiter;
+limiter_name(resync) -> asobi_world_resync_limiter;
+limiter_name(resync_global) -> asobi_world_resync_global_limiter.
 
 cluster_spec() ->
     #{

--- a/src/social/asobi_presence.erl
+++ b/src/social/asobi_presence.erl
@@ -58,7 +58,8 @@ clauses against the same named type rather than an ad-hoc guess.
     | {world_joined, pid(), pid() | undefined}
     | {world_zone_changed, pid()}
     | {world_event, event_name(), map()}
-    | {zone_delta, non_neg_integer(), [map()]}
+    | {zone_keyframe, map(), [map()]}
+    | {zone_removals, {integer(), integer()}, [map()]}
     | {zone_delta_raw, binary()}
     | {terrain_chunk, {integer(), integer()}, binary()}
     | {dm_message, map()}

--- a/src/world/asobi_world_server.erl
+++ b/src/world/asobi_world_server.erl
@@ -28,6 +28,7 @@ transient matches use `asobi_match_server` instead.
 -export([spawn_at/3, spawn_at/4]).
 -export([zone_created/3]).
 -export([reconnect/2]).
+-export([resync/3]).
 -export([start_vote/2, cast_vote/4, use_veto/3]).
 -export([whereis/1]).
 -export([pos_to_zone/3]).
@@ -57,6 +58,29 @@ transient matches use `asobi_match_server` instead.
 -spec start_link(map()) -> gen_statem:start_ret().
 start_link(Config) ->
     gen_statem:start_link(?MODULE, Config, []).
+
+-doc """
+Ask one zone of this world to re-send `PlayerId` a keyframe.
+
+The server half of `world.resync`. Deliberately ONE zone per request, named by
+its coords, rather than the player's whole interest ring: the ring is
+`(2*view_radius+1)^2` zones, nine at the default `view_radius` of 1, so a ring
+resync turns a ~120-byte request into nine keyframes and the amplification ratio
+goes with it. It is also the wrong shape on the merits, because `frame_seq` is
+per zone and a client that detects a gap knows exactly which zone gapped.
+
+Resolves through `asobi_zone_manager:get_zone/2`, which does NOT create a zone
+that is not loaded. A client must never be able to spin up world state by asking
+for it.
+
+Authorisation is the zone's own subscriber map, checked in `asobi_zone`, not an
+interest lookup here: the subscriber map is the ground truth for "did this
+client ever receive frames from this zone", which is exactly the question a
+repair request asks.
+""".
+-spec resync(pid(), binary(), {integer(), integer()}) -> ok.
+resync(Pid, PlayerId, Coords) ->
+    gen_statem:cast(Pid, {resync, PlayerId, Coords}).
 
 -spec join(pid(), binary()) -> ok | {error, term()}.
 join(Pid, PlayerId) ->
@@ -330,6 +354,25 @@ running(cast, {move_player, PlayerId, NewPos, Entity}, State) ->
     handle_move(PlayerId, NewPos, Entity, State);
 running(cast, {zone_created, Coords, ZonePid}, #{player_zones := PlayerZones}) ->
     backfill_zone_subscribers(Coords, ZonePid, undefined, PlayerZones),
+    keep_state_and_data;
+%% Guards narrow both cast arguments rather than trusting the sender. The ws
+%% handler validates the frame before it gets here, so this is defence in depth,
+%% and it is also what lets the call sites below be typed: a gen_statem cast
+%% payload is `term()`, and `is_pid` on the manager is the honest narrowing that
+%% `=/= undefined` only looks like.
+running(cast, {resync, PlayerId, {ZX, ZY} = Coords}, #{zone_manager_pid := ZMPid}) when
+    is_binary(PlayerId), is_integer(ZX), is_integer(ZY), is_pid(ZMPid)
+->
+    %% get_zone, never ensure_zone: a resync request must not be able to load a
+    %% zone. An unloaded zone has nothing to repair, so the request is dropped.
+    case asobi_zone_manager:get_zone(ZMPid, Coords) of
+        {ok, ZonePid} -> asobi_zone:resync(ZonePid, PlayerId);
+        _ -> ok
+    end,
+    keep_state_and_data;
+%% A resync before the zone manager is up, or with a payload that did not survive
+%% the guards, is dropped. There is nothing to repair and nothing to answer.
+running(cast, {resync, _PlayerId, _Coords}, _State) ->
     keep_state_and_data;
 running(
     cast,

--- a/src/world/asobi_zone.erl
+++ b/src/world/asobi_zone.erl
@@ -210,6 +210,20 @@ init(Config) ->
             prev_entities => #{},
             broadcast_entities => #{},
             broadcast_interval => maps:get(broadcast_interval, Config, 3),
+            %% Counts world.tick frames this zone has BROADCAST, so a client can
+            %% tell a lost or reordered frame from a quiet tick. Distinct from
+            %% `tick`: the tick number skips on `broadcast_interval` and is
+            %% suppressed entirely when a tick produces no deltas, so a gap in it
+            %% is ambiguous between "nothing changed" and "you missed one".
+            %% frame_seq has no gaps by construction.
+            %%
+            %% Only the shared broadcast path advances it. Per-connection frames
+            %% (a join keyframe) carry the CURRENT value and never advance it, so
+            %% they anchor to the shared stream rather than desynchronising every
+            %% other subscriber. 53-bit ceiling, matching the inbound bound at
+            %% asobi_ws_handler:world_input_seq/1: at 20 Hz that is 14 million
+            %% years, so there is no wrap rule to get wrong.
+            wire_seq => 0,
             subscribers => #{},
             zone_state => ZoneState,
             input_queue => [],
@@ -439,14 +453,15 @@ handle_cast(
 ) when is_binary(PlayerId), is_pid(PlayerPid) ->
     subscribe_new(PlayerId, PlayerPid, State);
 handle_cast(
-    {unsubscribe, PlayerId}, #{subscribers := Subs, entities := Entities} = State
+    {unsubscribe, PlayerId},
+    #{subscribers := Subs, broadcast_entities := BroadcastEntities, coords := Coords} = State
 ) ->
     case maps:get(PlayerId, Subs, undefined) of
         undefined ->
             {noreply, State};
         {Pid, MonRef} ->
             demonitor(MonRef, [flush]),
-            send_leave_removals(Pid, Entities),
+            send_leave_removals(Pid, Coords, BroadcastEntities),
             {noreply, State#{subscribers => maps:remove(PlayerId, Subs)}}
     end;
 handle_cast({start_entity_timer, Config}, #{entity_timers := ET} = State) when is_map(Config) ->
@@ -528,18 +543,31 @@ terminate(_Reason, #{world_id := WorldId, coords := Coords, entities := Entities
 subscribe_new(
     PlayerId,
     PlayerPid,
-    #{subscribers := Subs, entities := Entities, coords := Coords} = State
+    #{
+        subscribers := Subs,
+        broadcast_entities := BroadcastEntities,
+        coords := Coords,
+        wire_seq := WireSeq
+    } = State
 ) ->
     MonRef = monitor(process, PlayerPid),
-    %% Send immediate snapshot so new subscribers see all current entities
-    _ =
-        case map_size(Entities) of
-            0 ->
-                ok;
-            _ ->
-                Snapshot = [E#{~"op" => ~"a", ~"id" => Id} || {Id, E} <- maps:to_list(Entities)],
-                PlayerPid ! {asobi_message, {zone_delta, 0, Snapshot}}
-        end,
+    %% The join keyframe is the client's baseline, and it is built from
+    %% `broadcast_entities` rather than `entities` for a reason that is easy to
+    %% get wrong. The delta stream diffs against `broadcast_entities` (do_tick/2),
+    %% which only advances on a broadcast tick, so with the default
+    %% `broadcast_interval` of 3 `entities` can be two sim ticks ahead of it.
+    %% Snapshotting `entities` therefore hands the client a baseline AHEAD of the
+    %% stream that follows, and the next `op:"u"` diff never re-sends the fields
+    %% that changed in between - they are already equal to the server's own
+    %% baseline, so `compute_deltas/2` emits nothing for them and the client
+    %% keeps the newer value it was never told to expect. Anchoring both to the
+    %% same map is what makes `frame_seq` mean anything.
+    %%
+    %% Sent unconditionally, including when the zone is empty. An empty zone
+    %% still has a sequence position, and a client that receives no keyframe has
+    %% no baseline to reject a stale delta against.
+    Snapshot = [E#{~"op" => ~"a", ~"id" => Id} || {Id, E} <- maps:to_list(BroadcastEntities)],
+    PlayerPid ! {asobi_message, {zone_keyframe, frame_meta(Coords, WireSeq, true), Snapshot}},
     _ =
         case maps:get(terrain_store_pid, State, undefined) of
             undefined ->
@@ -554,14 +582,39 @@ subscribe_new(
         end,
     {noreply, State#{subscribers => Subs#{PlayerId => {PlayerPid, MonRef}}}}.
 
-%% Mirror of subscribe_new/3's snapshot, in reverse. See widgrensit/asobi#293.
--spec send_leave_removals(pid(), map()) -> ok.
-send_leave_removals(_Pid, Entities) when map_size(Entities) =:= 0 ->
+%% Mirror of subscribe_new/3's keyframe, in reverse. See widgrensit/asobi#293.
+%%
+%% Carries `zone` but deliberately no `frame_seq`, and the client applies it
+%% ungated. It is not a position in the zone's stream: it is the last thing this
+%% connection hears from a zone it is leaving, and gating it behind a sequence
+%% guard would let a client that was mid-gap keep a table of ghosts forever.
+%% Built from `broadcast_entities` for the same reason the keyframe is - removing
+%% the ids the client was actually told about, rather than the ids the zone
+%% happens to hold this sim tick.
+-spec send_leave_removals(pid(), {integer(), integer()}, map()) -> ok.
+send_leave_removals(_Pid, _Coords, Entities) when map_size(Entities) =:= 0 ->
     ok;
-send_leave_removals(Pid, Entities) ->
+send_leave_removals(Pid, Coords, Entities) ->
     Removals = encode_deltas([{removed, Id} || Id <- maps:keys(Entities)]),
-    Pid ! {asobi_message, {zone_delta, 0, Removals}},
+    Pid ! {asobi_message, {zone_removals, Coords, Removals}},
     ok.
+
+%% The three fields stage 1 adds to world.tick, in one place so the shared and
+%% per-connection paths cannot disagree about their shape.
+%%
+%% `zone` is the field that fixes the corruption bug, and it is the reason this
+%% work exists: a player subscribes to an interest ring of several zones
+%% (asobi_world_server:subscribe_interest_zones/4), each an independent process
+%% sending to the same session pid, and Erlang orders messages per
+%% sender-receiver pair only. A zone crossing emits `op:"r"` from the old zone
+%% and `op:"a"` from the new one, from two different senders, so they can arrive
+%% inverted - and a client applying both into one flat table then deletes the
+%% entity and never hears about it again. Per-zone tables make that unreachable.
+%% Binary keys, matching broadcast_deltas/4's own payload, so the shared and
+%% per-connection frames are byte-identical in shape and one merge covers both.
+-spec frame_meta({integer(), integer()}, non_neg_integer(), boolean()) -> map().
+frame_meta({ZX, ZY}, WireSeq, IsKeyframe) ->
+    #{~"zone" => [ZX, ZY], ~"frame_seq" => WireSeq, ~"kf" => IsKeyframe}.
 
 do_tick(
     TickN,
@@ -573,6 +626,7 @@ do_tick(
         prev_entities := _PrevEntities,
         broadcast_entities := BroadcastEntities,
         broadcast_interval := BroadcastInterval,
+        wire_seq := WireSeq,
         zone_state := ZoneState,
         input_queue := Queue,
         subscribers := Subs,
@@ -623,9 +677,9 @@ do_tick(
         case TickN rem BroadcastInterval of
             0 ->
                 Deltas = compute_deltas(BroadcastEntities, Entities4),
-                broadcast_deltas(TickN, Deltas, Subs),
+                WireSeq1 = broadcast_deltas(Coords, TickN, WireSeq, Deltas, Subs),
                 broadcast_acks(TickN, PlayerAck1, Subs),
-                State#{broadcast_entities => Entities4};
+                State#{broadcast_entities => Entities4, wire_seq => WireSeq1};
             _ ->
                 State
         end,
@@ -747,19 +801,34 @@ compute_deltas(OldEntities, NewEntities) ->
     ],
     Updates ++ Removed.
 
-broadcast_deltas(_TickN, [], _Subs) ->
-    ok;
-broadcast_deltas(TickN, Deltas, Subs) ->
+%% Returns the zone's new frame_seq, which is the ONLY place it advances.
+%%
+%% It advances on a frame actually sent, not on a broadcast tick. An empty delta
+%% list sends nothing (the clause below), so advancing there would put a gap in
+%% the sequence for a tick where nothing happened, and a gap is precisely what
+%% the client treats as loss. The `tick` field cannot serve this purpose for
+%% exactly that reason and is left alone: it stays the sim tick, ADR 0010 froze
+%% it, and clients read it.
+-spec broadcast_deltas(
+    {integer(), integer()}, non_neg_integer(), non_neg_integer(), [term()], map()
+) -> non_neg_integer().
+broadcast_deltas(_Coords, _TickN, WireSeq, [], _Subs) ->
+    WireSeq;
+broadcast_deltas(Coords, TickN, WireSeq, Deltas, Subs) ->
+    Seq = WireSeq + 1,
     EncodedDeltas = encode_deltas(Deltas),
+    Meta = frame_meta(Coords, Seq, false),
     Payload = #{
-        ~"type" => ~"world.tick", ~"payload" => #{~"tick" => TickN, ~"updates" => EncodedDeltas}
+        ~"type" => ~"world.tick",
+        ~"payload" => Meta#{~"tick" => TickN, ~"updates" => EncodedDeltas}
     },
     PreEncoded = iolist_to_binary(json:encode(Payload)),
     RawMsg = {asobi_message, {zone_delta_raw, PreEncoded}},
     maps:foreach(
         fun(_PlayerId, {Pid, _MonRef}) -> Pid ! RawMsg end,
         Subs
-    ).
+    ),
+    Seq.
 
 %% asobi#474: input ack, addressed to one connection. Iterate the opted-in
 %% players (those with a recorded seq) and send world.ack only to the ones still

--- a/src/world/asobi_zone.erl
+++ b/src/world/asobi_zone.erl
@@ -10,7 +10,7 @@ via `asobi_spatial`. Zones are created and reaped lazily as players move.
 -export([start_link/1, reap/1]).
 -export([tick/2, player_input/3, player_input/4, add_entity/3, remove_entity/2]).
 -export([spawn_entity/3, spawn_entity/4, spawn_entities/2, despawn_entity/2]).
--export([subscribe/2, unsubscribe/2]).
+-export([subscribe/2, unsubscribe/2, resync/2]).
 -export([get_entities/1, get_subscriber_count/1, sync/1]).
 -export([start_entity_timer/2, cancel_entity_timer/3]).
 -export([query_radius/3, query_rect/3]).
@@ -75,6 +75,22 @@ subscribe(Pid, {PlayerId, PlayerPid}) ->
 -spec unsubscribe(pid(), binary()) -> ok.
 unsubscribe(Pid, PlayerId) ->
     gen_server:cast(Pid, {unsubscribe, PlayerId}).
+
+-doc """
+Re-send `PlayerId` a keyframe for this zone, on their own request.
+
+The repair half of `frame_seq`: a client that sees a gap asks for a fresh
+baseline rather than carrying a corrupted entity table for the life of the
+world.
+
+The keyframe goes to the pid in this zone's own subscriber map, never to a pid
+the request names, and a player who is not subscribed here gets nothing. That is
+what stops the frame being redirected or used to read a zone the requester is
+not in.
+""".
+-spec resync(pid(), binary()) -> ok.
+resync(Pid, PlayerId) ->
+    gen_server:cast(Pid, {resync, PlayerId}).
 
 -spec get_entities(pid()) -> map().
 get_entities(Pid) ->
@@ -464,6 +480,26 @@ handle_cast(
             send_leave_removals(Pid, Coords, BroadcastEntities),
             {noreply, State#{subscribers => maps:remove(PlayerId, Subs)}}
     end;
+handle_cast(
+    {resync, PlayerId},
+    #{
+        subscribers := Subs,
+        broadcast_entities := BroadcastEntities,
+        coords := Coords,
+        wire_seq := WireSeq
+    } = State
+) ->
+    %% Serves the pid this zone already holds for PlayerId. A request naming a
+    %% zone the player is not subscribed to is dropped silently rather than
+    %% answered: there is nothing to repair, and answering would turn resync into
+    %% a way to read any zone in the world.
+    case maps:get(PlayerId, Subs, undefined) of
+        undefined ->
+            ok;
+        {Pid, _MonRef} ->
+            send_keyframe(Pid, Coords, WireSeq, BroadcastEntities)
+    end,
+    {noreply, State};
 handle_cast({start_entity_timer, Config}, #{entity_timers := ET} = State) when is_map(Config) ->
     {noreply, State#{entity_timers => asobi_entity_timer:start_timer(Config, ET)}};
 handle_cast({cancel_entity_timer, EntityId, TimerId}, #{entity_timers := ET} = State) when
@@ -551,23 +587,7 @@ subscribe_new(
     } = State
 ) ->
     MonRef = monitor(process, PlayerPid),
-    %% The join keyframe is the client's baseline, and it is built from
-    %% `broadcast_entities` rather than `entities` for a reason that is easy to
-    %% get wrong. The delta stream diffs against `broadcast_entities` (do_tick/2),
-    %% which only advances on a broadcast tick, so with the default
-    %% `broadcast_interval` of 3 `entities` can be two sim ticks ahead of it.
-    %% Snapshotting `entities` therefore hands the client a baseline AHEAD of the
-    %% stream that follows, and the next `op:"u"` diff never re-sends the fields
-    %% that changed in between - they are already equal to the server's own
-    %% baseline, so `compute_deltas/2` emits nothing for them and the client
-    %% keeps the newer value it was never told to expect. Anchoring both to the
-    %% same map is what makes `frame_seq` mean anything.
-    %%
-    %% Sent unconditionally, including when the zone is empty. An empty zone
-    %% still has a sequence position, and a client that receives no keyframe has
-    %% no baseline to reject a stale delta against.
-    Snapshot = [E#{~"op" => ~"a", ~"id" => Id} || {Id, E} <- maps:to_list(BroadcastEntities)],
-    PlayerPid ! {asobi_message, {zone_keyframe, frame_meta(Coords, WireSeq, true), Snapshot}},
+    send_keyframe(PlayerPid, Coords, WireSeq, BroadcastEntities),
     _ =
         case maps:get(terrain_store_pid, State, undefined) of
             undefined ->
@@ -610,7 +630,29 @@ send_leave_removals(Pid, Coords, Entities) ->
 %% and `op:"a"` from the new one, from two different senders, so they can arrive
 %% inverted - and a client applying both into one flat table then deletes the
 %% entity and never hears about it again. Per-zone tables make that unreachable.
-%% Binary keys, matching broadcast_deltas/4's own payload, so the shared and
+%% The client's baseline, and the one frame it adopts unconditionally.
+%%
+%% Built from `broadcast_entities` rather than `entities` for a reason that is
+%% easy to get wrong. The delta stream diffs against `broadcast_entities`
+%% (do_tick/2), which only advances on a broadcast tick, so with the default
+%% `broadcast_interval` of 3 `entities` can be two sim ticks ahead of it.
+%% Snapshotting `entities` hands the client a baseline AHEAD of the stream that
+%% follows, and the next `op:"u"` diff never re-sends the fields that changed in
+%% between - they already equal the server's own baseline, so compute_deltas/2
+%% emits nothing for them and the client keeps a value it was never told to
+%% expect. Anchoring both to the same map is what makes `frame_seq` mean
+%% anything.
+%%
+%% Sent unconditionally, including for an empty zone. An empty zone still has a
+%% sequence position, and a client with no keyframe has no baseline to reject a
+%% stale delta against.
+-spec send_keyframe(pid(), {integer(), integer()}, non_neg_integer(), map()) -> ok.
+send_keyframe(PlayerPid, Coords, WireSeq, BroadcastEntities) ->
+    Snapshot = [E#{~"op" => ~"a", ~"id" => Id} || {Id, E} <- maps:to_list(BroadcastEntities)],
+    PlayerPid ! {asobi_message, {zone_keyframe, frame_meta(Coords, WireSeq, true), Snapshot}},
+    ok.
+
+%% Binary keys, matching broadcast_deltas/5's own payload, so the shared and
 %% per-connection frames are byte-identical in shape and one merge covers both.
 -spec frame_meta({integer(), integer()}, non_neg_integer(), boolean()) -> map().
 frame_meta({ZX, ZY}, WireSeq, IsKeyframe) ->

--- a/src/ws/asobi_ws_handler.erl
+++ b/src/ws/asobi_ws_handler.erl
@@ -298,8 +298,22 @@ websocket_info({asobi_message, {match_event, Event, Payload}}, State) when
     end;
 websocket_info({asobi_message, {zone_delta_raw, PreEncoded}}, State) when is_binary(PreEncoded) ->
     {reply, {text, PreEncoded}, State};
-websocket_info({asobi_message, {zone_delta, TickN, Deltas}}, State) ->
-    Reply = encode_reply(undefined, ~"world.tick", #{tick => TickN, updates => Deltas}),
+websocket_info({asobi_message, {zone_keyframe, Meta, Deltas}}, State) when is_map(Meta) ->
+    %% A per-connection baseline. Carries the zone's CURRENT frame_seq and
+    %% `kf: true`, so a client adopts it unconditionally and resets its
+    %% high-water mark to that value - which is what makes a zone restart
+    %% recoverable, since the restart resets the sequence while the zone
+    %% identity is unchanged and a monotonic guard would otherwise reject the
+    %% one frame that repairs it.
+    Reply = encode_reply(undefined, ~"world.tick", Meta#{~"tick" => 0, ~"updates" => Deltas}),
+    {reply, {text, Reply}, State};
+websocket_info({asobi_message, {zone_removals, {ZX, ZY}, Deltas}}, State) ->
+    %% The leave mirror. Carries `zone` so the client knows which table to empty,
+    %% and deliberately no frame_seq: it is not a position in the zone's stream
+    %% and is applied ungated.
+    Reply = encode_reply(undefined, ~"world.tick", #{
+        ~"zone" => [ZX, ZY], ~"tick" => 0, ~"updates" => Deltas
+    }),
     {reply, {text, Reply}, State};
 websocket_info({asobi_message, {world_ack, TickN, Seq}}, State) ->
     %% asobi#474: per-connection input ack, sent beside the shared world.tick.

--- a/src/ws/asobi_ws_handler.erl
+++ b/src/ws/asobi_ws_handler.erl
@@ -164,6 +164,34 @@ world_input_data(Payload) when is_map(Payload) ->
 world_input_data(_) ->
     invalid.
 
+%% `zone` comes off the wire as the same [X, Y] pair asobi puts on world.tick and
+%% world.terrain, so a client echoes back exactly the value it was given rather
+%% than constructing one. Bounded to a plain integer pair: the coords index a
+%% zone grid, so anything else - a float, a bignum, a third element - names no
+%% zone and is refused before it reaches a gen_statem cast.
+-spec resync_coords(term()) -> {integer(), integer()} | invalid.
+resync_coords(#{~"zone" := [X, Y]}) when
+    is_integer(X), is_integer(Y), abs(X) =< 16#FFFFFFFF, abs(Y) =< 16#FFFFFFFF
+->
+    {X, Y};
+resync_coords(_) ->
+    invalid.
+
+%% Both buckets, per player and fleet-wide, and the per-player one is checked
+%% first so a single looping client is refused without consuming global budget
+%% that honest clients share.
+-spec resync_allowed(binary()) -> boolean().
+resync_allowed(PlayerId) ->
+    case seki:check(asobi_world_resync_limiter, PlayerId) of
+        {allow, _} ->
+            case seki:check(asobi_world_resync_global_limiter, ~"global") of
+                {allow, _} -> true;
+                {deny, _} -> false
+            end;
+        {deny, _} ->
+            false
+    end.
+
 %% match.input carries the same shapes plus one of its own: a sole `data` holding
 %% a JSON *string*, which predates world.input and is what asobi-unity's
 %% SendMatchInput sends. The decode is total - `json:decode/1` RAISES on malformed
@@ -974,6 +1002,44 @@ handle_message(
     catch
         exit:{noproc, _} ->
             {ok, State#{session => undefined}}
+    end;
+%% The repair half of `frame_seq`: a client that sees a gap in a zone's frame
+%% sequence asks for a fresh baseline for THAT zone. One zone per request, named
+%% by its coords, because frame_seq is per zone and a client that detects a gap
+%% knows which zone gapped - and because the interest ring is nine zones at the
+%% default view_radius, so a ring-shaped resync would multiply one small request
+%% into nine keyframes.
+%%
+%% Rate limited on two buckets before any work happens, because this is the one
+%% inbound frame whose response is hundreds of times larger than the request.
+%% Refused quietly rather than with an error frame: a gap is the client's problem
+%% to back off from, and an error reply on a repair path is one more thing for a
+%% broken client to loop on.
+handle_message(
+    #{~"type" := ~"world.resync", ~"payload" := Payload},
+    #{session := SessionPid} = State
+) when SessionPid =/= undefined ->
+    case resync_coords(Payload) of
+        invalid ->
+            {ok, State};
+        Coords ->
+            try asobi_player_session:get_state(SessionPid) of
+                #{player_id := PlayerId} = SState ->
+                    case maps:get(world_pid, SState, undefined) of
+                        undefined ->
+                            {ok, State};
+                        WorldPid ->
+                            _ =
+                                case resync_allowed(PlayerId) of
+                                    true -> asobi_world_server:resync(WorldPid, PlayerId, Coords);
+                                    false -> ok
+                                end,
+                            {ok, State}
+                    end
+            catch
+                exit:{noproc, _} ->
+                    {ok, State#{session => undefined}}
+            end
     end;
 %% The extension wire (Wave 2b). Everything about the call - `cid` validation,
 %% readiness, the method table, the error object - belongs to asobi_rpc; this

--- a/test/asobi_world_zone_integration_tests.erl
+++ b/test/asobi_world_zone_integration_tests.erl
@@ -522,24 +522,44 @@ fake_session(PlayerId, Owner) ->
     ok = pg:join(nova_scope, {player, PlayerId}, Pid),
     Pid.
 
-%% Blocks until PlayerId's forwarded messages include a zone_delta mentioning
-%% EntityId, or the timeout elapses.
+%% Blocks until PlayerId's forwarded messages mention EntityId in ANY of the
+%% three world.tick carriers, or the timeout elapses.
+%%
+%% All three are needed since the join keyframe stopped being a snapshot of
+%% `entities`. A backfilled entity now reaches an existing subscriber through the
+%% shared broadcast, which is pre-encoded JSON precisely so one encode serves
+%% every subscriber (ADR 0001), so a helper that only reads the tuple carriers
+%% would sit blind through the frame that actually delivers it.
 received_entity(PlayerId, EntityId) ->
     receive
-        {PlayerId, {asobi_message, {zone_delta, _Tick, Ops}}} ->
-            HasEntity = lists:any(
-                fun
-                    (#{~"id" := Id}) -> Id =:= EntityId;
-                    (_) -> false
-                end,
-                Ops
-            ),
-            case HasEntity of
-                true -> true;
-                false -> received_entity(PlayerId, EntityId)
+        {PlayerId, {asobi_message, Msg}} ->
+            case tick_ops(Msg) of
+                skip ->
+                    received_entity(PlayerId, EntityId);
+                Ops ->
+                    case lists:any(fun(Op) -> op_id(Op) =:= EntityId end, Ops) of
+                        true -> true;
+                        false -> received_entity(PlayerId, EntityId)
+                    end
             end
     after 500 -> false
     end.
+
+%% The op list out of whichever world.tick carrier this is, or `skip` for a
+%% message that is not one.
+tick_ops({zone_keyframe, _Meta, Ops}) -> Ops;
+tick_ops({zone_removals, _Coords, Ops}) -> Ops;
+tick_ops({zone_delta_raw, PreEncoded}) -> decoded_ops(PreEncoded);
+tick_ops(_Other) -> skip.
+
+decoded_ops(PreEncoded) ->
+    case json:decode(PreEncoded) of
+        #{~"type" := ~"world.tick", ~"payload" := #{~"updates" := Ops}} -> Ops;
+        _ -> skip
+    end.
+
+op_id(#{~"id" := Id}) -> Id;
+op_id(_) -> undefined.
 
 %% Regression for widgrensit/asobi#275: a zone that a crossing brings into
 %% existence for the first time must pick up every already-connected player
@@ -669,7 +689,16 @@ script_spawn_into_a_lazily_created_zone_backfills_neighbours() ->
 %% (op "r") for EntityId, or the timeout elapses.
 received_removal(PlayerId, EntityId) ->
     receive
-        {PlayerId, {asobi_message, {zone_delta, _Tick, Ops}}} ->
+        {PlayerId, {asobi_message, Msg}} when
+            element(1, Msg) =:= zone_removals;
+            element(1, Msg) =:= zone_delta_raw;
+            element(1, Msg) =:= zone_keyframe
+        ->
+            Ops =
+                case tick_ops(Msg) of
+                    skip -> [];
+                    L -> L
+                end,
             HasRemoval = lists:any(
                 fun
                     (#{~"op" := ~"r", ~"id" := Id}) -> Id =:= EntityId;

--- a/test/asobi_zone_tests.erl
+++ b/test/asobi_zone_tests.erl
@@ -353,18 +353,23 @@ recv_ack() ->
 %% of this zone freezes at its last known state forever (the zone never
 %% sends it another update once the subscription is gone).
 unsubscribe_sends_removals_for_entities() ->
-    Pid = start_zone(),
+    %% broadcast_interval 1 so one tick is one broadcast: the leave frame removes
+    %% what the client was TOLD about (broadcast_entities), not what the zone
+    %% happens to hold, so the entities have to reach the client first.
+    Pid = start_zone(#{broadcast_interval => 1}),
     asobi_zone:add_entity(Pid, ~"e1", #{x => 1, y => 1, type => ~"player"}),
     asobi_zone:add_entity(Pid, ~"e2", #{x => 2, y => 2, type => ~"npc"}),
     timer:sleep(10),
     asobi_zone:subscribe(Pid, {~"p1", self()}),
     timer:sleep(10),
+    asobi_zone:tick(Pid, 1),
+    timer:sleep(20),
     flush_messages(),
 
     asobi_zone:unsubscribe(Pid, ~"p1"),
     Removals =
         receive
-            {asobi_message, {zone_delta, 0, Deltas}} -> Deltas
+            {asobi_message, {zone_removals, {0, 0}, Deltas}} -> Deltas
         after 200 -> []
         end,
     ?assertEqual(
@@ -447,11 +452,14 @@ resubscribe_new_pid_replaces_and_demonitors_old() ->
     #{subscribers := #{~"p1" := {NewPid, NewRef}}} = sys:get_state(Pid),
     ?assertEqual(self(), NewPid),
     ?assertNotEqual(OldRef, NewRef),
+    %% The re-subscribe keyframe is built from the shared broadcast baseline, so
+    %% before any broadcast tick it is legitimately empty. What matters here is
+    %% that a keyframe arrives at all, and that it is marked as one.
     ?assertMatch(
-        [_ | _],
+        {#{~"kf" := true, ~"zone" := [0, 0]}, _},
         receive
-            {asobi_message, {zone_delta, 0, Snapshot}} -> Snapshot
-        after 200 -> []
+            {asobi_message, {zone_keyframe, Meta, Snapshot}} -> {Meta, Snapshot}
+        after 200 -> timeout
         end
     ),
 
@@ -466,13 +474,16 @@ tick_broadcasts() ->
     timer:sleep(10),
     asobi_zone:subscribe(Pid, {<<"p1">>, self()}),
     timer:sleep(10),
-    %% Subscribe sends immediate snapshot
+    %% Subscribe sends a keyframe built from the shared broadcast baseline. e1 was
+    %% added but never broadcast, so it is NOT in the keyframe - it arrives as an
+    %% op:"a" in the first delta instead. Snapshotting `entities` here is what
+    %% used to send it twice, once in the snapshot and again in that first delta.
     receive
-        {asobi_message, {zone_delta, 0, Snapshot}} ->
-            ?assertEqual(1, length(Snapshot)),
-            [S] = Snapshot,
-            ?assertEqual(~"a", maps:get(~"op", S)),
-            ?assertEqual(<<"e1">>, maps:get(~"id", S))
+        {asobi_message, {zone_keyframe, Meta, Snapshot}} ->
+            ?assertEqual(true, maps:get(~"kf", Meta)),
+            ?assertEqual(0, maps:get(~"frame_seq", Meta)),
+            ?assertEqual([0, 0], maps:get(~"zone", Meta)),
+            ?assertEqual([], Snapshot)
     after 1000 ->
         ?assert(false)
     end,

--- a/test/asobi_zone_tests.erl
+++ b/test/asobi_zone_tests.erl
@@ -39,6 +39,9 @@ zone_test_() ->
             fun unsubscribe_sends_removals_for_entities/0},
         {"unsubscribe of an unknown player sends nothing",
             fun unsubscribe_unknown_player_is_noop/0},
+        {"resync re-sends a keyframe to a subscriber", fun resync_sends_keyframe/0},
+        {"resync for a player who is not subscribed sends nothing",
+            fun resync_unsubscribed_sends_nothing/0},
         {"resubscribing the same pid is idempotent", fun resubscribe_same_pid_is_idempotent/0},
         {"resubscribing a new pid replaces and demonitors the old one",
             fun resubscribe_new_pid_replaces_and_demonitors_old/0},
@@ -352,6 +355,50 @@ recv_ack() ->
 %% send an `r` for every entity still held, or the departing client's copy
 %% of this zone freezes at its last known state forever (the zone never
 %% sends it another update once the subscription is gone).
+%% The repair half of frame_seq. A client that saw a gap asks for a baseline and
+%% gets one carrying the zone's CURRENT frame_seq with kf: true, which is what it
+%% resets its high-water mark to.
+resync_sends_keyframe() ->
+    Pid = start_zone(#{broadcast_interval => 1}),
+    asobi_zone:add_entity(Pid, ~"e1", #{x => 1, y => 1, type => ~"player"}),
+    timer:sleep(10),
+    asobi_zone:subscribe(Pid, {~"p1", self()}),
+    timer:sleep(10),
+    %% One broadcast so the zone has a non-zero frame_seq and a real baseline,
+    %% which is what makes the assertion below distinguishable from the join
+    %% keyframe's frame_seq of 0.
+    asobi_zone:tick(Pid, 1),
+    timer:sleep(20),
+    flush_messages(),
+
+    asobi_zone:resync(Pid, ~"p1"),
+    receive
+        {asobi_message, {zone_keyframe, Meta, Snapshot}} ->
+            ?assertEqual(true, maps:get(~"kf", Meta)),
+            ?assertEqual([0, 0], maps:get(~"zone", Meta)),
+            ?assertEqual(1, maps:get(~"frame_seq", Meta)),
+            ?assertEqual([~"e1"], [Id || #{~"id" := Id} <- Snapshot])
+    after 500 ->
+        ?assert(false)
+    end,
+    gen_server:stop(Pid).
+
+%% A resync naming a zone the requester is not subscribed to is dropped, not
+%% answered. Answering would make the frame a way to read any zone in the world,
+%% and there is nothing to repair for a client that was never told anything.
+resync_unsubscribed_sends_nothing() ->
+    Pid = start_zone(#{broadcast_interval => 1}),
+    asobi_zone:add_entity(Pid, ~"e1", #{x => 1, y => 1, type => ~"player"}),
+    timer:sleep(10),
+    flush_messages(),
+
+    asobi_zone:resync(Pid, ~"never_subscribed"),
+    receive
+        {asobi_message, {zone_keyframe, _, _}} -> ?assert(false)
+    after 200 -> ok
+    end,
+    gen_server:stop(Pid).
+
 unsubscribe_sends_removals_for_entities() ->
     %% broadcast_interval 1 so one tick is one broadcast: the leave frame removes
     %% what the client was TOLD about (broadcast_entities), not what the zone


### PR DESCRIPTION
Stage 1 server side. Fixes a live corruption path on today's wire and lays the sequence rule the client reconciler needs. Investigation write-up at `~/.claude/sessions/research/udp-transport-2026-08-15/`.

## The bug

A player subscribes to an interest ring of **several** zones, not one (`asobi_world_server:subscribe_interest_zones/4`). Each zone is an independent process sending directly to the same session pid, and Erlang orders messages per sender-receiver pair only, so frames from two zones have no order relative to each other.

A zone crossing emits `op:"r"` from the zone being left and `op:"a"` from the zone being entered, from those two different senders. Arrive inverted, and a client applying both into one flat entity table deletes the entity and never hears about it again: `compute_deltas/2` will not re-emit an add for an entity already in its baseline, so nothing repairs it for the life of the world.

No packet loss required. And `world.tick` carried no zone identifier, so a client could not have kept per-zone tables even if it wanted to.

## What changes on the wire

Three additive payload fields. Additive is unconditional here because the `world.tick` payload is framework-owned, not game-authored, so `?RESERVED_EVENT_NAMES` is not in play:

| Field | Meaning |
|---|---|
| `zone` | `[X, Y]`, matching the coords encoding `world.terrain` already uses |
| `frame_seq` | frames this zone has broadcast, so loss and reordering become visible |
| `kf` | `true` on a full baseline, `false` on an incremental delta |

`frame_seq` cannot be `tick`. `tick` skips on `broadcast_interval` and is suppressed entirely when a tick yields no deltas, so a gap in it is ambiguous between "nothing changed" and "you missed one". `frame_seq` advances only when a frame is actually sent.

## The sequence rule, which matters more than the fields

- Only the **shared broadcast** path advances the counter.
- A per-connection **keyframe** carries the current value with `kf: true` and never advances it, so it anchors to the shared stream instead of desynchronising every other subscriber. This is also what makes a zone restart recoverable: the restart resets the sequence while zone identity is unchanged, and a monotonic guard would otherwise reject the one frame that repairs it.
- The **leave** frame carries `zone` but no `frame_seq`, and is applied ungated. It is not a position in the stream, and gating it would let a client that was mid-gap keep ghosts forever.

## A pre-existing defect this exposed

Anchoring is only sound if the keyframe *is* the shared baseline. `subscribe_new/3` snapshotted `entities` while the delta stream diffs `broadcast_entities`, and those differ by up to `broadcast_interval` sim ticks.

So a joining client got a baseline **ahead** of the stream that followed, and the next `op:"u"` never re-sent the fields that changed in between: they already matched the server's own baseline, so `compute_deltas/2` emitted nothing and the client kept a value it was never told to expect. On a cold join the same mismatch sent every entity **twice**, once in the snapshot and again as `op:"a"` in the first delta diffed from an empty baseline.

Both the keyframe and the leave removals now read `broadcast_entities`. The empty-zone short circuits go with it: an empty zone still has a sequence position, and a client with no keyframe has no baseline to reject a stale delta against.

## One deliberate behaviour change, worth a look

A joiner's baseline is now the last broadcast rather than live `entities`, so an entity spawned since that broadcast reaches them on the **next** one instead of immediately. At most `broadcast_interval * tick_rate`, so 150 ms on defaults.

That is the price of a truthful baseline, and I think it is the right trade: it makes a joiner exactly as current as every other subscriber, rather than briefly fresher and then permanently wrong. Flagging it because it is a real latency change on zone crossing and backfill.

## Internal contract

`asobi_presence:message/0` loses `{zone_delta, _, _}` and gains `{zone_keyframe, Meta, Ops}` and `{zone_removals, Coords, Ops}`, one per carrier. Internal only; ADR 0010 governs the wire and the wire change here is additive.

## Note on merge

The `world.tick` fixture changed, so `protocol-sync.yml` will open a PR in all seven SDK repos. Five of them are already 4-5 fixture files adrift, so those PRs will carry more than this change. None of the SDKs needs a code change to keep working: the new fields are additive and every SDK ignores unknown payload keys.

## Second commit: `world.resync`

`frame_seq` makes loss visible; this makes it repairable. A client that detects a gap asks that zone for a fresh keyframe instead of carrying a corrupted table for the life of the world.

Inbound additions are unconditionally safe under ADR 0010. The **response deliberately reuses `world.tick` with `kf: true`** rather than adding an outbound `world.resync`: a new outbound `world.<leaf>` would force `resync` into `?RESERVED_EVENT_NAMES` and retroactively ban that leaf for any shipped game already broadcasting it via `game.broadcast`, which ADR 0010 weighs as a break. Reusing a frame the client already decodes costs nothing.

**One zone per request**, named by coords. The interest ring is nine zones at the default `view_radius`, so a ring-shaped resync turns one ~120-byte request into nine full keyframes. It is also wrong on the merits: `frame_seq` is per zone, so a client that detects a gap already knows which zone gapped.

Three bounds, because this is the only inbound frame whose response is hundreds of times larger than the request (~120 B against ~50 KB of JSON for a 400-entity zone):

- per-player, 2 per 10 s. A gap on TCP should be impossible, so an honest client needs this once per incident.
- a global bucket, 20/s, because per-player alone lets N players cost N times the egress.
- keyed on `player_id`, not IP. The frame needs an authenticated session, and IP keying would starve everyone behind one CGNAT, the same reasoning `asobi_sup` already applies to the rehome pair.

Refused quietly rather than with an error frame, so a broken client has nothing extra to loop on.

Two properties do the security work: the zone serves the pid in its **own subscriber map**, never one the request names, so a forged request cannot redirect a keyframe; and resolution goes through `asobi_zone_manager:get_zone/2`, never `ensure_zone`, so a client cannot load world state by asking for it.

## Not in this PR

The SDK reconciler, which needs the scope decision: detector-only, or a full per-zone entity table in the five SDKs that have none today.

Worth noting I originally planned `world.resync` as a separate PR and changed my mind: stacking it would have left the second PR with no CI at all, which is a worse trade than one slightly larger review.

## Checks

`fmt --check` · `xref` · `dialyzer` · `eunit` **1991/0**. eqWAlizer and elp lint findings in both touched modules are pre-existing and outside the diff (`asobi_zone.erl:1061-1062` and `:1452`, `asobi_ws_handler.erl:442` and `:461`), verified against a pristine `origin/main` worktree.

Separately: `world_input_crossing_touches_only_ring_delta` fails 3/3 when `asobi_world_zone_integration_tests` runs in isolation, on pristine main as well as here, but passes in the full suite and in CI. Pre-existing test-isolation issue, worth its own ticket.
