### PR TITLE
fix: a latched zone tries the binary wire again, on a doubling backoff

### DIFF
--- a/guides/configuration.md
+++ b/guides/configuration.md
@@ -453,6 +453,18 @@ is correct but costs the entities in it their datagram fast path - see
 [the protocol guide](websocket-protocol.md#binary-worldtick) for what to watch
 for.
 
+A zone that cannot encode its entities at all drops to the text wire and then
+retries on a doubling backoff, starting at a minute and stopping at an hour:
+
+```erlang
+{binary_wire_retry_ms, 60000}
+```
+
+Lower it if your game legitimately produces short-lived unencodable entities and
+you would rather it recovered sooner; the cost of a retry is one refused encode
+on one broadcast tick. `0` retries on every broadcast, which is what the tests
+use and not a setting a deployment needs.
+
 What it costs while on: a zone can have subscribers on both wires, so it builds
 two buffers per broadcast instead of one. That is two encodes per zone per tick
 rather than one per subscriber, and it is paid whether or not anyone has

--- a/guides/websocket-protocol.md
+++ b/guides/websocket-protocol.md
@@ -838,9 +838,12 @@ So the server repairs it rather than leaving it to you. The frame after a refuse
 one is a **keyframe** - `kf: true`, all adds - which re-establishes every binding.
 Nothing is required of a client that already applies keyframes the way this guide
 describes. If that keyframe is refused too, the cause is the shape of the game's
-entities rather than one frame, and the zone gives the binary wire up for its
-life: every client on it falls back to text, which carries everything, and the
-datagram plane switches off with it.
+entities rather than one frame, and the zone gives the binary wire up: every
+client on it falls back to text, which carries everything, and the datagram
+plane switches off with it. The zone asks again later on a doubling backoff -
+a minute, then two, up to an hour - so an entity that was briefly unencodable
+costs a pause rather than the rest of the zone's life. A successful retry is
+itself a keyframe, so every client is rebound by it.
 
 Both outcomes are visible server-side, and neither is silent on the client's
 behalf. If a game seems to be missing the datagram plane, count the fields on its

--- a/src/world/asobi_zone.erl
+++ b/src/world/asobi_zone.erl
@@ -34,6 +34,12 @@ via `asobi_spatial`. Zones are created and reaped lazily as players move.
 %% the manager is saturated - in which case the NPC waits in this zone for a
 %% later tick rather than the zone stalling behind a 5s gen_server default.
 -define(ENSURE_ZONE_TIMEOUT, 1_000).
+%% How long a zone stays on the text wire before trying the binary one again, and
+%% the ceiling the doubling stops at. Read from the environment at zone start so a
+%% deployment whose games legitimately produce short-lived unencodable entities can
+%% ask sooner, and a test can ask immediately.
+-define(WIRE_RETRY_MS, 60_000).
+-define(WIRE_RETRY_MAX_MS, 3_600_000).
 
 %% --- Public API ---
 
@@ -272,6 +278,12 @@ init(Config) ->
             %% contiguous `frame_seq` that gives the client no reason to resync
             %% (asobi#510).
             wire_rebind => false,
+            %% `at` is when to try the binary wire again, or `undefined` for "not
+            %% latched". The backoff doubles on each failed retry (latch_to_text/5).
+            wire_retry => #{
+                at => undefined,
+                backoff => application:get_env(asobi, binary_wire_retry_ms, ?WIRE_RETRY_MS)
+            },
             %% Throttle state for the refusal warning. A zone holding one
             %% entity the encoder cannot take refuses every frame, which at 20
             %% Hz is a warning five times a second for the life of the zone.
@@ -832,17 +844,18 @@ do_tick(
         case TickN rem BroadcastInterval of
             0 ->
                 Deltas = compute_deltas(BroadcastEntities, Entities4),
+                State0 = maybe_retry_binary_wire(State),
                 {FrameSlots, Slots1} = advance_slots(
-                    maps:get(binary_wire, State),
+                    maps:get(binary_wire, State0),
                     BroadcastEntities,
                     Entities4,
-                    maps:get(slots, State)
+                    maps:get(slots, State0)
                 ),
-                Rebind = maps:get(wire_rebind, State),
+                Rebind = maps:get(wire_rebind, State0),
                 {WireSeq1, Refusal} = broadcast_deltas(
                     Coords, TickN, WireSeq, Deltas, Subs, FrameSlots, Rebind, Entities4
                 ),
-                State2 = apply_refusal(Refusal, Rebind, Coords, TickN, Deltas, State),
+                State2 = apply_refusal(Refusal, Rebind, Coords, TickN, Deltas, State0),
                 broadcast_acks(TickN, PlayerAck1, Subs),
                 PoseSeq1 = broadcast_pose(
                     Coords, TickN, State2, Deltas, Entities4, Slots1, Subs
@@ -1072,6 +1085,7 @@ apply_refusal({refused, Reason}, true, Coords, TickN, Deltas, State) ->
 -spec latch_to_text(refusal(), {integer(), integer()}, non_neg_integer(), [term()], map()) ->
     map().
 latch_to_text(Reason, Coords, TickN, Deltas, State) ->
+    #{backoff := Backoff} = Retry = maps:get(wire_retry, State),
     ?LOG_WARNING(
         maps:merge(
             #{
@@ -1079,13 +1093,51 @@ latch_to_text(Reason, Coords, TickN, Deltas, State) ->
                 coords => Coords,
                 tick => TickN,
                 field_names => distinct_field_names(Deltas),
-                widest_entity => widest_entity(Deltas)
+                widest_entity => widest_entity(Deltas),
+                retry_in_ms => Backoff
             },
             refusal_detail(Reason)
         )
     ),
     asobi_telemetry:binary_wire_refused(refusal_kind(Reason)),
-    State#{binary_wire => false, wire_rebind => false, slots => asobi_wire_slots:new()}.
+    State#{
+        binary_wire => false,
+        wire_rebind => false,
+        slots => asobi_wire_slots:new(),
+        wire_retry => Retry#{
+            at => erlang:monotonic_time(millisecond) + Backoff,
+            backoff => min(Backoff * 2, ?WIRE_RETRY_MAX_MS)
+        }
+    }.
+
+%% A latched zone tries the binary wire again, on a doubling backoff.
+%%
+%% The alternative was to latch for the zone's life, which is correct and, for a
+%% persistent world, means one entity carrying a debug field for ten seconds costs
+%% every player the datagram plane until the zone is restarted. Every refusal
+%% cause is a property of entity shape, so most latches ARE permanent - but "most"
+%% is not "all", and the zone cannot tell which it has without asking.
+%%
+%% Asking is cheap and self-limiting: one refused encode and one text frame, which
+%% is what the tick was already paying while latched. The backoff doubles to an
+%% hour so a genuinely unencodable zone settles into asking twice a day rather
+%% than flapping, and `wire_rebind` makes the retry frame a keyframe, so a
+%% successful one rebinds every client rather than stranding the slots it just
+%% allocated.
+-spec maybe_retry_binary_wire(map()) -> map().
+maybe_retry_binary_wire(#{wire_retry := #{at := At} = Retry} = State) when is_integer(At) ->
+    case erlang:monotonic_time(millisecond) >= At of
+        false ->
+            State;
+        true ->
+            State#{
+                binary_wire => true,
+                wire_rebind => true,
+                wire_retry => Retry#{at => undefined}
+            }
+    end;
+maybe_retry_binary_wire(State) ->
+    State.
 
 %% Slots are needed by the binary wire AND by the pose plane, and they are the
 %% same slots: two allocations for one zone would eventually disagree about which

