### PR TITLE
feat: configure the datagram plane from the environment

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -59,6 +59,29 @@ ENV ASOBI_PORT=8084 \
 # secret-bearing (the release already sets a small crash-dump policy).
 ENV ASOBI_GUEST_VERIFIER_PEPPER=""
 
+# The datagram plane (ADR 0013). Every one of these is unset by default and the
+# plane does not exist until they are: ASOBI_ROLE stays `engine`, nothing binds a
+# UDP port, and a client asking to open the plane is told it is unavailable.
+#
+#   ASOBI_ROLE                     `engine` (default) or `dgram_gw`. One image,
+#                                  two roles, run as two containers - the gateway
+#                                  parses packets from the internet and must not
+#                                  share a process tree with the Lua sandbox or
+#                                  the database credentials.
+#   ASOBI_DGRAM_PORT               UDP port the gateway binds (default 7777).
+#   ASOBI_DGRAM_LINK_PORT          Engine link, loopback only (default 7778).
+#   ASOBI_DGRAM_SHARDS             SO_REUSEPORT receivers. Fixed at boot.
+#   ASOBI_DGRAM_LINK_SECRET        Shared secret for the engine link. Prefer the
+#   ASOBI_DGRAM_LINK_SECRET_FILE   file form: it stays out of `docker inspect`.
+#   ASOBI_DGRAM_GATEWAY            host:port the ENGINE dials. Its opt-in.
+#   ASOBI_DGRAM_ENDPOINT           host:port clients are told to send to.
+#   ASOBI_DGRAM_POSE_FIELDS        `x:100,y:100,vx:100,vy:100` - name and scale,
+#                                  in canonical order. Reordering changes what
+#                                  every field on the wire means.
+#   ASOBI_DGRAM_POSE_PERIOD        Axial refresh, in ticks (default 20).
+#
+# See guides/self-hosting.md for a two-service compose file.
+
 # Erlang term fragment spliced into kura's socket_options list.
 # Default forces IPv4; set to "inet6" for IPv6-only Postgres networks.
 ENV ASOBI_DB_SOCKET_OPTS=inet

--- a/guides/self-hosting.md
+++ b/guides/self-hosting.md
@@ -335,6 +335,84 @@ a player or refund a purchase.
 Both share the game port, so anyone who can reach your game can reach
 `/console`. Restrict it at the proxy.
 
+## Adding the datagram plane
+
+Optional, off by default, and worth it only if your game moves things around: it
+puts entity **positions** on UDP so one lost packet costs one frame of staleness
+rather than stalling everything behind a TCP retransmit. Everything else -
+including entity creation, removal and every non-transform field - keeps
+travelling on the WebSocket, in every state, whatever happens to the plane.
+
+**It is two containers from the same image.** The gateway binds a UDP port and
+parses packets from anyone on the internet, so it must not share a process tree
+with your Lua sandbox or your database credentials. In the `dgram_gw` role no
+zone, world, match, Lua VM or database pool is ever started.
+
+```bash
+openssl rand -hex 32 > dgram_secret.txt
+printf 'dgram_secret.txt\n' >> .gitignore
+```
+
+```yaml
+  asobi:
+    image: ghcr.io/widgrensit/asobi:latest
+    # ...everything from the compose above, plus:
+    environment:
+      # Where to dial the gateway. This is the engine's opt-in: without it
+      # nothing is dialled and clients are told the plane is unavailable.
+      ASOBI_DGRAM_GATEWAY: "dgram:7778"
+      # What clients are told to send to. Your public address, not the
+      # container's - and it is delivered in the mint reply, which is why the
+      # plane needs no DNS and no SNI and why a non-standard port is free.
+      ASOBI_DGRAM_ENDPOINT: "udp.example.com:7777"
+      ASOBI_DGRAM_LINK_SECRET_FILE: /run/secrets/dgram
+      # What a position IS, in canonical order. No default: guessing a scale
+      # would silently pick a precision for a world that might be a thousand
+      # times larger. `100` gives two decimals and a range of about +/-327 world
+      # units - a bigger world needs a smaller scale and coarser steps.
+      ASOBI_DGRAM_POSE_FIELDS: "x:100,y:100,vx:100,vy:100"
+    volumes:
+      - ./dgram_secret.txt:/run/secrets/dgram:ro
+
+  dgram:
+    image: ghcr.io/widgrensit/asobi:latest
+    environment:
+      ASOBI_ROLE: dgram_gw
+      ASOBI_DGRAM_PORT: 7777
+      ASOBI_DGRAM_LINK_PORT: 7778
+      ASOBI_DGRAM_LINK_SECRET_FILE: /run/secrets/dgram
+      # Same manifest as the engine. The gateway does not read it, but a future
+      # version might, and two copies that can disagree is worse than one.
+      ASOBI_DGRAM_POSE_FIELDS: "x:100,y:100,vx:100,vy:100"
+    ports:
+      - "7777:7777/udp"
+    volumes:
+      - ./dgram_secret.txt:/run/secrets/dgram:ro
+    restart: unless-stopped
+```
+
+Open **UDP** 7777 on your firewall. The link port is loopback-only inside the
+compose network and must never be published: it carries mint secrets and has no
+transport security of its own.
+
+Clients opt in per SDK - `realtime.request_datagram = true` in Defold and LOVE
+today. A client on a network that blocks UDP, or a web export where raw UDP does
+not exist, silently stays on the WebSocket and loses nothing but latency.
+
+### Checking it works
+
+```
+asobi.dgram.link_up          the engine attached to the gateway
+asobi.dgram.canary_missed    consecutive >= 2 means the receive loop is wedged
+asobi.dgram.dropped          gate=mac is the one to wake up for
+asobi.dgram.pose_saturated   your scale is wrong for your world size
+```
+
+The gateway proves itself by sending itself a real datagram every five seconds
+and waiting for the reply, so a wedged receive loop fails readiness where a
+port-bound check would not. It does **not** prove every shard: the kernel chooses
+which one receives the probe, so a healthy canary means at least one is alive.
+
 ## Tuning knobs
 
 All five go under `{asobi, [...]}`; an existing `{asobi_lua, [...]}` block also

