### PR TITLE
fix: gate the gateway supervisor on the role, and drop a ${} literal from gw_sys.config.src

### DIFF
--- a/apps/asobi_dgram_gw/src/asobi_dgram_gw_app.erl
+++ b/apps/asobi_dgram_gw/src/asobi_dgram_gw_app.erl
@@ -21,8 +21,9 @@ would read them is not in the container.
 
 `asobi` depends on this application for the shared codec, so the engine loads it
 too. Starting the gateway's tree there would bind a UDP port on every engine, so
-the role is read here as well and the engine gets an empty supervisor. One
-application, two roles, and the release decides which one can happen.
+`asobi_dgram_gw_sup:init/1` reads the role as well and the engine gets a
+supervisor with no children. One application, two roles, and the release decides
+which one can happen.
 """.
 
 -behaviour(application).

--- a/apps/asobi_dgram_gw/src/asobi_dgram_gw_sup.erl
+++ b/apps/asobi_dgram_gw/src/asobi_dgram_gw_sup.erl
@@ -94,6 +94,16 @@ start_link() ->
 -spec init([]) -> {ok, {supervisor:sup_flags(), [supervisor:child_spec()]}}.
 init([]) ->
     SupFlags = #{strategy => one_for_one, intensity => 10, period => 60},
+    {ok, {SupFlags, children(enabled())}}.
+
+%% The engine loads this application for the shared codec, so `init/1` runs there
+%% too. Starting the tree would bind the public UDP port and 7778 inside the
+%% process tree holding the Lua sandbox and the tenant credentials - the exact
+%% thing ADR 0012 decision 14 splits the roles to prevent - and would leave a real
+%% gateway sidecar crash-looping on eaddrinuse (asobi#530).
+children(false) ->
+    [];
+children(true) ->
     %% Order matters on the way up and is the reason this is a list rather than
     %% a set: limiters before anything can be received, the table before a
     %% datagram can name a conn_id, and the sender before a receiver can need to
@@ -101,15 +111,14 @@ init([]) ->
     %% can be handed work by someone outside the node - which is also why the
     %% sender resolves its socket on first use rather than at init: it starts
     %% before the sockets it borrows from exist.
-    {ok,
-        {SupFlags, [
-            limits_spec(),
-            table_spec(),
-            link_server_spec(),
-            sender_spec(),
-            rx_sup_spec(),
-            canary_spec()
-        ]}}.
+    [
+        limits_spec(),
+        table_spec(),
+        link_server_spec(),
+        sender_spec(),
+        rx_sup_spec(),
+        canary_spec()
+    ].
 
 %% --- Internal ---
 

--- a/config/gw_sys.config.src
+++ b/config/gw_sys.config.src
@@ -2,9 +2,13 @@
 %%
 %% Deliberately tiny, and that is the point of asobi#513: this release contains
 %% no nova, no kura and no shigoto, so it has nothing to configure for them - and
-%% it must not reference ${ASOBI_DB_*}, which a gateway container has no reason to
-%% be given. Everything the gateway itself needs (role, ports, shard count, link
-%% secret) arrives through environment variables read by `asobi_dgram_env`.
+%% it must not reference any ASOBI_DB_ variable, which a gateway container has no
+%% reason to be given. Written without braces on purpose: relx's start script
+%% substitutes every $-brace form it finds in this file, comments included, and a
+%% name it cannot resolve spins its awk loop at 100% CPU forever (asobi#529).
+%%
+%% Everything the gateway itself needs (role, ports, shard count, link secret)
+%% arrives through environment variables read by `asobi_dgram_env`.
 [
     {kernel, [
         {logger_level, info},

--- a/rebar.config
+++ b/rebar.config
@@ -48,8 +48,8 @@
         [
             %% Its own, and it is four lines long: with no nova, kura or shigoto
             %% in the release there is nothing to configure for them, and a
-            %% gateway container must not be handed ${ASOBI_DB_*} just to render
-            %% a config file it never reads.
+            %% gateway container must not be handed any ASOBI_DB_ variable just
+            %% to render a config file it never reads.
             {sys_config_src, "./config/gw_sys.config.src"},
             {vm_args_src, "./config/vm.args.src"}
         ]},

--- a/test/asobi_dgram_gw_tests.erl
+++ b/test/asobi_dgram_gw_tests.erl
@@ -7,6 +7,8 @@ role_test_() ->
     {foreach, fun setup/0, fun cleanup/1, [
         {"engine is the default, and it is the whole tree", fun engine_is_the_default/0},
         {"the gateway role starts none of the engine", fun gw_role_starts_no_engine/0},
+        {"the engine role starts none of the gateway", fun engine_role_starts_no_gateway/0},
+        {"the gateway role starts all of the gateway", fun gw_role_starts_the_tree/0},
         {"the gateway application carries nothing that holds credentials",
             fun gateway_application_is_minimal/0},
         {"shards default to the schedulers, capped", fun shard_default/0}
@@ -37,7 +39,7 @@ engine_is_the_default() ->
     application:unset_env(asobi, role),
     ?assertNot(asobi_dgram_gw_sup:enabled()),
     {ok, {_Flags, Children}} = asobi_sup:init([]),
-    Ids = [maps:get(id, C) || C <- Children],
+    Ids = [Id || #{id := Id} <- Children],
     ?assert(lists:member(asobi_world_sup, Ids)),
     ?assert(lists:member(asobi_lua_sup, Ids)),
     ?assertNot(lists:member(asobi_dgram_gw_sup, Ids)).
@@ -71,6 +73,34 @@ gateway_application_is_minimal() ->
     _ = application:load(asobi),
     {ok, AsobiDeps} = application:get_key(asobi, applications),
     ?assert(lists:member(asobi_dgram_gw, AsobiDeps)).
+
+%% asobi#530: `asobi` lists `asobi_dgram_gw` in `applications` for the shared
+%% codec, so this supervisor's `init/1` runs on every engine. Returning the child
+%% list there binds the public UDP port and 7778 inside the process tree holding
+%% the Lua sandbox and the tenant credentials - the isolation ADR 0012 decision 14
+%% exists to enforce - and crash-loops any real gateway sidecar on eaddrinuse.
+%% Worse, without a sidecar the plane keeps working through the engine's
+%% in-process gateway, so nothing tells the operator the boundary is gone.
+engine_role_starts_no_gateway() ->
+    application:unset_env(asobi, role),
+    {ok, {_Flags, Children}} = asobi_dgram_gw_sup:init([]),
+    ?assertEqual([], Children).
+
+gw_role_starts_the_tree() ->
+    application:set_env(asobi, role, dgram_gw),
+    {ok, {_Flags, Children}} = asobi_dgram_gw_sup:init([]),
+    Ids = [Id || #{id := Id} <- Children],
+    ?assertEqual(
+        [
+            asobi_dgram_limits,
+            asobi_dgram_table,
+            asobi_dgram_link_server,
+            asobi_dgram_sender,
+            asobi_dgram_rx_sup,
+            asobi_dgram_canary
+        ],
+        Ids
+    ).
 
 %% One receiver per scheduler is the shape SO_REUSEPORT is for. More sockets than
 %% schedulers buys nothing and multiplies the flows a restart breaks, because the

--- a/test/asobi_release_config_tests.erl
+++ b/test/asobi_release_config_tests.erl
@@ -1,0 +1,37 @@
+-module(asobi_release_config_tests).
+-include_lib("eunit/include/eunit.hrl").
+
+%% asobi#529: relx's extended start script substitutes every `${...}` form in a
+%% `.src` release file, comments included, and its awk loop spins at 100% CPU
+%% forever on a name it cannot resolve. A gateway image shipped that way looks
+%% Running, logs nothing and never boots, so the trap is invisible by design -
+%% which is why it is worth a test rather than a code-review habit.
+placeholders_are_resolvable_names_test_() ->
+    [
+        {File, fun() -> ?assertEqual([], bad_placeholders(File)) end}
+     || File <- filelib:wildcard("config/*.src")
+    ].
+
+bad_placeholders(File) ->
+    {ok, Bin} = file:read_file(File),
+    [Name || Name <- placeholders(Bin), not is_env_name(Name)].
+
+placeholders(Bin) ->
+    case re:run(Bin, "[$]{([^}]*)}", [global, {capture, [1], binary}]) of
+        {match, Matches} -> [Name || [Name] <- Matches, is_binary(Name)];
+        nomatch -> []
+    end.
+
+is_env_name(<<C, Rest/binary>>) when C =:= $_; C >= $A, C =< $Z; C >= $a, C =< $z ->
+    is_env_name_tail(Rest);
+is_env_name(_) ->
+    false.
+
+is_env_name_tail(<<>>) ->
+    true;
+is_env_name_tail(<<C, Rest/binary>>) when
+    C =:= $_; C >= $0, C =< $9; C >= $A, C =< $Z; C >= $a, C =< $z
+->
+    is_env_name_tail(Rest);
+is_env_name_tail(_) ->
+    false.


### PR DESCRIPTION
Two v0.93.2 gateway defects, both reported against the published image.

## #530 - every engine booted a full in-process gateway

`asobi_dgram_gw_sup:init/1` returned the full child list regardless of
`asobi.role`. `asobi` lists `asobi_dgram_gw` in `applications` for the shared
codec, so every engine started the link server on 7778, the SO_REUSEPORT shards
on the public UDP port and the canary, inside the process tree holding the Lua
sandbox and the tenant DB credentials. That is what ADR 0012 decision 14 splits
the roles to prevent.

`enabled/0` already implemented the check and both moduledocs already described
it; only `init/1` never consulted it. `init/1` now delegates to
`children(enabled())`, empty in the engine role.

The `asobi_dgram_gw_app` moduledoc also credited the check to the wrong module,
so it now points at the supervisor.

## #529 - the gateway image never booted

`config/gw_sys.config.src` carried the literal `${ASOBI_DB_*}` in a comment
explaining why a gateway container needs no database variables. relx's extended
start script substitutes every `$`-brace form it finds, comments included, and
its awk loop spins at 100% CPU forever on a name it cannot resolve. The
container looked Running, logged nothing and never booted.

The comment now says the same thing without braces. The matching comment in
`rebar.config` is reworded too, so nobody copies it back.

Not fixed here: making relx's substitution loop bail out on an unresolvable
name. That is upstream relx, not this repo.

## Tests

- `asobi_dgram_gw_tests`: the engine role starts no gateway children, the
  gateway role starts all six in order.
- `asobi_release_config_tests`: walks `config/*.src` and rejects any `${...}`
  whose contents are not a resolvable environment-variable name. Verified
  against the bug by re-inserting the old comment, which fails with
  `got: [<<"ASOBI_DB_*">>]`.

`fmt --check`, `xref`, `dialyzer` and `elp lint` clean of new findings.
`elp eqwalize-all` gains nothing and loses one pre-existing error.
Full `rebar3 eunit`: 2193 tests, 0 failures. CT not run - it needs Docker
Postgres and nothing here touches the database path.

Closes #530
Closes #529
