### PR TITLE
feat(world): apply a tick's inputs in one call, not one per input

### DIFF
--- a/docs/adr/0015-luerl-vm-owns-the-state.md
+++ b/docs/adr/0015-luerl-vm-owns-the-state.md
@@ -130,6 +130,43 @@ small message to the process that owns the state.**
 - A Lua tick's cost stops tracking the size of the state. That is the entire
   point, and it is what makes a large-state game viable rather than merely
   diagnosable.
+- **Every Luerl reference held across a call must be anchored, and this needs to
+  be a stated contract before 0015 lands rather than reasoned about per site.**
+  Decision item 2 makes "the bridge holds opaque refs and passes them back and
+  forth" the normal shape, so what is today one value (`game_state`, anchored by
+  `collect_state/1`) becomes many. `handle_input_batch/2` is the first of those,
+  and the failure mode is worth stating precisely, because "nothing collects
+  here" is the reasoning that produces it. luerl's root set is `_G`, the stack
+  and the live call frames, so a table Erlang carries between calls is reachable
+  only while some frame names it - and a script declaring
+  `function handle_input(p, i)` when three arguments were passed drops it. A
+  collection at that moment frees it, its slot returns to the free list, the
+  next `luerl:encode/2` recycles it, and the held reference aliases that data.
+  Reproduced during this PR: a zone's entire entity map came back as one
+  player's input frame, which `asobi_zone` accepts (it is still a map) and the
+  snapshotter persists.
+
+  Three things close it, and only the last generalises. `collectgarbage` was
+  reachable from Lua and has since been stripped from the sandbox
+  (`guides/security-sandbox.md`), which removes the reachable path.
+  `asobi_lua_loader:anchor_ref/2` roots the reference in a second raw `_G` slot
+  alongside the collector's, and `ref_anchored/2` re-checks it after every call
+  because `_G` is script-writable. Under 0015 the class is what matters: every
+  ref crossing a call boundary needs the same treatment, which is why this
+  belongs in the contract rather than in a fix.
+
+  A second lesson from the same change, and the one that will matter more under
+  0015: **the Luerl state being functional is a rollback primitive.** A batched
+  `handle_input` hands the script the entity table itself, so an empty return
+  could not "leave the entities alone" the way the per-input path does - there
+  is no Erlang-side copy to fall back on. Reverting to the state from before the
+  call reverts the heap the mutation lived in, at no cost. Anything under 0015
+  that needs to undo a callback's effect without copying has the same tool.
+- **The blast radius of a killed VM widens if `handle_input` is ever batched and
+  budgeted.** The Consequences below reopen the `handle_input` sandbox exemption
+  on the grounds that its reason is gone. If it comes back under a budget, note
+  that a batched `handle_input` makes one bad input cost the whole tick's inputs
+  rather than one, because the batch is a single callback.
 - The `handle_input` exemption (ADR 0002 in the asobi_lua lineage) can be
   revisited, because the reason for it — a copy per input frame — is gone.
   Whether it *should* be is a separate decision.

--- a/guides/performance-tuning.md
+++ b/guides/performance-tuning.md
@@ -160,6 +160,64 @@ so this is visible before zones start dying of it; asobi also logs
 Set `{asobi, [{lua_gc, false}]}` to turn the collector off entirely. There is
 no reason to do this outside diagnosing a problem with the collector itself.
 
+### Players in one zone
+
+The entity map is encoded into Lua **once per tick**, not once per input. That
+matters for any game where players cluster - a station, a battle, a spawn point
+- because the alternative scales with the product of the two.
+
+Measured on 2026-08-21, OTP 29.0.2 and luerl 1.5.1, 10 cores, on a zone holding
+200 entities of 27 fields, applying one five-step input frame per player per
+tick. One machine on one day, not a promise: measure your own game before you
+size anything, the way [Benchmarks](benchmarks.md) says. The tick rate here is 12.5 Hz (`tick_rate =
+80`), not the shipped default of 50 - the budget column says what each figure
+costs against **the default 50 ms**:
+
+| Players in the zone | Lua tables allocated per tick | Mean tick | Of a 50 ms budget |
+|---|---|---|---|
+| 1 | 386 | 16.0 ms | 32% |
+| 8 | 435 | 16.6 ms | 33% |
+| 32 | 603 | 17.3 ms | 35% |
+| 64 | 827 | 19.3 ms | 39% |
+
+The cost is dominated by entities: going from 1 player to 64 adds about seven
+Lua tables per player and 21% to the tick, where the entity count sets
+everything else. So the number to design around is how many entities a zone
+holds, not how many players stand in it.
+
+Before the entity map was hoisted out of the per-input path the same 64-player
+row allocated 13,490 tables and took 439 ms, which is nearly nine times the
+default budget and over five times an 80 ms one.
+
+A game module can opt into the same shape from Erlang by exporting
+`handle_input_batch/2` (see `asobi_world`); a module that does not gets
+`handle_input/3` per input, unchanged.
+
+Nothing about writing `handle_input` changes. Every input in a tick is handed
+the same entity table rather than a fresh copy, but an empty or invalid return
+still means "leave the entities alone" - asobi reverts the Lua state the call
+produced, which reverts the mutation with it. So this stays correct, and costs
+what it always did:
+
+```lua
+function handle_input(player_id, input, entities)
+    local p = entities[player_id]
+    if not p then return entities end
+    if math.abs(input.dx) > MAX_STEP then return end   -- rejected, move discarded
+    p.x = p.x + input.dx
+    return entities
+end
+```
+
+One thing the revert does take with it: a global the handler wrote before
+returning, or randomness it consumed, is rolled back too, where the per-input
+path kept those. Keep anything that must survive a rejection in `game_state` or
+on an entity rather than in a Lua global.
+
+The `nil` check is not decoration: an input can arrive for a player whose entity
+is not in this zone, and a script that indexes `p` blindly raises. asobi catches
+it and acks, so nothing corrupts, but the input is lost either way.
+
 ## Checkpoint
 
 1. In a match where everyone shares one view, set `state_strategy = "shared"`

--- a/guides/security-sandbox.md
+++ b/guides/security-sandbox.md
@@ -19,6 +19,16 @@ cannot reach them:
   `game.log(level, message[, meta])`, which routes a structured, size-bounded
   line through the host logger behind a rate limit (per match or zone, plus a
   node-wide backstop). See the Logging section of the Lua scripting guide.
+- Collection - `collectgarbage`. It runs a full mark-and-sweep of the state
+  synchronously on the shared zone process, and Luerl's mark phase is
+  superlinear in the live set, so a script calling it in a per-tick callback
+  stalls every other player in that zone. It also decides when values asobi is
+  holding between calls are freed, which is a correctness surface and not just a
+  performance one. Nothing is lost: asobi collects each state on its own
+  adaptive schedule, and Luerl's `collectgarbage` ignores every argument except
+  `"collect"`, so there was never a working `"count"` to read memory with. Use
+  the `[asobi, lua, state]` gauge instead - see
+  [Observability](observability.md).
 
 `os.clock`, `os.date`, `os.difftime` and `os.time` stay, so games can timestamp.
 

--- a/guides/security-trust-model.md
+++ b/guides/security-trust-model.md
@@ -76,12 +76,18 @@ The macros are not all in one place. Match budgets are `?*_TIMEOUT` in
 budget is a literal `50` at the call site in `asobi_bot.erl` rather than a
 macro. Grep for `asobi_lua_loader:call(` if you need the authoritative set.
 
-## The GC anchor is written past `_G`'s metatable
+## The anchors are written past `_G`'s metatable
 
-asobi collects each Lua state periodically, and to do that it has to keep the
-one value it holds between callbacks (`game_state`) reachable from Lua's root
-set for the duration. It writes that anchor **raw**, past any metatable the
-script has installed on `_G`.
+asobi holds Luerl references between callbacks, and Lua's root set is `_G`, the
+stack and the live call frames - so a reference Erlang is carrying is reachable
+only while something roots it. There are two anchors:
+
+- `game_state`, rooted for the duration of a collection.
+- The entity map, rooted for the duration of an input batch
+  (`handle_input_batch/2`). This one is live **while your script runs**, which
+  the next section explains.
+
+Both are written **raw**, past any metatable the script has installed on `_G`.
 
 That matters because `setmetatable(_G, ...)` is permitted (above), and the
 metamethod-honouring setter would make asobi's own bookkeeping write run script
@@ -90,8 +96,17 @@ with no wall-clock budget, no reduction budget and no heap cap. A `__newindex`
 that never returns would wedge that process permanently; an ordinary
 strict-globals `__newindex` that raises would make every collection silently
 fail while the collector reported itself healthy. Neither is reachable: the raw
-write runs no Lua and cannot fail, and the anchor is cleared again before the
-callback runs, so a script never observes it.
+write runs no Lua and cannot fail.
+
+The collector's anchor is cleared again before the callback runs, so a script
+never observes that one. The batch anchor is different and deliberately so: it
+has to stay rooted across the calls it protects, so a script **can** see
+`__asobi_ref_anchor` in `pairs(_G)` and can clear it. Clearing it does not
+corrupt anything. asobi re-checks the anchor after every call with a raw read -
+which a `__index` metamethod cannot spoof, for the same reason the write cannot
+be intercepted - and a batch whose anchor has gone abandons the tick's inputs
+and hands the zone back the entity map it started with. The cost of tampering
+falls on the script that tampered.
 
 ## handle-input is not a sandbox boundary
 

--- a/guides/world-server.md
+++ b/guides/world-server.md
@@ -210,7 +210,7 @@ end
 | `spawn_position(player_id, state)` | yes | Return a `{x=N, y=N}` table |
 | `post_tick(tick, state)` | yes | Global tick logic. Set `_finished` and `_result` on state to end the world |
 | `zone_tick(entities, zone_state)` | no | Per-zone simulation; return both |
