### PR TITLE
feat(auth): persist Steam's VAC verdict, and emit the session.disconnected event nothing ever emitted

### DIFF
--- a/src/auth/asobi_steam.erl
+++ b/src/auth/asobi_steam.erl
@@ -109,8 +109,15 @@ maybe_fetch_profile(SteamId, Params) ->
         provider_uid => SteamId,
         provider_email => undefined,
         provider_display_name => undefined,
-        owner_steamid => maps:get(~"ownersteamid", Params, SteamId),
-        vac_banned => maps:get(~"vacbanned", Params, false)
+        %% Under `provider_metadata` rather than loose at the top level, because
+        %% that is the field the identity row already has for provider-specific
+        %% claims and it is what makes these survive the write (asobi#520).
+        %% Binary keys: it lands in jsonb, and the guest provider's verifier
+        %% metadata already established that shape.
+        provider_metadata => #{
+            ~"owner_steamid" => maps:get(~"ownersteamid", Params, SteamId),
+            ~"vac_banned" => maps:get(~"vacbanned", Params, false)
+        }
     },
     case fetch_player_summary(SteamId) of
         {ok, Summary} ->

--- a/src/controllers/asobi_oauth_controller.erl
+++ b/src/controllers/asobi_oauth_controller.erl
@@ -6,7 +6,7 @@
 -export([authenticate/1, link/1, unlink/1]).
 
 -ifdef(TEST).
--export([create_player_with_identity/2, validate_oidc_token/2]).
+-export([create_player_with_identity/2, validate_oidc_token/2, refresh_provider_metadata/2]).
 -endif.
 
 -define(MAX_USERNAME_ATTEMPTS, 3).
