### PR TITLE
fix: atom field names, unbindable slots, and the two-container gateway

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -44,6 +44,7 @@ EXPOSE 8084
 
 ENV ASOBI_PORT=8084 \
     ASOBI_NODE_HOST=127.0.0.1 \
+    ASOBI_NODE_NAME=asobi \
     ASOBI_DB_HOST=db \
     ASOBI_DB_NAME=asobi \
     ASOBI_DB_USER=postgres \

--- a/Dockerfile
+++ b/Dockerfile
@@ -90,9 +90,11 @@ ENV ASOBI_DB_SOCKET_OPTS=inet
 # vm.args has `-setcookie ${ERLANG_COOKIE}`. Left unset, relx renders an
 # EMPTY value and erlexec silently consumes the next flag (+pc) as the
 # cookie, so `+pc unicode` never applies and bin/asobi rpc/remote
-# can't attach. Distribution stays container-internal (-sname, no epmd
-# port exposed), so a static default is fine; override per deploy if you
-# expose distribution.
+# can't attach. The default is the literal string `asobi` and therefore
+# public: override it per deploy. It is not enough that no epmd port is
+# published - two containers sharing a network namespace share a loopback
+# and an epmd, so the engine and the datagram gateway must be given
+# DIFFERENT cookies or either one can rpc into the other.
 ENV ERLANG_COOKIE=asobi
 
 ENTRYPOINT ["tini", "--"]

--- a/config/vm.args.src
+++ b/config/vm.args.src
@@ -1,4 +1,9 @@
--name asobi@${ASOBI_NODE_HOST}
+## The node name is a variable so that two roles from the same image can share a
+## network namespace - which the datagram gateway must, since its link port binds
+## loopback. One namespace is one EPMD, and two nodes registering the same name
+## means the second one does not boot. Defaults to `asobi` in the published
+## image; a cluster still shares that base name (see guides/clustering.md).
+-name ${ASOBI_NODE_NAME}@${ASOBI_NODE_HOST}
 
 -setcookie ${ERLANG_COOKIE}
 

--- a/docs/adr/0013-binary-wire-and-single-node-datagrams.md
+++ b/docs/adr/0013-binary-wire-and-single-node-datagrams.md
@@ -276,6 +276,42 @@ build. The sizes came out with room to spare: padded `hello` 64 against
 
 ## Consequences
 
