### PR TITLE
fix: reply from the public datagram port, not an ephemeral one

### DIFF
--- a/apps/asobi_dgram_gw/src/asobi_dgram_canary.erl
+++ b/apps/asobi_dgram_gw/src/asobi_dgram_canary.erl
@@ -7,7 +7,9 @@ failure this exists to catch: the socket stays bound as long as the process is
 alive, so "is the port open" answers a question nobody is asking. This sends a
 genuine `ping` to the gateway's own port over loopback and waits for the `pong`,
 which only comes back if the guard, the limiters, the binding table, the MAC
-check, the dispatcher and the sender are all working.
+check, the dispatcher and the sender are all working - and it checks that the
+pong came back **from the public port**, which is the one property loopback will
+otherwise hide (asobi#515).
 
 ## It uses a real binding, because a fake one would prove less
 
@@ -189,13 +191,18 @@ probe(#{socket := Socket, conn_id := ConnId, kup := KUp, cseq := CSeq} = State) 
     State1 = State#{cseq => Next},
     Target = #{family => inet, addr => loopback, port => Port},
     case socket:sendto(Socket, Ping, Target) of
-        ok -> await_pong(Socket, ConnId, State1);
+        ok -> await_pong(Socket, ConnId, Port, State1);
         {error, Reason} -> {{error, Reason}, miss(Reason, State1)}
     end.
 
-await_pong(Socket, ConnId, State) ->
+await_pong(Socket, ConnId, Port, State) ->
     case socket:recvfrom(Socket, 0, [], ?TIMEOUT_MS) of
-        {ok, {_From, Data}} ->
+        %% The source port is checked, not just the payload. Over loopback a
+        %% reply from anywhere arrives regardless, so a canary that ignored it
+        %% stayed green while every real player behind NAT was dropped
+        %% (asobi#515). This is the only place the gateway can catch that
+        %% without a second host.
+        {ok, {#{port := Port}, Data}} ->
             case asobi_dgram:decode_downlink(Data) of
                 {ok, #{opcode := pong, conn_id := ConnId}} ->
                     {ok, hit(State)};
@@ -204,6 +211,8 @@ await_pong(Socket, ConnId, State) ->
                     %% this socket, so it counts as a miss rather than a retry.
                     {{error, unexpected_reply}, miss(unexpected_reply, State)}
             end;
+        {ok, {_Elsewhere, _Data}} ->
+            {{error, wrong_source_port}, miss(wrong_source_port, State)};
         {error, Reason} ->
             {{error, Reason}, miss(Reason, State)}
     end.

--- a/apps/asobi_dgram_gw/src/asobi_dgram_gw_sup.erl
+++ b/apps/asobi_dgram_gw/src/asobi_dgram_gw_sup.erl
@@ -18,8 +18,9 @@ this gets exactly what it had.
     asobi_dgram_gw_sup  (one_for_one)
       asobi_dgram_limits    the rate-limit tiers, registered once
       asobi_dgram_table     the binding table's owner
-      asobi_dgram_sender    owns the send socket
-      asobi_dgram_rx_sup    one receiver per SO_REUSEPORT shard
+      asobi_dgram_sender    serialises the fan-out
+      asobi_dgram_rx_sup    one receiver per SO_REUSEPORT shard, and the only
+                            sockets bound to the public port
       asobi_dgram_canary    readiness, by real loopback exchange
       asobi_dgram_link_server  the engine's attachment point
 
@@ -97,7 +98,9 @@ init([]) ->
     %% a set: limiters before anything can be received, the table before a
     %% datagram can name a conn_id, and the sender before a receiver can need to
     %% answer one. The receivers come last because they are the only child that
-    %% can be handed work by someone outside the node.
+    %% can be handed work by someone outside the node - which is also why the
+    %% sender resolves its socket on first use rather than at init: it starts
+    %% before the sockets it borrows from exist.
     {ok,
         {SupFlags, [
             limits_spec(),

--- a/apps/asobi_dgram_gw/src/asobi_dgram_rx_sup.erl
+++ b/apps/asobi_dgram_gw/src/asobi_dgram_rx_sup.erl
@@ -11,12 +11,44 @@ design is worth having.
 
 -behaviour(supervisor).
 
--export([start_link/0]).
+-export([start_link/0, lend_to/1]).
 -export([init/1]).
 
 -spec start_link() -> supervisor:startlink_ret().
 start_link() ->
     supervisor:start_link({local, ?MODULE}, ?MODULE, []).
+
+-doc """
+Asks every live receiver to lend its socket to `To`, which is always the sender.
+
+The receivers are the only sockets bound to the public port, which is why this
+lives here: a reply that does not leave from the port the client sent to is
+dropped by conntrack and filtered by any SDK that `connect()`s its socket, and a
+second socket bound there purely to send would join the `SO_REUSEPORT` group and
+swallow every flow the kernel hashed onto it (asobi#515).
+
+Each shard offers its socket unprompted when it starts, so this is only for the
+case the offer cannot cover: a sender that restarted after the shards did, and
+so was not listening when they spoke. Asking all of them rather than one means
+the answer does not depend on which shard happens to be healthy. Which one wins
+does not matter - they are all bound to the same port, so the source port is the
+same whichever answers first.
+""".
+-spec lend_to(pid()) -> ok.
+lend_to(To) ->
+    try
+        lists:foreach(
+            fun
+                ({_Id, Pid, _Type, _Mods}) when is_pid(Pid) -> asobi_dgram_shard:lend_to(Pid, To);
+                (_Restarting) -> ok
+            end,
+            supervisor:which_children(?MODULE)
+        )
+    catch
+        %% No receivers yet, or the whole tree is on its way down. Either way
+        %% there is nothing to reply through and the caller drops the datagram.
+        exit:_ -> ok
+    end.
 
 -spec init([]) -> {ok, {supervisor:sup_flags(), [supervisor:child_spec()]}}.
 init([]) ->

--- a/apps/asobi_dgram_gw/src/asobi_dgram_sender.erl
+++ b/apps/asobi_dgram_gw/src/asobi_dgram_sender.erl
@@ -1,6 +1,45 @@
 -module(asobi_dgram_sender).
 -moduledoc """
-Owns the send socket and does the fan-out.
+Serialises the fan-out, and writes it through a receiver's socket.
+
+## Replies must leave from the public port
+
+A datagram sent from a socket the kernel gave an ephemeral port to never reaches
+the client (asobi#515). The client's flow is `client -> gw:7777`, so a reply
+from `gw:51426` is a different 4-tuple: conntrack will not reverse-map it, which
+breaks docker port-publishing and every player behind a home router, and any SDK
+that `connect()`s its UDP socket to the minted endpoint filters it on arrival
+anyway. The failure is silent on both ends - nothing is dropped server-side, so
+it reads exactly like a blocked firewall.
+
+Only a socket bound to that port egresses from it. But binding a second socket
+there means `SO_REUSEPORT`, and a socket in that group receives a share of the
+inbound traffic whether or not anyone reads it. The kernel hashes per 4-tuple,
+not per packet, so what a send-only socket swallows is not a fraction of every
+client's datagrams - it is every datagram of the clients that hashed onto it.
+One in `shards + 1` players would simply never complete a handshake.
+
+So this process owns no socket. Each receiver offers its own as it starts - one
+already bound to the public port and already drained - and the first offer is
+kept until a write says it is gone. A sender that restarted after the receivers
+did missed the offers, so it asks; that is the only reason `lend_to/1` exists.
+
+The socket is pushed rather than fetched because that is the only direction the
+type survives: `gen_server:call` is typed `term()` and a socket is opaque, so a
+socket pulled back through a reply cannot be narrowed to one again without an
+assertion nothing checks.
+
+The superseded rationale is worth naming because it reads plausibly: a separate
+socket was said to stop the reply's source port varying with the shard. It never
+could. Every shard is bound to the *same* port by `SO_REUSEPORT`, so the source
+port is the public port whichever one writes.
+
+## One process, though
+
+What the single owner buys is ordering, not addressing: two `send/3` calls are
+written in the order they arrived, which is what keeps `bseq` arriving in the
+order it was assigned. That is a property of the process and survives the socket
+being borrowed.
 
 ## The two-element iovec is the whole point
 
@@ -32,10 +71,15 @@ transport chosen for having none.
 
 -behaviour(gen_server).
 
--export([start_link/0, send/3, send_one/3]).
+-export([start_link/0, send/3, send_one/3, lend/1, lend/2]).
 -export([init/1, handle_call/3, handle_cast/2, terminate/2]).
 
 -type target() :: {non_neg_integer(), non_neg_integer(), asobi_dgram_binding:handle()}.
+
+-type cast() ::
+    {fanout, asobi_dgram:opcode(), binary(), [target()]}
+    | {send_one, binary(), asobi_dgram_binding:handle()}
+    | {lend, socket:socket()}.
 
 -type state() :: #{socket := socket:socket() | undefined}.
 
@@ -59,40 +103,71 @@ send(Opcode, SharedBody, Targets) ->
 send_one(Datagram, Handle, Server) ->
     gen_server:cast(Server, {send_one, Datagram, Handle}).
 
+-doc "Offers a receiver's socket to write replies through. See the module doc.".
+-spec lend(socket:socket()) -> ok.
+lend(Socket) ->
+    lend(?MODULE, Socket).
+
+-doc "As `lend/1`, to a sender named explicitly - a restarted one asking again.".
+-spec lend(pid() | atom(), socket:socket()) -> ok.
+lend(Sender, Socket) ->
+    gen_server:cast(Sender, {lend, Socket}).
+
 %% --- gen_server ---
 
--spec init([]) -> {ok, state()} | {stop, term()}.
+-spec init([]) -> {ok, state()}.
 init([]) ->
-    %% A separate socket from the receivers'. The receivers are bound with
-    %% SO_REUSEPORT and the kernel picks one per incoming flow; replies must not
-    %% depend on which of them happens to be chosen, and a shard writing to its
-    %% own socket would make the source port of a reply vary with the shard.
-    case socket:open(inet, dgram, udp) of
-        {ok, Socket} -> {ok, #{socket => Socket}};
-        {error, Reason} -> {stop, {socket_open_failed, Reason}}
-    end.
+    %% Nothing is opened here, and nothing may be asked for here either: the
+    %% receivers start after this process, so there is nobody to ask yet. They
+    %% offer as they start, and a sender that restarted asks on its first send.
+    {ok, #{socket => undefined}}.
 
 -spec handle_call(term(), gen_server:from(), state()) -> {reply, term(), state()}.
 handle_call(_Request, _From, State) -> {reply, {error, unknown_call}, State}.
 
--spec handle_cast(term(), state()) -> {noreply, state()}.
-handle_cast({fanout, Opcode, SharedBody, Targets}, #{socket := Socket} = State) ->
-    fanout(Socket, Opcode, SharedBody, Targets),
-    {noreply, State};
-handle_cast({send_one, Datagram, Handle}, #{socket := Socket} = State) ->
-    write(Socket, Handle, [Datagram]),
-    {noreply, State};
-handle_cast(_Msg, State) ->
+%% The argument is narrowed to `cast()` rather than left as `term()` on purpose:
+%% it is what makes the lent socket arrive as a `socket:socket()` instead of a
+%% `term()` nothing has checked. A socket cannot be narrowed back out of a
+%% `gen_server:call` reply, so pushing it in is the only typed direction.
+-spec handle_cast(cast(), state()) -> {noreply, state()}.
+handle_cast({fanout, Opcode, SharedBody, Targets}, State) ->
+    {noreply,
+        through_socket(State, fun(Socket) -> fanout(Socket, Opcode, SharedBody, Targets) end)};
+handle_cast({send_one, Datagram, Handle}, State) ->
+    {noreply, through_socket(State, fun(Socket) -> write(Socket, Handle, [Datagram]) end)};
+%% First offer wins. Every shard offers at boot and they are all bound to the
+%% same port, so taking the first keeps one consistent source socket without
+%% caring which shard it came from.
+handle_cast({lend, Socket}, #{socket := undefined} = State) ->
+    {noreply, State#{socket => Socket}};
+handle_cast({lend, _Socket}, State) ->
     {noreply, State}.
 
 -spec terminate(term(), state()) -> ok.
-terminate(_Reason, #{socket := undefined}) ->
-    ok;
-terminate(_Reason, #{socket := Socket}) ->
-    _ = socket:close(Socket),
+terminate(_Reason, _State) ->
+    %% The socket belongs to a receiver, which closes it with itself. Closing a
+    %% borrowed socket here would take that receiver's flows down with a process
+    %% that is merely stopping.
     ok.
 
 %% --- Internal ---
+
+%% Runs the write, and forgets the socket if the write reported it gone - a
+%% lender that restarted, or a tree on its way down. With nothing lent yet there
+%% is nothing to write through: ask, count the drop, and let the next datagram
+%% carry it. On this plane the next one always comes.
+through_socket(#{socket := undefined} = State, _Write) ->
+    ok = asobi_dgram_rx_sup:lend_to(self()),
+    asobi_dgram_telemetry:send_failed(no_socket),
+    State;
+through_socket(#{socket := Socket} = State, Write) ->
+    case Write(Socket) of
+        ok ->
+            State;
+        stale ->
+            ok = asobi_dgram_rx_sup:lend_to(self()),
+            State#{socket => undefined}
+    end.
 
 fanout(_Socket, _Opcode, _SharedBody, []) ->
     ok;
@@ -100,8 +175,12 @@ fanout(Socket, Opcode, SharedBody, [{ConnId, PathTag, Handle} | Rest]) ->
     Prefix = asobi_dgram:prefix(#{opcode => Opcode, conn_id => ConnId, path_tag => PathTag}),
     %% Two elements, never one concatenated binary: the body is referenced here,
     %% and joining them would copy it once per subscriber.
-    write(Socket, Handle, [Prefix, SharedBody]),
-    fanout(Socket, Opcode, SharedBody, Rest).
+    case write(Socket, Handle, [Prefix, SharedBody]) of
+        ok -> fanout(Socket, Opcode, SharedBody, Rest);
+        %% The socket is gone, not this subscriber. Carrying on would emit one
+        %% telemetry event per remaining subscriber for a single fault.
+        stale -> stale
+    end.
 
 write(Socket, Handle, IoData) ->
     case socket:sendto(Socket, iolist_to_binary(IoData), Handle) of
@@ -112,5 +191,12 @@ write(Socket, Handle, IoData) ->
             %% supersedes this one, which is the property that made this plane
             %% worth having.
             asobi_dgram_telemetry:send_failed(Reason),
-            ok
+            lender_gone(Reason)
     end.
+
+%% Only the errors that mean the borrowed socket itself is finished. Everything
+%% else - a full buffer, an unreachable peer - is about this one datagram, and
+%% dropping the socket over it would re-resolve on every send under load.
+lender_gone(closed) -> stale;
+lender_gone(ebadf) -> stale;
+lender_gone(_Reason) -> ok.

--- a/apps/asobi_dgram_gw/src/asobi_dgram_shard.erl
+++ b/apps/asobi_dgram_gw/src/asobi_dgram_shard.erl
@@ -27,7 +27,7 @@ the cap is what turns "responsive unless attacked" into "responsive".
 
 -behaviour(gen_server).
 
--export([start_link/2]).
+-export([start_link/2, lend_to/2]).
 -export([init/1, handle_call/3, handle_cast/2, handle_continue/2, handle_info/2, terminate/2]).
 
 %% Datagrams per drain pass. Big enough that the common case costs one select
@@ -40,6 +40,23 @@ the cap is what turns "responsive unless attacked" into "responsive".
 -spec start_link(non_neg_integer(), inet:port_number()) -> gen_server:start_ret().
 start_link(Index, Port) ->
     gen_server:start_link(?MODULE, {Index, Port}, []).
+
+-doc """
+Asks this shard to lend its socket to `To`, which is always the sender.
+
+Lending rather than letting the sender open its own socket is what keeps replies
+egressing from the public port without adding a socket to the `SO_REUSEPORT`
+group that nobody reads (asobi#515). Only this process reads it; only the sender
+writes to it, and the two directions do not contend.
+
+The socket is **pushed**, never fetched. A `gen_server:call` returns `term()`, so
+a socket pulled across the boundary arrives untyped and the spec claiming
+otherwise would be checked by nothing; pushed into a callback whose spec names
+the type, it stays a `socket:socket()` the whole way.
+""".
+-spec lend_to(pid(), pid()) -> ok.
+lend_to(Shard, To) ->
+    gen_server:cast(Shard, {lend_to, To}).
 
 -spec init({non_neg_integer(), inet:port_number()}) ->
     {ok, state(), {continue, recv}} | {stop, term()}.
@@ -56,11 +73,21 @@ init({Index, Port}) ->
 handle_call(_Request, _From, State) -> {reply, {error, unknown_call}, State}.
 
 -spec handle_cast(term(), state()) -> {noreply, state()}.
-handle_cast(drain, State) -> drain(State);
-handle_cast(_Msg, State) -> {noreply, State}.
+handle_cast(drain, State) ->
+    drain(State);
+handle_cast({lend_to, To}, #{socket := Socket} = State) when is_pid(To) ->
+    asobi_dgram_sender:lend(To, Socket),
+    {noreply, State};
+handle_cast(_Msg, State) ->
+    {noreply, State}.
 
 -spec handle_continue(recv, state()) -> {noreply, state()} | {stop, term(), state()}.
-handle_continue(recv, State) -> drain(State).
+handle_continue(recv, #{socket := Socket} = State) ->
+    %% Offered before the first datagram can need answering, so the reply path is
+    %% ready without the sender having to ask. The sender keeps the first offer
+    %% it gets and ignores the rest.
+    asobi_dgram_sender:lend(Socket),
+    drain(State).
 
 -spec handle_info(term(), state()) -> {noreply, state()} | {stop, term(), state()}.
 %% The socket is ready again. Nothing in the message is needed beyond the fact

--- a/guides/datagram-plane.md
+++ b/guides/datagram-plane.md
@@ -272,6 +272,25 @@ on before you have tested every player's network.
 **The WebSocket carries everything in every state.** There is no state in which
 correctness depends on this plane.
 
+### If it never leaves probing
+
+A blocked firewall and a reply that never arrives look identical from the client,
+and both end as three probes and a fall back to the WebSocket. Server-side
+telemetry cannot tell them apart either: nothing is dropped, so
+`asobi.dgram.dropped` stays at zero in both cases.
+
+Capture on the gateway and compare the ports:
+
+```
+tcpdump -ni any udp port 7777
+```
+
+Every reply must leave from the port the client sent to. A reply from any other
+source port is dropped by NAT on the way back, and filtered by SDKs that
+`connect()` their socket even when it does arrive. Gateways up to and including
+v0.92.3 sent from an ephemeral port and hit exactly this; upgrade rather than
+reconfigure.
+
 ### Poses need the binary wire; input does not
 
 A pose record carries a slot and nothing else, and the only frame that binds a

--- a/test/asobi_dgram_socket_tests.erl
+++ b/test/asobi_dgram_socket_tests.erl
@@ -27,6 +27,21 @@ socket_test_() ->
             fun(Ctx) ->
                 {"a malformed datagram is answered with silence", fun() -> garbage_silent(Ctx) end}
             end,
+            fun(Ctx) ->
+                {"every reply leaves from the public port", fun() ->
+                    replies_from_public_port(Ctx)
+                end}
+            end,
+            fun(Ctx) ->
+                {"the gateway binds no socket a receiver is not draining", fun() ->
+                    no_undrained_socket(Ctx)
+                end}
+            end,
+            fun(Ctx) ->
+                {"a sender that restarted after the receivers still answers", fun() ->
+                    sender_recovers_after_restart(Ctx)
+                end}
+            end,
             fun(_Ctx) ->
                 {"the canary proves the gateway by talking to it", fun canary_probes/0}
             end,
@@ -73,9 +88,93 @@ shards_share(_Ctx) ->
     ?assertEqual(3, length(Children)),
     ?assert(lists:all(fun({_, Pid, _, _}) -> is_pid(Pid) end, Children)).
 
+%% A reply that does not leave from the public port never reaches a real client:
+%% conntrack will not reverse-map a different 4-tuple, and an SDK that connect()s
+%% its socket filters it on arrival. This suite could not see that, because
+%% `recv/1` discarded the source (asobi#515).
+%%
+%% Connected, deliberately - that is what the Godot SDK does, so a reply from the
+%% wrong port is not merely wrong here, it never arrives at all. The assertion is
+%% a timeout, which is exactly what the player saw.
+replies_from_public_port(#{port := Port}) ->
+    {ok, Client} = socket:open(inet, dgram, udp),
+    ok = socket:connect(Client, #{family => inet, addr => loopback, port => Port}),
+    try
+        ok = socket:send(Client, uplink(hello, 1, <<>>)),
+        {ok, #{opcode := hello_ok, body := Challenge}} = decode(connected_recv(Client), hello_ok),
+
+        ok = socket:send(Client, uplink(hello_confirm, 2, Challenge)),
+        wait_until(fun() -> asobi_dgram_table:sendable(?CONN) =/= error end),
+
+        ok = socket:send(Client, uplink(ping, 3, <<7:64>>)),
+        {ok, #{opcode := pong}} = decode(connected_recv(Client), pong)
+    after
+        _ = socket:close(Client)
+    end.
+
+%% The fix that looks obvious and is wrong: bind a second, send-only socket to
+%% the public port with SO_REUSEPORT. It joins the receive group, and the kernel
+%% hashes per 4-tuple rather than per packet - so what it swallows is not a share
+%% of everyone's datagrams but every datagram of the clients that hashed onto it.
+%% One player in `shards + 1` would never complete a handshake.
+%%
+%% Distinct source ports are the only thing that catches this. A single client
+%% hashes to one socket and passes or fails by luck; twenty-four make the odds of
+%% missing an undrained socket among three shards about one in a thousand.
+no_undrained_socket(#{port := Port}) ->
+    [
+        begin
+            ConnId = 700_000 + N,
+            ok = asobi_dgram_table:register(binding(ConnId)),
+            {ok, C} = socket:open(inet, dgram, udp),
+            ok = socket:bind(C, #{family => inet, addr => loopback, port => 0}),
+            ok = send(C, Port, uplink(ConnId, hello, 1, <<>>)),
+            case recv(C) of
+                {ok, From, _Data} -> ?assertEqual(Port, maps:get(port, From));
+                timeout -> erlang:error({flow_never_answered, N, ConnId})
+            end,
+            _ = socket:close(C)
+        end
+     || N <- lists:seq(1, 24)
+    ].
+
+%% The receivers offer their sockets as they start, which covers a normal boot
+%% because they start after the sender. A sender that crashed and came back later
+%% missed every offer, so it has to ask - and if it does not, the gateway is mute
+%% from then on with nothing server-side to say so.
+sender_recovers_after_restart(#{client := Client, port := Port}) ->
+    Pid = sender_pid(),
+    Ref = monitor(process, Pid),
+    exit(Pid, kill),
+    receive
+        {'DOWN', Ref, process, Pid, _} -> ok
+    after 5000 -> error(sender_did_not_die)
+    end,
+    wait_until(fun() ->
+        case whereis(asobi_dgram_sender) of
+            New when is_pid(New) -> New =/= Pid;
+            _NotYet -> false
+        end
+    end),
+
+    %% Retried the way a client's probe ladder would: the datagram that finds no
+    %% socket is the one that asks for it, so the answer arrives for the next.
+    ok = send(Client, Port, uplink(hello, 1, <<>>)),
+    From =
+        case recv(Client) of
+            {ok, First, _} ->
+                First;
+            timeout ->
+                ok = send(Client, Port, uplink(hello, 2, <<>>)),
+                {ok, Second, _} = recv(Client),
+                Second
+        end,
+    ?assertEqual(Port, maps:get(port, From)).
+
 handshake(#{client := Client, port := Port}) ->
     ok = send(Client, Port, uplink(hello, 1, <<>>)),
-    {ok, Reply} = recv(Client),
+    {ok, HelloFrom, Reply} = recv(Client),
+    ?assertEqual(Port, maps:get(port, HelloFrom)),
     {ok, #{opcode := hello_ok, conn_id := ?CONN, body := Challenge}} =
         asobi_dgram:decode_downlink(Reply),
 
@@ -94,7 +193,8 @@ handshake(#{client := Client, port := Port}) ->
     %% ping answers, and the answer is not larger than the question.
     Ping = uplink(ping, 3, <<42:64>>),
     ok = send(Client, Port, Ping),
-    {ok, Pong} = recv(Client),
+    {ok, PongFrom, Pong} = recv(Client),
+    ?assertEqual(Port, maps:get(port, PongFrom)),
     ?assert(byte_size(Pong) =< byte_size(Ping)),
     ?assertMatch({ok, #{opcode := pong}}, asobi_dgram:decode_downlink(Pong)).
 
@@ -131,7 +231,9 @@ canary_detects_wedge() ->
     ?assertEqual(ok, asobi_dgram_canary:probe_now()),
     ?assert(asobi_dgram_canary:ready()),
 
-    %% Take the receive side away without touching the canary or the sender.
+    %% Take the receive side away. Since the sender writes through a receiver's
+    %% socket, this now silences the reply path too - which is the honest result:
+    %% there is no socket left that could answer while nothing is being read.
     ok = supervisor:terminate_child(asobi_dgram_gw_sup, asobi_dgram_rx_sup),
 
     ?assertMatch({error, _}, asobi_dgram_canary:probe_now()),
@@ -146,11 +248,29 @@ canary_detects_wedge() ->
 send(Client, Port, Data) ->
     socket:sendto(Client, Data, #{family => inet, addr => loopback, port => Port}).
 
+%% The source is returned, not discarded. Throwing it away is what let a reply
+%% from an ephemeral port pass every assertion in this file (asobi#515).
 recv(Client) ->
     case socket:recvfrom(Client, 0, [], 500) of
-        {ok, {_From, Data}} -> {ok, Data};
+        {ok, {From, Data}} -> {ok, From, Data};
         {error, timeout} -> timeout
     end.
+
+connected_recv(Client) ->
+    socket:recv(Client, 0, 500).
+
+sender_pid() ->
+    case whereis(asobi_dgram_sender) of
+        Pid when is_pid(Pid) -> Pid;
+        _ -> error(sender_not_running)
+    end.
+
+decode({ok, Data}, _Expected) ->
+    asobi_dgram:decode_downlink(Data);
+decode({error, timeout}, Expected) ->
+    %% The shape of the bug: the gateway generated the reply and the kernel
+    %% refused to hand it over, because its source was not the endpoint.
+    erlang:error({no_reply_reached_a_connected_client, Expected}).
 
 wait_until(Pred) -> wait_until(Pred, 50).
 
@@ -173,13 +293,16 @@ free_port() ->
     Port.
 
 uplink(Opcode, CSeq, Body) ->
+    uplink(?CONN, Opcode, CSeq, Body).
+
+uplink(ConnId, Opcode, CSeq, Body) ->
     Pad =
         case Opcode of
             hello -> asobi_dgram:min_hello();
             _ -> 0
         end,
     asobi_dgram:encode_uplink(
-        #{opcode => Opcode, conn_id => ?CONN, cseq => CSeq, body => Body}, ?KUP, Pad
+        #{opcode => Opcode, conn_id => ConnId, cseq => CSeq, body => Body}, ?KUP, Pad
     ).
 
 binding(ConnId) ->


### PR DESCRIPTION
Closes #515.

## The bug

`asobi_dgram_sender` opened its socket with `socket:open(inet, dgram, udp)` and never bound it, so the kernel assigned an ephemeral port on first send. Every `hello_ok` and every pose left from there rather than from the port the client sent to.

The reply reaches nobody. The outbound flow is `client -> :7777`, so a reply from `:51426` is a different 4-tuple that conntrack will not reverse-map, and an SDK that `connect()`s its UDP socket filters it on arrival regardless. Mint succeeds, the MAC verifies, the reply is generated, and the plane still never leaves `PROBING` - indistinguishable from a blocked firewall, with `asobi.dgram.dropped` at zero because nothing is dropped server-side.

## Why not just bind it with SO_REUSEPORT

That is what the issue proposes and it fixes the source port, but it introduces a worse fault: a socket in a `SO_REUSEPORT` group receives a share of the inbound traffic whether or not anyone reads it.

I measured the distribution rather than assuming it. Three sockets in a group, 60 datagrams from one source: `[0, 0, 60]`. The kernel hashes per 4-tuple, not per packet, so a send-only socket would not swallow a fraction of everyone's datagrams - it would swallow **every** datagram of the clients that hashed onto it. One player in `shards + 1` would never connect at all, and the symptom would be identical to the bug being fixed.

## The fix

The sender stops owning a socket. Each receiver offers its own as it starts - already bound to the public port, already drained - and the sender keeps the first offer until a write reports it gone. A sender that restarted after the receivers missed the offers, so it asks; that is the only reason `asobi_dgram_rx_sup:lend_to/1` exists.

The socket is **pushed, never fetched**. `gen_server:call` is typed `term()` and `socket:socket()` is opaque, so a socket pulled back through a reply cannot be narrowed to one again without an assertion nothing checks. Pushed into a callback whose spec names the type, it stays typed the whole way - which is why `asobi_dgram_sender:handle_cast/2` now takes a narrowed `cast()` rather than `term()`.

The rationale this replaces was wrong on its own terms. The old comment said a separate socket stopped the reply's source port varying with the shard. It never could: `SO_REUSEPORT` binds every shard to the same port, so the source port is the public port whichever one writes.

## Why nothing caught it

Both the canary and the real-socket suite discarded the source of the datagrams they received. Both now check it:

- `asobi_dgram_canary` asserts the pong came back from the public port. Over loopback a reply from anywhere arrives regardless, so this is the only place the gateway can catch this without a second host.
- `asobi_dgram_socket_tests:recv/1` returns the source instead of dropping it, and `handshake` asserts it.

New tests:
- **every reply leaves from the public port** - uses a *connected* client socket, the way the Godot SDK does, so a reply from the wrong port never arrives. The assertion is a timeout, which is exactly what the player saw.
- **the gateway binds no socket a receiver is not draining** - 24 distinct source ports, because a single client hashes to one socket and would pass or fail by luck.
- **a sender that restarted after the receivers still answers** - covers the ask-back path.

Verified against the pre-fix behaviour: 5 of 8 tests in the suite fail, including all three assertions above.

## Checks

`fmt`, `xref`, `dialyzer`, `elp eqwalize-all` (363 errors with and without this change - no regression, changed modules clean), `elp lint` (changed files clean), `eunit` 2155/0, `ct` 388/0, `fmt --check`, `ex_doc` (no new warnings). `rebar3 mutate` skipped - the plugin is not in this project.

Docs: `guides/datagram-plane.md` gains a short "If it never leaves probing" section, because operators on v0.92.3 and earlier saw this and had every reason to blame their firewall.