@@ -27,7 +27,7 @@ authenticate(#{json := #{~"provider" := Provider, ~"token" := Token}} = _Req) wh
             ProviderUid = maps:get(provider_uid, Claims),
             case find_identity(Provider, ProviderUid) of
                 {ok, Identity} ->
-                    login_existing_player(Identity);
+                    login_existing_player(refresh_provider_metadata(Identity, Claims));
                 {error, not_found} ->
                     case asobi_registration:check(oauth) of
                         {deny, Reason} -> asobi_auth_error:registration_denied(Reason);
@@ -185,6 +185,45 @@ find_player_identity(PlayerId, Provider) ->
         _ -> {error, not_found}
     end.
 
+%% A provider's claims about a player are not constant. Steam's `vac_banned` is
+%% the case that matters: written once at signup it would be a snapshot of the
+%% day the account was created, and a stale `false` reads as "this player is
+%% clean" rather than "nobody has looked since". So the identity is refreshed on
+%% every login, from the claims the provider just returned.
+%%
+%% Best-effort on purpose. A failed refresh must not fail a login that the
+%% provider has already accepted - the same call the guest controller makes about
+%% its own metadata write. The caller gets the row it will actually use either
+%% way, refreshed if the write landed and unchanged if it did not.
+-spec refresh_provider_metadata(map(), map()) -> map().
+refresh_provider_metadata(Identity, Claims) ->
+    case maps:get(provider_metadata, Claims, #{}) of
+        Fresh when is_map(Fresh), map_size(Fresh) > 0 ->
+            case maps:get(provider_metadata, Identity, #{}) of
+                Fresh ->
+                    Identity;
+                _Stale ->
+                    write_provider_metadata(Identity, Fresh)
+            end;
+        _NothingToSay ->
+            Identity
+    end.
+
+-spec write_provider_metadata(map(), map()) -> map().
+write_provider_metadata(Identity, Fresh) ->
+    CS = asobi_player_identity:changeset(Identity, #{provider_metadata => Fresh}),
+    case asobi_repo:update(CS) of
+        {ok, Updated} ->
+            Updated;
+        {error, Reason} ->
+            ?LOG_WARNING(#{
+                event => provider_metadata_refresh_failed,
+                provider => maps:get(provider, Identity, undefined),
+                reason => Reason
+            }),
+            Identity
+    end.
+
 -spec login_existing_player(map()) -> response().
 login_existing_player(Identity) ->
     PlayerId = maps:get(player_id, Identity),
@@ -298,7 +337,11 @@ insert_identity(PlayerId, Provider, Claims) ->
         provider => Provider,
         provider_uid => maps:get(provider_uid, Claims),
         provider_email => maps:get(provider_email, Claims, undefined),
-        provider_display_name => maps:get(provider_display_name, Claims, undefined)
+        provider_display_name => maps:get(provider_display_name, Claims, undefined),
+        %% Whatever the provider considers its own. Steam puts the VAC verdict
+        %% and the Family Sharing owner here; a provider that supplies nothing
+        %% gets the column default and nothing changes for it (asobi#520).
+        provider_metadata => maps:get(provider_metadata, Claims, #{})
     },
     CS = asobi_player_identity:changeset(#{}, Params),
     asobi_repo:insert(CS).

--- a/src/ws/asobi_ws_handler.erl
+++ b/src/ws/asobi_ws_handler.erl
@@ -577,6 +577,7 @@ terminate(_Reason, _Req, State) when is_map(State) ->
         true -> asobi_telemetry:ws_disconnected();
         false -> ok
     end,
+    session_disconnected(State),
     case maps:get(session, State, undefined) of
         undefined -> ok;
         SessionPid -> asobi_player_session:stop(SessionPid)
@@ -584,6 +585,30 @@ terminate(_Reason, _Req, State) when is_map(State) ->
     ok;
 terminate(_Reason, _Req, _State) ->
     ok.
+
+%% Closes out `[asobi, session, connected]`, which until now had no counterpart:
+%% the only disconnect emitted was `ws_disconnected/0`, which carries no
+%% player_id, so a consumer could open a session and never close it (asobi#525).
+%%
+%% Both keys are set together at `session.connect`, so a socket that never
+%% authenticated matches neither clause and stays silent - it was never a
+%% session.
+session_disconnected(#{player_id := PlayerId, session_started_at := StartedAt}) when
+    is_binary(PlayerId), is_integer(StartedAt)
+->
+    Elapsed = erlang:system_time(millisecond) - StartedAt,
+    asobi_telemetry:session_disconnected(PlayerId, at_least_one_ms(Elapsed));
+session_disconnected(_State) ->
+    ok.
+
+%% `duration_ms` is declared `pos_integer()`, and a session that opens and closes
+%% inside the same millisecond would otherwise report zero. A clause rather than
+%% `max/2` because eqWAlizer types `erlang:max/2` as `term()` - it orders any two
+%% terms - so the spec would stop being checked at the one call site that needs
+%% it.
+-spec at_least_one_ms(integer()) -> pos_integer().
+at_least_one_ms(Ms) when Ms > 0 -> Ms;
+at_least_one_ms(_NotYetAMillisecond) -> 1.
 
 %% --- Message Routing ---
 
@@ -608,7 +633,14 @@ handle_message(#{~"type" := ~"session.connect", ~"payload" := Payload} = Msg, St
             }),
             State1 = cancel_idle_auth_timer(State),
             {reply, {text, Reply}, State1#{
-                session => SessionPid, player_id => PlayerId, wire => Wire
+                session => SessionPid,
+                player_id => PlayerId,
+                wire => Wire,
+                %% Its own clock, not `connected_at`. That one starts when the
+                %% socket opens, so it counts the pre-auth idle window too - a
+                %% duration reported under `[asobi, session, disconnected]` would
+                %% then mean "socket lifetime" while the event name says session.
+                session_started_at => erlang:system_time(millisecond)
             }};
         {error, Reason} ->
             Reply = encode_error(Cid, Reason),

--- a/test/asobi_oauth_SUITE.erl
+++ b/test/asobi_oauth_SUITE.erl
@@ -15,6 +15,7 @@
     unlink_success/1,
     identity_db_roundtrip/1,
     login_existing_identity/1,
+    provider_metadata_refreshed_on_login/1,
     create_player_retries_on_username_collision/1,
     create_player_no_retry_on_non_unique_username_error/1,
     create_player_deletes_orphan_on_identity_race_loss/1,
@@ -38,7 +39,7 @@ groups() ->
             unlink_success
         ]},
         {identity_db, [sequence], [
-            identity_db_roundtrip, login_existing_identity
+            identity_db_roundtrip, login_existing_identity, provider_metadata_refreshed_on_login
         ]},
         {create_player, [], [
             create_player_retries_on_username_collision,
@@ -233,6 +234,39 @@ login_existing_identity(Config) ->
     ),
     {ok, [Identity]} = asobi_repo:all(Q),
     ?assertEqual(PlayerId, maps:get(player_id, Identity)),
+    Config.
+
+%% A provider's claims change after signup, and Steam's VAC verdict is the one
+%% that matters: written only at insert it would be a snapshot of the day the
+%% account was created, and a stale `false` reads as "clean" rather than "nobody
+%% has looked" (asobi#520). Re-login must overwrite it.
+provider_metadata_refreshed_on_login(Config) ->
+    {player1_id, PlayerId} = lists:keyfind(player1_id, 1, Config),
+    ProviderUid = asobi_test_helpers:unique_id(~"steam_uid"),
+    {ok, Identity} = asobi_repo:insert(
+        asobi_player_identity:changeset(#{}, #{
+            player_id => PlayerId,
+            provider => ~"steam",
+            provider_uid => ProviderUid,
+            provider_metadata => #{~"owner_steamid" => ProviderUid, ~"vac_banned" => false}
+        })
+    ),
+
+    Fresh = #{~"owner_steamid" => ProviderUid, ~"vac_banned" => true},
+    Refreshed = asobi_oauth_controller:refresh_provider_metadata(Identity, #{
+        provider_metadata => Fresh
+    }),
+    ?assertEqual(Fresh, maps:get(provider_metadata, Refreshed)),
+
+    %% ...and it is on the row, not only in the returned term.
+    {ok, Reloaded} = asobi_repo:get(asobi_player_identity, maps:get(id, Identity)),
+    ?assertEqual(Fresh, maps:get(provider_metadata, Reloaded)),
+
+    %% A provider that says nothing must not blank what another login stored.
+    Untouched = asobi_oauth_controller:refresh_provider_metadata(Reloaded, #{}),
+    ?assertEqual(Fresh, maps:get(provider_metadata, Untouched)),
+
+    {ok, _} = asobi_repo:delete(asobi_player_identity, Reloaded),
     Config.
 
 %% --- Username Collision Retry ---

--- a/test/asobi_steam_tests.erl
+++ b/test/asobi_steam_tests.erl
@@ -4,6 +4,8 @@
 steam_test_() ->
     {foreach, fun setup/0, fun cleanup/1, [
         fun ok_ticket_returns_claims/0,
+        fun vac_ban_is_surfaced_not_rejected/0,
+        fun family_sharing_owner_is_carried/0,
         fun publisher_banned_rejected/0,
         fun identity_param_included_when_configured/0,
         fun outbound_call_sets_tls_options/0
@@ -23,12 +25,34 @@ cleanup(_) ->
     application:unset_env(asobi, steam_identity),
     ok.
 
+%% The two Steam-specific claims live under `provider_metadata` with binary keys,
+%% because that is the identity field they are written to and it is jsonb
+%% (asobi#520). Loose at the top level they were computed and dropped.
 ok_ticket_returns_claims() ->
     stub_steam(#{~"result" => ~"OK", ~"steamid" => ~"123", ~"ownersteamid" => ~"123"}),
     {ok, Claims} = asobi_steam:validate_ticket(~"deadbeef"),
     ?assertEqual(~"123", maps:get(provider_uid, Claims)),
-    ?assertEqual(~"123", maps:get(owner_steamid, Claims)),
-    ?assertEqual(false, maps:get(vac_banned, Claims)).
+    ?assertEqual(
+        #{~"owner_steamid" => ~"123", ~"vac_banned" => false},
+        maps:get(provider_metadata, Claims)
+    ).
+
+%% A VAC ban is not a rejection - it is Valve's verdict about another game, and
+%% only publisherbanned (this app) refuses the login. Carrying it lets a title
+%% decide for itself.
+vac_ban_is_surfaced_not_rejected() ->
+    stub_steam(#{~"result" => ~"OK", ~"steamid" => ~"123", ~"vacbanned" => true}),
+    {ok, Claims} = asobi_steam:validate_ticket(~"deadbeef"),
+    ?assertEqual(true, maps:get(~"vac_banned", maps:get(provider_metadata, Claims))).
+
+%% Family Sharing: the ticket is authenticated against the borrower, the licence
+%% belongs to the owner. Without the owner id the two are indistinguishable.
+family_sharing_owner_is_carried() ->
+    stub_steam(#{~"result" => ~"OK", ~"steamid" => ~"borrower", ~"ownersteamid" => ~"owner"}),
+    {ok, Claims} = asobi_steam:validate_ticket(~"deadbeef"),
+    Meta = maps:get(provider_metadata, Claims),
+    ?assertEqual(~"borrower", maps:get(provider_uid, Claims)),
+    ?assertEqual(~"owner", maps:get(~"owner_steamid", Meta)).
 
 publisher_banned_rejected() ->
     stub_steam(#{~"result" => ~"OK", ~"steamid" => ~"123", ~"publisherbanned" => true}),

--- a/test/asobi_ws_handler_tests.erl
+++ b/test/asobi_ws_handler_tests.erl
@@ -473,6 +473,64 @@ a_rejected_connection_does_not_decrement_test() ->
     ok = asobi_ws_handler:terminate(normal, undefined, #{session => undefined}),
     ?assertEqual(0, Count()).
 
+%% asobi#525: `[asobi, session, disconnected]` was declared in the frozen event
+%% surface, specced, and emitted by nobody - so a consumer saw session starts
+%% carrying a player_id and ends carrying none, and could never close one out.
+capture_event(Ref, Event) ->
+    {ok, _} = application:ensure_all_started(telemetry),
+    Self = self(),
+    telemetry:attach(Ref, Event, fun(_E, M, Meta, _) -> Self ! {Ref, M, Meta} end, []),
+    fun() ->
+        telemetry:detach(Ref),
+        receive
+            {Ref, M, Meta} -> {M, Meta}
+        after 0 -> none
+        end
+    end.
+
+an_authenticated_session_closes_out_on_terminate_test() ->
+    Ref = make_ref(),
+    Captured = capture_event(Ref, [asobi, session, disconnected]),
+    Started = erlang:system_time(millisecond) - 1500,
+    ok = asobi_ws_handler:terminate(normal, undefined, #{
+        connected_at => 1,
+        session => undefined,
+        player_id => ~"p1",
+        session_started_at => Started
+    }),
+    {Measurements, Metadata} = Captured(),
+    ?assertEqual(~"p1", maps:get(player_id, Metadata)),
+    ?assertEqual(1, maps:get(count, Measurements)),
+    %% Roughly the elapsed time, not the exact value - the clock moves between
+    %% the two calls.
+    ?assert(maps:get(duration_ms, Measurements) >= 1500).
+
+%% The trap the fix exists to avoid. `connected_at` is set when the SOCKET opens,
+%% before authentication, so it is not the session clock: a state that has it and
+%% no `session_started_at` never became a session and must stay silent rather
+%% than report the socket's lifetime under a session event.
+a_socket_that_never_authenticated_emits_no_session_end_test() ->
+    Ref = make_ref(),
+    Captured = capture_event(Ref, [asobi, session, disconnected]),
+    ok = asobi_ws_handler:terminate(normal, undefined, #{
+        connected_at => 1, session => undefined
+    }),
+    ?assertEqual(none, Captured()).
+
+%% duration_ms is specced pos_integer(). A session that opens and closes inside
+%% the same millisecond must not report zero.
+a_sub_millisecond_session_reports_one_not_zero_test() ->
+    Ref = make_ref(),
+    Captured = capture_event(Ref, [asobi, session, disconnected]),
+    ok = asobi_ws_handler:terminate(normal, undefined, #{
+        connected_at => 1,
+        session => undefined,
+        player_id => ~"p1",
+        session_started_at => erlang:system_time(millisecond)
+    }),
+    {Measurements, _Metadata} = Captured(),
+    ?assert(maps:get(duration_ms, Measurements) >= 1).
+
 %% The gauge fix must not cost a session its shutdown. A state carrying a session
 %% pid stops it whether or not the connection was ever counted, which is why
 %% terminate/3 checks the two conditions separately rather than matching both at


### PR DESCRIPTION
Two small independent gaps found in the same audit, batched into one PR.

Closes #520
Closes #525

---

## 1. Steam's VAC verdict was computed and discarded (#520)

`asobi_steam` already asks Valve for `vacbanned` and `ownersteamid` on every login and builds them into the claims map. `insert_identity/3` persisted `provider_uid`, `provider_email` and `provider_display_name`, and nothing else. The comment above the claims even said Family Sharing was "surfaced in the claims so game policy can decide" - it never reached anywhere a policy could read it.

**Both now travel under `provider_metadata`.** That is the field the identity row already has for provider-specific claims, and until now only the guest provider wrote it. Binary keys, since it lands in jsonb and the guest verifier established that shape.

This diverges from what the issue proposed, which was typed `vac_banned` / `owner_steamid` columns. Two Steam-shaped columns on a table every provider shares is warping, and it would need a migration; `provider_metadata` needs neither, and a provider that supplies nothing gets the column default exactly as before.

**The write happens on every login, not only at signup.** This is the part that isn't in the issue and matters most. `authenticate/1` finds an existing identity and goes straight to `login_existing_player/1` without touching the row, so a VAC ban acquired after the account was created would leave a stored `false` forever. A stale `false` reads as "this player is clean" rather than "nobody has looked since" - worse than storing nothing, because it looks current. The refresh is best-effort and logged, following the guest controller's precedent: a failed metadata write must not fail a login the provider has already accepted.

Deliberately out of scope: what to *do* with a positive verdict. A VAC ban is Valve's finding about another title and a game may reasonably not care. Acting on it needs the enforcement path that doesn't exist yet (#521).

## 2. `[asobi, session, disconnected]` never fired (#525)

It's in the semver-locked event list, `session_disconnected/2` is exported and specced, and nothing called it. The only disconnect emitted was `ws_disconnected/0`, which takes no arguments and carries empty metadata - so a consumer saw session starts with a `player_id` and session ends without one, and could never close one out. Anything counting live sessions from telemetry leaked upward forever.

**The session gets its own clock.** The obvious fix is to pass `connected_at`, and it would be wrong: that's set when the *socket* opens, next to `ws_connected/0`, so it starts before authentication and includes the whole pre-auth idle window. Using it would ship an event whose `duration_ms` silently meant "socket lifetime" while the name promised session. A socket that never authenticated has neither key and stays silent, which is correct - it was never a session.

`at_least_one_ms/1` rather than `max/2`: `duration_ms` is declared `pos_integer()`, and eqWAlizer types `erlang:max/2` as `term()` (it orders any two terms), so the spec would have stopped being checked at the one call site that needs it.

## Tests

- `asobi_steam_tests`: claim shape, plus a VAC ban is surfaced not rejected, plus Family Sharing carries a distinct owner.
- `asobi_oauth_SUITE`: a DB round-trip proving a changed verdict overwrites the row and that a provider saying nothing does not blank what another login stored.
- `asobi_ws_handler_tests`: the event fires with `player_id` and a plausible duration; a socket that never authenticated emits nothing; a sub-millisecond session reports 1, not 0.

Verified negatively: neutering the emit fails 2 of the 3 new handler tests (the third asserts absence, so it correctly still passes).

## Checks

`fmt`, `xref`, `dialyzer`, `elp eqwalize-all` (363, identical to baseline), `elp lint` (changed files clean), `eunit` 2158/0, `ct` 389/0, `fmt --check`, `ex_doc` (no new warnings). `rebar3 mutate` skipped - plugin not in this project.

## Note on the base

`git fetch` is blocked in my environment, so this branches off `71128e7` (#518) rather than current `main`, which now also has #519. No file overlap, so it merges clean - but the base is one commit stale.
