### PR TITLE
docs: correct the binary wire's size claim to the measured figure

### DIFF
--- a/docs/adr/0013-binary-wire-and-single-node-datagrams.md
+++ b/docs/adr/0013-binary-wire-and-single-node-datagrams.md
@@ -78,7 +78,47 @@ structure both ways, with faithful 36-char UUIDv7 ids in the JSON:
 | Godot 4, GDScript, `PackedByteArray.decode_*` | 23.4-26.1 us | 55.8-63.5 us | binary **2.4x faster** |
 | Lua 5.4, `string.unpack` vs the SDK's own pure-Lua parser | 13.5-14.2 us | 438.8-490.4 us | binary **33x faster** |
 
-Bytes: 807 against 3856, so 4.8x smaller. Three runs each, stable.
+Bytes on the benchmark's own frame: 807 against 3856, so 4.8x smaller. Three
+runs each, stable.
+
+**That 4.8x is not the shipped ratio, and this is the correction rather than the
+number to quote.** The benchmark frame carried `x, y` per record; a real steady
+state carries `x, y, vx, vy`, which doubles the binary side and barely moves the
+JSON side. The wire has also since gained a `gen` byte per record for the
+datagram plane's merge rule (decision 6). Measured against shipped `main`, with
+36-char UUIDv7 ids in the JSON throughout:
+
+| Frame | JSON | binary | smaller by |
+|---|---|---|---|
+| 1 update | 192 | 64 | 3.0x |
+| 10 updates | 1019 | 289 | 3.5x |
+| **40 updates (the steady state)** | **3795** | **1039** | **3.7x** |
+| 400 updates | 37790 | 10039 | 3.8x |
+| 40 adds (a keyframe) | 3795 | 2519 | 1.5x |
+| 40 records as a `pose` datagram | 3795 | 512 | 7.4x |
+
+Three things that table says and the single figure did not.
+
+The ratio *settles* around 3.7x from roughly ten entities up. Below that the
+26-byte frame header dominates, so a one-entity frame is only 3.0x.
+
+**Keyframes get 1.5x and that is by design, not a shortfall.** An `add` carries
+the full 36-character id because that is where the slot binding is established;
+updates and removes carry two bytes of slot instead. Sending ids as text costs 20
+bytes per add and buys a client an id byte-identical to the one
+`session.connected` gave it. Keyframes are rare - join and resync - and updates
+are every tick, so the wire is optimised for the frequent case and pays on the
+rare one.
+
+**The `pose` datagram is where the bytes actually matter**, at 7.4x, because it
+drops everything a delta needs: no field names, no ids, no dictionary, just slot,
+generation, mask and four int16s at twelve bytes an entity. That is what puts 400
+entities inside one 1200-byte datagram (1100 bytes) where the same set as JSON is
+37 KB. Decision 3's whole case rests on that number and not on this one.
+
+**None of which is why the codec ships.** Bandwidth is the argument for the
+datagram plane, where fitting one MTU is pass or fail. The WebSocket codec is
+justified on the decode figures above and nothing else.
 
 The design's fear was true but irrelevant at this frame size: `decode_u16` and
 `decode_float` are themselves native calls, the loop is 40 iterations, and the

--- a/guides/configuration.md
+++ b/guides/configuration.md
@@ -416,7 +416,7 @@ does not work.
 ## Binary `world.tick`
 
 Off by default. Turning it on lets a client ask for `world.tick` as a binary
