### PR TITLE
fix: prevent guest_auth from being silently overwritten for erlang-based games

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -92,8 +92,9 @@ ENV ASOBI_PORT=8084 \
     ASOBI_DB_PASSWORD=postgres
 
 # Anonymous guest auth (POST /api/v1/auth/guest) is off by default. The game
-# opts in with `guest_auth = true` in its Lua; the operator only supplies the
-# secret pepper (ADR 0004). Guest auth is on iff both are set. Use a base64/hex
+# opts in with `guest_auth = true` in its Lua, or the operator does it in a
+# mounted sys.config, which wins when set (ADR 0011); the operator always
+# supplies the secret pepper (ADR 0004). Guest auth is on iff both are set. Use a base64/hex
 # pepper from >= 32 random bytes (NOT raw /dev/urandom bytes, whose quotes/
 # newlines would break the rendered config):  openssl rand -base64 48
 # A pepper under 32 bytes is treated as unconfigured, so guest auth fails closed.

--- a/Dockerfile
+++ b/Dockerfile
@@ -93,7 +93,7 @@ ENV ASOBI_PORT=8084 \
 
 # Anonymous guest auth (POST /api/v1/auth/guest) is off by default. The game
 # opts in with `guest_auth = true` in its Lua, or the operator does it in a
-# mounted sys.config, which wins when set (ADR 0011); the operator always
+# mounted sys.config, which wins when set (ADR 0014); the operator always
 # supplies the secret pepper (ADR 0004). Guest auth is on iff both are set. Use a base64/hex
 # pepper from >= 32 random bytes (NOT raw /dev/urandom bytes, whose quotes/
 # newlines would break the rendered config):  openssl rand -base64 48

--- a/docs/adr/0004-guest-auth-declared-by-game-pepper-by-operator.md
+++ b/docs/adr/0004-guest-auth-declared-by-game-pepper-by-operator.md
@@ -41,6 +41,9 @@ Split the toggle from the secret.
   must not be committed to a bundle.
 - **The `ASOBI_GUEST_AUTH` env var is removed.** Operator control collapses into
   "is a pepper present?", so a separate flag is redundant.
+  **Amended by ADR 0014**, which gives the operator a `guest_auth` key in
+  `sys.config` that outranks the game's declaration in both directions. A
+  deployment with no game script had no way to turn guest auth on.
 - `guest_enabled/0` is unchanged: **guest auth is on iff the game declared
   `guest_auth` AND the operator supplied a valid pepper.**
 
@@ -56,7 +59,9 @@ Split the toggle from the secret.
 - **Per-env control via pepper presence.** The same bundle deploys to dev and
   prod; dev has no pepper (off), prod/demo has one (on). Per-environment
   behaviour without the toggle being per-env.
-- **One operator lever.** The operator's only control is whether a valid pepper is
+- **One operator lever.** (Superseded by ADR 0014: there are now two, and the
+  flag is the non-destructive one - withdrawing a pepper invalidates every
+  existing guest.) The operator's only control is whether a valid pepper is
   present for a deployment; there is no separate flag to coordinate. How the pepper
   is supplied - an env var a self-hoster sets, or automated provisioning on a
   managed host - is outside this decision and out of scope for this library.

--- a/docs/adr/0006-core-owns-the-game-config-write-path.md
+++ b/docs/adr/0006-core-owns-the-game-config-write-path.md
@@ -64,6 +64,11 @@ without touching auth posture at runtime.
 `guest_auth` is replaced rather than merged: it is the game's half of ADR
 0004's two-key AND, and the operator's half is the pepper, not the flag.
 
+**Amended by ADR 0014.** `guest_auth` is two layers in two keys as well, for
+the reason this ADR gives for the modes: a derived value and an operator's
+value cannot share a key. The loader writes `script_guest_auth`, and
+`asobi_game_config:guest_auth/0` composes it with the operator's `guest_auth`.
+
 ## Consequences
 
 - **A removed mode is actually removed.** The script layer is a replacement, so