-| `handle_input(player_id, input, entities)` | no | Apply one player's input to that zone's entities. A second return value is the client seq you consumed - see [Batched input and the ack](websocket-protocol.md#client-side-prediction) |
+| `handle_input(player_id, input, entities)` | no | Apply one player's input to that zone's entities. A second return value is the client seq you consumed - see [Batched input and the ack](websocket-protocol.md#client-side-prediction). Every input in a tick is handed the same table rather than a copy, but returning nothing still discards whatever that call mutated - see [Players in one zone](performance-tuning.md#players-in-one-zone) |
 | `generate_world(seed, config)` | no | Return a table keyed by `"x,y"` strings |
 | `get_state(player_id, state)` | no | Player-visible state |
 | `spawn_templates(config)` | no | See [Spawn templates](#spawn-templates) |
@@ -321,7 +321,8 @@ post_tick(_TickN, State) ->
 | `leave/2` | yes | Player left the world |
 | `spawn_position/2` | yes | Return `{ok, {X, Y}}` for new player placement |
 | `zone_tick/2` | yes | Per-zone simulation: `(Entities, ZoneState) -> {Entities, ZoneState}` |
-| `handle_input/3` | yes | Process player input within a zone's entities. Return `{ok, Entities, ConsumedSeq}` to ack what you *ran* rather than what arrived - see [Batched input and the ack](websocket-protocol.md#client-side-prediction) |
+| `handle_input/3` | one of | Process player input within a zone's entities. Return `{ok, Entities, ConsumedSeq}` to ack what you *ran* rather than what arrived - see [Batched input and the ack](websocket-protocol.md#client-side-prediction) |
+| `handle_input_batch/2` | one of | The whole tick's inputs in one call, returning one entity map plus one outcome per input. Export it instead of `handle_input/3` when your per-input cost is dominated by marshalling the entity map rather than by the input. Exporting it shadows `handle_input/3` entirely. asobi still owns the ack policy: you return one outcome per input - see [Players in one zone](performance-tuning.md#players-in-one-zone) |
 | `post_tick/2` | yes | Global post-tick: return `{ok, State}`, `{vote, Config, State}`, or `{finished, Result, State}` |
 | `generate_world/2` | no | Procedural generation: `(Seed, Config) -> {ok, #{Coords => ZoneState}}` |
 | `get_state/2` | no | Per-player state view |

--- a/src/asobi_telemetry.erl
+++ b/src/asobi_telemetry.erl
@@ -33,7 +33,15 @@
 
 %% Categories of game-code error. A fixed literal set on purpose - never derive
 %% Kind from untrusted input (atom-table exhaustion). Extend as categories arise.
--type game_error_kind() :: lua_error | unknown_spawn_template | zone_unavailable.
+-type game_error_kind() ::
+    lua_error
+    | unknown_spawn_template
+    | zone_unavailable
+    | no_input_handler
+    | batch_contract
+    | unknown_outcome
+    | input_rejected
+    | invalid_consumed_seq.
 -export_type([game_error_kind/0]).
 -export([economy_transaction/4, store_purchase/3]).
 -export([chat_message_sent/2]).

--- a/src/lua/asobi_lua_config.erl
+++ b/src/lua/asobi_lua_config.erl
@@ -55,7 +55,7 @@ player_ttl_ms           = 0               -- optional, 0=remove on disconnect, -
 ```
 
 Setting `game_type = "world"` routes the script through the `asobi_lua_world`
-bridge (zone_tick/2 + handle_input/3 returning entities). Defaults to "match",
+bridge (zone_tick/2 + an input callback returning entities). Defaults to "match",
 which uses the `asobi_lua_match` bridge (tick/1 + wrapped-state callbacks).
 
 `guest_auth` and `registration` are read from `match.lua` in single-mode and

--- a/src/lua/asobi_lua_loader.erl
+++ b/src/lua/asobi_lua_loader.erl
@@ -9,6 +9,9 @@ standard-library entry point cleared:
   `os.tmpname`
 - `io` (the whole library)
 - `dofile`, `loadfile`, `load`, `loadstring`
+- `collectgarbage` - asobi collects on its own schedule via `luerl:gc/1`;
+  letting a script force a synchronous mark-and-sweep on the zone process is
+  both a DoS surface and a way to free references Erlang is still holding
 - `package` (the whole library) — replaced by an `asobi_lua`-controlled
   `require/1` so scripts can still split logic across files
 
@@ -32,6 +35,7 @@ load a specific script and pin its base directory for `require`.
 -export([new/1, new/2, new/3, init_sandboxed/0, call/3, call/4, do_with_timeout/3]).
 -export([is_defined/2]).
 -export([collect_state/1]).
+-export([anchor_ref/2, unanchor_ref/1, ref_anchored/2]).
 -ifdef(TEST).
 -export([next_gc/4, gc_budget_us/1, state_words/0]).
 -endif.
@@ -91,7 +95,8 @@ load a specific script and pin its base directory for `require`.
 -define(REDUCTION_POLL_MS, 10).
 
 %% #426: Luerl never collects a long-lived state on its own - only an explicit
-%% `collectgarbage()` from Lua or `luerl:gc/1` from Erlang reclaims anything.
+%% `luerl:gc/1` from Erlang reclaims anything, and since `collectgarbage` is
+%% stripped from the sandbox that call is asobi's alone to make.
 %% Every per-tick `luerl:encode/2` therefore leaks: measured at ~3900 words per
 %% tick for a 50-entity zone, which is ~625 KB/s per zone at a 50 ms tick, and
 %% `bounded_eval` copies the whole state into the eval worker and back on every
@@ -140,6 +145,10 @@ load a specific script and pin its base directory for `require`.
 %% tidy-up. A quarter leaves the back-off a working range either side.
 -define(GC_BUDGET_CEILING_US, (?GC_ABANDON_US div 4)).
 -define(GC_ANCHOR, ~"__asobi_gc_anchor").
+%% A second root, for a value Erlang holds across `call/3` invocations rather
+%% than across a collection. Distinct from ?GC_ANCHOR so the two never evict
+%% each other: a collection can run while an input batch is mid-flight.
+-define(REF_ANCHOR, ~"__asobi_ref_anchor").
 
 %% How often `collect_state/1` reports the measured state size. The collector's
 %% own interval is adaptive and can be off entirely, so the size cannot ride on
@@ -639,8 +648,58 @@ collect(St, Anchor) ->
 unanchor(St) ->
     raw_anchor(nil, St).
 
-raw_anchor(Value, #luerl{g = G} = St) ->
-    luerl_heap:raw_set_table_key(G, ?GC_ANCHOR, Value, St).
+raw_anchor(Value, St) ->
+    raw_anchor_key(?GC_ANCHOR, Value, St).
+
+raw_anchor_key(Key, Value, #luerl{g = G} = St) ->
+    luerl_heap:raw_set_table_key(G, Key, Value, St).
+
+-doc """
+Root a Luerl reference in `_G` for as long as Erlang holds it between calls.
+
+Luerl's root set is `_G`, the stack and the live call frames, so a table that
+Erlang is carrying across `call/3` is reachable only while some frame happens to
+name it. A script that ignores an argument - `function handle_input(p, i)` when
+three were passed - drops it from the frame. If anything then collects, the
+table is freed, its slot returns to the free list, and the next
+`luerl:encode/2` recycles it: the reference Erlang still holds now aliases
+somebody else's data.
+
+`collectgarbage` is stripped from the sandbox, so no script can force that
+today, and this is the second layer rather than the only one. It is still the
+load-bearing one, because the strip closes one reachable path while this closes
+the class: any Erlang-side collection between two calls - which ADR 0015 makes
+the normal shape by holding refs across every call - has the same effect.
+
+Anchoring costs one raw `_G` write. Raw, for the reason `collect/2` gives: the
+metamethod-honouring setter would run a script's `__newindex` on the bridge
+process, outside `bounded_eval`.
+
+Pair every `anchor_ref/2` with an `unanchor_ref/1`, or the anchored table stays
+reachable and no collection can reclaim it.
+""".
+-spec anchor_ref(term(), dynamic()) -> dynamic().
+anchor_ref(Value, St) ->
+    raw_anchor_key(?REF_ANCHOR, Value, St).
+
+-doc "Drop the `anchor_ref/2` root.".
+-spec unanchor_ref(dynamic()) -> dynamic().
+unanchor_ref(St) ->
+    raw_anchor_key(?REF_ANCHOR, nil, St).
+
+-doc """
+Is `Value` still the value `anchor_ref/2` rooted?
+
+The raw write cannot be intercepted by a script's `_G` metatable, but the slot
+it writes to lives in `_G`, which scripts can assign to. `__asobi_ref_anchor =
+nil` from Lua drops asobi's root, and anything Erlang still holds is then one
+collection away from naming a recycled slot. A caller carrying a reference
+across `call/3` therefore has to re-check rather than assume, and treat `false`
+as "nothing I am holding is safe to decode".
+""".
+-spec ref_anchored(term(), dynamic()) -> boolean().
+ref_anchored(Value, #luerl{g = G} = St) ->
+    luerl_heap:raw_get_table_key(G, ?REF_ANCHOR, St) =:= Value.
 
 gc_disabled() ->
     asobi_lua_env:get_env(lua_gc) =:= {ok, false}.
@@ -670,7 +729,13 @@ strip_dangerous_globals(St) ->
     %% `game.log` (asobi_lua_api), which routes structured reports
     %% through the host logger behind a rate limit - closing exactly
     %% the two holes print was removed for.
+    %% `collectgarbage` is stripped for two reasons, both in
+    %% `guides/security-sandbox.md`: it is a synchronous, superlinear
+    %% mark-and-sweep on the shared zone process, and it lets a script decide
+    %% when references asobi holds between calls are freed. asobi collects on
+    %% its own schedule through `luerl:gc/1`, which is Erlang-side.
     Paths = [
+        [~"collectgarbage"],
         [~"os", ~"execute"],
         [~"os", ~"exit"],
         [~"os", ~"getenv"],

--- a/src/lua/asobi_lua_world.erl
+++ b/src/lua/asobi_lua_world.erl
@@ -45,7 +45,7 @@ of hot reloads.
 -include("asobi_ack.hrl").
 
 -export([init/1, join/2, join/3, leave/2, spawn_position/2]).
--export([zone_tick/2, handle_input/3, post_tick/2]).
+-export([zone_tick/2, handle_input/3, handle_input_batch/2, post_tick/2]).
 -ifdef(TEST).
 -export([zone_ctx/2, make_ctx/1]).
 -endif.
@@ -304,7 +304,7 @@ stamp is used, so a script cannot ack something the client will not accept.
 -spec handle_input(binary(), map(), map()) ->
     {ok, map()} | {ok, map(), non_neg_integer()} | {error, term()}.
 handle_input(PlayerId, Input, Entities) ->
-    case erlang:get(?PD_KEY) of
+    case stashed_zone_state() of
         #{lua_state := LuaSt} = ZoneState ->
             {EncInput, LuaSt1} = luerl:encode(Input, LuaSt),
             {EncEntities, LuaSt2} = luerl:encode(Entities, LuaSt1),
@@ -329,6 +329,179 @@ handle_input(PlayerId, Input, Entities) ->
             end;
         _ ->
             {ok, Entities}
+    end.
+
+-doc """
+Apply a tick's whole input queue with one encode of the entity map.
+
+`handle_input/3` encodes the entity map into Luerl on every call, so a zone with
+P players applied it P times per tick and decoded it P times back. That is the
+same map every time, and it dominated both the allocation and the tick: measured
+at 200 entities, `handle_input` allocated `208 x P` Lua tables per tick against
+`zone_tick`'s constant 177.6, and 64 players in one zone ran a tick well past
+any budget the world could be given. See
+`guides/performance-tuning.md`.
+
+Here the map is encoded once, the resulting Luerl reference is threaded through
+every input, and it is decoded once at the end. Each input still pays for its
+own (small) input frame.
+
+The reference is **anchored** for the batch (`asobi_lua_loader:anchor_ref/2`).
+Luerl's root set is `_G`, the stack and the live call frames, so a table Erlang
+carries between calls is reachable only while some frame happens to name it, and
+a script that ignores the argument (`function handle_input(p, i)` when three were
+passed) drops the map from its frame. A collection at that moment frees it, its
+slot returns to luerl's free list, the next input's `luerl:encode/2` recycles it,
+and the reference then aliases that input's frame: the zone's whole entity map
+silently becomes one player's input, which `asobi_zone` accepts and the
+snapshotter persists.
+
+Two things stop that, and they close different doors. `collectgarbage` is
+stripped from the sandbox, so a script cannot force a collection mid-batch. The
+anchor makes the reference survive one regardless, which is what keeps this
+correct if a collection is ever introduced on this path. `_G` is script-writable,
+so the anchor is re-checked after every call: a script that clears it loses that
+tick's inputs rather than corrupting the zone.
+
+An empty or invalid return means what it means under `handle_input/3`: leave the
+entities alone. The script holds the table itself here, so that is not free -
+see `batch_result/2`.
+""".
+-spec handle_input_batch([{binary(), map()}], map()) ->
+    {ok, map(), [asobi_world:input_outcome()]}.
+handle_input_batch([], Entities) ->
+    {ok, Entities, []};
+handle_input_batch(Inputs, Entities) ->
+    case stashed_zone_state() of
+        #{lua_state := LuaSt} = ZoneState ->
+            {EncEntities, LuaSt1} = luerl:encode(Entities, LuaSt),
+            {EncEntities1, Outcomes, LuaSt2, ZoneState1} = run_input_batch(
+                Inputs, EncEntities, LuaSt1, ZoneState, []
+            ),
+            %% Decode BEFORE unanchoring: the reference is only rooted until the
+            %% slot is cleared, and nothing should read an unrooted one.
+            Result =
+                case EncEntities1 of
+                    anchor_lost ->
+                        {ok, Entities, Outcomes};
+                    _ ->
+                        Decoded = asobi_lua_api:atomize_entities(
+                            decode_to_map(EncEntities1, LuaSt2)
+                        ),
+                        {ok, Decoded, Outcomes}
+                end,
+            LuaSt3 = asobi_lua_loader:unanchor_ref(LuaSt2),
+            erlang:put(?PD_KEY, ZoneState1#{lua_state => LuaSt3}),
+            Result;
+        _ ->
+            {ok, Entities, [ok || _ <- Inputs]}
+    end.
+
+%% `erlang:get/1` is typed `term()`, so matching a zone state straight out of the
+%% process dictionary loses the map shape and every luerl call on what comes out
+%% of it reads as untyped. Narrowing it once here keeps the callers honest
+%% without an eqwalizer suppression.
+-spec stashed_zone_state() -> map() | undefined.
+stashed_zone_state() ->
+    case erlang:get(?PD_KEY) of
+        ZoneState when is_map(ZoneState) -> ZoneState;
+        _ -> undefined
+    end.
+
+run_input_batch([], Enc, LuaSt, ZoneState, Acc) ->
+    {Enc, lists:reverse(Acc), LuaSt, ZoneState};
+run_input_batch([{PlayerId, Input} | Rest], Enc, LuaSt, ZoneState, Acc) ->
+    %% Anchor BEFORE the input encode, not after: `Enc` has to be rooted across
+    %% every allocation, not merely across the call. Re-anchored each iteration
+    %% because `Enc` changes - whatever the last script returned is what the
+    %% next one is handed.
+    LuaSt0 = asobi_lua_loader:anchor_ref(Enc, LuaSt),
+    {EncInput, LuaSt1} = luerl:encode(Input, LuaSt0),
+    case asobi_lua_loader:call(handle_input, [PlayerId, EncInput, Enc], LuaSt1) of
+        {ok, Rets, LuaSt2} ->
+            %% `_G` is script-writable, so a script can clear asobi's root with
+            %% `__asobi_ref_anchor = nil`. Nothing Erlang is holding is safe to
+            %% decode after that, so abandon the batch and hand back the map the
+            %% zone gave us rather than one that may alias a recycled slot.
+            case asobi_lua_loader:ref_anchored(Enc, LuaSt2) of
+                true ->
+                    case batch_result(Rets, ZoneState) of
+                        {keep, Enc1, Outcome} ->
+                            run_input_batch(Rest, Enc1, LuaSt2, ZoneState, [Outcome | Acc]);
+                        {revert, Outcome} ->
+                            run_input_batch(Rest, Enc, LuaSt0, ZoneState, [Outcome | Acc])
+                    end;
+                false ->
+                    log_anchor_cleared(ZoneState),
+                    %% Carry the outcomes already produced this tick rather than
+                    %% flattening them to stamps. A {consumed, Seq} replaced by
+                    %% a frame stamp is buried for good - the session ack gate
+                    %% is monotonic - and the input that cleared the anchor is
+                    %% not the input that reported. The current input and the
+                    %% un-run remainder ack by stamp, which is all asobi knows.
+                    Unrun = [ok || _ <- [dropped | Rest]],
+                    {anchor_lost, lists:reverse(Acc, Unrun), LuaSt2, ZoneState}
+            end;
+        {error, Reason} ->
+            log_lua_error(handle_input, Reason, ZoneState),
+            ZoneState1 = asobi_lua_dev_errors:maybe_notify(
+                handle_input, Reason, PlayerId, ZoneState
+            ),
+            %% `ok`, not `{error, Reason}`. A Lua exception is a bridge failure,
+            %% not a module rejection: handle_input/3 maps one to
+            %% `{ok, Entities}` after a rate-limited, shape-classified
+            %% log_lua_error/3, and reporting it as a rejection instead would
+            %% classify every throwing handler as the game refusing the input.
+            run_input_batch(Rest, Enc, LuaSt0, ZoneState1, [ok | Acc])
+    end.
+
+-doc """
+What a script's `handle_input` return means for the table the batch is carrying.
+
+`{keep, Enc1, Outcome}` takes what the script returned. `{revert, Outcome}`
+means it returned nothing usable, and `run_input_batch/5` then drops the Luerl
+state the call produced.
+
+Dropping the state is what makes an empty return mean the same thing here as it
+does under `handle_input/3` **for the entities**. It is wider than that in one
+respect worth knowing: the Luerl state is the whole VM, so anything else the
+call did - a global it wrote, randomness it consumed - goes with the revert,
+where `handle_input/3` kept it. A handler that counts strikes in a global on its
+reject path has to keep that count in `game_state` or in an entity instead. There, the module gets a fresh copy of the entity
+map per input, so a mutation it made and did not return is discarded because
+Erlang still holds the original. Here the script is handed the table itself, and
+there is no Erlang-side copy to fall back on - but the Luerl state is
+functional, so reverting to the state from before the call reverts the heap the
+mutation lives in. It costs nothing and it is the difference between "returning
+nothing rejects the input" and "returning nothing keeps whatever you touched,
+including another player's entity".
+
+The same revert runs on a Lua exception, which is why a raising handler leaves
+no input frame behind either.
+""".
+batch_result([], _ZoneState) ->
+    {revert, ok};
+%% A Luerl table reference is a tuple, so anything else is a script returning a
+%% scalar where entities belong. Stated as what is ACCEPTED rather than as a
+%% list of rejects: the accepted value is threaded onward as `Enc` and written
+%% into `_G` by anchor_ref/2, so it has to be a reference and nothing else.
+batch_result([Ents | _Rest], ZoneState) when not is_tuple(Ents) ->
+    log_invalid_input_return(ZoneState),
+    {revert, ok};
+batch_result([Ents | Rest], ZoneState) ->
+    case Rest of
+        [] ->
+            {keep, Ents, ok};
+        [Consumed | _] ->
+            case consumed_seq(Consumed) of
+                {ok, Seq} ->
+                    {keep, Ents, {consumed, Seq}};
+                none ->
+                    {keep, Ents, ok};
+                invalid ->
+                    log_invalid_input_return(ZoneState),
+                    {keep, Ents, ok}
+            end
     end.
 
 -spec post_tick(non_neg_integer(), map()) ->
@@ -789,11 +962,23 @@ input_result([Ents | Rest], LuaSt, _Entities, ZoneState) ->
             end
     end.
 
-%% Its own limiter bucket, and deliberately NOT log_lua_error/3: that keys on
-%% {Script, Callback}, so a client posting junk in the field a script echoes
-%% would exhaust the budget real handle_input exceptions are logged from, and
-%% its unconditional telemetry emit would classify a well-behaved script as
-%% throwing a Lua runtime error at input rate.
+%% Its own limiter bucket, for the same reason log_invalid_input_return/1 below
+%% has one: keying on {Script, Callback} the way log_lua_error/3 does would let
+%% script-driven noise exhaust the budget real Lua exceptions are logged from.
+log_anchor_cleared(ZoneState) ->
+    Script = maps:get(script, ZoneState, ~"<unknown>"),
+    case asobi_script_log_limiter:allow({Script, anchor_cleared}) of
+        {true, SuppressedSinceLast} ->
+            ?LOG_WARNING(#{
+                msg =>
+                    ~"lua script cleared asobi's reference anchor; this tick's inputs were dropped",
+                script => asobi_lua_game_error:script_basename(Script),
+                suppressed_since_last => SuppressedSinceLast
+            });
+        false ->
+            ok
+    end.
+
 log_invalid_input_return(ZoneState) ->
     Script = maps:get(script, ZoneState, ~"<unknown>"),
     case asobi_script_log_limiter:allow({Script, invalid_input_return}) of

--- a/src/world/asobi_world.erl
+++ b/src/world/asobi_world.erl
@@ -4,10 +4,26 @@ Behaviour for large-session world game modules.
 
 Unlike `asobi_match`, world games are spatially partitioned into zones. The game
 module provides zone-level tick logic and global post-tick events. Only `init/1`,
-`join/2`, `leave/2`, `spawn_position/2`, `zone_tick/2`, `handle_input/3`,
-`post_tick/2`, `init_zone_state/2`, and `dump_zone_state/1` are required; the rest
-are optional hooks (see `-optional_callbacks`).
+`join/2`, `leave/2`, `spawn_position/2`, `zone_tick/2` and `post_tick/2` are
+required; the rest are optional hooks (see `-optional_callbacks`).
+
+Input handling needs **one of** `handle_input/3` or `handle_input_batch/2`.
+Both are optional so a module can implement either, and a world that takes no
+player input at all can implement neither - asobi acks such inputs by frame
+stamp and logs once rather than failing the zone.
 """.
+
+-doc """
+What happened to one input in a `handle_input_batch/2` call. One per input, in
+the order they were handed over. The three constructors mirror `handle_input/3`'s
+three return shapes, minus the entity map the batch returns once.
+""".
+-type input_outcome() ::
+    ok
+    | {consumed, ConsumedSeq :: non_neg_integer()}
+    | {error, Reason :: term()}.
+
+-export_type([input_outcome/0]).
 
 -doc "Initialise global game state from the match config.".
 -callback init(Config :: map()) ->
@@ -99,6 +115,64 @@ move again.
     {ok, Entities1 :: map()}
     | {ok, Entities1 :: map(), ConsumedSeq :: non_neg_integer()}
     | {error, Reason :: term()}.
+
+-doc """
+Optional: apply a whole tick's queued inputs in one call.
+
+A module that exports this is handed the tick's inputs together and returns one
+entity map plus one outcome per input, in the same order. asobi still owns the
+ack policy - an outcome only says what happened to that input, and the mapping
+from outcome to `world.ack` is unchanged from `handle_input/3`:
+
+- `ok` acks the frame stamp, exactly as `{ok, Entities1}` does
+- `{consumed, Seq}` reports a watermark, exactly as `{ok, Entities1, Seq}` does
+- `{error, Reason}` logs and still advances the stamp, exactly as
+  `{error, Reason}` does
+
+It exists for bridges whose per-input cost is dominated by marshalling the
+entity map across a language boundary rather than by the input itself.
+`asobi_lua_world` encodes the map into Luerl once per tick here instead of once
+per input, which is the difference between O(inputs x entities) and O(entities)
+work per tick. The measurements are in
+[Performance tuning](performance-tuning.md#players-in-one-zone).
+
+Breaking the contract - a wrong-length outcome list, or a return that is not
+`{ok, Entities1, Outcomes}` at all - logs and acks **nothing** for that tick. A
+frame stamp would be worse than silence: the session's ack gate is monotonic, so
+stamping over a watermark the module did report buries it permanently, while a
+missing ack is undone by the next clean tick. A wrong-length list still keeps
+the entities the module handed back (it may already have applied them); an
+unusable return keeps the ones the zone held. Neither is re-run through
+`handle_input/3`, for the same reason.
+
+A module that does not export this gets `handle_input/3` per input, unchanged.
+
+Exporting it **shadows `handle_input/3` entirely** for that module: asobi never
+calls the per-input path when the batch exists. A module that exports both is
+carrying two implementations of one semantic and has to keep them in lockstep.
+
+An empty or invalid return means the same thing on both paths for the entities:
+leave them alone. That is not free here - the module is handed the map itself
+rather than a copy - so asobi reverts the Luerl state the call produced, which
+reverts the heap the mutation lived in. Without it, a handler written as "apply
+the move, then `return` to reject it" would keep the move, and one that looks
+its target up from a client-controlled field would be a write primitive on any
+entity in the zone. The revert is of the whole Luerl state, so a global the
+handler wrote on its reject path, or randomness it consumed, is discarded with
+it - `handle_input/3` kept those. Keep anything that must survive a rejection in
+`game_state` or on an entity.
+
+`asobi_lua_world` deliberately exports both. The batch is what production runs;
+`handle_input/3` is kept as the reference semantic the batch is checked against,
+and `asobi_lua_input_batch_tests:batch_agrees_with_per_input/0` drives the
+hostile-return corpus through both, comparing entities and outcomes. Delete it
+and the only cross-check on `batch_result/3` goes with it.
+""".
+-callback handle_input_batch(
+    Inputs :: [{PlayerId :: binary(), Input :: map()}],
+    Entities :: map()
+) ->
+    {ok, Entities1 :: map(), Outcomes :: [input_outcome()]}.
 
 -doc "Global post-tick hook: continue, trigger a vote, or finish the world.".
 -callback post_tick(Tick :: non_neg_integer(), GameState :: term()) ->
@@ -197,5 +271,7 @@ plain terms. The inverse of `init_zone_state`'s restore path.
     on_zone_loaded/2,
     on_zone_unloaded/2,
     init_zone_state/2,
-    dump_zone_state/1
+    dump_zone_state/1,
+    handle_input/3,
+    handle_input_batch/2
 ]).

--- a/src/world/asobi_world_ticker.erl
+++ b/src/world/asobi_world_ticker.erl
@@ -180,7 +180,7 @@ handle_info(
     %% than sent another one. Without this the fan-out is open-loop - a zone
     %% whose `zone_tick` outruns `tick_rate` takes casts faster than it can
     %% retire them and its mailbox grows without bound, which on a Lua world
-    %% is terminal: the upkeep that would recover it (a `collectgarbage/0`,
+    %% is terminal: the upkeep that would recover it (a Luerl collection,
     %% releasing entities so the reaper can stop the zone) is itself carried
     %% by a tick, so it queues behind the backlog exactly when it is needed.
     %% Dropping a tick is strictly better than queueing one - the zone tick is

--- a/src/world/asobi_zone.erl
+++ b/src/world/asobi_zone.erl
@@ -16,6 +16,7 @@ via `asobi_spatial`. Zones are created and reaped lazily as players move.
 -export([query_radius/3, query_rect/3]).
 -export([init/1, handle_call/3, handle_cast/2, handle_continue/2, handle_info/2, terminate/2]).
 -ifdef(TEST).
+-export([shape_of/1]).
 -export([past_zone_margin/4, classify_crossing/5]).
 -export([log_refusal/6, distinct_field_names/1, widest_entity/1]).
 -endif.
@@ -818,7 +819,7 @@ do_tick(
     %% OLDEST input's state — every later move gets overwritten by the
     %% next-handle_input call walking the list head-first.
     {Entities2, TickAcks} = apply_inputs(
-        GameMod, lists:reverse(Queue), Entities0, invalid_seq_log_key(WorldId, Coords)
+        GameMod, lists:reverse(Queue), Entities0, {WorldId, Coords}
     ),
     PlayerAck1 = maps:fold(fun record_ack/3, maps:get(player_ack, State, #{}), TickAcks),
     Now = erlang:system_time(millisecond),
@@ -924,8 +925,224 @@ apply_timer_events([{entity_timer_expired, EntityId, _TimerId, OnComplete} | Res
         end,
     apply_timer_events(Rest, Entities1).
 
+%% A module that exports handle_input_batch/2 gets the whole queue in one call.
+%% The ack policy below is unchanged either way - the batch reports an outcome
+%% per input and asobi still decides what that means for world.ack - so the only
+%% thing the batch buys is that a bridge marshalling the entity map across a
+%% language boundary does it once per tick instead of once per input.
+apply_inputs(_GameMod, [], Entities, _LogKey) ->
+    {Entities, #{}};
 apply_inputs(GameMod, Queue, Entities, LogKey) ->
-    apply_inputs(GameMod, Queue, Entities, LogKey, {#{}, #{}}).
+    case input_mode(GameMod) of
+        batch ->
+            apply_input_batch(GameMod, Queue, Entities, LogKey);
+        per_input ->
+            apply_per_input(GameMod, Queue, Entities, LogKey, {#{}, #{}});
+        none ->
+            %% Both input callbacks are optional, so a world that takes no player
+            %% input is legal - but one that RECEIVES input with no handler will
+            %% never process any, so this is an error, not a degraded mode.
+            log_no_input_handler(GameMod, LogKey),
+            {Entities, stamp_all(Queue)}
+    end.
+
+%% No code:ensure_loaded/1: do_tick/2 calls GameMod:zone_tick/2 before it ever
+%% reaches here, and a remote call forces the load.
+input_mode(GameMod) ->
+    case erlang:function_exported(GameMod, handle_input_batch, 2) of
+        true ->
+            batch;
+        false ->
+            case erlang:function_exported(GameMod, handle_input, 3) of
+                true -> per_input;
+                false -> none
+            end
+    end.
+
+%% Telemetry is emitted unconditionally, outside the limiter: suppressing the
+%% line must not suppress the rate an operator alerts on (asobi_script_log_limiter's
+%% own contract). Same at every other limited site below.
+log_no_input_handler(GameMod, LogKey) ->
+    asobi_telemetry:game_error(no_input_handler, #{game_module => GameMod}),
+    case asobi_script_log_limiter:allow(no_input_handler_log_key(LogKey)) of
+        {true, SuppressedSinceLast} ->
+            ?LOG_ERROR(#{
+                msg =>
+                    ~"game module exports neither handle_input/3 nor handle_input_batch/2; inputs acked and dropped",
+                game_module => GameMod,
+                suppressed_since_last => SuppressedSinceLast
+            });
+        false ->
+            ok
+    end.
+
+apply_input_batch(GameMod, Queue, Entities, LogKey) ->
+    Inputs = [{PlayerId, Input} || {PlayerId, _Seq, Input} <- Queue],
+    case GameMod:handle_input_batch(Inputs, Entities) of
+        {ok, Entities1, Outcomes} when is_map(Entities1) ->
+            %% No length/1 on `Outcomes`: is_list/1 admits an IMPROPER list, and
+            %% length/1 then raises badarg inside the zone every other player
+            %% here is simulated by. Walking the two lists in lockstep makes
+            %% wrong-length, improper-tail and not-a-list one case, and that case
+            %% is a bail-out rather than a crash.
+            case pair_outcomes(Queue, Outcomes, LogKey) of
+                {ok, Acks} ->
+                    {Entities1, Acks};
+                mismatch ->
+                    log_bad_batch(GameMod, length(Queue), outcome_shape(Outcomes), LogKey),
+                    %% NOT stamp_all/1. A stamp claims every arriving seq ran,
+                    %% and asobi_player_session's ack gate is monotonic per
+                    %% socket - so an overclaim here permanently buries whatever
+                    %% watermark the module meant to report, for every player in
+                    %% the tick, including ones whose own input was fine.
+                    %% Acking nothing is recoverable: the next clean tick acks
+                    %% past it.
+                    {Entities1, #{}}
+            end;
+        Other ->
+            %% Deliberately NOT a fallback to the per-input path: the batch may
+            %% already have applied some of these inputs, and running them again
+            %% would double-apply them.
+            log_bad_batch(GameMod, length(Queue), return_shape(Other), LogKey),
+            %% Acks nothing, same as the mismatch arm and for the same reason:
+            %% `{ok, not_a_map, [{consumed, 30}]}` lands here, and stamping over
+            %% that report would bury it permanently.
+            {Entities, #{}}
+    end.
+
+%% Limited as well as shape-only: this fires once per tick for as long as the
+%% module stays broken, and multiplies by every live zone in the world.
+log_bad_batch(GameMod, Expected, Got, LogKey) ->
+    asobi_telemetry:game_error(batch_contract, #{game_module => GameMod}),
+    case asobi_script_log_limiter:allow(bad_batch_log_key(LogKey)) of
+        {true, SuppressedSinceLast} ->
+            ?LOG_WARNING(#{
+                msg => ~"handle_input_batch broke its contract; this tick's inputs are unacked",
+                game_module => GameMod,
+                inputs => Expected,
+                outcomes => Got,
+                suppressed_since_last => SuppressedSinceLast
+            });
+        false ->
+            ok
+    end.
+
+%% Shape, never the term: a game module's return can carry the whole entity map,
+%% and this is written synchronously on the zone at tick rate. Same reasoning as
+%% reported_ack/5's. `{ok, Map, _}` needs no clause - it matches
+%% apply_input_batch/4's first case clause and never reaches this arm.
+return_shape(T) -> shape_of(T).
+
+outcome_shape(L) when is_list(L) ->
+    try
+        {list, length(L)}
+    catch
+        error:badarg -> improper_list
+    end;
+outcome_shape(T) ->
+    shape_of(T).
+
+shape_of(T) when is_atom(T) -> T;
+shape_of(T) when is_map(T) -> map;
+shape_of(T) when is_binary(T) -> {binary, byte_size(T)};
+shape_of(T) when is_number(T) -> number;
+%% Tag and arity. `{error, {out_of_range, 5}}` is the ordinary shape of a
+%% rejection reason and the tag is the developer's own word for what went wrong,
+%% so collapsing it to `other` would redact the only useful half.
+shape_of(T) when is_tuple(T), tuple_size(T) > 0 ->
+    {tuple, tag_of(element(1, T)), tuple_size(T)};
+shape_of(_) ->
+    other.
+
+%% One level, not one level per nesting. Recursing through shape_of/1 here is
+%% O(depth) to build and O(depth^2) to pretty-print - a 200k-deep left-spine
+%% tuple renders a 40 GB log line. A tag that is itself a tuple carries no
+%% developer word worth preserving.
+tag_of(T) when is_atom(T) -> T;
+tag_of(T) when is_binary(T) -> {binary, byte_size(T)};
+tag_of(T) when is_number(T) -> number;
+tag_of(_) -> other.
+
+%% Only the no-input-handler path, where nothing else will ever ack and the
+%% client would otherwise wait forever. Both contract-violation arms ack nothing
+%% instead: a stamp over a report is permanent, a missing ack is not.
+stamp_all(Queue) ->
+    stamp_all(Queue, #{}).
+
+stamp_all([], Stamped) ->
+    Stamped;
+stamp_all([{PlayerId, Seq, _Input} | Rest], Stamped) ->
+    stamp_all(Rest, record_ack(PlayerId, Seq, Stamped)).
+
+%% Shape first, apply second. apply_outcomes/4 emits rate-limited logs as it
+%% walks, so discovering the mismatch halfway would spend limiter budget on
+%% rejections the zone then discards - and starve the contract warning that
+%% actually explains the tick.
+pair_outcomes(Queue, Outcomes, LogKey) ->
+    case same_length(Queue, Outcomes) of
+        true -> {ok, apply_outcomes(Queue, Outcomes, LogKey, {#{}, #{}})};
+        false -> mismatch
+    end.
+
+%% Total, and deliberately not length/1 on either side: is_list/1 admits an
+%% improper list and length/1 would then raise badarg inside the zone.
+same_length([], []) -> true;
+same_length([_ | Q], [_ | O]) -> same_length(Q, O);
+same_length(_, _) -> false.
+
+apply_outcomes([], [], _LogKey, {Stamped, Reported}) ->
+    maps:merge(Stamped, Reported);
+apply_outcomes([{PlayerId, Seq, _Input} | Rest], [ok | Outcomes], LogKey, Acks) ->
+    apply_outcomes(Rest, Outcomes, LogKey, stamped_ack(PlayerId, Seq, Acks));
+apply_outcomes(
+    [{PlayerId, Seq, _Input} | Rest], [{consumed, Consumed} | Outcomes], LogKey, Acks
+) ->
+    apply_outcomes(
+        Rest, Outcomes, LogKey, reported_ack(PlayerId, Seq, Consumed, LogKey, Acks)
+    );
+apply_outcomes([{PlayerId, Seq, _Input} | Rest], [{error, Reason} | Outcomes], LogKey, Acks) ->
+    %% Limited, unlike the per-input path's equivalent: a batch hands back every
+    %% rejection in the tick at once, so an always-rejecting module turns this
+    %% into inputs-per-tick warnings per tick, written synchronously on the zone
+    %% every other player in it is simulated by. Same bucket and same reasoning
+    %% as reported_ack/5.
+    log_rejected(PlayerId, Reason, LogKey),
+    apply_outcomes(Rest, Outcomes, LogKey, stamped_ack(PlayerId, Seq, Acks));
+apply_outcomes([{PlayerId, Seq, _Input} | Rest], [Bad | Outcomes], LogKey, Acks) ->
+    %% Shape and limited, for the same reason as log_rejected/3: this runs once
+    %% per input, and the documented way to write the callback lifts values
+    %% straight off the client payload, so `Bad` is attacker-influenced in both
+    %% size and depth.
+    asobi_telemetry:game_error(unknown_outcome, #{}),
+    case asobi_script_log_limiter:allow(unknown_outcome_log_key(LogKey)) of
+        {true, SuppressedSinceLast} ->
+            ?LOG_WARNING(#{
+                msg => ~"handle_input_batch returned an unknown outcome; acking by frame stamp",
+                player_id => PlayerId,
+                outcome => shape_of(Bad),
+                suppressed_since_last => SuppressedSinceLast
+            });
+        false ->
+            ok
+    end,
+    apply_outcomes(Rest, Outcomes, LogKey, stamped_ack(PlayerId, Seq, Acks)).
+
+%% Shape rather than the term, because a Lua script fills a rejection reason from
+%% client input via `error(...)`, and limited because this fires once per
+%% rejected input.
+log_rejected(PlayerId, Reason, LogKey) ->
+    asobi_telemetry:game_error(input_rejected, #{}),
+    case asobi_script_log_limiter:allow(reject_log_key(LogKey)) of
+        {true, SuppressedSinceLast} ->
+            ?LOG_WARNING(#{
+                msg => ~"zone input rejected",
+                player_id => PlayerId,
+                reason => shape_of(Reason),
+                suppressed_since_last => SuppressedSinceLast
+            });
+        false ->
+            ok
+    end.
 
 %% Two maps, not one tagged map: a stamp says an input ARRIVED, a report says
 %% how much of it RAN, and the merge below is the whole rule - a report is
@@ -934,14 +1151,14 @@ apply_inputs(GameMod, Queue, Entities, LogKey) ->
 %% which is the overclaim a game that parks overflow steps needs to avoid.
 %% Stamps still max among themselves, via the same record_ack/3 that merges
 %% this tick into player_ack.
-apply_inputs(_GameMod, [], Entities, _LogKey, {Stamped, Reported}) ->
+apply_per_input(_GameMod, [], Entities, _LogKey, {Stamped, Reported}) ->
     {Entities, maps:merge(Stamped, Reported)};
-apply_inputs(GameMod, [{PlayerId, Seq, Input} | Rest], Entities, LogKey, Acks) ->
+apply_per_input(GameMod, [{PlayerId, Seq, Input} | Rest], Entities, LogKey, Acks) ->
     case GameMod:handle_input(PlayerId, Input, Entities) of
         {ok, Entities1} ->
-            apply_inputs(GameMod, Rest, Entities1, LogKey, stamped_ack(PlayerId, Seq, Acks));
+            apply_per_input(GameMod, Rest, Entities1, LogKey, stamped_ack(PlayerId, Seq, Acks));
         {ok, Entities1, Consumed} ->
-            apply_inputs(
+            apply_per_input(
                 GameMod,
                 Rest,
                 Entities1,
@@ -954,12 +1171,8 @@ apply_inputs(GameMod, [{PlayerId, Seq, Input} | Rest], Entities, LogKey, Acks) -
             %% the effect. Otherwise a client waits forever on an input the
             %% server chose to drop. A report already recorded this tick still
             %% outranks it - refusing one input does not unrun the others.
-            ?LOG_WARNING(#{
-                msg => ~"zone input rejected",
-                player_id => PlayerId,
-                reason => Reason
-            }),
-            apply_inputs(GameMod, Rest, Entities, LogKey, stamped_ack(PlayerId, Seq, Acks))
+            log_rejected(PlayerId, Reason, LogKey),
+            apply_per_input(GameMod, Rest, Entities, LogKey, stamped_ack(PlayerId, Seq, Acks))
     end.
 
 stamped_ack(PlayerId, Seq, {Stamped, Reported}) ->
@@ -994,7 +1207,8 @@ reported_ack(PlayerId, Seq, Consumed, LogKey, Acks) ->
     %% Keyed per zone rather than per player: a player-keyed bucket is minted
     %% by the flood it is meant to bound and nothing would ever reclaim it,
     %% since forget/1 runs at zone terminate and deletes an exact key.
-    case asobi_script_log_limiter:allow(LogKey) of
+    asobi_telemetry:game_error(invalid_consumed_seq, #{}),
+    case asobi_script_log_limiter:allow(invalid_seq_log_key(LogKey)) of
         {true, SuppressedSinceLast} ->
             ?LOG_WARNING(#{
                 msg => ~"handle_input reported an invalid consumed seq",
@@ -1012,8 +1226,15 @@ classify_consumed(N) when is_integer(N) -> above_max_ack_seq;
 classify_consumed(N) when is_float(N) -> float;
 classify_consumed(_) -> not_a_number.
 
-invalid_seq_log_key(WorldId, Coords) ->
-    {WorldId, Coords, invalid_consumed_seq}.
+%% One bucket per class of failure, all derived from the zone's own id. Sharing
+%% one bucket blinds the others: the site that fires at input rate is the
+%% rejection warning, and a rejection happens because a CLIENT sent something
+%% invalid - so three bad inputs would silence the module-is-broken signals.
+invalid_seq_log_key({WorldId, Coords}) -> {WorldId, Coords, invalid_consumed_seq}.
+reject_log_key({WorldId, Coords}) -> {WorldId, Coords, input_rejected}.
+bad_batch_log_key({WorldId, Coords}) -> {WorldId, Coords, batch_contract}.
+unknown_outcome_log_key({WorldId, Coords}) -> {WorldId, Coords, unknown_outcome}.
+no_input_handler_log_key({WorldId, Coords}) -> {WorldId, Coords, no_input_handler}.
 
 %% Keep the highest seq per player. world.input carries a monotonic client seq;
 %% out-of-order or duplicate delivery must never regress the ack. Inputs with no
@@ -1928,8 +2149,13 @@ maybe_final_snapshot(_) ->
 %% Every limiter key this zone can mint. forget/1 deletes an exact key, so a
 %% new bucket that is not listed here is a permanent ETS row per zone.
 forget_log_keys(WorldId, Coords) ->
-    asobi_script_log_limiter:forget({WorldId, Coords}),
-    asobi_script_log_limiter:forget(invalid_seq_log_key(WorldId, Coords)).
+    Zone = {WorldId, Coords},
+    asobi_script_log_limiter:forget(Zone),
+    asobi_script_log_limiter:forget(invalid_seq_log_key(Zone)),
+    asobi_script_log_limiter:forget(reject_log_key(Zone)),
+    asobi_script_log_limiter:forget(bad_batch_log_key(Zone)),
+    asobi_script_log_limiter:forget(unknown_outcome_log_key(Zone)),
+    asobi_script_log_limiter:forget(no_input_handler_log_key(Zone)).
 
 backup_zone_state(WorldId, Coords, Entities) ->
     case ets:info(asobi_world_state) of

--- a/test/asobi_batch_test_game.erl
+++ b/test/asobi_batch_test_game.erl
@@ -1,0 +1,102 @@
+-module(asobi_batch_test_game).
+-moduledoc """
+A world game module that exports `handle_input_batch/2`, so the zone takes the
+batch path. It records every call in the process dictionary of the zone that
+ran it, which is how the tests prove the batch was used *instead of* the
+per-input path rather than as well as it.
+
+`~"outcomes"` in an input lets a test force the returned outcome list, including
+a list of the wrong length, so the contract-violation branch is reachable.
+""".
+-behaviour(asobi_world).
+
+-export([init/1, join/2, leave/2, spawn_position/2]).
+-export([zone_tick/2, handle_input/3, handle_input_batch/2, post_tick/2]).
+-export([calls/1]).
+
+-define(CALLS, {?MODULE, calls}).
+
+-spec init(map()) -> {ok, map()}.
+init(_Config) -> {ok, #{}}.
+
+-spec join(binary(), map()) -> {ok, map()}.
+join(_PlayerId, State) -> {ok, State}.
+
+-spec leave(binary(), map()) -> {ok, map()}.
+leave(_PlayerId, State) -> {ok, State}.
+
+-spec spawn_position(binary(), map()) -> {ok, {number(), number()}}.
+spawn_position(_PlayerId, _State) -> {ok, {0.0, 0.0}}.
+
+-spec zone_tick(map(), term()) -> {map(), term()}.
+zone_tick(Entities, ZoneState) -> {Entities, ZoneState}.
+
+-doc "Never reached while handle_input_batch/2 is exported; records it if it is.".
+-spec handle_input(binary(), map(), map()) -> {ok, map()}.
+handle_input(_PlayerId, _Input, Entities) ->
+    record(single),
+    {ok, Entities}.
+
+-spec handle_input_batch([{binary(), map()}], map()) ->
+    {ok, map(), [asobi_world:input_outcome()]}.
+handle_input_batch(Inputs, Entities) ->
+    record({batch, length(Inputs)}),
+    {Entities1, Outcomes} = apply_each(Inputs, Entities, []),
+    case forced_return(Inputs) of
+        {return, Forced} -> Forced;
+        {outcomes, Forced} -> {ok, Entities1, Forced};
+        none -> {ok, Entities1, Outcomes}
+    end.
+
+%% `~"return"` replaces the whole return value, so the non-conforming arm is
+%% reachable; `~"outcomes"` replaces only the outcome list, so the wrong-length
+%% and improper-list arms are. Inputs are applied either way, which is what lets
+%% a test tell "kept the module's entities" from "kept the zone's".
+forced_return([]) ->
+    none;
+forced_return([{_PlayerId, #{~"return" := Forced}} | _]) ->
+    {return, Forced};
+forced_return([{_PlayerId, #{~"outcomes" := Forced}} | _]) ->
+    {outcomes, Forced};
+forced_return([_ | Rest]) ->
+    forced_return(Rest).
+
+apply_each([], Entities, Acc) ->
+    {Entities, lists:reverse(Acc)};
+apply_each([{PlayerId, Input} | Rest], Entities, Acc) ->
+    case Input of
+        #{~"action" := ~"move", ~"x" := X, ~"y" := Y} ->
+            case maps:get(PlayerId, Entities, undefined) of
+                undefined ->
+                    apply_each(Rest, Entities, [{error, not_found} | Acc]);
+                Entity ->
+                    apply_each(Rest, Entities#{PlayerId => Entity#{x => X, y => Y}}, [ok | Acc])
+            end;
+        #{~"action" := ~"consume", ~"consumed" := Consumed} ->
+            apply_each(Rest, Entities, [{consumed, Consumed} | Acc]);
+        #{~"action" := ~"bad_outcome"} ->
+            apply_each(Rest, Entities, [not_an_outcome | Acc]);
+        #{~"action" := ~"reject"} ->
+            apply_each(Rest, Entities, [{error, {out_of_range, 5}} | Acc]);
+        _ ->
+            apply_each(Rest, Entities, [ok | Acc])
+    end.
+
+-spec post_tick(non_neg_integer(), map()) -> {ok, map()}.
+post_tick(_TickN, State) -> {ok, State}.
+
+record(What) ->
+    Prev =
+        case erlang:get(?CALLS) of
+            L when is_list(L) -> L;
+            _ -> []
+        end,
+    erlang:put(?CALLS, [What | Prev]).
+
+-doc "The calls this game module saw, oldest first, read from the zone process.".
+-spec calls(pid()) -> [term()].
+calls(Pid) ->
+    case erlang:process_info(Pid, {dictionary, ?CALLS}) of
+        {{dictionary, ?CALLS}, L} when is_list(L) -> lists:reverse(L);
+        _ -> []
+    end.

--- a/test/asobi_lua_input_batch_tests.erl
+++ b/test/asobi_lua_input_batch_tests.erl
@@ -1,0 +1,219 @@
+-module(asobi_lua_input_batch_tests).
+-moduledoc """
+Bridge-level tests for `asobi_lua_world:handle_input_batch/2`.
+
+Two things are checked here that the zone-level tests cannot see.
+
+The first is that a script cannot collect the entity map out from under the
+batch. The batch carries one encoded map across every input, and a script
+declaring fewer parameters than it was passed drops it from its call frame, so a
+collection at that moment would free it and the next input's encode would recycle
+the slot. `gc_hostile_input.lua` is that script, and it tries.
+`collectgarbage` is stripped from the sandbox so the call raises instead;
+the anchor that makes the reference survive a collection regardless is covered
+in `asobi_lua_loader_tests`.
+
+The second is that exporting the batch shadows `handle_input/3` for every Lua
+zone, so the two must agree. The hostile-return corpus is aimed at the per-input
+path by every existing test; here it is driven through both.
+""".
+-include_lib("eunit/include/eunit.hrl").
+
+-define(PD_KEY, {asobi_lua_world, zone_state}).
+
+fixture(Name) ->
+    case code:lib_dir(asobi) of
+        {error, _} -> error(asobi_not_loaded);
+        Dir -> filename:absname(filename:join([Dir, "test", "fixtures", "lua", Name]))
+    end.
+
+setup() ->
+    case whereis(nova_scope) of
+        undefined -> pg:start_link(nova_scope);
+        _ -> ok
+    end,
+    ok.
+
+cleanup(_) ->
+    erlang:erase(?PD_KEY),
+    ok.
+
+zone_state(Script) ->
+    Config = #{
+        world_id => ~"lua_batch",
+        coords => {0, 0},
+        game_config => #{lua_script => fixture(Script)},
+        grid_size => 1,
+        zone_size => 500
+    },
+    asobi_lua_world:init_zone_state(Config, #{}).
+
+%% Atom-keyed, which is what a zone actually holds: zone_tick/2 runs
+%% asobi_lua_api:atomize_entities/1 on everything coming back from Lua so the
+%% shared tick path can pattern-match on it (asobi#270).
+entities() ->
+    #{
+        ~"p1" => #{type => ~"pilot", x => 1.0, hp => 100},
+        ~"p2" => #{type => ~"pilot", x => 2.0, hp => 100}
+    }.
+
+batch_test_() ->
+    {setup, fun setup/0, fun cleanup/1, [
+        {"a script that raises leaves the zone's entities alone",
+            fun raising_script_leaves_entities_alone/0},
+        {"a Lua exception is not reported as a module rejection",
+            fun lua_error_is_not_an_error_outcome/0},
+        {"the batch and the per-input path agree", fun batch_agrees_with_per_input/0},
+        {"a script clearing the anchor loses its own inputs, not the zone's entities",
+            fun clearing_the_anchor_fails_closed/0},
+        {"clearing the anchor does not bury an earlier input's reported seq",
+            fun anchor_loss_keeps_earlier_outcomes/0},
+        {"an empty return discards the mutation, on both paths",
+            fun in_place_mutation_is_discarded/0},
+        {"an empty return cannot write another player's entity",
+            fun empty_return_is_not_a_cross_player_write/0}
+    ]}.
+
+%% `gc_hostile_input.lua` calls `collectgarbage`, which the sandbox strips, so the
+%% call raises and this is the end-to-end check on the strip: the entities the
+%% zone handed over come back untouched. The anchor that would ALSO have caught
+%% it, had the collection happened, is covered directly in
+%% `asobi_lua_loader_tests`.
+raising_script_leaves_entities_alone() ->
+    erlang:put(?PD_KEY, zone_state("gc_hostile_input.lua")),
+    Inputs = [
+        {~"p1", #{~"tag" => ~"first", ~"n" => 1}},
+        {~"p2", #{~"tag" => ~"second", ~"n" => 2}}
+    ],
+    {ok, Out, Outcomes} = asobi_lua_world:handle_input_batch(Inputs, entities()),
+    ?assertEqual([~"p1", ~"p2"], lists:sort(maps:keys(Out))),
+    ?assertEqual([ok, ok], Outcomes),
+    ?assertEqual(100, maps:get(hp, maps:get(~"p1", Out))),
+    erlang:erase(?PD_KEY).
+
+%% handle_input/3 maps a Lua exception to {ok, Entities} after a rate-limited
+%% log, so the batch must not turn one into {error, _}: that is asobi_zone's
+%% "the game module refused this input" channel, and a script that throws has
+%% not refused anything.
+lua_error_is_not_an_error_outcome() ->
+    erlang:put(?PD_KEY, zone_state("error_world.lua")),
+    Inputs = [{~"p1", #{~"action" => ~"boom"}}],
+    {ok, _Out, Outcomes} = asobi_lua_world:handle_input_batch(Inputs, entities()),
+    ?assertEqual([ok], Outcomes),
+    erlang:erase(?PD_KEY).
+
+%% Same script, same inputs, both paths, comparing entities AND outcomes. The
+%% batch shadows handle_input/3 in production, so a divergence here is one
+%% nothing else would catch - which means the corpus has to be scripts that
+%% reach `batch_result/3` at all. A script that raises agrees trivially on both
+%% paths and hides drift, so the raising cases live in their own tests and this
+%% is the hostile-RETURN corpus: the malformed shapes, the empty return, a
+%% script that applies its input, and one that reports a seq.
+batch_agrees_with_per_input() ->
+    Cases = [
+        {"config_move_world.lua", [{~"p1", #{~"kind" => ~"move", ~"x" => 5, ~"y" => 6}}]},
+        {"config_ack_world.lua", [{~"p1", #{~"x" => 1, ~"y" => 2, ~"consumed" => 9}}]},
+        {"config_ack_world.lua", [{~"p1", #{~"x" => 1, ~"y" => 2, ~"consumed" => -3}}]},
+        {"config_silent_input_world.lua", [{~"p1", #{~"kind" => ~"move"}}]},
+        {"config_hostile_input_world.lua", [{~"p1", #{~"kind" => ~"cyclic"}}]},
+        {"config_hostile_input_world.lua", [{~"p1", #{~"kind" => ~"huge"}}]},
+        {"config_hostile_input_world.lua", [{~"p1", #{~"kind" => ~"scalar"}}]},
+        {"mutate_then_reject_input.lua", [{~"p1", #{~"target" => ~"p2"}}]},
+        %% Two inputs whose outcomes DIFFER. Every other case is a single input,
+        %% so a reversed outcome list would pair one player's watermark with
+        %% another player's seq and no test would notice.
+        {"config_ack_world.lua", [
+            {~"p1", #{~"x" => 1, ~"y" => 1, ~"consumed" => 9}},
+            {~"p2", #{~"x" => 2, ~"y" => 2}}
+        ]}
+    ],
+    [
+        begin
+            erlang:put(?PD_KEY, zone_state(Script)),
+            {ok, Batched, BatchedOutcomes} = asobi_lua_world:handle_input_batch(
+                Inputs, entities()
+            ),
+            erlang:erase(?PD_KEY),
+            erlang:put(?PD_KEY, zone_state(Script)),
+            Sequential = per_input(Inputs, entities()),
+            erlang:erase(?PD_KEY),
+            ?assertEqual({Script, Sequential}, {Script, {Batched, BatchedOutcomes}})
+        end
+     || {Script, Inputs} <- Cases
+    ].
+
+%% _G is script-writable, so a script can drop asobi's root with one assignment.
+%% Everything the batch holds is then a collection away from aliasing a recycled
+%% slot, so the batch has to fail closed rather than decode it.
+clearing_the_anchor_fails_closed() ->
+    erlang:put(?PD_KEY, zone_state("anchor_clearing_input.lua")),
+    Inputs = [
+        {~"p1", #{~"clear" => true}},
+        {~"p2", #{~"clear" => true}}
+    ],
+    {ok, Out, Outcomes} = asobi_lua_world:handle_input_batch(Inputs, entities()),
+    %% The fixture mutates and returns entities, so honouring its return would
+    %% show hp = 0. The original map is what proves the batch bailed out.
+    ?assertEqual(entities(), Out),
+    ?assertEqual(100, maps:get(hp, maps:get(~"p1", Out))),
+    ?assertEqual([ok, ok], Outcomes),
+    erlang:erase(?PD_KEY).
+
+%% The empty return is the reject idiom, and it has to mean the same thing on
+%% both paths. It does not come free on the batch: the script holds the table, so
+%% parity is restored by reverting the Luerl state, which is functional.
+in_place_mutation_is_discarded() ->
+    Inputs = [{~"p1", #{~"tag" => ~"first"}}],
+    ?assertEqual(100, hp_after_batch("mutate_then_reject_input.lua", Inputs, ~"p1")),
+    ?assertEqual(100, hp_after_per_input("mutate_then_reject_input.lua", Inputs, ~"p1")).
+
+%% The exploit the revert closes: `entities[input.target]` is a client-chosen
+%% key, so without it a rejecting handler could zero any entity in the zone.
+empty_return_is_not_a_cross_player_write() ->
+    Inputs = [{~"p1", #{~"target" => ~"p2"}}],
+    ?assertEqual(100, hp_after_batch("mutate_then_reject_input.lua", Inputs, ~"p2")),
+    ?assertEqual(100, hp_after_per_input("mutate_then_reject_input.lua", Inputs, ~"p2")).
+
+hp_after_batch(Script, Inputs, PlayerId) ->
+    erlang:put(?PD_KEY, zone_state(Script)),
+    {ok, Out, _} = asobi_lua_world:handle_input_batch(Inputs, entities()),
+    erlang:erase(?PD_KEY),
+    maps:get(hp, maps:get(PlayerId, Out)).
+
+hp_after_per_input(Script, Inputs, PlayerId) ->
+    erlang:put(?PD_KEY, zone_state(Script)),
+    {Out, _Outcomes} = per_input(Inputs, entities()),
+    erlang:erase(?PD_KEY),
+    maps:get(hp, maps:get(PlayerId, Out)).
+
+%% Returns outcomes as well as entities, in handle_input_batch/2's own
+%% vocabulary. Comparing only the entities leaves batch_result/3's consumed-seq
+%% classification - the half that feeds a monotonic, permanently-poisonable ack -
+%% with no cross-check at all.
+%% A reporting input AHEAD of the tampering one. The bail-out must carry the
+%% {consumed, 9} it already produced: replacing it with a frame stamp would bury
+%% that watermark permanently, since the session ack gate is monotonic.
+anchor_loss_keeps_earlier_outcomes() ->
+    erlang:put(?PD_KEY, zone_state("anchor_clearing_input.lua")),
+    Inputs = [
+        {~"p1", #{~"consumed" => 9}},
+        {~"p2", #{~"clear" => true}}
+    ],
+    {ok, Out, Outcomes} = asobi_lua_world:handle_input_batch(Inputs, entities()),
+    ?assertEqual([{consumed, 9}, ok], Outcomes),
+    ?assertEqual(entities(), Out),
+    erlang:erase(?PD_KEY).
+
+per_input(Inputs, Entities) ->
+    per_input(Inputs, Entities, []).
+
+per_input([], Entities, Acc) ->
+    {Entities, lists:reverse(Acc)};
+per_input([{PlayerId, Input} | Rest], Entities, Acc) ->
+    {Entities1, Outcome} =
+        case asobi_lua_world:handle_input(PlayerId, Input, Entities) of
+            {ok, E} -> {E, ok};
+            {ok, E, Seq} -> {E, {consumed, Seq}};
+            {error, _} -> {Entities, ok}
+        end,
+    per_input(Rest, Entities1, [Outcome | Acc]).

--- a/test/asobi_lua_loader_tests.erl
+++ b/test/asobi_lua_loader_tests.erl
@@ -663,7 +663,42 @@ is_defined_true_for_non_function_global() ->
     ?assert(asobi_lua_loader:is_defined(match_size, St)),
     ?assertNot(asobi_lua_loader:is_defined(some_field_never_set, St)).
 
+%% --- anchor_ref: what it is for ---
+
+%% The hazard, stated as a test so it stays true. A Luerl reference Erlang holds
+%% between calls is reachable only through luerl's root set - `_G`, the stack and
+%% the live call frames - so a collection while nothing names it frees the table,
+%% its slot goes back on the free list, and the very next encode recycles it. The
+%% reference then silently names somebody else's data rather than failing.
+unanchored_ref_aliases_after_a_collection_test() ->
+    St = sandboxed(),
+    {Held, St1} = luerl:encode(#{~"held" => true}, St),
+    St2 = luerl:gc(St1),
+    {_Other, St3} = luerl:encode(#{~"other" => 42}, St2),
+    ?assertEqual(#{~"other" => 42}, asobi_lua_api:decode_to_map(Held, St3)).
+
+anchored_ref_survives_a_collection_test() ->
+    St = sandboxed(),
+    {Held, St1} = luerl:encode(#{~"held" => true}, St),
+    St2 = asobi_lua_loader:anchor_ref(Held, St1),
+    St3 = luerl:gc(St2),
+    {_Other, St4} = luerl:encode(#{~"other" => 42}, St3),
+    ?assertEqual(#{~"held" => true}, asobi_lua_api:decode_to_map(Held, St4)).
+
+%% The anchor is one slot, so releasing it has to actually release: an anchor
+%% that never cleared would pin one table per bridge for the life of the zone.
+unanchor_ref_releases_the_root_test() ->
+    St = sandboxed(),
+    {Held, St1} = luerl:encode(#{~"held" => true}, St),
+    St2 = asobi_lua_loader:unanchor_ref(asobi_lua_loader:anchor_ref(Held, St1)),
+    St3 = luerl:gc(St2),
+    {_Other, St4} = luerl:encode(#{~"other" => 42}, St3),
+    ?assertEqual(#{~"other" => 42}, asobi_lua_api:decode_to_map(Held, St4)).
+
 %% --- Helpers ---
+
+sandboxed() ->
+    asobi_lua_loader:init_sandboxed().
 
 -spec encode_map(map(), dynamic()) -> dynamic().
 encode_map(Map, St) ->

--- a/test/asobi_lua_sandbox_tests.erl
+++ b/test/asobi_lua_sandbox_tests.erl
@@ -99,6 +99,15 @@ package_is_nil_test() ->
     St = fresh_state(),
     ?assertEqual(nil, eval_and_decode("return package", St)).
 
+%% --- collection blocked ---
+
+%% A script forcing a synchronous mark-and-sweep stalls the shared zone process,
+%% and decides when values asobi holds between calls are freed. asobi collects on
+%% its own schedule through luerl:gc/1, which is Erlang-side.
+collectgarbage_is_nil_test() ->
+    St = fresh_state(),
+    ?assertEqual(nil, eval_and_decode("return collectgarbage", St)).
+
 %% --- require: validation, traversal, escape ---
 
 require_rejects_dot_dot_test() ->

--- a/test/asobi_no_input_game.erl
+++ b/test/asobi_no_input_game.erl
@@ -1,0 +1,30 @@
+-module(asobi_no_input_game).
+-moduledoc """
+A world module that exports neither `handle_input/3` nor `handle_input_batch/2`.
+
+Both are optional, so this compiles without a missing-callback warning - which
+is exactly why the runtime has to say something. A world that takes no player
+input is legal; one that RECEIVES input with no handler will never process any.
+""".
+-behaviour(asobi_world).
+
+-export([init/1, join/2, leave/2, spawn_position/2]).
+-export([zone_tick/2, post_tick/2]).
+
+-spec init(map()) -> {ok, map()}.
+init(_Config) -> {ok, #{}}.
+
+-spec join(binary(), map()) -> {ok, map()}.
+join(_PlayerId, State) -> {ok, State}.
+
+-spec leave(binary(), map()) -> {ok, map()}.
+leave(_PlayerId, State) -> {ok, State}.
+
+-spec spawn_position(binary(), map()) -> {ok, {number(), number()}}.
+spawn_position(_PlayerId, _State) -> {ok, {0.0, 0.0}}.
+
+-spec zone_tick(map(), term()) -> {map(), term()}.
+zone_tick(Entities, ZoneState) -> {Entities, ZoneState}.
+
+-spec post_tick(non_neg_integer(), map()) -> {ok, map()}.
+post_tick(_TickN, State) -> {ok, State}.

--- a/test/asobi_zone_input_batch_tests.erl
+++ b/test/asobi_zone_input_batch_tests.erl
@@ -1,0 +1,376 @@
+-module(asobi_zone_input_batch_tests).
+-moduledoc """
+`handle_input_batch/2`: a zone hands a whole tick's inputs to a game module that
+exports it, and the `world.ack` policy comes out identical to the per-input
+path.
+
+The batch exists because `asobi_lua_world` re-encoded the entire entity map into
+Luerl once per input. What must not change is the ack contract, so most of these
+mirror the `#474`/`#532` cases in `asobi_zone_tests` against the batch module.
+""".
+-include_lib("eunit/include/eunit.hrl").
+
+-define(GAME, asobi_batch_test_game).
+
+-export([on_telemetry/4]).
+
+setup() ->
+    case whereis(nova_scope) of
+        undefined -> pg:start_link(nova_scope);
+        _ -> ok
+    end,
+    %% no_input_callback_acks_and_drops/0 attaches to [asobi, error] to prove the
+    %% counter is emitted outside the limiter.
+    {ok, _} = application:ensure_all_started(telemetry),
+    ok.
+
+start_zone() ->
+    {ok, Pid} = asobi_zone:start_link(#{
+        world_id => ~"batch_test_world",
+        coords => {0, 0},
+        ticker_pid => self(),
+        game_module => ?GAME,
+        zone_state => #{},
+        broadcast_interval => 1
+    }),
+    Pid.
+
+batch_test_() ->
+    {setup, fun setup/0, [
+        {"a module exporting handle_input_batch/2 gets one call, not one per input",
+            fun one_call_per_tick/0},
+        {"the per-input path is untouched for a module without it", fun single_path_intact/0},
+        {"entities come back applied, in arrival order", fun applies_in_order/0},
+        {"an ok outcome acks the frame stamp", fun ok_acks_stamp/0},
+        {"a consumed outcome acks the reported seq, not the stamp", fun consumed_acks_report/0},
+        {"an error outcome still advances the ack", fun error_advances_ack/0},
+        {"a report still beats a stamp made later in the same tick", fun report_beats_stamp/0},
+        {"an outcome list of the wrong length acks nothing and does not re-run",
+            fun bad_length_acks_nothing_without_rerun/0},
+        {"a contract violation does not bury another player's reported watermark",
+            fun mismatch_does_not_bury_a_report/0},
+        {"a non-conforming return keeps the entities the ZONE held",
+            fun non_conforming_return_keeps_zone_entities/0},
+        {"a tuple-tagged rejection reason keeps its tag", fun tuple_reason_keeps_its_tag/0},
+        {"an unknown outcome falls back to the frame stamp", fun unknown_outcome_stamps/0},
+        {"a nonsense consumed seq falls back to the frame stamp", fun invalid_consumed_stamps/0},
+        {"an improper outcome list does not kill the zone", fun improper_outcome_list_survives/0},
+        {"a non-list outcome does not kill the zone", fun non_list_outcome_survives/0},
+        {"an unstamped input still produces no ack", fun unstamped_produces_no_ack/0},
+        {"a module with no input callback at all keeps the zone alive",
+            fun no_input_callback_acks_and_drops/0}
+    ]}.
+
+one_call_per_tick() ->
+    Pid = start_zone(),
+    add_player(Pid, ~"p1"),
+    add_player(Pid, ~"p2"),
+    move(Pid, ~"p1", 1, 1, 10),
+    move(Pid, ~"p2", 2, 2, 11),
+    move(Pid, ~"p1", 3, 3, 12),
+    asobi_zone:tick(Pid, 1),
+    ok = asobi_zone:sync(Pid),
+    ?assertEqual([{batch, 3}], ?GAME:calls(Pid)),
+    gen_server:stop(Pid).
+
+%% asobi_test_world_game does not export handle_input_batch/2, so it must still
+%% take the per-input path with its ack behaviour unchanged.
+single_path_intact() ->
+    {ok, Pid} = asobi_zone:start_link(#{
+        world_id => ~"batch_test_world_single",
+        coords => {0, 0},
+        ticker_pid => self(),
+        game_module => asobi_test_world_game,
+        zone_state => #{},
+        broadcast_interval => 1
+    }),
+    asobi_zone:subscribe(Pid, {~"p1", self()}),
+    asobi_zone:add_entity(Pid, ~"p1", #{x => 0, y => 0, type => ~"player"}),
+    ok = asobi_zone:sync(Pid),
+    flush(),
+    asobi_zone:player_input(Pid, ~"p1", #{~"action" => ~"move", ~"x" => 5, ~"y" => 5}, 412),
+    asobi_zone:tick(Pid, 1),
+    ?assertEqual(412, recv_ack()),
+    Entities = asobi_zone:get_entities(Pid),
+    ?assertMatch(#{x := 5, y := 5}, maps:get(~"p1", Entities)),
+    gen_server:stop(Pid).
+
+applies_in_order() ->
+    Pid = start_zone(),
+    add_player(Pid, ~"p1"),
+    move(Pid, ~"p1", 1, 1, 1),
+    move(Pid, ~"p1", 2, 2, 2),
+    move(Pid, ~"p1", 9, 9, 3),
+    asobi_zone:tick(Pid, 1),
+    ok = asobi_zone:sync(Pid),
+    Entities = asobi_zone:get_entities(Pid),
+    ?assertMatch(#{x := 9, y := 9}, maps:get(~"p1", Entities)),
+    gen_server:stop(Pid).
+
+ok_acks_stamp() ->
+    Pid = start_zone(),
+    subscribe(Pid, ~"p1"),
+    add_player(Pid, ~"p1"),
+    flush(),
+    move(Pid, ~"p1", 4, 4, 77),
+    asobi_zone:tick(Pid, 1),
+    ?assertEqual(77, recv_ack()),
+    gen_server:stop(Pid).
+
+consumed_acks_report() ->
+    Pid = start_zone(),
+    subscribe(Pid, ~"p1"),
+    add_player(Pid, ~"p1"),
+    flush(),
+    asobi_zone:player_input(
+        Pid, ~"p1", #{~"action" => ~"consume", ~"consumed" => 48}, 52
+    ),
+    asobi_zone:tick(Pid, 1),
+    ?assertEqual(48, recv_ack()),
+    gen_server:stop(Pid).
+
+%% No p1 entity, so the move comes back {error, not_found} - and the ack still
+%% advances, exactly as the per-input path does.
+error_advances_ack() ->
+    Pid = start_zone(),
+    subscribe(Pid, ~"p1"),
+    flush(),
+    move(Pid, ~"p1", 1, 1, 7),
+    asobi_zone:tick(Pid, 1),
+    ?assertEqual(7, recv_ack()),
+    gen_server:stop(Pid).
+
+report_beats_stamp() ->
+    Pid = start_zone(),
+    subscribe(Pid, ~"p1"),
+    add_player(Pid, ~"p1"),
+    flush(),
+    asobi_zone:player_input(
+        Pid, ~"p1", #{~"action" => ~"consume", ~"consumed" => 30}, 40
+    ),
+    move(Pid, ~"p1", 1, 1, 99),
+    asobi_zone:tick(Pid, 1),
+    ?assertEqual(30, recv_ack()),
+    gen_server:stop(Pid).
+
+%% Acking NOTHING, not by stamp: the session's ack gate is monotonic, so a stamp
+%% here would permanently bury any watermark the module meant to report. A
+%% missing ack is recoverable - the next clean tick acks past it.
+bad_length_acks_nothing_without_rerun() ->
+    Pid = start_zone(),
+    subscribe(Pid, ~"p1"),
+    add_player(Pid, ~"p1"),
+    flush(),
+    %% Two inputs, one outcome: a contract violation.
+    asobi_zone:player_input(Pid, ~"p1", #{~"outcomes" => [ok]}, 5),
+    move(Pid, ~"p1", 1, 1, 6),
+    asobi_zone:tick(Pid, 1),
+    ?assertEqual(no_ack, recv_ack()),
+    ok = asobi_zone:sync(Pid),
+    %% The MODULE's entities, not the zone's: a wrong-length outcome list says
+    %% nothing about whether the inputs were applied, and they may have been.
+    ?assertMatch(#{x := 1, y := 1}, maps:get(~"p1", asobi_zone:get_entities(Pid))),
+    %% One batch call and no fallback to the per-input path: re-running would
+    %% double-apply whatever the batch already did.
+    ?assertEqual([{batch, 2}], ?GAME:calls(Pid)),
+    gen_server:stop(Pid).
+
+unknown_outcome_stamps() ->
+    Pid = start_zone(),
+    subscribe(Pid, ~"p1"),
+    add_player(Pid, ~"p1"),
+    flush(),
+    asobi_zone:player_input(Pid, ~"p1", #{~"action" => ~"bad_outcome"}, 21),
+    asobi_zone:tick(Pid, 1),
+    ?assertEqual(21, recv_ack()),
+    gen_server:stop(Pid).
+
+%% reported_ack/5's guard is the same on both paths, but nothing drove its
+%% failure arm from the batch: a negative seq is outside the ack space, so the
+%% frame stamp wins and the zone stays up.
+invalid_consumed_stamps() ->
+    Pid = start_zone(),
+    subscribe(Pid, ~"p1"),
+    add_player(Pid, ~"p1"),
+    flush(),
+    asobi_zone:player_input(Pid, ~"p1", #{~"action" => ~"consume", ~"consumed" => -1}, 64),
+    asobi_zone:tick(Pid, 1),
+    ?assertEqual(64, recv_ack()),
+    ?assert(is_process_alive(Pid)),
+    gen_server:stop(Pid).
+
+%% is_list/1 is true for any cons cell, so an improper list passed the old guard
+%% and length/1 then raised badarg inside the zone - taking every player in it
+%% down over one module's bad return.
+improper_outcome_list_survives() ->
+    Pid = start_zone(),
+    subscribe(Pid, ~"p1"),
+    add_player(Pid, ~"p1"),
+    flush(),
+    asobi_zone:player_input(Pid, ~"p1", #{~"outcomes" => [ok | junk]}, 11),
+    asobi_zone:tick(Pid, 1),
+    ?assertEqual(no_ack, recv_ack()),
+    ?assert(is_process_alive(Pid)),
+    gen_server:stop(Pid).
+
+non_list_outcome_survives() ->
+    Pid = start_zone(),
+    subscribe(Pid, ~"p1"),
+    add_player(Pid, ~"p1"),
+    flush(),
+    asobi_zone:player_input(Pid, ~"p1", #{~"outcomes" => not_a_list}, 12),
+    asobi_zone:tick(Pid, 1),
+    ?assertEqual(no_ack, recv_ack()),
+    ?assert(is_process_alive(Pid)),
+    gen_server:stop(Pid).
+
+%% p2's malformed batch must not cost p1 the watermark p1's module reported. The
+%% ack gate is monotonic, so an overclaim here is unrecoverable for that socket.
+mismatch_does_not_bury_a_report() ->
+    Pid = start_zone(),
+    subscribe(Pid, ~"p1"),
+    add_player(Pid, ~"p1"),
+    add_player(Pid, ~"p2"),
+    flush(),
+    asobi_zone:player_input(Pid, ~"p1", #{~"action" => ~"consume", ~"consumed" => 30}, 40),
+    asobi_zone:player_input(Pid, ~"p2", #{~"outcomes" => [ok]}, 41),
+    asobi_zone:tick(Pid, 1),
+    ?assertEqual(no_ack, recv_ack()),
+    %% The next clean tick still acks p1 past it, which is the recoverability
+    %% a frame stamp of 41 would have destroyed.
+    flush(),
+    asobi_zone:player_input(Pid, ~"p1", #{~"action" => ~"consume", ~"consumed" => 31}, 42),
+    asobi_zone:tick(Pid, 2),
+    ?assertEqual(31, recv_ack()),
+    gen_server:stop(Pid).
+
+%% The `Other` arm: the return is not {ok, Map, _} at all, so nothing in it is
+%% trustworthy - including the map. Distinct from the mismatch arm, which keeps
+%% the entities the module handed back.
+non_conforming_return_keeps_zone_entities() ->
+    Pid = start_zone(),
+    subscribe(Pid, ~"p1"),
+    add_player(Pid, ~"p1"),
+    flush(),
+    move(Pid, ~"p1", 8, 8, 5),
+    asobi_zone:player_input(Pid, ~"p1", #{~"return" => {ok, not_a_map, [ok, ok]}}, 6),
+    asobi_zone:tick(Pid, 1),
+    %% Acks nothing, like the mismatch arm: `{ok, not_a_map, [{consumed, 30}]}`
+    %% lands here too, and stamping over that report would bury it.
+    ?assertEqual(no_ack, recv_ack()),
+    ok = asobi_zone:sync(Pid),
+    ?assertMatch(#{x := 0, y := 0}, maps:get(~"p1", asobi_zone:get_entities(Pid))),
+    ?assert(is_process_alive(Pid)),
+    gen_server:stop(Pid).
+
+%% shape_of/1's tuple clause exists so a tagged rejection reason keeps the
+%% developer's own word for what went wrong instead of collapsing to `other`.
+tuple_reason_keeps_its_tag() ->
+    Pid = start_zone(),
+    subscribe(Pid, ~"p1"),
+    add_player(Pid, ~"p1"),
+    flush(),
+    asobi_zone:player_input(Pid, ~"p1", #{~"action" => ~"reject"}, 71),
+    asobi_zone:tick(Pid, 1),
+    ?assertEqual(71, recv_ack()),
+    ?assert(is_process_alive(Pid)),
+    gen_server:stop(Pid).
+
+unstamped_produces_no_ack() ->
+    Pid = start_zone(),
+    subscribe(Pid, ~"p1"),
+    add_player(Pid, ~"p1"),
+    flush(),
+    asobi_zone:player_input(Pid, ~"p1", #{~"action" => ~"move", ~"x" => 3, ~"y" => 3}),
+    asobi_zone:tick(Pid, 1),
+    ?assertEqual(no_ack, recv_ack()),
+    gen_server:stop(Pid).
+
+%% Both input callbacks are optional now, so this module compiles clean and the
+%% only signal is at runtime. Deleting the `none` branch of the dispatch makes
+%% this fail with undef inside the zone.
+no_input_callback_acks_and_drops() ->
+    {ok, Pid} = asobi_zone:start_link(#{
+        world_id => ~"batch_test_world_no_input",
+        coords => {0, 0},
+        ticker_pid => self(),
+        game_module => asobi_no_input_game,
+        zone_state => #{},
+        broadcast_interval => 1
+    }),
+    ok = telemetry:attach(?MODULE, [asobi, error], fun ?MODULE:on_telemetry/4, self()),
+    asobi_zone:subscribe(Pid, {~"p1", self()}),
+    asobi_zone:add_entity(Pid, ~"p1", #{x => 0, y => 0, type => ~"player"}),
+    ok = asobi_zone:sync(Pid),
+    flush(),
+    move(Pid, ~"p1", 5, 5, 33),
+    asobi_zone:tick(Pid, 1),
+    %% Acked so the client stops waiting, dropped because nothing can apply it,
+    %% and the zone survives.
+    ?assertEqual(33, recv_ack()),
+    ?assert(is_process_alive(Pid)),
+    ?assertMatch(#{x := 0, y := 0}, maps:get(~"p1", asobi_zone:get_entities(Pid))),
+    %% The counter is the signal an operator alerts on, and it is emitted
+    %% outside the limiter so suppressing the line cannot suppress the rate.
+    ?assertEqual(#{game_module => asobi_no_input_game}, recv_telemetry()),
+    telemetry:detach(?MODULE),
+    gen_server:stop(Pid).
+
+%% shape_of/1 is what keeps a client-influenced term out of the log while still
+%% naming what went wrong. Tested directly because it is pure and because its
+%% bound is the whole point.
+shape_of_test() ->
+    ?assertEqual({tuple, error, 2}, asobi_zone:shape_of({error, {out_of_range, 5}})),
+    ?assertEqual({tuple, ok, 2}, asobi_zone:shape_of({ok, #{a => 1}})),
+    ?assertEqual({tuple, {binary, 3}, 2}, asobi_zone:shape_of({~"abc", 1})),
+    ?assertEqual(other, asobi_zone:shape_of({})),
+    ?assertEqual({binary, 5}, asobi_zone:shape_of(~"hello")),
+    ?assertEqual(map, asobi_zone:shape_of(#{a => 1})),
+    ?assertEqual(number, asobi_zone:shape_of(1.5)).
+
+%% One level, not one per nesting: recursing would be O(depth) to build and
+%% O(depth^2) to pretty-print, which is a 40 GB log line for a 200k-deep tuple.
+shape_of_does_not_recurse_test() ->
+    Deep = nest(5000, deepest),
+    ?assertEqual({tuple, other, 2}, asobi_zone:shape_of(Deep)),
+    ?assert(erts_debug:flat_size(asobi_zone:shape_of(Deep)) < 20).
+
+nest(0, Acc) -> Acc;
+nest(N, Acc) -> nest(N - 1, {Acc, x}).
+
+%% --- helpers ---
+
+subscribe(Pid, PlayerId) ->
+    asobi_zone:subscribe(Pid, {PlayerId, self()}),
+    ok = asobi_zone:sync(Pid).
+
+add_player(Pid, PlayerId) ->
+    asobi_zone:add_entity(Pid, PlayerId, #{x => 0, y => 0, type => ~"player"}),
+    ok = asobi_zone:sync(Pid).
+
+move(Pid, PlayerId, X, Y, Seq) ->
+    asobi_zone:player_input(Pid, PlayerId, #{~"action" => ~"move", ~"x" => X, ~"y" => Y}, Seq).
+
+on_telemetry(_Event, _Measurements, #{kind := no_input_handler, details := Details}, Pid) ->
+    Pid ! {telemetry, Details},
+    ok;
+on_telemetry(_Event, _Measurements, _Meta, _Pid) ->
+    ok.
+
+recv_telemetry() ->
+    receive
+        {telemetry, Details} -> Details
+    after 300 -> no_telemetry
+    end.
+
+recv_ack() ->
+    receive
+        {asobi_message, {world_ack, _Tick, Seq}} -> Seq
+    after 300 -> no_ack
+    end.
+
+flush() ->
+    receive
+        _ -> flush()
+    after 0 -> ok
+    end.

--- a/test/asobi_zone_lifecycle_tests.erl
+++ b/test/asobi_zone_lifecycle_tests.erl
@@ -101,12 +101,23 @@ dump_zone_state_strips_runtime() ->
 %% zone. All three clauses call forget/1 identically (same call, same
 %% position, before pg:leave), so this single case already protects the
 %% wiring a refactor could plausibly break.
+%% Every bucket a zone can mint, not just the base one: forget/1 deletes an exact
+%% key, so a derived bucket that terminate/2 does not name is a permanent ETS row
+%% per zone. Seeding only {WorldId, Coords} is what let the derived buckets go
+%% uncovered - deleting their forget/1 call left the whole suite green.
 terminate_clears_script_log_drop_row() ->
     ok = asobi_script_log_limiter:init_table(),
     WorldId = ~"lc_normal",
     Coords = {9, 1},
-    Key = {WorldId, Coords},
-    true = ets:insert(asobi_script_log_limiter_drops, {Key, 3}),
+    Keys = [
+        {WorldId, Coords},
+        {WorldId, Coords, invalid_consumed_seq},
+        {WorldId, Coords, input_rejected},
+        {WorldId, Coords, batch_contract},
+        {WorldId, Coords, unknown_outcome},
+        {WorldId, Coords, no_input_handler}
+    ],
+    [true = ets:insert(asobi_script_log_limiter_drops, {K, 3}) || K <- Keys],
     Pid = start_zone(asobi_test_world_game, #{world_id => WorldId, coords => Coords}),
     gen_server:stop(Pid),
-    ?assertEqual([], ets:lookup(asobi_script_log_limiter_drops, Key)).
+    [?assertEqual({K, []}, {K, ets:lookup(asobi_script_log_limiter_drops, K)}) || K <- Keys].

--- a/test/fixtures/lua/anchor_clearing_input.lua
+++ b/test/fixtures/lua/anchor_clearing_input.lua
@@ -1,0 +1,42 @@
+-- Clears asobi's reference anchor from _G when the input says to, and otherwise
+-- behaves: it reports a consumed seq. That lets a test put a well-behaved,
+-- REPORTING input ahead of the one that tampers, which is how the outcomes
+-- already produced for the tick get checked.
+--
+-- On the clearing input it also mutates and returns entities, so honouring that
+-- return would show up - seeing the ORIGINAL entities is what proves the batch
+-- bailed out rather than trusting a reference that may alias a recycled slot.
+--
+-- Two parameters on purpose where it clears: the entity map is then not rooted
+-- by this call's own frame either.
+
+game_type   = "world"
+match_size  = 1
+max_players = 8
+grid_size   = 1
+zone_size   = 500
+view_radius = 0
+
+function init(config)
+    return {}
+end
+
+function zone_tick(entities, zone_state)
+    return entities, zone_state
+end
+
+function post_tick(tick_n, state)
+    return state
+end
+
+function handle_input(player_id, input, entities)
+    if input.clear then
+        __asobi_ref_anchor = nil
+        local victim = entities[player_id]
+        if victim then
+            victim.hp = 0
+        end
+        return entities
+    end
+    return entities, input.consumed
+end

--- a/test/fixtures/lua/gc_hostile_input.lua
+++ b/test/fixtures/lua/gc_hostile_input.lua
@@ -1,0 +1,34 @@
+-- A script that tries to collect from inside handle_input and never names the
+-- entity map. Two parameters, not three, so luerl's call frame does not root the
+-- map the bridge carries across an input batch.
+--
+-- Both halves of the defence meet here. `collectgarbage` is stripped from the
+-- sandbox, so the call raises rather than collecting, and the bridge turns a Lua
+-- exception into "this input did nothing" - the zone's entities survive. Were it
+-- ever reachable again, the map is also anchored (asobi_lua_loader:anchor_ref/2,
+-- covered directly in asobi_lua_loader_tests), so the collection would not free
+-- it either.
+
+game_type   = "world"
+match_size  = 1
+max_players = 8
+grid_size   = 1
+zone_size   = 500
+view_radius = 0
+
+function init(config)
+    return {}
+end
+
+function zone_tick(entities, zone_state)
+    return entities, zone_state
+end
+
+function post_tick(tick_n, state)
+    return state
+end
+
+function handle_input(p, i)
+    collectgarbage()
+    return nil
+end

--- a/test/fixtures/lua/mutate_then_reject_input.lua
+++ b/test/fixtures/lua/mutate_then_reject_input.lua
@@ -1,0 +1,36 @@
+-- Mutates an entity the CLIENT names and then returns nothing, which is the
+-- "apply optimistically, reject on validation" shape.
+--
+-- Under handle_input/3 the mutation is discarded: Erlang keeps its own copy of
+-- the map and an empty return means "leave the entities alone". The batch hands
+-- the script the Luerl table itself, so it has to get the same answer by
+-- reverting the Luerl state - otherwise a handler that looks its target up from
+-- a client-controlled field and rejects with a bare `return` is a write
+-- primitive on any entity in the zone.
+
+game_type   = "world"
+match_size  = 1
+max_players = 8
+grid_size   = 1
+zone_size   = 500
+view_radius = 0
+
+function init(config)
+    return {}
+end
+
+function zone_tick(entities, zone_state)
+    return entities, zone_state
+end
+
+function post_tick(tick_n, state)
+    return state
+end
+
+function handle_input(player_id, input, entities)
+    local victim = entities[input.target or player_id]
+    if victim then
+        victim.hp = 0
+    end
+    return
+end


### PR DESCRIPTION
`asobi_lua_world:handle_input/3` encoded the whole zone entity map into Luerl
before every input and decoded it back after, and `asobi_zone:apply_inputs/4`
folds that over the entire input queue each tick. So a zone paid
`P x (encode E + decode E + atomize E)` for work that is one encode plus P input
frames. The map is the same map every time; only the player and the frame differ.

This adds an optional `asobi_world` callback, `handle_input_batch/2`, taking a
tick's whole queue and returning one entity map plus one outcome per input. Same
shape as ADR 0001's `get_state/1` on the match path, down to the
`function_exported/3` dispatch. A module that does not export it takes the
per-input path, unchanged.

## Measured

12.5 Hz zone, 200 entities of 27 fields, one five-step input frame per player
per tick:

| players | tables/tick | mean tick |
|---|---|---|
| 8 | 1,842 -> 435 | 61.4 -> 16.6 ms |
| 32 | 6,834 -> 603 | 232.5 -> 17.3 ms |
| 64 | 13,490 -> 827 | 438.6 -> 19.3 ms |

Peak zone memory at 64 players falls from 203 MB to 9.2 MB, and at 400 entities
from 421 MB to 13.2 MB. The tick cost is now dominated by entities rather than
by players.

This is item 4 of #536. The heap budget fix in 0eb74d5 and the state-copy
proposal in ADR 0015 both leave the per-input encode in place, and it is the
term that scales with player count.

## What makes sharing one table safe

**The reference is anchored.** luerl's root set is `_G`, the stack and the live
call frames, so a table Erlang carries between calls is reachable only while
some frame names it - and a script declaring `function handle_input(p, i)` when
three arguments were passed drops it. A collection then frees it, its slot
returns to the free list, the next encode recycles it, and the reference aliases
that data. Reproduced during review: a zone's whole entity map came back as one
player's input frame, which `asobi_zone` accepts and the snapshotter persists.
`asobi_lua_loader:anchor_ref/2` roots it in a second raw `_G` slot beside the
collector's, and `ref_anchored/2` re-checks after every call because `_G` is
script-writable.

**`collectgarbage` is stripped from the sandbox.** It is a synchronous,
superlinear mark-and-sweep on the shared zone process, and it let a script
choose when references asobi holds between calls were freed. Nothing is lost:
asobi collects on its own adaptive schedule via `luerl:gc/1`, and luerl's
`collectgarbage` ignores every argument except `"collect"`, so there was never a
working `"count"`.

**An empty or invalid return still reverts.** On the per-input path a mutation
the module made and did not return was discarded, because Erlang held the
original; here the script holds the table itself. The Luerl state is functional,
so reverting to the state from before the call reverts the heap the mutation
lived in, at no cost. Without it a handler written as "apply the move, then
return to reject it" keeps the move - and one that looks its target up from a
client-controlled field is a write primitive on any entity in the zone. The
revert takes the whole VM with it, so a global written on a reject path goes
too; that is the one difference from `handle_input/3` and it is documented.

## Ack policy

Unchanged for the three normal outcomes. What is new is what happens when the
contract is broken - a wrong-length outcome list, an unusable return, or a
script clearing the anchor mid-tick: asobi acks **nothing** rather than falling
back to frame stamps. `asobi_player_session`'s ack gate is monotonic per socket,
so a stamp over a watermark the module did report buries it permanently, for
every player in that tick; a missing ack is undone by the next clean one.
Outcomes already produced before a bail-out are carried out with it.

## Also

Both input callbacks are optional now, so a module implementing the batch is not
compelled to carry a per-input function asobi never calls, and a world that
takes no input at all is legal. One that receives input with no handler logs an
error, counts it, and acks by frame stamp rather than raising undef on the zone.

Hardening on the paths a game module can drive: no `length/1` on an untrusted
outcome list (an improper list raised badarg inside the zone); every log site
shape-only, rate-limited, on its own bucket, and emitting telemetry outside the
limiter so suppressing a line cannot suppress the rate; and `shape_of/1`
classifying a tuple tag one level down rather than recursing, which rendered a
40 GB log line for a deeply nested term.

`guides/security-trust-model.md` gains the second anchor, which a script can
observe and clear where the collector's cannot be. ADR 0015 gains two notes: the
anchor discipline has to be a stated contract before it lands, since it makes
held refs the normal shape, and the functional state is a rollback primitive for
anything that needs to undo a callback without copying.

## Checks

`fmt`, `xref`, `dialyzer`, `ex_doc` clean; `elp lint` and `eqwalize` at the
`main` baseline for every touched module; 2,255 eunit tests, 0 failures. The new
guards were mutation-tested rather than assumed: reversing the outcome
accumulator, flattening outcomes on a bail-out, stubbing the anchor check,
perturbing a consumed seq and removing a limiter `forget/1` each make a test
fail.

Not run: `mutate` over the whole tree (~40 min, unscoped) and `ct`.
