### PR TITLE
fix: poses go only to connections that can resolve a slot

### DIFF
--- a/guides/datagram-plane.md
+++ b/guides/datagram-plane.md
@@ -263,6 +263,7 @@ on before you have tested every player's network.
 | Situation | What happens |
 |---|---|
 | Server has no gateway | The mint answers `datagram_unavailable`. The client stays on the WebSocket. |
+| The client did not ask for the binary wire | It mints, and its **input** still travels over UDP. It is not sent poses, because it has no slot table to resolve them against - positions keep coming on `world.tick`. See below. |
 | A firewall drops UDP | Three probes over three seconds, then the client gives up to `off`. |
 | The path goes quiet for 2s | `degraded`: positions come from `world.tick` again while the client re-probes in the background. |
 | The WebSocket reconnects | Back to `off`, and a fresh mint. A credential is bound to a session. |
@@ -270,6 +271,24 @@ on before you have tested every player's network.
 
 **The WebSocket carries everything in every state.** There is no state in which
 correctness depends on this plane.
+
+### Poses need the binary wire; input does not
+
+A pose record carries a slot and nothing else, and the only frame that binds a
+slot to an entity is an `add` on the [binary
+`world.tick`](websocket-protocol.md#binary-worldtick). So a client that connected
+without `"wire": "binary"` cannot resolve a pose, and the server does not send it
+any - it would be dropped client-side and the entity would look frozen with
+nothing in either log to say why.
+
+The plane's other half is unaffected: `world.input` travelling upstream over UDP
+resolves a player by `conn_id`, needs no slots, and works on either wire. So
+minting is allowed either way, and a client that wants only the latency win on
+its own input can have it.
+
+Every SDK that supports the plane asks for both, so this is not something you
+configure - it matters if you are writing a client by hand, or debugging why a
+plane that reports `on` never moves anything.
 
 The client keepalive is not optional and cannot be moved to the server: with a
 NAT anywhere in the path a quiet client loses its mapping and the downlink is

--- a/src/dgram/asobi_dgram_mint.erl
+++ b/src/dgram/asobi_dgram_mint.erl
@@ -29,7 +29,7 @@ metric labels.
 
 -behaviour(gen_server).
 
--export([start_link/0, open/2, close/1, player_of/1, conn_of/1]).
+-export([start_link/0, open/3, close/1, player_of/1, pose_conn_of/1]).
 -export([init/1, handle_call/3, handle_cast/2, handle_info/2]).
 
 %% How long a mint is good for if the client never opens the plane. Long enough
@@ -53,7 +53,7 @@ metric labels.
 }.
 
 -type request() ::
-    {open, binary(), pid()}
+    {open, binary(), pid(), binary()}
     | {player_of, non_neg_integer()}.
 
 -type state() :: #{by_conn := #{non_neg_integer() => mint()}, epoch := 0..65535}.
@@ -70,9 +70,9 @@ turns into "no datagram plane for this session" rather than into a failure: the
 WebSocket carries everything regardless, so an absent gateway is a degraded plane
 and not a broken session.
 """.
--spec open(binary(), pid()) -> {ok, map()} | {error, term()}.
-open(PlayerId, SessionPid) ->
-    case gen_server:call(?MODULE, {open, PlayerId, SessionPid}, 5000) of
+-spec open(binary(), pid(), binary()) -> {ok, map()} | {error, term()}.
+open(PlayerId, SessionPid, Wire) ->
+    case gen_server:call(?MODULE, {open, PlayerId, SessionPid, Wire}, 5000) of
         {ok, Credential} when is_map(Credential) -> {ok, Credential};
         {error, Reason} -> {error, Reason}
     end.
@@ -82,16 +82,27 @@ open(PlayerId, SessionPid) ->
 close(ConnId) -> gen_server:cast(?MODULE, {close, ConnId}).
 
 -doc """
-This player's `conn_id`, or `error`.
+This player's `conn_id`, if poses can reach them, or `error`.
+
+**Not simply "this player's conn_id".** A pose record names a slot and nothing
+else, and the only frame that binds a slot to an entity is an `add` on the binary
+`world.tick`. A client that connected on the JSON wire never receives one, so
+every pose sent to it names a slot it cannot resolve and is dropped there - the
+entity looks frozen, with nothing in either log to say why (asobi#510, again, one
+layer out). Minting is still allowed for such a client: the plane's other half
+carries `world.input` UPSTREAM, which resolves a player by `conn_id` and needs no
+slots at all, so UDP input works on either wire.
 
 Reads the mirror directly, with no message to this process at all: a zone calls
 it once per subscriber per broadcast tick, and a gen_server call there would put