+**Amended 2026-08-18 (asobi#509, asobi#510, asobi#511), in two places.**
+
+*The binary wire is a precondition for the datagram plane, not an independent
+switch.* Decision 5 gates the dual encode on `asobi.binary_wire`, off by default,
+"so a deployment with no binary clients pays nothing". What was not said is that a
+deployment with a pose manifest and the wire off pays worse than nothing: a pose
+carries a slot and only decision 4's `add` binds one, and `negotiate_wire/1`
+serves no client the binary wire while the flag is off, so every datagram was
+unresolvable by construction. `asobi_dgram_pose:manifest/0` now answers `disabled`
+when the wire is off, which is one predicate read by the zone that emits poses and
+the mint that advertises the manifest - splitting them let the mint promise a
+plane the zone would never send.
+
+*A refused frame is repaired by a keyframe, and a zone that cannot be repaired
+latches to text.* Decision 5 says a frame the encoder cannot produce "is sent as
+text, never dropped or mangled", and calls the cost "bandwidth rather than
+correctness". That holds for the frame and not for the stream: a text add carries
+no slot, so the entities it introduced are unbound on every binary client, and the
+next frame that does encode names them in `op:"u"` records the client must drop -
+with a contiguous `frame_seq` that gives it no reason to resync. The repair is
+decision 4's own ("a keyframe is all-adds, so `world.resync` re-establishes every
+binding"), applied by the server without being asked: the frame after a refusal is
+a keyframe. A refusal *of that keyframe* means the cause is the shape of the
+game's entities rather than one frame, and the zone drops to the text wire for its
+life - decision 5's "whole-zone decision on purpose" extended from one frame to
+the zone's lifetime.
+
+**Deploying decision 14's two roles requires a shared network namespace.** The
+gateway binds its engine link on loopback, so two containers on a network cannot
+reach each other over it. The roles therefore run as a sidecar or a single pod,
+which means they also share an EPMD and a loopback: they must be given different
+Erlang cookies and different node names, or a bug in the code parsing internet
+packets is `rpc:call` into the node running the Lua sandbox. Decision 14's
+isolation is the container boundary, and the container boundary does not include
+the network namespace. What remains un-split is tracked in asobi#513.
+
 **The prerequisite chain is real and unchanged.** The codec is 6-11 person-weeks
 across seven SDKs; the datagram plane 10-20 more. ADR 0011's 6.5 are already
 spent. This is the largest single commitment on the roadmap and it competes with

--- a/guides/clustering.md
+++ b/guides/clustering.md
@@ -22,14 +22,21 @@ already written to Postgres survive; play does not resume elsewhere.
 ## Forming a cluster
 
 The image is driven by environment variables, and that includes the node name
-and the cookie. `config/vm.args.src` renders `-name asobi@${ASOBI_NODE_HOST}`
-and `-setcookie ${ERLANG_COOKIE}`, so every node shares the base name `asobi`
-and one cookie:
+and the cookie. `config/vm.args.src` renders
+`-name ${ASOBI_NODE_NAME}@${ASOBI_NODE_HOST}` and `-setcookie ${ERLANG_COOKIE}`,
+so every node shares one base name and one cookie:
 
 ```
 ASOBI_NODE_HOST=10.0.0.1
 ERLANG_COOKIE=<shared-secret>
 ```
+
+**Leave `ASOBI_NODE_NAME` alone in a cluster.** It defaults to `asobi`, and
+`asobi_cluster` builds every peer name by reusing the *current* node's base name
+- so a per-host value makes discovery find nothing, silently and with no error
+anywhere. The one deployment that changes it is the datagram gateway, which is
+not a cluster member: it shares a network namespace with its engine and needs a
+name that does not collide in the shared EPMD.
 
 `ghcr.io/widgrensit/asobi` also reads `ASOBI_PORT`, `ASOBI_DB_HOST`,
 `ASOBI_DB_NAME`, `ASOBI_DB_USER`, `ASOBI_DB_PASSWORD`, `ASOBI_DB_SOCKET_OPTS`

--- a/guides/configuration.md
+++ b/guides/configuration.md
@@ -79,8 +79,10 @@ you write `sys.config` instead.
 | `ASOBI_DB_PASSWORD` | `postgres` | Database password |
 | `ASOBI_DB_SOCKET_OPTS` | `inet` | Erlang term fragment spliced into kura's `socket_options` list. `inet`, `inet6`, `inet, {nodelay, true}`. Set `inet6` for IPv6-only Postgres networks |
 | `ASOBI_CORS_ORIGINS` | none | Allowed CORS origin. Effectively required for any browser client: unset renders an empty `Access-Control-Allow-Origin`, which no browser accepts |
-| `ASOBI_NODE_HOST` | `127.0.0.1` | Erlang node hostname, in `-name asobi@...`. Not a bind address |
-| `ERLANG_COOKIE` | `asobi` | Erlang distribution cookie. The default is the literal string `asobi` |
+| `ASOBI_NODE_HOST` | `127.0.0.1` | Erlang node hostname, in `-name ${ASOBI_NODE_NAME}@...`. Not a bind address |
+| `ASOBI_NODE_NAME` | `asobi` | Erlang node base name. Change it only to run a second asobi node in the same network namespace - the datagram gateway is the one case. **Every node in a cluster must use the same value**: `asobi_cluster` builds its peers by reusing the current node's base name |
+| `ERLANG_COOKIE` | `asobi` | Erlang distribution cookie. The default is the literal string `asobi`, so it is public. Two nodes sharing a network namespace share an EPMD, so the engine and the datagram gateway must be given **different** cookies |
+| `ASOBI_BINARY_WIRE` | off | `1` / `true` turns on the binary `world.tick` for clients that ask for it. Required by the [datagram plane](datagram-plane.md), which cannot bind a slot without it |
 
 The database port is **not** a variable. It is fixed at `5432` in the image's
 `sys.config`, so a Postgres on another port means supplying your own.

--- a/guides/configuration.md
+++ b/guides/configuration.md
@@ -424,8 +424,26 @@ cheaper to decode - the numbers and the encoding are in
 {binary_wire, true}
 ```
 
+or, from a container:
+
+```
+ASOBI_BINARY_WIRE=1
+```
+
 A zone reads this once when it starts, so an already-running world keeps the
 setting it started with.
+
+**The [datagram plane](datagram-plane.md) requires it.** A pose datagram carries
+a slot and nothing else, and the only frame that binds a slot to an entity is an
+`add` on this wire - which `session.connect` refuses to hand any client while
+this is off. asobi logs `dgram_pose_without_binary_wire` at boot and disables
+poses rather than sending datagrams every client would discard.
+
+**A frame carries at most 32 distinct field names**, because the field header
+indexes the dictionary in five bits. Past that the frame is sent as text, which
+is correct but costs the entities in it their datagram fast path - see
+[the protocol guide](websocket-protocol.md#binary-worldtick) for what to watch
+for.
 
 What it costs while on: a zone can have subscribers on both wires, so it builds
 two buffers per broadcast instead of one. That is two encodes per zone per tick

--- a/guides/datagram-plane.md
+++ b/guides/datagram-plane.md
@@ -64,13 +64,30 @@ Everything with authority travels only on the TLS WebSocket, in every state.
 ## Server setup
 
 Two containers from the same image. The gateway binds a UDP port and parses
-packets from anyone on the internet, so it must not share a process tree with
-your Lua sandbox or your database credentials: in the `dgram_gw` role no zone,
-world, match, Lua VM or database pool is ever started.
+packets from anyone on the internet, so it must not run your game: in the
+`dgram_gw` role no zone, world, match, Lua VM, extension or HTTP listener is
+started, and no migration is run.
+
+What that does **not** yet cover: `kura` and `shigoto` are application
+dependencies and start before asobi reads its role, so the gateway container does
+open a database pool with your credentials. See the note in
+[self-hosting](self-hosting.md#adding-the-datagram-plane) and
+[asobi#513](https://github.com/widgrensit/asobi/issues/513).
 
 ```bash
 openssl rand -hex 32 > dgram_secret.txt
 printf 'dgram_secret.txt\n' >> .gitignore
+```
+
+The two roles also need **different Erlang cookies**. They share a network
+namespace, so they share a loopback and an EPMD, and a shared cookie means the
+container parsing hostile UDP can `rpc:call` into the one holding your Lua
+sandbox and your database credentials. The image ships a public default, so
+setting both is not optional:
+
+```bash
+echo "ERLANG_COOKIE=$(openssl rand -hex 24)"    # engine, in your .env
+echo "DGRAM_COOKIE=$(openssl rand -hex 24)"     # gateway, in your .env
 ```
 
 ```yaml
@@ -93,12 +110,12 @@ printf 'dgram_secret.txt\n' >> .gitignore
       ASOBI_DGRAM_ENDPOINT: "udp.example.com:7777"
       ASOBI_DGRAM_LINK_SECRET_FILE: /run/secrets/dgram
       ASOBI_DGRAM_POSE_FIELDS: "x:100,y:100,vx:100,vy:100"
-      # The plane's precondition. A pose carries a slot and nothing else, and the
-      # only frame that binds a slot to an entity is an `add` on the binary
-      # `world.tick`, which no client is served while this is off - so every pose
-      # would be discarded by every client. asobi logs an error at boot and
-      # disables poses if you configure the manifest without it.
+      # The plane's precondition: only the binary `world.tick` binds a slot, and
+      # no client is served it while this is off - so every pose would be
+      # discarded client-side. asobi logs an error at boot and disables poses if
+      # the manifest is configured without it.
       ASOBI_BINARY_WIRE: "1"
+      ERLANG_COOKIE: ${ERLANG_COOKIE:?set ERLANG_COOKIE in .env}
     ports:
       # The gateway's UDP port, published here because it lives in this
       # container's network namespace.
@@ -122,6 +139,14 @@ printf 'dgram_secret.txt\n' >> .gitignore
       # A distinct Erlang node name. One namespace means one EPMD, and two nodes
       # registering the same name means the second one does not boot.
       ASOBI_NODE_NAME: asobi_gw
+      # A DIFFERENT cookie from the engine's. One namespace means one loopback,
+      # and a shared cookie makes distribution a path from the process parsing
+      # internet packets into the one running your game.
+      ERLANG_COOKIE: ${DGRAM_COOKIE:?set DGRAM_COOKIE in .env}
+      # The gateway role starts no HTTP listener, so it does not contend for the
+      # engine's port. Set anyway: the variable is read while the release boots,
+      # before the role is known.
+      ASOBI_PORT: 8085
     volumes:
       - ./dgram_secret.txt:/run/secrets/dgram:ro
     restart: unless-stopped
@@ -129,10 +154,13 @@ printf 'dgram_secret.txt\n' >> .gitignore
 
 **The two roles share a network namespace.** That is a `network_mode:
 "service:asobi"` sidecar in compose, and two containers in one pod on Kubernetes
-(where they already do). It is not a weakening of the split: the gateway keeps
-its own environment, its own filesystem and its own process tree, and those are
-where the isolation is. What it does not keep is a private loopback, which is
-exactly what the link needs to be reachable.
+(where they already do). The gateway keeps its own environment, its own
+filesystem and its own process tree, which is where most of the split lives. What
+it does not keep is a private loopback - which is exactly what makes the link
+reachable, and also what puts both nodes on one EPMD. **Give them different
+`ERLANG_COOKIE`s**, as below: a shared cookie lets the container parsing hostile
+UDP `rpc:call` into the one running your Lua and holding your database
+credentials, and the image default is public.
 
 Open **UDP** 7777 on your firewall. Never publish the link port: it carries mint
 credentials and has no transport security of its own, which is why it binds

--- a/guides/datagram-plane.md
+++ b/guides/datagram-plane.md
@@ -80,34 +80,67 @@ printf 'dgram_secret.txt\n' >> .gitignore
     environment:
       # Where to dial the gateway. This is the engine's opt-in: without it
       # nothing is dialled and clients are told the plane is unavailable.
-      ASOBI_DGRAM_GATEWAY: "dgram:7778"
+      #
+      # Loopback, not a compose service name. The gateway binds its link port on
+      # 127.0.0.1 - it carries mint credentials with no transport security of its
+      # own - so a gateway on its own compose network is unreachable no matter
+      # what you point this at, and the plane degrades to WebSocket for everyone
+      # (asobi#511). The two roles share one network namespace instead.
+      ASOBI_DGRAM_GATEWAY: "127.0.0.1:7778"
       # What clients are told to send to - your public address, not the
       # container's. Delivered in the mint reply, which is why the plane needs
       # no DNS and no SNI and why a non-standard port costs nothing.
       ASOBI_DGRAM_ENDPOINT: "udp.example.com:7777"
       ASOBI_DGRAM_LINK_SECRET_FILE: /run/secrets/dgram
       ASOBI_DGRAM_POSE_FIELDS: "x:100,y:100,vx:100,vy:100"
+      # The plane's precondition. A pose carries a slot and nothing else, and the
+      # only frame that binds a slot to an entity is an `add` on the binary
+      # `world.tick`, which no client is served while this is off - so every pose
+      # would be discarded by every client. asobi logs an error at boot and
+      # disables poses if you configure the manifest without it.
+      ASOBI_BINARY_WIRE: "1"
+    ports:
+      # The gateway's UDP port, published here because it lives in this
+      # container's network namespace.
+      - "7777:7777/udp"
     volumes:
       - ./dgram_secret.txt:/run/secrets/dgram:ro
 
   dgram:
     image: ghcr.io/widgrensit/asobi:latest
+    # The engine's network namespace. On Kubernetes this is a second container in
+    # the same pod, where it comes for free.
+    network_mode: "service:asobi"
+    depends_on:
+      - asobi
     environment:
       ASOBI_ROLE: dgram_gw
       ASOBI_DGRAM_PORT: 7777
       ASOBI_DGRAM_LINK_PORT: 7778
       ASOBI_DGRAM_LINK_SECRET_FILE: /run/secrets/dgram
       ASOBI_DGRAM_POSE_FIELDS: "x:100,y:100,vx:100,vy:100"
-    ports:
-      - "7777:7777/udp"
+      # A distinct Erlang node name. One namespace means one EPMD, and two nodes
+      # registering the same name means the second one does not boot.
+      ASOBI_NODE_NAME: asobi_gw
     volumes:
       - ./dgram_secret.txt:/run/secrets/dgram:ro
     restart: unless-stopped
 ```
 
+**The two roles share a network namespace.** That is a `network_mode:
+"service:asobi"` sidecar in compose, and two containers in one pod on Kubernetes
+(where they already do). It is not a weakening of the split: the gateway keeps
+its own environment, its own filesystem and its own process tree, and those are
+where the isolation is. What it does not keep is a private loopback, which is
+exactly what the link needs to be reachable.
+
 Open **UDP** 7777 on your firewall. Never publish the link port: it carries mint
-credentials, has no transport security of its own, and binds loopback for that
-reason.
+credentials and has no transport security of its own, which is why it binds
+loopback and why the namespace is shared rather than the port exposed.
+
+The gateway role starts no HTTP listener, so it does not compete for
+`ASOBI_PORT` and there is no half-booted API answering requests from a node with
+no auth subsystem behind it.
 
 The engine dials the gateway rather than the other way round, so the gateway
 needs no knowledge of where the engine is. The link is deliberately **not**
@@ -224,6 +257,18 @@ asobi.dgram.canary_missed    consecutive >= 2 means the receive loop is wedged
 asobi.dgram.dropped          gate=mac is the one to wake up for
 asobi.dgram.pose_saturated   your scale is wrong for your world size
 ```
+
+Two log lines say the plane is not working, and both name the cause:
+
+- `dgram link unreachable, datagram plane is down` - the engine cannot reach the
+  gateway. Almost always the topology: the link port binds loopback, so the two
+  roles have to share a network namespace. Every client is answered
+  `datagram_unavailable` until this clears.
+- `binary world.tick frame refused, falling back to text` - a zone's entities do
+  not fit the binary wire, so the entities that frame introduced get no poses.
+  The line carries the zone, the distinct field-name count (the cap is 32) and
+  the widest entity, and it is throttled to one per zone per minute with the
+  suppressed count attached.
 
 The gateway proves itself by sending itself a real datagram every five seconds
 and waiting for the reply, so a wedged receive loop fails readiness where a

--- a/guides/observability.md
+++ b/guides/observability.md
@@ -13,7 +13,7 @@ which is a different question with a different tool. See
 
 ## What you get
 
-- **40 telemetry events**, listed below. Stable names; the measurement and
+- **53 telemetry events**, listed below. Stable names; the measurement and
   metadata keys are documented per-event in `m:asobi_telemetry`.
 - **Structured JSON logs** on stdout, one object per line, via
   `nova_jsonlogger`. No configuration needed - a container log shipper reads
@@ -109,7 +109,7 @@ both are the kind of thing that is otherwise noticed a day later.
 
 ## The events
 
-Fifty-two, grouped by what they are about. Measurement and metadata keys
+Fifty-three, grouped by what they are about. Measurement and metadata keys
 are in `m:asobi_telemetry`, which is also the list `asobi_telemetry:events/0`
 returns - attach to that rather than restating the names.
 
@@ -127,6 +127,7 @@ asobi.dgram.input_undelivered    asobi.dgram.input_unknown
 asobi.dgram.input_undecodable    asobi.dgram.canary_missed
 asobi.dgram.link_up              asobi.dgram.link_closed
 asobi.dgram.link_error           asobi.dgram.pose_saturated
+asobi.wire.binary_refused
 ```
 
 The `asobi.dgram.*` events fire only on a node in the
@@ -158,6 +159,21 @@ that is `asobi.dgram.recv_failed` plus client-side telemetry.
 configured scale. Any sustained rate means the `scale` in
 [`dgram_pose`](configuration.md#describing-your-transform-fields) is wrong for
 this game's world size, and the fix is configuration rather than code.
+
+`asobi.wire.binary_refused` fires on the **engine**, not the gateway, and counts
+`world.tick` frames the binary encoder could not produce, which are sent as text
+instead. One is not a fault - a client that
+negotiated binary still handles text - but a sustained rate is, and it is a
+quiet one: an entity introduced by a text frame carries no slot, so it stays
+unbound on every binary client and asobi withholds its pose datagrams rather
+than send records that would be dropped there. The entity keeps moving on
+`world.tick` and loses only the UDP fast path. `reason` says which:
+`dict_too_large` for a frame past the 32 field names the dictionary can index
+(count the fields on your widest entity), `unencodable_field` for a list or a
+nested map where the wire carries scalars, `bad_field_name` for a field name
+that is neither an atom nor a binary, and `no_slot` for a slot map that has
+drifted from the baseline. The matching log line names the zone and the widest
+entity, throttled to one per zone per minute.
 
 `asobi.dgram.link_error` with `reason = bad_auth` is worth an alert. The engine
 link is loopback-only, so a failed authentication is either a misconfigured

--- a/guides/observability.md
+++ b/guides/observability.md
@@ -162,18 +162,20 @@ this game's world size, and the fix is configuration rather than code.
 
 `asobi.wire.binary_refused` fires on the **engine**, not the gateway, and counts
 `world.tick` frames the binary encoder could not produce, which are sent as text
-instead. One is not a fault - a client that
-negotiated binary still handles text - but a sustained rate is, and it is a
-quiet one: an entity introduced by a text frame carries no slot, so it stays
-unbound on every binary client and asobi withholds its pose datagrams rather
-than send records that would be dropped there. The entity keeps moving on
-`world.tick` and loses only the UDP fast path. `reason` says which:
-`dict_too_large` for a frame past the 32 field names the dictionary can index
-(count the fields on your widest entity), `unencodable_field` for a list or a
-nested map where the wire carries scalars, `bad_field_name` for a field name
-that is neither an atom nor a binary, and `no_slot` for a slot map that has
-drifted from the baseline. The matching log line names the zone and the widest
-entity, throttled to one per zone per minute.
+instead. One is not a fault - a client that negotiated binary still handles text,
+and the frame after it is a keyframe that rebinds every slot. A **sustained** rate
+is: it means the zone is refusing, repairing and refusing again, and a zone whose
+rebind keyframe also refuses drops off the binary wire and the datagram plane for
+its life (look for `binary wire disabled for this zone`).
+
+`reason` says which: `dict_too_large` for a frame past the 32 field names the
+dictionary can index - count the fields on your widest entity, the log line names
+it - `unencodable_field` for a list or a nested map where the wire carries
+scalars, `bad_field_name` and `bad_entity_id` for a name or id that is not text or
+is past 255 bytes, `ambiguous_field_name` for two names that collide once atoms
+are rendered as text, `value_too_large` for a string past 65535 bytes, and
+`no_slot` for a slot map that has drifted from the baseline. The matching log line
+is throttled to one per zone per minute and carries the count it suppressed.
 
 `asobi.dgram.link_error` with `reason = bad_auth` is worth an alert. The engine
 link is loopback-only, so a failed authentication is either a misconfigured

--- a/guides/security-known-limitations.md
+++ b/guides/security-known-limitations.md
@@ -31,11 +31,20 @@ model](security-sandbox.md).
 
 ## Erlang distribution is on by default
 
-`config/vm.args.src` sets `-name asobi@${ASOBI_NODE_HOST}` and
+`config/vm.args.src` sets `-name ${ASOBI_NODE_NAME}@${ASOBI_NODE_HOST}` and
 `-setcookie ${ERLANG_COOKIE}`. EPMD listens on `0.0.0.0:4369`, the distribution
 port range is unbounded, and the cookie is the only protection. The published
 image ships a fixed, publicly known `ERLANG_COOKIE=asobi`, so any deployment
 that exposes the distribution port must override it.
+
+**Running the [datagram gateway](datagram-plane.md) makes this sharper, and the
+localhost bind below does not answer it.** The two roles share a network
+namespace, which is what makes the loopback link reachable - so they also share
+a loopback and an EPMD, and "container-internal" now spans both containers. The
+gateway is the process parsing packets from anyone on the internet. Give the two
+roles **different** `ERLANG_COOKIE`s, or a bug in that codec is `rpc:call` into
+the node holding your Lua sandbox and your database credentials. The compose in
+the self-hosting guide shows both.
 
 For a single node, uncomment the localhost bind in `vm.args.src`. For a
 cluster, constrain `inet_dist_listen_min/max` and turn on TLS for

--- a/guides/self-hosting.md
+++ b/guides/self-hosting.md
@@ -289,9 +289,12 @@ close a quiet WebSocket, which surfaces as players dropping on a timer nobody
 configured.
 
 `ASOBI_NODE_HOST` is not in that compose on purpose. It names the Erlang node
-(`-name asobi@${ASOBI_NODE_HOST}` in `config/vm.args.src`), not a bind address;
-the port asobi listens on is `ASOBI_PORT`. The image default `127.0.0.1` is
-what you want for a single-node deploy.
+(`-name ${ASOBI_NODE_NAME}@${ASOBI_NODE_HOST}` in `config/vm.args.src`), not a
+bind address; the port asobi listens on is `ASOBI_PORT`. The image default
+`127.0.0.1` is what you want for a single-node deploy. `ASOBI_NODE_NAME`
+defaults to `asobi` and only needs changing to run two asobi nodes in one
+network namespace, which the [datagram gateway](#adding-the-datagram-plane)
+does.
 
 For a single node, also close distribution off. The shipped `vm.args` carries
 the line commented out:
@@ -344,9 +347,17 @@ including entity creation, removal and every non-transform field - keeps
 travelling on the WebSocket, in every state, whatever happens to the plane.
 
 **It is two containers from the same image.** The gateway binds a UDP port and
-parses packets from anyone on the internet, so it must not share a process tree
-with your Lua sandbox or your database credentials. In the `dgram_gw` role no
-zone, world, match, Lua VM, database pool or HTTP listener is ever started.
+parses packets from anyone on the internet, so it must not run your game. In the
+`dgram_gw` role no zone, world, match, Lua VM, extension or HTTP listener is
+started, and no migration is run.
+
+Be precise about what that is worth, because one image with a role switch is not
+a security boundary on its own. `kura` and `shigoto` are application
+dependencies, so they start **before** asobi reads its role: the gateway
+container does open a pool with your `ASOBI_DB_*` credentials. Treat those
+credentials as reachable from the gateway and give it a database user you are
+willing to see there, until [asobi#513](https://github.com/widgrensit/asobi/issues/513)
+splits the roles into separate releases.
 
 They **share a network namespace** - a sidecar in compose, two containers in one
 pod on Kubernetes. The engine dials the gateway over loopback, because the
@@ -354,12 +365,29 @@ gateway binds its link port on `127.0.0.1`: the link carries mint credentials
 with no transport security of its own, so it must never touch a routable address.
 A gateway on its own compose network is therefore unreachable whatever you point
 `ASOBI_DGRAM_GATEWAY` at, and the plane silently degrades to WebSocket for every
-player (asobi#511). Sharing the namespace costs none of the isolation that
-matters: the gateway keeps its own environment, filesystem and process tree.
+player (asobi#511).
+
+What the shared namespace keeps is the isolation that does the work: the gateway
+has its own environment, its own filesystem and its own process tree. What it
+gives up is a private loopback, and **that is where Erlang distribution lives**.
+Give the two roles different cookies and different `ASOBI_NODE_NAME`s, both shown
+below; without that, a bug in the code parsing internet packets is a shell on the
+node running your game.
 
 ```bash
 openssl rand -hex 32 > dgram_secret.txt
 printf 'dgram_secret.txt\n' >> .gitignore
+```
+
+The two roles also need **different Erlang cookies**. They share a network
+namespace, so they share a loopback and an EPMD, and a shared cookie means the
+container parsing hostile UDP can `rpc:call` into the one holding your Lua
+sandbox and your database credentials. The image ships a public default, so
+setting both is not optional:
+
+```bash
+echo "ERLANG_COOKIE=$(openssl rand -hex 24)"    # engine, in your .env
+echo "DGRAM_COOKIE=$(openssl rand -hex 24)"     # gateway, in your .env
 ```
 
 ```yaml
@@ -381,12 +409,12 @@ printf 'dgram_secret.txt\n' >> .gitignore
       # times larger. `100` gives two decimals and a range of about +/-327 world
       # units - a bigger world needs a smaller scale and coarser steps.
       ASOBI_DGRAM_POSE_FIELDS: "x:100,y:100,vx:100,vy:100"
-      # The plane's precondition. A pose carries a slot and nothing else, and the
-      # only frame that binds a slot to an entity is an `add` on the binary
-      # `world.tick` - which no client is served while this is off, so every pose
-      # would be discarded client-side. asobi logs an error at boot and disables
-      # poses if the manifest is configured without it.
+      # The plane's precondition: only the binary `world.tick` binds a slot, and
+      # no client is served it while this is off - so every pose would be
+      # discarded client-side. asobi logs an error at boot and disables poses if
+      # the manifest is configured without it.
       ASOBI_BINARY_WIRE: "1"
+      ERLANG_COOKIE: ${ERLANG_COOKIE:?set ERLANG_COOKIE in .env}
     ports:
       # The gateway's UDP port, published here: it is this container's namespace.
       - "7777:7777/udp"
@@ -409,6 +437,14 @@ printf 'dgram_secret.txt\n' >> .gitignore
       # A distinct Erlang node name. One network namespace means one EPMD, and
       # two nodes registering the same name means the second one does not boot.
       ASOBI_NODE_NAME: asobi_gw
+      # A DIFFERENT cookie from the engine's. One namespace means one loopback,
+      # and a shared cookie makes distribution a path from the process parsing
+      # internet packets into the one running your game.
+      ERLANG_COOKIE: ${DGRAM_COOKIE:?set DGRAM_COOKIE in .env}
+      # The gateway role starts no HTTP listener, so it does not contend for the
+      # engine's port. Set anyway: the variable is read while the release boots,
+      # before the role is known.
+      ASOBI_PORT: 8085
     volumes:
       - ./dgram_secret.txt:/run/secrets/dgram:ro
     restart: unless-stopped

--- a/guides/self-hosting.md
+++ b/guides/self-hosting.md
@@ -346,7 +346,16 @@ travelling on the WebSocket, in every state, whatever happens to the plane.
 **It is two containers from the same image.** The gateway binds a UDP port and
 parses packets from anyone on the internet, so it must not share a process tree
 with your Lua sandbox or your database credentials. In the `dgram_gw` role no
-zone, world, match, Lua VM or database pool is ever started.
+zone, world, match, Lua VM, database pool or HTTP listener is ever started.
+
+They **share a network namespace** - a sidecar in compose, two containers in one
+pod on Kubernetes. The engine dials the gateway over loopback, because the
+gateway binds its link port on `127.0.0.1`: the link carries mint credentials
+with no transport security of its own, so it must never touch a routable address.
+A gateway on its own compose network is therefore unreachable whatever you point
+`ASOBI_DGRAM_GATEWAY` at, and the plane silently degrades to WebSocket for every
+player (asobi#511). Sharing the namespace costs none of the isolation that
+matters: the gateway keeps its own environment, filesystem and process tree.
 
 ```bash
 openssl rand -hex 32 > dgram_secret.txt
@@ -360,7 +369,8 @@ printf 'dgram_secret.txt\n' >> .gitignore
     environment:
       # Where to dial the gateway. This is the engine's opt-in: without it
       # nothing is dialled and clients are told the plane is unavailable.
-      ASOBI_DGRAM_GATEWAY: "dgram:7778"
+      # Loopback, not a compose service name - see above.
+      ASOBI_DGRAM_GATEWAY: "127.0.0.1:7778"
       # What clients are told to send to. Your public address, not the
       # container's - and it is delivered in the mint reply, which is why the
       # plane needs no DNS and no SNI and why a non-standard port is free.
@@ -371,11 +381,23 @@ printf 'dgram_secret.txt\n' >> .gitignore
       # times larger. `100` gives two decimals and a range of about +/-327 world
       # units - a bigger world needs a smaller scale and coarser steps.
       ASOBI_DGRAM_POSE_FIELDS: "x:100,y:100,vx:100,vy:100"
+      # The plane's precondition. A pose carries a slot and nothing else, and the
+      # only frame that binds a slot to an entity is an `add` on the binary
+      # `world.tick` - which no client is served while this is off, so every pose
+      # would be discarded client-side. asobi logs an error at boot and disables
+      # poses if the manifest is configured without it.
+      ASOBI_BINARY_WIRE: "1"
+    ports:
+      # The gateway's UDP port, published here: it is this container's namespace.
+      - "7777:7777/udp"
     volumes:
       - ./dgram_secret.txt:/run/secrets/dgram:ro
 
   dgram:
     image: ghcr.io/widgrensit/asobi:latest
+    network_mode: "service:asobi"
+    depends_on:
+      - asobi
     environment:
       ASOBI_ROLE: dgram_gw
       ASOBI_DGRAM_PORT: 7777
@@ -384,16 +406,17 @@ printf 'dgram_secret.txt\n' >> .gitignore
       # Same manifest as the engine. The gateway does not read it, but a future
       # version might, and two copies that can disagree is worse than one.
       ASOBI_DGRAM_POSE_FIELDS: "x:100,y:100,vx:100,vy:100"
-    ports:
-      - "7777:7777/udp"
+      # A distinct Erlang node name. One network namespace means one EPMD, and
+      # two nodes registering the same name means the second one does not boot.
+      ASOBI_NODE_NAME: asobi_gw
     volumes:
       - ./dgram_secret.txt:/run/secrets/dgram:ro
     restart: unless-stopped
 ```
 
-Open **UDP** 7777 on your firewall. The link port is loopback-only inside the
-compose network and must never be published: it carries mint secrets and has no
-transport security of its own.
+Open **UDP** 7777 on your firewall. Never publish the link port: it carries mint
+secrets and has no transport security of its own, which is why it binds loopback
+and why the namespace is shared rather than the port exposed.
 
 Clients opt in per SDK - `realtime.request_datagram = true` in Godot, Defold and
 LOVE today; see [the datagram plane](datagram-plane.md) for the client side and
@@ -408,6 +431,18 @@ asobi.dgram.canary_missed    consecutive >= 2 means the receive loop is wedged
 asobi.dgram.dropped          gate=mac is the one to wake up for
 asobi.dgram.pose_saturated   your scale is wrong for your world size
 ```
+
+Two log lines say the plane is not working, and both name the cause:
+
+- `dgram link unreachable, datagram plane is down` - the engine cannot reach the
+  gateway. Almost always the topology: the link port binds loopback, so the two
+  roles have to share a network namespace. Every client is answered
+  `datagram_unavailable` until this clears.
+- `binary world.tick frame refused, falling back to text` - a zone's entities do
+  not fit the binary wire, so the entities that frame introduced get no poses.
+  The line carries the zone, the distinct field-name count (the cap is 32) and
+  the widest entity, and it is throttled to one per zone per minute with the
+  suppressed count attached.
 
 The gateway proves itself by sending itself a real datagram every five seconds
 and waiting for the reply, so a wedged receive loop fails readiness where a

--- a/guides/websocket-protocol.md
+++ b/guides/websocket-protocol.md
@@ -125,8 +125,9 @@ frame that happens to arrive.
 Asking for binary changes `world.tick` and nothing else. `world.ack`,
 `world.terrain`, `match.*`, `module.*` and every `error` stay JSON text on both
 wires, so a binary client is one that handles both frame types, not one that
-stops handling text. A frame the server cannot encode as binary (an entity field
-holding a list or a nested map, for instance) also arrives as text.
+stops handling text. A frame the server cannot encode as binary also arrives as
+text: an entity field holding a list or a nested map, or a frame needing more
+than the 32 field names the dictionary can index.
 
 The uplink is text-only on both wires. A binary frame sent to the server answers
 `error` with reason `binary_uplink_unsupported`.
@@ -820,6 +821,23 @@ A `2` frame is the leave-removal list, and it is applied ungated.
 `x, y, vx, vy` pay for four names rather than a hundred and sixty. The frame is
 self-describing: nothing is negotiated up front and nothing survives a
 reconnect.
+
+**Five bits of index means a frame carries at most 32 distinct field names**, and
+this is a budget worth knowing before you hit it. It is counted across the whole
+frame, not per entity, but one entity is what usually spends it: a delta names
+only the fields that changed, while the `add` that introduces an entity names all
+of them. An entity with 33 fields therefore cannot ride this wire at all.
+
+A frame past the budget is sent as text instead - correct, and slower, and it
+costs more than bandwidth. **A text add carries no slot**, so an entity
+introduced by one is never bound in your slot table, and the datagram `pose`
+records that name its slot have nothing to bind to. The server will not send
+poses for an entity it knows it announced as text (asobi#510), so the entity
+keeps moving on `world.tick` rather than disappearing - but it loses the UDP fast
+path for the life of the zone. If entities in your game seem to be missing the
+datagram plane, count their fields first and look for
+`binary world.tick frame refused` in the server log; the line names the zone, the
+distinct-name count and the widest entity.
 
 **Entities are 2-byte slots, and the slot is scoped to the zone.** A record
 carries the full entity id on an **add only**, which is where the binding is

--- a/guides/websocket-protocol.md
+++ b/guides/websocket-protocol.md
@@ -828,15 +828,24 @@ frame, not per entity, but one entity is what usually spends it: a delta names
 only the fields that changed, while the `add` that introduces an entity names all
 of them. An entity with 33 fields therefore cannot ride this wire at all.
 
-A frame past the budget is sent as text instead - correct, and slower, and it
-costs more than bandwidth. **A text add carries no slot**, so an entity
-introduced by one is never bound in your slot table, and the datagram `pose`
-records that name its slot have nothing to bind to. The server will not send
-poses for an entity it knows it announced as text (asobi#510), so the entity
-keeps moving on `world.tick` rather than disappearing - but it loses the UDP fast
-path for the life of the zone. If entities in your game seem to be missing the
-datagram plane, count their fields first and look for
-`binary world.tick frame refused` in the server log; the line names the zone, the
+A frame past the budget is sent as text instead. That is safe for the frame and
+not safe on its own for what follows: **a text add carries no slot**, so the
+entities it introduced are not in your table, and the next binary frame names
+them in `op:"u"` records you have to drop - with a contiguous `frame_seq` that
+gives you no reason to resync.
+
+So the server repairs it rather than leaving it to you. The frame after a refused
+one is a **keyframe** - `kf: true`, all adds - which re-establishes every binding.
+Nothing is required of a client that already applies keyframes the way this guide
+describes. If that keyframe is refused too, the cause is the shape of the game's
+entities rather than one frame, and the zone gives the binary wire up for its
+life: every client on it falls back to text, which carries everything, and the
+datagram plane switches off with it.
+
+Both outcomes are visible server-side, and neither is silent on the client's
+behalf. If a game seems to be missing the datagram plane, count the fields on its
+widest entity and look for `binary world.tick frame refused` or
+`binary wire disabled for this zone` in the server log; both name the zone, the
 distinct-name count and the widest entity.
 
 **Entities are 2-byte slots, and the slot is scoped to the zone.** A record

--- a/src/asobi_app.erl
+++ b/src/asobi_app.erl
@@ -3,6 +3,8 @@
 
 -export([start/2, stop/1]).
 
+-include_lib("kernel/include/logger.hrl").
+
 -spec start(application:start_type(), term()) -> {ok, pid()} | {error, term()}.
 start(_StartType, _StartArgs) ->
     %% Before the router compiles: whether the console routes exist at all is
@@ -38,18 +40,24 @@ start(_StartType, _StartArgs) ->
 %% where the loopback link actually connects) it also raced the engine for the
 %% port and sometimes won (asobi#511).
 %%
-%% Stopped rather than never started: nova is an application dependency and binds
-%% its listener before asobi's start callback runs, so this is the first moment
-%% the role is known. The window is one boot, not the life of the container.
+%% Suspended rather than never started: nova is an application dependency and
+%% binds its listener before asobi's start callback runs, so this is the first
+%% moment the role is known. The window is one boot, not the life of the
+%% container.
+%%
+%% And suspended rather than STOPPED, which is not a detail: suspending closes the
+%% listening socket and frees the port, but leaves the listener registered with
+%% ranch. `nova_app:prep_stop/1` calls `ranch:suspend_listener/1` and
+%% `ranch:info/1` on the way down, and both raise `badarg` on a listener that has
+%% been removed - so stopping it made every gateway shutdown produce a crash
+%% report for a state the operator configured deliberately.
 start_gateway() ->
-    _ =
-        case cowboy:stop_listener(nova_listener) of
-            ok ->
-                logger:notice(#{msg => ~"http_listener_stopped", reason => ~"role=dgram_gw"});
-            {error, Reason} ->
-                logger:warning(#{msg => ~"http_listener_stop_failed", error => Reason})
-        end,
-    ok.
+    case ranch:suspend_listener(nova_listener) of
+        ok ->
+            ?LOG_NOTICE(#{msg => ~"http_listener_suspended", reason => ~"role=dgram_gw"});
+        {error, Reason} ->
+            ?LOG_WARNING(#{msg => ~"http_listener_suspend_failed", error => Reason})
+    end.
 
 %% Everything the gateway role must not do: it has no database, no Lua runtime and
 %% no extensions, and running any of it there is either a crash or a connection to

--- a/src/asobi_app.erl
+++ b/src/asobi_app.erl
@@ -21,6 +21,40 @@ start(_StartType, _StartArgs) ->
     asobi_dgram_env:apply(),
     setup_telemetry(),
     asobi_error:register_handler(),
+    case asobi_dgram_gw_sup:enabled() of
+        true -> start_gateway();
+        false -> start_engine()
+    end,
+    case asobi_sup:start_link() of
+        {ok, Pid} -> {ok, Pid};
+        ignore -> {error, supervisor_ignored};
+        {error, _} = Err -> Err
+    end.
+
+%% The gateway role exists to shrink the internet-facing surface, and an HTTP API
+%% is surface. Nothing behind it starts in this role - no auth limiter, no session
+%% store, no database - so every request it answered was a 500 out of a
+%% half-booted plugin chain, and in a shared network namespace (the only topology
+%% where the loopback link actually connects) it also raced the engine for the
+%% port and sometimes won (asobi#511).
+%%
+%% Stopped rather than never started: nova is an application dependency and binds
+%% its listener before asobi's start callback runs, so this is the first moment
+%% the role is known. The window is one boot, not the life of the container.
+start_gateway() ->
+    _ =
+        case cowboy:stop_listener(nova_listener) of
+            ok ->
+                logger:notice(#{msg => ~"http_listener_stopped", reason => ~"role=dgram_gw"});
+            {error, Reason} ->
+                logger:warning(#{msg => ~"http_listener_stop_failed", error => Reason})
+        end,
+    ok.
+
+%% Everything the gateway role must not do: it has no database, no Lua runtime and
+%% no extensions, and running any of it there is either a crash or a connection to
+%% a database the role is specifically built not to hold credentials for.
+start_engine() ->
     register_lua_game_modes(),
     report_extensions(),
     case kura_migrator:migrate(asobi_repo) of
@@ -31,11 +65,7 @@ start(_StartType, _StartArgs) ->
             logger:error(#{msg => ~"migration_failed", error => MigErr})
     end,
     asobi_registration:log_mode(),
-    case asobi_sup:start_link() of
-        {ok, Pid} -> {ok, Pid};
-        ignore -> {error, supervisor_ignored};
-        {error, _} = Err -> Err
-    end.
+    ok.
 
 setup_telemetry() ->
     asobi_telemetry:setup(),

--- a/src/asobi_telemetry.erl
+++ b/src/asobi_telemetry.erl
@@ -360,9 +360,11 @@ handles text - but a sustained rate is one: an entity introduced by a text frame
 carries no slot, so it stays unbound on every binary client and its pose
 datagrams are dropped there (asobi#510). `reason` is `dict_too_large` for a frame
 past the 32 field names the dictionary can index, `unencodable_field` for a list
-or map where the wire carries scalars, `bad_field_name` for a field name that is
-neither an atom nor a binary, and `no_slot` for a slot map that has drifted from
-the baseline.
+or map where the wire carries scalars, `bad_field_name` and `bad_entity_id` for a
+name or id that is not text or is past 255 bytes, `ambiguous_field_name` for two
+names that collide once atoms are rendered as text, `value_too_large` for a string
+past 65535 bytes, and `no_slot` for a slot map that has drifted from the
+baseline.
 """.
 -spec binary_wire_refused(atom()) -> ok.
 binary_wire_refused(Reason) ->

--- a/src/asobi_telemetry.erl
+++ b/src/asobi_telemetry.erl
@@ -36,7 +36,8 @@
     rehome_rate_limited/1,
     ws_idle_auth_timeout/0,
     ws_origin_rejected/0,
-    ws_legacy_input_unwrap/0
+    ws_legacy_input_unwrap/0,
+    binary_wire_refused/1
 ]).
 -export([anticheat_violation/3]).
 -export([game_error/1, game_error/2]).
@@ -99,6 +100,7 @@ events() ->
         [asobi, dgram, input_undecodable],
         [asobi, dgram, canary_missed],
         [asobi, dgram, pose_saturated],
+        [asobi, wire, binary_refused],
         [asobi, dgram, link_up],
         [asobi, dgram, link_closed],
         [asobi, dgram, link_error],
@@ -349,6 +351,22 @@ size, and the fix is configuration rather than code.
 -spec dgram_pose_saturated(non_neg_integer()) -> ok.
 dgram_pose_saturated(Count) ->
     telemetry:execute([asobi, dgram, pose_saturated], #{count => Count}, #{}).
+
+-doc """
+A `world.tick` the binary encoder refused, sent as text instead.
+
+Not a correctness failure on its own - a client that negotiated binary still
+handles text - but a sustained rate is one: an entity introduced by a text frame
+carries no slot, so it stays unbound on every binary client and its pose
+datagrams are dropped there (asobi#510). `reason` is `dict_too_large` for a frame
+past the 32 field names the dictionary can index, `unencodable_field` for a list
+or map where the wire carries scalars, `bad_field_name` for a field name that is
+neither an atom nor a binary, and `no_slot` for a slot map that has drifted from
+the baseline.
+""".
+-spec binary_wire_refused(atom()) -> ok.
+binary_wire_refused(Reason) ->
+    telemetry:execute([asobi, wire, binary_refused], #{count => 1}, #{reason => Reason}).
 
 -doc "An engine attached to the gateway's link and authenticated.".
 -spec dgram_link_up() -> ok.

--- a/src/dgram/asobi_dgram_env.erl
+++ b/src/dgram/asobi_dgram_env.erl
@@ -30,6 +30,9 @@ the path wrong must not come up quietly with no authentication on its link.
 -include_lib("kernel/include/logger.hrl").
 
 -export([apply/0]).
+-ifdef(TEST).
+-export([check_pose_carrier/0]).
+-endif.
 
 -doc "Reads the environment into the application env. Idempotent.".
 -spec apply() -> ok.
@@ -39,7 +42,9 @@ apply() ->
     set_link_secret(),
     set_engine_link(),
     set_endpoint(),
+    set_binary_wire(),
     set_pose(),
+    _ = check_pose_carrier(),
     ok.
 
 %% --- Internal ---
@@ -130,6 +135,43 @@ set_endpoint() ->
     case application:get_env(asobi, dgram_endpoint) of
         {ok, _} -> ok;
         undefined -> set_binary(dgram_endpoint, "ASOBI_DGRAM_ENDPOINT")
+    end.
+
+%% Not a datagram variable, and here anyway. The binary `world.tick` is what binds
+%% a slot to an entity (ADR 0013, decision 4) and a pose datagram carries a slot
+%% and nothing else, so the plane cannot work without it - and until this existed
+%% there was no way to turn it on from the published image at all, which made the
+%% whole plane unreachable for exactly the audience that configures asobi with
+%% environment variables.
+set_binary_wire() ->
+    case {application:get_env(asobi, binary_wire), os:getenv("ASOBI_BINARY_WIRE")} of
+        {undefined, Value} when Value =:= "1"; Value =:= "true" ->
+            application:set_env(asobi, binary_wire, true);
+        {undefined, Value} when Value =:= "0"; Value =:= "false" ->
+            application:set_env(asobi, binary_wire, false);
+        _ ->
+            ok
+    end.
+
+%% A pose manifest with the binary wire off is a plane that mints, sends and is
+%% discarded by every client: `asobi_ws_handler:negotiate_wire/1` answers `"json"`
+%% while `binary_wire` is off, so no client ever receives the `add` records the
+%% slots are bound by, and every pose names a slot the decoder cannot resolve
+%% (asobi#509). Reported here, once at boot, rather than left to be found from a
+%% game that looks like it has no other players.
+-spec check_pose_carrier() -> ok | {error, no_binary_wire}.
+check_pose_carrier() ->
+    case {application:get_env(asobi, dgram_pose), application:get_env(asobi, binary_wire, false)} of
+        {{ok, _Manifest}, true} ->
+            ok;
+        {{ok, _Manifest}, _Off} ->
+            ?LOG_ERROR(#{
+                msg => ~"dgram_pose_without_binary_wire",
+                detail => ~"the pose plane needs asobi.binary_wire (ASOBI_BINARY_WIRE=1)"
+            }),
+            {error, no_binary_wire};
+        _ ->
+            ok
     end.
 
 %% `x:100,y:100,vx:100,vy:100` - name and scale, in canonical order. Terse

--- a/src/dgram/asobi_dgram_env.erl
+++ b/src/dgram/asobi_dgram_env.erl
@@ -137,30 +137,47 @@ set_endpoint() ->
         undefined -> set_binary(dgram_endpoint, "ASOBI_DGRAM_ENDPOINT")
     end.
 
-%% Not a datagram variable, and here anyway. The binary `world.tick` is what binds
-%% a slot to an entity (ADR 0013, decision 4) and a pose datagram carries a slot
-%% and nothing else, so the plane cannot work without it - and until this existed
-%% there was no way to turn it on from the published image at all, which made the
-%% whole plane unreachable for exactly the audience that configures asobi with
-%% environment variables.
+%% Not a datagram variable, and here anyway: the datagram plane cannot work
+%% without it, and until this existed there was no way to turn the binary wire on
+%% from the published image at all - which made the whole plane unreachable for
+%% exactly the audience that configures asobi with environment variables.
 set_binary_wire() ->
     case {application:get_env(asobi, binary_wire), os:getenv("ASOBI_BINARY_WIRE")} of
         {undefined, Value} when Value =:= "1"; Value =:= "true" ->
             application:set_env(asobi, binary_wire, true);
         {undefined, Value} when Value =:= "0"; Value =:= "false" ->
             application:set_env(asobi, binary_wire, false);
+        {undefined, Value} when is_list(Value), Value =/= "" ->
+            %% Said rather than swallowed, like every other malformed value in
+            %% this module. `ASOBI_BINARY_WIRE=yes` otherwise leaves the wire off
+            %% and the operator is then told to set the variable they did set.
+            ?LOG_ERROR(#{
+                msg => ~"binary_wire_malformed",
+                detail => ~"expected 1, true, 0 or false",
+                value => list_to_binary(Value)
+            });
         _ ->
             ok
     end.
 
-%% A pose manifest with the binary wire off is a plane that mints, sends and is
-%% discarded by every client: `asobi_ws_handler:negotiate_wire/1` answers `"json"`
-%% while `binary_wire` is off, so no client ever receives the `add` records the
-%% slots are bound by, and every pose names a slot the decoder cannot resolve
-%% (asobi#509). Reported here, once at boot, rather than left to be found from a
-%% game that looks like it has no other players.
+%% A pose manifest with the binary wire off configures a plane that can never
+%% deliver anything (`asobi_dgram_pose:manifest/0` has the why). Said once at boot
+%% rather than left to be found from a game that looks like it has no other
+%% players (asobi#509).
 -spec check_pose_carrier() -> ok | {error, no_binary_wire}.
+%% Engine only. The gateway carries the same manifest so the two roles cannot
+%% disagree about it, and never encodes a frame, so the carrier rule is not its
+%% business - reporting it there would put an error in every gateway's boot log
+%% for the configuration the guides themselves recommend, which is how a boot
+%% error stops being read.
 check_pose_carrier() ->
+    case asobi_dgram_gw_sup:enabled() of
+        true -> ok;
+        false -> check_engine_pose_carrier()
+    end.
+
+-spec check_engine_pose_carrier() -> ok | {error, no_binary_wire}.
+check_engine_pose_carrier() ->
     case {application:get_env(asobi, dgram_pose), application:get_env(asobi, binary_wire, false)} of
         {{ok, _Manifest}, true} ->
             ok;

--- a/src/dgram/asobi_dgram_link_client.erl
+++ b/src/dgram/asobi_dgram_link_client.erl
@@ -43,7 +43,9 @@ TCP.
 -define(DIAL_LOG_INTERVAL_MS, 60_000).
 
 -type state() :: #{
-    socket := gen_tcp:socket() | undefined, buffer := binary(), dial_logged_at := integer()
+    socket := gen_tcp:socket() | undefined,
+    buffer := binary(),
+    dial_logged_at := integer() | undefined
 }.
 
 -doc """
@@ -116,7 +118,7 @@ unregister(ConnId) ->
 -spec init([]) -> {ok, state()}.
 init([]) ->
     self() ! connect,
-    {ok, #{socket => undefined, buffer => <<>>, dial_logged_at => 0}}.
+    {ok, #{socket => undefined, buffer => <<>>, dial_logged_at => undefined}}.
 
 -type request() :: connected | {send, asobi_dgram_link:message()}.
 
@@ -175,7 +177,7 @@ connect(State) ->
             case dial(Host, Port) of
                 {ok, Socket} ->
                     asobi_telemetry:dgram_link_up(),
-                    State#{socket => Socket, dial_logged_at => 0};
+                    State#{socket => Socket, dial_logged_at => undefined};
                 {error, Reason} ->
                     asobi_telemetry:dgram_link_error(Reason),
                     _ = erlang:send_after(?RECONNECT_MS, self(), connect),
@@ -189,16 +191,23 @@ connect(State) ->
 %% (asobi#511). The gateway binds its link port on loopback, so the two roles have
 %% to share a network namespace; that is the first thing to check and the line
 %% says so.
--spec log_dial_failure(string(), inet:port_number(), term(), state()) -> state().
+-spec log_dial_failure(term(), inet:port_number(), term(), state()) -> state().
 log_dial_failure(Host, Port, Reason, #{dial_logged_at := At} = State) ->
-    Now = erlang:system_time(millisecond),
-    case Now - At >= ?DIAL_LOG_INTERVAL_MS of
+    %% Monotonic, not system time: a clock stepped backwards over an NTP
+    %% correction would suppress the line for the size of the step. `undefined`
+    %% rather than 0 for the same reason - monotonic time can start negative.
+    Now = erlang:monotonic_time(millisecond),
+    case At =:= undefined orelse Now - At >= ?DIAL_LOG_INTERVAL_MS of
         false ->
             State;
         true ->
             ?LOG_WARNING(#{
                 msg => ~"dgram link unreachable, datagram plane is down",
-                host => list_to_binary(Host),
+                %% Not `list_to_binary/1`: `dgram_gateway` can also be written
+                %% into sys.config by hand, where a binary host is the natural
+                %% form, and raising here would take the plane's supervisor down
+                %% on the one path that only runs when something is already wrong.
+                host => iolist_to_binary(io_lib:format("~ts", [Host])),
                 port => Port,
                 error => Reason,
                 detail => ~"the gateway binds its link port on loopback only"

--- a/src/dgram/asobi_dgram_link_client.erl
+++ b/src/dgram/asobi_dgram_link_client.erl
@@ -29,11 +29,22 @@ TCP.
 -export([start_link/0, enabled/0, register/1, unregister/1, pose/2, connected/0]).
 -export([init/1, handle_call/3, handle_cast/2, handle_info/2, terminate/2]).
 
+-include_lib("kernel/include/logger.hrl").
+
 -define(RECONNECT_MS, 2_000).
 -define(CONNECT_TIMEOUT_MS, 2_000).
 -define(NONCE_BYTES, 16).
 
--type state() :: #{socket := gen_tcp:socket() | undefined, buffer := binary()}.
+%% At most one dial-failure warning per minute. Reconnects are two seconds apart,
+%% so an unreachable gateway is 30 lines a minute un-throttled - and the failure
+%% it has to report is a permanent one (a wrong address, a link port bound to a
+%% loopback the engine is not on), which is exactly the case where a flood buries
+%% the line that says so.
+-define(DIAL_LOG_INTERVAL_MS, 60_000).
+
+-type state() :: #{
+    socket := gen_tcp:socket() | undefined, buffer := binary(), dial_logged_at := integer()
+}.
 
 -doc """
 Whether this engine has a gateway to talk to.
@@ -105,7 +116,7 @@ unregister(ConnId) ->
 -spec init([]) -> {ok, state()}.
 init([]) ->
     self() ! connect,
-    {ok, #{socket => undefined, buffer => <<>>}}.
+    {ok, #{socket => undefined, buffer => <<>>, dial_logged_at => 0}}.
 
 -type request() :: connected | {send, asobi_dgram_link:message()}.
 
@@ -164,12 +175,35 @@ connect(State) ->
             case dial(Host, Port) of
                 {ok, Socket} ->
                     asobi_telemetry:dgram_link_up(),
-                    State#{socket => Socket};
+                    State#{socket => Socket, dial_logged_at => 0};
                 {error, Reason} ->
                     asobi_telemetry:dgram_link_error(Reason),
                     _ = erlang:send_after(?RECONNECT_MS, self(), connect),
-                    State#{socket => undefined}
+                    log_dial_failure(Host, Port, Reason, State#{socket => undefined})
             end
+    end.
+
+%% A telemetry counter was the only thing this emitted, so an engine that could
+%% not reach its gateway looked exactly like one with no gateway configured: every
+%% client was answered `datagram_unavailable` and no log on either side said why
+%% (asobi#511). The gateway binds its link port on loopback, so the two roles have
+%% to share a network namespace; that is the first thing to check and the line
+%% says so.
+-spec log_dial_failure(string(), inet:port_number(), term(), state()) -> state().
+log_dial_failure(Host, Port, Reason, #{dial_logged_at := At} = State) ->
+    Now = erlang:system_time(millisecond),
+    case Now - At >= ?DIAL_LOG_INTERVAL_MS of
+        false ->
+            State;
+        true ->
+            ?LOG_WARNING(#{
+                msg => ~"dgram link unreachable, datagram plane is down",
+                host => list_to_binary(Host),
+                port => Port,
+                error => Reason,
+                detail => ~"the gateway binds its link port on loopback only"
+            }),
+            State#{dial_logged_at => Now}
     end.
 
 dial(Host, Port) ->

--- a/src/dgram/asobi_dgram_pose.erl
+++ b/src/dgram/asobi_dgram_pose.erl
@@ -77,9 +77,25 @@ The configured manifest, or `disabled`.
 has not described its transform fields cannot have them quantised, and guessing
 at `x` and `y` would silently pick a scale for a game whose world is a thousand
 times larger.
+
+Also `disabled` when `asobi.binary_wire` is off, and that is the whole of the
+plane's carrier rule in one place. A pose record names a slot and nothing else,
+and the only frame that binds a slot to an entity is an `add` on the binary
+`world.tick` (ADR 0013, decision 4) - which the socket's wire negotiation refuses
+to serve while the wire is off. Every reader goes through here, so the
+zone stops emitting AND the mint stops advertising a manifest it cannot honour:
+a client told `period_ticks` and then sent nothing decides the plane is degraded,
+re-sends `hello`, and is torn down by the rebind limiter (asobi#509).
 """.
 -spec manifest() -> {ok, manifest()} | disabled.
 manifest() ->
+    case application:get_env(asobi, binary_wire, false) of
+        true -> configured_manifest();
+        _Off -> disabled
+    end.
+
+-spec configured_manifest() -> {ok, manifest()} | disabled.
+configured_manifest() ->
     case application:get_env(asobi, dgram_pose) of
         {ok, #{fields := Fields}} when is_list(Fields), Fields =/= [] ->
             case validate(Fields, []) of

--- a/src/world/asobi_zone.erl
+++ b/src/world/asobi_zone.erl
@@ -17,6 +17,7 @@ via `asobi_spatial`. Zones are created and reaped lazily as players move.
 -export([init/1, handle_call/3, handle_cast/2, handle_continue/2, handle_info/2, terminate/2]).
 -ifdef(TEST).
 -export([past_zone_margin/4, classify_crossing/5]).
+-export([log_refusal/6, distinct_field_names/1, widest_entity/1]).
 -endif.
 
 -include_lib("kernel/include/logger.hrl").
@@ -249,25 +250,34 @@ init(Config) ->
             %% carriers lose frames independently and sharing a counter would
             %% make each look like it had gaps the other caused.
             pose_seq => 0,
-            %% Read once at init rather than per tick. A zone that started under
-            %% one setting keeps it for its life, which is what makes the two
-            %% wires consistent for every subscriber of that zone.
+            %% Read once at init rather than per tick, so a zone that started
+            %% under one setting keeps it, which is what makes the two wires
+            %% consistent for every subscriber. It can still be turned OFF for
+            %% this zone's life by `latch_to_text/5` when the encoder proves it
+            %% cannot express this game's entities; it is never turned on.
             binary_wire => application:get_env(asobi, binary_wire, false) =:= true,
             slots => asobi_wire_slots:new(),
-            %% Entity ids whose `add` record has actually gone out on a binary
-            %% frame, which is the only place a slot binding is established
-            %% (ADR 0013, decision 4). A frame the encoder refuses is sent as
-            %% text, and a text add carries no slot, so the entities in it stay
-            %% unbound on every binary client - and a pose datagram naming an
-            %% unbound slot is dropped by the client rather than applied
-            %% (asobi#510). The pose plane therefore carries only what this set
-            %% says the clients can resolve; everything else keeps moving on
-            %% `world.tick`, which is where it was already going.
-            announced => #{},
+            %% Set when a frame was refused and sent as text, which leaves every
+            %% binary client without the slot bindings that frame's `add` records
+            %% carried (ADR 0013, decision 4). The next binary frame is then a
+            %% KEYFRAME rather than a delta, which re-establishes the whole
+            %% mapping - decision 4's own stated repair. If that keyframe is
+            %% refused too the cause is structural rather than passing, and the
+            %% zone latches to the text wire for its life (`binary_wire` below).
+            %%
+            %% Without this an entity introduced by a text frame is not merely
+            %% off the datagram plane: the next successful binary frame carries
+            %% `op:"u"` for a slot the client never bound, so the update is
+            %% dropped there and the entity is stale on BOTH carriers, with a
+            %% contiguous `frame_seq` that gives the client no reason to resync
+            %% (asobi#510).
+            wire_rebind => false,
             %% Throttle state for the refusal warning. A zone holding one
             %% entity the encoder cannot take refuses every frame, which at 20
             %% Hz is a warning five times a second for the life of the zone.
-            wire_log => #{logged_at => 0, suppressed => 0},
+            %% `undefined` rather than 0 because the clock is monotonic and can
+            %% start negative, which would make the first refusal look recent.
+            wire_log => #{logged_at => undefined, suppressed => 0},
             subscribers => #{},
             zone_state => ZoneState,
             input_queue => [],
@@ -468,9 +478,23 @@ handle_cast({input, PlayerId, Input, Seq}, #{input_queue := Queue} = State) ->
     {noreply, State#{input_queue => [{PlayerId, Seq, Input} | Queue]}};
 handle_cast(
     {add_entity, EntityId, EntityState}, #{entities := Entities, spatial_grid := Grid} = State
-) ->
+) when is_binary(EntityId) ->
     Grid1 = spatial_grid_insert(EntityId, EntityState, Grid),
     {noreply, State#{entities => Entities#{EntityId => EntityState}, spatial_grid => Grid1}};
+%% Every other id-bearing cast in this module guards, and this one did not. A Lua
+%% table that mixes named and numeric keys hands the zone a non-binary entity id
+%% (`asobi_lua_api:ensure_pairs/1` does not normalise them), which then reached
+%% `byte_size/1` in the encoder and killed the zone mid-tick - the same crash as
+%% asobi#509, one layer up. Refused loudly here rather than dropped by the
+%% catch-all clause, which would be a silent no-op for a game doing something it
+%% has no way to discover is wrong.
+handle_cast({add_entity, EntityId, _EntityState}, State) ->
+    ?LOG_WARNING(#{
+        msg => ~"entity id is not a binary, add ignored",
+        coords => maps:get(coords, State, undefined),
+        id => io_lib:format("~0p", [EntityId])
+    }),
+    {noreply, State};
 handle_cast({remove_entity, EntityId}, #{entities := Entities, spatial_grid := Grid} = State) ->
     Grid1 = spatial_grid_remove(EntityId, Grid),
     {noreply, State#{entities => maps:remove(EntityId, Entities), spatial_grid => Grid1}};
@@ -521,13 +545,14 @@ handle_cast(
     %% zone the player is not subscribed to is dropped silently rather than
     %% answered: there is nothing to repair, and answering would turn resync into
     %% a way to read any zone in the world.
-    case maps:get(PlayerId, Subs, undefined) of
-        undefined ->
-            ok;
-        {Pid, _MonRef} ->
-            send_keyframe(Pid, Coords, WireSeq, BroadcastEntities, frame_slots(State))
-    end,
-    {noreply, State};
+    KeyframeResult =
+        case maps:get(PlayerId, Subs, undefined) of
+            undefined ->
+                ok;
+            {Pid, _MonRef} ->
+                send_keyframe(Pid, Coords, WireSeq, BroadcastEntities, frame_slots(State))
+        end,
+    {noreply, owe_rebind(KeyframeResult, State)};
 handle_cast({start_entity_timer, Config}, #{entity_timers := ET} = State) when is_map(Config) ->
     {noreply, State#{entity_timers => asobi_entity_timer:start_timer(Config, ET)}};
 handle_cast({cancel_entity_timer, EntityId, TimerId}, #{entity_timers := ET} = State) when
@@ -615,7 +640,9 @@ subscribe_new(
     } = State
 ) ->
     MonRef = monitor(process, PlayerPid),
-    send_keyframe(PlayerPid, Coords, WireSeq, BroadcastEntities, frame_slots(State)),
+    KeyframeResult = send_keyframe(
+        PlayerPid, Coords, WireSeq, BroadcastEntities, frame_slots(State)
+    ),
     _ =
         case maps:get(terrain_store_pid, State, undefined) of
             undefined ->
@@ -628,7 +655,28 @@ subscribe_new(
                         ok
                 end
         end,
-    {noreply, State#{subscribers => Subs#{PlayerId => {PlayerPid, MonRef}}}}.
+    State1 = owe_rebind(KeyframeResult, State),
+    {noreply, State1#{subscribers => Subs#{PlayerId => {PlayerPid, MonRef}}}}.
+
+%% A refused keyframe is the worst refusal there is: it is all-adds, so the client
+%% it was built for has NO slot bindings at all, and it says nothing about whether
+%% the shared delta stream is fine (a keyframe's field-name union is a superset of
+%% any delta's, so a zone can encode every delta and refuse every keyframe). Owing
+%% a rebind puts the question to the shared path, which either repairs it for
+%% everyone on the next frame or latches the zone to text.
+-spec owe_rebind(ok | {refused, refusal()}, map()) -> map().
+owe_rebind(ok, State) ->
+    State;
+owe_rebind({refused, Reason}, #{coords := Coords, broadcast_entities := Entities} = State) ->
+    State1 = log_refusal(
+        Reason,
+        ~"binary keyframe refused, joining client has no slot bindings",
+        Coords,
+        0,
+        [{added, Id, EntityState} || Id := EntityState <- Entities],
+        State
+    ),
+    State1#{wire_rebind => true}.
 
 %% Mirror of subscribe_new/3's keyframe, in reverse. See widgrensit/asobi#293.
 %%
@@ -697,40 +745,25 @@ send_leave_removals(Pid, Coords, Entities, Slots) ->
     non_neg_integer(),
     map(),
     asobi_wire_slots:slots() | undefined
-) -> ok.
+) -> ok | {refused, refusal()}.
 send_keyframe(PlayerPid, Coords, WireSeq, BroadcastEntities, Slots) ->
     Snapshot = [E#{~"op" => ~"a", ~"id" => Id} || Id := E <- BroadcastEntities],
     Adds = [{added, Id, E} || Id := E <- BroadcastEntities],
     Meta = frame_meta(Coords, WireSeq, true),
+    Encoded = encode_binary(sequenced, Coords, WireSeq, 0, true, Adds, Slots),
     Msg =
-        case encode_binary(sequenced, Coords, WireSeq, 0, true, Adds, Slots) of
-            {skip, disabled} ->
-                {zone_keyframe, Meta, Snapshot};
-            {skip, Reason} ->
-                %% The one refusal worth a log per occurrence: a keyframe is
-                %% all-adds and is where a joining binary client gets its whole
-                %% slot mapping, so a refused one leaves that connection unable
-                %% to resolve any slot for as long as it stays in the zone. It
-                %% happens once per join rather than once per tick, so it is not
-                %% routed through the throttle.
-                ?LOG_WARNING(
-                    maps:merge(
-                        #{
-                            msg =>
-                                ~"binary keyframe refused, joining client has no slot bindings",
-                            coords => Coords,
-                            field_names => distinct_field_names(Adds),
-                            widest_entity => widest_entity(Adds)
-                        },
-                        refusal_detail(Reason)
-                    )
-                ),
-                {zone_keyframe, Meta, Snapshot};
-            {ok, Bin} ->
-                {zone_keyframe, Meta, Snapshot, Bin}
+        case Encoded of
+            {ok, Bin} -> {zone_keyframe, Meta, Snapshot, Bin};
+            {skip, _Reason} -> {zone_keyframe, Meta, Snapshot}
         end,
     PlayerPid ! {asobi_message, Msg},
-    ok.
+    %% Counted here rather than left to the caller, so the rate is visible even
+    %% while the shared path encodes cleanly - a zone can refuse every keyframe
+    %% and no delta. The LOG is the caller's, because the throttle lives in the
+    %% zone's state and this path is client-driven through `world.resync`.
+    Refusal = refusal(Encoded),
+    _ = count_refusal(Refusal),
+    Refusal.
 
 %% Binary keys, matching broadcast_deltas/5's own payload, so the shared and
 %% per-connection frames are byte-identical in shape and one merge covers both.
@@ -805,24 +838,20 @@ do_tick(
                     Entities4,
                     maps:get(slots, State)
                 ),
+                Rebind = maps:get(wire_rebind, State),
                 {WireSeq1, Refusal} = broadcast_deltas(
-                    Coords, TickN, WireSeq, Deltas, Subs, FrameSlots
+                    Coords, TickN, WireSeq, Deltas, Subs, FrameSlots, Rebind, Entities4
                 ),
-                WireLog1 = log_wire_refusal(
-                    Refusal, Coords, TickN, Deltas, maps:get(wire_log, State)
-                ),
-                Announced1 = announce(Refusal, Deltas, maps:get(announced, State)),
+                State2 = apply_refusal(Refusal, Rebind, Coords, TickN, Deltas, State),
                 broadcast_acks(TickN, PlayerAck1, Subs),
                 PoseSeq1 = broadcast_pose(
-                    Coords, TickN, State, Deltas, Entities4, Slots1, Subs, Announced1
+                    Coords, TickN, State2, Deltas, Entities4, Slots1, Subs
                 ),
-                State#{
+                State2#{
                     broadcast_entities => Entities4,
                     wire_seq => WireSeq1,
                     slots => Slots1,
-                    pose_seq => PoseSeq1,
-                    wire_log => WireLog1,
-                    announced => Announced1
+                    pose_seq => PoseSeq1
                 };
             _ ->
                 State
@@ -959,11 +988,13 @@ compute_deltas(OldEntities, NewEntities) ->
     non_neg_integer(),
     [term()],
     map(),
-    asobi_wire_slots:slots() | undefined
+    asobi_wire_slots:slots() | undefined,
+    boolean(),
+    map()
 ) -> {non_neg_integer(), ok | {refused, refusal()}}.
-broadcast_deltas(_Coords, _TickN, WireSeq, [], _Subs, _FrameSlots) ->
+broadcast_deltas(_Coords, _TickN, WireSeq, [], _Subs, _FrameSlots, _Rebind, _Entities) ->
     {WireSeq, ok};
-broadcast_deltas(Coords, TickN, WireSeq, Deltas, Subs, FrameSlots) ->
+broadcast_deltas(Coords, TickN, WireSeq, Deltas, Subs, FrameSlots, Rebind, Entities) ->
     Seq = WireSeq + 1,
     EncodedDeltas = encode_deltas(Deltas),
     Meta = frame_meta(Coords, Seq, false),
@@ -972,7 +1003,10 @@ broadcast_deltas(Coords, TickN, WireSeq, Deltas, Subs, FrameSlots) ->
         ~"payload" => Meta#{~"tick" => TickN, ~"updates" => EncodedDeltas}
     },
     PreEncoded = iolist_to_binary(json:encode(Payload)),
-    Encoded = encode_binary(sequenced, Coords, Seq, TickN, false, Deltas, FrameSlots),
+    %% The binary buffer is a keyframe rather than this tick's delta when a repair
+    %% is owed. The JSON buffer stays the delta either way: a text client never
+    %% lost anything and does not need the baseline resent to it.
+    Encoded = encode_tick(Rebind, Coords, Seq, TickN, Deltas, Entities, FrameSlots),
     RawMsg = delta_msg(PreEncoded, Encoded),
     maps:foreach(
         fun(_PlayerId, {Pid, _MonRef}) -> Pid ! RawMsg end,
@@ -988,19 +1022,85 @@ refusal({ok, _Bin}) -> ok;
 refusal({skip, disabled}) -> ok;
 refusal({skip, Reason}) -> {refused, Reason}.
 
+%% All-adds when a repair is owed, so the binary frame re-establishes every slot
+%% binding the refused frame failed to carry. Built from the new baseline rather
+%% than from the deltas, which is what makes it a baseline.
+-spec encode_tick(
+    boolean(),
+    {integer(), integer()},
+    non_neg_integer(),
+    non_neg_integer(),
+    [term()],
+    map(),
+    asobi_wire_slots:slots() | undefined
+) -> {ok, binary()} | {skip, disabled | refusal()}.
+encode_tick(false, Coords, Seq, TickN, Deltas, _Entities, FrameSlots) ->
+    encode_binary(sequenced, Coords, Seq, TickN, false, Deltas, FrameSlots);
+encode_tick(true, Coords, Seq, TickN, _Deltas, Entities, FrameSlots) ->
+    Adds = [{added, Id, EntityState} || Id := EntityState <- Entities],
+    encode_binary(sequenced, Coords, Seq, TickN, true, Adds, FrameSlots).
+
+%% What a refusal costs the zone, in one place.
+%%
+%% First refusal: owe a keyframe. A refusal WHILE that keyframe was being built
+%% means the cause is the shape of this game's entities rather than one passing
+%% frame - a 33-field entity or a list-valued field is still there next tick, and
+%% every keyframe after it refuses too - so the zone gives the binary wire up
+%% rather than stream frames its clients cannot bind. Every subscriber falls back
+%% to text, which carries everything and which a binary client handles by
+%% construction (ADR 0013, decision 5).
+-spec apply_refusal(
+    ok | {refused, refusal()}, boolean(), {integer(), integer()}, non_neg_integer(), [term()], map()
+) -> map().
+apply_refusal(ok, _Rebind, _Coords, _TickN, _Deltas, State) ->
+    State#{wire_rebind => false};
+apply_refusal({refused, Reason}, false, Coords, TickN, Deltas, State) ->
+    State1 = report_refusal(
+        Reason,
+        ~"binary world.tick frame refused, falling back to text",
+        Coords,
+        TickN,
+        Deltas,
+        State
+    ),
+    State1#{wire_rebind => true};
+apply_refusal({refused, Reason}, true, Coords, TickN, Deltas, State) ->
+    latch_to_text(Reason, Coords, TickN, Deltas, State).
+
+%% Off for this zone's life. Logged unthrottled because it happens once and it is
+%% the line that explains why a game's binary wire and datagram plane went quiet.
+-spec latch_to_text(refusal(), {integer(), integer()}, non_neg_integer(), [term()], map()) ->
+    map().
+latch_to_text(Reason, Coords, TickN, Deltas, State) ->
+    ?LOG_WARNING(
+        maps:merge(
+            #{
+                msg => ~"binary wire disabled for this zone, its entities cannot be encoded",
+                coords => Coords,
+                tick => TickN,
+                field_names => distinct_field_names(Deltas),
+                widest_entity => widest_entity(Deltas)
+            },
+            refusal_detail(Reason)
+        )
+    ),
+    asobi_telemetry:binary_wire_refused(refusal_kind(Reason)),
+    State#{binary_wire => false, wire_rebind => false, slots => asobi_wire_slots:new()}.
+
 %% Slots are needed by the binary wire AND by the pose plane, and they are the
 %% same slots: two allocations for one zone would eventually disagree about which
 %% entity holds a slot, which is the class of defect ADR 0011 exists to close.
-%% The binary wire is a precondition, not an independent switch. A pose datagram
-%% names a slot and nothing else, and the only carrier that binds a slot to an
-%% entity is an `add` on the binary `world.tick` (ADR 0013, decision 4) - which
-%% `asobi_ws_handler:negotiate_wire/1` refuses to hand any client while
-%% `asobi.binary_wire` is off. Poses sent into that configuration are unresolvable
-%% by construction and were dropped by every client that received them, while the
-%% zone paid for the encode (asobi#509). `asobi_dgram_env` says so at boot; this
-%% is what makes it true at the tick.
+%% `binary_wire` is in the guard because the plane cannot resolve a slot without
+%% it - the rule and its reasoning are in `asobi_dgram_pose:manifest/0`, which is
+%% where every reader of it goes. Repeated in this guard because a zone can also
+%% LATCH the wire off for itself, which the manifest cannot know.
+%%
+%% `wire_rebind` is in the guard for the same reason `binary_wire` is: while a
+%% repair is owed the clients' slot tables are known to be behind the zone's, so a
+%% pose naming a slot would be dropped where it landed. It clears on the next
+%% frame that encodes, so this costs one broadcast interval rather than the plane.
 -spec pose_enabled(map()) -> boolean().
-pose_enabled(#{pose_manifest := {ok, _}, binary_wire := true}) -> true;
+pose_enabled(#{pose_manifest := {ok, _}, binary_wire := true, wire_rebind := false}) -> true;
 pose_enabled(_State) -> false.
 
 %% The datagram plane's half of the tick. Returns the zone's new pose sequence.
@@ -1015,10 +1115,9 @@ pose_enabled(_State) -> false.
     [term()],
     map(),
     asobi_wire_slots:slots(),
-    map(),
-    #{binary() => true}
+    map()
 ) -> non_neg_integer().
-broadcast_pose(Coords, TickN, State, Deltas, Entities, Slots, Subs, Announced) ->
+broadcast_pose(Coords, TickN, State, Deltas, Entities, Slots, Subs) ->
     PoseSeq = maps:get(pose_seq, State),
     case {pose_enabled(State), maps:get(pose_manifest, State)} of
         {true, {ok, Manifest}} ->
@@ -1028,45 +1127,11 @@ broadcast_pose(Coords, TickN, State, Deltas, Entities, Slots, Subs, Announced) -
                     %% cost this whole path can trivially avoid.
                     PoseSeq;
                 ConnIds ->
-                    emit_pose(
-                        Coords,
-                        TickN,
-                        PoseSeq,
-                        Manifest,
-                        Deltas,
-                        bound_entities(Entities, Announced),
-                        Slots,
-                        ConnIds
-                    )
+                    emit_pose(Coords, TickN, PoseSeq, Manifest, Deltas, Entities, Slots, ConnIds)
             end;
         _ ->
             PoseSeq
     end.
-
-%% Only entities a binary client can resolve. An entity whose `add` rode the text
-%% wire has no slot binding on any client, so a pose naming its slot is dropped
-%% there and the entity looks frozen (asobi#510); its transform keeps arriving on
-%% `world.tick` instead, which is the carrier that can name it.
--spec bound_entities(map(), #{binary() => true}) -> map().
-bound_entities(Entities, Announced) ->
-    maps:filter(fun(Id, _State) -> is_map_key(Id, Announced) end, Entities).
-
-%% What the shared frame actually told the clients. An `add` counts only when the
-%% frame carrying it encoded, and a `remove` always drops the id: the text frame
-%% carries removals too, so the client is rid of the entity either way and keeping
-%% it here would grow the set for the life of the zone.
--spec announce(ok | {refused, refusal()}, [term()], #{binary() => true}) ->
-    #{binary() => true}.
-announce(_Refusal, [], Announced) ->
-    Announced;
-announce(ok, [{added, Id, _State} | Rest], Announced) when is_binary(Id) ->
-    announce(ok, Rest, Announced#{Id => true});
-announce(Refusal, [{added, Id, _State} | Rest], Announced) ->
-    announce(Refusal, Rest, maps:remove(Id, Announced));
-announce(Refusal, [{removed, Id} | Rest], Announced) ->
-    announce(Refusal, Rest, maps:remove(Id, Announced));
-announce(Refusal, [_Delta | Rest], Announced) ->
-    announce(Refusal, Rest, Announced).
 
 emit_pose(Coords, TickN, PoseSeq, Manifest, Deltas, Entities, Slots, ConnIds) ->
     Changed = changed_fields(Deltas, #{}),
@@ -1155,6 +1220,8 @@ advance_slots(true, Old, New, Slots) ->
     dict_too_large
     | bad_field_name
     | ambiguous_field_name
+    | bad_entity_id
+    | value_too_large
     | {no_slot, binary()}
     | {unencodable_field, binary()}.
 
@@ -1165,18 +1232,30 @@ advance_slots(true, Old, New, Slots) ->
 %% line, so the rate is still visible.
 -define(WIRE_LOG_INTERVAL_MS, 60_000).
 
--spec log_wire_refusal(
-    ok | {refused, refusal()}, {integer(), integer()}, non_neg_integer(), [term()], map()
+%% Counted on every refusal, on every path. The log is throttled and this is not:
+%% a dashboard has to see the rate the log deliberately hides.
+-spec count_refusal(ok | {refused, refusal()}) -> ok.
+count_refusal(ok) -> ok;
+count_refusal({refused, Reason}) -> asobi_telemetry:binary_wire_refused(refusal_kind(Reason)).
+
+%% Both refusal paths, one line shape and one throttle. The attribution is built
+%% INSIDE the branch that logs: `distinct_field_names/1` sorts every field name in
+%% the frame, and `world.resync` lets a client ask for keyframes at the resync
+%% limiter's rate, so computing it per refusal would hand that client an O(N log N)
+%% walk of the whole zone per request.
+-spec log_refusal(
+    refusal(), binary(), {integer(), integer()}, non_neg_integer(), [term()], map()
 ) -> map().
-log_wire_refusal(ok, _Coords, _TickN, _Deltas, Log) ->
-    Log;
-log_wire_refusal({refused, Reason}, Coords, TickN, Deltas, #{logged_at := At} = Log) ->
+log_refusal(Reason, Msg, Coords, TickN, Deltas, State) ->
+    Log = maps:get(wire_log, State),
+    At = maps:get(logged_at, Log, undefined),
     Suppressed = maps:get(suppressed, Log, 0),
-    asobi_telemetry:binary_wire_refused(refusal_kind(Reason)),
-    Now = erlang:system_time(millisecond),
-    case Now - At >= ?WIRE_LOG_INTERVAL_MS of
+    %% Monotonic, not system time: a clock stepped backwards over an NTP
+    %% correction would suppress the line for the size of the step.
+    Now = erlang:monotonic_time(millisecond),
+    case At =:= undefined orelse Now - At >= ?WIRE_LOG_INTERVAL_MS of
         false ->
-            Log#{suppressed => Suppressed + 1};
+            State#{wire_log => Log#{suppressed => Suppressed + 1}};
         true ->
             %% The two numbers that identify the cause of the common refusal:
             %% the frame carries at most 32 distinct field names (asobi_wire),
@@ -1184,7 +1263,7 @@ log_wire_refusal({refused, Reason}, Coords, TickN, Deltas, #{logged_at := At} = 
             ?LOG_WARNING(
                 maps:merge(
                     #{
-                        msg => ~"binary world.tick frame refused, falling back to text",
+                        msg => Msg,
                         coords => Coords,
                         tick => TickN,
                         field_names => distinct_field_names(Deltas),
@@ -1194,8 +1273,15 @@ log_wire_refusal({refused, Reason}, Coords, TickN, Deltas, #{logged_at := At} = 
                     refusal_detail(Reason)
                 )
             ),
-            #{logged_at => Now, suppressed => 0}
+            State#{wire_log => #{logged_at => Now, suppressed => 0}}
     end.
+
+-spec report_refusal(
+    refusal(), binary(), {integer(), integer()}, non_neg_integer(), [term()], map()
+) -> map().
+report_refusal(Reason, Msg, Coords, TickN, Deltas, State) ->
+    _ = count_refusal({refused, Reason}),
+    log_refusal(Reason, Msg, Coords, TickN, Deltas, State).
 
 -spec refusal_detail(refusal()) -> map().
 refusal_detail({no_slot, Id}) -> #{reason => ~"no_slot", entity => Id};

--- a/src/world/asobi_zone.erl
+++ b/src/world/asobi_zone.erl
@@ -254,6 +254,20 @@ init(Config) ->
             %% wires consistent for every subscriber of that zone.
             binary_wire => application:get_env(asobi, binary_wire, false) =:= true,
             slots => asobi_wire_slots:new(),
+            %% Entity ids whose `add` record has actually gone out on a binary
+            %% frame, which is the only place a slot binding is established
+            %% (ADR 0013, decision 4). A frame the encoder refuses is sent as
+            %% text, and a text add carries no slot, so the entities in it stay
+            %% unbound on every binary client - and a pose datagram naming an
+            %% unbound slot is dropped by the client rather than applied
+            %% (asobi#510). The pose plane therefore carries only what this set
+            %% says the clients can resolve; everything else keeps moving on
+            %% `world.tick`, which is where it was already going.
+            announced => #{},
+            %% Throttle state for the refusal warning. A zone holding one
+            %% entity the encoder cannot take refuses every frame, which at 20
+            %% Hz is a warning five times a second for the life of the zone.
+            wire_log => #{logged_at => 0, suppressed => 0},
             subscribers => #{},
             zone_state => ZoneState,
             input_queue => [],
@@ -639,7 +653,7 @@ send_leave_removals(Pid, Coords, Entities, Slots) ->
     %% discard the one message that clears the ghosts.
     Msg =
         case encode_binary(ungated, Coords, 0, 0, false, Deltas, Slots) of
-            skip -> {zone_removals, Coords, Removals};
+            {skip, _Reason} -> {zone_removals, Coords, Removals};
             {ok, Bin} -> {zone_removals, Coords, Removals, Bin}
         end,
     Pid ! {asobi_message, Msg},
@@ -690,8 +704,30 @@ send_keyframe(PlayerPid, Coords, WireSeq, BroadcastEntities, Slots) ->
     Meta = frame_meta(Coords, WireSeq, true),
     Msg =
         case encode_binary(sequenced, Coords, WireSeq, 0, true, Adds, Slots) of
-            skip -> {zone_keyframe, Meta, Snapshot};
-            {ok, Bin} -> {zone_keyframe, Meta, Snapshot, Bin}
+            {skip, disabled} ->
+                {zone_keyframe, Meta, Snapshot};
+            {skip, Reason} ->
+                %% The one refusal worth a log per occurrence: a keyframe is
+                %% all-adds and is where a joining binary client gets its whole
+                %% slot mapping, so a refused one leaves that connection unable
+                %% to resolve any slot for as long as it stays in the zone. It
+                %% happens once per join rather than once per tick, so it is not
+                %% routed through the throttle.
+                ?LOG_WARNING(
+                    maps:merge(
+                        #{
+                            msg =>
+                                ~"binary keyframe refused, joining client has no slot bindings",
+                            coords => Coords,
+                            field_names => distinct_field_names(Adds),
+                            widest_entity => widest_entity(Adds)
+                        },
+                        refusal_detail(Reason)
+                    )
+                ),
+                {zone_keyframe, Meta, Snapshot};
+            {ok, Bin} ->
+                {zone_keyframe, Meta, Snapshot, Bin}
         end,
     PlayerPid ! {asobi_message, Msg},
     ok.
@@ -764,19 +800,29 @@ do_tick(
             0 ->
                 Deltas = compute_deltas(BroadcastEntities, Entities4),
                 {FrameSlots, Slots1} = advance_slots(
-                    maps:get(binary_wire, State) orelse pose_enabled(State),
+                    maps:get(binary_wire, State),
                     BroadcastEntities,
                     Entities4,
                     maps:get(slots, State)
                 ),
-                WireSeq1 = broadcast_deltas(Coords, TickN, WireSeq, Deltas, Subs, FrameSlots),
+                {WireSeq1, Refusal} = broadcast_deltas(
+                    Coords, TickN, WireSeq, Deltas, Subs, FrameSlots
+                ),
+                WireLog1 = log_wire_refusal(
+                    Refusal, Coords, TickN, Deltas, maps:get(wire_log, State)
+                ),
+                Announced1 = announce(Refusal, Deltas, maps:get(announced, State)),
                 broadcast_acks(TickN, PlayerAck1, Subs),
-                PoseSeq1 = broadcast_pose(Coords, TickN, State, Deltas, Entities4, Slots1, Subs),
+                PoseSeq1 = broadcast_pose(
+                    Coords, TickN, State, Deltas, Entities4, Slots1, Subs, Announced1
+                ),
                 State#{
                     broadcast_entities => Entities4,
                     wire_seq => WireSeq1,
                     slots => Slots1,
-                    pose_seq => PoseSeq1
+                    pose_seq => PoseSeq1,
+                    wire_log => WireLog1,
+                    announced => Announced1
                 };
             _ ->
                 State
@@ -914,9 +960,9 @@ compute_deltas(OldEntities, NewEntities) ->
     [term()],
     map(),
     asobi_wire_slots:slots() | undefined
-) -> non_neg_integer().
+) -> {non_neg_integer(), ok | {refused, refusal()}}.
 broadcast_deltas(_Coords, _TickN, WireSeq, [], _Subs, _FrameSlots) ->
-    WireSeq;
+    {WireSeq, ok};
 broadcast_deltas(Coords, TickN, WireSeq, Deltas, Subs, FrameSlots) ->
     Seq = WireSeq + 1,
     EncodedDeltas = encode_deltas(Deltas),
@@ -926,20 +972,35 @@ broadcast_deltas(Coords, TickN, WireSeq, Deltas, Subs, FrameSlots) ->
         ~"payload" => Meta#{~"tick" => TickN, ~"updates" => EncodedDeltas}
     },
     PreEncoded = iolist_to_binary(json:encode(Payload)),
-    RawMsg = delta_msg(
-        PreEncoded, encode_binary(sequenced, Coords, Seq, TickN, false, Deltas, FrameSlots)
-    ),
+    Encoded = encode_binary(sequenced, Coords, Seq, TickN, false, Deltas, FrameSlots),
+    RawMsg = delta_msg(PreEncoded, Encoded),
     maps:foreach(
         fun(_PlayerId, {Pid, _MonRef}) -> Pid ! RawMsg end,
         Subs
     ),
-    Seq.
+    {Seq, refusal(Encoded)}.
+
+%% The binary wire being off is not a refusal. Nothing was attempted, no client
+%% is on that wire, and reporting it would suppress the pose plane for every
+%% deployment that never turned the wire on.
+-spec refusal({ok, binary()} | {skip, disabled | refusal()}) -> ok | {refused, refusal()}.
+refusal({ok, _Bin}) -> ok;
+refusal({skip, disabled}) -> ok;
+refusal({skip, Reason}) -> {refused, Reason}.
 
 %% Slots are needed by the binary wire AND by the pose plane, and they are the
 %% same slots: two allocations for one zone would eventually disagree about which
 %% entity holds a slot, which is the class of defect ADR 0011 exists to close.
+%% The binary wire is a precondition, not an independent switch. A pose datagram
+%% names a slot and nothing else, and the only carrier that binds a slot to an
+%% entity is an `add` on the binary `world.tick` (ADR 0013, decision 4) - which
+%% `asobi_ws_handler:negotiate_wire/1` refuses to hand any client while
+%% `asobi.binary_wire` is off. Poses sent into that configuration are unresolvable
+%% by construction and were dropped by every client that received them, while the
+%% zone paid for the encode (asobi#509). `asobi_dgram_env` says so at boot; this
+%% is what makes it true at the tick.
 -spec pose_enabled(map()) -> boolean().
-pose_enabled(#{pose_manifest := {ok, _}}) -> true;
+pose_enabled(#{pose_manifest := {ok, _}, binary_wire := true}) -> true;
 pose_enabled(_State) -> false.
 
 %% The datagram plane's half of the tick. Returns the zone's new pose sequence.
@@ -954,23 +1015,58 @@ pose_enabled(_State) -> false.
     [term()],
     map(),
     asobi_wire_slots:slots(),
-    map()
+    map(),
+    #{binary() => true}
 ) -> non_neg_integer().
-broadcast_pose(Coords, TickN, State, Deltas, Entities, Slots, Subs) ->
+broadcast_pose(Coords, TickN, State, Deltas, Entities, Slots, Subs, Announced) ->
     PoseSeq = maps:get(pose_seq, State),
-    case maps:get(pose_manifest, State) of
-        disabled ->
-            PoseSeq;
-        {ok, Manifest} ->
+    case {pose_enabled(State), maps:get(pose_manifest, State)} of
+        {true, {ok, Manifest}} ->
             case pose_targets(Subs) of
                 [] ->
                     %% Nobody on the plane. Building a body for no one is the one
                     %% cost this whole path can trivially avoid.
                     PoseSeq;
                 ConnIds ->
-                    emit_pose(Coords, TickN, PoseSeq, Manifest, Deltas, Entities, Slots, ConnIds)
-            end
+                    emit_pose(
+                        Coords,
+                        TickN,
+                        PoseSeq,
+                        Manifest,
+                        Deltas,
+                        bound_entities(Entities, Announced),
+                        Slots,
+                        ConnIds
+                    )
+            end;
+        _ ->
+            PoseSeq
     end.
+
+%% Only entities a binary client can resolve. An entity whose `add` rode the text
+%% wire has no slot binding on any client, so a pose naming its slot is dropped
+%% there and the entity looks frozen (asobi#510); its transform keeps arriving on
+%% `world.tick` instead, which is the carrier that can name it.
+-spec bound_entities(map(), #{binary() => true}) -> map().
+bound_entities(Entities, Announced) ->
+    maps:filter(fun(Id, _State) -> is_map_key(Id, Announced) end, Entities).
+
+%% What the shared frame actually told the clients. An `add` counts only when the
+%% frame carrying it encoded, and a `remove` always drops the id: the text frame
+%% carries removals too, so the client is rid of the entity either way and keeping
+%% it here would grow the set for the life of the zone.
+-spec announce(ok | {refused, refusal()}, [term()], #{binary() => true}) ->
+    #{binary() => true}.
+announce(_Refusal, [], Announced) ->
+    Announced;
+announce(ok, [{added, Id, _State} | Rest], Announced) when is_binary(Id) ->
+    announce(ok, Rest, Announced#{Id => true});
+announce(Refusal, [{added, Id, _State} | Rest], Announced) ->
+    announce(Refusal, Rest, maps:remove(Id, Announced));
+announce(Refusal, [{removed, Id} | Rest], Announced) ->
+    announce(Refusal, Rest, maps:remove(Id, Announced));
+announce(Refusal, [_Delta | Rest], Announced) ->
+    announce(Refusal, Rest, Announced).
 
 emit_pose(Coords, TickN, PoseSeq, Manifest, Deltas, Entities, Slots, ConnIds) ->
     Changed = changed_fields(Deltas, #{}),
@@ -1016,7 +1112,7 @@ pose_targets(Subs) ->
 %% travel in ONE message. The connection picks; the zone does not need to know
 %% who negotiated what, so no per-subscriber state and no race between
 %% negotiation and subscription.
-delta_msg(Json, skip) -> {asobi_message, {zone_delta_raw, Json}};
+delta_msg(Json, {skip, _Reason}) -> {asobi_message, {zone_delta_raw, Json}};
 delta_msg(Json, {ok, Bin}) -> {asobi_message, {zone_delta_raw, Json, Bin}}.
 
 %% `undefined` when the binary wire is off, so the per-connection paths do the
@@ -1052,6 +1148,98 @@ advance_slots(true, Old, New, Slots) ->
             {undefined, Slots}
     end.
 
+%% Why a frame could not be encoded. Carried rather than logged at the point of
+%% failure so one throttled warning can name the zone, the reason AND the entity,
+%% which is what the report of this being un-diagnosable asked for (asobi#510).
+-type refusal() ::
+    dict_too_large
+    | bad_field_name
+    | ambiguous_field_name
+    | {no_slot, binary()}
+    | {unencodable_field, binary()}.
+
+%% At most one refusal warning per zone per minute. A zone holding one entity the
+%% encoder cannot take refuses every single frame, so an un-throttled warning is
+%% five lines a second per zone for the life of the zone - which is how a real
+%% signal ends up filtered out of a log pipeline. The suppressed count goes in the
+%% line, so the rate is still visible.
+-define(WIRE_LOG_INTERVAL_MS, 60_000).
+
+-spec log_wire_refusal(
+    ok | {refused, refusal()}, {integer(), integer()}, non_neg_integer(), [term()], map()
+) -> map().
+log_wire_refusal(ok, _Coords, _TickN, _Deltas, Log) ->
+    Log;
+log_wire_refusal({refused, Reason}, Coords, TickN, Deltas, #{logged_at := At} = Log) ->
+    Suppressed = maps:get(suppressed, Log, 0),
+    asobi_telemetry:binary_wire_refused(refusal_kind(Reason)),
+    Now = erlang:system_time(millisecond),
+    case Now - At >= ?WIRE_LOG_INTERVAL_MS of
+        false ->
+            Log#{suppressed => Suppressed + 1};
+        true ->
+            %% The two numbers that identify the cause of the common refusal:
+            %% the frame carries at most 32 distinct field names (asobi_wire),
+            %% and one entity is usually the reason.
+            ?LOG_WARNING(
+                maps:merge(
+                    #{
+                        msg => ~"binary world.tick frame refused, falling back to text",
+                        coords => Coords,
+                        tick => TickN,
+                        field_names => distinct_field_names(Deltas),
+                        widest_entity => widest_entity(Deltas),
+                        suppressed_since => Suppressed
+                    },
+                    refusal_detail(Reason)
+                )
+            ),
+            #{logged_at => Now, suppressed => 0}
+    end.
+
+-spec refusal_detail(refusal()) -> map().
+refusal_detail({no_slot, Id}) -> #{reason => ~"no_slot", entity => Id};
+refusal_detail({unencodable_field, Id}) -> #{reason => ~"unencodable_field", entity => Id};
+refusal_detail(Reason) -> #{reason => atom_to_binary(Reason, utf8)}.
+
+-spec refusal_kind(refusal()) -> atom().
+refusal_kind({Kind, _Id}) -> Kind;
+refusal_kind(Kind) -> Kind.
+
+%% How many distinct field names this frame would need in its dictionary, which
+%% is the number that has to stay within 32 and the one nothing reported before.
+-spec distinct_field_names([term()]) -> non_neg_integer().
+distinct_field_names(Deltas) ->
+    length(lists:usort([Name || Delta <- Deltas, Name := _V <- delta_fields(Delta)])).
+
+%% The entity most likely to be the reason, so the line names something a game
+%% developer can go and look at rather than a count.
+-spec widest_entity([term()]) -> map().
+widest_entity(Deltas) ->
+    widest_entity(Deltas, #{entity => undefined, fields => 0}).
+
+widest_entity([], Widest) ->
+    Widest;
+widest_entity([Delta | Rest], #{fields := Most} = Widest) ->
+    case map_size(delta_fields(Delta)) of
+        Count when Count > Most ->
+            widest_entity(Rest, #{entity => delta_id(Delta), fields => Count});
+        _ ->
+            widest_entity(Rest, Widest)
+    end.
+
+-spec delta_fields(term()) -> map().
+delta_fields({added, _Id, Fields}) when is_map(Fields) -> Fields;
+delta_fields({updated, _Id, Fields}) when is_map(Fields) -> Fields;
+delta_fields(_Delta) -> #{}.
+
+%% `term()` and not `binary()`: the delta list is untyped here, and this value only
+%% ever lands in a log report.
+-spec delta_id(term()) -> term().
+delta_id({added, Id, _Fields}) -> Id;
+delta_id({updated, Id, _Fields}) -> Id;
+delta_id({removed, Id}) -> Id.
+
 %% `skip` rather than an error: binary negotiation covers `world.tick` alone and
 %% every other frame is text regardless, so a client that asked for binary can
 %% always take a text frame. Falling back therefore costs bandwidth, not
@@ -1064,9 +1252,9 @@ advance_slots(true, Old, New, Slots) ->
     boolean(),
     [term()],
     asobi_wire_slots:slots() | undefined
-) -> {ok, binary()} | skip.
+) -> {ok, binary()} | {skip, disabled | refusal()}.
 encode_binary(_Kind, _Coords, _Seq, _TickN, _Kf, _Deltas, undefined) ->
-    skip;
+    {skip, disabled};
 encode_binary(Kind, {ZX, ZY}, Seq, TickN, Kf, Deltas, Slots) ->
     case wire_records(Deltas, Slots) of
         {ok, Records} ->
@@ -1079,17 +1267,11 @@ encode_binary(Kind, {ZX, ZY}, Seq, TickN, Kf, Deltas, Slots) ->
                 records => Records
             },
             case asobi_wire:encode(Frame) of
-                {ok, Bin} ->
-                    {ok, Bin};
-                {error, Reason} ->
-                    ?LOG_WARNING(#{
-                        msg => ~"binary world.tick frame refused, falling back to text",
-                        reason => Reason
-                    }),
-                    skip
+                {ok, Bin} -> {ok, Bin};
+                {error, Reason} -> {skip, Reason}
             end;
-        skip ->
-            skip
+        {skip, Reason} ->
+            {skip, Reason}
     end.
 
 %% Built from the delta TUPLES rather than from encode_deltas/1's JSON maps: the
@@ -1101,16 +1283,16 @@ encode_binary(Kind, {ZX, ZY}, Seq, TickN, Kf, Deltas, Slots) ->
 %% of records the encoder can be trusted with. Recursion depth is one frame's
 %% delta count, which a zone's entity count already bounds.
 -spec wire_records([term()], asobi_wire_slots:slots()) ->
-    {ok, [asobi_wire:delta()]} | skip.
+    {ok, [asobi_wire:delta()]} | {skip, refusal()}.
 wire_records([], _Slots) ->
     {ok, []};
 wire_records([Delta | Rest], Slots) ->
     case wire_record(Delta, Slots) of
-        skip ->
-            skip;
+        {skip, Reason} ->
+            {skip, Reason};
         {ok, Rec} ->
             case wire_records(Rest, Slots) of
-                skip -> skip;
+                {skip, Reason} -> {skip, Reason};
                 {ok, Recs} -> {ok, [Rec | Recs]}
             end
     end.
@@ -1128,6 +1310,10 @@ wire_record({removed, Id}, Slots) ->
         #{op => remove, slot => Slot, gen => Gen}
     end).
 
+%% Reports rather than logs: every refusal in this module funnels through one
+%% throttled warning in `log_wire_refusal/5`, because a zone holding one entity
+%% the encoder cannot take refuses every frame and would otherwise emit a warning
+%% per broadcast tick for the life of the zone (asobi#510).
 with_slot(Id, Slots, Fields, Build) ->
     case {asobi_wire_slots:slot_of(Id, Slots), wire_encodable(Fields)} of
         {{ok, {Slot, Gen}}, true} ->
@@ -1137,13 +1323,9 @@ with_slot(Id, Slots, Fields, Build) ->
             %% every id in the diff has a slot. Missing one means the two have
             %% drifted, and a frame encoded around the gap would bind the wrong
             %% entity on a client; drop to text and say so.
-            ?LOG_WARNING(#{msg => ~"entity has no wire slot, falling back to text", id => Id}),
-            skip;
+            {skip, {no_slot, Id}};
         {_, false} ->
-            ?LOG_WARNING(#{
-                msg => ~"entity field has no binary form, falling back to text", id => Id
-            }),
-            skip
+            {skip, {unencodable_field, Id}}
     end.
 
 %% asobi_wire carries six scalar value types. A game is free to put a list or a

--- a/src/ws/asobi_wire.erl
+++ b/src/ws/asobi_wire.erl
@@ -103,7 +103,22 @@ without knowing how the wire encoded it.
 
 %% Named `delta()` and not `record()`: the latter is a built-in type name and
 %% shadowing it is a compile error, the same trap as clashing with a BIF name.
+%%
+%% Field names are accepted as atoms as well as binaries, because a Luerl table
+%% hands the zone whichever the game happened to write and the text wire renders
+%% both as the same JSON key. `encode/1` normalises them before anything reads a
+%% name, so only `wire_delta()` below ever reaches the encoder.
 -type delta() :: #{
+    op := add | update | remove,
+    slot := non_neg_integer(),
+    gen := 0..255,
+    id => binary(),
+    fields => #{atom() | binary() => term()}
+}.
+
+%% A delta whose field names are already binaries. Separate from `delta()` so the
+%% dictionary index is built from a list the type system knows is binaries.
+-type wire_delta() :: #{
     op := add | update | remove,
     slot := non_neg_integer(),
     gen := 0..255,
@@ -114,14 +129,30 @@ without knowing how the wire encoded it.
 -doc """
 Encodes one `world.tick` frame.
 
+Total on the field names, which is the whole reason this returns a tagged tuple.
+A game's entity is an open map built by a Lua script, so its keys are whatever
+that script wrote: atoms are normalised to their text form, matching what the
+text wire's `json:encode/1` does with the same key, and anything else refuses the
+frame as `{error, bad_field_name}`. Calling `byte_size/1` on such a key instead
+would kill the zone gen_server mid-tick and take every subscriber's session with
+it (asobi#509).
+
 Returns `{error, dict_too_large}` rather than truncating when a frame's distinct
 field names exceed 32. Silently dropping fields would be undetectable corruption
 on the client; a refused frame is a server-side error someone can see.
 """.
--spec encode(frame()) -> {ok, binary()} | {error, dict_too_large}.
-encode(#{
-    kind := Kind, zone := {ZX, ZY}, frame_seq := Seq, kf := Kf, tick := Tick, records := Recs
-}) ->
+-spec encode(frame()) ->
+    {ok, binary()} | {error, dict_too_large | bad_field_name | ambiguous_field_name}.
+encode(#{records := Recs0} = Frame) ->
+    case normalise_records(Recs0) of
+        {ok, Recs} -> encode_normalised(Frame, Recs);
+        {error, _} = Err -> Err
+    end.
+
+-spec encode_normalised(frame(), [wire_delta()]) -> {ok, binary()} | {error, dict_too_large}.
+encode_normalised(
+    #{kind := Kind, zone := {ZX, ZY}, frame_seq := Seq, kf := Kf, tick := Tick}, Recs
+) ->
     Names = dict_names(Recs),
     case length(Names) > ?MAX_DICT of
         true ->
@@ -188,15 +219,65 @@ field_type_tag(null) -> ?T_NULL.
 
 %% --- Internal ---
 
+%% Atom keys to their text form, and a refusal for anything else. Built as a whole
+%% new record list rather than fixed up inside the encoder so that the dictionary,
+%% the index and every field header read the same names - a normalisation applied
+%% in one of those three places and not the others would put a name in the
+%% dictionary that no record refers to.
+%%
+%% Two keys that normalise to the same name (`type` and `~"type"` in one entity)
+%% refuse the frame rather than silently keeping one. The text wire emits both, so
+%% dropping one here would make the two wires disagree about what the entity is,
+%% which is the same call `asobi_zone` makes for a field with no binary form.
+-spec normalise_records([delta()]) ->
+    {ok, [wire_delta()]} | {error, bad_field_name | ambiguous_field_name}.
+normalise_records([]) ->
+    {ok, []};
+normalise_records([Rec | Rest]) ->
+    case normalise_record(Rec) of
+        {error, _} = Err ->
+            Err;
+        {ok, Normalised} ->
+            case normalise_records(Rest) of
+                {error, _} = Err -> Err;
+                {ok, Recs} -> {ok, [Normalised | Recs]}
+            end
+    end.
+
+-spec normalise_record(delta()) ->
+    {ok, wire_delta()} | {error, bad_field_name | ambiguous_field_name}.
+normalise_record(#{fields := Fields} = Rec) ->
+    case normalise_fields(maps:to_list(Fields), #{}) of
+        error -> {error, bad_field_name};
+        {ok, Named} when map_size(Named) =:= map_size(Fields) -> {ok, Rec#{fields => Named}};
+        {ok, _Collided} -> {error, ambiguous_field_name}
+    end;
+normalise_record(#{op := Op, slot := Slot, gen := Gen} = Rec) ->
+    case Rec of
+        #{id := Id} -> {ok, #{op => Op, slot => Slot, gen => Gen, id => Id}};
+        _ -> {ok, #{op => Op, slot => Slot, gen => Gen}}
+    end.
+
+-spec normalise_fields([{atom() | binary(), term()}], #{binary() => term()}) ->
+    {ok, #{binary() => term()}} | error.
+normalise_fields([], Acc) ->
+    {ok, Acc};
+normalise_fields([{Name, Value} | Rest], Acc) when is_binary(Name) ->
+    normalise_fields(Rest, Acc#{Name => Value});
+normalise_fields([{Name, Value} | Rest], Acc) when is_atom(Name) ->
+    normalise_fields(Rest, Acc#{atom_to_binary(Name, utf8) => Value});
+normalise_fields(_Fields, _Acc) ->
+    error.
+
 %% Distinct field names in first-appearance order, so a frame's dictionary is
 %% deterministic for a given record list and the encoder is testable by equality.
--spec dict_names([delta()]) -> [binary()].
+-spec dict_names([wire_delta()]) -> [binary()].
 dict_names(Recs) -> dict_names(Recs, [], []).
 
 %% Threaded explicitly rather than via lists:append/1 over a comprehension: that
 %% shape erases the element type on the way through, and the dictionary index is
 %% only sound if the names are known to be binaries.
--spec dict_names([delta()], [binary()], [binary()]) -> [binary()].
+-spec dict_names([wire_delta()], [binary()], [binary()]) -> [binary()].
 dict_names([], _Seen, Acc) ->
     Acc;
 dict_names([R | Rest], Seen, Acc) ->
@@ -219,7 +300,7 @@ add_names([K | Rest], Seen, Acc) ->
 %% Pattern-matched rather than maps:get/3 with a default: the default widens the
 %% map type and the key type goes with it, so the dictionary ends up untypeable
 %% for the sake of one line of brevity.
--spec field_keys(delta()) -> [binary()].
+-spec field_keys(wire_delta()) -> [binary()].
 field_keys(#{fields := Fields}) -> maps:keys(Fields);
 field_keys(_) -> [].
 

--- a/src/ws/asobi_wire.erl
+++ b/src/ws/asobi_wire.erl
@@ -89,6 +89,17 @@ without knowing how the wire encoded it.
 
 -define(MAX_DICT, 32).
 
+%% The lengths the frame layout can express. Erlang's bit syntax TRUNCATES rather
+%% than raising - `<<300:8>>` is `<<44>>` - so an unchecked length does not produce
+%% a big frame, it produces a frame whose every following byte is read at the wrong
+%% offset. `decode/1` then rejects the whole thing and every entity in it, and the
+%% encoder has already reported success. These three are the only unbounded values
+%% the layout writes, and a game script chooses all three: field names and entity
+%% ids are the keys of the map `zone_tick` returns.
+-define(MAX_NAME, 255).
+-define(MAX_ID, 255).
+-define(MAX_STR, 65_535).
+
 -define(KIND_SEQUENCED, 1).
 -define(KIND_UNGATED, 2).
 
@@ -129,20 +140,37 @@ without knowing how the wire encoded it.
 -doc """
 Encodes one `world.tick` frame.
 
-Total on the field names, which is the whole reason this returns a tagged tuple.
-A game's entity is an open map built by a Lua script, so its keys are whatever
-that script wrote: atoms are normalised to their text form, matching what the
-text wire's `json:encode/1` does with the same key, and anything else refuses the
-frame as `{error, bad_field_name}`. Calling `byte_size/1` on such a key instead
-would kill the zone gen_server mid-tick and take every subscriber's session with
-it (asobi#509).
+Total. Every value it writes comes from a map a Lua script built, so nothing here
+may raise and nothing may truncate - this runs inside the zone's tick, and a
+`badarg` kills the zone gen_server and every subscriber's session with it
+(asobi#509).
 
-Returns `{error, dict_too_large}` rather than truncating when a frame's distinct
-field names exceed 32. Silently dropping fields would be undetectable corruption
-on the client; a refused frame is a server-side error someone can see.
+Field names are normalised: atoms become their text form, matching what the text
+wire's `json:encode/1` does with the same key, so the two wires agree. Everything
+the layout cannot express refuses the frame as a value instead:
+
+- `bad_field_name` - a name that is neither an atom nor a binary, or one past 255
+  bytes, which is what the dictionary's length prefix can count.
+- `ambiguous_field_name` - two names that normalise to the same one. The text wire
+  emits both, so keeping one would make the wires disagree about the entity.
+- `bad_entity_id` - an id that is not a binary, or one past 255 bytes.
+- `value_too_large` - a string value past 65535 bytes.
+- `dict_too_large` - more than 32 distinct field names, which is all a 5-bit index
+  can address.
+
+Refusing rather than truncating is the whole point: a truncated length is not a
+big frame, it is a frame read at the wrong offset from that byte on, which
+`decode/1` rejects entirely - so silent corruption on the client instead of a
+server-side error someone can see.
 """.
 -spec encode(frame()) ->
-    {ok, binary()} | {error, dict_too_large | bad_field_name | ambiguous_field_name}.
+    {ok, binary()}
+    | {error,
+        dict_too_large
+        | bad_field_name
+        | ambiguous_field_name
+        | bad_entity_id
+        | value_too_large}.
 encode(#{records := Recs0} = Frame) ->
     case normalise_records(Recs0) of
         {ok, Recs} -> encode_normalised(Frame, Recs);
@@ -230,7 +258,8 @@ field_type_tag(null) -> ?T_NULL.
 %% dropping one here would make the two wires disagree about what the entity is,
 %% which is the same call `asobi_zone` makes for a field with no binary form.
 -spec normalise_records([delta()]) ->
-    {ok, [wire_delta()]} | {error, bad_field_name | ambiguous_field_name}.
+    {ok, [wire_delta()]}
+    | {error, bad_field_name | ambiguous_field_name | bad_entity_id | value_too_large}.
 normalise_records([]) ->
     {ok, []};
 normalise_records([Rec | Rest]) ->
@@ -245,10 +274,16 @@ normalise_records([Rec | Rest]) ->
     end.
 
 -spec normalise_record(delta()) ->
-    {ok, wire_delta()} | {error, bad_field_name | ambiguous_field_name}.
+    {ok, wire_delta()}
+    | {error, bad_field_name | ambiguous_field_name | bad_entity_id | value_too_large}.
+%% The id is checked before the fields because it is the cheaper refusal and
+%% because it is the one that used to raise: `encode_record/2` calls `byte_size/1`
+%% on it, and only an `add` carries one.
+normalise_record(#{id := Id}) when not is_binary(Id); byte_size(Id) > ?MAX_ID ->
+    {error, bad_entity_id};
 normalise_record(#{fields := Fields} = Rec) ->
     case normalise_fields(maps:to_list(Fields), #{}) of
-        error -> {error, bad_field_name};
+        {error, _} = Err -> Err;
         {ok, Named} when map_size(Named) =:= map_size(Fields) -> {ok, Rec#{fields => Named}};
         {ok, _Collided} -> {error, ambiguous_field_name}
     end;
@@ -259,15 +294,24 @@ normalise_record(#{op := Op, slot := Slot, gen := Gen} = Rec) ->
     end.
 
 -spec normalise_fields([{atom() | binary(), term()}], #{binary() => term()}) ->
-    {ok, #{binary() => term()}} | error.
+    {ok, #{binary() => term()}} | {error, bad_field_name | value_too_large}.
 normalise_fields([], Acc) ->
     {ok, Acc};
-normalise_fields([{Name, Value} | Rest], Acc) when is_binary(Name) ->
+normalise_fields([{_Name, Value} | _Rest], _Acc) when
+    is_binary(Value), byte_size(Value) > ?MAX_STR
+->
+    {error, value_too_large};
+normalise_fields([{Name, Value} | Rest], Acc) when
+    is_binary(Name), byte_size(Name) =< ?MAX_NAME
+->
     normalise_fields(Rest, Acc#{Name => Value});
 normalise_fields([{Name, Value} | Rest], Acc) when is_atom(Name) ->
-    normalise_fields(Rest, Acc#{atom_to_binary(Name, utf8) => Value});
+    case atom_to_binary(Name, utf8) of
+        Text when byte_size(Text) =< ?MAX_NAME -> normalise_fields(Rest, Acc#{Text => Value});
+        _Long -> {error, bad_field_name}
+    end;
 normalise_fields(_Fields, _Acc) ->
-    error.
+    {error, bad_field_name}.
 
 %% Distinct field names in first-appearance order, so a frame's dictionary is
 %% deterministic for a given record list and the encoder is testable by equality.

--- a/test/asobi_dgram_env_tests.erl
+++ b/test/asobi_dgram_env_tests.erl
@@ -135,7 +135,10 @@ pose_parses() ->
         }},
         application:get_env(asobi, dgram_pose)
     ),
-    %% ...and it is the shape the manifest reader accepts, not merely a map.
+    %% ...and it is the shape the manifest reader accepts, not merely a map. The
+    %% reader also holds the plane's carrier rule, so the wire has to be on for it
+    %% to answer at all.
+    application:set_env(asobi, binary_wire, true),
     ?assertMatch({ok, #{fields := [_, _, _]}}, asobi_dgram_pose:manifest()).
 
 pose_malformed() ->

--- a/test/asobi_dgram_env_tests.erl
+++ b/test/asobi_dgram_env_tests.erl
@@ -16,10 +16,13 @@
     "ASOBI_DGRAM_GATEWAY",
     "ASOBI_DGRAM_ENDPOINT",
     "ASOBI_DGRAM_POSE_FIELDS",
-    "ASOBI_DGRAM_POSE_PERIOD"
+    "ASOBI_DGRAM_POSE_PERIOD",
+    "ASOBI_BINARY_WIRE"
 ]).
 
--define(KEYS, [role, dgram, dgram_link_secret, dgram_gateway, dgram_endpoint, dgram_pose]).
+-define(KEYS, [
+    role, dgram, dgram_link_secret, dgram_gateway, dgram_endpoint, dgram_pose, binary_wire
+]).
 
 env_test_() ->
     {foreach, fun setup/0, fun cleanup/1, [
@@ -32,7 +35,10 @@ env_test_() ->
         {"the pose manifest parses in canonical order", fun pose_parses/0},
         {"a malformed pose manifest is refused", fun pose_malformed/0},
         {"a secret file beats a secret variable", fun secret_file_wins/0},
-        {"an unreadable secret file leaves no secret", fun secret_file_unreadable/0}
+        {"an unreadable secret file leaves no secret", fun secret_file_unreadable/0},
+        {"the binary wire folds in, which is what carries the plane", fun binary_wire_folds_in/0},
+        {"a pose manifest without the binary wire is reported, not accepted",
+            fun pose_without_binary_wire_is_reported/0}
     ]}.
 
 setup() ->
@@ -169,3 +175,40 @@ tmp_file(Contents) ->
     ),
     ok = file:write_file(Path, Contents),
     Path.
+
+%% asobi#509. The plane cannot work without the binary wire - a pose names a slot
+%% and only an `add` on that wire binds one - and until this existed the wire
+%% could not be turned on from the published image at all, so the whole plane was
+%% unreachable for the audience it was built for.
+binary_wire_folds_in() ->
+    os:putenv("ASOBI_BINARY_WIRE", "1"),
+    asobi_dgram_env:apply(),
+    ?assertEqual({ok, true}, application:get_env(asobi, binary_wire)),
+
+    application:unset_env(asobi, binary_wire),
+    os:putenv("ASOBI_BINARY_WIRE", "false"),
+    asobi_dgram_env:apply(),
+    ?assertEqual({ok, false}, application:get_env(asobi, binary_wire)),
+
+    %% A configured sys.config wins, the same as every other key here.
+    application:set_env(asobi, binary_wire, true),
+    os:putenv("ASOBI_BINARY_WIRE", "0"),
+    asobi_dgram_env:apply(),
+    ?assertEqual({ok, true}, application:get_env(asobi, binary_wire)).
+
+%% asobi#509. Configuring the manifest and leaving the wire off looks like a
+%% working plane and is not one: every pose names a slot no client can resolve,
+%% because the frame that binds slots is the one the server refuses to send.
+pose_without_binary_wire_is_reported() ->
+    os:putenv("ASOBI_DGRAM_POSE_FIELDS", "x:100,y:100"),
+    asobi_dgram_env:apply(),
+    ?assertMatch({ok, #{fields := [_ | _]}}, application:get_env(asobi, dgram_pose)),
+    ?assertEqual({error, no_binary_wire}, asobi_dgram_env:check_pose_carrier()),
+
+    application:set_env(asobi, binary_wire, true),
+    ?assertEqual(ok, asobi_dgram_env:check_pose_carrier()),
+
+    %% No manifest is not a misconfiguration: the plane is simply off.
+    application:unset_env(asobi, dgram_pose),
+    application:unset_env(asobi, binary_wire),
+    ?assertEqual(ok, asobi_dgram_env:check_pose_carrier()).

--- a/test/asobi_dgram_pose_tests.erl
+++ b/test/asobi_dgram_pose_tests.erl
@@ -15,11 +15,15 @@ pose_test_() ->
         {"entities at rest are refreshed by the axial rotation", fun axial_rotation/0},
         {"the whole zone is covered within one period", fun axial_covers_everything/0},
         {"a non-numeric transform field is skipped, not guessed", fun non_numeric_skipped/0},
-        {"an entity with no slot is skipped silently", fun no_slot_skipped/0}
+        {"an entity with no slot is skipped silently", fun no_slot_skipped/0},
+        {"no binary wire, no manifest", fun no_binary_wire_no_manifest/0}
     ]}.
 
 setup() ->
-    Prev = application:get_env(asobi, dgram_pose),
+    Prev = [{K, application:get_env(asobi, K)} || K <- [dgram_pose, binary_wire]],
+    %% `manifest/0` is the plane's carrier rule: the binary wire is what binds a
+    %% slot to an entity, so without it there is no manifest to have.
+    application:set_env(asobi, binary_wire, true),
     application:set_env(asobi, dgram_pose, #{
         period_ticks => 4,
         fields => [
@@ -30,8 +34,15 @@ setup() ->
     }),
     Prev.
 
-cleanup(undefined) -> application:unset_env(asobi, dgram_pose);
-cleanup({ok, V}) -> application:set_env(asobi, dgram_pose, V).
+cleanup(Prev) ->
+    [
+        case V of
+            undefined -> application:unset_env(asobi, K);
+            {ok, Val} -> application:set_env(asobi, K, Val)
+        end
+     || {K, V} <- Prev
+    ],
+    ok.
 
 %% --- The manifest ---
 
@@ -178,3 +189,12 @@ phase_miss(Slots) ->
     hd([T || T <- lists:seq(0, 3), not lists:member(T, [S rem 4 || S <- Taken])]).
 
 count_bits(N) -> length([B || B <- lists:seq(0, 7), N band (1 bsl B) =/= 0]).
+
+%% asobi#509. One predicate for the plane's carrier rule, read by the zone that
+%% emits poses AND by the mint that advertises the manifest to a client. Splitting
+%% them let the mint promise a plane the zone would never send, which a client
+%% reads as degraded and answers with a rebind storm.
+no_binary_wire_no_manifest() ->
+    ?assertMatch({ok, #{fields := [_ | _]}}, asobi_dgram_pose:manifest()),
+    application:set_env(asobi, binary_wire, false),
+    ?assertEqual(disabled, asobi_dgram_pose:manifest()).

--- a/test/asobi_dgram_pose_zone_tests.erl
+++ b/test/asobi_dgram_pose_zone_tests.erl
@@ -10,9 +10,10 @@ zone_pose_test_() ->
     {foreach, fun setup/0, fun cleanup/1, [
         {"a zone with no manifest emits nothing", fun no_manifest_no_pose/0},
         {"a zone with the binary wire off emits nothing", fun no_binary_wire_no_pose/0},
-        {"an entity whose add fell back to text gets no pose", fun unannounced_entity_no_pose/0},
-        {"one unencodable entity does not cost the others their plane",
-            fun bound_entities_keep_their_poses/0},
+        {"an entity the wire cannot carry takes the zone off the plane",
+            fun unencodable_entity_stops_the_plane/0},
+        {"a passing refusal costs one tick of poses, not the plane",
+            fun passing_refusal_recovers/0},
         {"a zone with no datagram subscribers emits nothing", fun no_subscribers_no_pose/0},
         {"a moving entity produces a decodable pose", fun moving_entity_produces_pose/0},
         {"pose and the binary wire share one slot map", fun one_slot_map/0},
@@ -29,9 +30,8 @@ setup() ->
         period_ticks => 20,
         fields => [#{name => ~"x", scale => 100}, #{name => ~"y", scale => 100}]
     }),
-    %% The plane's precondition, not a detail of the fixture: a pose names a slot
-    %% and only the binary `world.tick` binds one, so every test that expects a
-    %% pose needs the wire that makes it resolvable (asobi#509).
+    %% The plane's precondition, not a detail of the fixture - see
+    %% `asobi_dgram_pose:manifest/0`.
     application:set_env(asobi, binary_wire, true),
     %% Stand in for the mint's ETS mirror. The zone reads it directly, so a test
     %% can populate it without a whole engine behind it.
@@ -74,10 +74,8 @@ no_manifest_no_pose() ->
     ?assertEqual(no_pose, recv_pose()),
     gen_server:stop(Pid).
 
-%% A pose carries a slot and nothing else, and the only frame that binds a slot to
-%% an entity is an `add` on the binary wire - which no client is served while
-%% `binary_wire` is off. Emitting poses into that configuration burned an encode
-%% per tick to produce datagrams every client discarded (asobi#509).
+%% asobi#509. Emitting poses with the wire off burned an encode per tick to
+%% produce datagrams every client discarded.
 no_binary_wire_no_pose() ->
     application:set_env(asobi, binary_wire, false),
     Pid = start_zone(),
@@ -88,12 +86,12 @@ no_binary_wire_no_pose() ->
     ?assertEqual(no_pose, recv_pose()),
     gen_server:stop(Pid).
 
-%% asobi#510. An entity the encoder cannot take rides the text wire, and a text
-%% add carries no slot, so the client has no binding for it - a pose naming that
-%% slot is dropped there and the entity looks frozen for the whole session. The
-%% zone therefore keeps it off the plane entirely and lets `world.tick` carry it,
-%% which is the carrier that can name it.
-unannounced_entity_no_pose() ->
+%% asobi#510. An entity the encoder cannot take drops the frame to text, and a
+%% text add carries no slot - so no client can resolve a pose, for this entity or
+%% any other in the zone. The zone latches to the text wire instead of streaming
+%% datagrams every client would discard, and every entity keeps moving on
+%% `world.tick`, which is the carrier that can name them.
+unencodable_entity_stops_the_plane() ->
     Pid = start_zone(),
     ets:insert(asobi_dgram_conns, {~"p1", 4242}),
     asobi_zone:subscribe(Pid, {~"p1", self()}),
@@ -104,27 +102,29 @@ unannounced_entity_no_pose() ->
     ?assertEqual(no_pose, recv_pose()),
     gen_server:stop(Pid).
 
-%% The other half of asobi#510: a refusal is a whole-frame decision, so without a
-%% record of what was actually announced the safe answer would be to stop the
-%% plane for the zone. An entity bound by an earlier frame keeps its poses; only
-%% the one that never made it onto the wire is held back.
-bound_entities_keep_their_poses() ->
+%% A refusal that passes must not cost the zone its plane. The frame that follows
+%% one is a keyframe, so every client is rebound in a single broadcast interval
+%% and the poses resume - the plane pauses for one tick rather than latching off.
+passing_refusal_recovers() ->
     Pid = start_zone(),
     ets:insert(asobi_dgram_conns, {~"p1", 4242}),
     asobi_zone:subscribe(Pid, {~"p1", self()}),
     asobi_zone:add_entity(Pid, ~"e1", #{~"x" => 1.0, ~"y" => 2.0}),
     asobi_zone:tick(Pid, 1),
-    {pose, _First, _} = recv_pose(),
+    ?assertMatch({pose, _, _}, recv_pose()),
 
-    %% e2 cannot ride the wire, so the frame carrying both is text and e2 is
-    %% never bound. e1 was bound by the frame before it and moves on.
+    %% A frame the encoder refuses: no poses this tick, because no client can be
+    %% sure of its slot table until the repair lands.
     asobi_zone:add_entity(Pid, ~"e2", #{~"x" => 5.0, ~"y" => 5.0, ~"path" => [1, 2]}),
-    asobi_zone:add_entity(Pid, ~"e1", #{~"x" => 3.0, ~"y" => 2.0}),
     asobi_zone:tick(Pid, 2),
-    {pose, Body, _} = recv_pose(),
-    <<_Tick:32/little, _Seq:32/little, _ZX:16/signed-little, _ZY:16/signed-little, _Mask:8, Count:8,
-        _Epoch:16/little, _Rest/binary>> = Body,
-    ?assertEqual(1, Count),
+    ?assertEqual(no_pose, recv_pose()),
+
+    %% The offending entity leaves, the keyframe rebinds everyone, poses resume.
+    asobi_zone:remove_entity(Pid, ~"e2"),
+    asobi_zone:tick(Pid, 3),
+    asobi_zone:add_entity(Pid, ~"e1", #{~"x" => 7.0, ~"y" => 2.0}),
+    asobi_zone:tick(Pid, 4),
+    ?assertMatch({pose, _, _}, recv_pose()),
     gen_server:stop(Pid).
 
 %% Building a body for nobody is the one cost on this path that is trivially

--- a/test/asobi_dgram_pose_zone_tests.erl
+++ b/test/asobi_dgram_pose_zone_tests.erl
@@ -9,6 +9,8 @@
 zone_pose_test_() ->
     {foreach, fun setup/0, fun cleanup/1, [
         {"a zone with no manifest emits nothing", fun no_manifest_no_pose/0},
+        {"a zone with the binary wire off emits nothing", fun no_binary_wire_no_pose/0},
+        {"an entity whose add fell back to text gets no pose", fun unannounced_entity_no_pose/0},
         {"a zone with no datagram subscribers emits nothing", fun no_subscribers_no_pose/0},
         {"a moving entity produces a decodable pose", fun moving_entity_produces_pose/0},
         {"pose and the binary wire share one slot map", fun one_slot_map/0},
@@ -25,6 +27,10 @@ setup() ->
         period_ticks => 20,
         fields => [#{name => ~"x", scale => 100}, #{name => ~"y", scale => 100}]
     }),
+    %% The plane's precondition, not a detail of the fixture: a pose names a slot
+    %% and only the binary `world.tick` binds one, so every test that expects a
+    %% pose needs the wire that makes it resolvable (asobi#509).
+    application:set_env(asobi, binary_wire, true),
     %% Stand in for the mint's ETS mirror. The zone reads it directly, so a test
     %% can populate it without a whole engine behind it.
     ensure_table(asobi_dgram_conns, [named_table, public, {read_concurrency, true}]),
@@ -66,6 +72,36 @@ no_manifest_no_pose() ->
     ?assertEqual(no_pose, recv_pose()),
     gen_server:stop(Pid).
 
+%% A pose carries a slot and nothing else, and the only frame that binds a slot to
+%% an entity is an `add` on the binary wire - which no client is served while
+%% `binary_wire` is off. Emitting poses into that configuration burned an encode
+%% per tick to produce datagrams every client discarded (asobi#509).
+no_binary_wire_no_pose() ->
+    application:set_env(asobi, binary_wire, false),
+    Pid = start_zone(),
+    ets:insert(asobi_dgram_conns, {~"p1", 4242}),
+    asobi_zone:subscribe(Pid, {~"p1", self()}),
+    asobi_zone:add_entity(Pid, ~"e1", #{~"x" => 1.0, ~"y" => 2.0}),
+    asobi_zone:tick(Pid, 1),
+    ?assertEqual(no_pose, recv_pose()),
+    gen_server:stop(Pid).
+
+%% asobi#510. An entity the encoder cannot take rides the text wire, and a text
+%% add carries no slot, so the client has no binding for it - a pose naming that
+%% slot is dropped there and the entity looks frozen for the whole session. The
+%% zone therefore keeps it off the plane entirely and lets `world.tick` carry it,
+%% which is the carrier that can name it.
+unannounced_entity_no_pose() ->
+    Pid = start_zone(),
+    ets:insert(asobi_dgram_conns, {~"p1", 4242}),
+    asobi_zone:subscribe(Pid, {~"p1", self()}),
+    %% A list is not one of the six scalar types the wire carries, so the frame
+    %% announcing this entity is refused and sent as text.
+    asobi_zone:add_entity(Pid, ~"e1", #{~"x" => 1.0, ~"y" => 2.0, ~"path" => [1, 2]}),
+    asobi_zone:tick(Pid, 1),
+    ?assertEqual(no_pose, recv_pose()),
+    gen_server:stop(Pid).
+
 %% Building a body for nobody is the one cost on this path that is trivially
 %% avoidable, and a zone whose players are all on the WebSocket is the common case.
 no_subscribers_no_pose() ->
@@ -103,7 +139,6 @@ moving_entity_produces_pose() ->
 %% the pose plane and the binary wire read the SAME slot, and this proves it by
 %% comparing the two wires' own bytes.
 one_slot_map() ->
-    application:set_env(asobi, binary_wire, true),
     Pid = start_zone(),
     ets:insert(asobi_dgram_conns, {~"p1", 4242}),
     asobi_zone:subscribe(Pid, {~"p1", self()}),
@@ -117,7 +152,6 @@ one_slot_map() ->
 
     ?assertEqual(WireSlot, PoseSlot),
     ?assertEqual(WireGen, PoseGen),
-    application:unset_env(asobi, binary_wire),
     gen_server:stop(Pid).
 
 %% The two carriers lose frames independently, so sharing a counter would make

--- a/test/asobi_dgram_pose_zone_tests.erl
+++ b/test/asobi_dgram_pose_zone_tests.erl
@@ -11,6 +11,8 @@ zone_pose_test_() ->
         {"a zone with no manifest emits nothing", fun no_manifest_no_pose/0},
         {"a zone with the binary wire off emits nothing", fun no_binary_wire_no_pose/0},
         {"an entity whose add fell back to text gets no pose", fun unannounced_entity_no_pose/0},
+        {"one unencodable entity does not cost the others their plane",
+            fun bound_entities_keep_their_poses/0},
         {"a zone with no datagram subscribers emits nothing", fun no_subscribers_no_pose/0},
         {"a moving entity produces a decodable pose", fun moving_entity_produces_pose/0},
         {"pose and the binary wire share one slot map", fun one_slot_map/0},
@@ -100,6 +102,29 @@ unannounced_entity_no_pose() ->
     asobi_zone:add_entity(Pid, ~"e1", #{~"x" => 1.0, ~"y" => 2.0, ~"path" => [1, 2]}),
     asobi_zone:tick(Pid, 1),
     ?assertEqual(no_pose, recv_pose()),
+    gen_server:stop(Pid).
+
+%% The other half of asobi#510: a refusal is a whole-frame decision, so without a
+%% record of what was actually announced the safe answer would be to stop the
+%% plane for the zone. An entity bound by an earlier frame keeps its poses; only
+%% the one that never made it onto the wire is held back.
+bound_entities_keep_their_poses() ->
+    Pid = start_zone(),
+    ets:insert(asobi_dgram_conns, {~"p1", 4242}),
+    asobi_zone:subscribe(Pid, {~"p1", self()}),
+    asobi_zone:add_entity(Pid, ~"e1", #{~"x" => 1.0, ~"y" => 2.0}),
+    asobi_zone:tick(Pid, 1),
+    {pose, _First, _} = recv_pose(),
+
+    %% e2 cannot ride the wire, so the frame carrying both is text and e2 is
+    %% never bound. e1 was bound by the frame before it and moves on.
+    asobi_zone:add_entity(Pid, ~"e2", #{~"x" => 5.0, ~"y" => 5.0, ~"path" => [1, 2]}),
+    asobi_zone:add_entity(Pid, ~"e1", #{~"x" => 3.0, ~"y" => 2.0}),
+    asobi_zone:tick(Pid, 2),
+    {pose, Body, _} = recv_pose(),
+    <<_Tick:32/little, _Seq:32/little, _ZX:16/signed-little, _ZY:16/signed-little, _Mask:8, Count:8,
+        _Epoch:16/little, _Rest/binary>> = Body,
+    ?assertEqual(1, Count),
     gen_server:stop(Pid).
 
 %% Building a body for nobody is the one cost on this path that is trivially

--- a/test/asobi_wire_tests.erl
+++ b/test/asobi_wire_tests.erl
@@ -101,6 +101,126 @@ atom_field_names_encode_as_their_text_form_test() ->
     {ok, Bin} = asobi_wire:encode(Atoms),
     ?assertMatch({ok, #{records := [#{fields := #{~"type" := 7}}]}}, asobi_wire:decode(Bin)).
 
+%% The invariant the length checks exist for, and the one the module was missing:
+%% `encode/1` must never hand back bytes `decode/1` will not take. Erlang's bit
+%% syntax truncates rather than raising, so an over-long name, id or string used to
+%% produce a frame read at the wrong offset from that byte on - `{ok, Bytes}` from
+%% the encoder and a discarded frame on the client, which is corruption the server
+%% never hears about.
+encode_never_produces_bytes_decode_rejects_test() ->
+    Long = binary:copy(~"a", 300),
+    Huge = binary:copy(~"b", 70_000),
+    Frames = [
+        frame([#{op => update, slot => 1, gen => 0, fields => #{Long => 1.0}}]),
+        frame([#{op => add, slot => 1, gen => 0, id => Long, fields => #{~"x" => 1.0}}]),
+        frame([#{op => update, slot => 1, gen => 0, fields => #{~"s" => Huge}}])
+    ],
+    [
+        ?assertMatch({ok, _}, asobi_wire:decode(Bin))
+     || F <- Frames, {ok, Bin} <- [asobi_wire:encode(F)]
+    ],
+    ?assertEqual({error, bad_field_name}, asobi_wire:encode(hd(Frames))),
+    ?assertEqual({error, bad_entity_id}, asobi_wire:encode(lists:nth(2, Frames))),
+    ?assertEqual({error, value_too_large}, asobi_wire:encode(lists:nth(3, Frames))).
+
+%% The boundaries are where they say they are: the dictionary and the id both
+%% count their length in one byte, and a string value in two.
+length_limits_are_inclusive_test() ->
+    Name = binary:copy(~"a", 255),
+    ?assertMatch(
+        {ok, _},
+        asobi_wire:encode(
+            frame([#{op => update, slot => 1, gen => 0, fields => #{Name => 1.0}}])
+        )
+    ),
+    Id = binary:copy(~"i", 255),
+    ?assertMatch(
+        {ok, _},
+        asobi_wire:encode(
+            frame([#{op => add, slot => 1, gen => 0, id => Id, fields => #{~"x" => 1.0}}])
+        )
+    ),
+    Str = binary:copy(~"s", 65_535),
+    ?assertMatch(
+        {ok, _},
+        asobi_wire:encode(
+            frame([#{op => update, slot => 1, gen => 0, fields => #{~"s" => Str}}])
+        )
+    ),
+    %% One byte past each is the refusal, so the boundary is exact rather than
+    %% approximately right.
+    ?assertEqual(
+        {error, bad_field_name},
+        asobi_wire:encode(
+            frame([
+                #{op => update, slot => 1, gen => 0, fields => #{binary:copy(~"a", 256) => 1.0}}
+            ])
+        )
+    ),
+    ?assertEqual(
+        {error, bad_entity_id},
+        asobi_wire:encode(
+            frame([
+                #{
+                    op => add,
+                    slot => 1,
+                    gen => 0,
+                    id => binary:copy(~"i", 256),
+                    fields => #{~"x" => 1.0}
+                }
+            ])
+        )
+    ),
+    ?assertEqual(
+        {error, value_too_large},
+        asobi_wire:encode(
+            frame([
+                #{
+                    op => update,
+                    slot => 1,
+                    gen => 0,
+                    fields => #{~"s" => binary:copy(~"s", 65_536)}
+                }
+            ])
+        )
+    ).
+
+%% An atom key is bounded by the same 255 bytes a binary one is, and an atom of 255
+%% CHARACTERS can be four times that in UTF-8 - so the check has to be on the
+%% rendered text rather than on the atom.
+atom_field_name_past_the_limit_refuses_the_frame_test() ->
+    Wide = list_to_atom(lists:duplicate(200, 16#4E2D)),
+    F = frame([#{op => update, slot => 1, gen => 0, fields => #{Wide => 1.0}}]),
+    ?assert(byte_size(atom_to_binary(Wide, utf8)) > 255),
+    ?assertEqual({error, bad_field_name}, asobi_wire:encode(F)),
+    %% The boundary is where it says it is, on the rendered bytes: 85 three-byte
+    %% characters is exactly 255, one ASCII character more is 256.
+    Exact = list_to_atom(lists:duplicate(85, 16#4E2D)),
+    ?assertEqual(255, byte_size(atom_to_binary(Exact, utf8))),
+    ?assertMatch(
+        {ok, _},
+        asobi_wire:encode(frame([#{op => update, slot => 1, gen => 0, fields => #{Exact => 1.0}}]))
+    ),
+    Over = list_to_atom(lists:duplicate(85, 16#4E2D) ++ "a"),
+    ?assertEqual(256, byte_size(atom_to_binary(Over, utf8))),
+    ?assertEqual(
+        {error, bad_field_name},
+        asobi_wire:encode(frame([#{op => update, slot => 1, gen => 0, fields => #{Over => 1.0}}]))
+    ),
+    %% ...and one that fits still encodes, so the bound is on length not on atoms.
+    Narrow = list_to_atom(lists:duplicate(80, 16#4E2D)),
+    ?assertMatch(
+        {ok, _},
+        asobi_wire:encode(frame([#{op => update, slot => 1, gen => 0, fields => #{Narrow => 1.0}}]))
+    ).
+
+%% asobi#509 again, one branch below where it was fixed. The entity id reaches
+%% `byte_size/1` too, and a Lua table that mixes named and numeric keys hands the
+%% zone a non-binary one - so this raised, and the zone died mid-tick.
+non_binary_entity_id_refuses_the_frame_test() ->
+    F = frame([#{op => add, slot => 1, gen => 0, id => 5.0, fields => #{~"x" => 1.0}}]),
+    ?assertEqual({error, bad_entity_id}, asobi_wire:encode(F)).
+
 %% A record with no `fields` at all is legal on both wires - an add for an entity
 %% with an empty state, and every remove. Normalising must leave those alone
 %% rather than treating the absent key as an empty one it then has to rebuild.

--- a/test/asobi_wire_tests.erl
+++ b/test/asobi_wire_tests.erl
@@ -88,6 +88,44 @@ too_many_distinct_field_names_is_refused_test() ->
         asobi_wire:encode(F#{records => [#{op => update, slot => 1, gen => 0, fields => Ok}]})
     ).
 
+%% asobi#509. A Luerl table hands the zone whichever key form the game script
+%% wrote, and an atom one reached `byte_size/1` and killed the zone gen_server
+%% mid-tick - taking every subscriber's session with it. Atoms are the form the
+%% text wire already renders as a plain JSON key, so the two wires agree.
+atom_field_names_encode_as_their_text_form_test() ->
+    Atoms = frame([#{op => update, slot => 1, gen => 0, fields => #{type => 7, ~"x" => 1.0}}]),
+    Binaries = frame([
+        #{op => update, slot => 1, gen => 0, fields => #{~"type" => 7, ~"x" => 1.0}}
+    ]),
+    ?assertEqual(asobi_wire:encode(Binaries), asobi_wire:encode(Atoms)),
+    {ok, Bin} = asobi_wire:encode(Atoms),
+    ?assertMatch({ok, #{records := [#{fields := #{~"type" := 7}}]}}, asobi_wire:decode(Bin)).
+
+%% A record with no `fields` at all is legal on both wires - an add for an entity
+%% with an empty state, and every remove. Normalising must leave those alone
+%% rather than treating the absent key as an empty one it then has to rebuild.
+records_without_fields_survive_normalisation_test() ->
+    Add = frame([#{op => add, slot => 1, gen => 0, id => ~"e1"}]),
+    ?assertEqual({ok, Add}, roundtrip(Add)),
+    Remove = frame([#{op => remove, slot => 1, gen => 0}]),
+    ?assertEqual({ok, Remove}, roundtrip(Remove)).
+
+%% Total on the field names, which is the whole point: the encoder runs inside the
+%% zone's tick, so anything it cannot express has to come back as a value rather
+%% than as an exception.
+non_textual_field_names_refuse_the_frame_test() ->
+    Numeric = frame([#{op => update, slot => 1, gen => 0, fields => #{1 => 1.0}}]),
+    ?assertEqual({error, bad_field_name}, asobi_wire:encode(Numeric)),
+    Tuple = frame([#{op => update, slot => 1, gen => 0, fields => #{{a, b} => 1.0}}]),
+    ?assertEqual({error, bad_field_name}, asobi_wire:encode(Tuple)).
+
+%% Keeping one of two keys that normalise to the same name would put a value on
+%% the binary wire that the text wire does not carry, which is the disagreement
+%% the whole-frame fallback exists to prevent.
+colliding_field_names_refuse_the_frame_test() ->
+    F = frame([#{op => update, slot => 1, gen => 0, fields => #{type => 1, ~"type" => 2}}]),
+    ?assertEqual({error, ambiguous_field_name}, asobi_wire:encode(F)).
+
 %% The leave-removal frame carries no position in the zone's stream - on the text
 %% wire that is said by omitting frame_seq, which a fixed-layout binary frame
 %% cannot do. If the kind byte did not survive, that frame would decode as

--- a/test/asobi_zone_binary_wire_tests.erl
+++ b/test/asobi_zone_binary_wire_tests.erl
@@ -21,7 +21,9 @@ binary_wire_test_() ->
         {"a slot survives across ticks so update records stay bound",
             fun slots_are_stable_across_ticks/0},
         {"a non-scalar field drops the whole zone to text rather than diverging",
-            fun non_scalar_field_falls_back_to_text/0}
+            fun non_scalar_field_falls_back_to_text/0},
+        {"an atom-keyed entity encodes rather than killing the zone",
+            fun atom_field_names_survive_the_tick/0}
     ]}.
 
 setup() ->
@@ -198,3 +200,21 @@ recv_matching(Pred) ->
                 false -> recv_matching(Pred)
             end
     end.
+
+%% asobi#509. Field names out of a Luerl `zone_tick` can be atoms, and the encoder
+%% called `byte_size/1` on them - a badarg inside the tick, so the zone
+%% gen_server died and every subscriber's WS handler followed it into a call on a
+%% dead pid. From the players' side that was a hung loading screen with nothing
+%% pointing at the wire.
+atom_field_names_survive_the_tick() ->
+    application:set_env(asobi, binary_wire, true),
+    Pid = start_zone(),
+    asobi_zone:subscribe(Pid, {~"p1", self()}),
+    _ = recv(),
+    asobi_zone:add_entity(Pid, ~"e1", #{type => ~"ship", ~"x" => 1.0}),
+    asobi_zone:tick(Pid, 1),
+    {zone_delta_raw, _Json, Bin} = recv_delta(),
+    {ok, #{records := [#{fields := Fields}]}} = asobi_wire:decode(Bin),
+    ?assertEqual(#{~"type" => ~"ship", ~"x" => 1.0}, Fields),
+    ?assert(is_process_alive(Pid)),
+    gen_server:stop(Pid).

--- a/test/asobi_zone_binary_wire_tests.erl
+++ b/test/asobi_zone_binary_wire_tests.erl
@@ -23,7 +23,11 @@ binary_wire_test_() ->
         {"a non-scalar field drops the whole zone to text rather than diverging",
             fun non_scalar_field_falls_back_to_text/0},
         {"an atom-keyed entity encodes rather than killing the zone",
-            fun atom_field_names_survive_the_tick/0}
+            fun atom_field_names_survive_the_tick/0},
+        {"a passing refusal is repaired by a keyframe on the next frame",
+            fun refusal_is_repaired_by_a_keyframe/0},
+        {"a structural refusal latches the zone to text rather than stranding slots",
+            fun structural_refusal_latches_to_text/0}
     ]}.
 
 setup() ->
@@ -217,4 +221,63 @@ atom_field_names_survive_the_tick() ->
     {ok, #{records := [#{fields := Fields}]}} = asobi_wire:decode(Bin),
     ?assertEqual(#{~"type" => ~"ship", ~"x" => 1.0}, Fields),
     ?assert(is_process_alive(Pid)),
+    gen_server:stop(Pid).
+
+%% asobi#510. A text frame carries no slots, so every binding its `add` records
+%% would have established is missing on every binary client - and the NEXT
+%% successful binary frame then names those slots in `op:"u"` records the client
+%% drops, with a contiguous `frame_seq` that gives it no reason to resync. The
+%% repair is the one ADR 0013 decision 4 already names: send a keyframe, which is
+%% all-adds and re-establishes the whole mapping.
+refusal_is_repaired_by_a_keyframe() ->
+    application:set_env(asobi, binary_wire, true),
+    Pid = start_zone(),
+    asobi_zone:subscribe(Pid, {~"p1", self()}),
+    _ = recv(),
+    asobi_zone:add_entity(Pid, ~"e1", #{~"x" => 1.0}),
+    asobi_zone:tick(Pid, 1),
+    ?assertMatch({zone_delta_raw, _, _}, recv_delta()),
+
+    %% A list has no binary form, so the frame introducing e2 is text.
+    asobi_zone:add_entity(Pid, ~"e2", #{~"x" => 2.0, ~"path" => [1, 2]}),
+    asobi_zone:tick(Pid, 2),
+    ?assertMatch({zone_delta_raw, _}, recv_delta()),
+
+    %% e2 leaves, so the zone can encode again - and what it sends is a keyframe,
+    %% not the delta, because a binary client's slot table is a frame behind.
+    asobi_zone:remove_entity(Pid, ~"e2"),
+    asobi_zone:tick(Pid, 3),
+    {zone_delta_raw, _Json, Bin} = recv_delta(),
+    {ok, #{kf := Kf, records := Records}} = asobi_wire:decode(Bin),
+    ?assert(Kf),
+    ?assertEqual([{add, ~"e1"}], [{Op, Id} || #{op := Op, id := Id} <- Records]),
+    gen_server:stop(Pid).
+
+%% When the cause is the shape of the game's entities rather than one frame, every
+%% keyframe after it refuses too. Streaming binary frames whose slots no client can
+%% bind is worse than not using the wire, so the zone gives it up for its life and
+%% everyone falls back to text - which carries everything, and which a binary
+%% client handles by construction.
+structural_refusal_latches_to_text() ->
+    application:set_env(asobi, binary_wire, true),
+    Pid = start_zone(),
+    asobi_zone:subscribe(Pid, {~"p1", self()}),
+    _ = recv(),
+    asobi_zone:add_entity(Pid, ~"e1", #{~"x" => 1.0}),
+    asobi_zone:add_entity(Pid, ~"e2", #{~"x" => 2.0, ~"path" => [1, 2]}),
+    asobi_zone:tick(Pid, 1),
+    ?assertMatch({zone_delta_raw, _}, recv_delta()),
+
+    %% The rebind keyframe refuses for the same reason, so the wire latches off.
+    asobi_zone:add_entity(Pid, ~"e1", #{~"x" => 3.0}),
+    asobi_zone:tick(Pid, 2),
+    ?assertMatch({zone_delta_raw, _}, recv_delta()),
+
+    %% And stays off, including for an entity that could be encoded on its own.
+    asobi_zone:remove_entity(Pid, ~"e2"),
+    asobi_zone:tick(Pid, 3),
+    ?assertMatch({zone_delta_raw, _}, recv_delta()),
+    asobi_zone:add_entity(Pid, ~"e1", #{~"x" => 4.0}),
+    asobi_zone:tick(Pid, 4),
+    ?assertMatch({zone_delta_raw, _}, recv_delta()),
     gen_server:stop(Pid).

--- a/test/asobi_zone_wire_refusal_tests.erl
+++ b/test/asobi_zone_wire_refusal_tests.erl
@@ -1,0 +1,84 @@
+-module(asobi_zone_wire_refusal_tests).
+-include_lib("eunit/include/eunit.hrl").
+
+%% The throttle on the binary-wire refusal warning, and the attribution the line
+%% carries. A zone holding one entity the encoder cannot take refuses every frame,
+%% so this is what decides between a log an operator can read and five lines a
+%% second for the life of the zone.
+
+-define(DELTAS, [
+    {added, ~"e1", #{~"x" => 1.0, ~"y" => 2.0}},
+    {updated, ~"e2", #{~"x" => 1.0, ~"y" => 2.0, ~"hp" => 3}}
+]).
+
+-define(STATE(Log), #{wire_log => Log}).
+
+first_refusal_logs_immediately_test() ->
+    State = asobi_zone:log_refusal(
+        dict_too_large,
+        ~"refused",
+        {0, 0},
+        1,
+        ?DELTAS,
+        ?STATE(#{
+            logged_at => undefined, suppressed => 0
+        })
+    ),
+    #{wire_log := Log} = State,
+    ?assertEqual(0, maps:get(suppressed, Log)),
+    ?assertNotEqual(undefined, maps:get(logged_at, Log)).
+
+%% The number an operator actually needs is how much the quiet minute hid.
+subsequent_refusals_count_rather_than_log_test() ->
+    Now = erlang:monotonic_time(millisecond),
+    S1 = asobi_zone:log_refusal(
+        dict_too_large, ~"refused", {0, 0}, 2, ?DELTAS, ?STATE(#{logged_at => Now, suppressed => 0})
+    ),
+    S2 = asobi_zone:log_refusal(dict_too_large, ~"refused", {0, 0}, 3, ?DELTAS, S1),
+    #{wire_log := Log} = S2,
+    ?assertEqual(2, maps:get(suppressed, Log)),
+    ?assertEqual(Now, maps:get(logged_at, Log)).
+
+window_expiry_logs_and_resets_the_counter_test() ->
+    Stale = erlang:monotonic_time(millisecond) - 61_000,
+    State = asobi_zone:log_refusal(
+        dict_too_large,
+        ~"refused",
+        {0, 0},
+        4,
+        ?DELTAS,
+        ?STATE(#{
+            logged_at => Stale, suppressed => 41
+        })
+    ),
+    #{wire_log := Log} = State,
+    ?assertEqual(0, maps:get(suppressed, Log)),
+    ?assert(maps:get(logged_at, Log) > Stale).
+
+%% Monotonic rather than wall-clock: an NTP step backwards must not buy a zone a
+%% silent window the size of the correction.
+a_backward_clock_does_not_suppress_the_line_test() ->
+    Future = erlang:monotonic_time(millisecond) + 3_600_000,
+    State = asobi_zone:log_refusal(
+        dict_too_large,
+        ~"refused",
+        {0, 0},
+        5,
+        ?DELTAS,
+        ?STATE(#{
+            logged_at => Future, suppressed => 0
+        })
+    ),
+    #{wire_log := Log} = State,
+    ?assertEqual(1, maps:get(suppressed, Log)).
+
+%% The two numbers the line is worth reading for: the dictionary is capped at 32
+%% names, and one entity is usually the reason.
+attribution_names_the_widest_entity_test() ->
+    ?assertEqual(3, asobi_zone:distinct_field_names(?DELTAS)),
+    ?assertEqual(#{entity => ~"e2", fields => 3}, asobi_zone:widest_entity(?DELTAS)),
+    %% A frame of removals has no fields and nothing to blame.
+    ?assertEqual(0, asobi_zone:distinct_field_names([{removed, ~"e1"}])),
+    ?assertEqual(
+        #{entity => undefined, fields => 0}, asobi_zone:widest_entity([{removed, ~"e1"}])
+    ).


### PR DESCRIPTION
Fixes the three v0.92.1 reports against the binary wire and the datagram plane. All three were silent from the player's side, which is most of what made them expensive.

Closes #509
Closes #510
Closes #511

## #509 - the encoder killed the zone on an atom field name

`asobi_wire:encode/1` called `byte_size/1` on every field name. A Luerl `zone_tick` can hand the zone an atom key, so the first frame carrying such an entity raised `badarg` mid-tick, the zone gen_server died, and every subscriber's WS handler followed it into a call on a dead pid.

Atom names now normalise to their text form, which is exactly what the JSON wire already renders them as, so the two wires still agree about what an entity is. A name that is neither an atom nor a binary refuses the frame as `{error, bad_field_name}`, and two names that collide after normalisation refuse it as `{error, ambiguous_field_name}` rather than quietly keeping one.

The same report noted the encoder ran whenever a gateway was configured even with `binary_wire` off. It did, and the underlying problem was worse than a wasted encode: **the pose plane cannot work without the binary wire at all.** A pose carries a slot and nothing else, and the only frame that binds a slot to an entity is an `add` on the binary `world.tick` - which `negotiate_wire/1` refuses to hand any client while `binary_wire` is off. So that configuration minted, sent and had every datagram discarded client-side.

- `pose_enabled/1` now requires `binary_wire`, so the encoder stops running and no undeliverable poses are sent.
- `asobi_dgram_env` logs `dgram_pose_without_binary_wire` at boot.
- **`ASOBI_BINARY_WIRE` is new.** There was no environment variable for `binary_wire`, so the wire - and therefore the whole plane - was unreachable from the published image, which is how the audience this was built for configures asobi.

## #510 - a refused frame left entities permanently unbound

A frame past the 32-name dictionary is sent as text. That is a correct fallback for the frame, and it has a protocol consequence: a text `add` carries no slot, so the entities it introduced are never bound in the client's decoder, and every later pose naming their slot is dropped there. One entity with 33 fields cost that entity its plane for the whole session, with no client log and a server line that named nothing.

The zone now tracks which entity ids it actually announced on a binary frame that went out, and keeps everything else off the pose plane. Those entities keep moving on `world.tick`, which is the carrier that can name them - they lose the UDP fast path, not their position. One unencodable entity no longer costs the others theirs, which is what the new `bound_entities_keep_their_poses` test pins.

The refusal warning now names the zone, the tick, the distinct field-name count, the widest entity and the reason, and is throttled to one per zone per minute with the suppressed count attached (a zone with one fat entity refuses every frame, so the un-throttled line was five warnings a second for the life of the zone). A refused keyframe gets its own line, because that one leaves a joining client with no bindings at all. New telemetry event: `[asobi, wire, binary_refused]`.

The 32-name budget is now documented in the protocol guide, the configuration guide and both plane guides, with what it costs when you cross it.

## #511 - the documented topology could never link

`asobi_dgram_link_server` binds the link port on `127.0.0.1` (deliberately - it carries mint secrets with no transport security of its own), so the guide's two-compose-services setup got `econnrefused` forever and the plane degraded to WebSocket for everyone with nothing in either log saying so.

- Both guides now show the shared-network-namespace topology: `network_mode: "service:asobi"` in compose, two containers in one pod on Kubernetes, `ASOBI_DGRAM_GATEWAY=127.0.0.1:7778`. Credential isolation is unaffected - own environment, own filesystem, own process tree, which is where the isolation actually is.
- The engine now logs `dgram link unreachable, datagram plane is down` (throttled to one a minute) with the address and the loopback hint. It only emitted a telemetry counter before, so an engine that could not reach its gateway looked exactly like one with no gateway configured.
- **`ASOBI_ROLE=dgram_gw` no longer starts the HTTP listener.** Nothing behind it starts in that role, so every request it answered was a 500 out of a half-booted plugin chain (`limiter_not_found`), and in a shared namespace it raced the engine for `ASOBI_PORT` and sometimes won. It also no longer runs migrations, registers Lua game modes or resolves extensions - the role is documented as having no database pool and now actually has none. nova binds before asobi's start callback runs, so the listener is stopped rather than never started; the window is one boot rather than the life of the container.
- **`ASOBI_NODE_NAME` is new**, defaulting to `asobi`. One network namespace is one EPMD, and two nodes registering the same name means the second one does not boot.

## Behaviour changes worth calling out

1. A pose manifest without `binary_wire` now disables poses instead of sending undeliverable ones. It logs an error saying so.
2. The `dgram_gw` role serves no HTTP. If anything probed that port, it needs to stop.
3. `vm.args.src` reads `${ASOBI_NODE_NAME}`. The published image defaults it; a release built from source that renders its own `vm.args` must set it.

## Checks

`fmt` / `xref` / `dialyzer` / `elp eqwalize` / `elp lint` / `eunit` (2134, 0 failures) / `ct` (388, 0 failures) / `ex_doc`, all clean - the two remaining eqWAlizer errors in `asobi_zone` and the lint warnings in the touched files are pre-existing and untouched by this branch. `rebar3 mutate` on `asobi_wire` is 100% (335/335); the changed lines in `asobi_dgram_env` are at 73%.
