### PR TITLE
fix: rpc dispatch carries the negotiated wire into the handler ctx

### DIFF
--- a/guides/extensions.md
+++ b/guides/extensions.md
@@ -236,8 +236,10 @@ differently, and a code you declared in `codes/0` reaches the client as
 itself. It is the same dialect core's own controllers speak
 (`{asobi_error, Code, Details}`), so there is one shape to learn.
 
-`Ctx` is `#{player_id, session, method}`. It may gain keys: match the ones you
-need with `:=` and never match it exhaustively.
+`Ctx` is `#{player_id, session, method, transport, wire}` - `transport` is `ws`
+or `http`, `wire` is the wire that transport negotiated (`~"json"` or
+`~"binary"`, and `~"json"` over HTTP, which has no wire of its own). It may
+gain keys: match the ones you need with `:=` and never match it exhaustively.
 
 Everything else is a defect and answers `internal` with one logged line naming
 the method: a handler that raises, one that returns outside the contract, one

--- a/src/extensions/asobi_rpc.erl
+++ b/src/extensions/asobi_rpc.erl
@@ -126,7 +126,11 @@ everything in front of the dispatcher, and these divergences are frozen:
 
 -doc "What a handler is told about its caller. Additive; never match it exhaustively.".
 -type ctx() :: #{
-    player_id := binary(), session := pid(), method := binary(), transport := ws | http
+    player_id := binary(),
+    session := pid(),
+    method := binary(),
+    transport := ws | http,
+    wire := binary()
 }.
 
 -doc "What a handler returns.".
@@ -140,10 +144,14 @@ The authenticated player behind the transport, or `unauthenticated`.
 
 `transport` marks which one so a handler can branch on `Ctx.transport`; it is
 optional here and defaults to `ws` in `invoke/5`, so a caller built without it