--- a/docs/adr/0014-operator-layer-for-guest-auth.md
+++ b/docs/adr/0014-operator-layer-for-guest-auth.md
@@ -1,0 +1,110 @@
+# ADR 0014: An operator layer over the game's guest-auth declaration
+
+Date: 2026-08-19
+
+## Status
+
+Accepted.
+
+Amends ADR 0004 (which removed operator control of the flag) and ADR 0006
+(which recorded `guest_auth` as replaced rather than layered).
+
+## Context
+
+ADR 0004 made `guest_auth` a game global and gave the operator a single lever:
+supply a pepper, or do not. ADR 0006 kept that shape while moving the write
+into `asobi_game_config`. Both assumed the game declares and the operator
+consents.
+
+A deployment that embeds asobi as an Erlang library breaks the assumption. It
+ships no Lua bundle, so there is no script to declare anything, and
+`asobi_lua_config:declared_config/1` derives `guest_auth => false` from the
+missing entry point. That value was written to the same key the operator uses,
+by an `asobi_sup` child, on every boot. `{guest_auth, true}` in `sys.config`
+was therefore overwritten during the start that read it, with no error and no
+warning, and `POST /api/v1/auth/guest` answered `403 guest.disabled` for ever
+(asobi#494).
+
+The operator lever ADR 0004 left in place did not help. The pepper is an AND,
+so it can only keep guest auth off; nothing could turn it on for a deployment
+with no game script to declare it.
+
+The `false` write is not itself the bug and cannot simply be dropped. It is
+what resets a stale `true` when a bundle is replaced by one that no longer
+declares the global. The bug is that a derived value and an operator's value
+shared one key.
+
+## Decision
+
+**Two keys and one reader, the way ADR 0006 already split the mode registry.**
+
+1. `guest_auth` - the operator layer, from `sys.config`. asobi never writes it.
+2. `script_guest_auth` - the script layer, what the currently loaded game
+   declares. `apply_config/1` replaces it wholesale, including the `false` a
+   missing or broken bundle derives.
+
+`asobi_game_config:guest_auth/0` composes them. **The operator layer wins on
+key presence, not on truth**: an operator `false` pins guest auth off against a
+bundle declaring `true`, and an operator `true` survives a boot with no bundle
+at all. Only omitting the key defers to the game.
+
+| `guest_auth` | `script_guest_auth` | effective |
+| --- | --- | --- |
+| `true` | anything | `true` |
+| `false` | anything | `false` |
+| unset | `true` | `true` |
+| unset | `false` or unset | `false` |
+
+Anything that is not a boolean in the operator key pins guest auth off and does
+not fall through to the game, so a typo cannot open the endpoint.
+
+**The pepper AND is unchanged.** `asobi_guest_controller:enabled/0` is the one
+place the whole gate is written down: the composed flag AND a pepper of at
+least 32 bytes. ADR 0004's mutual consent still holds in the direction that
+matters - a game author cannot open an unauthenticated endpoint on an
+operator's infrastructure, because the operator can pin the flag off as well as
+withhold the pepper.
+
+## Alternatives rejected
+
+**Let the game win, and give it a third state.** `read_global_bool/2` already
+distinguishes "absent" from `false`; the loader collapses the two. Keeping the
+distinction and letting a declared value outrank `sys.config` would fix
+asobi#494 just as well, and it is the more natural reading of "the game
+declares its own posture".
+
+It fails wherever the person who writes the game and the person who runs the
+server are not the same person. ADR 0004 assumed the operator could always
+decline by withholding a pepper, but that is not a usable veto: the verifier is
+keyed on the pepper, so withdrawing one leaves every existing guest unable to
+authenticate. An operator who wants to close an unauthenticated endpoint needs
+something reversible that a bundle cannot overrule, and the flag is it. On a
+single-operator self-host the two models are indistinguishable anyway, so the
+choice costs that deployment nothing.
+
+**Keep one key and move the config load earlier in `asobi_sup`.** Changes what
+every core child sees at boot in order to fix one key, and still leaves a
+derived value and an operator's value fighting over it.
+
+## Consequences
+
+- **A pure-Erlang deployment can turn guest auth on.** The reported case works:
+  `{guest_auth, true}` plus a pepper, no Lua anywhere.
+- **The operator gains a kill switch.** `{guest_auth, false}` stops the
+  endpoint without touching the pepper, so existing guests stay
+  authenticatable. Note it also stops `asobi_guest_reaper` sweeping, since the
+  reaper reads the same composed flag: retention pauses while the feature is
+  off. `POST /api/v1/ops/players/guests/purge` is the manual lever meanwhile.
+- **An existing `{guest_auth, ...}` in a `sys.config` becomes authoritative on
+  upgrade.** It previously did nothing whenever a bundle loaded, so a key left
+  behind after an experiment now decides the posture. Release-note material.
+- **`guest_auth` is no longer the whole picture.** Anything reading the raw
+  app-env key sees only the operator layer, exactly as ADR 0006 warned for
+  `game_modes`. In-tree readers go through `asobi_game_config:guest_auth/0`;
+  out-of-tree code must do the same. A loader that writes the raw key is now
+  writing the operator's answer, and no later load can clear it.
+- **The lever exists only where a `sys.config` is written.** A deployment that
+  generates its configuration has to set the key deliberately; leaving it unset
+  keeps the previous behaviour, where the game's declaration decides.
+- **`registration` and `guest_auth` now layer identically**, and both differ
+  from `modes/0` only in that a boolean has no per-key merge to do.

--- a/src/asobi_game_config.erl
+++ b/src/asobi_game_config.erl
@@ -26,16 +26,16 @@ reload can redefine or drop it. Every reader goes through `modes/0`.
 
 ## guest_auth is a second layer too
 
-`guest_auth` is the game's half of ADR 0004's two-key AND (the operator owns
-the pepper). A declared value replaces the script layer wholesale, in
-`script_guest_auth`, and never lands in `guest_auth` - the operator's key from
-`sys.config`. `guest_auth/0` composes the two the way `modes/0` does, except
-that the operator layer wins on key *presence* rather than on truth: an
-operator `false` pins guest auth off against a bundle that declares `true`, and
-an operator `true` survives a boot with no bundle at all. Before ADR 0011 there
-was no operator layer, and the loader's unconditional write meant a release
-embedding asobi with no Lua bundle had its `{guest_auth, true}` silently
-overwritten with `false` on every boot.
+A declared value replaces the script layer wholesale, in `script_guest_auth`,
+and never lands in `guest_auth` - the operator's key from `sys.config`.
+`guest_auth/0` composes them the way `m:asobi_registration` layers the signup
+posture (ADR 0014).
+
+The surprising part, and the reason this is not "the operator overrides a
+true": for a boolean, **unset and `false` are different**. `false` is an
+operator veto, absent is a deferral to the game. So an operator `false` pins
+guest auth off against a bundle declaring `true`, and an operator `true`
+survives a boot with no bundle at all.
 
 It is written before the modes so a reader waking on the mode change already
 sees the final auth posture.
@@ -72,12 +72,13 @@ auth posture at runtime.
 modes() ->
     maps:merge(env_modes(script_game_modes), env_modes(game_modes)).
 
--doc "The effective guest-auth flag: the operator's key when set, else the script's.".
+-doc "The effective guest-auth flag: the operator's key when set, else the game's.".
 -spec guest_auth() -> boolean().
 guest_auth() ->
     case application:get_env(asobi, guest_auth) of
-        undefined -> application:get_env(asobi, script_guest_auth, false) =:= true;
-        {ok, Value} -> Value =:= true
+        {ok, Value} when is_boolean(Value) -> Value;
+        {ok, _} -> false;
+        undefined -> application:get_env(asobi, script_guest_auth) =:= {ok, true}
     end.
 
 -doc "Apply a declared game config. The only supported writer of these keys.".

--- a/src/asobi_game_config.erl
+++ b/src/asobi_game_config.erl
@@ -24,12 +24,21 @@ so neither source can clobber the other:
 layer on top. An operator mode therefore wins a name clash, and no bundle
 reload can redefine or drop it. Every reader goes through `modes/0`.
 
-## guest_auth is replaced, not merged
+## guest_auth is a second layer too
 
 `guest_auth` is the game's half of ADR 0004's two-key AND (the operator owns
-the pepper), so a declared value simply replaces the current flag. It is
-written before the modes so a reader waking on the mode change already sees
-the final auth posture.
+the pepper). A declared value replaces the script layer wholesale, in
+`script_guest_auth`, and never lands in `guest_auth` - the operator's key from
+`sys.config`. `guest_auth/0` composes the two the way `modes/0` does, except
+that the operator layer wins on key *presence* rather than on truth: an
+operator `false` pins guest auth off against a bundle that declares `true`, and
+an operator `true` survives a boot with no bundle at all. Before ADR 0011 there
+was no operator layer, and the loader's unconditional write meant a release
+embedding asobi with no Lua bundle had its `{guest_auth, true}` silently
+overwritten with `false` on every boot.
+
+It is written before the modes so a reader waking on the mode change already
+sees the final auth posture.
 
 ## registration is a second layer, like the modes
 
@@ -47,7 +56,7 @@ auth posture at runtime.
 
 -include_lib("kernel/include/logger.hrl").
 
--export([apply_config/1, modes/0]).
+-export([apply_config/1, modes/0, guest_auth/0]).
 
 -type modes() :: #{binary() => map() | module()}.
 -type config() :: #{
@@ -63,6 +72,14 @@ auth posture at runtime.
 modes() ->
     maps:merge(env_modes(script_game_modes), env_modes(game_modes)).
 
+-doc "The effective guest-auth flag: the operator's key when set, else the script's.".
+-spec guest_auth() -> boolean().
+guest_auth() ->
+    case application:get_env(asobi, guest_auth) of
+        undefined -> application:get_env(asobi, script_guest_auth, false) =:= true;
+        {ok, Value} -> Value =:= true
+    end.
+
 -doc "Apply a declared game config. The only supported writer of these keys.".
 -spec apply_config(config()) -> ok.
 apply_config(Config) ->