-one process in the path of every zone's tick.
+one process in the path of every zone's tick. Answering the question the caller
+actually has - "may I send this player a pose?" - keeps the wire out of the zone,
+which ADR 0013 decision 4 declined to track per subscriber.
 """.
--spec conn_of(binary()) -> {ok, non_neg_integer()} | error.
-conn_of(PlayerId) ->
+-spec pose_conn_of(binary()) -> {ok, non_neg_integer()} | error.
+pose_conn_of(PlayerId) ->
     try ets:lookup(?MIRROR, PlayerId) of
-        [{_, ConnId}] when is_integer(ConnId) -> {ok, ConnId};
+        [{_, ConnId, true}] when is_integer(ConnId) -> {ok, ConnId};
         _ -> error
     catch
         %% No mirror: the plane is not configured on this node.
@@ -130,7 +141,9 @@ init([]) ->
     {ok, #{by_conn => #{}, epoch => rand_epoch()}}.
 
 -spec handle_call(request(), gen_server:from(), state()) -> {reply, term(), state()}.
-handle_call({open, PlayerId, SessionPid}, _From, #{by_conn := ByConn, epoch := Epoch} = State) ->
+handle_call(
+    {open, PlayerId, SessionPid, Wire}, _From, #{by_conn := ByConn, epoch := Epoch} = State
+) ->
     ConnId = binary:decode_unsigned(crypto:strong_rand_bytes(4)),
     KUp = crypto:strong_rand_bytes(32),
     ExpiresAt = erlang:system_time(millisecond) + ?TTL_MS,
@@ -163,7 +176,11 @@ handle_call({open, PlayerId, SessionPid}, _From, #{by_conn := ByConn, epoch := E
                 },
                 pose_manifest()
             ),
-            true = ets:insert(?MIRROR, {PlayerId, ConnId}),
+            %% The third element is the pose question, decided here because this
+            %% is where the connection is known. `world.tick` is the carrier that
+            %% binds slots, so only a client that negotiated the binary one can
+            %% resolve a pose.
+            true = ets:insert(?MIRROR, {PlayerId, ConnId, Wire =:= ~"binary"}),
             {reply, {ok, Reply}, State#{by_conn => ByConn#{ConnId => Mint}}};
         {error, Reason} ->
             {reply, {error, Reason}, State}
@@ -239,7 +256,7 @@ forget(ConnId, ByConn) ->
     case ByConn of
         #{ConnId := #{player_id := PlayerId}} ->
             case ets:lookup(?MIRROR, PlayerId) of
-                [{_, ConnId}] -> ets:delete(?MIRROR, PlayerId);
+                [{_, ConnId, _Poses}] -> ets:delete(?MIRROR, PlayerId);
                 _ -> true
             end;
         _ ->

--- a/src/dgram/asobi_dgram_rpc.erl
+++ b/src/dgram/asobi_dgram_rpc.erl
@@ -29,12 +29,17 @@ session.
 
 -doc "Mints a credential for the calling session.".
 -spec open(map(), map()) -> {ok, map()} | {error, binary()}.
-open(_Params, #{player_id := PlayerId, session := SessionPid}) ->
+open(_Params, #{player_id := PlayerId, session := SessionPid} = Caller) ->
     case asobi_dgram_link_client:enabled() of
         false ->
             {error, ~"datagram_unavailable"};
         true ->
-            case asobi_dgram_mint:open(PlayerId, SessionPid) of
+            %% The wire this connection negotiated, which decides whether poses
+            %% can reach it. Minting is allowed either way - UDP input needs no
+            %% slots - so this is recorded rather than refused. An HTTP caller has
+            %% no WebSocket and therefore no wire, which is the same answer.
+            Wire = maps:get(wire, Caller, ~"json"),
+            case asobi_dgram_mint:open(PlayerId, SessionPid, Wire) of
                 {ok, Credential} ->
                     {ok, Credential};
                 {error, _Reason} ->

--- a/src/world/asobi_zone.erl
+++ b/src/world/asobi_zone.erl
@@ -1170,7 +1170,7 @@ changed_fields([_Removed | Rest], Acc) ->
 %% rather than by asking it, because this runs once per subscriber per broadcast
 %% tick and a gen_server call there would put one process in every zone's path.
 pose_targets(Subs) ->
-    [C || PlayerId := _ <- Subs, {ok, C} <- [asobi_dgram_mint:conn_of(PlayerId)]].
+    [C || PlayerId := _ <- Subs, {ok, C} <- [asobi_dgram_mint:pose_conn_of(PlayerId)]].
 
 %% One shared buffer per wire in use, never one per subscriber - that is the
 %% whole point of ADR 0001's encode-once fan-out and the reason both buffers

--- a/src/ws/asobi_ws_handler.erl
+++ b/src/ws/asobi_ws_handler.erl
@@ -1155,10 +1155,18 @@ handle_message(#{~"type" := _Type} = Msg, State) ->
 handle_message(_Msg, State) ->
     {ok, State}.
 
-rpc_caller(#{session := SessionPid, player_id := PlayerId}) when
+rpc_caller(#{session := SessionPid, player_id := PlayerId} = State) when
     is_pid(SessionPid), is_binary(PlayerId)
 ->
-    #{player_id => PlayerId, session => SessionPid, transport => ws};
+    %% `wire` travels with the caller because the datagram mint needs it: a pose
+    %% names a slot, and only the binary `world.tick` binds one, so a connection
+    %% on the JSON wire can send UDP input but can never resolve a pose.
+    #{
+        player_id => PlayerId,
+        session => SessionPid,
+        transport => ws,
+        wire => maps:get(wire, State, ~"json")
+    };
 rpc_caller(_State) ->
     unauthenticated.
 

--- a/test/asobi_dgram_mint_tests.erl
+++ b/test/asobi_dgram_mint_tests.erl
@@ -1,0 +1,51 @@
+-module(asobi_dgram_mint_tests).
+-include_lib("eunit/include/eunit.hrl").
+
+%% The contract between the mint and the zone: which connections may be sent a
+%% pose. It is one ETS row read on every zone's broadcast tick, so it is worth
+%% pinning the shape rather than discovering a change from frozen entities.
+
+-define(MIRROR, asobi_dgram_conns).
+
+pose_conn_test_() ->
+    {foreach, fun setup/0, fun cleanup/1, [
+        {"a binary-wire connection is a pose target", fun binary_wire_is_a_target/0},
+        {"a JSON-wire connection is not", fun json_wire_is_not_a_target/0},
+        {"an unminted player is not", fun unminted_is_not_a_target/0}
+    ]}.
+
+setup() ->
+    drop_mirror(),
+    ets:new(?MIRROR, [named_table, public, {read_concurrency, true}]),
+    ok.
+
+cleanup(_) ->
+    drop_mirror().
+
+drop_mirror() ->
+    case ets:whereis(?MIRROR) of
+        undefined -> ok;
+        _Tid -> ets:delete(?MIRROR)
+    end,
+    ok.
+
+binary_wire_is_a_target() ->
+    ets:insert(?MIRROR, {~"p1", 4242, true}),
+    ?assertEqual({ok, 4242}, asobi_dgram_mint:pose_conn_of(~"p1")).
+
+%% The whole point. This player HAS minted - UDP input from them is delivered -
+%% but they connected on the text wire, so they were never sent an `add` record
+%% and cannot resolve a slot. A pose would be dropped client-side and the entity
+%% would look frozen (asobi#510).
+json_wire_is_not_a_target() ->
+    ets:insert(?MIRROR, {~"p1", 4242, false}),
+    ?assertEqual(error, asobi_dgram_mint:pose_conn_of(~"p1")).
+
+unminted_is_not_a_target() ->
+    ?assertEqual(error, asobi_dgram_mint:pose_conn_of(~"nobody")).
+
+%% No mirror at all is the common case: the plane is not configured on this node,
+%% and a zone still calls this once per subscriber per tick.
+no_mirror_is_not_a_target_test() ->
+    drop_mirror(),
+    ?assertEqual(error, asobi_dgram_mint:pose_conn_of(~"p1")).

--- a/test/asobi_dgram_pose_zone_tests.erl
+++ b/test/asobi_dgram_pose_zone_tests.erl
@@ -15,6 +15,8 @@ zone_pose_test_() ->
         {"a passing refusal costs one tick of poses, not the plane",
             fun passing_refusal_recovers/0},
         {"a zone with no datagram subscribers emits nothing", fun no_subscribers_no_pose/0},
+        {"a client on the JSON wire is not sent poses it cannot resolve",
+            fun json_wire_client_gets_no_pose/0},
         {"a moving entity produces a decodable pose", fun moving_entity_produces_pose/0},
         {"pose and the binary wire share one slot map", fun one_slot_map/0},
         {"the pose sequence is independent of frame_seq", fun independent_sequences/0}
@@ -67,7 +69,7 @@ cleanup(Prev) ->
 no_manifest_no_pose() ->
     application:unset_env(asobi, dgram_pose),
     Pid = start_zone(),
-    ets:insert(asobi_dgram_conns, {~"p1", 4242}),
+    ets:insert(asobi_dgram_conns, {~"p1", 4242, true}),
     asobi_zone:subscribe(Pid, {~"p1", self()}),
     asobi_zone:add_entity(Pid, ~"e1", #{~"x" => 1.0, ~"y" => 2.0}),
     asobi_zone:tick(Pid, 1),
@@ -79,7 +81,7 @@ no_manifest_no_pose() ->
 no_binary_wire_no_pose() ->
     application:set_env(asobi, binary_wire, false),
     Pid = start_zone(),
-    ets:insert(asobi_dgram_conns, {~"p1", 4242}),
+    ets:insert(asobi_dgram_conns, {~"p1", 4242, true}),
     asobi_zone:subscribe(Pid, {~"p1", self()}),
     asobi_zone:add_entity(Pid, ~"e1", #{~"x" => 1.0, ~"y" => 2.0}),
     asobi_zone:tick(Pid, 1),
@@ -93,7 +95,7 @@ no_binary_wire_no_pose() ->
 %% `world.tick`, which is the carrier that can name them.
 unencodable_entity_stops_the_plane() ->
     Pid = start_zone(),
-    ets:insert(asobi_dgram_conns, {~"p1", 4242}),
+    ets:insert(asobi_dgram_conns, {~"p1", 4242, true}),
     asobi_zone:subscribe(Pid, {~"p1", self()}),
     %% A list is not one of the six scalar types the wire carries, so the frame
     %% announcing this entity is refused and sent as text.
@@ -107,7 +109,7 @@ unencodable_entity_stops_the_plane() ->
 %% and the poses resume - the plane pauses for one tick rather than latching off.
 passing_refusal_recovers() ->
     Pid = start_zone(),
-    ets:insert(asobi_dgram_conns, {~"p1", 4242}),
+    ets:insert(asobi_dgram_conns, {~"p1", 4242, true}),
     asobi_zone:subscribe(Pid, {~"p1", self()}),
     asobi_zone:add_entity(Pid, ~"e1", #{~"x" => 1.0, ~"y" => 2.0}),
     asobi_zone:tick(Pid, 1),
@@ -141,7 +143,7 @@ no_subscribers_no_pose() ->
 %% a position.
 moving_entity_produces_pose() ->
     Pid = start_zone(),
-    ets:insert(asobi_dgram_conns, {~"p1", 4242}),
+    ets:insert(asobi_dgram_conns, {~"p1", 4242, true}),
     asobi_zone:subscribe(Pid, {~"p1", self()}),
     asobi_zone:add_entity(Pid, ~"e1", #{~"x" => 12.5, ~"y" => -3.25}),
     asobi_zone:tick(Pid, 1),
@@ -165,7 +167,7 @@ moving_entity_produces_pose() ->
 %% comparing the two wires' own bytes.
 one_slot_map() ->
     Pid = start_zone(),
-    ets:insert(asobi_dgram_conns, {~"p1", 4242}),
+    ets:insert(asobi_dgram_conns, {~"p1", 4242, true}),
     asobi_zone:subscribe(Pid, {~"p1", self()}),
     asobi_zone:add_entity(Pid, ~"e1", #{~"x" => 1.0, ~"y" => 2.0}),
     asobi_zone:tick(Pid, 1),
@@ -183,7 +185,7 @@ one_slot_map() ->
 %% each look like it had gaps the other caused. A client gap-detects them apart.
 independent_sequences() ->
     Pid = start_zone(),
-    ets:insert(asobi_dgram_conns, {~"p1", 4242}),
+    ets:insert(asobi_dgram_conns, {~"p1", 4242, true}),
     asobi_zone:subscribe(Pid, {~"p1", self()}),
     asobi_zone:add_entity(Pid, ~"e1", #{~"x" => 1.0, ~"y" => 2.0}),
     asobi_zone:tick(Pid, 1),
@@ -244,3 +246,20 @@ recv_delta() ->
         {asobi_message, _Other} -> recv_delta()
     after 500 -> no_delta
     end.
+
+%% asobi#510, one layer out from the zone. `asobi.datagram.open` mints for any
+%% session with a gateway configured - deliberately, because the plane's other
+%% half carries `world.input` upstream and that needs no slots, so UDP input
+%% works on either wire. What it must not do is put a JSON-wire client on the
+%% receiving end: it never gets an `add` record, so every pose names a slot it
+%% cannot resolve and drops it, and the entity looks frozen with nothing logged
+%% anywhere. The mint records the answer; the zone asks for it.
+json_wire_client_gets_no_pose() ->
+    Pid = start_zone(),
+    %% Minted, and on the text wire - the flag the mint writes for it.
+    ets:insert(asobi_dgram_conns, {~"p1", 4242, false}),
+    asobi_zone:subscribe(Pid, {~"p1", self()}),
+    asobi_zone:add_entity(Pid, ~"e1", #{~"x" => 1.0, ~"y" => 2.0}),
+    asobi_zone:tick(Pid, 1),
+    ?assertEqual(no_pose, recv_pose()),
+    gen_server:stop(Pid).


### PR DESCRIPTION
The last route of the #510 class, found while answering "are bad UDP routes in zones solved now?" — and it isn't in the zone.

## The route

`asobi.datagram.open` mints for any session as long as a gateway is configured (`asobi_dgram_rpc:open/2`), with no check on the wire the connection negotiated. `asobi_zone:pose_targets/1` then sends to every subscriber holding a mint.

So a client that connects with `"wire": "json"` — the default — and then opens a datagram is sent pose records for slots it was never given, because the JSON `world.tick` carries no slots. It drops every one. Frozen entity, no client log, nothing on the server. Exactly the symptom #510 describes, arriving through the mint rather than through a refused frame.

## Why refusing the mint would have been wrong

The plane has two halves and only one of them needs slots. `world.input` travelling upstream over UDP is resolved by `conn_id` in `asobi_dgram_input`, touches no slot table, and works perfectly on the text wire. A client that wants the latency win on its own input without the pose downlink is doing something reasonable, and refusing to mint would have taken that away to fix a different problem.

So the mint still mints. It records whether poses can reach the connection, and the zone asks for *pose targets* rather than for conn ids.

- `asobi_dgram_mint:open/3` takes the negotiated wire; the mirror row becomes `{PlayerId, ConnId, PosesResolvable}`.
- `conn_of/1` → `pose_conn_of/1`. It had exactly one caller, and the new name states the invariant instead of leaving it to the caller to remember.
- The wire travels in the RPC caller context, which is where `asobi_ws_handler` already had it. An HTTP RPC caller has no WebSocket and therefore no wire, which lands on the same answer — correctly, since it can never receive a `world.tick` at all.
- No per-connection state in the zone: ADR 0013 decision 4 declined to track the wire per subscriber, and this keeps that. The mint already holds per-connection state; the question is answered where the connection is known.

## Tests

- `asobi_dgram_pose_zone_tests`: a minted JSON-wire client subscribed to a moving zone receives no pose.
- `asobi_dgram_mint_tests` (new): pins the mint→zone contract — binary-wire row is a target, JSON-wire row is not, unminted is not, and no mirror at all is not (the common case, hit once per subscriber per tick).

## Docs

`guides/datagram-plane.md` gains a row in the "when it does not work" table and a short section on why poses need the binary wire and input does not. Every SDK that supports the plane already asks for both, so this matters for hand-written clients and for anyone debugging a plane that reports `on` and never moves anything.

## Checks

`fmt --check` / `xref` / `dialyzer` / `elp eqwalize` (mint, rpc and zone clean; the 2 in `asobi_ws_handler` are pre-existing, verified by stashing) / `elp lint` / `eunit` 2152, 0 failures / `ct` 388, 0 failures / error-drift.