--- a/src/asobi_app.erl
+++ b/src/asobi_app.erl
@@ -14,6 +14,11 @@ start(_StartType, _StartArgs) ->
     %% second meaning for that one. Order does not matter: the reaper reads the
     %% key at sweep time, not at start.
     asobi_guest_env:apply(),
+    %% Before asobi_sup reads `role`, because the role decides which supervision
+    %% tree starts at all. Without this the whole datagram plane is unreachable
+    %% from the published image, which is configured by environment variables
+    %% rather than by a sys.config nobody using that image can edit.
+    asobi_dgram_env:apply(),
     setup_telemetry(),
     asobi_error:register_handler(),
     register_lua_game_modes(),

--- a/src/dgram/asobi_dgram_env.erl
+++ b/src/dgram/asobi_dgram_env.erl
@@ -1,0 +1,252 @@
+-module(asobi_dgram_env).
+-moduledoc """
+Folds the datagram plane's environment variables into the application env.
+
+Every other way of configuring asobi ends up as an Erlang term in `sys.config`,
+and that is not reachable from the published image: a self-hoster runs
+`ghcr.io/widgrensit/asobi` and configures it with environment variables. Without
+this module the whole datagram plane is unreachable by exactly the audience it
+was built for, which is the sort of gap that makes a feature technically present
+and practically absent.
+
+Applied at boot, **before** the supervisor reads `role`, because the role decides
+which tree starts at all.
+
+## The application env wins
+
+A value already set in `sys.config` is never overwritten. A deployment that
+configures asobi in Erlang keeps doing so, and a container deployment gets the
+same surface through variables. Nothing has two sources of truth at once.
+
+## The secret prefers a file
+
+`ASOBI_DGRAM_LINK_SECRET_FILE` beats `ASOBI_DGRAM_LINK_SECRET`, matching how the
+ops secret is handled and for the same reason: a file stays out of
+`docker inspect` and out of the process environment. An unreadable file is an
+error rather than a silent fallback - a deployment that mounted a secret and got
+the path wrong must not come up quietly with no authentication on its link.
+""".
+
+-include_lib("kernel/include/logger.hrl").
+
+-export([apply/0]).
+
+-doc "Reads the environment into the application env. Idempotent.".
+-spec apply() -> ok.
+apply() ->
+    set_role(),
+    set_gateway_config(),
+    set_link_secret(),
+    set_engine_link(),
+    set_endpoint(),
+    set_pose(),
+    ok.
+
+%% --- Internal ---
+
+%% Anything but `dgram_gw` is the engine, including a typo. Defaulting a
+%% misspelling to the engine keeps a deployment serving its game; defaulting it
+%% to the gateway would silently take the game down.
+set_role() ->
+    case {application:get_env(asobi, role), os:getenv("ASOBI_ROLE")} of
+        {undefined, "dgram_gw"} -> application:set_env(asobi, role, dgram_gw);
+        _ -> ok
+    end.
+
+set_gateway_config() ->
+    case application:get_env(asobi, dgram) of
+        {ok, _} ->
+            ok;
+        undefined ->
+            Config = put_int(
+                shards,
+                "ASOBI_DGRAM_SHARDS",
+                put_int(
+                    link_port,
+                    "ASOBI_DGRAM_LINK_PORT",
+                    put_int(port, "ASOBI_DGRAM_PORT", #{})
+                )
+            ),
+            case map_size(Config) of
+                0 -> ok;
+                _ -> application:set_env(asobi, dgram, Config)
+            end
+    end.
+
+set_link_secret() ->
+    case application:get_env(asobi, dgram_link_secret) of
+        {ok, _} ->
+            ok;
+        undefined ->
+            case os:getenv("ASOBI_DGRAM_LINK_SECRET_FILE") of
+                False when False =:= false; False =:= "" ->
+                    set_binary(dgram_link_secret, "ASOBI_DGRAM_LINK_SECRET");
+                Path ->
+                    read_secret_file(Path)
+            end
+    end.
+
+read_secret_file(Path) ->
+    case file:read_file(Path) of
+        {ok, Contents} ->
+            case string:trim(Contents) of
+                ~"" ->
+                    ?LOG_ERROR(#{
+                        msg => ~"dgram_link_secret_file_empty", path => list_to_binary(Path)
+                    });
+                Secret ->
+                    application:set_env(asobi, dgram_link_secret, Secret)
+            end,
+            ok;
+        {error, Reason} ->
+            ?LOG_ERROR(#{
+                msg => ~"dgram_link_secret_file_unreadable",
+                path => list_to_binary(Path),
+                reason => Reason
+            }),
+            ok
+    end.
+
+%% `host:port`, which is what a compose file has to hand. Configuring this is the
+%% engine's opt-in: without it nothing is dialled and no client can mint.
+set_engine_link() ->
+    case {application:get_env(asobi, dgram_gateway), os:getenv("ASOBI_DGRAM_GATEWAY")} of
+        {undefined, Value} when is_list(Value), Value =/= "" ->
+            case host_port(Value) of
+                {ok, Host, Port} ->
+                    application:set_env(asobi, dgram_gateway, #{host => Host, port => Port});
+                error ->
+                    ?LOG_ERROR(#{
+                        msg => ~"dgram_gateway_malformed",
+                        detail => ~"expected host:port",
+                        value => list_to_binary(Value)
+                    })
+            end;
+        _ ->
+            ok
+    end.
+
+set_endpoint() ->
+    case application:get_env(asobi, dgram_endpoint) of
+        {ok, _} -> ok;
+        undefined -> set_binary(dgram_endpoint, "ASOBI_DGRAM_ENDPOINT")
+    end.
+
+%% `x:100,y:100,vx:100,vy:100` - name and scale, in canonical order. Terse
+%% because it is a compose file, and order-bearing because the wire is a fixed
+%% layout: reordering this changes what every field on the wire means.
+set_pose() ->
+    case {application:get_env(asobi, dgram_pose), os:getenv("ASOBI_DGRAM_POSE_FIELDS")} of
+        {undefined, Value} when is_list(Value), Value =/= "" ->
+            case parse_fields(binary:split(list_to_binary(Value), ~",", [global]), []) of
+                {ok, Fields} ->
+                    Pose = #{fields => Fields},
+                    application:set_env(asobi, dgram_pose, with_period(Pose));
+                error ->
+                    ?LOG_ERROR(#{
+                        msg => ~"dgram_pose_fields_malformed",
+                        detail => ~"expected name:scale,name:scale",
+                        value => list_to_binary(Value)
+                    })
+            end;
+        _ ->
+            ok
+    end.
+
+with_period(Pose) ->
+    case int_env("ASOBI_DGRAM_POSE_PERIOD") of
+        {ok, P} -> Pose#{period_ticks => P};
+        error -> Pose
+    end.
+
+%% Parsed in binaries rather than through the `string` module, whose every
+%% function types as chardata() even when handed a plain string. Binaries keep
+%% the types honest end to end and are what these values are stored as anyway.
+parse_fields([], Acc) ->
+    {ok, Acc};
+parse_fields([Spec | Rest], Acc) ->
+    case binary:split(trim(Spec), ~":", [global]) of
+        [Name, ScaleBin] when Name =/= ~"" ->
+            case to_int(ScaleBin) of
+                {ok, Scale} when Scale > 0 ->
+                    %% Appended rather than consed-and-reversed: the list is
+                    %% capped at eight fields, and lists:reverse/1's overlay
+                    %% erases the element type.
+                    parse_fields(Rest, Acc ++ [#{name => Name, scale => Scale}]);
+                _ ->
+                    error
+            end;
+        _ ->
+            error
+    end.
+
+%% Splits on the LAST colon, so an address is read the way a reader would.
+host_port(Value) ->
+    Bin = trim(list_to_binary(Value)),
+    case binary:matches(Bin, ~":") of
+        [] ->
+            error;
+        Matches ->
+            At = last_match(Matches),
+            Host = binary:part(Bin, 0, At),
+            Port = binary:part(Bin, At + 1, byte_size(Bin) - At - 1),
+            case {Host, to_int(Port)} of
+                {~"", _} -> error;
+                {_, {ok, N}} when N > 0, N =< 65535 -> {ok, binary_to_list(Host), N};
+                _ -> error
+            end
+    end.
+
+%% Only keys that were actually set land in the map, so an unset variable leaves
+%% the built-in default in place rather than overwriting it with something.
+put_int(Key, Var, Map) ->
+    case int_env(Var) of
+        {ok, N} -> Map#{Key => N};
+        error -> Map
+    end.
+
+%% Written out rather than via lists:last/1, whose overlay erases the element
+%% type and leaves the offset untypeable.
+-spec last_match([{non_neg_integer(), non_neg_integer()}]) -> non_neg_integer().
+last_match([{At, _}]) -> At;
+last_match([_ | Rest]) -> last_match(Rest).
+
+int_env(Var) ->
+    case os:getenv(Var) of
+        False when False =:= false; False =:= "" -> error;
+        Value -> to_int(list_to_binary(Value))
+    end.
+
+-spec to_int(binary()) -> {ok, integer()} | error.
+to_int(Bin) ->
+    try
+        {ok, binary_to_integer(trim(Bin))}
+    catch
+        _:_ -> error
+    end.
+
+%% Leading and trailing ASCII whitespace, written out because `string:trim/1`
+%% types as chardata() and a compose file's values are worth being forgiving of.
+-spec trim(binary()) -> binary().
+trim(Bin) -> trim_trailing(trim_leading(Bin)).
+
+trim_leading(<<C:8, Rest/binary>>) when C =:= $\s; C =:= $\t; C =:= $\n; C =:= $\r ->
+    trim_leading(Rest);
+trim_leading(Bin) ->
+    Bin.
+
+trim_trailing(<<>>) ->
+    <<>>;
+trim_trailing(Bin) ->
+    case binary:last(Bin) of
+        C when C =:= $\s; C =:= $\t; C =:= $\n; C =:= $\r ->
+            trim_trailing(binary:part(Bin, 0, byte_size(Bin) - 1));
+        _ ->
+            Bin
+    end.
+
+set_binary(Key, Var) ->
+    case os:getenv(Var) of
+        False when False =:= false; False =:= "" -> ok;
+        Value -> application:set_env(asobi, Key, list_to_binary(Value))
+    end.

--- a/test/asobi_dgram_env_tests.erl
+++ b/test/asobi_dgram_env_tests.erl
@@ -1,0 +1,171 @@
+-module(asobi_dgram_env_tests).
+-include_lib("eunit/include/eunit.hrl").
+
+%% Folding environment variables into the application env.
+%%
+%% This is the only path by which a self-hoster running the published image can
+%% reach the datagram plane at all, so "it parses" is the whole feature.
+
+-define(VARS, [
+    "ASOBI_ROLE",
+    "ASOBI_DGRAM_PORT",
+    "ASOBI_DGRAM_LINK_PORT",
+    "ASOBI_DGRAM_SHARDS",
+    "ASOBI_DGRAM_LINK_SECRET",
+    "ASOBI_DGRAM_LINK_SECRET_FILE",
+    "ASOBI_DGRAM_GATEWAY",
+    "ASOBI_DGRAM_ENDPOINT",
+    "ASOBI_DGRAM_POSE_FIELDS",
+    "ASOBI_DGRAM_POSE_PERIOD"
+]).
+
+-define(KEYS, [role, dgram, dgram_link_secret, dgram_gateway, dgram_endpoint, dgram_pose]).
+
+env_test_() ->
+    {foreach, fun setup/0, fun cleanup/1, [
+        {"nothing set changes nothing", fun empty_is_a_noop/0},
+        {"the gateway role is opt-in and a typo is not it", fun role_typo_is_the_engine/0},
+        {"ports and shards fold in", fun ports_fold_in/0},
+        {"a configured sys.config always wins", fun app_env_wins/0},
+        {"the gateway address parses as host:port", fun gateway_parses/0},
+        {"a malformed gateway is refused, not half-applied", fun gateway_malformed/0},
+        {"the pose manifest parses in canonical order", fun pose_parses/0},
+        {"a malformed pose manifest is refused", fun pose_malformed/0},
+        {"a secret file beats a secret variable", fun secret_file_wins/0},
+        {"an unreadable secret file leaves no secret", fun secret_file_unreadable/0}
+    ]}.
+
+setup() ->
+    Saved = [{K, application:get_env(asobi, K)} || K <- ?KEYS],
+    [application:unset_env(asobi, K) || K <- ?KEYS],
+    [os:unsetenv(V) || V <- ?VARS],
+    Saved.
+
+cleanup(Saved) ->
+    [os:unsetenv(V) || V <- ?VARS],
+    [application:unset_env(asobi, K) || K <- ?KEYS],
+    [
+        case V of
+            undefined -> ok;
+            {ok, Val} -> application:set_env(asobi, K, Val)
+        end
+     || {K, V} <- Saved
+    ],
+    ok.
+
+%% --- Tests ---
+
+empty_is_a_noop() ->
+    ok = asobi_dgram_env:apply(),
+    [?assertEqual(undefined, application:get_env(asobi, K)) || K <- ?KEYS].
+
+%% Defaulting a misspelling to the engine keeps a deployment serving its game.
+%% Defaulting it to the gateway would silently take the game down, which is a
+%% much worse answer to the same typo.
+role_typo_is_the_engine() ->
+    os:putenv("ASOBI_ROLE", "dgram-gw"),
+    ok = asobi_dgram_env:apply(),
+    ?assertEqual(undefined, application:get_env(asobi, role)),
+
+    os:putenv("ASOBI_ROLE", "dgram_gw"),
+    ok = asobi_dgram_env:apply(),
+    ?assertEqual({ok, dgram_gw}, application:get_env(asobi, role)).
+
+ports_fold_in() ->
+    os:putenv("ASOBI_DGRAM_PORT", "9000"),
+    os:putenv("ASOBI_DGRAM_LINK_PORT", "9001"),
+    os:putenv("ASOBI_DGRAM_SHARDS", "2"),
+    ok = asobi_dgram_env:apply(),
+    ?assertEqual(
+        {ok, #{port => 9000, link_port => 9001, shards => 2}},
+        application:get_env(asobi, dgram)
+    ).
+
+%% Nothing may have two sources of truth at once. A deployment that configures
+%% asobi in Erlang keeps doing so, whatever the container image sets.
+app_env_wins() ->
+    application:set_env(asobi, dgram, #{port => 1234}),
+    application:set_env(asobi, role, engine),
+    os:putenv("ASOBI_DGRAM_PORT", "9000"),
+    os:putenv("ASOBI_ROLE", "dgram_gw"),
+    ok = asobi_dgram_env:apply(),
+    ?assertEqual({ok, #{port => 1234}}, application:get_env(asobi, dgram)),
+    ?assertEqual({ok, engine}, application:get_env(asobi, role)).
+
+gateway_parses() ->
+    os:putenv("ASOBI_DGRAM_GATEWAY", "gateway:7778"),
+    ok = asobi_dgram_env:apply(),
+    ?assertEqual(
+        {ok, #{host => "gateway", port => 7778}}, application:get_env(asobi, dgram_gateway)
+    ).
+
+%% Refused rather than half-applied. Configuring this is the engine's opt-in, so
+%% a half-parsed value would be an engine that dials somewhere unintended.
+gateway_malformed() ->
+    [
+        begin
+            os:putenv("ASOBI_DGRAM_GATEWAY", Bad),
+            application:unset_env(asobi, dgram_gateway),
+            ok = asobi_dgram_env:apply(),
+            ?assertEqual(undefined, application:get_env(asobi, dgram_gateway), Bad)
+        end
+     || Bad <- ["gateway", "gateway:", ":7778", "gateway:notaport", "gateway:99999"]
+    ].
+
+%% The order is load-bearing: the wire is a fixed layout with no field names in
+%% it, so reordering this changes what every field on the wire means.
+pose_parses() ->
+    os:putenv("ASOBI_DGRAM_POSE_FIELDS", "x:100,y:100,vx:50"),
+    os:putenv("ASOBI_DGRAM_POSE_PERIOD", "30"),
+    ok = asobi_dgram_env:apply(),
+    ?assertEqual(
+        {ok, #{
+            fields => [
+                #{name => ~"x", scale => 100},
+                #{name => ~"y", scale => 100},
+                #{name => ~"vx", scale => 50}
+            ],
+            period_ticks => 30
+        }},
+        application:get_env(asobi, dgram_pose)
+    ),
+    %% ...and it is the shape the manifest reader accepts, not merely a map.
+    ?assertMatch({ok, #{fields := [_, _, _]}}, asobi_dgram_pose:manifest()).
+
+pose_malformed() ->
+    [
+        begin
+            os:putenv("ASOBI_DGRAM_POSE_FIELDS", Bad),
+            application:unset_env(asobi, dgram_pose),
+            ok = asobi_dgram_env:apply(),
+            ?assertEqual(undefined, application:get_env(asobi, dgram_pose), Bad)
+        end
+     || Bad <- ["x", "x:", ":100", "x:0", "x:-1", "x:100,y", "x:abc"]
+    ].
+
+%% A file stays out of `docker inspect` and out of the process environment, which
+%% is the whole reason to prefer one.
+secret_file_wins() ->
+    Path = tmp_file(<<"  from-the-file\n">>),
+    os:putenv("ASOBI_DGRAM_LINK_SECRET", "from-the-variable"),
+    os:putenv("ASOBI_DGRAM_LINK_SECRET_FILE", Path),
+    ok = asobi_dgram_env:apply(),
+    ?assertEqual({ok, ~"from-the-file"}, application:get_env(asobi, dgram_link_secret)),
+    file:delete(Path).
+
+%% NOT a silent fallback to the variable. A deployment that mounted a secret and
+%% got the path wrong must not come up quietly with the wrong one - or with none.
+secret_file_unreadable() ->
+    os:putenv("ASOBI_DGRAM_LINK_SECRET", "from-the-variable"),
+    os:putenv("ASOBI_DGRAM_LINK_SECRET_FILE", "/nonexistent/asobi-secret"),
+    ok = asobi_dgram_env:apply(),
+    ?assertEqual(undefined, application:get_env(asobi, dgram_link_secret)).
+
+%% --- Helpers ---
+
+tmp_file(Contents) ->
+    Path = lists:flatten(
+        io_lib:format("/tmp/asobi-dgram-env-~p", [erlang:unique_integer([positive])])
+    ),
+    ok = file:write_file(Path, Contents),
+    Path.


### PR DESCRIPTION
The datagram plane shipped in #505 configurable only as Erlang terms in `sys.config` - which the published image's users cannot edit. This makes it reachable from `ghcr.io/widgrensit/asobi`, which is how a self-hoster actually runs asobi, and adds the two-service compose file to `guides/self-hosting.md` that makes it runnable rather than merely documented.

The application env always wins, so an Erlang-configured deployment is unchanged.

A misspelled `ASOBI_ROLE` is the engine, not the gateway: defaulting a typo to the engine keeps a deployment serving its game, where defaulting it to the gateway would silently take the game down.

`ASOBI_DGRAM_LINK_SECRET_FILE` beats the plain variable, and an unreadable file leaves **no** secret rather than falling back - a deployment that mounted a secret and got the path wrong must not come up quietly with no authentication on a link carrying mint credentials.

Checks: fmt, xref, dialyzer, elp lint clean; eqWAlizer NO ERRORS; eunit 2124/0.