### PR TITLE
feat(world): let handle_input report the input seq it consumed

### DIFF
--- a/guides/websocket-protocol.md
+++ b/guides/websocket-protocol.md
@@ -937,8 +937,12 @@ end
 ```
 
 The number is in your client's own sequence space - the same numbering the steps
-inside the payload carry - and asobi only refuses to let it walk the ack
-backwards. Three rules come with it:
+inside the payload carry - and must be a non-negative integer no larger than
+2^53-1, the same bound the client-stamped `seq` is held to. Anything else is
+refused with a warning and the frame stamp is used instead: the value is echoed
+to your client on every broadcast tick, so a wider one would be an encode
+amplifier and unreadable to any SDK holding it in an int64. The rules that come
+with it:
 
 - **Report on every input or on none.** Within a tick a report always beats a
   frame stamp, whatever order they arrive in. Across ticks it does not: a tick
@@ -946,14 +950,18 @@ backwards. Three rules come with it:
   keeps the highest value it has recorded, so one unreported tick pins the ack
   above your watermark for good.
 - **Reporting acks a client that never stamped a `seq`.** If your client numbers
-  its steps inside the payload it never needs to stamp the frame at all.
+  its steps inside the payload it never needs to stamp the frame at all. SDK
+  authors: this means `world.ack` can arrive unsolicited, so a client that never
+  opted in must drop it silently rather than log or raise per frame.
 - **Draining parked steps in `zone_tick` has no report channel.** The watermark
   rides out on the next input you handle, which a client re-sending
   unacknowledged steps produces every tick - so it costs a tick, except for a
   player at rest, whose final drain stays unacked until they move.
 - **`{error, Reason}` still acks the frame stamp**, because a client must never
-  wait forever on an input the server chose to drop. A game that parks should
-  model refusal as `{ok, Entities, Watermark}` instead.
+  wait forever on an input the server chose to drop - unless a report already
+  landed this tick, which outranks it. Refusing one input does not unrun the
+  steps another already consumed. A game that parks should model refusal as
+  `{ok, Entities, Watermark}` instead.
 - **Deduplicate by the same watermark.** A client that re-sends unacknowledged
   steps for redundancy (what makes an unreliable carrier safe) will hand you
   steps you have already run; skip them, and report the watermark either way.

--- a/guides/websocket-protocol.md
+++ b/guides/websocket-protocol.md
@@ -891,9 +891,12 @@ authoritative state already includes - is a first-class primitive:
 
 Set [`broadcast_interval`](world-server.md) to 1 so the ack returns every tick.
 
-The ack is addressed to one connection: it is sent only to clients that opted in
-by stamping a `seq`, and never rides the shared `world.tick`, so one player's
-input stream is never broadcast to the rest of the zone.
+The ack is addressed to one connection and never rides the shared `world.tick`,
+so one player's input stream is never broadcast to the rest of the zone. It is
+sent to clients that opted in by stamping a `seq`, and to clients whose game
+module reports a consumed seq for them - see
+[Batched input and the ack](#batched-input-and-the-ack), where numbering the
+steps inside the payload replaces stamping the frame.
 
 **`seq` never goes backwards on a connection.** The high-water mark is recorded
 per zone, and a player is subscribed to their whole interest ring, so during a
@@ -937,9 +940,17 @@ The number is in your client's own sequence space - the same numbering the steps
 inside the payload carry - and asobi only refuses to let it walk the ack
 backwards. Three rules come with it:
 
-- **Report on every input or on none.** A reported seq wins over a frame stamp
-  for the rest of that tick, but an input you do not report for contributes its
-  stamp, and the higher of the two is what the client hears.
+- **Report on every input or on none.** Within a tick a report always beats a
+  frame stamp, whatever order they arrive in. Across ticks it does not: a tick
+  in which you reported nothing records the frame stamp instead, and the ack
+  keeps the highest value it has recorded, so one unreported tick pins the ack
+  above your watermark for good.
+- **Reporting acks a client that never stamped a `seq`.** If your client numbers
+  its steps inside the payload it never needs to stamp the frame at all.
+- **Draining parked steps in `zone_tick` has no report channel.** The watermark
+  rides out on the next input you handle, which a client re-sending
+  unacknowledged steps produces every tick - so it costs a tick, except for a
+  player at rest, whose final drain stays unacked until they move.
 - **`{error, Reason}` still acks the frame stamp**, because a client must never
   wait forever on an input the server chose to drop. A game that parks should
   model refusal as `{ok, Entities, Watermark}` instead.

--- a/guides/websocket-protocol.md
+++ b/guides/websocket-protocol.md
@@ -901,6 +901,52 @@ crossing more than one zone can hold a mark for them. The connection drops any
 ack that does not advance the highest `seq` it has already sent you, so you can
 prune against the value you receive without tracking a maximum yourself.
 
+#### Batched input and the ack
+
+Step 2 says "the highest `seq` it consumed", and by default that is the `seq`
+stamped on the frame: one input frame, one input, nothing to disagree about.
+
+A client predicting faster than the zone ticks changes that. At 60 Hz against a
+12.5 Hz zone there are roughly five simulation steps per tick, so a frame
+carries a *batch* of steps rather than one, and a zone that caps how many steps
+it runs per tick parks the rest for the next one. The frame stamp then no longer
+describes what ran:
+
+- Stamp the frame with the **last** seq in the batch and the ack overclaims
+  whenever steps are parked. The client discards predicted steps the server has
+  not applied yet, cannot replay them, and drifts until something resyncs it.
+- Stamp it with the **first** seq and the ack underclaims. The client replays
+  steps the server already applied and overshoots on every reconciliation.
+
+Return the seq you actually consumed and the ack carries that instead:
+
+```erlang
+handle_input(PlayerId, #{~"steps" := Steps}, Entities) ->
+    {Entities1, Watermark} = apply_steps(PlayerId, Steps, Entities),
+    {ok, Entities1, Watermark}.
+```
+
+```lua
+function handle_input(player_id, input, entities)
+  local watermark = apply_steps(input.steps, entities)
+  return entities, watermark
+end
+```
+
+The number is in your client's own sequence space - the same numbering the steps
+inside the payload carry - and asobi only refuses to let it walk the ack
+backwards. Three rules come with it:
+
+- **Report on every input or on none.** A reported seq wins over a frame stamp
+  for the rest of that tick, but an input you do not report for contributes its
+  stamp, and the higher of the two is what the client hears.
+- **`{error, Reason}` still acks the frame stamp**, because a client must never
+  wait forever on an input the server chose to drop. A game that parks should
+  model refusal as `{ok, Entities, Watermark}` instead.
+- **Deduplicate by the same watermark.** A client that re-sends unacknowledged
+  steps for redundancy (what makes an unreliable carrier safe) will hand you
+  steps you have already run; skip them, and report the watermark either way.
+
 **If your SDK does not yet surface `world.ack`**, the same reconciliation works
 in userland: write the `seq` onto the player's entity in `handle_input/3`
 (`entity.last_seq = input.seq`) and read it back off the `world.tick` delta. The

--- a/guides/world-server.md
+++ b/guides/world-server.md
@@ -210,7 +210,7 @@ end
 | `spawn_position(player_id, state)` | yes | Return a `{x=N, y=N}` table |
 | `post_tick(tick, state)` | yes | Global tick logic. Set `_finished` and `_result` on state to end the world |
 | `zone_tick(entities, zone_state)` | no | Per-zone simulation; return both |
-| `handle_input(player_id, input, entities)` | no | Apply one player's input to that zone's entities |
+| `handle_input(player_id, input, entities)` | no | Apply one player's input to that zone's entities. A second return value is the client seq you consumed - see [Batched input and the ack](websocket-protocol.md#batched-input-and-the-ack) |
 | `generate_world(seed, config)` | no | Return a table keyed by `"x,y"` strings |
 | `get_state(player_id, state)` | no | Player-visible state |
 | `spawn_templates(config)` | no | See [Spawn templates](#spawn-templates) |
@@ -321,7 +321,7 @@ post_tick(_TickN, State) ->
 | `leave/2` | yes | Player left the world |
 | `spawn_position/2` | yes | Return `{ok, {X, Y}}` for new player placement |
 | `zone_tick/2` | yes | Per-zone simulation: `(Entities, ZoneState) -> {Entities, ZoneState}` |
-| `handle_input/3` | yes | Process player input within a zone's entities |
+| `handle_input/3` | yes | Process player input within a zone's entities. Return `{ok, Entities, ConsumedSeq}` to ack what you *ran* rather than what arrived - see [Batched input and the ack](websocket-protocol.md#batched-input-and-the-ack) |
 | `post_tick/2` | yes | Global post-tick: return `{ok, State}`, `{vote, Config, State}`, or `{finished, Result, State}` |
 | `generate_world/2` | no | Procedural generation: `(Seed, Config) -> {ok, #{Coords => ZoneState}}` |
 | `get_state/2` | no | Per-player state view |

--- a/include/asobi_ack.hrl
+++ b/include/asobi_ack.hrl
@@ -1,0 +1,9 @@
+%% The `seq` on a world.input, and the seq that comes back as a world.ack.
+%%
+%% Bounded to a non-negative JS-safe integer at EVERY door: the value is echoed
+%% back on every broadcast tick, so an unbounded bignum is a per-tick
+%% json:encode amplifier, and the SDKs that read this field into an int64
+%% (Dart, C#, C++) cannot parse a wider one at all. There are three doors -
+%% the WebSocket handler, the datagram uplink, and a game module reporting what
+%% it consumed - and a cap on two of them is a cap on none.
+-define(MAX_ACK_SEQ, 16#1FFFFFFFFFFFFF).

--- a/src/dgram/asobi_dgram_input.erl
+++ b/src/dgram/asobi_dgram_input.erl
@@ -20,6 +20,8 @@ gateway, and the engine keeping its own record is what lets this resolution
 happen without asking the untrusted end anything.
 """.
 
+-include("asobi_ack.hrl").
+
 -export([apply/2]).
 
 -doc "Resolves the player and applies the input. Silent on an unknown conn_id.".
@@ -79,5 +81,5 @@ decode_input(Body) ->
         _:_ -> error
     end.
 
-seq_of(#{~"seq" := Seq}) when is_integer(Seq), Seq >= 0 -> Seq;
+seq_of(#{~"seq" := Seq}) when is_integer(Seq), Seq >= 0, Seq =< ?MAX_ACK_SEQ -> Seq;
 seq_of(_) -> undefined.

--- a/src/lua/asobi_lua_world.erl
+++ b/src/lua/asobi_lua_world.erl
@@ -42,6 +42,7 @@ of hot reloads.
 -behaviour(asobi_world).
 
 -include_lib("kernel/include/logger.hrl").
+-include("asobi_ack.hrl").
 
 -export([init/1, join/2, join/3, leave/2, spawn_position/2]).
 -export([zone_tick/2, handle_input/3, post_tick/2]).
@@ -745,21 +746,48 @@ parse_coords(Bin) ->
 %% nothing: leave the entities alone rather than crashing the shared zone.
 input_result([], _LuaSt, Entities, _ZoneState) ->
     {ok, Entities};
+input_result([Ents | _Rest], _LuaSt, Entities, ZoneState) when
+    not is_tuple(Ents), not is_map(Ents), not is_list(Ents)
+->
+    %% `return nil, 5` or `return "ok"`. decode_to_map/2 case_clauses on a
+    %% scalar, one line from the guard above, and this runs in the zone process
+    %% - so the same author mistake that used to kill every player in the zone
+    %% would just kill them a different way.
+    log_invalid_input_return(ZoneState),
+    {ok, Entities};
 input_result([Ents | Rest], LuaSt, _Entities, ZoneState) ->
     Decoded = asobi_lua_api:atomize_entities(decode_to_map(Ents, LuaSt)),
     case Rest of
         [] ->
             {ok, Decoded};
         [Consumed | _] ->
-            case consumed_seq(Consumed, LuaSt) of
+            case consumed_seq(Consumed) of
                 {ok, Seq} ->
                     {ok, Decoded, Seq};
                 none ->
                     {ok, Decoded};
                 invalid ->
-                    log_lua_error(handle_input, invalid_consumed_seq, ZoneState),
+                    log_invalid_input_return(ZoneState),
                     {ok, Decoded}
             end
+    end.
+
+%% Its own limiter bucket, and deliberately NOT log_lua_error/3: that keys on
+%% {Script, Callback}, so a client posting junk in the field a script echoes
+%% would exhaust the budget real handle_input exceptions are logged from, and
+%% its unconditional telemetry emit would classify a well-behaved script as
+%% throwing a Lua runtime error at input rate.
+log_invalid_input_return(ZoneState) ->
+    Script = maps:get(script, ZoneState, ~"<unknown>"),
+    case asobi_script_log_limiter:allow({Script, invalid_input_return}) of
+        {true, SuppressedSinceLast} ->
+            ?LOG_WARNING(#{
+                msg => ~"lua handle_input returned something that is not entities and a seq",
+                script => asobi_lua_game_error:script_basename(Script),
+                suppressed_since_last => SuppressedSinceLast
+            });
+        false ->
+            ok
     end.
 
 %% Deliberately NOT asobi_lua_phases:to_integer/1, which turns anything
@@ -767,14 +795,19 @@ input_result([Ents | Rest], LuaSt, _Entities, ZoneState) ->
 %% consumed nothing, which is a worse answer than falling back to the frame
 %% stamp. An explicit `nil` is the ordinary "no ack for this input" case a
 %% script writes when it has nothing new to report, so it is not an error.
-consumed_seq(nil, _LuaSt) ->
+%%
+%% Shape-guarded rather than decoded. luerl carries a Lua number as a plain
+%% Erlang number, so there is nothing to decode - and luerl:decode/2 raises
+%% `recursive_table` on a self-referential table, which here would be an
+%% uncaught exit in the zone process (this runs after asobi_lua_loader:call/3
+%% has returned, so nothing is guarding it any more). ?MAX_ACK_SEQ is enforced
+%% before trunc/1, which happily mints a 309-digit integer out of 1e308.
+consumed_seq(nil) ->
     none;
-consumed_seq(Value, LuaSt) ->
-    case luerl:decode(Value, LuaSt) of
-        N when is_number(N), N >= 0 -> {ok, trunc(N)};
-        nil -> none;
-        _ -> invalid
-    end.
+consumed_seq(N) when is_number(N), N >= 0, N =< ?MAX_ACK_SEQ ->
+    {ok, trunc(N)};
+consumed_seq(_) ->
+    invalid.
 
 decode_to_map(Term, LuaSt) ->
     asobi_lua_api:decode_to_map(Term, LuaSt).

--- a/src/lua/asobi_lua_world.erl
+++ b/src/lua/asobi_lua_world.erl
@@ -11,7 +11,7 @@ function join(player_id, state, ctx)         -- ctx is the client join context
 function leave(player_id, state)             -- return updated state
 function spawn_position(player_id, state)    -- return {x, y}
 function zone_tick(entities, zone_state)     -- return entities, zone_state
-function handle_input(player_id, input, entities) -- return entities
+function handle_input(player_id, input, entities) -- return entities[, consumed_seq]
 function post_tick(tick, state)              -- return state (or state + vote/finished)
 -- Optional:
 function generate_world(seed, config)        -- return zone_states table
@@ -267,7 +267,27 @@ zone_tick(Entities, ZoneState0) when is_map(ZoneState0) ->
 zone_tick(Entities, ZoneState) ->
     {Entities, ZoneState}.
 
--spec handle_input(binary(), map(), map()) -> {ok, map()} | {error, term()}.
+-doc """
+Delegates to the script's `handle_input`.
+
+A second Lua return value is the client sequence the script has consumed, and
+it becomes the `world.ack` for that player instead of the seq the client
+stamped on the frame - see the `asobi_world` callback for why a game that
+batches several simulation steps into one frame needs to say what it *ran*
+rather than what *arrived*:
+
+```lua
+function handle_input(player_id, input, entities)
+  local watermark = apply_steps(input.steps, entities)
+  return entities, watermark
+end
+```
+
+A non-numeric or negative second value is refused with a warning and the frame
+stamp is used, so a script cannot ack something the client will not accept.
+""".
+-spec handle_input(binary(), map(), map()) ->
+    {ok, map()} | {ok, map(), non_neg_integer()} | {error, term()}.
 handle_input(PlayerId, Input, Entities) ->
     case erlang:get(?PD_KEY) of
         #{lua_state := LuaSt} = ZoneState ->
@@ -279,9 +299,10 @@ handle_input(PlayerId, Input, Entities) ->
                     handle_input, [PlayerId, EncInput, EncEntities], LuaSt2
                 )
             of
-                {ok, [Ents1 | _], LuaSt3} ->
-                    erlang:put(?PD_KEY, ZoneState#{lua_state => LuaSt3}),
-                    {ok, asobi_lua_api:atomize_entities(decode_to_map(Ents1, LuaSt3))};
+                {ok, Rets, LuaSt3} ->
+                    ZoneState1 = ZoneState#{lua_state => LuaSt3},
+                    erlang:put(?PD_KEY, ZoneState1),
+                    input_result(Rets, LuaSt3, Entities, ZoneState1);
                 {error, Reason} ->
                     log_lua_error(handle_input, Reason, ZoneState),
                     ZoneState1 = asobi_lua_dev_errors:maybe_notify(
@@ -714,6 +735,45 @@ parse_coords(Bin) ->
             end;
         _ ->
             error
+    end.
+
+%% `handle_input` returns entities, and optionally the client seq the script has
+%% consumed. The seq becomes that player's world.ack instead of the seq stamped
+%% on the frame, so a script that batches several simulation steps into one
+%% frame acks what it RAN rather than what ARRIVED (see the `asobi_world`
+%% callback). An empty return list is a script whose handle_input returns
+%% nothing: leave the entities alone rather than crashing the shared zone.
+input_result([], _LuaSt, Entities, _ZoneState) ->
+    {ok, Entities};
+input_result([Ents | Rest], LuaSt, _Entities, ZoneState) ->
+    Decoded = asobi_lua_api:atomize_entities(decode_to_map(Ents, LuaSt)),
+    case Rest of
+        [] ->
+            {ok, Decoded};
+        [Consumed | _] ->
+            case consumed_seq(Consumed, LuaSt) of
+                {ok, Seq} ->
+                    {ok, Decoded, Seq};
+                none ->
+                    {ok, Decoded};
+                invalid ->
+                    log_lua_error(handle_input, invalid_consumed_seq, ZoneState),
+                    {ok, Decoded}
+            end
+    end.
+
+%% Deliberately NOT asobi_lua_phases:to_integer/1, which turns anything
+%% non-numeric into 0 - acking seq 0 would tell the client the server had
+%% consumed nothing, which is a worse answer than falling back to the frame
+%% stamp. An explicit `nil` is the ordinary "no ack for this input" case a
+%% script writes when it has nothing new to report, so it is not an error.
+consumed_seq(nil, _LuaSt) ->
+    none;
+consumed_seq(Value, LuaSt) ->
+    case luerl:decode(Value, LuaSt) of
+        N when is_number(N), N >= 0 -> {ok, trunc(N)};
+        nil -> none;
+        _ -> invalid
     end.
 
 decode_to_map(Term, LuaSt) ->

--- a/src/world/asobi_world.erl
+++ b/src/world/asobi_world.erl
@@ -62,13 +62,31 @@ run and can never replay them) or underclaims (the client replays steps the
 server already applied and overshoots).
 
 `ConsumedSeq` is in the client's own sequence space - the same numbering the
-steps inside `Input` carry - and asobi never interprets it beyond refusing
-to let the ack go backwards. Report it on **every** input or on none: a
-module that reports for some inputs and not others makes the frame stamp of
-an unreported input race its own watermark, and the higher of the two wins.
-`{error, Reason}` still advances the ack to the frame stamp, so a module
+steps inside `Input` carry - and asobi does not interpret it. Three rules
+come with it.
+
+**Report on every input or on none.** Within a tick a report always beats a
+frame stamp, whatever order they arrive in. The leak is across ticks and is
+not a race: a tick in which this module reported nothing records the frame
+stamp instead, and the ack keeps the highest value it has recorded, so one
+unreported tick pins the ack above the watermark for good.
+
+**Reporting acks a client that never stamped a `seq`.** Numbering the steps
+inside the payload and never stamping the frame is the cleanest form of the
+batching design, and a module reporting a consumed seq is asserting that its
+clients reconcile. A client that does not want acks should not be playing a
+game whose module reports them.
+
+**`{error, Reason}` still advances the ack to the frame stamp**, so a module
 that parks should model refusal as `{ok, Entities, Watermark}` rather than
 an error.
+
+A module that parks steps in `handle_input/3` and drains them in
+`zone_tick/2` has no channel to report the drain: the watermark rides out on
+the next input this module handles. Clients re-sending unacknowledged steps
+for redundancy produce one every tick, so this costs a tick of latency; a
+player at rest, sending nothing, leaves their final drain unacked until they
+move again.
 """.
 -callback handle_input(PlayerId :: binary(), Input :: map(), Entities :: map()) ->
     {ok, Entities1 :: map()}

--- a/src/world/asobi_world.erl
+++ b/src/world/asobi_world.erl
@@ -62,8 +62,14 @@ run and can never replay them) or underclaims (the client replays steps the
 server already applied and overshoots).
 
 `ConsumedSeq` is in the client's own sequence space - the same numbering the
-steps inside `Input` carry - and asobi does not interpret it. Three rules
-come with it.
+steps inside `Input` carry - and asobi does not interpret it beyond bounding
+it: a non-negative integer no larger than `?MAX_ACK_SEQ`
+(`-include_lib("asobi/include/asobi_ack.hrl")`), the same bound the
+client-stamped `seq` is held to, because this value is echoed to that client on
+every broadcast tick and the SDKs read it into an int64. Anything else is
+refused with a warning and the frame stamp is used instead.
+
+The rules that come with it.
 
 **Report on every input or on none.** Within a tick a report always beats a
 frame stamp, whatever order they arrive in. The leak is across ticks and is
@@ -77,9 +83,10 @@ batching design, and a module reporting a consumed seq is asserting that its
 clients reconcile. A client that does not want acks should not be playing a
 game whose module reports them.
 
-**`{error, Reason}` still advances the ack to the frame stamp**, so a module
-that parks should model refusal as `{ok, Entities, Watermark}` rather than
-an error.
+**`{error, Reason}` still advances the ack to the frame stamp** - unless a
+report already landed this tick, which outranks it, because refusing one input
+does not unrun the steps another already consumed. A module that parks should
+model refusal as `{ok, Entities, Watermark}` rather than an error.
 
 A module that parks steps in `handle_input/3` and drains them in
 `zone_tick/2` has no channel to report the drain: the watermark rides out on

--- a/src/world/asobi_world.erl
+++ b/src/world/asobi_world.erl
@@ -47,9 +47,33 @@ behind the join.
 -callback zone_tick(Entities :: map(), ZoneState :: term()) ->
     {Entities1 :: map(), ZoneState1 :: term()}.
 
--doc "Apply a player input to a zone's entities.".
+-doc """
+Apply a player input to a zone's entities.
+
+Return `{ok, Entities1, ConsumedSeq}` to tell asobi which client sequence
+this input actually advanced the simulation to. Without it the `world.ack`
+carries the `seq` the client stamped on the frame, which says the frame
+*arrived*, not how much of it *ran*. The two differ for any game that puts
+more than one simulation step in a frame: a client predicting at 60 Hz
+against a 12.5 Hz zone batches several steps per frame, and a zone that
+caps how many it runs per tick parks the rest. Acking the frame stamp then
+either overclaims (the client discards predicted steps the server has not
+run and can never replay them) or underclaims (the client replays steps the
+server already applied and overshoots).
+
+`ConsumedSeq` is in the client's own sequence space - the same numbering the
+steps inside `Input` carry - and asobi never interprets it beyond refusing
+to let the ack go backwards. Report it on **every** input or on none: a
+module that reports for some inputs and not others makes the frame stamp of
+an unreported input race its own watermark, and the higher of the two wins.
+`{error, Reason}` still advances the ack to the frame stamp, so a module
+that parks should model refusal as `{ok, Entities, Watermark}` rather than
+an error.
+""".
 -callback handle_input(PlayerId :: binary(), Input :: map(), Entities :: map()) ->
-    {ok, Entities1 :: map()} | {error, Reason :: term()}.
+    {ok, Entities1 :: map()}
+    | {ok, Entities1 :: map(), ConsumedSeq :: non_neg_integer()}
+    | {error, Reason :: term()}.
 
 -doc "Global post-tick hook: continue, trigger a vote, or finish the world.".
 -callback post_tick(Tick :: non_neg_integer(), GameState :: term()) ->

--- a/src/world/asobi_zone.erl
+++ b/src/world/asobi_zone.erl
@@ -21,6 +21,7 @@ via `asobi_spatial`. Zones are created and reaped lazily as players move.
 -endif.
 
 -include_lib("kernel/include/logger.hrl").
+-include("asobi_ack.hrl").
 
 -define(PG_SCOPE, nova_scope).
 %% Must match asobi_world_server's own defaults of the same name.
@@ -618,15 +619,15 @@ terminate(normal, #{world_id := WorldId, coords := Coords} = State) ->
     clear_zone_backup(WorldId, Coords),
     notify_zone_manager_terminated(State),
     %% asobi#252 review: a zone that ever suppressed a log line leaves a
-    %% permanent drop-count row otherwise - this Key's lifetime ends here.
-    asobi_script_log_limiter:forget({WorldId, Coords}),
+    %% permanent drop-count row otherwise - these Keys' lifetime ends here.
+    forget_log_keys(WorldId, Coords),
     pg:leave(?PG_SCOPE, {asobi_zone, WorldId, Coords}, self()),
     ok;
 terminate({shutdown, _}, #{world_id := WorldId, coords := Coords} = State) ->
     maybe_final_snapshot(State),
     clear_zone_backup(WorldId, Coords),
     notify_zone_manager_terminated(State),
-    asobi_script_log_limiter:forget({WorldId, Coords}),
+    forget_log_keys(WorldId, Coords),
     pg:leave(?PG_SCOPE, {asobi_zone, WorldId, Coords}, self()),
     ok;
 terminate(_Reason, #{world_id := WorldId, coords := Coords, entities := Entities} = State) ->
@@ -634,7 +635,7 @@ terminate(_Reason, #{world_id := WorldId, coords := Coords, entities := Entities
     maybe_final_snapshot(State),
     backup_zone_state(WorldId, Coords, Entities),
     notify_zone_manager_terminated(State),
-    asobi_script_log_limiter:forget({WorldId, Coords}),
+    forget_log_keys(WorldId, Coords),
     pg:leave(?PG_SCOPE, {asobi_zone, WorldId, Coords}, self()),
     ok.
 
@@ -816,7 +817,9 @@ do_tick(
     %% this, a burst of moves arriving in one tick window collapses to the
     %% OLDEST input's state — every later move gets overwritten by the
     %% next-handle_input call walking the list head-first.
-    {Entities2, TickAcks} = apply_inputs(GameMod, lists:reverse(Queue), Entities0),
+    {Entities2, TickAcks} = apply_inputs(
+        GameMod, lists:reverse(Queue), Entities0, invalid_seq_log_key(WorldId, Coords)
+    ),
     PlayerAck1 = maps:fold(fun record_ack/3, maps:get(player_ack, State, #{}), TickAcks),
     Now = erlang:system_time(millisecond),
     {TimerEvents, ET1} = asobi_entity_timer:tick(Now, ET),
@@ -921,67 +924,96 @@ apply_timer_events([{entity_timer_expired, EntityId, _TimerId, OnComplete} | Res
         end,
     apply_timer_events(Rest, Entities1).
 
-apply_inputs(GameMod, Queue, Entities) ->
-    apply_inputs(GameMod, Queue, Entities, #{}).
+apply_inputs(GameMod, Queue, Entities, LogKey) ->
+    apply_inputs(GameMod, Queue, Entities, LogKey, {#{}, #{}}).
 
-apply_inputs(_GameMod, [], Entities, Acks) ->
-    {Entities, unwrap_acks(Acks)};
-apply_inputs(GameMod, [{PlayerId, Seq, Input} | Rest], Entities, Acks) ->
+%% Two maps, not one tagged map: a stamp says an input ARRIVED, a report says
+%% how much of it RAN, and the merge below is the whole rule - a report is
+%% authoritative for the rest of the tick, so the right-hand map wins per
+%% player. Max-ing the two together instead would let "arrived" beat "ran",
+%% which is the overclaim a game that parks overflow steps needs to avoid.
+%% Stamps still max among themselves, via the same record_ack/3 that merges
+%% this tick into player_ack.
+apply_inputs(_GameMod, [], Entities, _LogKey, {Stamped, Reported}) ->
+    {Entities, maps:merge(Stamped, Reported)};
+apply_inputs(GameMod, [{PlayerId, Seq, Input} | Rest], Entities, LogKey, Acks) ->
     case GameMod:handle_input(PlayerId, Input, Entities) of
         {ok, Entities1} ->
-            apply_inputs(GameMod, Rest, Entities1, stamped_ack(PlayerId, Seq, Acks));
+            apply_inputs(GameMod, Rest, Entities1, LogKey, stamped_ack(PlayerId, Seq, Acks));
         {ok, Entities1, Consumed} ->
-            apply_inputs(GameMod, Rest, Entities1, reported_ack(PlayerId, Seq, Consumed, Acks));
+            apply_inputs(
+                GameMod,
+                Rest,
+                Entities1,
+                LogKey,
+                reported_ack(PlayerId, Seq, Consumed, LogKey, Acks)
+            );
         {error, Reason} ->
             %% A rejected input still advances the ack (asobi#474): the client
             %% asked the server to consume this seq and it did, it just declined
             %% the effect. Otherwise a client waits forever on an input the
-            %% server chose to drop.
+            %% server chose to drop. A report already recorded this tick still
+            %% outranks it - refusing one input does not unrun the others.
             ?LOG_WARNING(#{
                 msg => ~"zone input rejected",
                 player_id => PlayerId,
                 reason => Reason
             }),
-            apply_inputs(GameMod, Rest, Entities, stamped_ack(PlayerId, Seq, Acks))
+            apply_inputs(GameMod, Rest, Entities, LogKey, stamped_ack(PlayerId, Seq, Acks))
     end.
 
-%% Within one tick an ack candidate is either STAMPED (the seq the client put on
-%% the frame, meaning "this arrived") or REPORTED (what handle_input said it
-%% consumed, meaning "this ran"). A report is authoritative for the rest of the
-%% tick and the newest report wins, because a game that batches steps into one
-%% frame and parks the overflow has to be able to ack BELOW the frame stamp -
-%% max-ing the two would let "arrived" overwrite "ran", which is the overclaim
-%% this exists to prevent. Cross-tick monotonicity is still enforced by
-%% record_ack when the tick's candidates merge into player_ack.
-stamped_ack(_PlayerId, undefined, Acks) ->
-    Acks;
-stamped_ack(PlayerId, Seq, Acks) ->
-    case Acks of
-        #{PlayerId := {reported, _}} -> Acks;
-        #{PlayerId := {stamped, Prev}} when Prev >= Seq -> Acks;
-        _ when is_integer(Seq), Seq >= 0 -> Acks#{PlayerId => {stamped, Seq}};
-        _ -> Acks
-    end.
+stamped_ack(PlayerId, Seq, {Stamped, Reported}) ->
+    {record_ack(PlayerId, Seq, Stamped), Reported}.
 
 %% Note the absent `Seq` guard: a report acks a client that never stamped one.
 %% Numbering steps inside the payload and leaving the frame unstamped is the
 %% cleanest form of the batching design, and a module that reports is asserting
 %% its clients reconcile - #474's stamp is not the only way to say so.
-reported_ack(PlayerId, _Seq, Consumed, Acks) when is_integer(Consumed), Consumed >= 0 ->
-    Acks#{PlayerId => {reported, Consumed}};
-reported_ack(PlayerId, Seq, Consumed, Acks) ->
+%%
+%% ?MAX_ACK_SEQ is not decoration. The documented way to write this callback is
+%% to derive the watermark from the client's own payload, so the value is
+%% attacker-influenced by design, and it is echoed on every broadcast tick to a
+%% session whose ack gate keeps the highest seq it has sent. One unbounded
+%% bignum would therefore be both a per-tick encode amplifier and a permanent
+%% kill of that connection's ack stream from every zone.
+reported_ack(PlayerId, _Seq, Consumed, _LogKey, {Stamped, Reported}) when
+    is_integer(Consumed), Consumed >= 0, Consumed =< ?MAX_ACK_SEQ
+->
+    %% Newest report wins: a module revising its watermark down within a tick
+    %% is the parking case this exists for.
+    {Stamped, Reported#{PlayerId => Consumed}};
+reported_ack(PlayerId, Seq, Consumed, LogKey, Acks) ->
     %% A game module is user code, so a nonsense consumed seq must neither crash
     %% the shared zone nor silently ack something the client cannot use. Fall
     %% back to the frame stamp and say so.
-    ?LOG_WARNING(#{
-        msg => ~"handle_input reported an invalid consumed seq",
-        player_id => PlayerId,
-        consumed => Consumed
-    }),
+    %%
+    %% The term itself is never logged, only its shape: it is usually a field
+    %% lifted straight off the client's payload, so its size and depth are
+    %% attacker-chosen, and `logger` in sync mode charges the write back to
+    %% THIS process - the zone every other player in it is simulated by.
+    %% Keyed per zone rather than per player: a player-keyed bucket is minted
+    %% by the flood it is meant to bound and nothing would ever reclaim it,
+    %% since forget/1 runs at zone terminate and deletes an exact key.
+    case asobi_script_log_limiter:allow(LogKey) of
+        {true, SuppressedSinceLast} ->
+            ?LOG_WARNING(#{
+                msg => ~"handle_input reported an invalid consumed seq",
+                player_id => PlayerId,
+                consumed => classify_consumed(Consumed),
+                suppressed_since_last => SuppressedSinceLast
+            });
+        false ->
+            ok
+    end,
     stamped_ack(PlayerId, Seq, Acks).
 
-unwrap_acks(Acks) ->
-    maps:map(fun(_PlayerId, {_Kind, Seq}) -> Seq end, Acks).
+classify_consumed(N) when is_integer(N), N < 0 -> negative;
+classify_consumed(N) when is_integer(N) -> above_max_ack_seq;
+classify_consumed(N) when is_float(N) -> float;
+classify_consumed(_) -> not_a_number.
+
+invalid_seq_log_key(WorldId, Coords) ->
+    {WorldId, Coords, invalid_consumed_seq}.
 
 %% Keep the highest seq per player. world.input carries a monotonic client seq;
 %% out-of-order or duplicate delivery must never regress the ack. Inputs with no
@@ -1517,9 +1549,9 @@ wire_encodable(Fields) ->
 is_wire_value(V) when is_number(V); is_boolean(V); is_binary(V); V =:= null -> true;
 is_wire_value(_) -> false.
 
-%% asobi#474: input ack, addressed to one connection. Iterate the opted-in
-%% players (those with a recorded seq) and send world.ack only to the ones still
-%% subscribed. The mark is per zone, so a crossing player can be acked by both
+%% asobi#474: input ack, addressed to one connection. Iterate the players with a
+%% recorded mark - a stamped seq, or a seq their game module reported consuming
+%% - and send world.ack only to the ones still subscribed. The mark is per zone, so a crossing player can be acked by both
 %% the zone they left and the one they entered; asobi_player_session drops any
 %% ack that does not advance, which is what makes the frame monotonic. Kept
 %% off the shared world.tick binary so the ack never leaks one player's input
@@ -1892,6 +1924,12 @@ maybe_final_snapshot(_) ->
     ok.
 
 %% --- Zone State Backup/Recovery ---
+
+%% Every limiter key this zone can mint. forget/1 deletes an exact key, so a
+%% new bucket that is not listed here is a permanent ETS row per zone.
+forget_log_keys(WorldId, Coords) ->
+    asobi_script_log_limiter:forget({WorldId, Coords}),
+    asobi_script_log_limiter:forget(invalid_seq_log_key(WorldId, Coords)).
 
 backup_zone_state(WorldId, Coords, Entities) ->
     case ets:info(asobi_world_state) of

--- a/src/world/asobi_zone.erl
+++ b/src/world/asobi_zone.erl
@@ -925,23 +925,57 @@ apply_inputs(GameMod, Queue, Entities) ->
     apply_inputs(GameMod, Queue, Entities, #{}).
 
 apply_inputs(_GameMod, [], Entities, Acks) ->
-    {Entities, Acks};
+    {Entities, unwrap_acks(Acks)};
 apply_inputs(GameMod, [{PlayerId, Seq, Input} | Rest], Entities, Acks) ->
-    %% A rejected input still advances the ack (asobi#474): the client asked the
-    %% server to consume this seq and it did, it just declined the effect.
-    %% Otherwise a client waits forever on an input the server chose to drop.
-    Acks1 = record_ack(PlayerId, Seq, Acks),
     case GameMod:handle_input(PlayerId, Input, Entities) of
         {ok, Entities1} ->
-            apply_inputs(GameMod, Rest, Entities1, Acks1);
+            apply_inputs(GameMod, Rest, Entities1, stamped_ack(PlayerId, Seq, Acks));
+        {ok, Entities1, Consumed} ->
+            apply_inputs(GameMod, Rest, Entities1, reported_ack(PlayerId, Seq, Consumed, Acks));
         {error, Reason} ->
+            %% A rejected input still advances the ack (asobi#474): the client
+            %% asked the server to consume this seq and it did, it just declined
+            %% the effect. Otherwise a client waits forever on an input the
+            %% server chose to drop.
             ?LOG_WARNING(#{
                 msg => ~"zone input rejected",
                 player_id => PlayerId,
                 reason => Reason
             }),
-            apply_inputs(GameMod, Rest, Entities, Acks1)
+            apply_inputs(GameMod, Rest, Entities, stamped_ack(PlayerId, Seq, Acks))
     end.
+
+%% Within one tick an ack candidate is either STAMPED (the seq the client put on
+%% the frame, meaning "this arrived") or REPORTED (what handle_input said it
+%% consumed, meaning "this ran"). A report is authoritative for the rest of the
+%% tick and the newest report wins, because a game that batches steps into one
+%% frame and parks the overflow has to be able to ack BELOW the frame stamp -
+%% max-ing the two would let "arrived" overwrite "ran", which is the overclaim
+%% this exists to prevent. Cross-tick monotonicity is still enforced by
+%% record_ack when the tick's candidates merge into player_ack.
+stamped_ack(PlayerId, Seq, Acks) ->
+    case Acks of
+        #{PlayerId := {reported, _}} -> Acks;
+        #{PlayerId := {stamped, Prev}} when Prev >= Seq -> Acks;
+        _ when is_integer(Seq), Seq >= 0 -> Acks#{PlayerId => {stamped, Seq}};
+        _ -> Acks
+    end.
+
+reported_ack(PlayerId, _Seq, Consumed, Acks) when is_integer(Consumed), Consumed >= 0 ->
+    Acks#{PlayerId => {reported, Consumed}};
+reported_ack(PlayerId, Seq, Consumed, Acks) ->
+    %% A game module is user code, so a nonsense consumed seq must neither crash
+    %% the shared zone nor silently ack something the client cannot use. Fall
+    %% back to the frame stamp and say so.
+    ?LOG_WARNING(#{
+        msg => ~"handle_input reported an invalid consumed seq",
+        player_id => PlayerId,
+        consumed => Consumed
+    }),
+    stamped_ack(PlayerId, Seq, Acks).
+
+unwrap_acks(Acks) ->
+    maps:map(fun(_PlayerId, {_Kind, Seq}) -> Seq end, Acks).
 
 %% Keep the highest seq per player. world.input carries a monotonic client seq;
 %% out-of-order or duplicate delivery must never regress the ack. Inputs with no

--- a/src/world/asobi_zone.erl
+++ b/src/world/asobi_zone.erl
@@ -953,6 +953,8 @@ apply_inputs(GameMod, [{PlayerId, Seq, Input} | Rest], Entities, Acks) ->
 %% max-ing the two would let "arrived" overwrite "ran", which is the overclaim
 %% this exists to prevent. Cross-tick monotonicity is still enforced by
 %% record_ack when the tick's candidates merge into player_ack.
+stamped_ack(_PlayerId, undefined, Acks) ->
+    Acks;
 stamped_ack(PlayerId, Seq, Acks) ->
     case Acks of
         #{PlayerId := {reported, _}} -> Acks;
@@ -961,6 +963,10 @@ stamped_ack(PlayerId, Seq, Acks) ->
         _ -> Acks
     end.
 
+%% Note the absent `Seq` guard: a report acks a client that never stamped one.
+%% Numbering steps inside the payload and leaving the frame unstamped is the
+%% cleanest form of the batching design, and a module that reports is asserting
+%% its clients reconcile - #474's stamp is not the only way to say so.
 reported_ack(PlayerId, _Seq, Consumed, Acks) when is_integer(Consumed), Consumed >= 0 ->
     Acks#{PlayerId => {reported, Consumed}};
 reported_ack(PlayerId, Seq, Consumed, Acks) ->

--- a/src/ws/asobi_ws_handler.erl
+++ b/src/ws/asobi_ws_handler.erl
@@ -18,6 +18,7 @@
 -export([reserved_event_names/0, event_name_binary/1, is_event_name_char/1]).
 
 -include_lib("kernel/include/logger.hrl").
+-include("asobi_ack.hrl").
 
 -define(WS_MSG_LIMIT, 60).
 -define(WS_MSG_WINDOW_MS, 1000).
@@ -1103,7 +1104,7 @@ handle_message(
     %% out of range degrades to no-ack rather than crashing the handler.
     Seq =
         case maps:get(~"seq", Msg, undefined) of
-            N when is_integer(N), N >= 0, N =< 16#1FFFFFFFFFFFFF -> N;
+            N when is_integer(N), N >= 0, N =< ?MAX_ACK_SEQ -> N;
             _ -> undefined
         end,
     try asobi_player_session:get_state(SessionPid) of

--- a/test/asobi_lua_world_tests.erl
+++ b/test/asobi_lua_world_tests.erl
@@ -82,7 +82,7 @@ handle_input_uses_zone_state_from_proc_dict_test() ->
 %% reports the seq it actually consumed as a second return value, and that
 %% becomes the world.ack instead of the seq stamped on the frame.
 handle_input_reports_consumed_seq_test() ->
-    ZoneState1 = prime_ack_zone(),
+    _ = prime_ack_zone(),
     ?assertEqual(
         {ok, #{~"p1" => #{type => ~"player", x => 1, y => 2}}, 42},
         asobi_lua_world:handle_input(
@@ -95,7 +95,6 @@ handle_input_reports_consumed_seq_test() ->
         {ok, _, 7},
         asobi_lua_world:handle_input(~"p1", #{~"consumed" => 7.9}, #{})
     ),
-    _ = ZoneState1,
     erlang:erase({asobi_lua_world, zone_state}).
 
 %% No second return value is the ordinary case and must stay a 2-tuple, so
@@ -139,13 +138,41 @@ handle_input_returning_nothing_leaves_entities_alone_test() ->
     ),
     erlang:erase({asobi_lua_world, zone_state}).
 
-prime_ack_zone() ->
-    Config = #{game_config => #{lua_script => fixture("config_ack_world.lua")}},
+%% The second return value reaches the bridge AFTER asobi_lua_loader:call/3 has
+%% returned, so nothing is guarding it and the zone process is what dies. Three
+%% shapes a script can hand back, none of which may take the zone with them.
+handle_input_hostile_returns_do_not_kill_the_zone_test() ->
+    _ = prime_zone("config_hostile_input_world.lua"),
+    %% luerl:decode/2 raises recursive_table on this; shape-guarding never
+    %% decodes it at all.
+    ?assertMatch(
+        {ok, _},
+        asobi_lua_world:handle_input(~"p1", #{~"kind" => ~"cyclic"}, #{~"p1" => #{x => 1}})
+    ),
+    %% trunc(1.0e308) is a 309-digit integer. The ack space is 53 bits, and the
+    %% session keeps the highest seq it has sent, so acking one would silence
+    %% that connection's ack stream for good.
+    ?assertMatch(
+        {ok, _},
+        asobi_lua_world:handle_input(~"p1", #{~"kind" => ~"huge"}, #{~"p1" => #{x => 1}})
+    ),
+    %% A scalar first return reaches decode_to_map/2, which case_clauses on it.
+    ?assertEqual(
+        {ok, #{~"p1" => #{x => 1}}},
+        asobi_lua_world:handle_input(~"p1", #{~"kind" => ~"scalar"}, #{~"p1" => #{x => 1}})
+    ),
+    erlang:erase({asobi_lua_world, zone_state}).
+
+prime_zone(Fixture) ->
+    Config = #{game_config => #{lua_script => fixture(Fixture)}},
     {ok, ZoneStates} = asobi_lua_world:generate_world(0, Config),
     ZoneState = asobi_lua_world:init_zone_state(Config, maps:get({0, 0}, ZoneStates)),
     erlang:erase({asobi_lua_world, zone_state}),
     {_, ZoneState1} = asobi_lua_world:zone_tick(#{}, ZoneState),
     ZoneState1.
+
+prime_ack_zone() ->
+    prime_zone("config_ack_world.lua").
 
 handle_input_without_stash_is_noop_test() ->
     erlang:erase({asobi_lua_world, zone_state}),

--- a/test/asobi_lua_world_tests.erl
+++ b/test/asobi_lua_world_tests.erl
@@ -78,6 +78,58 @@ handle_input_uses_zone_state_from_proc_dict_test() ->
     {_, _ZoneState2} = asobi_lua_world:zone_tick(Entities1, ZoneState1),
     erlang:erase({asobi_lua_world, zone_state}).
 
+%% asobi#532: a script that batches several simulation steps into one frame
+%% reports the seq it actually consumed as a second return value, and that
+%% becomes the world.ack instead of the seq stamped on the frame.
+handle_input_reports_consumed_seq_test() ->
+    ZoneState1 = prime_ack_zone(),
+    ?assertEqual(
+        {ok, #{~"p1" => #{type => ~"player", x => 1, y => 2}}, 42},
+        asobi_lua_world:handle_input(
+            ~"p1", #{~"x" => 1, ~"y" => 2, ~"consumed" => 42}, #{}
+        )
+    ),
+    %% A fractional seq truncates rather than reaching the zone as a float:
+    %% Lua has one number type and every integer arrives here as one.
+    ?assertMatch(
+        {ok, _, 7},
+        asobi_lua_world:handle_input(~"p1", #{~"consumed" => 7.9}, #{})
+    ),
+    _ = ZoneState1,
+    erlang:erase({asobi_lua_world, zone_state}).
+
+%% No second return value is the ordinary case and must stay a 2-tuple, so
+%% every script written before this existed keeps acking the frame stamp.
+handle_input_without_consumed_seq_is_unchanged_test() ->
+    _ = prime_ack_zone(),
+    ?assertMatch(
+        {ok, #{~"p1" := #{x := 3}}},
+        asobi_lua_world:handle_input(~"p1", #{~"x" => 3}, #{})
+    ),
+    erlang:erase({asobi_lua_world, zone_state}).
+
+%% A script returning something that is not a seq must not ack it: falling back
+%% to the frame stamp is recoverable, acking garbage is not.
+handle_input_invalid_consumed_seq_falls_back_test() ->
+    _ = prime_ack_zone(),
+    ?assertMatch(
+        {ok, #{~"p1" := #{x := 4}}},
+        asobi_lua_world:handle_input(~"p1", #{~"x" => 4, ~"consumed" => ~"nope"}, #{})
+    ),
+    ?assertMatch(
+        {ok, #{~"p1" := #{x := 5}}},
+        asobi_lua_world:handle_input(~"p1", #{~"x" => 5, ~"consumed" => -1}, #{})
+    ),
+    erlang:erase({asobi_lua_world, zone_state}).
+
+prime_ack_zone() ->
+    Config = #{game_config => #{lua_script => fixture("config_ack_world.lua")}},
+    {ok, ZoneStates} = asobi_lua_world:generate_world(0, Config),
+    ZoneState = asobi_lua_world:init_zone_state(Config, maps:get({0, 0}, ZoneStates)),
+    erlang:erase({asobi_lua_world, zone_state}),
+    {_, ZoneState1} = asobi_lua_world:zone_tick(#{}, ZoneState),
+    ZoneState1.
+
 handle_input_without_stash_is_noop_test() ->
     erlang:erase({asobi_lua_world, zone_state}),
     ?assertEqual(

--- a/test/asobi_lua_world_tests.erl
+++ b/test/asobi_lua_world_tests.erl
@@ -122,6 +122,23 @@ handle_input_invalid_consumed_seq_falls_back_test() ->
     ),
     erlang:erase({asobi_lua_world, zone_state}).
 
+%% A script whose handle_input falls off its end returns no values at all.
+%% asobi_lua_loader:call/3 hands back {ok, [], St} for that, which used to be a
+%% case_clause in the bridge - and the bridge runs inside the zone process, so
+%% one author's missing return killed the simulation for every player in that
+%% zone. Mirrors the same guard on the match side's `join`.
+handle_input_returning_nothing_leaves_entities_alone_test() ->
+    Config = #{game_config => #{lua_script => fixture("config_silent_input_world.lua")}},
+    {ok, ZoneStates} = asobi_lua_world:generate_world(0, Config),
+    ZoneState = asobi_lua_world:init_zone_state(Config, maps:get({0, 0}, ZoneStates)),
+    erlang:erase({asobi_lua_world, zone_state}),
+    {_, _} = asobi_lua_world:zone_tick(#{}, ZoneState),
+    ?assertEqual(
+        {ok, #{~"p1" => #{x => 1}}},
+        asobi_lua_world:handle_input(~"p1", #{~"x" => 1}, #{~"p1" => #{x => 1}})
+    ),
+    erlang:erase({asobi_lua_world, zone_state}).
+
 prime_ack_zone() ->
     Config = #{game_config => #{lua_script => fixture("config_ack_world.lua")}},
     {ok, ZoneStates} = asobi_lua_world:generate_world(0, Config),

--- a/test/asobi_test_world_game.erl
+++ b/test/asobi_test_world_game.erl
@@ -29,7 +29,10 @@ spawn_position(_PlayerId, _State) ->
 zone_tick(Entities, ZoneState) ->
     {Entities, ZoneState}.
 
--spec handle_input(binary(), map(), map()) -> {ok, map()} | {error, term()}.
+-spec handle_input(binary(), map(), map()) ->
+    {ok, map()} | {ok, map(), non_neg_integer()} | {error, term()}.
+handle_input(_PlayerId, #{~"action" := ~"consume", ~"consumed" := Consumed}, Entities) ->
+    {ok, Entities, Consumed};
 handle_input(PlayerId, #{~"action" := ~"move", ~"x" := X, ~"y" := Y}, Entities) ->
     case maps:find(PlayerId, Entities) of
         {ok, Entity} ->

--- a/test/asobi_zone_tests.erl
+++ b/test/asobi_zone_tests.erl
@@ -64,6 +64,16 @@ zone_test_() ->
             fun world_ack_reported_seq_never_regresses/0},
         {"an invalid reported seq falls back to the frame stamp (#532)",
             fun world_ack_invalid_reported_seq_falls_back/0},
+        {"a reported seq wider than the ack space is refused (#532)",
+            fun world_ack_reported_seq_is_bounded/0},
+        {"a report beats a stamp that arrived before it (#532)",
+            fun world_ack_report_beats_an_earlier_stamp/0},
+        {"the newest report in a tick wins, even downwards (#532)",
+            fun world_ack_newest_report_wins/0},
+        {"a rejected input's stamp does not beat a report already made (#532)",
+            fun world_ack_error_stamp_does_not_beat_a_report/0},
+        {"a spec-violating seq neither acks nor kills the zone (#532)",
+            fun world_ack_garbage_seq_does_not_kill_the_zone/0},
         {"world.ack is per-connection - p1's ack never reaches p2 (#474)",
             fun world_ack_is_per_connection/0},
         {"a straggler input re-arms the zone's ack after the entity left (#477)",
@@ -330,9 +340,96 @@ world_ack_reported_seq_never_regresses() ->
     asobi_zone:player_input(Pid, ~"p1", #{~"action" => ~"consume", ~"consumed" => 50}, 50),
     asobi_zone:tick(Pid, 1),
     ?assertEqual(50, recv_ack()),
-    asobi_zone:player_input(Pid, ~"p1", #{~"action" => ~"consume", ~"consumed" => 20}, 20),
+    %% Stamp 60 on a report of 20: the stamp must not sneak the ack up, and the
+    %% report must not walk it back. With the feature reverted this reads 60,
+    %% so the case actually discriminates.
+    asobi_zone:player_input(Pid, ~"p1", #{~"action" => ~"consume", ~"consumed" => 20}, 60),
     asobi_zone:tick(Pid, 2),
     ?assertEqual(50, recv_ack()),
+    gen_server:stop(Pid).
+
+%% The mirror of world_ack_report_beats_a_later_stamp: the rule is that a report
+%% is authoritative for the tick whatever order the two arrive in, and only one
+%% of the two orders was pinned.
+world_ack_report_beats_an_earlier_stamp() ->
+    Pid = start_zone(#{broadcast_interval => 1}),
+    asobi_zone:subscribe(Pid, {~"p1", self()}),
+    timer:sleep(10),
+    flush_messages(),
+    asobi_zone:player_input(Pid, ~"p1", #{}, 30),
+    asobi_zone:player_input(Pid, ~"p1", #{~"action" => ~"consume", ~"consumed" => 12}, 40),
+    asobi_zone:tick(Pid, 1),
+    ?assertEqual(12, recv_ack()),
+    gen_server:stop(Pid).
+
+%% A module revising its watermark DOWN within a tick is the parking case this
+%% feature exists for, so the newest report has to win rather than the highest.
+world_ack_newest_report_wins() ->
+    Pid = start_zone(#{broadcast_interval => 1}),
+    asobi_zone:subscribe(Pid, {~"p1", self()}),
+    timer:sleep(10),
+    flush_messages(),
+    asobi_zone:player_input(Pid, ~"p1", #{~"action" => ~"consume", ~"consumed" => 40}, 100),
+    asobi_zone:player_input(Pid, ~"p1", #{~"action" => ~"consume", ~"consumed" => 12}, 101),
+    asobi_zone:tick(Pid, 1),
+    ?assertEqual(12, recv_ack()),
+    gen_server:stop(Pid).
+
+%% #474 says a rejected input still advances the ack to its frame stamp, and
+%% this feature says a report outranks a stamp. Both are true: refusing one
+%% input does not unrun the steps another input already consumed.
+world_ack_error_stamp_does_not_beat_a_report() ->
+    Pid = start_zone(#{broadcast_interval => 1}),
+    asobi_zone:subscribe(Pid, {~"p1", self()}),
+    timer:sleep(10),
+    flush_messages(),
+    asobi_zone:player_input(Pid, ~"p1", #{~"action" => ~"consume", ~"consumed" => 12}, 40),
+    asobi_zone:player_input(Pid, ~"p1", #{~"action" => ~"invalid"}, 50),
+    asobi_zone:tick(Pid, 1),
+    ?assertEqual(12, recv_ack()),
+    gen_server:stop(Pid).
+
+%% player_input/4 is exported, so a spec-violating seq must neither ack nor
+%% function_clause the shared zone - which would DoS every player in it. The
+%% tick-local path is total for the same reason record_ack/3 is.
+world_ack_garbage_seq_does_not_kill_the_zone() ->
+    Pid = start_zone(#{broadcast_interval => 1}),
+    asobi_zone:subscribe(Pid, {~"p1", self()}),
+    timer:sleep(10),
+    flush_messages(),
+    asobi_zone:player_input(Pid, ~"p1", #{}, ~"garbage"),
+    asobi_zone:player_input(Pid, ~"p1", #{}, {tuple, 1}),
+    asobi_zone:player_input(Pid, ~"p1", #{}, [1, 2, 3]),
+    asobi_zone:tick(Pid, 1),
+    ?assertEqual(no_ack, recv_ack()),
+    ?assert(is_process_alive(Pid)),
+    gen_server:stop(Pid).
+
+%% The documented way to write this callback derives the watermark from the
+%% client's payload, so the reported value is attacker-influenced by design.
+%% asobi_ws_handler bounds the stamped seq to a JS-safe integer for exactly this
+%% reason; the reported one is a second door into the same wire field, and an
+%% ack the session gate keeps forever - so a bignum here would silence that
+%% connection's acks from every zone, not just this one.
+world_ack_reported_seq_is_bounded() ->
+    Pid = start_zone(#{broadcast_interval => 1}),
+    asobi_zone:subscribe(Pid, {~"p1", self()}),
+    timer:sleep(10),
+    flush_messages(),
+    Huge = 16#1FFFFFFFFFFFFF + 1,
+    asobi_zone:player_input(
+        Pid, ~"p1", #{~"action" => ~"consume", ~"consumed" => Huge}, 11
+    ),
+    asobi_zone:tick(Pid, 1),
+    ?assertEqual(11, recv_ack()),
+    ?assert(is_process_alive(Pid)),
+    %% The largest in-range value is still acked, so the bound is a ceiling and
+    %% not an off-by-one that costs a legitimate game its last seq.
+    asobi_zone:player_input(
+        Pid, ~"p1", #{~"action" => ~"consume", ~"consumed" => 16#1FFFFFFFFFFFFF}, 12
+    ),
+    asobi_zone:tick(Pid, 2),
+    ?assertEqual(16#1FFFFFFFFFFFFF, recv_ack()),
     gen_server:stop(Pid).
 
 %% A game module is user code. A nonsense consumed seq must neither crash the

--- a/test/asobi_zone_tests.erl
+++ b/test/asobi_zone_tests.erl
@@ -54,6 +54,16 @@ zone_test_() ->
         {"world.input without a seq produces no world.ack (#474)",
             fun world_ack_absent_without_seq/0},
         {"world.ack keeps the highest seq (#474)", fun world_ack_keeps_highest_seq/0},
+        {"a consumed seq reported by handle_input acks below the frame stamp (#532)",
+            fun world_ack_uses_reported_consumed_seq/0},
+        {"a reported seq above the frame stamp is acked too (#532)",
+            fun world_ack_reported_seq_above_stamp/0},
+        {"a report is authoritative for the rest of the tick (#532)",
+            fun world_ack_report_beats_a_later_stamp/0},
+        {"a reported seq never regresses the ack across ticks (#532)",
+            fun world_ack_reported_seq_never_regresses/0},
+        {"an invalid reported seq falls back to the frame stamp (#532)",
+            fun world_ack_invalid_reported_seq_falls_back/0},
         {"world.ack is per-connection - p1's ack never reaches p2 (#474)",
             fun world_ack_is_per_connection/0},
         {"a straggler input re-arms the zone's ack after the entity left (#477)",
@@ -262,6 +272,82 @@ world_ack_keeps_highest_seq() ->
     asobi_zone:player_input(Pid, ~"p1", #{}, 3),
     asobi_zone:tick(Pid, 1),
     ?assertEqual(5, recv_ack()),
+    gen_server:stop(Pid).
+
+%% asobi#532: a client predicting at 60 Hz against a 12.5 Hz zone batches
+%% several simulation steps into one frame. If the zone caps how many it runs
+%% per tick and parks the rest, the frame stamp says more ran than did - the
+%% client would discard predicted steps the server has not applied and could
+%% never replay them. handle_input reporting what it consumed acks BELOW the
+%% stamp, which is the whole point: a max would let "arrived" beat "ran".
+world_ack_uses_reported_consumed_seq() ->
+    Pid = start_zone(#{broadcast_interval => 1}),
+    asobi_zone:subscribe(Pid, {~"p1", self()}),
+    timer:sleep(10),
+    flush_messages(),
+    asobi_zone:player_input(
+        Pid, ~"p1", #{~"action" => ~"consume", ~"consumed" => 42}, 100
+    ),
+    asobi_zone:tick(Pid, 1),
+    ?assertEqual(42, recv_ack()),
+    gen_server:stop(Pid).
+
+%% The other stamping convention: a frame stamped with the FIRST seq in its
+%% batch, where the zone ran through the end of it. The report is above the
+%% stamp and the client must hear the higher number or it replays steps the
+%% server already applied.
+world_ack_reported_seq_above_stamp() ->
+    Pid = start_zone(#{broadcast_interval => 1}),
+    asobi_zone:subscribe(Pid, {~"p1", self()}),
+    timer:sleep(10),
+    flush_messages(),
+    asobi_zone:player_input(Pid, ~"p1", #{~"action" => ~"consume", ~"consumed" => 9}, 5),
+    asobi_zone:tick(Pid, 1),
+    ?assertEqual(9, recv_ack()),
+    gen_server:stop(Pid).
+
+%% Once a module has said what it consumed, a plain stamped input arriving
+%% later in the same tick must not raise the ack past it.
+world_ack_report_beats_a_later_stamp() ->
+    Pid = start_zone(#{broadcast_interval => 1}),
+    asobi_zone:subscribe(Pid, {~"p1", self()}),
+    timer:sleep(10),
+    flush_messages(),
+    asobi_zone:player_input(Pid, ~"p1", #{~"action" => ~"consume", ~"consumed" => 12}, 40),
+    asobi_zone:player_input(Pid, ~"p1", #{}, 30),
+    asobi_zone:tick(Pid, 1),
+    ?assertEqual(12, recv_ack()),
+    gen_server:stop(Pid).
+
+%% Cross-tick monotonicity still holds: a report is authoritative within a tick,
+%% never a licence to walk the ack backwards, which would make the client
+%% replay from a point it has already reconciled past.
+world_ack_reported_seq_never_regresses() ->
+    Pid = start_zone(#{broadcast_interval => 1}),
+    asobi_zone:subscribe(Pid, {~"p1", self()}),
+    timer:sleep(10),
+    flush_messages(),
+    asobi_zone:player_input(Pid, ~"p1", #{~"action" => ~"consume", ~"consumed" => 50}, 50),
+    asobi_zone:tick(Pid, 1),
+    ?assertEqual(50, recv_ack()),
+    asobi_zone:player_input(Pid, ~"p1", #{~"action" => ~"consume", ~"consumed" => 20}, 20),
+    asobi_zone:tick(Pid, 2),
+    ?assertEqual(50, recv_ack()),
+    gen_server:stop(Pid).
+
+%% A game module is user code. A nonsense consumed seq must neither crash the
+%% shared zone process nor be acked: the frame stamp is the recoverable answer.
+world_ack_invalid_reported_seq_falls_back() ->
+    Pid = start_zone(#{broadcast_interval => 1}),
+    asobi_zone:subscribe(Pid, {~"p1", self()}),
+    timer:sleep(10),
+    flush_messages(),
+    asobi_zone:player_input(
+        Pid, ~"p1", #{~"action" => ~"consume", ~"consumed" => ~"nope"}, 7
+    ),
+    asobi_zone:tick(Pid, 1),
+    ?assertEqual(7, recv_ack()),
+    ?assert(is_process_alive(Pid)),
     gen_server:stop(Pid).
 
 %% asobi#474: the ack is per-connection - p1's seq reaches p1 only, never p2's

--- a/test/fixtures/lua/config_ack_world.lua
+++ b/test/fixtures/lua/config_ack_world.lua
@@ -11,6 +11,10 @@ function leave(player_id, state) return state end
 function spawn_position(player_id, state) return { x = 0, y = 0 } end
 function zone_tick(entities, zone_state) return entities, zone_state end
 
+-- Reports whatever the test hands it, INCLUDING nothing, so the absent and
+-- invalid cases are exercisable from one fixture. A real script must report on
+-- every input or on none: `input.consumed` going nil on some inputs is the
+-- mixed mode the asobi_world callback docs warn about.
 function handle_input(player_id, input, entities)
     entities[player_id] = { type = "player", x = input.x or 0, y = input.y or 0 }
     return entities, input.consumed

--- a/test/fixtures/lua/config_ack_world.lua
+++ b/test/fixtures/lua/config_ack_world.lua
@@ -1,0 +1,23 @@
+-- World-bridge fixture: handle_input reports the client seq it consumed as a
+-- second return value, which is what a script batching several simulation
+-- steps into one frame does so the world.ack names what RAN, not what arrived.
+match_size = 1
+max_players = 16
+game_type = "world"
+
+function init(config) return { tick = 0 } end
+function join(player_id, state) return state end
+function leave(player_id, state) return state end
+function spawn_position(player_id, state) return { x = 0, y = 0 } end
+function zone_tick(entities, zone_state) return entities, zone_state end
+
+function handle_input(player_id, input, entities)
+    entities[player_id] = { type = "player", x = input.x or 0, y = input.y or 0 }
+    return entities, input.consumed
+end
+
+function post_tick(tick, state) return state end
+
+function generate_world(seed, config)
+    return { ["0,0"] = { tiles = {}, mobs = {} } }
+end

--- a/test/fixtures/lua/config_hostile_input_world.lua
+++ b/test/fixtures/lua/config_hostile_input_world.lua
@@ -1,0 +1,32 @@
+-- World-bridge fixture for the ways a script's handle_input return can be
+-- hostile to the zone process every player in that zone is simulated by:
+-- a self-referential table (luerl:decode/2 raises on it), a number wider than
+-- the ack space, and a first return value that is not entities at all.
+match_size = 1
+max_players = 16
+game_type = "world"
+
+function init(config) return { tick = 0 } end
+function join(player_id, state) return state end
+function leave(player_id, state) return state end
+function spawn_position(player_id, state) return { x = 0, y = 0 } end
+function zone_tick(entities, zone_state) return entities, zone_state end
+
+function handle_input(player_id, input, entities)
+    if input.kind == "cyclic" then
+        local t = {}
+        t.self = t
+        return entities, t
+    elseif input.kind == "huge" then
+        return entities, 1e308
+    elseif input.kind == "scalar" then
+        return "not entities at all"
+    end
+    return entities
+end
+
+function post_tick(tick, state) return state end
+
+function generate_world(seed, config)
+    return { ["0,0"] = { tiles = {}, mobs = {} } }
+end

--- a/test/fixtures/lua/config_silent_input_world.lua
+++ b/test/fixtures/lua/config_silent_input_world.lua
@@ -1,0 +1,22 @@
+-- World-bridge fixture: handle_input falls off its end and returns nothing at
+-- all, which is what a script does when an author forgets the return. It must
+-- cost that author their input, not the zone process every other player in the
+-- zone is being simulated by.
+match_size = 1
+max_players = 16
+game_type = "world"
+
+function init(config) return { tick = 0 } end
+function join(player_id, state) return state end
+function leave(player_id, state) return state end
+function spawn_position(player_id, state) return { x = 0, y = 0 } end
+function zone_tick(entities, zone_state) return entities, zone_state end
+
+function handle_input(player_id, input, entities)
+end
+
+function post_tick(tick, state) return state end
+
+function generate_world(seed, config)
+    return { ["0,0"] = { tiles = {}, mobs = {} } }
+end


### PR DESCRIPTION
Closes #532.

`world.ack` carried the `seq` stamped on the `world.input` frame. That says the frame **arrived**, not how much of it the zone **ran**.

This is not a new primitive. `guides/websocket-protocol.md` has said since #474 that the server "records the highest `seq` it **consumed** for that player", and calls the ack a first-class primitive. The implementation only ever had the arrival stamp available. This completes a contract that was already written down.

The two numbers are the same for one input per frame. They diverge for any game where accepted is not applied - a client predicting at 60 Hz against a 12.5 Hz zone batches roughly five simulation steps per frame and a zone capping steps-per-tick parks the rest, but so does any ability queue, cast time or input buffer that accepts an input this tick and applies it later, with no batching anywhere. The frame stamp then either overclaims (the client discards predicted steps the server has not applied and can never replay them) or underclaims (the client replays applied steps and overshoots). Only the game module knows which steps ran, and asobi deliberately never looks inside `Input`, so the callback return is the only channel that exists.

## Change

`handle_input/3` may now return `{ok, Entities1, ConsumedSeq}`, and a Lua `handle_input` may return the seq as a second value. Additive - every module returning `{ok, Entities}` keeps acking the frame stamp, and a game with no prediction pays nothing.

Semantics:

- A reported seq is authoritative for the rest of the tick and the newest report wins. Max-ing report against frame stamp would let "arrived" beat "ran".
- Cross-tick monotonicity is unchanged: the ack keeps the highest value recorded.
- A report acks a client that never stamped a `seq`. Numbering steps inside the payload and leaving the frame unstamped is the cleanest form of the batching design, so #474's stamp is not the only way to opt in.
- `{error, Reason}` still advances to the frame stamp (#474). A parking game should model refusal as `{ok, Entities, Watermark}`.
- A non-integer or negative report is refused with a warning and falls back to the stamp, rather than crashing the shared zone or acking a number the client cannot use.

Reserved rather than rejected: an explicit `game.ack(player_id, seq)` seam would also let a module report from `zone_tick`, which is the one gap the return value does not cover (a module that parks in `handle_input` and drains in `zone_tick` has its watermark ride out on the next input). The return tuple is a strict subset, so that seam can be added later without removing this. Documented as a limitation for now.

Also fixes a latent crash: a Lua `handle_input` that returns nothing produced a `case_clause` in the zone process. The same crash is still live on the match side, where it takes the whole match `gen_statem` down - swept in #534.

## Not fixed here

#535: a reconnecting client meets the zone's stale ack high-water mark. Pre-existing since #474/#477; the reason this PR's docs stop short of promising the ack never regresses.

## Tests

Six zone cases (report below the stamp, above the stamp, report beats a later stamp in the same tick, no cross-tick regression, invalid report falls back and the zone survives) and four Lua bridge cases (reported, absent, invalid, returns-nothing). Full suite green: 2201 tests, 0 failures before the review commit added four more.

## Checks

`fmt` / `xref` / `dialyzer` / `eqwalize-all` / `elp lint` / `eunit` / `ex_doc` / `fmt --check`. eqwalizer is 364 errors on this branch and 364 on `main` - unchanged baseline; `elp lint` W0032 count is 19 on both. Mutation testing is disabled in this repo's CI by an existing decision.

Reviewed by the asobi architecture guardian: ship with changes, all of which are in the second commit.