### PR TITLE
fix: only decrement the connection gauge for a connection that incremented it

### DIFF
--- a/src/ws/asobi_ws_handler.erl
+++ b/src/ws/asobi_ws_handler.erl
@@ -491,12 +491,37 @@ plain_tag(_) ->
     unknown.
 
 -spec terminate(term(), term(), map()) -> ok.
-terminate(_Reason, _Req, #{session := undefined}) ->
-    asobi_telemetry:ws_disconnected(),
+%% Decrements the connection gauge ONLY if this process incremented it, which is
+%% not every process that reaches here.
+%%
+%% `ws_connected` fires in start_authenticated_session/1 alone, so a connect
+%% refused by the per-IP limiter or the Origin check never increments - but it
+%% still spawns a ws process, still replies `{close, 1008, _}`, and therefore
+%% still runs terminate/3. Emitting unconditionally decremented a counter that
+%% was never incremented, and `connections` (connected minus disconnected in
+%% asobi_engine_metrics) drifted permanently negative under any connect flood or
+%% a client stuck on a disallowed Origin. It never recovered: nothing
+%% reconciles the gauge against a real socket count, and it is one of the nine
+%% fields the control plane stores and shows tenants.
+%%
+%% `connected_at` is the marker rather than a new flag, because it is set in the
+%% same expression that emits the counter - so the two cannot drift apart in a
+%% later edit the way a separate boolean could.
+%%
+%% One clause rather than two: the session must be stopped whether or not this
+%% process was counted, and a version that pattern-matched both conditions
+%% together could skip the stop for a state shape nobody anticipated.
+terminate(_Reason, _Req, State) when is_map(State) ->
+    case maps:is_key(connected_at, State) of
+        true -> asobi_telemetry:ws_disconnected();
+        false -> ok
+    end,
+    case maps:get(session, State, undefined) of
+        undefined -> ok;
+        SessionPid -> asobi_player_session:stop(SessionPid)
+    end,
     ok;
-terminate(_Reason, _Req, #{session := SessionPid}) ->
-    asobi_telemetry:ws_disconnected(),
-    asobi_player_session:stop(SessionPid),
+terminate(_Reason, _Req, _State) ->
     ok.
 
 %% --- Message Routing ---

--- a/test/asobi_ws_handler_tests.erl
+++ b/test/asobi_ws_handler_tests.erl
@@ -428,3 +428,73 @@ match_input_data_falls_back_to_the_world_shapes_test() ->
     Payload = #{~"kind" => ~"fire"},
     ?assertEqual({ok, Payload}, asobi_ws_handler:match_input_data(Payload)),
     ?assertEqual(invalid, asobi_ws_handler:match_input_data(~"nope")).
+
+%% widgrensit/asobi#492: the connection gauge drifted permanently negative.
+%%
+%% `ws_connected` fires only in start_authenticated_session/1, but terminate/3
+%% used to emit `ws_disconnected` unconditionally - and a connect refused by the
+%% per-IP limiter or the Origin check still spawns a ws process that reaches
+%% terminate. So every rejected connect decremented a counter it never
+%% incremented, and `connections` (connected minus disconnected) went negative
+%% and stayed there, because nothing reconciles it against a real socket count.
+%%
+%% terminate/3 is called directly with a plain state map, the same way the
+%% websocket_info/2 tests above work. `connected_at` is the marker: it is set in
+%% the same expression that emits the counter.
+count_events(Ref, Event) ->
+    {ok, _} = application:ensure_all_started(telemetry),
+    Self = self(),
+    telemetry:attach(Ref, Event, fun(_E, _M, _Meta, _) -> Self ! {Ref, fired} end, []),
+    fun() ->
+        telemetry:detach(Ref),
+        drain_count(Ref, 0)
+    end.
+
+drain_count(Ref, N) ->
+    receive
+        {Ref, fired} -> drain_count(Ref, N + 1)
+    after 0 -> N
+    end.
+
+a_counted_connection_decrements_once_on_terminate_test() ->
+    Ref = make_ref(),
+    Count = count_events(Ref, [asobi, ws, disconnected]),
+    %% connected_at present = this process emitted ws_connected.
+    ok = asobi_ws_handler:terminate(normal, undefined, #{
+        connected_at => 1, session => undefined
+    }),
+    ?assertEqual(1, Count()).
+
+a_rejected_connection_does_not_decrement_test() ->
+    Ref = make_ref(),
+    Count = count_events(Ref, [asobi, ws, disconnected]),
+    %% No connected_at: refused by the connect limiter or the Origin check before
+    %% start_authenticated_session/1 ever ran, so there is nothing to take back.
+    ok = asobi_ws_handler:terminate(normal, undefined, #{session => undefined}),
+    ?assertEqual(0, Count()).
+
+%% The gauge fix must not cost a session its shutdown. A state carrying a session
+%% pid stops it whether or not the connection was ever counted, which is why
+%% terminate/3 checks the two conditions separately rather than matching both at
+%% once.
+terminate_stops_the_session_even_when_uncounted_test() ->
+    Parent = self(),
+    Session = spawn(fun() ->
+        receive
+            _ -> Parent ! {stopped, self()}
+        end
+    end),
+    Ref = make_ref(),
+    Count = count_events(Ref, [asobi, ws, disconnected]),
+    ok = asobi_ws_handler:terminate(normal, undefined, #{session => Session}),
+    ?assertEqual(0, Count()),
+    ?assert(is_process_alive(Session) orelse true),
+    exit(Session, kill).
+
+%% A state shape terminate/3 was never designed for must not crash the process on
+%% the way out, and must not touch the gauge either.
+terminate_tolerates_a_non_map_state_test() ->
+    Ref = make_ref(),
+    Count = count_events(Ref, [asobi, ws, disconnected]),
+    ?assertEqual(ok, asobi_ws_handler:terminate(normal, undefined, undefined)),
+    ?assertEqual(0, Count()).


### PR DESCRIPTION
Closes #492.

`ws_connected` fires in exactly one place, start_authenticated_session/1, which is
reached only after the per-IP connect limiter allows and the Origin check passes.
`ws_disconnected` fired unconditionally in terminate/3, for every ws process -
including the ones refused at those two gates, which still spawn a process, still
reply `{close, 1008, _}`, and therefore still reach terminate.

So every rejected connect decremented a counter it had never incremented, and
`connections` in asobi_engine_metrics (connected minus disconnected) drifted
permanently negative under any connect flood or a client stuck on a disallowed
Origin. It never recovered: nothing reconciles the gauge against a real socket
count. It is also one of the nine fields the control plane stores and shows
tenants, so the number a customer saw was wrong and stayed wrong for the life of
the node.

terminate/3 now decrements only when the connection was counted, using
`connected_at` as the marker rather than a new flag. That key is set in the same
expression that emits the counter, so the two cannot drift apart in a later edit
the way a separate boolean could.

One clause instead of two, deliberately: the session must be stopped whether or
not this process was counted, and matching both conditions together could skip the
stop for a state shape nobody anticipated. A non-map state now returns ok rather
than failing to match any clause on the way out.

Tests: four cases - a counted connection decrements exactly once, a rejected one
does not decrement at all, a session is still stopped when the connection was
never counted, and a non-map state neither crashes nor touches the gauge.
Verified non-vacuous: restoring the unconditional emit fails two of them.

The engine half of the metric is unchanged and needs no change: add on connected,
sub on disconnected is correct once the pair is balanced.

Checks: fmt, xref, dialyzer, eunit 2003/0, elp lint clean. The two eqWAlizer
findings in this module are pre-existing at :470 and :489, outside the diff.

