### PR TITLE
fix: name the gateway release and image asobi_dgram

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -145,11 +145,11 @@ jobs:
       - name: Assemble both releases
         run: |
           rebar3 as prod release -n asobi
-          rebar3 as prod release -n asobi_gw
+          rebar3 as prod release -n asobi_dgram
 
       - name: The gateway release carries nothing that holds credentials
         run: |
-          libs="$(ls _build/prod/rel/asobi_gw/lib | sed 's/-[0-9].*//' | sort -u)"
+          libs="$(ls _build/prod/rel/asobi_dgram/lib | sed 's/-[0-9].*//' | sort -u)"
           echo "$libs"
           for heavy in nova kura kura_postgres shigoto luerl nova_auth nova_resilience cowboy ranch; do
             if printf '%s\n' "$libs" | grep -qx "$heavy"; then
@@ -163,4 +163,4 @@ jobs:
               exit 1
             }
           done
-          test -x _build/prod/rel/asobi_gw/bin/asobi_gw
+          test -x _build/prod/rel/asobi_dgram/bin/asobi_dgram

--- a/.github/workflows/docker-publish-gateway.yml
+++ b/.github/workflows/docker-publish-gateway.yml
@@ -1,6 +1,11 @@
 name: Docker publish (gateway)
 
-# Publishes ghcr.io/widgrensit/asobi-dgram - the datagram gateway, and only that.
+# Publishes ghcr.io/widgrensit/asobi_dgram - the datagram gateway, and only that.
+#
+# Underscore, matching ghcr.io/widgrensit/asobi_engine and the Erlang naming
+# everything else here uses. It was briefly published as
+# `asobi-dgram`; that package is orphaned and should be deleted rather than
+# left to look like a second image someone could pull.
 #
 # The engine image is NOT built here. It comes from the asobi_bundle
 # meta-package, because it has to carry the full closure of first-party
@@ -48,7 +53,7 @@ jobs:
         id: meta
         uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302 # v6.2.0
         with:
-          images: ghcr.io/${{ github.repository }}-dgram
+          images: ghcr.io/${{ github.repository }}_dgram
           tags: |
             type=ref,event=branch
             type=sha,format=long
@@ -68,14 +73,14 @@ jobs:
           target: gateway
           load: true
           push: false
-          tags: asobi-dgram:guard
+          tags: asobi_dgram:guard
           cache-from: type=gha
           cache-to: type=gha,mode=max
           provenance: false
 
       - name: The image carries nothing that holds credentials
         run: |
-          libs="$(docker run --rm --entrypoint sh asobi-dgram:guard -c 'ls /app/lib' | sed 's/-[0-9].*//' | sort -u)"
+          libs="$(docker run --rm --entrypoint sh asobi_dgram:guard -c 'ls /app/lib' | sed 's/-[0-9].*//' | sort -u)"
           echo "$libs"
           for heavy in nova kura kura_postgres shigoto luerl nova_auth nova_resilience cowboy ranch; do
             if printf '%s\n' "$libs" | grep -qx "$heavy"; then

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,7 +22,7 @@ COPY include/ include/
 COPY src/ src/
 COPY apps/ apps/
 COPY priv/ priv/
-RUN rebar3 as prod release -n asobi && rebar3 as prod release -n asobi_gw
+RUN rebar3 as prod release -n asobi && rebar3 as prod release -n asobi_dgram
 
 # --- The datagram gateway image ---
 # `docker build --target gateway`. Its own image and not a role of the engine's,
@@ -41,7 +41,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 RUN groupadd -r asobi && useradd -r -g asobi -d /app asobi
 
 WORKDIR /app
-COPY --from=builder /build/_build/prod/rel/asobi_gw/ ./
+COPY --from=builder /build/_build/prod/rel/asobi_dgram/ ./
 RUN chown -R asobi:asobi /app
 
 USER asobi
@@ -50,7 +50,7 @@ EXPOSE 7777/udp
 
 ENV ASOBI_ROLE=dgram_gw \
     ASOBI_NODE_HOST=127.0.0.1 \
-    ASOBI_NODE_NAME=asobi_gw \
+    ASOBI_NODE_NAME=asobi_dgram \
     ASOBI_DGRAM_PORT=7777 \
     ASOBI_DGRAM_LINK_PORT=7778
 
@@ -60,7 +60,7 @@ ENV ASOBI_ROLE=dgram_gw \
 ENV ERLANG_COOKIE=asobi
 
 ENTRYPOINT ["tini", "--"]
-CMD ["bin/asobi_gw", "foreground"]
+CMD ["bin/asobi_dgram", "foreground"]
 
 # --- Runtime ---
 # Must match the builder's Debian release (erlang:28.4.2-slim is trixie-based)

--- a/docs/adr/0013-binary-wire-and-single-node-datagrams.md
+++ b/docs/adr/0013-binary-wire-and-single-node-datagrams.md
@@ -311,7 +311,7 @@ an application's dependencies before its start callback runs, so by the time
 credentials and `shigoto` had run migrations and started job workers. No code
 inside `start/2` can undo that. The gateway is now its own OTP application with
 its own dependency list (kernel, stdlib, crypto, telemetry, seki), its own relx