-frame at `session.connect`, roughly a fifth of the bytes and several times
+frame at `session.connect`, about a quarter of the bytes and several times
 cheaper to decode - the numbers and the encoding are in
 [the protocol guide](websocket-protocol.md#binary-worldtick).
 

--- a/guides/datagram-plane.md
+++ b/guides/datagram-plane.md
@@ -17,9 +17,14 @@ retransmitted, typically 100-200ms. For a chat message that is invisible. For
 ## What it carries, and what it never carries
 
 Downstream, exactly one thing: `pose`, the absolute transform state of entities.
-`x, y, vx, vy` as `int16` against a scale you configure, about ten bytes an
-entity. Upstream, `world.input`, the frame your client already sends when a
-player moves.
+`x, y, vx, vy` as `int16` against a scale you configure: twelve bytes an entity,
+against about ninety-five for the same entity as JSON. Upstream, `world.input`,
+the frame your client already sends when a player moves.
+
+Measured on a forty-entity frame with real UUIDv7 ids: 3795 bytes as JSON on the
+WebSocket, 1039 as the binary `world.tick` wire, **512 as a pose datagram**. That
+last number is why four hundred entities fit inside a single 1200-byte datagram
+where the same set as JSON is 37 KB.
 
 **Never on this plane:** authentication, inventory, economy, chat, match results,
 and entity creation and removal. `world.tick` above all, which is an op-delta

--- a/guides/websocket-protocol.md
+++ b/guides/websocket-protocol.md
@@ -779,7 +779,7 @@ keyframe.
 
 A client that negotiated `"wire": "binary"` at
 [`session.connect`](#choosing-a-wire) receives `world.tick` as a **WebSocket
-binary frame** carrying the same information in about a fifth of the bytes, and
+binary frame** carrying the same information in about a quarter of the bytes, and
 materially cheaper to decode: measured against native JSON, 2.4x faster in
 Godot's GDScript and 33x faster than the pure-Lua parser Defold and LOVE ship.
 Every other message type still arrives as JSON text.

--- a/src/ws/asobi_wire.erl
+++ b/src/ws/asobi_wire.erl
@@ -2,7 +2,8 @@
 -moduledoc """
 The binary encoding of `world.tick`, for clients that negotiate it.
 
-Same information as the JSON frame, ~5x fewer bytes and materially cheaper to
+Same information as the JSON frame in about a quarter of the bytes - 3.7x on a
+steady-state delta - and materially cheaper to
 decode on the client - measured at 2.4x faster than native JSON in Godot's
 GDScript and 33x faster than the pure-Lua parser Defold and LOVE ship
 (ADR 0013, decision 1). The server-side saving is negligible and is not the

--- a/test/asobi_wire_tests.erl
+++ b/test/asobi_wire_tests.erl
@@ -67,7 +67,10 @@ forty_update_delta_fits_a_datagram_test() ->
     F = frame([#{op => update, slot => I, gen => 0, fields => Fields} || I <- lists:seq(1, 40)]),
     {ok, Bin} = asobi_wire:encode(F),
     ?assert(byte_size(Bin) =< 1200),
-    %% And decisively smaller than the JSON it replaces.
+    %% And decisively smaller than the JSON it replaces. Measured at 3.7x on this
+    %% frame (3795 against 1039); the assertion is a 3x floor rather than the
+    %% real figure, so a regression fails without the test needing an edit every
+    %% time a byte moves.
     Json = iolist_to_binary(json:encode(json_shape(F))),
     ?assert(byte_size(Bin) * 3 < byte_size(Json)).
 


### PR DESCRIPTION
Every doc and module header said *roughly a fifth of the bytes*, and ADR 0013 said 4.8x. Neither is the shipped ratio.

The 4.8x came from gate 11.4's benchmark frame, which carried `x,y` per record. A real steady state carries `x,y,vx,vy`, which doubles the binary side and barely moves the JSON side - and the wire has since gained a `gen` byte per record for the datagram plane's merge rule.

Measured against `main`, with 36-char UUIDv7 ids in the JSON throughout:

| Frame | JSON | binary | smaller by |
|---|---|---|---|
| 1 update | 192 | 64 | 3.0x |
| 10 updates | 1019 | 289 | 3.5x |
| **40 updates (steady state)** | **3795** | **1039** | **3.7x** |
| 400 updates | 37790 | 10039 | 3.8x |
| 40 adds (keyframe) | 3795 | 2519 | 1.5x |
| 40 as a pose datagram | 3795 | 512 | 7.4x |

So *about a quarter of the bytes*, not a fifth.

Three things the single figure hid, now stated in the ADR: the ratio settles from about ten entities up, because below that the 26-byte header dominates; keyframes get 1.5x **by design**, since an `add` carries the full 36-character id to establish the slot binding and keyframes are rare where updates are every tick; and the pose datagram at 7.4x is where bytes actually matter, being what puts 400 entities inside one 1200-byte datagram where the same set as JSON is 37 KB.

None of which is why the codec ships. Bandwidth is the argument for the datagram plane. The WebSocket codec is justified on decode cost - 2.4x faster than Godot's native JSON parser, 33x faster than the pure-Lua parser Defold and LOVE ship - and that part was never overstated.

The size test keeps a 3x floor rather than asserting 3.7x, so a regression fails without the test needing an edit every time a byte moves.