@@ -72,7 +89,7 @@ apply_config(Config) ->
 
 -spec write_guest_auth(config()) -> ok.
 write_guest_auth(#{guest_auth := Declared}) when is_boolean(Declared) ->
-    application:set_env(asobi, guest_auth, Declared);
+    application:set_env(asobi, script_guest_auth, Declared);
 write_guest_auth(_) ->
     ok.
 

--- a/src/asobi_guest_reaper.erl
+++ b/src/asobi_guest_reaper.erl
@@ -170,7 +170,7 @@ schedule() ->
 
 -spec run_sweep() -> non_neg_integer().
 run_sweep() ->
-    GuestAuth = application:get_env(asobi, guest_auth, false),
+    GuestAuth = asobi_game_config:guest_auth(),
     case application:get_env(asobi, guest_reap_after, undefined) of
         Seconds when GuestAuth =:= true, is_integer(Seconds), Seconds > 0 ->
             Cutoff = subtract_seconds(erlang:universaltime(), Seconds),

--- a/src/asobi_sup.erl
+++ b/src/asobi_sup.erl
@@ -111,7 +111,7 @@ dgram_link_children() ->
 %% the mode registry in its own init/1 (via scan/0), so the load has to precede
 %% asobi_lua_sup. Nothing reads the auth posture at boot any more -
 %% asobi_guest_reaper reads it when a sweep runs (asobi#327), the guest
-%% controller per request - and since ADR 0011 the load cannot overwrite an
+%% controller per request - and since ADR 0014 the load cannot overwrite an
 %% operator's `guest_auth` at all, because it writes the script layer. Moving
 %% the load earlier is still a real behaviour change and belongs in its own PR.
 lua_game_config_spec() ->

--- a/src/asobi_sup.erl
+++ b/src/asobi_sup.erl
@@ -103,12 +103,17 @@ dgram_link_children() ->
 %% The asobi_lua merge: asobi_lua used to be its own OTP application, whose
 %% start callback loaded the Lua game config and then started asobi_lua_sup.
 %% That application started AFTER asobi, so the config load landed after every
-%% asobi_sup child was already up - asobi_guest_reaper in particular reads
-%% `guest_auth` in start_link/0, and read it before asobi_lua_config could set
-%% it. Keeping these two entries last preserves that order exactly (core
-%% children -> config load -> Lua children) rather than quietly changing what
-%% the core sees at boot. Moving the load earlier is a real behaviour change
-%% and belongs in its own PR.
+%% asobi_sup child was already up. Keeping these two entries last preserves
+%% that order exactly (core children -> config load -> Lua children) rather
+%% than quietly changing what the core sees at boot.
+%%
+%% What still depends on the order, concretely: asobi_lua_config_watcher reads
+%% the mode registry in its own init/1 (via scan/0), so the load has to precede
+%% asobi_lua_sup. Nothing reads the auth posture at boot any more -
+%% asobi_guest_reaper reads it when a sweep runs (asobi#327), the guest
+%% controller per request - and since ADR 0011 the load cannot overwrite an
+%% operator's `guest_auth` at all, because it writes the script layer. Moving
+%% the load earlier is still a real behaviour change and belongs in its own PR.
 lua_game_config_spec() ->
     #{
         id => asobi_lua_config,

--- a/src/controllers/asobi_guest_controller.erl
+++ b/src/controllers/asobi_guest_controller.erl
@@ -11,7 +11,7 @@
 %% Opt-in: disabled unless `asobi_game_config:guest_auth/0` is true AND a
 %% `guest_verifier_pepper` is configured; both missing/false fail closed. The
 %% flag itself has two layers, the operator's `sys.config` key over the game's
-%% declaration (ADR 0011). Upgrade to a real account:
+%% declaration (ADR 0014). Upgrade to a real account:
 %% POST /auth/guest/upgrade (username+password, revokes the device verifier) or
 %% the existing /auth/link path (OAuth). Guardian + beam-security-reviewer gate.
 %%
@@ -20,7 +20,7 @@
 %% account is not a guest-shaped problem. A guest is just the case with no
 %% credential to re-confirm (asobi#419).
 
--export([authenticate/1, upgrade/1]).
+-export([authenticate/1, upgrade/1, enabled/0]).
 
 -ifdef(TEST).
 -export([make_verifier/1, verify/2, decode_secret/1, valid_device_id/1, create/2, cap_gate/2]).
@@ -453,22 +453,32 @@ insert_identity(PlayerId, DeviceId, SecretBin) ->
 
 %% --- Config (opt-in, fail closed and loud) ---
 
+-doc """
+Whether the guest routes will actually serve: the two-layer flag (ADR 0014) AND
+a usable pepper (ADR 0004). The one place that conjunction is written down.
+
+Silent, unlike `guest_enabled/0`, so `m:asobi_ops_features` can report it per
+request without writing a warning line each time an operator polls.
+""".
+-spec enabled() -> boolean().
+enabled() ->
+    asobi_game_config:guest_auth() andalso pepper(current_key_id()) =/= undefined.
+
+%% The request-path gate: `enabled/0` plus the diagnostic. A flag that is on
+%% while the gate is shut can only mean the pepper, and saying so is the
+%% difference between a five-minute fix and a support thread - the endpoint
+%% answers the same `guest.disabled` either way.
 -spec guest_enabled() -> boolean().
 guest_enabled() ->
-    case asobi_game_config:guest_auth() of
-        true ->
-            case pepper(current_key_id()) of
-                undefined ->
-                    ?LOG_WARNING(#{
-                        event => guest_auth_misconfigured,
-                        reason => missing_guest_verifier_pepper
-                    }),
-                    false;
-                _ ->
-                    true
-            end;
-        _ ->
-            false
+    case {enabled(), asobi_game_config:guest_auth()} of
+        {false, true} ->
+            ?LOG_WARNING(#{
+                event => guest_auth_misconfigured,
+                reason => missing_guest_verifier_pepper
+            }),
+            false;
+        {Enabled, _} ->
+            Enabled
     end.
 
 -spec current_key_id() -> binary().

--- a/src/controllers/asobi_guest_controller.erl
+++ b/src/controllers/asobi_guest_controller.erl
@@ -8,8 +8,10 @@
 %% provider_metadata (see provider=guest metadata: salt/key_id/verifier/revoked,
 %% base64) - the secret itself is never stored or logged.
 %%
-%% Opt-in: disabled unless `guest_auth` is true AND a `guest_verifier_pepper`
-%% is configured; both missing/false fail closed. Upgrade to a real account:
+%% Opt-in: disabled unless `asobi_game_config:guest_auth/0` is true AND a
+%% `guest_verifier_pepper` is configured; both missing/false fail closed. The
+%% flag itself has two layers, the operator's `sys.config` key over the game's
+%% declaration (ADR 0011). Upgrade to a real account:
 %% POST /auth/guest/upgrade (username+password, revokes the device verifier) or
 %% the existing /auth/link path (OAuth). Guardian + beam-security-reviewer gate.
 %%
@@ -453,7 +455,7 @@ insert_identity(PlayerId, DeviceId, SecretBin) ->
 
 -spec guest_enabled() -> boolean().
 guest_enabled() ->
-    case application:get_env(asobi, guest_auth, false) of
+    case asobi_game_config:guest_auth() of
         true ->
             case pepper(current_key_id()) of
                 undefined ->

--- a/src/lua/asobi_lua_config.erl
+++ b/src/lua/asobi_lua_config.erl
@@ -64,7 +64,7 @@ intent; guest auth is on iff the operator also supplies a >= 32-byte pepper
 (ADR 0004). Like `registration`, it lands in a script layer that
 `asobi_game_config:guest_auth/0` reads only when the operator's `sys.config`
 leaves `guest_auth` unset, so an operator can turn anonymous play on for a
-release that ships no Lua at all, and off for one that does (ADR 0011).
+release that ships no Lua at all, and off for one that does (ADR 0014).
 `registration` declares a signup posture for a deployment that
 states none: it lands in the script layer `asobi_registration` reads only when
 the operator's `sys.config` leaves `registration` unset, and an unrecognised
@@ -150,7 +150,7 @@ game_dir() ->
 %% agree (ADR 0004). Best-effort: any error just leaves the flag at its `false`
 %% default. The write lands in the script layer, so an operator that sets
 %% `guest_auth` in sys.config overrides whatever the bundle declares, in both
-%% directions (ADR 0011). Shared with asobi_engine's bundle loader so managed
+%% directions (ADR 0014). Shared with asobi_engine's bundle loader so managed
 %% cloud behaves the same.
 -spec apply_guest_auth(string() | binary()) -> ok.
 apply_guest_auth(GameDir) ->
@@ -171,7 +171,7 @@ apply_registration_mode(GameDir) ->
 %% The whole config term the game's script declares. `guest_auth` is always
 %% present because a stale `true` from a previous bundle has to be reset - that
 %% write lands in the script layer (`script_guest_auth`), so it resets what the
-%% previous bundle said and can never touch the operator's own key (ADR 0011).
+%% previous bundle said and can never touch the operator's own key (ADR 0014).
 %% `registration` is present only when the script declares a recognised value,
 %% since an absent key is what leaves the operator's layer alone (ADR 0006).
 -spec declared_config(string() | binary()) -> asobi_game_config:config().

--- a/src/lua/asobi_lua_config.erl
+++ b/src/lua/asobi_lua_config.erl
@@ -36,7 +36,7 @@ game_type      = "world"                    -- optional, "match" (default) or "w
 listed         = true                       -- optional, browsable via match.list / world.list (matches default false, worlds true)
 quick_play     = true                       -- optional, reachable via world.find_or_create (default true)
 state_strategy = "shared"                   -- optional, "shared" picks asobi_lua_match_shared (encode-once broadcast)
-guest_auth     = true                       -- optional, offer anonymous no-account play (needs an operator pepper; ADR 0004)
+guest_auth     = true                       -- optional, offer anonymous no-account play (needs an operator pepper; ADR 0004. Operator sys.config wins)
 registration   = "closed"                   -- optional, "open" | "oauth_only" | "closed" (operator sys.config wins)
 
 -- World mode config (large session games, game_type = "world"):
@@ -61,7 +61,11 @@ which uses the `asobi_lua_match` bridge (tick/1 + wrapped-state callbacks).
 `guest_auth` and `registration` are read from `match.lua` in single-mode and
 from `config.lua` (the manifest) in multi-mode. `guest_auth` only *declares*
 intent; guest auth is on iff the operator also supplies a >= 32-byte pepper
-(ADR 0004). `registration` declares a signup posture for a deployment that
+(ADR 0004). Like `registration`, it lands in a script layer that
+`asobi_game_config:guest_auth/0` reads only when the operator's `sys.config`
+leaves `guest_auth` unset, so an operator can turn anonymous play on for a
+release that ships no Lua at all, and off for one that does (ADR 0011).
+`registration` declares a signup posture for a deployment that
 states none: it lands in the script layer `asobi_registration` reads only when
 the operator's `sys.config` leaves `registration` unset, and an unrecognised
 value is logged and dropped rather than downgrading the posture.
@@ -99,7 +103,8 @@ maybe_load_game_config() ->
             asobi_game_config:apply_config(Declared#{modes => Modes});
         {error, _} = Err ->
             %% A broken bundle must still land its auth posture: leaving a stale
-            %% `true` behind is the one failure the loader cannot fail soft on.
+            %% `true` in the script layer behind is the one failure the loader
+            %% cannot fail soft on.
             ok = asobi_game_config:apply_config(Declared),
             Err
     end.
@@ -143,8 +148,10 @@ game_dir() ->
 %% global and hand it to core, which owns the flag; the operator still has to
 %% supply a >= 32-byte guest_verifier_pepper, so guest auth is on iff BOTH
 %% agree (ADR 0004). Best-effort: any error just leaves the flag at its `false`
-%% default. Shared with asobi_engine's bundle loader so managed cloud behaves
-%% the same.
+%% default. The write lands in the script layer, so an operator that sets
+%% `guest_auth` in sys.config overrides whatever the bundle declares, in both
+%% directions (ADR 0011). Shared with asobi_engine's bundle loader so managed
+%% cloud behaves the same.
 -spec apply_guest_auth(string() | binary()) -> ok.
 apply_guest_auth(GameDir) ->
     asobi_game_config:apply_config(
@@ -162,7 +169,9 @@ apply_registration_mode(GameDir) ->
     ).
 
 %% The whole config term the game's script declares. `guest_auth` is always
-%% present because a stale `true` from a previous bundle has to be reset;
+%% present because a stale `true` from a previous bundle has to be reset - that
+%% write lands in the script layer (`script_guest_auth`), so it resets what the
+%% previous bundle said and can never touch the operator's own key (ADR 0011).
 %% `registration` is present only when the script declares a recognised value,
 %% since an absent key is what leaves the operator's layer alone (ADR 0006).
 -spec declared_config(string() | binary()) -> asobi_game_config:config().

--- a/src/ops/asobi_ops_features.erl
+++ b/src/ops/asobi_ops_features.erl
@@ -20,6 +20,11 @@ needs to know whether Steam auth will work on this deployment, and "the module
 exists" does not answer that. Each entry is a name and a boolean only - never
 the configured value, which is usually a secret.
 
+A capability whose owning module already has the predicate calls it rather than
+re-deriving one here - `asobi_storage:enabled/0`, and `asobi_game_config:guest_auth/0`
+for the two-layer guest flag (ADR 0011), which `configured/1` cannot answer
+because it reports a key set to `false` as configured.
+
 `lua` is the exception and is a module check, because since the runtime merged
 into asobi there is nothing to configure: it is present in every stock release.
 It stays in the list so a console rendering against a stripped custom release
@@ -106,7 +111,7 @@ capabilities() ->
         #{name => Name, enabled => Enabled}
      || {Name, Enabled} <- lists:sort([
             {~"clustering", configured(cluster)},
-            {~"guest_auth", configured(guest_auth)},
+            {~"guest_auth", asobi_game_config:guest_auth()},
             {~"iap_apple", configured(apple_bundle_id)},
             {~"iap_google", configured(google_package_name)},
             {~"lua", module_available(asobi_lua_match)},

--- a/src/ops/asobi_ops_features.erl
+++ b/src/ops/asobi_ops_features.erl
@@ -21,9 +21,12 @@ exists" does not answer that. Each entry is a name and a boolean only - never
 the configured value, which is usually a secret.
 
 A capability whose owning module already has the predicate calls it rather than
-re-deriving one here - `asobi_storage:enabled/0`, and `asobi_game_config:guest_auth/0`
-for the two-layer guest flag (ADR 0011), which `configured/1` cannot answer
-because it reports a key set to `false` as configured.
+re-deriving one here - `asobi_storage:enabled/0`, and
+`asobi_guest_controller:enabled/0` for guest auth. Neither half of that gate is
+the answer on its own: `configured/1` reports a key set to `false` as
+configured, and the flag without a pepper advertises a route that answers 403.
+`enabled/0` is the silent half of the request-path gate, so an ops poll does not
+write a warning per request.
 
 `lua` is the exception and is a module check, because since the runtime merged
 into asobi there is nothing to configure: it is present in every stock release.
@@ -111,7 +114,7 @@ capabilities() ->
         #{name => Name, enabled => Enabled}
      || {Name, Enabled} <- lists:sort([
             {~"clustering", configured(cluster)},
-            {~"guest_auth", asobi_game_config:guest_auth()},
+            {~"guest_auth", asobi_guest_controller:enabled()},
             {~"iap_apple", configured(apple_bundle_id)},
             {~"iap_google", configured(google_package_name)},
             {~"lua", module_available(asobi_lua_match)},

--- a/test/asobi_game_config_tests.erl
+++ b/test/asobi_game_config_tests.erl
@@ -10,7 +10,13 @@ game_config_test_() ->
         {"a term without modes leaves the registry alone", fun modes_key_absent_is_a_no_op/0},
         {"a term without guest_auth leaves the posture alone",
             fun guest_auth_key_absent_is_a_no_op/0},
-        {"a declared guest_auth replaces the flag", fun guest_auth_declared_replaces_flag/0},
+        {"a declared guest_auth replaces the script layer",
+            fun guest_auth_declared_replaces_the_script_layer/0},
+        {"an operator guest_auth beats the script layer, both ways",
+            fun operator_guest_auth_beats_script/0},
+        {"guest auth is off when neither layer is set", fun guest_auth_defaults_to_false/0},
+        {"a non-boolean operator guest_auth pins it off",
+            fun non_boolean_operator_guest_auth_pins_off/0},
         {"a non-map operator env is ignored, not crashed on", fun non_map_operator_env_ignored/0},
         {"script modes resolve through asobi_game_modes", fun script_mode_resolves/0}
     ]}.
@@ -33,7 +39,7 @@ cleanup(Saved) ->
     ok.
 
 keys() ->
-    [game_modes, script_game_modes, guest_auth].
+    [game_modes, script_game_modes, guest_auth, script_guest_auth].
 
 restore(Key, {ok, Value}) -> application:set_env(asobi, Key, Value);
 restore(Key, undefined) -> application:unset_env(asobi, Key).
@@ -79,17 +85,50 @@ modes_key_absent_is_a_no_op() ->
 
 %% What keeps a live mode-shape reload from flipping auth posture (ADR 0004).
 guest_auth_key_absent_is_a_no_op() ->
-    application:set_env(asobi, guest_auth, true),
+    application:set_env(asobi, script_guest_auth, true),
     ok = asobi_game_config:apply_config(#{modes => #{~"arena" => #{match_size => 4}}}),
-    ?assertEqual({ok, true}, application:get_env(asobi, guest_auth)).
+    ?assertEqual({ok, true}, application:get_env(asobi, script_guest_auth)),
+    ?assert(asobi_game_config:guest_auth()).
 
-guest_auth_declared_replaces_flag() ->
-    application:set_env(asobi, guest_auth, true),
+%% A declared value replaces the script layer wholesale and never touches the
+%% operator's key - which is what a release with no Lua bundle depends on.
+guest_auth_declared_replaces_the_script_layer() ->
+    application:set_env(asobi, script_guest_auth, true),
     ok = asobi_game_config:apply_config(#{guest_auth => false, modes => #{}}),
-    ?assertEqual({ok, false}, application:get_env(asobi, guest_auth)),
+    ?assertEqual({ok, false}, application:get_env(asobi, script_guest_auth)),
+    ?assertNot(asobi_game_config:guest_auth()),
 
     ok = asobi_game_config:apply_config(#{guest_auth => true, modes => #{}}),
-    ?assertEqual({ok, true}, application:get_env(asobi, guest_auth)).
+    ?assertEqual({ok, true}, application:get_env(asobi, script_guest_auth)),
+    ?assert(asobi_game_config:guest_auth()),
+
+    ?assertEqual(undefined, application:get_env(asobi, guest_auth)).
+
+%% The operator layer wins on key presence, not on truth (ADR 0011), the way
+%% asobi_registration:classify/0 has always layered the signup posture.
+operator_guest_auth_beats_script() ->
+    application:set_env(asobi, guest_auth, false),
+    ok = asobi_game_config:apply_config(#{guest_auth => true, modes => #{}}),
+    ?assertEqual({ok, true}, application:get_env(asobi, script_guest_auth)),
+    ?assertNot(asobi_game_config:guest_auth()),
+
+    application:set_env(asobi, guest_auth, true),
+    ok = asobi_game_config:apply_config(#{guest_auth => false, modes => #{}}),
+    ?assertEqual({ok, false}, application:get_env(asobi, script_guest_auth)),
+    ?assert(asobi_game_config:guest_auth()).
+
+%% Fails closed with nothing configured at all (ADR 0004).
+guest_auth_defaults_to_false() ->
+    ?assertEqual(undefined, application:get_env(asobi, guest_auth)),
+    ?assertEqual(undefined, application:get_env(asobi, script_guest_auth)),
+    ?assertNot(asobi_game_config:guest_auth()).
+
+%% Anything other than the atom `true` is off, so a typo cannot open the
+%% endpoint - and it does not fall through to the script layer either.
+non_boolean_operator_guest_auth_pins_off() ->
+    application:set_env(asobi, script_guest_auth, true),
+    application:set_env(asobi, guest_auth, "true"),
+    ?assertNot(asobi_game_config:guest_auth()).
 
 non_map_operator_env_ignored() ->
     application:set_env(asobi, game_modes, not_a_map),

--- a/test/asobi_game_config_tests.erl
+++ b/test/asobi_game_config_tests.erl
@@ -104,7 +104,7 @@ guest_auth_declared_replaces_the_script_layer() ->
 
     ?assertEqual(undefined, application:get_env(asobi, guest_auth)).
 
-%% The operator layer wins on key presence, not on truth (ADR 0011), the way
+%% The operator layer wins on key presence, not on truth (ADR 0014), the way
 %% asobi_registration:classify/0 has always layered the signup posture.
 operator_guest_auth_beats_script() ->
     application:set_env(asobi, guest_auth, false),

--- a/test/asobi_guest_SUITE.erl
+++ b/test/asobi_guest_SUITE.erl
@@ -41,24 +41,22 @@ all() ->
         a_failing_count_is_asked_once_per_ttl
     ].
 
-%% Set AFTER the app starts, not before. Booting asobi runs
-%% `asobi_lua_config:maybe_load_game_config/0`, and a node with no game bundle
-%% takes the `error` branch of `declared_config/1`, which writes
-%% `{guest_auth, false}` unconditionally - by design, so a stale `true` from a
-%% previous bundle cannot survive a reload. A `set_env` before the start is
-%% therefore overwritten during it, guest auth is off for the whole suite, and
-%% every create returns 403 `guest.disabled`.
+%% Set BEFORE the app starts, which is the deployment this suite represents: an
+%% operator with `{guest_auth, true}` in sys.config and no Lua bundle at all.
 %%
-%% Setting it afterwards is safe because nothing here is read at boot:
-%% `asobi_guest_controller:guest_enabled/0` reads both keys per request, and the
-%% reaper is an unconditional child that reads `guest_reap_after` at sweep time
-%% (asobi#327).
+%% That ordering is itself the regression test. Until ADR 0011 the flag was a
+%% single key: booting asobi runs `asobi_lua_config:maybe_load_game_config/0`,
+%% a node with no game bundle takes the `error` branch of `declared_config/1`,
+%% and the `{guest_auth, false}` it derives was written straight over whatever
+%% the operator had set. These three set_env calls had to run after the start to
+%% survive at all. The flag now has an operator layer over a script layer, the
+%% loader writes only the script layer, and if that ever regresses every case
+%% here fails with 403 `guest.disabled`.
 init_per_suite(Config0) ->
-    Config = asobi_test_helpers:start(Config0),
     application:set_env(asobi, guest_auth, true),
     application:set_env(asobi, guest_verifier_pepper, crypto:strong_rand_bytes(32)),
     application:set_env(asobi, guest_reap_after, 1),
-    Config.
+    asobi_test_helpers:start(Config0).
 
 end_per_suite(Config) ->
     Config.

--- a/test/asobi_guest_SUITE.erl
+++ b/test/asobi_guest_SUITE.erl
@@ -41,24 +41,34 @@ all() ->
         a_failing_count_is_asked_once_per_ttl
     ].
 
-%% Set BEFORE the app starts, which is the deployment this suite represents: an
-%% operator with `{guest_auth, true}` in sys.config and no Lua bundle at all.
+%% The deployment this suite represents: an operator with `{guest_auth, true}`
+%% in sys.config and no Lua bundle at all (ADR 0014). The flag goes in before
+%% the start because that is where a sys.config value would be; the boot-time
+%% clobber it used to suffer is covered directly by
+%% `asobi_lua_config_tests:operator_guest_auth_survives_a_bundleless_boot/0`,
+%% which drives the loader rather than relying on suite ordering.
 %%
-%% That ordering is itself the regression test. Until ADR 0011 the flag was a
-%% single key: booting asobi runs `asobi_lua_config:maybe_load_game_config/0`,
-%% a node with no game bundle takes the `error` branch of `declared_config/1`,
-%% and the `{guest_auth, false}` it derives was written straight over whatever
-%% the operator had set. These three set_env calls had to run after the start to
-%% survive at all. The flag now has an operator layer over a script layer, the
-%% loader writes only the script layer, and if that ever regresses every case
-%% here fails with 403 `guest.disabled`.
+%% `guest_reap_after` goes in AFTER the start, and has to: `asobi_app:start/2`
+%% calls `asobi_guest_env:apply/0`, whose `off` branch unsets the key whenever
+%% `ASOBI_GUEST_REAP_AFTER` is absent from the environment, which it is here.
+%% Set before the start it is wiped during it and every reaper case sweeps
+%% nothing. Pinned by `asobi_guest_env_tests:reap_after_set_before_start_is_
+%% unset_by_apply_test/0`.
 init_per_suite(Config0) ->
     application:set_env(asobi, guest_auth, true),
     application:set_env(asobi, guest_verifier_pepper, crypto:strong_rand_bytes(32)),
+    Config = asobi_test_helpers:start(Config0),
     application:set_env(asobi, guest_reap_after, 1),
-    asobi_test_helpers:start(Config0).
+    Config.
 
+%% The operator layer is node-wide and nothing resets it any more: before the
+%% two-layer split a later config load wrote `guest_auth` back to `false`, and
+%% now every loader writes only the script layer. Leaving it set would hand the
+%% next suite in the run a posture it never asked for.
 end_per_suite(Config) ->
+    application:unset_env(asobi, guest_auth),
+    application:unset_env(asobi, guest_verifier_pepper),
+    application:unset_env(asobi, guest_reap_after),
     Config.
 
 %% --- Helpers ---

--- a/test/asobi_guest_controller_tests.erl
+++ b/test/asobi_guest_controller_tests.erl
@@ -76,6 +76,9 @@ decode_secret_upper_bound_test() ->
 
 authenticate_disabled_returns_403_test() ->
     application:unset_env(asobi, guest_auth),
+    %% Both layers: eunit runs every module in one node, and asobi_lua_config_tests
+    %% writes the script layer, which would otherwise turn this deployment on.
+    application:unset_env(asobi, script_guest_auth),
     Req = fake_req(#{
         json => #{
             ~"device_id" => ~"dev-abc",

--- a/test/asobi_guest_env_tests.erl
+++ b/test/asobi_guest_env_tests.erl
@@ -22,7 +22,8 @@ retention_test_() ->
         fun a_non_integer_reaps_nothing/0,
         fun an_empty_value_reaps_nothing/0,
         fun surrounding_whitespace_is_tolerated/0,
-        fun turning_the_policy_off_clears_an_earlier_value/0
+        fun turning_the_policy_off_clears_an_earlier_value/0,
+        fun an_absent_variable_clears_a_value_set_before_the_start/0
     ]}.
 
 setup() ->
@@ -87,5 +88,17 @@ surrounding_whitespace_is_tolerated() ->
 turning_the_policy_off_clears_an_earlier_value() ->
     application:set_env(asobi, guest_reap_after, 604800),
     os:putenv(?VAR, "0"),
+    ok = asobi_guest_env:apply(),
+    ?assertEqual(undefined, application:get_env(asobi, guest_reap_after)).
+
+%% Why a CT `init_per_suite/1` cannot set `guest_reap_after` before
+%% `asobi_test_helpers:start/1`: `asobi_app:start/2` calls `apply/0`, and with
+%% no variable in the environment - which is every test run - the `off` branch
+%% unsets whatever was put there. A suite that sets it early sweeps nothing,
+%% and only when it runs first in the node, since `ensure_all_started/1` makes
+%% the second suite's start a no-op. That is invisible in a full `rebar3 ct`
+%% run and red on `--suite`, so pin it here instead.
+an_absent_variable_clears_a_value_set_before_the_start() ->
+    application:set_env(asobi, guest_reap_after, 1),
     ok = asobi_guest_env:apply(),
     ?assertEqual(undefined, application:get_env(asobi, guest_reap_after)).

--- a/test/asobi_guest_purge_SUITE.erl
+++ b/test/asobi_guest_purge_SUITE.erl
@@ -36,8 +36,7 @@ all() ->
     ].
 
 %% Guest auth is set before the app starts, the way an operator's sys.config
-%% would have it - see `asobi_guest_SUITE` for why that ordering is the
-%% regression test for the boot-time clobber (ADR 0011).
+%% would have it (ADR 0014).
 %%
 %% `guest_reap_after` is deliberately NOT set. This is the on-demand half of
 %% retention, and it has to work on a deployment that never configured the
@@ -50,7 +49,11 @@ init_per_suite(Config0) ->
     application:unset_env(asobi, guest_reap_after),
     asobi_test_helpers:start(Config0).
 
+%% Nothing resets the operator layer any more, so the suite that set it clears
+%% it - see `asobi_guest_SUITE:end_per_suite/1`.
 end_per_suite(Config) ->
+    application:unset_env(asobi, guest_auth),
+    application:unset_env(asobi, guest_verifier_pepper),
     Config.
 
 %% --- Helpers ---

--- a/test/asobi_guest_purge_SUITE.erl
+++ b/test/asobi_guest_purge_SUITE.erl
@@ -35,9 +35,9 @@ all() ->
         the_cohort_size_has_to_be_echoed_back
     ].
 
-%% Guest auth is set after the app starts, for the reason `asobi_guest_SUITE`
-%% documents at length: booting with no game bundle writes `guest_auth = false`
-%% unconditionally, so anything set before the start is overwritten during it.
+%% Guest auth is set before the app starts, the way an operator's sys.config
+%% would have it - see `asobi_guest_SUITE` for why that ordering is the
+%% regression test for the boot-time clobber (ADR 0011).
 %%
 %% `guest_reap_after` is deliberately NOT set. This is the on-demand half of
 %% retention, and it has to work on a deployment that never configured the
@@ -45,11 +45,10 @@ all() ->
 %% first place. A stray background sweep would also delete the fixtures out
 %% from under these tests and make them pass for the wrong reason.
 init_per_suite(Config0) ->
-    Config = asobi_test_helpers:start(Config0),
     application:set_env(asobi, guest_auth, true),
     application:set_env(asobi, guest_verifier_pepper, crypto:strong_rand_bytes(32)),
     application:unset_env(asobi, guest_reap_after),
-    Config.
+    asobi_test_helpers:start(Config0).
 
 end_per_suite(Config) ->
     Config.

--- a/test/asobi_guest_reaper_tests.erl
+++ b/test/asobi_guest_reaper_tests.erl
@@ -69,7 +69,7 @@ sweep_runs_on_a_script_declared_flag() ->
     ?assertEqual(1, meck:num_calls(asobi_repo, all, '_')).
 
 %% And an operator that pinned guest auth off gets no sweep, whatever the
-%% bundle declared (ADR 0011).
+%% bundle declared (ADR 0014).
 operator_false_stops_the_sweep() ->
     {ok, _} = asobi_guest_reaper:start_link(),
     application:set_env(asobi, script_guest_auth, true),

--- a/test/asobi_guest_reaper_tests.erl
+++ b/test/asobi_guest_reaper_tests.erl
@@ -12,6 +12,9 @@ reaper_test_() ->
         {"starts even with guest_auth unset", fun starts_without_guest_auth/0},
         {"sweep is a no-op while guest auth is off", fun sweep_skipped_when_disabled/0},
         {"guest_auth set after start: a sweep queries", fun sweep_runs_when_enabled_later/0},
+        {"a script-declared flag runs a sweep too", fun sweep_runs_on_a_script_declared_flag/0},
+        {"an operator false stops a sweep the bundle asked for",
+            fun operator_false_stops_the_sweep/0},
         {"timer tick picks up a flag set after boot", fun timer_sweep_self_corrects/0},
         {"an installed extension erases before core deletes", fun extension_erases_first/0},
         {"a refusing extension leaves the player alone", fun refusing_extension_aborts_reap/0}
@@ -19,6 +22,7 @@ reaper_test_() ->
 
 setup() ->
     application:unset_env(asobi, guest_auth),
+    application:unset_env(asobi, script_guest_auth),
     application:set_env(asobi, guest_reap_after, 60),
     asobi_extensions:reset(),
     asobi_fixture_erase:reset(),
@@ -36,6 +40,7 @@ cleanup(_) ->
     asobi_fixture_erase:reset(),
     asobi_extensions:reset(),
     application:unset_env(asobi, guest_auth),
+    application:unset_env(asobi, script_guest_auth),
     application:unset_env(asobi, guest_reap_after),
     application:unset_env(asobi, guest_reap_interval_ms),
     ok.
@@ -54,6 +59,23 @@ sweep_runs_when_enabled_later() ->
     application:set_env(asobi, guest_auth, true),
     ?assertEqual({ok, 0}, asobi_guest_reaper:sweep_now()),
     ?assertEqual(1, meck:num_calls(asobi_repo, all, '_')).
+
+%% The reaper reads the composed flag, so a game that declares guest_auth in
+%% its Lua gets its guests reaped without the operator setting anything.
+sweep_runs_on_a_script_declared_flag() ->
+    {ok, _} = asobi_guest_reaper:start_link(),
+    application:set_env(asobi, script_guest_auth, true),
+    ?assertEqual({ok, 0}, asobi_guest_reaper:sweep_now()),
+    ?assertEqual(1, meck:num_calls(asobi_repo, all, '_')).
+
+%% And an operator that pinned guest auth off gets no sweep, whatever the
+%% bundle declared (ADR 0011).
+operator_false_stops_the_sweep() ->
+    {ok, _} = asobi_guest_reaper:start_link(),
+    application:set_env(asobi, script_guest_auth, true),
+    application:set_env(asobi, guest_auth, false),
+    ?assertEqual({ok, 0}, asobi_guest_reaper:sweep_now()),
+    ?assertEqual(0, meck:num_calls(asobi_repo, all, '_')).
 
 timer_sweep_self_corrects() ->
     application:set_env(asobi, guest_reap_interval_ms, 25),

--- a/test/asobi_lua_config_tests.erl
+++ b/test/asobi_lua_config_tests.erl
@@ -151,7 +151,7 @@ single_mode_minimal() ->
 %% These assert through asobi_game_config:guest_auth/0 rather than the raw app
 %% env, the way the registration cases below assert through
 %% asobi_registration:mode/0: what a script declares is the script layer, and
-%% the effective flag is that layer composed with the operator's (ADR 0011).
+%% the effective flag is that layer composed with the operator's (ADR 0014).
 guest_auth_global_enables() ->
     reset_guest_auth(),
     TmpDir = make_temp_dir(),

--- a/test/asobi_lua_config_tests.erl
+++ b/test/asobi_lua_config_tests.erl
@@ -91,6 +91,10 @@ config_test_() ->
         {"guest_auth truthy non-bool does not enable", fun guest_auth_truthy_nonbool_stays_off/0},
         {"guest_auth resets a stale true when a later bundle omits it",
             fun guest_auth_stale_true_is_reset/0},
+        {"an operator guest_auth survives a boot with no bundle at all",
+            fun operator_guest_auth_survives_a_bundleless_boot/0},
+        {"an operator guest_auth = false beats a bundle that declares true",
+            fun operator_guest_auth_false_beats_a_declaring_bundle/0},
         {"registration global sets the effective registration mode",
             fun registration_global_sets_mode/0},
         {"registration global is read from config.lua in multi-mode",
@@ -144,8 +148,12 @@ single_mode_minimal() ->
     ?assertEqual(2, maps:get(max_players, Mode)),
     cleanup_temp_dir(TmpDir).
 
+%% These assert through asobi_game_config:guest_auth/0 rather than the raw app
+%% env, the way the registration cases below assert through
+%% asobi_registration:mode/0: what a script declares is the script layer, and
+%% the effective flag is that layer composed with the operator's (ADR 0011).
 guest_auth_global_enables() ->
-    application:unset_env(asobi, guest_auth),
+    reset_guest_auth(),
     TmpDir = make_temp_dir(),
     ok = file:write_file(
         filename:join(TmpDir, "match.lua"),
@@ -153,21 +161,22 @@ guest_auth_global_enables() ->
     ),
     application:set_env(asobi, game_dir, TmpDir),
     ok = asobi_lua_config:maybe_load_game_config(),
-    ?assertEqual({ok, true}, application:get_env(asobi, guest_auth)),
-    application:unset_env(asobi, guest_auth),
+    ?assertEqual({ok, true}, application:get_env(asobi, script_guest_auth)),
+    ?assert(asobi_game_config:guest_auth()),
+    reset_guest_auth(),
     cleanup_temp_dir(TmpDir).
 
 guest_auth_absent_leaves_off() ->
-    application:unset_env(asobi, guest_auth),
+    reset_guest_auth(),
     TmpDir = make_temp_dir(),
     ok = file:write_file(filename:join(TmpDir, "match.lua"), ~"match_size = 2\n"),
     application:set_env(asobi, game_dir, TmpDir),
     ok = asobi_lua_config:maybe_load_game_config(),
-    ?assertNotEqual({ok, true}, application:get_env(asobi, guest_auth)),
+    ?assertNot(asobi_game_config:guest_auth()),
     cleanup_temp_dir(TmpDir).
 
 guest_auth_truthy_nonbool_stays_off() ->
-    application:unset_env(asobi, guest_auth),
+    reset_guest_auth(),
     TmpDir = make_temp_dir(),
     ok = file:write_file(
         filename:join(TmpDir, "match.lua"),
@@ -175,19 +184,63 @@ guest_auth_truthy_nonbool_stays_off() ->
     ),
     application:set_env(asobi, game_dir, TmpDir),
     ok = asobi_lua_config:maybe_load_game_config(),
-    ?assertNotEqual({ok, true}, application:get_env(asobi, guest_auth)),
-    application:unset_env(asobi, guest_auth),
+    ?assertNot(asobi_game_config:guest_auth()),
+    reset_guest_auth(),
     cleanup_temp_dir(TmpDir).
 
+%% The stale value a new bundle has to clear is the previous *bundle's*, so the
+%% reset lands in the script layer. Seed it there, not in the operator's key.
 guest_auth_stale_true_is_reset() ->
-    application:set_env(asobi, guest_auth, true),
+    reset_guest_auth(),
+    application:set_env(asobi, script_guest_auth, true),
     TmpDir = make_temp_dir(),
     ok = file:write_file(filename:join(TmpDir, "match.lua"), ~"match_size = 2\n"),
     application:set_env(asobi, game_dir, TmpDir),
     ok = asobi_lua_config:maybe_load_game_config(),
-    ?assertEqual({ok, false}, application:get_env(asobi, guest_auth)),
-    application:unset_env(asobi, guest_auth),
+    ?assertEqual({ok, false}, application:get_env(asobi, script_guest_auth)),
+    ?assertNot(asobi_game_config:guest_auth()),
+    reset_guest_auth(),
     cleanup_temp_dir(TmpDir).
+
+%% The reported bug: a release that embeds asobi as an Erlang library ships no
+%% Lua bundle, so this loader took the "no config script" branch and wrote the
+%% flag `false` straight over the operator's `{guest_auth, true}` - silently, on
+%% every boot, leaving POST /auth/guest answering 403 guest.disabled forever.
+%% The loader still writes that `false`, which is what resets a stale bundle,
+%% but it writes it to the script layer where the operator's key outranks it.
+operator_guest_auth_survives_a_bundleless_boot() ->
+    reset_guest_auth(),
+    application:set_env(asobi, guest_auth, true),
+    %% No config.lua and no match.lua, like a /app/game that does not exist.
+    TmpDir = make_temp_dir(),
+    application:set_env(asobi, game_dir, TmpDir),
+    ok = asobi_lua_config:maybe_load_game_config(),
+    ?assertEqual({ok, true}, application:get_env(asobi, guest_auth)),
+    ?assertEqual({ok, false}, application:get_env(asobi, script_guest_auth)),
+    ?assert(asobi_game_config:guest_auth()),
+    reset_guest_auth(),
+    cleanup_temp_dir(TmpDir).
+
+%% The other direction, and the half that keeps ADR 0004's trust boundary: a
+%% bundle cannot open an unauthenticated endpoint on a deployment that said no.
+operator_guest_auth_false_beats_a_declaring_bundle() ->
+    reset_guest_auth(),
+    application:set_env(asobi, guest_auth, false),
+    TmpDir = make_temp_dir(),
+    ok = file:write_file(
+        filename:join(TmpDir, "match.lua"),
+        ~"match_size = 2\nguest_auth = true\n"
+    ),
+    application:set_env(asobi, game_dir, TmpDir),
+    ok = asobi_lua_config:maybe_load_game_config(),
+    ?assertEqual({ok, true}, application:get_env(asobi, script_guest_auth)),
+    ?assertNot(asobi_game_config:guest_auth()),
+    reset_guest_auth(),
+    cleanup_temp_dir(TmpDir).
+
+reset_guest_auth() ->
+    application:unset_env(asobi, guest_auth),
+    application:unset_env(asobi, script_guest_auth).
 
 %% asobi_lua#122: an engine-hosted game has no sys.config, so a posture it
 %% cannot declare is a posture it never gets. Assert the effective mode
@@ -919,7 +972,10 @@ teardown_modes() ->
 
 reset_modes() ->
     application:set_env(asobi, game_modes, #{}),
-    application:set_env(asobi, script_game_modes, #{}).
+    application:set_env(asobi, script_game_modes, #{}),
+    %% Both auth layers too: the guest cases write these, and eunit runs every
+    %% module in one node, so a leftover `true` would decide a later assertion.
+    reset_guest_auth().
 
 -spec assert_luerl_state(dynamic()) -> dynamic().
 assert_luerl_state(St) when is_tuple(St), element(1, St) =:= luerl ->

--- a/test/asobi_ops_tests.erl
+++ b/test/asobi_ops_tests.erl
@@ -687,6 +687,38 @@ features_capability_reflects_configuration_test() ->
         end
     end.
 
+%% guest_auth is a two-layer flag, so the capability goes through
+%% asobi_game_config:guest_auth/0 rather than "is the key set" - which reported
+%% `true` for a key set to `false`, and the boot-time config load set exactly
+%% that on every node without a Lua bundle (ADR 0011).
+features_guest_auth_capability_reads_both_layers_test() ->
+    Saved = [{K, application:get_env(asobi, K)} || K <- [guest_auth, script_guest_auth]],
+    try
+        [application:unset_env(asobi, K) || K <- [guest_auth, script_guest_auth]],
+        ?assertEqual(false, capability_enabled(~"guest_auth")),
+
+        %% The game's own declaration is enough.
+        application:set_env(asobi, script_guest_auth, true),
+        ?assertEqual(true, capability_enabled(~"guest_auth")),
+
+        %% An operator that pinned it off is reported off, not "configured".
+        application:set_env(asobi, guest_auth, false),
+        ?assertEqual(false, capability_enabled(~"guest_auth")),
+
+        %% And an operator with no bundle at all is reported on.
+        application:unset_env(asobi, script_guest_auth),
+        application:set_env(asobi, guest_auth, true),
+        ?assertEqual(true, capability_enabled(~"guest_auth"))
+    after
+        [
+            case V of
+                {ok, Value} -> application:set_env(asobi, K, Value);
+                undefined -> application:unset_env(asobi, K)
+            end
+         || {K, V} <- Saved
+        ]
+    end.
+
 %% Storage is on by default (asobi_storage:enabled/0), unlike the configured
 %% capabilities above which are off until set. `false` is the only value that
 %% reports it disabled.

--- a/test/asobi_ops_tests.erl
+++ b/test/asobi_ops_tests.erl
@@ -688,13 +688,12 @@ features_capability_reflects_configuration_test() ->
     end.
 
 %% guest_auth is a two-layer flag, so the capability goes through
-%% asobi_game_config:guest_auth/0 rather than "is the key set" - which reported
-%% `true` for a key set to `false`, and the boot-time config load set exactly
-%% that on every node without a Lua bundle (ADR 0011).
+%% asobi_guest_controller:enabled/0 rather than "is the key set" - which
+%% reported `true` for a key set to `false`, and the boot-time config load set
+%% exactly that on every node without a Lua bundle (ADR 0014).
 features_guest_auth_capability_reads_both_layers_test() ->
-    Saved = [{K, application:get_env(asobi, K)} || K <- [guest_auth, script_guest_auth]],
-    try
-        [application:unset_env(asobi, K) || K <- [guest_auth, script_guest_auth]],
+    with_guest_env(fun() ->
+        application:set_env(asobi, guest_verifier_pepper, crypto:strong_rand_bytes(32)),
         ?assertEqual(false, capability_enabled(~"guest_auth")),
 
         %% The game's own declaration is enough.
@@ -709,6 +708,34 @@ features_guest_auth_capability_reads_both_layers_test() ->
         application:unset_env(asobi, script_guest_auth),
         application:set_env(asobi, guest_auth, true),
         ?assertEqual(true, capability_enabled(~"guest_auth"))
+    end).
+
+%% The other half of the endpoint's gate. A console that renders the capability
+%% list is deciding whether to offer anonymous play at all, so a `true` here
+%% against a deployment whose every guest request answers 403 is worse than no
+%% answer - the flag alone used to report exactly that (ADR 0004).
+features_guest_auth_capability_needs_a_pepper_test() ->
+    with_guest_env(fun() ->
+        application:set_env(asobi, guest_auth, true),
+        ?assertEqual(false, capability_enabled(~"guest_auth")),
+
+        %% Under the 32-byte floor is unconfigured, the way the controller
+        %% reads it - a short pepper is not a weak deployment, it is an off one.
+        application:set_env(asobi, guest_verifier_pepper, crypto:strong_rand_bytes(31)),
+        ?assertEqual(false, capability_enabled(~"guest_auth")),
+
+        application:set_env(asobi, guest_verifier_pepper, crypto:strong_rand_bytes(32)),
+        ?assertEqual(true, capability_enabled(~"guest_auth"))
+    end).
+
+%% Saves and restores every key the guest gate reads, since eunit runs each
+%% module in one node and a leaked posture decides someone else's assertion.
+with_guest_env(Body) ->
+    Keys = [guest_auth, script_guest_auth, guest_verifier_pepper],
+    Saved = [{K, application:get_env(asobi, K)} || K <- Keys],
+    try
+        [application:unset_env(asobi, K) || K <- Keys],
+        Body()
     after
         [
             case V of

--- a/test/asobi_player_erase_self_SUITE.erl
+++ b/test/asobi_player_erase_self_SUITE.erl
@@ -35,14 +35,12 @@ all() ->
         erase_takes_the_children_and_frees_the_device
     ].
 
-%% Guest auth is set after the app starts, for the reason asobi_guest_SUITE
-%% documents at length: booting asobi pins `guest_auth` to false when no game
-%% bundle is present, so a set_env before the start is overwritten during it.
+%% Operator-layer guest auth, set before the start the way a sys.config would
+%% have it - see asobi_guest_SUITE for why the ordering matters (ADR 0011).
 init_per_suite(Config0) ->
-    Config = asobi_test_helpers:start(Config0),
     application:set_env(asobi, guest_auth, true),
     application:set_env(asobi, guest_verifier_pepper, crypto:strong_rand_bytes(32)),
-    Config.
+    asobi_test_helpers:start(Config0).
 
 end_per_suite(Config) ->
     Config.

--- a/test/asobi_player_erase_self_SUITE.erl
+++ b/test/asobi_player_erase_self_SUITE.erl
@@ -36,13 +36,17 @@ all() ->
     ].
 
 %% Operator-layer guest auth, set before the start the way a sys.config would
-%% have it - see asobi_guest_SUITE for why the ordering matters (ADR 0011).
+%% have it (ADR 0014).
 init_per_suite(Config0) ->
     application:set_env(asobi, guest_auth, true),
     application:set_env(asobi, guest_verifier_pepper, crypto:strong_rand_bytes(32)),
     asobi_test_helpers:start(Config0).
 
+%% Nothing resets the operator layer any more, so the suite that set it clears
+%% it - see `asobi_guest_SUITE:end_per_suite/1`.
 end_per_suite(Config) ->
+    application:unset_env(asobi, guest_auth),
+    application:unset_env(asobi, guest_verifier_pepper),
     Config.
 
 %% Erasure has its own tight bucket (3 per minute per IP, because the

--- a/test/asobi_sup_lua_children_tests.erl
+++ b/test/asobi_sup_lua_children_tests.erl
@@ -4,9 +4,11 @@
 %% The asobi_lua merge folded asobi_lua_app:start/2 into asobi_app and
 %% asobi_sup. The order it used to produce came from the two applications:
 %% asobi's children were all up before asobi_lua loaded the game config and
-%% started its own children. asobi_guest_reaper reads `guest_auth` in
-%% start_link/0, so moving the config load in front of the core children would
-%% change what the core sees at boot.
+%% started its own children. asobi_lua_config_watcher reads the mode registry
+%% in its own init/1, so the load has to stay ahead of asobi_lua_sup, and a
+%% failed load aborts the boot (asobi_sup:load_lua_game_config/0) - moving it in
+%% front of the core children would change both what starts and what a broken
+%% bundle takes down with it.
 %% Pin the tail order so that stays a deliberate decision, not a refactor
 %% accident.
 
@@ -26,6 +28,9 @@ lua_children_start_after_core_and_before_extensions_test() ->
     Tail = [asobi_lua_config, asobi_lua_sup, asobi_extension_sup],
     ?assertEqual((Ids -- Tail) ++ Tail, Ids).
 
+%% The reaper is the last core child, so this pins the "core before the config
+%% load" boundary in one assertion. Not a data dependency: it reads the guest
+%% flag at sweep time (asobi#327), not in start_link/0.
 guest_reaper_starts_before_game_config_test() ->
     Ids = child_ids(asobi_sup),
     ?assert(index_of(asobi_guest_reaper, Ids) < index_of(asobi_lua_config, Ids)).


### PR DESCRIPTION
- Closes #494 