-release, and its own image - `ghcr.io/widgrensit/asobi-dgram`, built from this
+release, and its own image - `ghcr.io/widgrensit/asobi_dgram`, built from this
 repository with `docker build --target gateway`. The credentials are not in that
 container because the driver that would read them is not in it. `ASOBI_ROLE`
 still works for deployments already using it, and still carries the old flaw.

--- a/guides/configuration.md
+++ b/guides/configuration.md
@@ -306,7 +306,7 @@ before it reaches an external verification service.
 
 ## The datagram gateway
 
-Its own release and its own image, `ghcr.io/widgrensit/asobi-dgram`. It contains
+Its own release and its own image, `ghcr.io/widgrensit/asobi_dgram`. It contains
 the gateway application and its three dependencies - kernel, stdlib, telemetry,
 plus the rate limiter - and that is all: no nova, no kura, no shigoto, no Lua.
 

--- a/guides/datagram-plane.md
+++ b/guides/datagram-plane.md
@@ -66,7 +66,7 @@ Everything with authority travels only on the TLS WebSocket, in every state.
 Two containers, and two different images. The gateway binds a UDP port and
 parses packets from anyone on the internet, so it must not run your game -
 enforced by what is in the image rather than by a flag.
-`ghcr.io/widgrensit/asobi-dgram` is a release of the gateway application alone:
+`ghcr.io/widgrensit/asobi_dgram` is a release of the gateway application alone:
 no nova, no kura, no shigoto, no Lua, no HTTP listener, and no database driver to
 open a pool with.
 
@@ -127,7 +127,7 @@ echo "DGRAM_COOKIE=$(openssl rand -hex 24)"     # gateway, in your .env
 
   dgram:
     # Not the engine image with a role set - see above.
-    image: ghcr.io/widgrensit/asobi-dgram:latest
+    image: ghcr.io/widgrensit/asobi_dgram:latest
     # The engine's network namespace. On Kubernetes this is a second container in
     # the same pod, where it comes for free.
     network_mode: "service:asobi"

--- a/guides/self-hosting.md
+++ b/guides/self-hosting.md
@@ -181,7 +181,7 @@ and everything you do with it are unchanged. If you build your own release
 instead of using this image, depend on `asobi_bundle` (not bare `asobi`) to get
 the same set.
 
-`ghcr.io/widgrensit/asobi-dgram`, the [datagram gateway](#adding-the-datagram-plane),
+`ghcr.io/widgrensit/asobi_dgram`, the [datagram gateway](#adding-the-datagram-plane),
 is built from the asobi repository instead, and for the opposite reason: the
 bundle exists so an extension cannot silently vanish from the engine image, and
 the gateway must contain no extensions at all - no nova, no kura, no Lua. Its
@@ -356,7 +356,7 @@ travelling on the WebSocket, in every state, whatever happens to the plane.
 **It is two containers, and two different images.** The gateway binds a UDP port
 and parses packets from anyone on the internet, so it must not run your game -
 and "must not" here is a property of what is in the image, not of a flag it is
-started with. `ghcr.io/widgrensit/asobi-dgram` is a release containing the
+started with. `ghcr.io/widgrensit/asobi_dgram` is a release containing the
 gateway application and nothing else: no nova, no kura, no shigoto, no Lua. There
 is no HTTP listener in it, no migration to run, and no database driver to open a
 pool with.
@@ -435,7 +435,7 @@ echo "DGRAM_COOKIE=$(openssl rand -hex 24)"     # gateway, in your .env
 
   dgram:
     # Not the engine image with a role set - see above.
-    image: ghcr.io/widgrensit/asobi-dgram:latest
+    image: ghcr.io/widgrensit/asobi_dgram:latest
     network_mode: "service:asobi"
     depends_on:
       - asobi

--- a/rebar.config
+++ b/rebar.config
@@ -40,7 +40,7 @@
     %% un-start an application dependency, and the process parsing hostile UDP
     %% should not have a database driver in its image, let alone a pool
     %% (asobi#513).
-    {release, {asobi_gw, git},
+    {release, {asobi_dgram, git},
         [
             asobi_dgram_gw,
             sasl


### PR DESCRIPTION
Three names for one artifact, which is two too many:

| | before | after |
|---|---|---|
| OTP application | `asobi_dgram_gw` | `asobi_dgram_gw` |
| relx release | `asobi_gw` | `asobi_dgram` |
| image | `asobi-dgram` | `asobi_dgram` |

The hyphen was wrong twice over: Erlang names use underscores, and the org's published images do too.

The release and the image are now both `asobi_dgram`, so a self-hoster reads one name in the compose file, the Dockerfile, `bin/asobi_dgram` and the release directory.

**The OTP application keeps `_gw`,** deliberately. Inside it, `asobi_dgram` is already the codec module that both roles share, and the application is specifically the gateway half — so the suffix carries meaning there rather than noise. If you'd rather have strict 1:1 across all three, say so and I'll rename the app too; it's contained (the app.src, three module names, the closure guard and one test).

Verified after the rename: the release assembles, its closure is still exactly `asobi_dgram_gw crypto kernel sasl seki stdlib telemetry`, `bin/asobi_dgram` is present, and the application boots standalone. Both workflow files still parse.

## One cleanup outside this PR

`ghcr.io/widgrensit/asobi-dgram` was published once, by the #514 merge, before this rename. It is orphaned now and worth deleting from the registry — an image nobody should pull is worse sitting there than absent. That needs package-admin rights I don't have from here.