-stays safe.
+stays safe. `wire` is the wire that transport negotiated, optional the same way
+and defaulting to `~"json"` - a transport with no wire of its own (`http`) has
+the same answer as one that negotiated the text wire, which is what the mint
+records.
 """.
 -type caller() ::
-    #{player_id := binary(), session := pid(), transport => ws | http} | unauthenticated.
+    #{player_id := binary(), session := pid(), transport => ws | http, wire => binary()}
+    | unauthenticated.
 
 -export_type([params/0, ctx/0, reply/0, caller/0]).
 
@@ -260,7 +268,11 @@ invoke(Module, Function, Method, Params, #{player_id := PlayerId, session := Ses
         player_id => PlayerId,
         session => Session,
         method => Method,
-        transport => maps:get(transport, Caller, ws)
+        transport => maps:get(transport, Caller, ws),
+        %% Carried through rather than dropped: the datagram mint decides from it
+        %% whether poses can reach this connection, and a caller rebuilt without
+        %% it mints every session as JSON, so no pose is ever sent (asobi#527).
+        wire => maps:get(wire, Caller, ~"json")
     },
     try Module:Function(Params, Ctx) of
         Reply -> reply(Reply, Method)

--- a/test/asobi_dgram_pose_zone_tests.erl
+++ b/test/asobi_dgram_pose_zone_tests.erl
@@ -53,6 +53,11 @@ setup() ->
 
 cleanup(Prev) ->
     meck:unload(asobi_dgram_link_client),
+    %% The mirror is a named table the real mint creates for itself at boot, so a
+    %% stand-in left behind here makes any later test that starts a mint crash on
+    %% `already_exists`.
+    drop_table(asobi_dgram_conns),
+    drop_table(asobi_pose_capture),
     [
         case V of
             undefined -> application:unset_env(asobi, K);
@@ -60,6 +65,13 @@ cleanup(Prev) ->
         end
      || {K, V} <- Prev
     ],
+    ok.
+
+drop_table(Name) ->
+    case ets:whereis(Name) of
+        undefined -> ok;
+        _Tid -> ets:delete(Name)
+    end,
     ok.
 
 %% --- Tests ---

--- a/test/asobi_dgram_rpc_tests.erl
+++ b/test/asobi_dgram_rpc_tests.erl
@@ -1,6 +1,9 @@
 -module(asobi_dgram_rpc_tests).
 -include_lib("eunit/include/eunit.hrl").
 
+%% The capture handler the dispatcher calls back into.
+-export([capture/2]).
+
 %% The player-facing mint, and the built-in method table it arrives through.
 
 rpc_test_() ->
@@ -8,7 +11,9 @@ rpc_test_() ->
         {"the mint is reachable as a built-in rpc method", fun reachable_as_builtin/0},
         {"an unconfigured plane is unavailable, not unknown", fun unavailable_not_unknown/0},
         {"a built-in cannot be shadowed by an extension", fun not_shadowable/0},
-        {"close refuses a missing conn_id", fun close_refuses_bad_params/0}
+        {"close refuses a missing conn_id", fun close_refuses_bad_params/0},
+        {"the negotiated wire reaches the handler", fun wire_reaches_the_handler/0},
+        {"a caller without a wire is json", fun wireless_caller_is_json/0}
     ]}.
 
 %% The mint sits behind the same readiness guard as every other RPC method, which
@@ -56,7 +61,43 @@ close_refuses_bad_params() ->
         asobi_dgram_rpc:close(#{~"conn_id" => ~"not a number"}, caller())
     ).
 
+%% asobi#527: `invoke/5` rebuilds the ctx from a whitelist, so a key the socket
+%% deliberately put on the caller is dropped unless it is on that list. `wire`
+%% was not, and the mint records "can this connection resolve a pose?" from it,
+%% so every binary-wire session was minted as JSON and no pose was ever sent.
+wire_reaches_the_handler() ->
+    Ctx = dispatch_to_capture((caller())#{wire => ~"binary"}),
+    ?assertEqual(~"binary", maps:get(wire, Ctx, undefined)).
+
+%% An HTTP caller has no WebSocket and therefore no wire. It is the same answer
+%% as the text wire - mint, but never a pose target - so it defaults rather than
+%% being absent, which would make every handler re-state the default.
+wireless_caller_is_json() ->
+    Ctx = dispatch_to_capture(caller()),
+    ?assertEqual(~"json", maps:get(wire, Ctx, undefined)).
+
 %% --- Helpers ---
+
+%% Dispatches through the real table to a handler that hands its ctx back, which
+%% is the only way to see what the whitelist actually let through.
+dispatch_to_capture(Caller) ->
+    meck:new(asobi_extensions, [passthrough, non_strict]),
+    try
+        meck:expect(asobi_extensions, rpc_methods, 0, #{
+            ~"capture.ctx" => {?MODULE, capture, 2}
+        }),
+        {_Cid, {ok, _}} = asobi_rpc:handle(~"c-4", call(~"capture.ctx", #{}), Caller),
+        receive
+            {captured, Ctx} -> Ctx
+        after 1000 -> erlang:error(handler_never_ran)
+        end
+    after
+        meck:unload(asobi_extensions)
+    end.
+
+capture(_Params, Ctx) ->
+    self() ! {captured, Ctx},
+    {ok, #{}}.
 
 call(Method, Params) ->
     #{~"protocol" => 1, ~"method" => Method, ~"params" => Params}.

--- a/test/asobi_dgram_wire_path_tests.erl
+++ b/test/asobi_dgram_wire_path_tests.erl
@@ -1,0 +1,82 @@
+-module(asobi_dgram_wire_path_tests).
+-include_lib("eunit/include/eunit.hrl").
+
+%% asobi#527: the negotiated wire has to survive every hop between the socket and
+%% the mint, and each hop rebuilds the map it hands on. Both earlier datagram gaps
+%% were the same shape - a value correct at one end and absent at the other, with
+%% the transport itself reporting healthy - so this walks the whole path a client
+%% walks: a `rpc.call` frame on a session that negotiated the binary wire, through
+%% the dispatcher, into the mint, and then asks the mirror the question the zone
+%% asks on every tick.
+
+-define(MIRROR, asobi_dgram_conns).
+
+wire_path_test_() ->
+    {foreach, fun setup/0, fun cleanup/1, [
+        {"a binary-wire session mints a pose target", fun binary_wire_is_minted_as_a_target/0},
+        {"a json-wire session mints, but is not one", fun json_wire_is_minted_but_not/0}
+    ]}.
+
+setup() ->
+    asobi_readiness:mark_ready(),
+    %% The gateway half of the mint. It has to answer before the credential is
+    %% handed out, so the plane is "configured" here without a gateway to talk to.
+    meck:new(asobi_dgram_link_client, [passthrough, non_strict]),
+    meck:expect(asobi_dgram_link_client, enabled, 0, true),
+    meck:expect(asobi_dgram_link_client, register, 1, ok),
+    meck:expect(asobi_dgram_link_client, unregister, 1, ok),
+    {ok, Mint} = asobi_dgram_mint:start_link(),
+    Mint.
+
+cleanup(Mint) ->
+    gen_server:stop(Mint),
+    meck:unload(asobi_dgram_link_client),
+    asobi_readiness:reset(),
+    ok.
+
+%% The defect: the frame arrived on a binary-wire session, the mint recorded JSON,
+%% `pose_conn_of/1` answered `error` for every player, and the zone emitted no pose
+%% at all - which the SDK reads as a dead plane and shuts down, while the UDP
+%% handshake below it completes cleanly and reports nothing wrong.
+binary_wire_is_minted_as_a_target() ->
+    PlayerId = open_the_plane(~"binary"),
+    ?assertMatch({ok, ConnId} when is_integer(ConnId), asobi_dgram_mint:pose_conn_of(PlayerId)).
+
+%% The other half of the same contract, and the reason the wire travels at all: a
+%% JSON-wire client is still minted - `world.input` upstream needs no slots - but
+%% never receives an `add` on `world.tick`, so a pose would name a slot it cannot
+%% resolve.
+json_wire_is_minted_but_not() ->
+    PlayerId = open_the_plane(~"json"),
+    ?assertEqual(error, asobi_dgram_mint:pose_conn_of(PlayerId)),
+    ?assert(ets:member(?MIRROR, PlayerId)).
+
+%% --- Helpers ---
+
+%% One `asobi.datagram.open` the way a client sends it: a text frame into the
+%% socket handler, on a state carrying the wire `session.connect` negotiated.
+open_the_plane(Wire) ->
+    PlayerId = ~"p-527",
+    Frame = json:encode(#{
+        ~"type" => ~"rpc.call",
+        ~"cid" => ~"c-1",
+        ~"payload" => #{
+            ~"protocol" => asobi_rpc:protocol(),
+            ~"method" => ~"asobi.datagram.open",
+            ~"params" => #{}
+        }
+    }),
+    {reply, {text, Reply}, _State} = asobi_ws_handler:websocket_handle(
+        {text, iolist_to_binary(Frame)}, state(PlayerId, Wire)
+    ),
+    ?assertMatch(#{~"type" := ~"rpc.ok"}, json:decode(iolist_to_binary(Reply))),
+    PlayerId.
+
+state(PlayerId, Wire) ->
+    #{
+        player_id => PlayerId,
+        session => self(),
+        wire => Wire,
+        ws_msg_count => 0,
+        ws_msg_window_start => erlang:system_time(millisecond)
+    }.


### PR DESCRIPTION
Closes #527.

## What was wrong

`asobi_ws_handler:rpc_caller/1` deliberately puts the session's negotiated wire on the RPC caller map - the datagram mint decides from it whether poses can reach the connection. `asobi_rpc:invoke/5` then rebuilt the ctx from a whitelist that did not carry `wire` through, so `asobi_dgram_rpc:open/2` always fell back to its `~"json"` default.

Consequence: every mint wrote `false` into the pose mirror, `asobi_dgram_mint:pose_conn_of/1` answered `error` for every player, and no zone emitted a pose. The UDP handshake itself completed fine - hellos answered, confirms accepted, zero drops - so nothing at the transport layer reported a fault, while the SDK's liveness rule (first pose within 3s) shut the plane down on every client.

## The fix

`wire => maps:get(wire, Caller, ~"json")` in the rebuilt ctx, plus the type and guide updates that go with it. HTTP has no WebSocket and therefore no wire of its own, which is the same answer as the text wire, so the key defaults rather than being absent.

## Tests

Three new tests, all of which fail on `main` and pass here:

- `asobi_dgram_rpc_tests`: the dispatcher hands the negotiated wire to the handler, and a caller without one is `~"json"`.
- `asobi_dgram_wire_path_tests` (new): the regression test #527 asks for - a `rpc.call` text frame into `asobi_ws_handler` on a binary-wire session, through the dispatcher, into a real `asobi_dgram_mint`, asserting the mirror row the zone reads on every broadcast tick. Its json-wire twin asserts the other half of the contract: minted, but not a pose target.

`asobi_dgram_pose_zone_tests` now drops the mirror table it stands in for. It was leaking a named global table, which made any later test that starts a real mint crash on `already_exists`.

## Checks

fmt, xref, dialyzer, `elp eqwalize-all` (365 baseline errors, unchanged; `asobi_rpc` itself clean), `elp lint` (no new findings), eunit 2187/2187, ct 389/389, ex_doc (two pre-existing warnings only).