--- a/test/asobi_zone_binary_wire_tests.erl
+++ b/test/asobi_zone_binary_wire_tests.erl
@@ -27,7 +27,9 @@ binary_wire_test_() ->
         {"a passing refusal is repaired by a keyframe on the next frame",
             fun refusal_is_repaired_by_a_keyframe/0},
         {"a structural refusal latches the zone to text rather than stranding slots",
-            fun structural_refusal_latches_to_text/0}
+            fun structural_refusal_latches_to_text/0},
+        {"a latched zone tries the binary wire again once the entity is gone",
+            fun latch_retries_and_recovers/0}
     ]}.
 
 setup() ->
@@ -38,8 +40,12 @@ setup() ->
     Prev = application:get_env(asobi, binary_wire),
     Prev.
 
-cleanup(undefined) -> application:unset_env(asobi, binary_wire);
-cleanup({ok, V}) -> application:set_env(asobi, binary_wire, V).
+cleanup(Prev) ->
+    application:unset_env(asobi, binary_wire_retry_ms),
+    case Prev of
+        undefined -> application:unset_env(asobi, binary_wire);
+        {ok, V} -> application:set_env(asobi, binary_wire, V)
+    end.
 
 %% --- Tests ---
 
@@ -280,4 +286,43 @@ structural_refusal_latches_to_text() ->
     asobi_zone:add_entity(Pid, ~"e1", #{~"x" => 4.0}),
     asobi_zone:tick(Pid, 4),
     ?assertMatch({zone_delta_raw, _}, recv_delta()),
+    gen_server:stop(Pid).
+
+%% Latching for the zone's life is correct and, in a persistent world, expensive:
+%% one entity carrying a debug field for ten seconds would cost every player the
+%% datagram plane until the zone restarted. So the zone asks again on a doubling
+%% backoff, and the retry frame is a keyframe - a successful one rebinds every
+%% client rather than stranding the slots it just allocated.
+latch_retries_and_recovers() ->
+    application:set_env(asobi, binary_wire, true),
+    %% Ask again on the next broadcast rather than in a minute, which is the
+    %% knob's purpose. Zero rather than a small number because these ticks run
+    %% microseconds apart and any real delay would not have elapsed.
+    application:set_env(asobi, binary_wire_retry_ms, 0),
+    Pid = start_zone(),
+    asobi_zone:subscribe(Pid, {~"p1", self()}),
+    _ = recv(),
+    asobi_zone:add_entity(Pid, ~"e1", #{~"x" => 1.0}),
+    asobi_zone:add_entity(Pid, ~"e2", #{~"x" => 2.0, ~"path" => [1, 2]}),
+    asobi_zone:tick(Pid, 1),
+    ?assertMatch({zone_delta_raw, _}, recv_delta()),
+
+    %% The rebind keyframe refuses too, so the zone latches to text.
+    asobi_zone:add_entity(Pid, ~"e1", #{~"x" => 3.0}),
+    asobi_zone:tick(Pid, 2),
+    ?assertMatch({zone_delta_raw, _}, recv_delta()),
+
+    %% The offending entity leaves. The retry window has passed, so the next
+    %% broadcast re-arms the wire and sends a keyframe rather than a delta.
+    asobi_zone:remove_entity(Pid, ~"e2"),
+    asobi_zone:tick(Pid, 3),
+    {zone_delta_raw, _Json, Bin} = recv_delta(),
+    {ok, #{kf := Kf, records := Records}} = asobi_wire:decode(Bin),
+    ?assert(Kf),
+    ?assertEqual([{add, ~"e1"}], [{Op, Id} || #{op := Op, id := Id} <- Records]),
+
+    %% ...and it stays on the binary wire afterwards.
+    asobi_zone:add_entity(Pid, ~"e1", #{~"x" => 5.0}),
+    asobi_zone:tick(Pid, 4),
+    ?assertMatch({zone_delta_raw, _, _}, recv_delta()),
     gen_server:stop(Pid).


### PR DESCRIPTION
Answers the question #512 left open: should the latch ever lift.

## The call

Latching for the zone's life is correct, and in a persistent world it is costly in a way that is easy to miss. Every refusal cause is a property of entity shape — a 33-field entity, a list-valued field — so **most** latches genuinely are permanent. But "most" is not "all", and the zone cannot tell which kind it has without asking. One entity carrying a debug field for ten seconds would otherwise cost every player in that zone both the binary wire and the datagram plane until the zone restarted.

Asking is cheap and self-limiting: one refused encode and one text frame per attempt, which is exactly what the tick was already paying while latched.

- Backoff doubles from **1 minute to a 1 hour** ceiling, so a genuinely unencodable zone settles into asking twice a day rather than flapping every tick.
- The retry frame is a **keyframe**, so a successful retry rebinds every client rather than stranding the slots it just reallocated. That falls out of the existing `wire_rebind` path rather than being new machinery.
- While a retry is pending, poses stay suppressed — the same guard that already covers the rebind window.
- `binary_wire_retry_ms` makes the first interval configurable for a game that legitimately produces short-lived unencodable entities. `0` retries on every broadcast, which is what the test uses.

## Test

`latch_retries_and_recovers` walks the whole arc: a zone with an unencodable entity refuses, refuses its rebind keyframe, latches to text — then once the entity leaves, the next broadcast re-arms the wire, sends a **keyframe** (asserted: `kf` is true and it carries the add for the surviving entity), and stays on binary afterwards.

The test sets the interval to `0` rather than a small number, because these ticks run microseconds apart and any real delay would not have elapsed — a 1ms interval failed for exactly that reason before I pinned it.

## Checks

`fmt --check` / `xref` / `dialyzer` / `elp eqwalize` (the 2 in `asobi_zone` are the pre-existing min/max clamp at lines 1708-1709) / `eunit` 2153, 0 failures / `ct` 388, 0 failures / telemetry drift.
