### PR TITLE
feat(guest): read guest retention from the environment, in the public library

### DIFF
--- a/guides/configuration.md
+++ b/guides/configuration.md
@@ -487,7 +487,7 @@ operator half.
 | `guest_verifier_pepper` | none | Key-id -> pepper map, or a single binary. Each pepper must be at least 32 bytes; a shorter one is treated as absent. Presence is the operator's on switch |
 | `guest_verifier_key_id` | `~"v1"` | Which pepper key id to use when minting new verifiers |
 | `guest_unlinked_cap` | `100000` | Soft ceiling on unclaimed guests, or `infinity`. Anything else falls back to the default and logs `invalid_guest_unlinked_cap` |
-| `guest_reap_after` | unset | Seconds of inactivity since the device last resumed; unset disables the reaper, so guests are permanent. On cloud this is the **Guests** picker on the environment row, not a key you write |
+| `guest_reap_after` | unset | Seconds of inactivity since the device last resumed; unset disables the reaper, so guests are permanent. Also reads `ASOBI_GUEST_REAP_AFTER`. On cloud this is the **Guests** picker on the environment row, not a key you write |
 
 The cap is a soft ceiling, not an exact one: the count comes from a short-TTL
 cache rather than a `COUNT` per create, so it can overshoot by roughly (TTL x
@@ -632,6 +632,12 @@ five - `console_session_ttl`, `console_secure_cookie`, `console_api_base`,
 `console_erasure` and `console_bundle_app` - have no environment variable and
 need a `sys.config`. A variable overrides `sys.config` only when it is set, so
 the two coexist.
+
+`guest_reap_after` reads `ASOBI_GUEST_REAP_AFTER`, in seconds, on the same
+terms. Anything that is not a positive integer leaves it unset, which means
+guests are kept for ever: a node that cannot parse its own retention setting
+must not fall back to deleting accounts on a schedule nobody chose. `0` is the
+explicit "off".
 
 `console_bundle_app` is only for a host whose extensions ship their own operator
 screens; see [Extending the operator console](console-extensions.md). It has no

--- a/src/asobi_app.erl
+++ b/src/asobi_app.erl
@@ -9,6 +9,11 @@ start(_StartType, _StartArgs) ->
     %% read from the `console` key, so the environment has to have been folded
     %% in by now.
     asobi_console_env:apply(),
+    %% Guest retention is read the same way and for the same reason, but it is
+    %% not console configuration, so it gets its own module rather than a
+    %% second meaning for that one. Order does not matter: the reaper reads the
+    %% key at sweep time, not at start.
+    asobi_guest_env:apply(),
     setup_telemetry(),
     asobi_error:register_handler(),
     register_lua_game_modes(),

--- a/src/asobi_guest_env.erl
+++ b/src/asobi_guest_env.erl
@@ -1,0 +1,107 @@
+-module(asobi_guest_env).
+-moduledoc """
+Guest settings read from the environment, for deployments that run a release
+rather than write a `sys.config`.
+
+The sibling of `m:asobi_console_env`, and it exists for the same reason: relx
+substitutes `${VAR}` into `sys.config` before the VM starts, which is fine for
+a value that is always set and fatal for one that is not. An unset variable
+leaves the literal `${VAR}` in the file and the node does not boot. Reading the
+environment here instead means a missing variable is simply a missing variable,
+the key stays optional, and a self-hoster who does write a `sys.config` is
+unaffected - an OS variable overrides it only when set.
+
+## `ASOBI_GUEST_REAP_AFTER`
+
+Seconds of inactivity before `m:asobi_guest_reaper` erases an unclaimed guest.
+The reaper reads the key with `application:get_env/3` at sweep time rather than
+at start, so a value set here is live on the next tick.
+
+**Anything that is not a positive integer leaves the key unset**, which the
+reaper reads as "permanent guests". Absent, empty, `0`, negative, a float, a
+word - one answer, and it deletes nobody.
+
+That is the only safe direction for a fail case. A guessed default would mean a
+node that could not parse its own configuration erasing player accounts on a
+schedule nobody chose; the sweep writes no audit rows, so there would be no
+record of it either. `0` is the explicit "off" a managed deployment sends, so
+the value travels as a number rather than as an empty string something could
+mangle.
+
+Setting it back to off must actually turn the sweeper off, so an unparseable or
+absent value *unsets* the key rather than leaving whatever an earlier boot put
+there.
+""".
+
+-include_lib("kernel/include/logger.hrl").
+
+-export([apply/0]).
+
+-define(REAP_AFTER, "ASOBI_GUEST_REAP_AFTER").
+-define(IS_SPACE(C), (C =:= $\s orelse C =:= $\t orelse C =:= $\n orelse C =:= $\r)).
+
+-doc "Fold the guest environment variables into `asobi`'s application env.".
+-spec apply() -> ok.
+apply() ->
+    ok = set_reap_after().
+
+-spec set_reap_after() -> ok.
+set_reap_after() ->
+    case seconds(os:getenv(?REAP_AFTER)) of
+        {ok, Seconds} ->
+            application:set_env(asobi, guest_reap_after, Seconds),
+            ?LOG_INFO(#{msg => ~"guest_retention_applied", reap_after_seconds => Seconds});
+        off ->
+            %% Unset rather than set to something falsy: the reaper keys
+            %% "never" on the absence of the key, and a stale value from an
+            %% earlier boot of the same node must not survive a policy change
+            %% back to off.
+            application:unset_env(asobi, guest_reap_after),
+            ?LOG_INFO(#{msg => ~"guest_retention_off", detail => detail(os:getenv(?REAP_AFTER))})
+    end,
+    ok.
+
+-spec seconds(string() | false) -> {ok, pos_integer()} | off.
+seconds(false) ->
+    off;
+seconds(Value) ->
+    try list_to_integer(trim(Value)) of
+        Seconds when Seconds > 0 -> {ok, Seconds};
+        _NonPositive -> off
+    catch
+        error:badarg -> off
+    end.
+
+%% Not `string:trim/1`, which is typed to return a charlist and so cannot be
+%% handed to `list_to_integer/1` without a cast. A value typed by hand into a
+%% deployment field picks up a stray space often enough to be worth tolerating,
+%% and tolerating it keeps the failure direction unchanged: anything this does
+%% not turn into a positive integer still means "keep everyone".
+-spec trim(string()) -> string().
+trim(Value) ->
+    trailing(leading(Value)).
+
+-spec leading(string()) -> string().
+leading([C | Rest]) when ?IS_SPACE(C) -> leading(Rest);
+leading(Value) -> Value.
+
+%% Recursive rather than a `lists:reverse/1` round trip, which eqwalizer widens
+%% to `[term()]` and then refuses to hand back to `list_to_integer/1`.
+-spec trailing(string()) -> string().
+trailing([]) ->
+    [];
+trailing([C | Rest]) ->
+    case trailing(Rest) of
+        [] when ?IS_SPACE(C) -> [];
+        Trimmed -> [C | Trimmed]
+    end.
+
+%% A malformed value and an absent one produce the same behaviour but not the
+%% same cause, and only one of them is somebody's mistake.
+-spec detail(string() | false) -> binary().
+detail(false) ->
+    ~"no ASOBI_GUEST_REAP_AFTER set - unclaimed guests are kept for ever";
+detail("0") ->
+    ~"ASOBI_GUEST_REAP_AFTER is 0 - unclaimed guests are kept for ever";
+detail(_Other) ->
+    ~"ASOBI_GUEST_REAP_AFTER is not a positive integer - unclaimed guests are kept for ever".

--- a/test/asobi_guest_env_tests.erl
+++ b/test/asobi_guest_env_tests.erl
@@ -1,0 +1,91 @@
+-module(asobi_guest_env_tests).
+
+-include_lib("eunit/include/eunit.hrl").
+
+-define(VAR, "ASOBI_GUEST_REAP_AFTER").
+
+%% Every case here is about one question: can this module ever cause an
+%% erasure nobody asked for? A wrong value must reach "keep everyone", never a
+%% guessed default, because the reaper it feeds deletes accounts permanently
+%% and writes no audit row.
+%%
+%% Moved here from asobi_engine along with the module. It lived in the private
+%% wrapper, where a self-hoster running a release - the exact population that
+%% cannot write a sys.config - could not use the mechanism at all.
+
+retention_test_() ->
+    {foreach, fun setup/0, fun cleanup/1, [
+        fun a_positive_integer_is_applied/0,
+        fun an_absent_variable_reaps_nothing/0,
+        fun zero_reaps_nothing/0,
+        fun a_negative_value_reaps_nothing/0,
+        fun a_non_integer_reaps_nothing/0,
+        fun an_empty_value_reaps_nothing/0,
+        fun surrounding_whitespace_is_tolerated/0,
+        fun turning_the_policy_off_clears_an_earlier_value/0
+    ]}.
+
+setup() ->
+    Previous = application:get_env(asobi, guest_reap_after),
+    os:unsetenv(?VAR),
+    application:unset_env(asobi, guest_reap_after),
+    Previous.
+
+cleanup(Previous) ->
+    os:unsetenv(?VAR),
+    case Previous of
+        {ok, Value} -> application:set_env(asobi, guest_reap_after, Value);
+        undefined -> application:unset_env(asobi, guest_reap_after)
+    end.
+
+a_positive_integer_is_applied() ->
+    os:putenv(?VAR, "2592000"),
+    ok = asobi_guest_env:apply(),
+    ?assertEqual({ok, 2592000}, application:get_env(asobi, guest_reap_after)).
+
+%% The state every environment provisioned before this shipped is in, and the
+%% state a self-hoster who never sets it is in. Both must keep their guests.
+an_absent_variable_reaps_nothing() ->
+    ok = asobi_guest_env:apply(),
+    ?assertEqual(undefined, application:get_env(asobi, guest_reap_after)).
+
+%% The explicit "off" the provisioner sends. It travels as a number so no
+%% substitution can turn an empty string into something else on the way.
+zero_reaps_nothing() ->
+    os:putenv(?VAR, "0"),
+    ok = asobi_guest_env:apply(),
+    ?assertEqual(undefined, application:get_env(asobi, guest_reap_after)).
+
+%% Not "reap everything older than a negative cutoff", which is every guest
+%% that ever existed.
+a_negative_value_reaps_nothing() ->
+    os:putenv(?VAR, "-1"),
+    ok = asobi_guest_env:apply(),
+    ?assertEqual(undefined, application:get_env(asobi, guest_reap_after)).
+
+a_non_integer_reaps_nothing() ->
+    os:putenv(?VAR, "30 days"),
+    ok = asobi_guest_env:apply(),
+    ?assertEqual(undefined, application:get_env(asobi, guest_reap_after)),
+    os:putenv(?VAR, "2592000.0"),
+    ok = asobi_guest_env:apply(),
+    ?assertEqual(undefined, application:get_env(asobi, guest_reap_after)).
+
+an_empty_value_reaps_nothing() ->
+    os:putenv(?VAR, ""),
+    ok = asobi_guest_env:apply(),
+    ?assertEqual(undefined, application:get_env(asobi, guest_reap_after)).
+
+surrounding_whitespace_is_tolerated() ->
+    os:putenv(?VAR, " 86400 "),
+    ok = asobi_guest_env:apply(),
+    ?assertEqual({ok, 86400}, application:get_env(asobi, guest_reap_after)).
+
+%% A policy moved back to off must actually turn the sweeper off. Leaving the
+%% previous number in place would keep deleting players after the studio said
+%% stop, which is the worst failure this module has available to it.
+turning_the_policy_off_clears_an_earlier_value() ->
+    application:set_env(asobi, guest_reap_after, 604800),
+    os:putenv(?VAR, "0"),
+    ok = asobi_guest_env:apply(),
+    ?assertEqual(undefined, application:get_env(asobi, guest_reap_after)).


### PR DESCRIPTION
Confirmed by the architecture guardian, and required by an ADR written the same day the code breaching it shipped.

## Why it moves

`asobi_engine_retention` did this in the private wrapper. Two consequences:

- A **self-hoster running a release image** — the exact population that cannot write a `sys.config` — could not use the mechanism at all. They got the container idiom for `console` and `ops_secret` and not for retention, for no reason other than where the code sat.
- The same behaviour lived in a repo only cloud benefits from, which is the anti-pattern the engine boundary exists to prevent.

ADR 0012 item 7 already says *"Read it in public asobi, not in `asobi_engine`. `asobi_console_env` is the pattern."* The engine module breached it.

And `asobi_console_env` had been solving this since the console shipped, stating the identical rationale in its own moduledoc: relx substitutes `${VAR}` into `sys.config` before the VM starts, so an unset variable leaves a literal `${VAR}` and the node does not boot. A setting that can legitimately be unset must not be able to take the node down when it is. I re-derived that reasoning from scratch and wrote it into the wrong repo.

## Shape

Its own module rather than a second meaning for `asobi_console_env` — retention is not console configuration. Order in `start/2` does not matter: `asobi_guest_reaper` reads the key with `application:get_env/3` at sweep time, not at start.

Behaviour is unchanged and the tests move with it. Anything that is not a positive integer leaves the key **unset**, which reads as "keep every guest": absent, empty, `0`, negative, a float, a word — one answer, and it deletes nobody. A guessed default would mean a node that could not parse its own configuration erasing accounts on a schedule nobody chose, and the sweep writes no audit rows, so there would be no record of it either.

`turning_the_policy_off_clears_an_earlier_value` is the case worth reading: a policy moved back to off has to actually stop the sweeper, not leave the previous number behind.

## Docs

`guides/configuration.md` now lists `ASOBI_GUEST_REAP_AFTER` alongside the four console variables, on the same "a variable overrides `sys.config` only when set" terms.

## Paired with

widgrensit/asobi_engine deletes its copy in lockstep. Leaving both is harmless — the engine sets the same key from the same variable — but duplicates exactly what the ADR is trying to stop.

## Checks

`fmt --check`, `xref`, `dialyzer`, `ex_doc` (two warnings, both pre-existing and unrelated), `eunit` 1999 pass, `elp eqwalize asobi_guest_env` clean.