### PR TITLE
feat(world): see across a zone seam, and stop paying full price for empty zones

### DIFF
--- a/docs/adr/0015-luerl-vm-owns-the-state.md
+++ b/docs/adr/0015-luerl-vm-owns-the-state.md
@@ -4,12 +4,36 @@ Date: 2026-08-21
 
 ## Status
 
-**Proposed. Nothing implemented.** This records a decision to be taken, not one
-taken. The evidence is a test-only spike
-(`test/asobi_lua_vm_spike.erl`, `test/asobi_lua_vm_spike_bench.erl` on branch
-`spike/lua-vm-process`, which is deliberately not merged - the bench asserts
-nothing and would add eight seconds to every CI eunit run); no `src/` module
-has been moved onto this shape.
+**Accepted and implemented behind a flag, default off.** `asobi_lua_vm` owns
+the state; `asobi_lua_loader` dispatches every operation on whether the bridge
+holds a state or a handle; `asobi_lua_world` and `asobi_lua_match` are on the
+new shape. Selected by `lua_vm_mode` (`copy` | `owned`), which is decision
+item 6 below and defaults to `copy`.
+
+Measured on the shipped code rather than the spike - `asobi_lua_world:zone_tick/2`,
+an inert callback, two entities, a `game_state` grown to the size shown:
+
+| state | `copy` us/tick | `owned` us/tick | speedup |
+|---|---|---|---|
+| 0.1 MB | 151.0 | 16.2 | 9x |
+| 3.2 MB | 3,733.2 | 17.8 | 210x |
+| 15.7 MB | 20,385.3 | 15.8 | 1,288x |
+| 62.6 MB | 111,443.5 | 18.7 | 5,956x |
+
+The shape is the point, not the multiplier: `copy` grows with the state,
+`owned` is **flat**. A 62 MB state costs 111 ms per callback under `copy` and
+19 us under `owned`. The reporter on asobi#536 measured 400-690 MB.
+
+The win is much smaller when the per-tick work grows with the state - a zone
+holding 8,000 entities and encoding all of them every tick measured 1.4x,
+because there the encode is genuine work and the copy is a minority of it.
+`owned` removes a term that is O(state); it does not make encoding cheaper.
+
+What is **not** done: `new/1` and `new/2` still always copy, so
+`asobi_lua_config`, `asobi_lua_validate` and the bot runtime are unchanged.
+The throwaway probe states a bridge boots to ask a script one question are
+copied on purpose (`asobi_lua_loader:new_copied/3`) - an owned VM there would
+be a process nothing stops.
 
 asobi#536 shipped separately and is not this ADR. That change made the eval
 heap budget mean what it says and made the state size observable. It did not

--- a/guides/configuration.md
+++ b/guides/configuration.md
@@ -43,8 +43,9 @@ bots = { script = "bots/arena_bot.lua" }
 World-mode games (`game_type = "world"`) read a further set of globals -
 `tick_rate`, `grid_size`, `zone_size`, `view_radius`, `persistent`,
 `lazy_zones`, `zone_idle_timeout`, `max_active_zones`,
-`spatial_grid_cell_size`, `cold_tick_divisor`, `empty_grace_ms`,
-`player_ttl_ms`. [World server](world-server.md) documents those.
+`spatial_grid_cell_size`, `cold_tick_divisor`, `border_band`,
+`empty_grace_ms`, `player_ttl_ms`. [World server](world-server.md) documents
+those.
 
 **Where you put `guest_auth` and `registration` matters.** They are read from
 `match.lua` in single-mode and from `config.lua` in multi-mode. A game with a
@@ -98,6 +99,7 @@ Everything below goes under `{asobi, [...]}`.
 
 The Lua runtime used to be its own OTP application, so the keys it owns -
 `max_heap_words`, `max_reductions_per_ms`, `reload_mode`,
+`reload_poll_interval_ms`, `lua_vm_mode`, `vm_max_heap_words`,
 `config_watch_interval`, `dev_errors`, `terrain_providers`, `lua_gc`,
 `state_warn_words`, `state_sample_interval_ms` and `rate_limits` -
 are still read from `asobi_lua` first and `asobi` second

--- a/guides/lua-api.md
+++ b/guides/lua-api.md
@@ -247,7 +247,7 @@ disk.
 
 ## Spatial
 
-Three shapes, and mixing them up is the usual mistake.
+Four shapes, and mixing them up is the usual mistake.
 
 **Entity-list and zone forms.** `query_radius` takes either:
 
@@ -267,6 +267,24 @@ The entity-list forms return `{ id = ..., entity = ..., distance = ... }` per
 hit. The zone forms return `{ id = ..., x = ..., y = ... }` per hit - no
 `entity` and no `distance`. Without zone context the zone forms return
 `{ error = "... requires zone context" }`.
+
+**Neighbour forms.** These read the eight zones touching the caller's, and
+nothing else - not the caller's own zone, which is already in `entities`:
+
+```lua
+game.spatial.neighbours_radius(x, y, radius)          -- zone context required
+game.spatial.neighbours_radius(x, y, radius, opts)
+game.spatial.neighbours_rect(x1, y1, x2, y2)          -- zone context required
+game.spatial.neighbours_rect(x1, y1, x2, y2, opts)
+```
+
+`neighbours_radius` returns `{ id = ..., entity = ..., distance = ... }` per
+hit and `neighbours_rect` the same without `distance`. The entities are
+**copies**: the neighbour still owns them, and writing to what comes back
+changes nothing. They return nothing at all unless the world sets
+`border_band`, which is off by default - see
+[World server](world-server.md#seeing-across-a-seam) for what it costs and how
+to act on what you find.
 
 **Entity-list only.**
 
@@ -299,6 +317,7 @@ Anything else in `opts` is ignored.
 game.zone.spawn(template_id, x, y)                    -- true | false
 game.zone.spawn(template_id, x, y, overrides)         -- true | false
 game.zone.despawn(entity_id)                          -- true
+game.zone.apply(entity_id, event)                     -- true | false
 game.terrain.get_chunk(cx, cy)                        -- { ok = data }
 game.terrain.preload(coords_list)                     -- true
 ```
@@ -307,6 +326,13 @@ game.terrain.preload(coords_list)                     -- true
 itself is asynchronous, so the return says "the template resolved", not
 "something exists now". It reads the zone's live template set, so a hot reload
 that adds a template takes effect without a restart.
+
+`apply` asks the *neighbouring* zone that owns `entity_id` to act on it, and
+returns `false` when no neighbour currently publishes that entity - you can
+only affect what `neighbours_radius`/`neighbours_rect` would have shown you.
+The owning zone runs the event through its own `handle_effects(effects,
+entities)` on its next tick. A script that calls `apply` without defining
+`handle_effects` gets a rate-limited error and dropped effects.
 
 `terrain.preload` takes a list of tables carrying `cx`/`cy` (or `x`/`y`).
 Entries it cannot read are skipped rather than raising.

--- a/guides/observability.md
+++ b/guides/observability.md
@@ -259,11 +259,21 @@ asobi.world.player_joined        asobi.world.player_left
 asobi.world.phase_changed        asobi.world.tick
 asobi.zone.opened                asobi.zone.closed
 asobi.zone.tick_skipped          asobi.join.rate_limited
+asobi.zone.cold                  asobi.zone.hot
 asobi.rehome.rate_limited        asobi.lua.state
 ```
 
 `asobi.world.tick` is sampled rather than emitted every tick - at 20 Hz per
 world an unsampled event is a metrics pipeline of its own.
+
+`asobi.zone.cold` and `asobi.zone.hot` are the two halves of one gauge: a zone
+with nothing to simulate ticks at `cold_tick_divisor` instead of every tick, and
+these fire on the transition rather than per tick. On a large lazy world most
+zones should be cold most of the time, and a world where none are is a world
+paying the full per-callback cost for empty space. The direction worth an alert
+is the other one - a zone that goes cold and never comes back is a zone that has
+stopped responding to the players in it. See
+[Performance tuning](performance-tuning.md#zone-tick-hibernation-and-reaping).
 
 `asobi.zone.tick_skipped` is the one to alert on. It counts zones the world
 tick skipped because they had not finished the previous one, so a healthy

--- a/guides/performance-tuning.md
+++ b/guides/performance-tuning.md
@@ -92,14 +92,34 @@ in a shared file - see [Configuration](configuration.md).
 
 ## Zone tick, hibernation and reaping
 
-Every active zone in a world ticks at the world's `tick_rate`. There is no hot
-and cold split and nothing promotes or demotes a zone; if the zone is active,
-it ticks.
+Every active zone in a world ticks at the world's `tick_rate`, except in two
+cases.
 
-The one exception is a zone that has not finished its previous tick: it is
-skipped rather than sent another one, so `tick_rate` is a ceiling on how often
-a zone ticks, not a promise. A zone consistently missing ticks is a zone whose
-`zone_tick` is over budget, and `[asobi, zone, tick_skipped]` counts it.
+A zone that has not finished its previous tick is skipped rather than sent
+another one, so `tick_rate` is a ceiling on how often a zone ticks, not a
+promise. A zone consistently missing ticks is a zone whose `zone_tick` is over
+budget, and `[asobi, zone, tick_skipped]` counts it.
+
+A zone with **nothing to simulate** ticks once every `cold_tick_divisor` ticks
+(default 10) instead of every tick. "Nothing to simulate" means no entities, no
+queued input, no live entity timer and no pending respawn - subscribers
+deliberately do not count, because a player watching an empty neighbouring zone
+creates no work in it. The zone goes back to full rate on the message that
+creates the work, not on its own next tick, so entering a zone costs no extra
+latency.
+
+This matters most on a Lua world, and the reason is in [Lua memory](#lua-memory)
+below: an empty zone's tick is almost entirely the fixed per-callback cost of
+the bridge rather than anything the game asked for. Measured on one machine, a
+zone with no entities and an inert `zone_tick` costs about 2,400 reductions a
+tick, of which roughly 90% is the bridge and most of that is the state copy. At
+`tick_rate = 80` on a 225-zone grid that is the difference between a world
+spending most of a core on empty space and spending a tenth of it.
+
+Set `cold_tick_divisor = 1` if your game drives spawning from `zone_tick` on
+zones that hold nothing - that is the one shape this changes, because such a
+zone's `zone_tick` now runs at a tenth of the rate until something appears in
+it.
 
 What does happen automatically:
 
@@ -133,6 +153,48 @@ runs at: roughly 7 ms per MB of state. A callback that does nothing at all
 measures 1.8 ms against a 0.4 MB state, 41 ms against 6 MB and 418 ms against
 62 MB. A zone whose state reaches tens of MB is over its tick budget before
 its script has run a single line.
+
+A second, smaller fixed cost sits alongside it. With `reload_mode = auto`
+(the default) each bridge polls its script's mtime so an edit reloads without a
+restart. That poll is throttled to once per `reload_poll_interval_ms` (default
+200) rather than once per tick: at 80 Hz across 225 zones the per-tick version
+was 18,000 `stat()` calls a second to notice an edit made every few minutes.
+Set it to 0 for the old per-tick behaviour, or `reload_mode = off` in a sealed
+deployment where scripts never change under a running node.
+
+**`lua_vm_mode = owned` removes that copy entirely** (ADR 0015). The state
+moves into a process of its own, the bridge holds a handle, and every Luerl
+operation becomes a small message to the process that owns it. The cost of a
+callback stops tracking the size of the state:
+
+| state | `copy` us/tick | `owned` us/tick |
+|---|---|---|
+| 0.1 MB | 151 | 16 |
+| 3.2 MB | 3,733 | 18 |
+| 15.7 MB | 20,385 | 16 |
+| 62.6 MB | 111,444 | 19 |
+
+Flat, not merely faster. Set it in `sys.config`:
+
+```erlang
+{asobi, [{lua_vm_mode, owned}]}
+```
+
+It is **off by default**, because the two modes differ in what a runaway
+callback costs. Under `copy` the process killed on a timeout or heap overrun is
+a throwaway holding a copy, so a bad callback costs one tick and the zone
+carries on. Under `owned` the only killable thing is the process holding the
+state, so an overrun kills the state: the zone dies with its VM and its
+supervisor restarts it into the last snapshot. That is a better trade for a
+large-state game and a worse one for a game whose scripts are unreliable and
+whose state is small. `vm_max_heap_words` puts an absolute ceiling on the state
+under `owned` - the first time that number can mean what it says, because the
+capped process is the one holding it.
+
+The win is smaller when the per-tick work itself grows with the state: a zone
+holding 8,000 entities and encoding all of them every tick measured 1.4x, not
+1,000x. `owned` removes a term that is O(state); it does not make encoding
+cheaper.
 
 asobi collects each Lua state periodically to keep that flat, immediately
 before the tick's own callback so the copy is of the collected state. The

--- a/guides/security-trust-model.md
+++ b/guides/security-trust-model.md
@@ -126,6 +126,14 @@ zone process indefinitely: the tick stops, no supervisor restart happens, and
 every later call against that process times out in its own caller. Blast radius
 is one match or one zone. Recovery is manual.
 
+`game.zone.apply` is the one call that can send from inside `handle_input` into
+a *different* process, so it carries its own bound rather than relying on the
+caller having one: an event is capped at 4 KB and a caller at 64 sends per tick,
+both spent on the sender before the term is copied. The receiving zone caps what
+it queues as well (by count and by bytes), but that cap is only consulted once
+the message has already arrived, so the sender-side one is what keeps the blast
+radius at one zone. See [World server](world-server.md#seeing-across-a-seam).
+
 So treat `handle_input/3` as a hot path for trusted-author scripts, not as a
 boundary. Audit the inputs your script accepts, avoid dispatching on
 attacker-controlled strings, and treat it the way you would an Erlang

--- a/guides/world-server.md
+++ b/guides/world-server.md
@@ -211,6 +211,7 @@ end
 | `post_tick(tick, state)` | yes | Global tick logic. Set `_finished` and `_result` on state to end the world |
 | `zone_tick(entities, zone_state)` | no | Per-zone simulation; return both |
 | `handle_input(player_id, input, entities)` | no | Apply one player's input to that zone's entities. A second return value is the client seq you consumed - see [Batched input and the ack](websocket-protocol.md#client-side-prediction). Every input in a tick is handed the same table rather than a copy, but returning nothing still discards whatever that call mutated - see [Players in one zone](performance-tuning.md#players-in-one-zone) |
+| `handle_effects(effects, entities)` | no | This tick's cross-zone effects, batched. See [Seeing across a seam](#seeing-across-a-seam) |
 | `generate_world(seed, config)` | no | Return a table keyed by `"x,y"` strings |
 | `get_state(player_id, state)` | no | Player-visible state |
 | `spawn_templates(config)` | no | See [Spawn templates](#spawn-templates) |
@@ -323,6 +324,7 @@ post_tick(_TickN, State) ->
 | `zone_tick/2` | yes | Per-zone simulation: `(Entities, ZoneState) -> {Entities, ZoneState}` |
 | `handle_input/3` | one of | Process player input within a zone's entities. Return `{ok, Entities, ConsumedSeq}` to ack what you *ran* rather than what arrived - see [Batched input and the ack](websocket-protocol.md#client-side-prediction) |
 | `handle_input_batch/2` | one of | The whole tick's inputs in one call, returning one entity map plus one outcome per input. Export it instead of `handle_input/3` when your per-input cost is dominated by marshalling the entity map rather than by the input. Exporting it shadows `handle_input/3` entirely. asobi still owns the ack policy: you return one outcome per input - see [Players in one zone](performance-tuning.md#players-in-one-zone) |
+| `handle_effects/2` | no | This tick's cross-zone effects: `([{EntityId, Event}], Entities) -> {ok, Entities}`. Delivered after inputs, already filtered to entities this zone still owns. See [Seeing across a seam](#seeing-across-a-seam) |
 | `post_tick/2` | yes | Global post-tick: return `{ok, State}`, `{vote, Config, State}`, or `{finished, Result, State}` |
 | `generate_world/2` | no | Procedural generation: `(Seed, Config) -> {ok, #{Coords => ZoneState}}` |
 | `get_state/2` | no | Per-player state view |
@@ -390,6 +392,7 @@ Plan around them as facts of the deployment, not knobs.
 | Zone idle timeout | 30 seconds before an empty zone is released |
 | Rehome margin | 0.15 of `zone_size` (described below) |
 | Zone snapshot interval | 600 ticks, and moot - see [Snapshots](#snapshots) |
+| Border mirror | Off (`border_band = 0`) - see [Seeing across a seam](#seeing-across-a-seam) |
 
 An entity, player or NPC, must clear its zone's edge by the rehome margin (a
 fraction of `zone_size`) before re-homing to the neighbouring zone, so an
@@ -406,7 +409,83 @@ because it has not cleared the margin yet. A query issued from zone A over that
 area misses it entirely, and the gap persists - an NPC parked just past its
 zone's edge stays invisible to the neighbour's queries indefinitely, not only
 for the tick it takes to cross. Account for that if your NPC AI queries by
-position near zone edges.
+position near zone edges, or turn on the border mirror below.
+
+### Seeing across a seam
+
+`border_band` publishes each zone's edge entities where its neighbours can read
+them, which is what makes an NPC able to chase a player across a boundary and a
+projectile able to hit a target the next zone owns. Off by default:
+
+```lua
+border_band = 0.15   -- fraction of zone_size; 0 (the default) publishes nothing
+```
+
+With it on, each zone writes the entities within `border_band * zone_size` of
+any of its own edges into a shared read-only mirror once per tick, and two calls
+read the eight touching zones:
+
+```lua
+local seen = game.spatial.neighbours_radius(x, y, radius)        -- {id=, entity=, distance=}
+local seen = game.spatial.neighbours_radius(x, y, radius, opts)  -- same opts as query_radius
+local seen = game.spatial.neighbours_rect(x1, y1, x2, y2)        -- {id=, entity=}
+```
+
+They never return the calling zone's own entities: you already have those in
+`entities`, and returning both would double every in-zone result. What comes
+back is a **copy** - writing to it changes nothing, because the neighbour still
+owns the entity.
+
+To act on one, ask its owner:
+
+```lua
+local hit = game.spatial.neighbours_radius(shot.x, shot.y, 4.0, { type = "npc" })[1]
+if hit then game.zone.apply(hit.id, { kind = "damage", amount = 12 }) end
+```
+
+`game.zone.apply` returns `false` if no neighbour currently publishes that
+entity - you can only affect what you can see, which is the same rule as the
+read. The owning zone applies it in its own next tick, in order, through
+`handle_effects`:
+
+```lua
+function handle_effects(effects, entities)
+  for _, e in ipairs(effects) do
+    local target = entities[e.entity_id]           -- never nil: asobi drops
+    target.hp = target.hp - (e.event.amount or 0)  -- effects for entities it lost
+  end
+  return entities
+end
+```
+
+Default the fields you read: one `nil` arithmetic error takes the whole tick's
+batch with it, not just the effect that caused it. A script that calls
+`game.zone.apply` and has not defined `handle_effects` gets a rate-limited
+error and its effects dropped, rather than silence.
+
+An event is a verb, not a payload. asobi caps one at 4 KB and a caller at 64
+sends per tick, refusing past either with `false`, so a script cannot turn its
+own budget into a neighbour's unbounded mailbox.
+
+**What it costs.** Publishing is a filter over the zone's entities plus a copy
+of the band into shared storage, every tick, whether or not anything reads it.
+Measured on a zone holding 200 entities all inside the band, that is 10,998
+reductions per tick against 8,231 with `border_band = 0` - about a third more.
+The band is bounded by the zone's perimeter rather than its area, so a smaller
+`border_band` is cheaper; an empty zone pays nothing. Leave it at 0 unless the
+game reads the mirror.
+
+**What it is not.** It is not a general cross-zone query: it answers only for
+entities inside the band, only for the eight touching zones, and only at the
+last tick's positions. A zone still owns its own entities outright, and nothing
+here lets one zone write another's.
+
+The mirror is one table per world, owned by that world's supervisor, so it is
+reclaimed exactly when the world ends and one world can never read another's.
+The sender-side "you can only affect what you can see" check reads that table;
+the check that cannot be sidestepped is the receiving zone's, which applies an
+effect only to an entity it currently owns. Addressing an entity is gated;
+inventing one is not possible.
 
 The margin bounds this slack only for positions inside the world rectangle. An
 entity outside it entirely is clamped into the edge zone by `pos_to_zone` and

--- a/src/asobi_game_modes.erl
+++ b/src/asobi_game_modes.erl
@@ -140,7 +140,29 @@ world_config_1(Mode, ModeConfig) ->
             },
             {ok,
                 forward_optional(
-                    ModeConfig, [empty_grace_ms, player_ttl_ms, chat, broadcast_interval], Base
+                    ModeConfig,
+                    [
+                        empty_grace_ms,
+                        player_ttl_ms,
+                        chat,
+                        broadcast_interval,
+                        %% widgrensit/asobi#543: every one of these is read
+                        %% downstream and documented as a game-config global,
+                        %% and none of them was forwarded - so a world
+                        %% declaring `lazy_zones = true` pre-spawned its whole
+                        %% grid anyway, and `cold_tick_divisor` never reached
+                        %% the ticker that reads it. They fail silently: the
+                        %% world starts and plays, it just ignores what the
+                        %% script asked for.
+                        lazy_zones,
+                        zone_idle_timeout,
+                        max_active_zones,
+                        spatial_grid_cell_size,
+                        cold_tick_divisor,
+                        rehome_margin,
+                        border_band
+                    ],
+                    Base
                 )};
         {error, _} = Err ->
             Err

--- a/src/asobi_telemetry.erl
+++ b/src/asobi_telemetry.erl
@@ -6,6 +6,7 @@
 -export([world_started/2, world_finished/3, world_player_joined/2, world_player_left/2]).
 -export([world_phase_changed/3, world_tick/4]).
 -export([zone_opened/2, zone_closed/2, zone_tick_skipped/2]).
+-export([zone_cold/2, zone_hot/2]).
 -export([lua_state_size/2]).
 -export([
     matchmaker_queued/2,
@@ -41,7 +42,10 @@
     | batch_contract
     | unknown_outcome
     | input_rejected
-    | invalid_consumed_seq.
+    | invalid_consumed_seq
+    | effect_queue_full
+    | no_effect_handler
+    | bad_effects_return.
 -export_type([game_error_kind/0]).
 -export([economy_transaction/4, store_purchase/3]).
 -export([chat_message_sent/2]).
@@ -80,6 +84,8 @@ events() ->
         [asobi, zone, opened],
         [asobi, zone, closed],
         [asobi, zone, tick_skipped],
+        [asobi, zone, cold],
+        [asobi, zone, hot],
         [asobi, lua, state],
         [asobi, matchmaker, queued],
         [asobi, matchmaker, deduped],
@@ -223,6 +229,32 @@ zone_opened(WorldId, Coords) ->
 -spec zone_closed(binary() | undefined, {integer(), integer()}) -> ok.
 zone_closed(WorldId, Coords) ->
     telemetry:execute([asobi, zone, closed], #{count => 1}, #{
+        world_id => WorldId, coords => Coords
+    }).
+
+-doc """
+asobi#543: a zone stopped simulating at full rate, because it has no entities,
+no queued input, no live entity timer and no pending respawn. It now ticks once
+every `cold_tick_divisor` ticks until something gives it work.
+
+Pair with `zone_hot/2` and track the difference as a gauge: on a large lazy
+world most zones should be cold most of the time, and a world where none are is
+a world paying the full per-callback cost for empty space. The direction that
+needs an alert is the other one - a zone that goes cold and never comes back is
+a zone that has stopped responding to the players in it.
+
+Both metadata keys are unbounded - never a label, same as `zone_opened/2`.
+""".
+-spec zone_cold(binary() | undefined, {integer(), integer()}) -> ok.
+zone_cold(WorldId, Coords) ->
+    telemetry:execute([asobi, zone, cold], #{count => 1}, #{
+        world_id => WorldId, coords => Coords
+    }).
+
+-doc "asobi#543: a cold zone was given work and is back at full tick rate. See `zone_cold/2`.".
+-spec zone_hot(binary() | undefined, {integer(), integer()}) -> ok.
+zone_hot(WorldId, Coords) ->
+    telemetry:execute([asobi, zone, hot], #{count => 1}, #{
         world_id => WorldId, coords => Coords
     }).
 

--- a/src/lua/asobi_lua_api.erl
+++ b/src/lua/asobi_lua_api.erl
@@ -53,6 +53,10 @@ game.spatial.query_radius(entities, x, y, radius)
 game.spatial.query_radius(entities, x, y, radius, opts)
 game.spatial.query_radius(x, y, radius)              -- zone-based (requires zone_pid)
 game.spatial.query_rect(x1, y1, x2, y2)              -- zone-based (requires zone_pid)
+game.spatial.neighbours_radius(x, y, radius)        -- read-only copies from the 8 touching zones
+game.spatial.neighbours_radius(x, y, radius, opts)
+game.spatial.neighbours_rect(x1, y1, x2, y2)
+game.spatial.neighbours_rect(x1, y1, x2, y2, opts)
 game.spatial.nearest(entities, x, y, n)
 game.spatial.nearest(entities, x, y, n, opts)
 game.spatial.in_range(entity_a, entity_b, range)
@@ -62,6 +66,7 @@ game.spatial.distance(entity_a, entity_b)
 game.zone.spawn(template_id, x, y)              -- false if template_id is unknown
 game.zone.spawn(template_id, x, y, overrides)   -- false if template_id is unknown
 game.zone.despawn(entity_id)
+game.zone.apply(entity_id, event)               -- ask the owning neighbour zone to act; false if unseen
 
 -- Terrain (world mode only, requires terrain_store_pid in context)
 game.terrain.get_chunk(cx, cy)                   -- get compressed chunk data
@@ -101,6 +106,7 @@ through the same `{ ok = ... }` / `{ error = "..." }` envelope.
 -export([deep_decode/1, decode_to_map/2]).
 -export([to_storage_value/1]).
 -export([atomize_entities/1, atomize_keys/1]).
+-export([reset_effect_sends/0]).
 
 -spec install(map(), dynamic()) -> dynamic().
 install(#{probe := true} = Ctx, St0) ->
@@ -198,12 +204,15 @@ core_surface(Ctx) ->
         %% Spatial
         {[~"game", ~"spatial", ~"query_radius"], none, fun_spatial_query_radius(Ctx)},
         {[~"game", ~"spatial", ~"query_rect"], none, fun_spatial_query_rect(Ctx)},
+        {[~"game", ~"spatial", ~"neighbours_radius"], none, fun_spatial_neighbours(Ctx, radius)},
+        {[~"game", ~"spatial", ~"neighbours_rect"], none, fun_spatial_neighbours(Ctx, rect)},
         {[~"game", ~"spatial", ~"nearest"], none, fun_spatial_nearest()},
         {[~"game", ~"spatial", ~"in_range"], none, fun_spatial_in_range()},
         {[~"game", ~"spatial", ~"distance"], none, fun_spatial_distance()},
         %% Zone spawning
         {[~"game", ~"zone", ~"spawn"], zone_effect(Ctx), fun_zone_spawn(Ctx)},
         {[~"game", ~"zone", ~"despawn"], zone_effect(Ctx), fun_zone_despawn(Ctx)},
+        {[~"game", ~"zone", ~"apply"], zone_effect(Ctx), fun_zone_apply(Ctx)},
         %% Terrain
         {[~"game", ~"terrain", ~"get_chunk"], none, fun_terrain_get_chunk(Ctx)},
         {[~"game", ~"terrain", ~"preload"], terrain_effect(Ctx), fun_terrain_preload(Ctx)}
@@ -969,6 +978,75 @@ fun_spatial_query_rect(#{zone_pid := ZonePid}) ->
 fun_spatial_query_rect(_) ->
     fun(_, St) -> error_result(~"query_rect requires zone context", St) end.
 
+%% --- Neighbour-zone reads (widgrensit/asobi#544) ---
+
+%% Both shapes are one closure because they differ only in how many numbers
+%% they take: the geometry check, the read and the encoding are identical, and
+%% splitting them duplicated the part that is easy to get subtly different.
+fun_spatial_neighbours(Ctx, Kind) ->
+    fun(Args, St) ->
+        case {zone_grid(Ctx), decode_args(Args, St)} of
+            {error, _} ->
+                error_result(no_grid_message(Kind), St);
+            {{ok, Grid}, Decoded} ->
+                neighbours_query(Kind, Grid, Decoded, St)
+        end
+    end.
+
+no_grid_message(radius) -> ~"neighbours_radius requires zone context";
+no_grid_message(rect) -> ~"neighbours_rect requires zone context".
+
+bad_args_message(radius) -> ~"neighbours_radius requires (x, y, radius[, opts])";
+bad_args_message(rect) -> ~"neighbours_rect requires (x1, y1, x2, y2[, opts])".
+
+neighbours_query(radius, {_WorldId, Tab, Coords, GridSize}, [X, Y, R], St) when
+    is_number(X), is_number(Y), is_number(R)
+->
+    encode_spatial_results(asobi_zone_border:query_radius(Tab, Coords, GridSize, {X, Y}, R), St);
+neighbours_query(radius, {_WorldId, Tab, Coords, GridSize}, [X, Y, R, OptsRaw], St) when
+    is_number(X), is_number(Y), is_number(R)
+->
+    encode_spatial_results(
+        asobi_zone_border:query_radius(
+            Tab, Coords, GridSize, {X, Y}, R, decode_spatial_opts(OptsRaw)
+        ),
+        St
+    );
+neighbours_query(rect, {_WorldId, Tab, Coords, GridSize}, [X1, Y1, X2, Y2], St) when
+    is_number(X1), is_number(Y1), is_number(X2), is_number(Y2)
+->
+    encode_rect_results(
+        asobi_zone_border:query_rect(Tab, Coords, GridSize, {X1, Y1}, {X2, Y2}), St
+    );
+neighbours_query(rect, {_WorldId, Tab, Coords, GridSize}, [X1, Y1, X2, Y2, OptsRaw], St) when
+    is_number(X1), is_number(Y1), is_number(X2), is_number(Y2)
+->
+    encode_rect_results(
+        asobi_zone_border:query_rect(
+            Tab, Coords, GridSize, {X1, Y1}, {X2, Y2}, decode_spatial_opts(OptsRaw)
+        ),
+        St
+    );
+neighbours_query(Kind, _Grid, _Args, St) ->
+    error_result(bad_args_message(Kind), St).
+
+%% One place that decides whether a Ctx can answer a neighbour question at all,
+%% so a probe VM (no zone identity) and a match VM (no grid) both fail with the
+%% same message rather than crashing on a missing key.
+zone_grid(
+    #{
+        world_id := WorldId,
+        coords := {CX, CY} = Coords,
+        grid_size := GridSize,
+        border_tab := Tab
+    }
+) when
+    is_binary(WorldId), is_integer(CX), is_integer(CY), is_integer(GridSize), GridSize > 0
+->
+    {ok, {WorldId, Tab, Coords, GridSize}};
+zone_grid(_Ctx) ->
+    error.
+
 fun_spatial_nearest() ->
     fun(Args, St) ->
         case decode_args(Args, St) of
@@ -1036,6 +1114,13 @@ encode_spatial_results(Results, St) ->
         #{~"id" => Id, ~"entity" => Entity, ~"distance" => Dist}
      || {Id, Entity, Dist} <- Results
     ],
+    {Enc, St1} = luerl:encode(Encoded, St),
+    {[Enc], St1}.
+
+%% asobi_spatial:query_rect/4 has no distance to report, so the rect shape is
+%% the radius one minus that field rather than a different shape.
+encode_rect_results(Results, St) ->
+    Encoded = [#{~"id" => Id, ~"entity" => Entity} || {Id, Entity} <- Results],
     {Enc, St1} = luerl:encode(Encoded, St),
     {[Enc], St1}.
 
@@ -1162,6 +1247,107 @@ known_template(_TemplateId, _Ctx) ->
     %% never populate one) stays unrestricted. Only a genuine per-zone Ctx
     %% (built by zone_ctx/2) ever enforces the known-template allowlist.
     true.
+
+%% Ceiling on one cross-zone event, and on how many a caller may send in a tick.
+%% See effect_within_budget/1 for why both are spent on the sender.
+-define(MAX_EFFECT_BYTES, 4096).
+-define(MAX_EFFECT_SENDS, 64).
+-define(EFFECT_SENDS_KEY, {?MODULE, effect_sends}).
+
+-doc """
+Clear the calling process's per-tick `game.zone.apply` send budget.
+
+Called by `asobi_zone` at the top of each tick. Only the inline callbacks need
+it: a bounded callback runs in a throwaway worker whose process dictionary goes
+with it.
+""".
+-spec reset_effect_sends() -> ok.
+reset_effect_sends() ->
+    _ = erlang:erase(?EFFECT_SENDS_KEY),
+    ok.
+
+%% Only an entity currently published in the border mirror can be addressed,
+%% which makes "what a zone may affect" the same set as "what a zone can see"
+%% rather than two sets that drift apart. It also means `false` has one
+%% meaning a script can act on: you cannot see that entity from here.
+fun_zone_apply(Ctx) ->
+    fun(Args, St) ->
+        case {zone_grid(Ctx), decode_args(Args, St)} of
+            {error, _} ->
+                error_result(~"zone.apply requires zone context", St);
+            {{ok, Grid}, [EntityId, EventRaw]} when is_binary(EntityId) ->
+                case event_map(EventRaw) of
+                    {ok, Event} ->
+                        {[deliver_effect(Grid, EntityId, Event)], St};
+                    error ->
+                        error_result(~"zone.apply requires (entity_id, event_table)", St)
+                end;
+            _ ->
+                error_result(~"zone.apply requires (entity_id, event_table)", St)
+        end
+    end.
+
+%% An empty Lua table decodes to [], not #{} - see fun_spatial_query_radius/1's
+%% note on the same shape.
+event_map(Event) when is_map(Event) -> {ok, Event};
+event_map([]) -> {ok, #{}};
+event_map(_) -> error.
+
+deliver_effect({WorldId, Tab, Coords, GridSize}, EntityId, Event) ->
+    case effect_within_budget(Event) of
+        false ->
+            false;
+        true ->
+            case asobi_zone_border:owner(Tab, Coords, GridSize, EntityId) of
+                {ok, OwnerCoords} -> cast_effect(WorldId, OwnerCoords, EntityId, Event);
+                error -> false
+            end
+    end.
+
+cast_effect(WorldId, OwnerCoords, EntityId, Event) ->
+    case asobi_zone:whereis_zone(WorldId, OwnerCoords) of
+        {ok, Pid} ->
+            asobi_zone:apply_effect(Pid, EntityId, Event),
+            true;
+        error ->
+            false
+    end.
+
+%% Both halves of the bound are spent here, on the *calling* zone, because this
+%% is the last point at which refusing is free. Past it the term has been copied
+%% onto another process's heap and into its mailbox, which nothing downstream
+%% can un-send: `asobi_zone`'s own queue cap is only consulted once the message
+%% has already arrived.
+%%
+%% A cross-zone event is a verb, not a payload - `{kind = "damage", amount =
+%% 12}`, not a copy of the world - so a small size ceiling costs nothing real,
+%% and a per-tick send count keeps a script that loops on `apply` from turning
+%% its own budget into a neighbour's unbounded mailbox. `handle_input` makes
+%% this necessary rather than merely tidy: it runs inline with no wall-clock,
+%% heap or reduction budget at all (guides/security-trust-model.md), so it is
+%% the one caller that cannot be stopped by anything else.
+effect_within_budget(Event) ->
+    erts_debug:flat_size(Event) * erlang:system_info(wordsize) =< ?MAX_EFFECT_BYTES andalso
+        spend_effect_send().
+
+%% The process dictionary rather than Ctx: the closure's `self()` is the eval
+%% worker under `zone_tick` and the zone itself under `handle_input`, and both
+%% want one budget for the tick they are part of. A worker's dictionary dies
+%% with it, which is the reset for the first; asobi_zone:do_tick/2 erases the
+%% key for the second.
+spend_effect_send() ->
+    Spent =
+        case erlang:get(?EFFECT_SENDS_KEY) of
+            N when is_integer(N), N >= 0 -> N;
+            _ -> 0
+        end,
+    case Spent >= ?MAX_EFFECT_SENDS of
+        true ->
+            false;
+        false ->
+            _ = erlang:put(?EFFECT_SENDS_KEY, Spent + 1),
+            true
+    end.
 
 fun_zone_despawn(#{zone_pid := ZonePid}) ->
     fun(Args, St) ->
@@ -1368,9 +1554,19 @@ deep_decode(L, D) when is_list(L) ->
 deep_decode(V, _D) ->
     V.
 
+-doc """
+Decode a Luerl reference to a plain map.
+
+Goes through `asobi_lua_loader:decode/2` rather than `luerl:decode/2` because,
+unlike every other `luerl:*` call in this module, this one is reached from a
+*bridge* holding whatever `new/3` gave it - which under ADR 0015's `owned` mode
+is a handle to the process that owns the state, not the state. The rest of this
+module's Luerl calls live inside installed closures, which by construction run
+in the process that owns the state and are handed the real thing.
+""".
 -spec decode_to_map(term(), dynamic()) -> map().
 decode_to_map(Term, LuaSt) ->
-    case deep_decode(luerl:decode(Term, LuaSt)) of
+    case deep_decode(asobi_lua_loader:decode(Term, LuaSt)) of
         M when is_map(M) ->
             M;
         [] ->

--- a/src/lua/asobi_lua_config.erl
+++ b/src/lua/asobi_lua_config.erl
@@ -49,7 +49,8 @@ lazy_zones              = true            -- optional, on-demand zone loading
 zone_idle_timeout       = 30000           -- optional, ms before idle zone is reaped
 max_active_zones        = 10000           -- optional, cap on concurrent zones
 spatial_grid_cell_size  = 64              -- optional, cell size for spatial grid indexing
-cold_tick_divisor       = 10              -- optional, tick rate divisor for cold (unoccupied) zones
+cold_tick_divisor       = 10              -- optional, tick rate divisor for cold (idle) zones
+border_band             = 0.15            -- optional, fraction of zone_size mirrored to neighbours (default 0 = off)
 empty_grace_ms          = 60000           -- optional, ms to keep an empty world alive before finishing
 player_ttl_ms           = 0               -- optional, 0=remove on disconnect, -1=keep forever, N=grace ms
 ```
@@ -341,6 +342,7 @@ read_match_globals(ScriptPath, St) ->
     MaxActiveZones = read_global_int(~"max_active_zones", St),
     SpatialGridCellSize = read_global_int(~"spatial_grid_cell_size", St),
     ColdTickDivisor = read_global_int(~"cold_tick_divisor", St),
+    BorderBand = read_global_number(~"border_band", St),
     EmptyGraceMs = read_global_int(~"empty_grace_ms", St),
     PlayerTtlMs = read_global_int(~"player_ttl_ms", St),
     case MatchSize of
@@ -363,7 +365,8 @@ read_match_globals(ScriptPath, St) ->
             Config4 = maybe_add_zone_config(Config3, LazyZones, ZoneIdleTimeout, MaxActiveZones),
             Config5 = maybe_add_int(Config4, spatial_grid_cell_size, SpatialGridCellSize),
             Config6 = maybe_add_int(Config5, cold_tick_divisor, ColdTickDivisor),
-            Config7 = maybe_add_int(Config6, empty_grace_ms, EmptyGraceMs),
+            Config6a = maybe_add_fraction(Config6, border_band, BorderBand),
+            Config7 = maybe_add_int(Config6a, empty_grace_ms, EmptyGraceMs),
             Config8 = maybe_add_player_ttl(Config7, PlayerTtlMs),
             Config9 = maybe_add_int(Config8, tick_rate, TickRate),
             Config10 = maybe_add_int(Config9, grid_size, GridSize),
@@ -429,6 +432,16 @@ maybe_add_int(Config, _Key, undefined) ->
 maybe_add_int(Config, Key, Val) when is_integer(Val), Val > 0 ->
     Config#{Key => Val};
 maybe_add_int(Config, _Key, _Val) ->
+    Config.
+
+%% A fraction of zone_size. 0 is meaningful (publish nothing) and 1.0 is the
+%% whole zone; anything outside that is a typo rather than an intent, and
+%% dropping it leaves the documented default in place.
+maybe_add_fraction(Config, _Key, undefined) ->
+    Config;
+maybe_add_fraction(Config, Key, Val) when is_number(Val), Val >= 0, Val =< 1 ->
+    Config#{Key => Val};
+maybe_add_fraction(Config, _Key, _Val) ->
     Config.
 
 %% Like maybe_add_int/3 but accepts 0 — used for view_radius, where 0 is a
@@ -642,6 +655,12 @@ do_with_timeout_results(Code, St, TimeoutMs) ->
 read_global_int(Name, St) ->
     case luerl:get_table_keys([Name], St) of
         {ok, Val, _} when is_number(Val) -> trunc(Val);
+        _ -> undefined
+    end.
+
+read_global_number(Name, St) ->
+    case luerl:get_table_keys([Name], St) of
+        {ok, Val, _} when is_number(Val) -> Val;
         _ -> undefined
     end.
 

--- a/src/lua/asobi_lua_loader.erl
+++ b/src/lua/asobi_lua_loader.erl
@@ -32,10 +32,16 @@ attached (e.g. for evaluating a `config.lua` manifest); use `new/1` to
 load a specific script and pin its base directory for `require`.
 """.
 
--export([new/1, new/2, new/3, init_sandboxed/0, call/3, call/4, do_with_timeout/3]).
+-export([new/1, new/2, new/3, new_copied/3, init_sandboxed/0, call/3, call/4, do_with_timeout/3]).
 -export([is_defined/2]).
 -export([collect_state/1]).
 -export([anchor_ref/2, unanchor_ref/1, ref_anchored/2]).
+%% ADR 0015: the five luerl operations the bridges use, behind one door so a
+%% bridge does not care whether it is holding a Luerl state or a pid.
+-export([encode/2, decode/2, get_table_key/3, get_table_keys/2, set_table_keys/3]).
+-export([vm_mode/0, vm_max_heap_words/0, release/1, revert/1]).
+%% Called back by asobi_lua_vm, which runs these against the state it owns.
+-export([do_inline/2, gc_now/2]).
 -ifdef(TEST).
 -export([next_gc/4, gc_budget_us/1, state_words/0]).
 -endif.
@@ -178,13 +184,102 @@ load a specific script and pin its base directory for `require`.
 %% side can size the state without walking it.
 -define(STATE_WORDS_KEY, {?MODULE, state_words}).
 
+%% Ceiling on one un-budgeted VM operation. An encode or a table read is
+%% microseconds; anything reaching this is a VM wedged by something the caller
+%% cannot see, and waiting forever on it would hang the zone.
+-define(VM_OP_TIMEOUT, 5_000).
+
+-doc """
+Whether a bridge holds the Luerl state itself or a process that owns it.
+
+`copy` (the default) is the original path: the state lives in the bridge's own
+map and `call/4` spawns a worker per callback, which copies it in and back.
+`owned` is ADR 0015: an `asobi_lua_vm` process holds the state and the bridge
+holds a handle.
+
+Defaulting to `copy` for at least one release is ADR 0015's own decision item 6.
+The two paths differ in what a runaway callback costs - a tick under `copy`, the
+state under `owned` - and that is not a difference to flip on under an operator
+without warning.
+""".
+-spec vm_mode() -> copy | owned.
+vm_mode() ->
+    case asobi_lua_env:get_env(lua_vm_mode) of
+        {ok, owned} -> owned;
+        {ok, copy} -> copy;
+        _ -> copy
+    end.
+
+-doc """
+Absolute heap ceiling for an `asobi_lua_vm`, in words. 0 disables it.
+
+Meaningful only under `owned`: this is the first time an absolute cap bounds the
+persistent state rather than a copy of it, because the capped process is the one
+holding it. Under `copy` the equivalent knob (`max_heap_words`) has to be
+relative to the state, which is why it cannot be a ceiling on the state.
+""".
+-spec vm_max_heap_words() -> non_neg_integer().
+vm_max_heap_words() ->
+    case asobi_lua_env:get_env(vm_max_heap_words) of
+        {ok, N} when is_integer(N), N >= 0 -> N;
+        _ -> 0
+    end.
+
+-doc """
+Undo the last `call/3,4` against this state.
+
+Under `copy` this is a no-op, because a caller reverts simply by carrying on
+with the state variable it had before the call - a Luerl state is immutable and
+the mutated one is dropped. Under `owned` the mutation has already happened
+inside the VM, so the same intent has to be said out loud.
+
+Callers that rely on it are the ones where a *successful* call is rejected on
+its answer rather than on an error: a refused `join`, and an input in a batch
+that returned nothing usable. Both are load-bearing - a refused join that could
+still advance the game state lets a client drive a script by being turned away
+over and over, and an input that keeps what it touched without returning it can
+mutate another player's entity. An error needs no revert: the VM keeps the
+pre-call state on a raise, exactly as the copying path did by dropping the
+state the failed call produced.
+""".
+-spec revert(dynamic()) -> dynamic().
+revert(St) ->
+    case asobi_lua_vm:is_handle(St) of
+        true ->
+            _ = asobi_lua_vm:op(St, revert, ?VM_OP_TIMEOUT),
+            St;
+        false ->
+            St
+    end.
+
+-doc """
+Release whatever `new/3` returned. A no-op for a copied state; stops the VM for
+an owned one.
+""".
+-spec release(dynamic()) -> ok.
+release(St) ->
+    case asobi_lua_vm:is_handle(St) of
+        true -> asobi_lua_vm:stop(St);
+        false -> ok
+    end.
+
+-doc """
+Load a script into a plain copied state, with no `game.*` API installed.
+
+`new/1` and `new/2` are always the copying path, whatever `lua_vm_mode` says.
+ADR 0015 is about the bridges whose state is ticked thousands of times - zones
+and matches, which come through `new/3` - and its callers here are either
+one-shot (`asobi_lua_config`, `asobi_lua_validate`) or a separate lifecycle
+(bots). Moving those is a later step, not a wider blast radius for the first
+release of a default-off flag.
+""".
 -spec new(binary() | string()) -> {ok, dynamic()} | {error, term()}.
 new(ScriptPath) ->
-    new(ScriptPath, ?DEFAULT_INIT_TIMEOUT_MS, fun(St) -> St end).
+    new_copied(ScriptPath, ?DEFAULT_INIT_TIMEOUT_MS, fun(St) -> St end).
 
 -spec new(binary() | string(), non_neg_integer()) -> {ok, dynamic()} | {error, term()}.
 new(ScriptPath, TimeoutMs) ->
-    new(ScriptPath, TimeoutMs, fun(St) -> St end).
+    new_copied(ScriptPath, TimeoutMs, fun(St) -> St end).
 
 %% Lua closures capture `_ENV` at compile time, so any global installed
 %% AFTER the script chunk is evaluated is invisible to functions the
@@ -197,6 +292,9 @@ new(ScriptPath, TimeoutMs) ->
 -spec new(binary() | string(), non_neg_integer(), pre_install()) ->
     {ok, dynamic()} | {error, term()}.
 new(ScriptPath, TimeoutMs, PreInstall) when is_function(PreInstall, 1) ->
+    new_1(ScriptPath, TimeoutMs, PreInstall, vm_mode()).
+
+new_1(ScriptPath, TimeoutMs, PreInstall, Mode) when is_function(PreInstall, 1) ->
     BaseDir = filename:dirname(to_string(ScriptPath)),
     FileName = filename:basename(to_string(ScriptPath)),
     St0 = sandboxed_state(BaseDir),
@@ -205,31 +303,78 @@ new(ScriptPath, TimeoutMs, PreInstall) when is_function(PreInstall, 1) ->
     case file:read_file(FullPath) of
         {ok, Code} ->
             CodeStr = binary_to_list(Code),
-            do_with_timeout(CodeStr, St1, TimeoutMs);
+            %% The script body is evaluated the copying way whatever the mode:
+            %% it is script-author code with no state worth preserving if it
+            %% runs away, and a VM is only worth starting around a state that
+            %% loaded. Under `owned` the loaded state is then handed to a VM and
+            %% never copied again.
+            own(do_with_timeout(CodeStr, St1, TimeoutMs), Mode);
         {error, Reason} ->
             {error, {file_error, FullPath, Reason}}
     end.
+
+-doc """
+Like `new/3`, but always a plain copied state, never an owned VM.
+
+For the throwaway probe states a bridge boots to ask a script one question and
+then drops (`spawn_templates`, `phases`, `terrain_provider`, `generate_world`
+from a raw config). Under `owned` those would each start a process that nothing
+ever stops, and they would gain nothing by it: the whole point of an owned VM is
+to amortise a state across many callbacks, and these see exactly one.
+""".
+-spec new_copied(binary() | string(), non_neg_integer(), pre_install()) ->
+    {ok, dynamic()} | {error, term()}.
+new_copied(ScriptPath, TimeoutMs, PreInstall) ->
+    new_1(ScriptPath, TimeoutMs, PreInstall, copy).
+
+-spec own({ok, dynamic()} | {error, term()}, copy | owned) ->
+    {ok, dynamic()} | {error, term()}.
+own({ok, St}, copy) -> {ok, St};
+own({ok, St}, owned) -> asobi_lua_vm:start_link(St);
+own({error, _} = Err, _Mode) -> Err.
 
 %% M-2/M-3/H-1: spawn-and-kill wrapper around `luerl:do/2`. Required
 %% any time the input is script-author-controlled — that includes the
 %% top-level body of the loaded script, hot-reload code, and config
 %% manifests evaluated during app start.
+-doc """
+Evaluate `Code` against the state, in the calling process.
+
+Public only for `asobi_lua_vm`. Under `copy` the spawn-and-kill wrapper in
+`do_with_timeout/3` is what bounds script-author code; under `owned` the VM
+process is itself the killable thing, so the wrapper would be a copy of the
+state for no guard that the VM does not already have.
+""".
+-spec do_inline(string() | binary(), dynamic()) -> {ok, dynamic()} | {error, term()}.
+do_inline(Code, St) ->
+    try luerl:do(ensure_string(Code), St) of
+        {ok, _Results, St1} -> {ok, St1};
+        {error, Errors, _} -> {error, {lua_error, Errors}};
+        {lua_error, Reason, _} -> {error, {lua_error, Reason}}
+    catch
+        error:{lua_error, Reason, _} -> {error, {lua_error, Reason}};
+        error:Reason -> {error, Reason}
+    end.
+
 -spec do_with_timeout(string() | binary(), dynamic(), non_neg_integer()) ->
     {ok, dynamic()} | {error, term()}.
 do_with_timeout(Code, St, TimeoutMs) ->
-    bounded_eval(
-        fun() ->
-            try luerl:do(ensure_string(Code), St) of
-                {ok, _Results, St1} -> {ok, St1};
-                {error, Errors, _} -> {error, {lua_error, Errors}};
-                {lua_error, Reason, _} -> {error, {lua_error, Reason}}
-            catch
-                error:{lua_error, Reason, _} -> {error, {lua_error, Reason}};
-                error:Reason -> {error, Reason}
-            end
-        end,
-        TimeoutMs
-    ).
+    case asobi_lua_vm:is_handle(St) of
+        true ->
+            %% Hot reload re-runs the script body against the live state, so
+            %% under `owned` it has to happen where the state is. The VM is the
+            %% killable thing here, which is the same guard the spawn gave -
+            %% except that overrunning now costs the state rather than a copy of
+            %% it, so a reload that hangs takes the zone's VM with it and the
+            %% bridge rebuilds. That is ADR 0015's stated price, paid on the one
+            %% path where the code being run is definitely new.
+            case asobi_lua_vm:op(St, {do, Code}, TimeoutMs) of
+                ok -> {ok, St};
+                {error, _} = Err -> Err
+            end;
+        false ->
+            bounded_eval(fun() -> do_inline(Code, St) end, TimeoutMs)
+    end.
 
 -spec init_sandboxed() -> dynamic().
 init_sandboxed() ->
@@ -246,6 +391,12 @@ init_sandboxed() ->
 %% surface as the same {error, {lua_error, _}} shape.
 -spec is_defined(atom(), dynamic()) -> boolean().
 is_defined(FuncName, St) ->
+    case asobi_lua_vm:is_handle(St) of
+        true -> asobi_lua_vm:op(St, {is_defined, FuncName}, ?VM_OP_TIMEOUT) =:= true;
+        false -> inline_is_defined(FuncName, St)
+    end.
+
+inline_is_defined(FuncName, St) ->
     try luerl:get_table_keys([atom_to_binary(FuncName)], St) of
         {ok, nil, _} -> false;
         {ok, _, _} -> true;
@@ -254,11 +405,102 @@ is_defined(FuncName, St) ->
         _:_ -> false
     end.
 
+%% --- ADR 0015 facade -------------------------------------------------------
+%%
+%% Each of these takes whatever `new/3` handed the bridge and threads it back,
+%% so a bridge reads the same either way. Under `copy` that value is the Luerl
+%% state and these are thin wrappers; under `owned` it is a handle and the work
+%% happens in the process that owns the state.
+%%
+%% The returned "state" is deliberately the same value that went in under
+%% `owned`: a handle does not change when the state behind it does, which is the
+%% entire point - nothing is copied back.
+
+-doc "Encode an Erlang term into the Lua heap, returning an opaque reference.".
+-spec encode(term(), dynamic()) -> {term(), dynamic()}.
+encode(Term, St) ->
+    case asobi_lua_vm:is_handle(St) of
+        false ->
+            luerl:encode(Term, St);
+        true ->
+            case asobi_lua_vm:op(St, {encode, Term}, ?VM_OP_TIMEOUT) of
+                {ok, Ref} -> {Ref, St};
+                {error, _} -> {nil, St}
+            end
+    end.
+
+-doc "Decode an opaque Lua reference back to an Erlang term.".
+-spec decode(dynamic(), dynamic()) -> term().
+decode(Ref, St) ->
+    case asobi_lua_vm:is_handle(St) of
+        false ->
+            luerl:decode(Ref, St);
+        true ->
+            case asobi_lua_vm:op(St, {decode, Ref}, ?VM_OP_TIMEOUT) of
+                {ok, Term} -> Term;
+                {error, _} -> nil
+            end
+    end.
+
+-spec get_table_key(dynamic(), dynamic(), dynamic()) -> {ok, term(), dynamic()} | term().
+get_table_key(Tab, Key, St) ->
+    case asobi_lua_vm:is_handle(St) of
+        false ->
+            luerl:get_table_key(Tab, Key, St);
+        true ->
+            case asobi_lua_vm:op(St, {get_table_key, Tab, Key}, ?VM_OP_TIMEOUT) of
+                {ok, Value} -> {ok, Value, St};
+                Other -> Other
+            end
+    end.
+
+-spec get_table_keys([dynamic()], dynamic()) -> {ok, term(), dynamic()} | term().
+get_table_keys(Path, St) ->
+    case asobi_lua_vm:is_handle(St) of
+        false ->
+            luerl:get_table_keys(Path, St);
+        true ->
+            case asobi_lua_vm:op(St, {get_table_keys, Path}, ?VM_OP_TIMEOUT) of
+                {ok, Value} -> {ok, Value, St};
+                Other -> Other
+            end
+    end.
+
+-spec set_table_keys([dynamic()], dynamic(), dynamic()) -> {ok, dynamic()} | term().
+set_table_keys(Path, Value, St) ->
+    case asobi_lua_vm:is_handle(St) of
+        false ->
+            luerl:set_table_keys(Path, Value, St);
+        true ->
+            case asobi_lua_vm:op(St, {set_table_keys, Path, Value}, ?VM_OP_TIMEOUT) of
+                ok -> {ok, St};
+                Other -> Other
+            end
+    end.
+
 -spec call(atom() | [atom() | binary()], [term()], dynamic()) ->
     {ok, [term()], dynamic()} | {error, term()}.
 call(FuncName, Args, St) when is_atom(FuncName) ->
     call([atom_to_binary(FuncName)], Args, St);
 call(FuncPath, Args, St) ->
+    case asobi_lua_vm:is_handle(St) of
+        true -> vm_call(FuncPath, Args, St, ?VM_OP_TIMEOUT);
+        false -> inline_call(FuncPath, Args, St)
+    end.
+
+%% Under `owned` the wall-clock budget IS the gen_server:call timeout, and a
+%% timeout kills the VM - see asobi_lua_vm:op/3. `call/3` has no budget of its
+%% own by design (it is the unbounded path, used where the caller already has
+%% one), so it gets the default rather than none: an unbounded call into another
+%% process would hang the zone forever on a script that spins, which is strictly
+%% worse than the copying path it replaces.
+vm_call(FuncPath, Args, St, Timeout) ->
+    case asobi_lua_vm:op(St, {call, FuncPath, Args}, Timeout) of
+        {ok, Result} -> {ok, Result, St};
+        {error, _} = Err -> Err
+    end.
+
+inline_call(FuncPath, Args, St) ->
     BinPath = [ensure_binary(P) || P <- FuncPath],
     try
         case luerl:call_function(BinPath, Args, St) of
@@ -280,7 +522,10 @@ call(FuncPath, Args, St) ->
 -spec call(atom() | [atom() | binary()], [term()], dynamic(), non_neg_integer()) ->
     {ok, [term()], dynamic()} | {error, timeout | heap_exhausted | term()}.
 call(FuncPath, Args, St, TimeoutMs) ->
-    bounded_eval(fun() -> call(FuncPath, Args, St) end, TimeoutMs).
+    case asobi_lua_vm:is_handle(St) of
+        true -> vm_call(FuncPath, Args, St, TimeoutMs);
+        false -> bounded_eval(fun() -> call(FuncPath, Args, St) end, TimeoutMs)
+    end.
 
 %% Spawn the work in a child with a bounded wall-clock budget, a bounded
 %% heap AND a bounded reduction count, monitor it, and translate the four
@@ -466,7 +711,7 @@ Bookkeeping is kept under `lua_gc` in the same map. Set
 -spec collect_state(map()) -> map().
 collect_state(#{lua_state := St} = State) ->
     Gc0 = maps:get(lua_gc, State, new_gc()),
-    Words = take_state_words(),
+    Words = state_size(St),
     Gc1 = report_state_size(Words, State, Gc0),
     Anchor = maps:get(game_state, State, nil),
     {St1, Gc2} = maybe_gc(St, Anchor, Words, Gc1),
@@ -486,6 +731,22 @@ collect_state(State) ->
 state_words() ->
     normalise_words(erlang:get(?STATE_WORDS_KEY)).
 -endif.
+
+%% Under `copy` the eval worker's heap immediately after the spawn *is* the
+%% copied state, so bounded_eval measures it exactly and for free. Under `owned`
+%% there is no copy to measure, and the process that holds the state can size
+%% itself for the same price - which is the one measurement that got cheaper
+%% rather than harder under ADR 0015.
+state_size(St) ->
+    case asobi_lua_vm:is_handle(St) of
+        false ->
+            take_state_words();
+        true ->
+            case asobi_lua_vm:op(St, state_words, ?VM_OP_TIMEOUT) of
+                {ok, Words} -> Words;
+                {error, _} -> undefined
+            end
+    end.
 
 %% Consume rather than read: a value left behind outlives the call it belongs
 %% to, and `gc_budget_us/1` acts on it, so staleness is not merely cosmetic.
@@ -597,8 +858,19 @@ maybe_gc(St, Anchor, Words, #{interval := Interval} = Gc) ->
             %% instead of short-circuiting on `enabled := false`.
             {St, maps:remove(retry_at, Gc#{enabled := false})};
         false ->
-            {Us, St1} = timer:tc(fun() -> collect(St, Anchor) end),
+            {Us, St1} = timer:tc(fun() -> do_collect(St, Anchor) end),
             {St1, next_gc(Us, gc_budget_us(Words), Interval, Gc)}
+    end.
+
+%% The scheduling decision stays here on the bridge; only the collection itself
+%% has to move, because under `owned` the state is not here to collect.
+do_collect(St, Anchor) ->
+    case asobi_lua_vm:is_handle(St) of
+        true ->
+            _ = asobi_lua_vm:op(St, {gc, Anchor}, ?VM_OP_TIMEOUT),
+            St;
+        false ->
+            collect(St, Anchor)
     end.
 
 %% What one collection may cost, in us. Scales with the state so that the
@@ -645,6 +917,18 @@ next_gc(Us, Budget, Interval, Gc) ->
 collect(St, Anchor) ->
     unanchor(luerl:gc(raw_anchor(Anchor, St))).
 
+-doc """
+Collect now, rooting `Anchor` across it.
+
+Public only for `asobi_lua_vm`, which owns the state under ADR 0015 and so is
+the only process that can run a collection on it. The adaptive scheduling that
+decides *whether* to collect stays with the bridge in `collect_state/1`; this is
+just the collection.
+""".
+-spec gc_now(term(), dynamic()) -> dynamic().
+gc_now(Anchor, St) ->
+    collect(St, Anchor).
+
 unanchor(St) ->
     raw_anchor(nil, St).
 
@@ -680,12 +964,24 @@ reachable and no collection can reclaim it.
 """.
 -spec anchor_ref(term(), dynamic()) -> dynamic().
 anchor_ref(Value, St) ->
-    raw_anchor_key(?REF_ANCHOR, Value, St).
+    case asobi_lua_vm:is_handle(St) of
+        true ->
+            _ = asobi_lua_vm:op(St, {anchor_ref, Value}, ?VM_OP_TIMEOUT),
+            St;
+        false ->
+            raw_anchor_key(?REF_ANCHOR, Value, St)
+    end.
 
 -doc "Drop the `anchor_ref/2` root.".
 -spec unanchor_ref(dynamic()) -> dynamic().
 unanchor_ref(St) ->
-    raw_anchor_key(?REF_ANCHOR, nil, St).
+    case asobi_lua_vm:is_handle(St) of
+        true ->
+            _ = asobi_lua_vm:op(St, unanchor_ref, ?VM_OP_TIMEOUT),
+            St;
+        false ->
+            raw_anchor_key(?REF_ANCHOR, nil, St)
+    end.
 
 -doc """
 Is `Value` still the value `anchor_ref/2` rooted?
@@ -698,7 +994,13 @@ across `call/3` therefore has to re-check rather than assume, and treat `false`
 as "nothing I am holding is safe to decode".
 """.
 -spec ref_anchored(term(), dynamic()) -> boolean().
-ref_anchored(Value, #luerl{g = G} = St) ->
+ref_anchored(Value, St) ->
+    case asobi_lua_vm:is_handle(St) of
+        true -> asobi_lua_vm:op(St, {ref_anchored, Value}, ?VM_OP_TIMEOUT) =:= true;
+        false -> inline_ref_anchored(Value, St)
+    end.
+
+inline_ref_anchored(Value, #luerl{g = G} = St) ->
     luerl_heap:raw_get_table_key(G, ?REF_ANCHOR, St) =:= Value.
 
 gc_disabled() ->

--- a/src/lua/asobi_lua_match.erl
+++ b/src/lua/asobi_lua_match.erl
@@ -81,7 +81,7 @@ init(Config) ->
     PreInstall = fun(St) -> asobi_lua_api:install(Ctx, St) end,
     case asobi_lua_loader:new(ScriptPath, ?INIT_TIMEOUT, PreInstall) of
         {ok, LuaSt0} ->
-            {EncConfig, LuaSt1} = luerl:encode(GameConfig, LuaSt0),
+            {EncConfig, LuaSt1} = asobi_lua_loader:encode(GameConfig, LuaSt0),
             case asobi_lua_loader:call(init, [EncConfig], LuaSt1, ?INIT_TIMEOUT) of
                 {ok, [GameState | _], LuaSt2} ->
                     {ok, #{
@@ -156,20 +156,28 @@ in `details` and never becomes an asobi error code (see `m:asobi_error`).
 join(PlayerId, Ctx, #{lua_state := LuaSt, game_state := GS} = State) when is_map(Ctx) ->
     %% Erlang maps must be encoded before they cross into Luerl - GS is
     %% already a Lua value, but Ctx arrives raw from the client.
-    {EncCtx, LuaSt0} = luerl:encode(Ctx, LuaSt),
+    {EncCtx, LuaSt0} = asobi_lua_loader:encode(Ctx, LuaSt),
     case asobi_lua_loader:call(join, [PlayerId, GS, EncCtx], LuaSt0, ?JOIN_TIMEOUT) of
         {ok, [Falsey | Rest], LuaSt1} when Falsey =:= nil; Falsey =:= false ->
-            {error, {join_refused, refusal_reason(Rest, LuaSt1)}};
+            Reason = refusal_reason(Rest, LuaSt1),
+            %% A refused join must not advance the game state, or a client can
+            %% drive a script by being turned away over and over. Discarding
+            %% LuaSt1 is that revert under `copy`; under `owned` the state lives
+            %% in the VM and the revert has to be asked for. Read after the
+            %% reason, which is decoded out of the state being undone.
+            _ = asobi_lua_loader:revert(LuaSt1),
+            {error, {join_refused, Reason}};
         {ok, [GS1 | _], LuaSt1} ->
             {ok, State#{lua_state => LuaSt1, game_state => GS1}};
         %% A `join` that falls off its end returns no values at all. Before
         %% refusal existed this was a case_clause that killed the match
         %% server and with it every player already in the roster; a script
         %% bug must cost the author their own join, not the whole match.
-        {ok, [], _LuaSt1} ->
+        {ok, [], LuaSt1} ->
             log_match_lua_error(
                 warning, join, join_returned_no_state, State, #{player_id => PlayerId}
             ),
+            _ = asobi_lua_loader:revert(LuaSt1),
             {error, {join_refused, undefined}};
         {error, Reason} ->
             log_match_lua_error(warning, join, Reason, State, #{player_id => PlayerId}),
@@ -184,7 +192,7 @@ join(PlayerId, Ctx, #{lua_state := LuaSt, game_state := GS} = State) when is_map
 
 -spec refusal_reason([dynamic()], dynamic()) -> binary() | undefined.
 refusal_reason([Value | _], LuaSt) ->
-    case luerl:decode(Value, LuaSt) of
+    case asobi_lua_loader:decode(Value, LuaSt) of
         Reason when is_binary(Reason), byte_size(Reason) =< ?MAX_REFUSAL_REASON, Reason =/= <<>> ->
             case is_printable_ascii(Reason) of
                 true -> Reason;
@@ -212,7 +220,7 @@ leave(PlayerId, #{lua_state := LuaSt, game_state := GS} = State) ->
 
 -spec handle_input(binary(), map(), map()) -> {ok, map()}.
 handle_input(PlayerId, Input, #{lua_state := LuaSt, game_state := GS} = State) ->
-    {EncInput, LuaSt1} = luerl:encode(Input, LuaSt),
+    {EncInput, LuaSt1} = asobi_lua_loader:encode(Input, LuaSt),
     %% No bounded_eval: the per-input spawn dominates real Lua work at
     %% high input rates. tick/1 still spawn-isolates. See
     %% guides/security-trust-model.md.
@@ -341,7 +349,7 @@ atomise_keys([Key | Rest], Map) ->
 
 -spec vote_resolved(binary(), map(), map()) -> {ok, map()}.
 vote_resolved(Template, Result, #{lua_state := LuaSt, game_state := GS} = State) ->
-    {EncResult, LuaSt1} = luerl:encode(Result, LuaSt),
+    {EncResult, LuaSt1} = asobi_lua_loader:encode(Result, LuaSt),
     case asobi_lua_loader:call(vote_resolved, [Template, EncResult, GS], LuaSt1, ?VOTE_TIMEOUT) of
         {ok, [GS1 | _], LuaSt2} ->
             {ok, State#{lua_state => LuaSt2, game_state => GS1}};
@@ -450,10 +458,10 @@ log_match_lua_error(Level, Callback, Reason, State, ExtraMeta) ->
 
 is_finished(GS, LuaSt) ->
     try
-        {ok, FinVal, LuaSt1} = luerl:get_table_key(GS, ~"_finished", LuaSt),
+        {ok, FinVal, LuaSt1} = asobi_lua_loader:get_table_key(GS, ~"_finished", LuaSt),
         case FinVal of
             true ->
-                case luerl:get_table_key(GS, ~"_result", LuaSt1) of
+                case asobi_lua_loader:get_table_key(GS, ~"_result", LuaSt1) of
                     {ok, ResRef, LuaSt2} -> {true, decode_to_map(ResRef, LuaSt2)};
                     _ -> {true, #{}}
                 end;
@@ -491,7 +499,9 @@ boot_throwaway_lua_state(Config, Caller) ->
                 probe => true
             },
             PreInstall = fun(St) -> asobi_lua_api:install(Ctx, St) end,
-            case asobi_lua_loader:new(ScriptPath, ?INIT_TIMEOUT, PreInstall) of
+            %% Copied, never owned: this state answers one question and is
+            %% dropped, so an ADR 0015 VM here would be a process nothing stops.
+            case asobi_lua_loader:new_copied(ScriptPath, ?INIT_TIMEOUT, PreInstall) of
                 {ok, LuaSt} ->
                     {ok, #{lua_state => LuaSt, script => ScriptPath}};
                 {error, Reason} ->

--- a/src/lua/asobi_lua_phases.erl
+++ b/src/lua/asobi_lua_phases.erl
@@ -15,7 +15,7 @@ module holds that decode logic once so neither bridge forks it.
 
 -spec decode_phases(term(), dynamic()) -> [map()].
 decode_phases(PhasesRef, LuaSt) ->
-    case luerl:decode(PhasesRef, LuaSt) of
+    case asobi_lua_loader:decode(PhasesRef, LuaSt) of
         Decoded when is_list(Decoded) ->
             lists:filtermap(
                 fun

--- a/src/lua/asobi_lua_reload.erl
+++ b/src/lua/asobi_lua_reload.erl
@@ -52,10 +52,17 @@ Operators running self-hosted with high zone counts who want to suppress
 per-tick stat overhead can set `asobi_lua.reload_mode` (or the
 `ASOBI_LUA_RELOAD` env var the release script reads) to:
 
-- `auto` (default) — mtime-poll every tick. Suitable for dev and
-  self-hosted volume-mount setups.
+- `auto` (default) — mtime-poll, at most once per
+  `asobi_lua.reload_poll_interval_ms` (default 200) per bridge. Suitable for
+  dev and self-hosted volume-mount setups.
 - `off` — never reload. Suitable for sealed-bundle prod where code
-  changes are container restarts. The per-tick `stat()` is skipped.
+  changes are container restarts. The `stat()` is skipped entirely.
+
+The poll interval is what decouples reload cost from tick rate. At 80 Hz the
+per-tick stat was 80 `stat()` calls per second **per zone**, which on a 225-zone
+grid is 18,000 a second to notice an edit a developer makes every few minutes;
+the interval makes that 5 per zone with reload latency no human can perceive
+(widgrensit/asobi#543). Set it to 0 for the old per-tick behaviour.
 """.
 
 -include_lib("kernel/include/logger.hrl").
@@ -67,6 +74,9 @@ per-tick stat overhead can set `asobi_lua.reload_mode` (or the
 %% the moment its mtime ticked.
 -define(RELOAD_TIMEOUT_MS, 5000).
 
+%% Smallest gap between two `stat()` calls on one bridge's script.
+-define(DEFAULT_POLL_INTERVAL_MS, 200).
+
 -spec maybe_hot_reload(map()) -> map().
 maybe_hot_reload(State) ->
     %% just_reloaded is a one-tick signal, not a state field - clear it
@@ -76,7 +86,33 @@ maybe_hot_reload(State) ->
     State0 = maps:remove(just_reloaded, State),
     case reload_mode() of
         off -> State0;
-        auto -> do_maybe_reload(State0)
+        auto -> maybe_poll(State0)
+    end.
+
+%% The stamp lives in the bridge's own state map rather than in the process
+%% dictionary because a match bridge and a zone bridge can share a process in
+%% tests, and a per-process stamp would have one starve the other.
+-spec maybe_poll(map()) -> map().
+maybe_poll(State) ->
+    case poll_interval_ms() of
+        0 ->
+            do_maybe_reload(State);
+        Interval ->
+            Now = erlang:monotonic_time(millisecond),
+            %% Defaulting the deadline to `Now` makes the first call poll:
+            %% monotonic time has an arbitrary origin and is routinely
+            %% negative, so 0 would be a deadline in the future on a fresh node.
+            case Now >= maps:get(reload_poll_at, State, Now) of
+                true -> do_maybe_reload(State#{reload_poll_at => Now + Interval});
+                false -> State
+            end
+    end.
+
+-spec poll_interval_ms() -> non_neg_integer().
+poll_interval_ms() ->
+    case asobi_lua_env:get_env(reload_poll_interval_ms) of
+        {ok, N} when is_integer(N), N >= 0 -> N;
+        _ -> ?DEFAULT_POLL_INTERVAL_MS
     end.
 
 -spec do_maybe_reload(map()) -> map().
@@ -142,6 +178,6 @@ reload_script(Path, LuaSt) ->
 
 -spec clear_require_cache(dynamic()) -> dynamic().
 clear_require_cache(LuaSt) ->
-    {Empty, LuaSt1} = luerl:encode(#{}, LuaSt),
-    {ok, LuaSt2} = luerl:set_table_keys([~"_ASOBI_LOADED"], Empty, LuaSt1),
+    {Empty, LuaSt1} = asobi_lua_loader:encode(#{}, LuaSt),
+    {ok, LuaSt2} = asobi_lua_loader:set_table_keys([~"_ASOBI_LOADED"], Empty, LuaSt1),
     LuaSt2.

--- a/src/lua/asobi_lua_vm.erl
+++ b/src/lua/asobi_lua_vm.erl
@@ -1,0 +1,212 @@
+-module(asobi_lua_vm).
+-moduledoc """
+A process that owns one Luerl state, so a callback stops costing a copy of it.
+
+ADR 0015. Every bounded Lua callback used to run in a process spawned per call
+(`asobi_lua_loader`'s `bounded_eval/2`), and the spawn copied the closure - which
+holds the whole persistent Luerl state - into the new process and back. That
+made the cost of a callback linear in the size of the state rather than in the
+work it does: roughly 7 ms per MB, before the script runs a line. Measured on an
+empty zone with an inert `zone_tick`, the copy was ~765 of the 883 reductions
+the whole bridge spent per tick.
+
+Here the state does not move. The bridge holds a pid and opaque Luerl
+references, and every `luerl:*` operation becomes a small message to the process
+that owns the state. The cost becomes O(work) instead of O(state).
+
+**The protocol is closed on purpose.** A caller sends an operation tuple, never
+a function - a `fun` crossing a module boundary cannot be checkpointed, and
+would defeat any future snapshot of a VM (see the project's own rule, and ADR
+0015's rejection of the Luerl trace-hook alternative for the same reason).
+
+**What this costs, and it is the whole argument.** Under the copying path the
+process killed on a timeout, heap or reduction overrun was a throwaway, so a
+runaway callback cost one tick and the zone carried on. Here the only killable
+thing is the process holding the state, so an overrun kills the state. What
+comes back and from where is the caller's problem: `asobi_lua_world` rebuilds a
+zone from its script and last snapshot, which is a path zones already had.
+
+Selected by `lua_vm_mode` and **off by default** - see
+`asobi_lua_loader:vm_mode/0`.
+""".
+-behaviour(gen_server).
+
+-export([start_link/1, stop/1, is_alive/1, is_handle/1]).
+-export([op/3]).
+-export([init/1, handle_call/3, handle_cast/2, terminate/2]).
+
+-include_lib("kernel/include/logger.hrl").
+
+-export_type([handle/0, op/0]).
+
+-opaque handle() :: {?MODULE, pid()}.
+
+%% The closed set of things a bridge may ask of the state it no longer holds.
+%% Luerl references are `dynamic()` throughout asobi for the same reason they
+%% are here: they are opaque handles into a heap the type checker cannot see.
+-type op() ::
+    {encode, term()}
+    | {decode, dynamic()}
+    | {get_table_key, dynamic(), dynamic()}
+    | {get_table_keys, [dynamic()]}
+    | {set_table_keys, [dynamic()], dynamic()}
+    | {call, atom() | [atom() | binary()], [dynamic()]}
+    | {is_defined, atom()}
+    | {do, string() | binary()}
+    | {anchor_ref, dynamic()}
+    | unanchor_ref
+    | {ref_anchored, dynamic()}
+    | {gc, dynamic()}
+    | revert
+    | state_words.
+
+-spec start_link(dynamic()) -> {ok, handle()} | {error, term()}.
+start_link(LuaSt) ->
+    case gen_server:start_link(?MODULE, LuaSt, []) of
+        {ok, Pid} -> {ok, {?MODULE, Pid}};
+        {error, _} = Err -> Err
+    end.
+
+-spec stop(handle()) -> ok.
+stop({?MODULE, Pid}) when is_pid(Pid) ->
+    try
+        gen_server:stop(Pid)
+    catch
+        %% Already gone, or going. Stopping a VM is cleanup, never a decision.
+        exit:_ -> ok
+    end,
+    ok.
+
+-doc """
+Is this an owned-VM handle at all - alive or not?
+
+Dispatch is on the *shape*, never on liveness. A handle whose VM has died is
+still a handle, and treating it as a raw Luerl state (which is what asking
+`is_alive/1` would do) hands a tuple to `luerl:encode/2` and crashes the caller
+instead of reporting `{error, vm_down}`.
+""".
+-spec is_handle(handle() | term()) -> boolean().
+is_handle({?MODULE, Pid}) -> is_pid(Pid);
+is_handle(_) -> false.
+
+-spec is_alive(handle() | term()) -> boolean().
+is_alive({?MODULE, Pid}) -> is_pid(Pid) andalso is_process_alive(Pid);
+is_alive(_) -> false.
+
+-doc """
+Run one operation against the owned state.
+
+`{error, vm_down}` and `{error, timeout}` are ordinary answers, not exceptions:
+the caller is a zone or match tick and must keep running whatever the script
+did. A timeout kills the VM on the way out, because a `gen_server:call` that
+timed out leaves the server still working on the request - and a Lua callback
+that has outrun its budget is exactly the thing that must not carry on holding
+the state.
+""".
+-spec op(handle() | term(), op(), timeout()) -> term() | {error, vm_down | timeout}.
+op({?MODULE, Pid}, Op, Timeout) when is_pid(Pid) ->
+    try
+        gen_server:call(Pid, Op, Timeout)
+    catch
+        exit:{noproc, _} ->
+            {error, vm_down};
+        exit:{normal, _} ->
+            {error, vm_down};
+        exit:{shutdown, _} ->
+            {error, vm_down};
+        exit:{{shutdown, _}, _} ->
+            {error, vm_down};
+        exit:{timeout, _} ->
+            _ = exit(Pid, kill),
+            {error, timeout}
+    end;
+op(_NotAHandle, _Op, _Timeout) ->
+    {error, vm_down}.
+
+%% --- gen_server ---
+
+-spec init(dynamic()) -> {ok, map()}.
+init(LuaSt) ->
+    %% For the first time the cap means what it says. Under the copying path an
+    %% absolute `max_heap_size` bounded the *eval worker*, which held a copy;
+    %% the real state lived in the parent and survived the kill untouched, so a
+    %% 690 MB state was 690 MB before and after. Here the capped process is the
+    %% one holding the state, so the number is a ceiling on the state itself.
+    ok = cap_heap(asobi_lua_loader:vm_max_heap_words()),
+    {ok, #{lua_state => LuaSt, prev => LuaSt}}.
+
+-spec cap_heap(non_neg_integer()) -> ok.
+cap_heap(0) ->
+    ok;
+cap_heap(Words) ->
+    _ = process_flag(max_heap_size, #{size => Words, kill => true, error_logger => true}),
+    ok.
+
+-spec handle_call(op(), gen_server:from(), map()) -> {reply, term(), map()}.
+handle_call({encode, Term}, _From, #{lua_state := St} = S) ->
+    {Ref, St1} = luerl:encode(Term, St),
+    {reply, {ok, Ref}, S#{lua_state => St1}};
+handle_call({decode, Ref}, _From, #{lua_state := St} = S) ->
+    {reply, {ok, luerl:decode(Ref, St)}, S};
+handle_call({get_table_key, Tab, Key}, _From, #{lua_state := St} = S) ->
+    case luerl:get_table_key(Tab, Key, St) of
+        {ok, Value, St1} -> {reply, {ok, Value}, S#{lua_state => St1}};
+        Other -> {reply, Other, S}
+    end;
+handle_call({get_table_keys, Path}, _From, #{lua_state := St} = S) ->
+    case luerl:get_table_keys(Path, St) of
+        {ok, Value, St1} -> {reply, {ok, Value}, S#{lua_state => St1}};
+        Other -> {reply, Other, S}
+    end;
+handle_call({set_table_keys, Path, Value}, _From, #{lua_state := St} = S) ->
+    case luerl:set_table_keys(Path, Value, St) of
+        {ok, St1} -> {reply, ok, S#{lua_state => St1}};
+        Other -> {reply, Other, S}
+    end;
+%% The pre-call state is kept so `revert` can put it back. That costs nothing:
+%% a Luerl state is immutable and the post-call one shares structure with it, so
+%% what is retained is exactly what the call changed - which is exactly what a
+%% revert has to be able to undo. This is not the "snapshot before each risky
+%% callback" that ADR 0015 rejects; that one is a copy, this one is a pointer.
+%%
+%% A raising call keeps the pre-call state as it stands, which is what the
+%% copying path did by discarding the state the failed call produced.
+handle_call({call, FuncPath, Args}, _From, #{lua_state := St} = S) ->
+    case asobi_lua_loader:call(FuncPath, Args, St) of
+        {ok, Result, St1} -> {reply, {ok, Result}, S#{lua_state => St1, prev => St}};
+        {error, Reason} -> {reply, {error, Reason}, S}
+    end;
+handle_call(revert, _From, #{prev := Prev} = S) ->
+    {reply, ok, S#{lua_state => Prev}};
+handle_call({is_defined, Name}, _From, #{lua_state := St} = S) ->
+    {reply, asobi_lua_loader:is_defined(Name, St), S};
+handle_call({do, Code}, _From, #{lua_state := St} = S) ->
+    case asobi_lua_loader:do_inline(Code, St) of
+        {ok, St1} -> {reply, ok, S#{lua_state => St1}};
+        {error, _} = Err -> {reply, Err, S}
+    end;
+handle_call({anchor_ref, Value}, _From, #{lua_state := St} = S) ->
+    {reply, ok, S#{lua_state => asobi_lua_loader:anchor_ref(Value, St)}};
+handle_call(unanchor_ref, _From, #{lua_state := St} = S) ->
+    {reply, ok, S#{lua_state => asobi_lua_loader:unanchor_ref(St)}};
+handle_call({ref_anchored, Value}, _From, #{lua_state := St} = S) ->
+    {reply, asobi_lua_loader:ref_anchored(Value, St), S};
+handle_call({gc, Anchor}, _From, #{lua_state := St} = S) ->
+    {reply, ok, S#{lua_state => asobi_lua_loader:gc_now(Anchor, St)}};
+handle_call(state_words, _From, #{lua_state := _} = S) ->
+    %% Measured on this process, which *is* the state - no copy to size.
+    {total_heap_size, Words} = process_info(self(), total_heap_size),
+    {reply, {ok, Words}, S};
+handle_call(_Unknown, _From, S) ->
+    {reply, {error, unknown_op}, S}.
+
+-spec handle_cast(term(), map()) -> {noreply, map()}.
+handle_cast(_Msg, S) ->
+    {noreply, S}.
+
+-spec terminate(term(), map()) -> ok.
+terminate(Reason, _S) when Reason =/= normal, Reason =/= shutdown ->
+    ?LOG_WARNING(#{event => lua_vm_terminated, reason => Reason}),
+    ok;
+terminate(_Reason, _S) ->
+    ok.

--- a/src/lua/asobi_lua_world.erl
+++ b/src/lua/asobi_lua_world.erl
@@ -45,7 +45,7 @@ of hot reloads.
 -include("asobi_ack.hrl").
 
 -export([init/1, join/2, join/3, leave/2, spawn_position/2]).
--export([zone_tick/2, handle_input/3, handle_input_batch/2, post_tick/2]).
+-export([zone_tick/2, handle_input/3, handle_input_batch/2, handle_effects/2, post_tick/2]).
 -ifdef(TEST).
 -export([zone_ctx/2, make_ctx/1]).
 -endif.
@@ -84,7 +84,7 @@ init(Config) ->
     PreInstall = fun(St) -> asobi_lua_api:install(make_ctx(Config), St) end,
     case asobi_lua_loader:new(ScriptPath, ?INIT_TIMEOUT, PreInstall) of
         {ok, LuaSt0} ->
-            {EncConfig, LuaSt1} = luerl:encode(GameConfig, LuaSt0),
+            {EncConfig, LuaSt1} = asobi_lua_loader:encode(GameConfig, LuaSt0),
             case asobi_lua_loader:call(init, [EncConfig], LuaSt1, ?INIT_TIMEOUT) of
                 {ok, [GameState | _], LuaSt2} ->
                     {ok, #{
@@ -141,7 +141,7 @@ state)` keeps working (Lua discards extra arguments) and
 join(PlayerId, Ctx, #{lua_state := LuaSt, game_state := GS} = State) when is_map(Ctx) ->
     %% Erlang maps must be encoded before they cross into Luerl - GS is
     %% already a Lua value, but Ctx arrives raw from the client.
-    {EncCtx, LuaSt0} = luerl:encode(Ctx, LuaSt),
+    {EncCtx, LuaSt0} = asobi_lua_loader:encode(Ctx, LuaSt),
     case asobi_lua_loader:call(join, [PlayerId, GS, EncCtx], LuaSt0, ?JOIN_TIMEOUT) of
         {ok, [GS1 | _], LuaSt1} ->
             {ok, State#{lua_state => LuaSt1, game_state => GS1}};
@@ -258,7 +258,7 @@ zone_tick(Entities, ZoneState0) when is_map(ZoneState0) ->
             undefined ->
                 {Entities, ZoneState};
             LuaSt ->
-                {EncEntities, LuaSt1} = luerl:encode(Entities, LuaSt),
+                {EncEntities, LuaSt1} = asobi_lua_loader:encode(Entities, LuaSt),
                 GS = maps:get(game_state, ZoneState, nil),
                 case
                     asobi_lua_loader:call(
@@ -306,8 +306,8 @@ stamp is used, so a script cannot ack something the client will not accept.
 handle_input(PlayerId, Input, Entities) ->
     case stashed_zone_state() of
         #{lua_state := LuaSt} = ZoneState ->
-            {EncInput, LuaSt1} = luerl:encode(Input, LuaSt),
-            {EncEntities, LuaSt2} = luerl:encode(Entities, LuaSt1),
+            {EncInput, LuaSt1} = asobi_lua_loader:encode(Input, LuaSt),
+            {EncEntities, LuaSt2} = asobi_lua_loader:encode(Entities, LuaSt1),
             %% No bounded_eval: handle_input is not a sandbox boundary, see
             %% guides/security-trust-model.md.
             case
@@ -330,6 +330,68 @@ handle_input(PlayerId, Input, Entities) ->
         _ ->
             {ok, Entities}
     end.
+
+-doc """
+Delegates a tick's cross-zone effects to the script's `handle_effects`.
+
+```lua
+function handle_effects(effects, entities)
+  for _, e in ipairs(effects) do
+    local target = entities[e.entity_id]
+    target.hp = target.hp - (e.event.damage or 0)
+  end
+  return entities
+end
+```
+
+Batched, and inline on the zone process for the same reason
+`handle_input_batch/2` is: the entity map is encoded once for the whole tick's
+effects, and the copy a bounded call would make is the cost
+`widgrensit/asobi#543` is about. asobi has already filtered the list to effects
+naming an entity this zone still owns, so `entities[e.entity_id]` is never nil.
+
+A script with no `handle_effects` gets an error logged once per limiter window
+and its effects dropped - silently ignoring them would make a missing handler
+look like a delivery bug.
+""".
+-spec handle_effects([{binary(), map()}], map()) -> {ok, map()}.
+handle_effects(Effects, Entities) ->
+    case stashed_zone_state() of
+        #{lua_state := LuaSt} = ZoneState ->
+            %% asobi_zone cannot make this call for us: the bridge module always
+            %% exports handle_effects/2, so `function_exported` there says
+            %% nothing about whether the *script* defines one. Luerl cannot tell
+            %% an undefined global apart from a raising one either (see
+            %% asobi_lua_loader:is_defined/2), so the check has to be explicit or
+            %% a missing handler is reported as a script crash.
+            case asobi_lua_loader:is_defined(handle_effects, LuaSt) of
+                false ->
+                    log_lua_error(handle_effects, no_handler, ZoneState),
+                    {ok, Entities};
+                true ->
+                    call_handle_effects(Effects, Entities, LuaSt, ZoneState)
+            end;
+        _ ->
+            {ok, Entities}
+    end.
+
+call_handle_effects(Effects, Entities, LuaSt, ZoneState) ->
+    {EncEffects, LuaSt1} = asobi_lua_loader:encode(encode_effects(Effects), LuaSt),
+    {EncEntities, LuaSt2} = asobi_lua_loader:encode(Entities, LuaSt1),
+    case asobi_lua_loader:call(handle_effects, [EncEffects, EncEntities], LuaSt2) of
+        {ok, [Ents1 | _], LuaSt3} ->
+            erlang:put(?PD_KEY, ZoneState#{lua_state => LuaSt3}),
+            {ok, asobi_lua_api:atomize_entities(decode_to_map(Ents1, LuaSt3))};
+        {ok, [], LuaSt3} ->
+            erlang:put(?PD_KEY, ZoneState#{lua_state => LuaSt3}),
+            {ok, Entities};
+        {error, Reason} ->
+            log_lua_error(handle_effects, Reason, ZoneState),
+            {ok, Entities}
+    end.
+
+encode_effects(Effects) ->
+    [#{~"entity_id" => Id, ~"event" => Event} || {Id, Event} <- Effects].
 
 -doc """
 Apply a tick's whole input queue with one encode of the entity map.
@@ -374,7 +436,7 @@ handle_input_batch([], Entities) ->
 handle_input_batch(Inputs, Entities) ->
     case stashed_zone_state() of
         #{lua_state := LuaSt} = ZoneState ->
-            {EncEntities, LuaSt1} = luerl:encode(Entities, LuaSt),
+            {EncEntities, LuaSt1} = asobi_lua_loader:encode(Entities, LuaSt),
             {EncEntities1, Outcomes, LuaSt2, ZoneState1} = run_input_batch(
                 Inputs, EncEntities, LuaSt1, ZoneState, []
             ),
@@ -416,7 +478,7 @@ run_input_batch([{PlayerId, Input} | Rest], Enc, LuaSt, ZoneState, Acc) ->
     %% because `Enc` changes - whatever the last script returned is what the
     %% next one is handed.
     LuaSt0 = asobi_lua_loader:anchor_ref(Enc, LuaSt),
-    {EncInput, LuaSt1} = luerl:encode(Input, LuaSt0),
+    {EncInput, LuaSt1} = asobi_lua_loader:encode(Input, LuaSt0),
     case asobi_lua_loader:call(handle_input, [PlayerId, EncInput, Enc], LuaSt1) of
         {ok, Rets, LuaSt2} ->
             %% `_G` is script-writable, so a script can clear asobi's root with
@@ -429,7 +491,18 @@ run_input_batch([{PlayerId, Input} | Rest], Enc, LuaSt, ZoneState, Acc) ->
                         {keep, Enc1, Outcome} ->
                             run_input_batch(Rest, Enc1, LuaSt2, ZoneState, [Outcome | Acc]);
                         {revert, Outcome} ->
-                            run_input_batch(Rest, Enc, LuaSt0, ZoneState, [Outcome | Acc])
+                            %% Carrying LuaSt0 onward is the revert under
+                            %% `copy`; under `owned` the mutation already
+                            %% happened in the VM, so it has to be undone
+                            %% explicitly. Same intent, said twice because the
+                            %% two modes disagree about who holds the state.
+                            run_input_batch(
+                                Rest,
+                                Enc,
+                                asobi_lua_loader:revert(LuaSt0),
+                                ZoneState,
+                                [Outcome | Acc]
+                            )
                     end;
                 false ->
                     log_anchor_cleared(ZoneState),
@@ -474,7 +547,9 @@ there is no Erlang-side copy to fall back on - but the Luerl state is
 functional, so reverting to the state from before the call reverts the heap the
 mutation lives in. It costs nothing and it is the difference between "returning
 nothing rejects the input" and "returning nothing keeps whatever you touched,
-including another player's entity".
+including another player's entity". Under ADR 0015's `owned` mode the state is
+not the caller's to drop, so the same revert is asked of the VM explicitly -
+see `asobi_lua_loader:revert/1`.
 
 The same revert runs on a Lua exception, which is why a raising handler leaves
 no input frame behind either.
@@ -699,7 +774,7 @@ put_known_templates(_State, _Templates) ->
 
 -spec on_world_recovered(map(), map()) -> {ok, map()}.
 on_world_recovered(Snapshots, #{lua_state := LuaSt, game_state := GS} = State) ->
-    {EncSnap, LuaSt1} = luerl:encode(Snapshots, LuaSt),
+    {EncSnap, LuaSt1} = asobi_lua_loader:encode(Snapshots, LuaSt),
     case asobi_lua_loader:call(on_world_recovered, [EncSnap, GS], LuaSt1, ?INIT_TIMEOUT) of
         {ok, [GS1 | _], LuaSt2} ->
             {ok, State#{lua_state => LuaSt2, game_state => GS1}};
@@ -770,7 +845,7 @@ on_zone_unloaded({CX, CY}, #{lua_state := LuaSt, game_state := GS} = State) ->
 ]).
 
 decode_terrain_provider(Result, LuaSt) ->
-    Decoded = luerl:decode(Result, LuaSt),
+    Decoded = asobi_lua_loader:decode(Result, LuaSt),
     case Decoded of
         nil ->
             none;
@@ -865,7 +940,7 @@ log_lua_error(Callback, Reason, StateOrZoneState) ->
     asobi_lua_game_error:emit(Callback, Reason, Script).
 
 decode_position(PosTable, LuaSt) ->
-    case luerl:decode(PosTable, LuaSt) of
+    case asobi_lua_loader:decode(PosTable, LuaSt) of
         Decoded when is_list(Decoded) ->
             X = proplists:get_value(~"x", Decoded, 0.0),
             Y = proplists:get_value(~"y", Decoded, 0.0),
@@ -876,14 +951,14 @@ decode_position(PosTable, LuaSt) ->
 
 check_post_tick_result(GS, LuaSt) ->
     try
-        case luerl:get_table_key(GS, ~"_finished", LuaSt) of
+        case asobi_lua_loader:get_table_key(GS, ~"_finished", LuaSt) of
             {ok, true, LuaSt1} ->
-                case luerl:get_table_key(GS, ~"_result", LuaSt1) of
+                case asobi_lua_loader:get_table_key(GS, ~"_result", LuaSt1) of
                     {ok, ResRef, LuaSt2} -> {finished, decode_to_map(ResRef, LuaSt2)};
                     _ -> {finished, #{}}
                 end;
             _ ->
-                case luerl:get_table_key(GS, ~"_vote", LuaSt) of
+                case asobi_lua_loader:get_table_key(GS, ~"_vote", LuaSt) of
                     {ok, VoteRef, LuaSt1} when VoteRef =/= nil, VoteRef =/= false ->
                         {vote, decode_to_map(VoteRef, LuaSt1)};
                     _ ->
@@ -895,7 +970,7 @@ check_post_tick_result(GS, LuaSt) ->
     end.
 
 decode_zone_states(ZoneStatesRef, LuaSt) ->
-    case luerl:decode(ZoneStatesRef, LuaSt) of
+    case asobi_lua_loader:decode(ZoneStatesRef, LuaSt) of
         Decoded when is_list(Decoded) -> decode_zone_states_acc(Decoded, #{});
         _ -> #{}
     end.
@@ -1024,7 +1099,7 @@ to_integer(N) ->
     asobi_lua_phases:to_integer(N).
 
 decode_spawn_templates(TemplatesRef, LuaSt) ->
-    case luerl:decode(TemplatesRef, LuaSt) of
+    case asobi_lua_loader:decode(TemplatesRef, LuaSt) of
         Decoded when is_list(Decoded) -> decode_spawn_templates_acc(Decoded, #{});
         _ -> #{}
     end.
@@ -1165,7 +1240,7 @@ dump_zone_state(ZoneState) ->
 -spec restore_game_state(map(), dynamic()) -> {dynamic(), dynamic()}.
 restore_game_state(ZoneState0, LuaSt) ->
     case maps:get(~"game_state", ZoneState0, undefined) of
-        Map when is_map(Map) -> luerl:encode(Map, LuaSt);
+        Map when is_map(Map) -> asobi_lua_loader:encode(Map, LuaSt);
         _ -> {nil, LuaSt}
     end.
 
@@ -1177,6 +1252,14 @@ zone_ctx(Config, TemplatesTab) ->
         zone_pid => self(),
         match_pid => maps:get(world_server_pid, Config, self()),
         match_id => maps:get(match_id, GameConfig, maps:get(world_id, Config, undefined)),
+        %% The zone's own identity in the grid, for the neighbour-facing calls.
+        %% Fixed for the zone's life, so a Ctx snapshot is correct here in a way
+        %% it is not for the template set above.
+        world_id => maps:get(world_id, Config, undefined),
+        coords => maps:get(coords, Config, undefined),
+        zone_size => maps:get(zone_size, Config, undefined),
+        grid_size => maps:get(grid_size, Config, undefined),
+        border_tab => maps:get(border_tab, Config, undefined),
         script => maps:get(lua_script, GameConfig, undefined),
         %% asobi_lua#110 + asobi#253: NOT a known_templates snapshot here -
         %% a table reference, not the map value. asobi_lua_api:known_template/2
@@ -1228,7 +1311,9 @@ boot_throwaway_lua_state(Config, Caller) ->
         ScriptPath when is_binary(ScriptPath); is_list(ScriptPath) ->
             ProbeCtx = Ctx#{probe => true},
             PreInstall = fun(St) -> asobi_lua_api:install(ProbeCtx, St) end,
-            case asobi_lua_loader:new(ScriptPath, ?GENERATE_TIMEOUT, PreInstall) of
+            % Copied, never owned: this state answers one question and is
+            % dropped, so an ADR 0015 VM here would be a process nothing stops.
+            case asobi_lua_loader:new_copied(ScriptPath, ?GENERATE_TIMEOUT, PreInstall) of
                 {ok, LuaSt} ->
                     {ok, #{lua_state => LuaSt, script => ScriptPath}};
                 {error, Reason} ->

--- a/src/lua/bots/asobi_bot.erl
+++ b/src/lua/bots/asobi_bot.erl
@@ -151,7 +151,7 @@ send_input(#{lua_state := undefined, bot_id := BotId, match_pid := MatchPid, gam
 send_input(
     #{lua_state := LuaSt, bot_id := BotId, match_pid := MatchPid, game_state := GS} = State
 ) ->
-    {EncGS, LuaSt1} = luerl:encode(GS, LuaSt),
+    {EncGS, LuaSt1} = asobi_lua_loader:encode(GS, LuaSt),
     Input =
         case asobi_lua_loader:call(think, [BotId, EncGS], LuaSt1, 50) of
             {ok, [Result | _], LuaSt2} ->
@@ -302,7 +302,7 @@ pick_random_option(Options) ->
 decode_result(Result, _LuaSt) when is_map(Result) ->
     Result;
 decode_result(Result, LuaSt) ->
-    case luerl:decode(Result, LuaSt) of
+    case asobi_lua_loader:decode(Result, LuaSt) of
         L when is_list(L) -> props_to_map(L, #{});
         M when is_map(M) -> M;
         _ -> #{}

--- a/src/lua/bots/asobi_bot_spawner.erl
+++ b/src/lua/bots/asobi_bot_spawner.erl
@@ -423,9 +423,9 @@ load_bot_names(#{names := Names}) when is_list(Names) ->
 load_bot_names(#{script := Script}) when is_binary(Script); is_list(Script) ->
     case asobi_lua_loader:new(Script) of
         {ok, St} ->
-            case luerl:get_table_keys([~"names"], St) of
+            case asobi_lua_loader:get_table_keys([~"names"], St) of
                 {ok, Val, St1} when Val =/= nil, Val =/= false ->
-                    case luerl:decode(Val, St1) of
+                    case asobi_lua_loader:decode(Val, St1) of
                         Props when is_list(Props) ->
                             [V || {_, V} <- Props, is_binary(V)];
                         _ ->

--- a/src/world/asobi_world.erl
+++ b/src/world/asobi_world.erl
@@ -174,6 +174,31 @@ and the only cross-check on `batch_result/3` goes with it.
 ) ->
     {ok, Entities1 :: map(), Outcomes :: [input_outcome()]}.
 
+-doc """
+Optional: apply this tick's cross-zone effects.
+
+An effect arrives from a *neighbouring* zone that could see one of this zone's
+entities in the border mirror and asked for something to happen to it -
+`game.zone.apply` in Lua, `asobi_zone:apply_effect/3` in Erlang. The neighbour
+never writes the entity; this zone does, in its own tick, which is what keeps a
+single writer per entity while still letting a shot fired in one zone land in
+the next (widgrensit/asobi#544).
+
+Delivered after the tick's inputs, batched, and already filtered to effects
+naming an entity this zone still owns - a target that died or crossed away
+between the read and the tick is dropped rather than handed over as a nil
+lookup. Returning something that is not a map drops the tick's effects.
+
+A world that never calls `game.zone.apply` never needs this callback. One that
+does and has not defined it gets a rate-limited error rather than silence: a
+dropped effect is indistinguishable from a delivery bug from the game's side.
+""".
+-callback handle_effects(
+    Effects :: [{EntityId :: binary(), Event :: map()}],
+    Entities :: map()
+) ->
+    {ok, Entities1 :: map()} | Entities1 :: map().
+
 -doc "Global post-tick hook: continue, trigger a vote, or finish the world.".
 -callback post_tick(Tick :: non_neg_integer(), GameState :: term()) ->
     {ok, GameState1 :: term()}
@@ -273,5 +298,6 @@ plain terms. The inverse of `init_zone_state`'s restore path.
     init_zone_state/2,
     dump_zone_state/1,
     handle_input/3,
-    handle_input_batch/2
+    handle_input_batch/2,
+    handle_effects/2
 ]).

--- a/src/world/asobi_world_instance.erl
+++ b/src/world/asobi_world_instance.erl
@@ -36,6 +36,11 @@ init(Config) ->
     },
     GridSize = maps:get(grid_size, Config, 10),
     ZoneSize = maps:get(zone_size, Config, 200),
+    %% Owned by this supervisor so it dies exactly when the world does. No asobi
+    %% process traps exits, so nothing's terminate/2 runs on a supervisor
+    %% shutdown - hanging the mirror's cleanup off one would strand a whole grid
+    %% of rows on every world teardown. See asobi_zone_border.
+    BorderTab = asobi_zone_border:new(),
     ZoneManagerConfig = #{
         world_id => maps:get(world_id, Config, undefined),
         instance_sup => self(),
@@ -47,11 +52,15 @@ init(Config) ->
     },
     TickerConfig = #{
         tick_rate => maps:get(tick_rate, Config, 50),
+        %% Was never threaded through, so a world declaring `cold_tick_divisor`
+        %% silently got the ticker's own default (widgrensit/asobi#543).
+        cold_tick_divisor => maps:get(cold_tick_divisor, Config, 10),
         world_id => maps:get(world_id, Config, undefined),
         world_pid => self()
     },
     WorldConfig = Config#{
-        instance_sup => self()
+        instance_sup => self(),
+        border_tab => BorderTab
     },
     Children = [
         #{

--- a/src/world/asobi_world_server.erl
+++ b/src/world/asobi_world_server.erl
@@ -643,7 +643,13 @@ configure_zone_manager(
     } = State
 ) ->
     Templates = get_spawn_templates(GameMod, Config),
-    Persistence = maps:get(persistence, Config, false),
+    %% `persistent` is the public global a game declares
+    %% (guides/configuration.md); `persistence` is the internal zone-config key
+    %% every zone-side reader wants. Nothing translated between them, so
+    %% `persistence` was never set anywhere and the zone snapshot path was dead
+    %% for every world - a world declaring `persistent = true` kept its
+    %% snapshots on finish and restored from a set that was never written.
+    Persistence = maps:get(persistent, Config, false),
     TerrainStorePid = start_terrain_store(GameMod, Config),
     BaseZoneConfig = #{
         world_id => WorldId,
@@ -664,7 +670,17 @@ configure_zone_manager(
         %% resolve_zone_crossings/1 in asobi_zone.
         zone_size => ZoneSize,
         grid_size => GridSize,
-        rehome_margin => RehomeMargin
+        rehome_margin => RehomeMargin,
+        %% Fraction of zone_size each zone mirrors for its neighbours to read.
+        %% Off unless the game asks: see asobi_zone's ?DEFAULT_BORDER_BAND for
+        %% the measured cost (widgrensit/asobi#544).
+        border_band => maps:get(border_band, Config, 0),
+        %% This world's border mirror, owned by its instance supervisor. Absent
+        %% for a world started outside one, and then publishing is a no-op.
+        border_tab => maps:get(border_tab, Config, undefined),
+        %% Read by asobi_zone:init/1 and, before #543, never put anywhere the
+        %% zone could read it from.
+        spatial_grid_cell_size => maps:get(spatial_grid_cell_size, Config, undefined)
     },
     asobi_zone_manager:set_zone_config(ZoneManagerPid, BaseZoneConfig),
     State#{terrain_store_pid => TerrainStorePid}.
@@ -696,12 +712,13 @@ spawn_zones(
         game_state := GS
     } = State
 ) ->
-    Persistence = maps:get(persistence, Config, false),
+    %% See configure_zone_manager/1 for why this reads `persistent`.
+    Persistence = maps:get(persistent, Config, false),
     AllCoords = [{X, Y} || X <- lists:seq(0, GridSize - 1), Y <- lists:seq(0, GridSize - 1)],
     {ZoneStates, Entities, _SpawnerStates, GS1} =
         case Persistence of
             true ->
-                case asobi_zone_snapshotter:load_snapshots(WorldId) of
+                case safe_load_snapshots(WorldId) of
                     {ok, Snapshots} when map_size(Snapshots) > 0 ->
                         ZS = maps:map(fun(_, #{zone_state := V}) -> V end, Snapshots),
                         Ents = maps:map(fun(_, #{entities := V}) -> V end, Snapshots),
@@ -731,6 +748,26 @@ spawn_zones(
     %% Add recovered entities to zones
     restore_entities(AllCoords, Entities, ZoneManagerPid, WorldId),
     State#{game_state => GS1}.
+
+%% Mirrors asobi_zone:safe_load_snapshot/2. Until #543 nothing ever set
+%% `persistence`, so this call could not run and an unreachable database at
+%% world start could not be reached either. Now that it can, a raise here would
+%% take down the world server rather than starting the world un-restored, which
+%% is strictly worse: the snapshots are still on disk for the next attempt.
+-spec safe_load_snapshots(binary()) -> {ok, map()} | {error, term()}.
+safe_load_snapshots(WorldId) ->
+    try asobi_zone_snapshotter:load_snapshots(WorldId) of
+        {ok, _} = Ok -> Ok;
+        {error, _} = Err -> Err
+    catch
+        Class:Reason ->
+            ?LOG_ERROR(#{
+                event => world_snapshot_load_failed,
+                world_id => WorldId,
+                reason => {Class, Reason}
+            }),
+            {error, {Class, Reason}}
+    end.
 
 -spec restore_entities([term()], map(), pid() | atom(), binary()) -> ok.
 restore_entities([], _Entities, _ZoneManagerPid, _WorldId) ->

--- a/src/world/asobi_world_ticker.erl
+++ b/src/world/asobi_world_ticker.erl
@@ -159,13 +159,27 @@ handle_info(
 ) ->
     NextTick = Tick + 1,
     NextTickCount = TickCount + 1,
+    %% Under a zone manager the active set is the manager's, but which of those
+    %% zones are cold is still this ticker's own bookkeeping - it is fed by
+    %% asobi_zone's promote/demote casts. Before widgrensit/asobi#543 this
+    %% branch discarded `cold_zones` outright. That was not the only reason
+    %% `cold_tick_divisor` was inert: nothing anywhere called promote_zone/2 or
+    %% demote_zone/2, and `set_zones/3` (the only path that populates the static
+    %% lists) has no caller in src/ either, so no world of any shape ever had a
+    %% cold zone. This branch is what would have kept it inert for a lazy world
+    %% even after the zone side started classifying itself.
+    %%
+    %% Partitioning the manager's list also prunes the cold set: a zone that has
+    %% been reaped is absent from `AllZones` and so drops out of `cold_zones`
+    %% below without needing a `remove_zone` cast to arrive.
     {Hot, Cold} =
         case ZoneManager of
             undefined ->
                 {StaticHot, StaticCold};
             ZMPid ->
                 AllZones = asobi_zone_manager:get_active_zones(ZMPid),
-                {AllZones, []}
+                ColdSet = maps:from_keys(StaticCold, []),
+                lists:partition(fun(Z) -> not is_map_key(Z, ColdSet) end, AllZones)
         end,
     TickCold = (NextTickCount rem ColdTickDivisor) =:= 0,
     %% `uniq` because a zone dispatched twice in one tick replies twice, and
@@ -195,6 +209,8 @@ handle_info(
     State1 = State#{
         tick => NextTick,
         tick_count => NextTickCount,
+        hot_zones => Hot,
+        cold_zones => Cold,
         tick_started_at => erlang:monotonic_time(millisecond),
         tick_zone_count => length(ZonesToTick),
         pending => maps:merge(Pending0, maps:from_keys(ZonesToTick, NextTick)),

--- a/src/world/asobi_zone.erl
+++ b/src/world/asobi_zone.erl
@@ -14,6 +14,7 @@ via `asobi_spatial`. Zones are created and reaped lazily as players move.
 -export([get_entities/1, get_subscriber_count/1, sync/1]).
 -export([start_entity_timer/2, cancel_entity_timer/3]).
 -export([query_radius/3, query_rect/3]).
+-export([apply_effect/3, whereis_zone/2]).
 -export([init/1, handle_call/3, handle_cast/2, handle_continue/2, handle_info/2, terminate/2]).
 -ifdef(TEST).
 -export([shape_of/1]).
@@ -29,6 +30,32 @@ via `asobi_spatial`. Zones are created and reaped lazily as players move.
 -define(DEFAULT_ZONE_SIZE, 200).
 -define(DEFAULT_GRID_SIZE, 10).
 -define(DEFAULT_REHOME_MARGIN, 0.15).
+%% Fraction of `zone_size` a zone mirrors into `asobi_zone_border` for its
+%% neighbours to read. **Off by default**, because publishing costs every world
+%% a filter plus a copy of the band into ETS on every tick whether or not
+%% anything reads it. `guides/world-server.md` carries the measured figure and
+%% the reasoning; it is not repeated here so there is only one copy of it to
+%% drift. ?DEFAULT_REHOME_MARGIN is the value to reach for when turning it on.
+-define(DEFAULT_BORDER_BAND, 0).
+%% A fraction, so anything outside [0, 1] is a typo rather than an intent. The
+%% Lua config path already refuses one (asobi_lua_config:maybe_add_fraction/3);
+%% an Erlang-declared game mode reaches asobi_game_modes:forward_optional/3
+%% unvalidated, and `border_band => 50` would put every entity in the zone
+%% inside the band and copy the whole map into ETS every tick.
+-define(MAX_BORDER_BAND, 1).
+%% Cross-zone effects a zone will hold for one tick, by count and by size. The
+%% queue is drained every tick, so this only bites when a neighbour is casting
+%% faster than this zone ticks - which is a script fault, not traffic.
+%%
+%% Both bounds, because a count alone bounds nothing that matters: 256 entries
+%% of an arbitrary Lua table is an arbitrary number of megabytes on this
+%% process's heap. The sender is bounded too and more tightly
+%% (`asobi_lua_api:effect_within_budget/1`), which is the bound that protects
+%% the *mailbox*; this one protects the queue behind it, and holds for an
+%% Erlang game module calling `apply_effect/3` directly, which no sender-side
+%% budget covers.
+-define(MAX_EFFECT_QUEUE, 256).
+-define(MAX_EFFECT_BYTES_QUEUED, 1_048_576).
 %% Bound on the per-tick zone-manager call an NPC crossing into an unloaded
 %% neighbour makes (widgrensit/asobi#271). The manager's own work there is
 %% an ETS lookup plus a supervisor:start_child (the new zone's snapshot load
@@ -167,6 +194,35 @@ despawn_entity(Pid, EntityId) ->
 query_radius(Pid, Center, Radius) ->
     narrow_id_pos_list(gen_server:call(Pid, {query_radius, Center, Radius})).
 
+-doc """
+The pid currently serving `Coords` in `WorldId`, if one is running.
+
+Deliberately never creates the zone, unlike the crossing path's
+`target_zone_pid/2`: this answers "who owns what I can already see", and a
+coordinate with no live zone has nothing in the border mirror to have seen.
+""".
+-spec whereis_zone(binary(), {integer(), integer()}) -> {ok, pid()} | error.
+whereis_zone(WorldId, Coords) ->
+    case pg:get_members(?PG_SCOPE, {asobi_zone, WorldId, Coords}) of
+        [Pid | _] when is_pid(Pid) -> {ok, Pid};
+        _ -> error
+    end.
+
+-doc """
+Deliver `Event` to `EntityId`, which this zone owns.
+
+The point of it is what it does *not* do: the caller never touches the entity.
+A zone that can see a neighbour's entity through `asobi_zone_border` can ask
+the owning zone to act on it, and the owning zone applies it in its own tick,
+in order, under its own script. That keeps single-writer ownership intact
+while still letting a projectile resolved in one zone hit a target in the
+next - the case `guides/world-server.md` documents as impossible today
+(widgrensit/asobi#544).
+""".
+-spec apply_effect(pid(), binary(), map()) -> ok.
+apply_effect(Pid, EntityId, Event) when is_binary(EntityId), is_map(Event) ->
+    gen_server:cast(Pid, {entity_effect, EntityId, Event}).
+
 -spec query_rect(pid(), {number(), number()}, {number(), number()}) ->
     [{binary(), {number(), number()}}].
 query_rect(Pid, TopLeft, BottomRight) ->
@@ -196,7 +252,24 @@ init(Config) ->
     ZoneSize = maps:get(zone_size, Config, ?DEFAULT_ZONE_SIZE),
     GridSize = maps:get(grid_size, Config, ?DEFAULT_GRID_SIZE),
     RehomeMargin = maps:get(rehome_margin, Config, ?DEFAULT_REHOME_MARGIN),
+    BorderBand = clamp_border_band(maps:get(border_band, Config, ?DEFAULT_BORDER_BAND)),
+    BorderTab = maps:get(border_tab, Config, undefined),
+    %% terminate/2 is where this zone writes its final snapshot, clears its ETS
+    %% crash backup, forgets its rate-limiter keys and drops its border row.
+    %% None of that ran on a supervisor shutdown - which is to say on world
+    %% teardown, the one time a final snapshot is the whole point - because a
+    %% gen_server that does not trap exits is killed outright by the shutdown
+    %% signal. Paired with `shutdown => 5000` on the child spec in
+    %% asobi_zone_sup, without which the supervisor would brutal-kill it anyway.
+    process_flag(trap_exit, true),
     pg:join(?PG_SCOPE, {asobi_zone, WorldId, Coords}, self()),
+    %% Reclaim whatever the previous incarnation of this zone left behind. This
+    %% gen_server does not trap exits, so `terminate/2` does not run on a
+    %% supervisor shutdown, a linked crash or a `one_for_all` sibling restart -
+    %% and `border_live => false` below means the restarted zone would otherwise
+    %% never delete the row it inherited, leaving neighbours seeing a dead entity
+    %% at its death position for as long as the world lasts.
+    asobi_zone_border:clear(maps:get(border_tab, Config, undefined), Coords),
     %% Recover entity state from ETS backup if available (zone crash recovery)
     RecoveredEntities = recover_zone_state(WorldId, Coords),
     Templates = maps:get(spawn_templates, Config, #{}),
@@ -231,6 +304,33 @@ init(Config) ->
             zone_size => ZoneSize,
             grid_size => GridSize,
             rehome_margin => RehomeMargin,
+            %% In world units, resolved once here rather than per tick, so a
+            %% zone publishes the same band for its whole life even if the
+            %% config map is rebuilt under it.
+            border_band => BorderBand * ZoneSize,
+            border_tab => BorderTab,
+            %% Whether this zone currently has a row in asobi_zone_border, so a
+            %% zone that has published nothing never pays a delete.
+            border_live => false,
+            %% Effects other zones have addressed at entities this zone owns,
+            %% newest-first like input_queue and reversed at drain.
+            effect_queue => [],
+            %% Counted rather than measured with length/1: the cap is checked on
+            %% every inbound effect cast, so an O(n) check would be O(n^2) per
+            %% tick exactly when the queue is under pressure.
+            effect_count => 0,
+            effect_bytes => 0,
+            %% Counted rather than reported per message: unlike every other
+            %% game_error kind, this one's rate is set by another process's send
+            %% loop, so a telemetry fan-out per dropped cast would make the
+            %% drop path more expensive for the victim than the accept path -
+            %% which inverts the point of a cap. Emitted once per tick instead.
+            effect_dropped => 0,
+            %% A zone with nothing to simulate is demoted to the ticker's cold
+            %% set, which runs it once every `cold_tick_divisor` ticks instead
+            %% of every tick (widgrensit/asobi#543). Starts hot: the zone has
+            %% not ticked yet, so it has not established that it is idle.
+            cold => false,
             entities => RecoveredEntities,
             prev_entities => #{},
             broadcast_entities => #{},
@@ -328,7 +428,13 @@ handle_continue(init_zone_state, State0) ->
         coords => Coords,
         game_module => GameMod,
         game_config => GameConfig,
-        world_server_pid => WorldServerPid
+        world_server_pid => WorldServerPid,
+        %% The neighbour-facing game.* calls need the same grid geometry the
+        %% zone itself decides crossings with, or a script's idea of which
+        %% zones touch it disagrees with asobi's (widgrensit/asobi#544).
+        zone_size => maps:get(zone_size, State),
+        grid_size => maps:get(grid_size, State),
+        border_tab => maps:get(border_tab, State, undefined)
     },
     ZoneState1 = call_optional(GameMod, init_zone_state, [ZoneConfig, ZoneState], ZoneState),
     {noreply, State#{zone_state => ZoneState1}}.
@@ -473,28 +579,47 @@ handle_cast(reap, #{zone_manager_pid := ZMPid, coords := Coords} = State) ->
     {noreply, State};
 handle_cast({tick, TickN}, State) ->
     State1 = do_tick(TickN, State),
-    State2 = resolve_zone_crossings(State1),
-    #{subscribers := Subs, entities := Ents, zone_manager_pid := ZMPid, coords := Coords} = State2,
+    State2 = publish_border(resolve_zone_crossings(State1)),
+    State3 = reclassify(State2),
+    #{subscribers := Subs, entities := Ents, zone_manager_pid := ZMPid, coords := Coords} = State3,
     case map_size(Subs) of
         0 ->
             case has_tickable_entities(Ents) of
-                false -> {noreply, State2, hibernate};
-                true -> {noreply, State2}
+                false -> {noreply, State3, hibernate};
+                true -> {noreply, State3}
             end;
         _ ->
             case ZMPid of
                 undefined -> ok;
                 _ -> asobi_zone_manager:touch_zone(ZMPid, Coords)
             end,
-            {noreply, State2}
+            {noreply, State3}
     end;
 handle_cast({input, PlayerId, Input, Seq}, #{input_queue := Queue} = State) ->
-    {noreply, State#{input_queue => [{PlayerId, Seq, Input} | Queue]}};
+    {noreply, warm_up(State#{input_queue => [{PlayerId, Seq, Input} | Queue]})};
+%% Dropped rather than queued once the queue is full: see ?MAX_EFFECT_QUEUE.
+handle_cast(
+    {entity_effect, EntityId, Event},
+    #{effect_queue := Q, effect_count := N, effect_bytes := B} = State
+) when is_binary(EntityId), is_map(Event) ->
+    Size = erts_debug:size(Event) * erlang:system_info(wordsize),
+    case N >= ?MAX_EFFECT_QUEUE orelse B + Size > ?MAX_EFFECT_BYTES_QUEUED of
+        true ->
+            {noreply, State#{effect_dropped => maps:get(effect_dropped, State, 0) + 1}};
+        false ->
+            {noreply,
+                warm_up(State#{
+                    effect_queue => [{EntityId, Event} | Q],
+                    effect_count => N + 1,
+                    effect_bytes => B + Size
+                })}
+    end;
 handle_cast(
     {add_entity, EntityId, EntityState}, #{entities := Entities, spatial_grid := Grid} = State
 ) when is_binary(EntityId) ->
     Grid1 = spatial_grid_insert(EntityId, EntityState, Grid),
-    {noreply, State#{entities => Entities#{EntityId => EntityState}, spatial_grid => Grid1}};
+    {noreply,
+        warm_up(State#{entities => Entities#{EntityId => EntityState}, spatial_grid => Grid1})};
 %% Every other id-bearing cast in this module guards, and this one did not. A Lua
 %% table that mixes named and numeric keys hands the zone a non-binary entity id
 %% (`asobi_lua_api:ensure_pairs/1` does not normalise them), which then reached
@@ -568,7 +693,7 @@ handle_cast(
         end,
     {noreply, owe_rebind(KeyframeResult, State)};
 handle_cast({start_entity_timer, Config}, #{entity_timers := ET} = State) when is_map(Config) ->
-    {noreply, State#{entity_timers => asobi_entity_timer:start_timer(Config, ET)}};
+    {noreply, warm_up(State#{entity_timers => asobi_entity_timer:start_timer(Config, ET)})};
 handle_cast({cancel_entity_timer, EntityId, TimerId}, #{entity_timers := ET} = State) when
     is_binary(EntityId), is_binary(TimerId)
 ->
@@ -580,17 +705,18 @@ handle_cast(
     case asobi_zone_spawner:spawn_entity(TemplateId, Pos, Overrides, Spawner) of
         {ok, {EntityId, Entity}, Spawner1} ->
             Grid1 = spatial_grid_insert(EntityId, Entity, Grid),
-            {noreply, State#{
-                entities => Entities#{EntityId => Entity},
-                spawner => Spawner1,
-                spatial_grid => Grid1
-            }};
+            {noreply,
+                warm_up(State#{
+                    entities => Entities#{EntityId => Entity},
+                    spawner => Spawner1,
+                    spatial_grid => Grid1
+                })};
         {error, Reason} ->
             log_spawn_failed(TemplateId, Reason, State),
             {noreply, State}
     end;
 handle_cast({spawn_entities, Spawns}, State) when is_list(Spawns) ->
-    {noreply, apply_spawns(Spawns, State)};
+    {noreply, warm_up(apply_spawns(Spawns, State))};
 handle_cast(
     {despawn_entity, EntityId},
     #{entities := Entities, spawner := Spawner, spatial_grid := Grid} = State
@@ -604,13 +730,35 @@ handle_cast(
 handle_cast(_Msg, State) ->
     {noreply, State}.
 
--spec handle_info(term(), map()) -> {noreply, map()}.
+-spec handle_info(term(), map()) -> {noreply, map()} | {stop, term(), map()}.
 handle_info({'DOWN', _Ref, process, DownPid, _Reason}, #{subscribers := Subs} = State) ->
     Subs1 = maps:filter(
         fun(_PlayerId, {Pid, _MonRef}) -> Pid =/= DownPid end,
         Subs
     ),
     {noreply, State#{subscribers => Subs1}};
+%% The zone traps exits so terminate/2 runs on shutdown (see init/1), and
+%% trapping must not quietly change what a *linked crash* means. gen_server
+%% handles the parent's own EXIT; anything else reaching here is a process this
+%% zone's runtime is linked to - under ADR 0015's `owned` mode that is its
+%% `asobi_lua_vm`, the process now holding the Lua state - so the zone dies with
+%% it exactly as it would have before, and its `transient` child spec brings it
+%% back.
+%%
+%% The final snapshot is deliberately skipped on this path. The zone's
+%% `game_state` is a reference into the VM that just died, so dumping it would
+%% decode nothing and overwrite the last good row with an empty one. Leaving the
+%% stored snapshot alone is what lets the replacement zone restore into it,
+%% which is ADR 0015 decision 5.
+handle_info({'EXIT', Pid, Reason}, State) ->
+    ?LOG_ERROR(#{
+        event => zone_linked_process_died,
+        coords => maps:get(coords, State, undefined),
+        from => Pid,
+        reason => Reason,
+        msg => ~"a process this zone is linked to died; restarting into the last snapshot"
+    }),
+    {stop, Reason, State#{skip_final_snapshot => true}};
 handle_info(_Info, State) ->
     {noreply, State}.
 
@@ -622,6 +770,20 @@ terminate(normal, #{world_id := WorldId, coords := Coords} = State) ->
     %% asobi#252 review: a zone that ever suppressed a log line leaves a
     %% permanent drop-count row otherwise - these Keys' lifetime ends here.
     forget_log_keys(WorldId, Coords),
+    asobi_zone_border:clear(maps:get(border_tab, State, undefined), Coords),
+    pg:leave(?PG_SCOPE, {asobi_zone, WorldId, Coords}, self()),
+    ok;
+%% Bare `shutdown` is what a supervisor sends, and until the zone started
+%% trapping exits it could never be observed here at all - so it fell to the
+%% abnormal clause below and would now leave an ETS crash-backup row behind on
+%% an orderly world teardown. An orderly stop is an orderly stop however it is
+%% spelled.
+terminate(shutdown, #{world_id := WorldId, coords := Coords} = State) ->
+    maybe_final_snapshot(State),
+    clear_zone_backup(WorldId, Coords),
+    notify_zone_manager_terminated(State),
+    forget_log_keys(WorldId, Coords),
+    asobi_zone_border:clear(maps:get(border_tab, State, undefined), Coords),
     pg:leave(?PG_SCOPE, {asobi_zone, WorldId, Coords}, self()),
     ok;
 terminate({shutdown, _}, #{world_id := WorldId, coords := Coords} = State) ->
@@ -629,6 +791,7 @@ terminate({shutdown, _}, #{world_id := WorldId, coords := Coords} = State) ->
     clear_zone_backup(WorldId, Coords),
     notify_zone_manager_terminated(State),
     forget_log_keys(WorldId, Coords),
+    asobi_zone_border:clear(maps:get(border_tab, State, undefined), Coords),
     pg:leave(?PG_SCOPE, {asobi_zone, WorldId, Coords}, self()),
     ok;
 terminate(_Reason, #{world_id := WorldId, coords := Coords, entities := Entities} = State) ->
@@ -637,6 +800,7 @@ terminate(_Reason, #{world_id := WorldId, coords := Coords, entities := Entities
     backup_zone_state(WorldId, Coords, Entities),
     notify_zone_manager_terminated(State),
     forget_log_keys(WorldId, Coords),
+    asobi_zone_border:clear(maps:get(border_tab, State, undefined), Coords),
     pg:leave(?PG_SCOPE, {asobi_zone, WorldId, Coords}, self()),
     ok.
 
@@ -798,6 +962,7 @@ do_tick(
         wire_seq := WireSeq,
         zone_state := ZoneState,
         input_queue := Queue,
+        effect_queue := EffectQueue,
         subscribers := Subs,
         ticker_pid := TickerPid,
         entity_timers := ET
@@ -822,9 +987,19 @@ do_tick(
         GameMod, lists:reverse(Queue), Entities0, {WorldId, Coords}
     ),
     PlayerAck1 = maps:fold(fun record_ack/3, maps:get(player_ack, State, #{}), TickAcks),
+    %% After inputs, so an effect a neighbour addressed at an entity lands on
+    %% the same tick's post-input state rather than one the player has already
+    %% moved away from.
+    report_effects_dropped(State),
+    %% The sender-side per-tick send budget lives in the process dictionary and
+    %% is scoped to a tick, so this zone's own handle_input callers get a fresh
+    %% one each tick. A zone_tick caller runs in a throwaway eval worker whose
+    %% dictionary dies with it, so that half needs no reset.
+    _ = asobi_lua_api:reset_effect_sends(),
+    Entities2a = apply_effects(GameMod, drain_effects(EffectQueue), Entities2, State),
     Now = erlang:system_time(millisecond),
     {TimerEvents, ET1} = asobi_entity_timer:tick(Now, ET),
-    Entities3 = apply_timer_events(TimerEvents, Entities2),
+    Entities3 = apply_timer_events(TimerEvents, Entities2a),
     %% Tick spawner — process respawn queue. asobi#253: pick up a live
     %% template update (e.g. a script hot-reload) before ticking, so a
     %% just-renamed/added template doesn't have to wait for the next respawn
@@ -903,6 +1078,10 @@ do_tick(
         prev_entities => Entities4,
         zone_state => ZoneState1,
         input_queue => [],
+        effect_queue => [],
+        effect_count => 0,
+        effect_bytes => 0,
+        effect_dropped => 0,
         %% Bound player_ack to currently-subscribed players so it does not grow
         %% with everyone who ever sent an input (asobi#474).
         player_ack => maps:with(maps:keys(Subs), PlayerAck1),
@@ -1235,6 +1414,65 @@ reject_log_key({WorldId, Coords}) -> {WorldId, Coords, input_rejected}.
 bad_batch_log_key({WorldId, Coords}) -> {WorldId, Coords, batch_contract}.
 unknown_outcome_log_key({WorldId, Coords}) -> {WorldId, Coords, unknown_outcome}.
 no_input_handler_log_key({WorldId, Coords}) -> {WorldId, Coords, no_input_handler}.
+effect_log_key({WorldId, Coords}, Kind) -> {WorldId, Coords, Kind}.
+
+%% Same split as log_no_input_handler/2: the telemetry is unconditional and only
+%% the log line is limited, so a zone under a flood still shows up as a rate.
+%% One telemetry event and at most one log line per tick, carrying the tick's
+%% count - see `effect_dropped` in init/1 for why this is not per message.
+report_effects_dropped(#{effect_dropped := 0}) ->
+    ok;
+report_effects_dropped(#{effect_dropped := Dropped} = State) ->
+    asobi_telemetry:game_error(effect_queue_full, #{
+        game_module => maps:get(game_module, State, undefined),
+        dropped => Dropped
+    }),
+    case asobi_script_log_limiter:allow(effect_log_key(log_zone(State), effect_queue_full)) of
+        {true, SuppressedSinceLast} ->
+            ?LOG_ERROR(#{
+                msg => ~"cross-zone effect queue full; effects dropped",
+                coords => maps:get(coords, State, undefined),
+                dropped => Dropped,
+                suppressed_since_last => SuppressedSinceLast
+            });
+        false ->
+            ok
+    end;
+report_effects_dropped(_State) ->
+    ok.
+
+log_no_effect_handler(State) ->
+    log_effect_issue(
+        State,
+        no_effect_handler,
+        ~"game module does not export handle_effects/2; cross-zone effects dropped"
+    ).
+
+log_bad_effects_return(State) ->
+    log_effect_issue(
+        State,
+        bad_effects_return,
+        ~"handle_effects/2 did not return an entity map; this tick's effects are dropped"
+    ).
+
+log_zone(State) ->
+    {maps:get(world_id, State, undefined), maps:get(coords, State, undefined)}.
+
+log_effect_issue(State, Kind, Msg) ->
+    Zone = log_zone(State),
+    asobi_telemetry:game_error(Kind, #{
+        game_module => maps:get(game_module, State, undefined)
+    }),
+    case asobi_script_log_limiter:allow(effect_log_key(Zone, Kind)) of
+        {true, SuppressedSinceLast} ->
+            ?LOG_ERROR(#{
+                msg => Msg,
+                coords => maps:get(coords, State, undefined),
+                suppressed_since_last => SuppressedSinceLast
+            });
+        false ->
+            ok
+    end.
 
 %% Keep the highest seq per player. world.input carries a monotonic client seq;
 %% out-of-order or duplicate delivery must never regress the ack. Inputs with no
@@ -2117,6 +2355,10 @@ snapshot_entities(Entities) ->
         Entities
     ).
 
+%% See handle_info({'EXIT', ...}): the state this would dump is unreadable, and
+%% writing it would destroy the snapshot the replacement zone needs.
+maybe_final_snapshot(#{skip_final_snapshot := true}) ->
+    ok;
 maybe_final_snapshot(#{persistence := true} = State) ->
     #{
         world_id := WorldId,
@@ -2155,7 +2397,10 @@ forget_log_keys(WorldId, Coords) ->
     asobi_script_log_limiter:forget(reject_log_key(Zone)),
     asobi_script_log_limiter:forget(bad_batch_log_key(Zone)),
     asobi_script_log_limiter:forget(unknown_outcome_log_key(Zone)),
-    asobi_script_log_limiter:forget(no_input_handler_log_key(Zone)).
+    asobi_script_log_limiter:forget(no_input_handler_log_key(Zone)),
+    asobi_script_log_limiter:forget(effect_log_key(Zone, effect_queue_full)),
+    asobi_script_log_limiter:forget(effect_log_key(Zone, no_effect_handler)),
+    asobi_script_log_limiter:forget(effect_log_key(Zone, bad_effects_return)).
 
 backup_zone_state(WorldId, Coords, Entities) ->
     case ets:info(asobi_world_state) of
@@ -2186,6 +2431,174 @@ clear_zone_backup(WorldId, Coords) ->
 notify_zone_manager_terminated(#{zone_manager_pid := ZMPid, coords := Coords}) when is_pid(ZMPid) ->
     asobi_zone_manager:zone_terminated(ZMPid, Coords, self());
 notify_zone_manager_terminated(_) ->
+    ok.
+
+%% --- Cross-zone border mirror (widgrensit/asobi#544) ---
+
+%% Runs after resolve_zone_crossings/1, not before: an entity that crossed this
+%% tick is published by the zone that now owns it rather than by the one handing
+%% it over. A reader can still see it under both owners for at most one tick,
+%% because the old owner's row is only refreshed on its own next tick -
+%% apply_effects/4's ownership filter is what makes that harmless, not this
+%% ordering.
+publish_border(#{border_band := Band} = State) when Band =< 0 ->
+    State;
+publish_border(
+    #{
+        coords := Coords,
+        zone_size := ZoneSize,
+        border_band := Band,
+        border_live := Live,
+        border_tab := Tab,
+        entities := Entities
+    } = State
+) ->
+    InBand = asobi_zone_border:band_entities(Coords, ZoneSize, Band, Entities),
+    case {map_size(InBand), Live} of
+        {0, false} ->
+            %% The common case on a large grid: an empty zone with no row to
+            %% delete. Deleting an absent row every tick was measurably the
+            %% whole cost of this feature for a zone with nothing in it.
+            State;
+        {0, true} ->
+            asobi_zone_border:clear(Tab, Coords),
+            State#{border_live => false};
+        {_, _} ->
+            asobi_zone_border:write_band(Tab, Coords, InBand),
+            State#{border_live => true}
+    end.
+
+%% Narrows the queue back to its element type on the way out. The zone's state
+%% is a plain map, so everything read from it is `term()` as far as the type
+%% checker is concerned; only the cast that fills the queue guards the shape,
+%% and this is where that guarantee is restated rather than asserted.
+-spec drain_effects(term()) -> [{binary(), map()}].
+drain_effects(Queue) when is_list(Queue) ->
+    narrow_effects(Queue, []);
+drain_effects(_) ->
+    [].
+
+%% Reverses as it narrows: the queue is built newest-first.
+-spec narrow_effects([term()], [{binary(), map()}]) -> [{binary(), map()}].
+narrow_effects([], Acc) ->
+    Acc;
+narrow_effects([{Id, Event} | Rest], Acc) when is_binary(Id), is_map(Event) ->
+    narrow_effects(Rest, [{Id, Event} | Acc]);
+narrow_effects([_ | Rest], Acc) ->
+    narrow_effects(Rest, Acc).
+
+%% Effects naming an entity this zone no longer owns are dropped silently: the
+%% target died, or crossed into a third zone, between the neighbour reading the
+%% band and this tick draining the queue. Both are ordinary, and handing the
+%% script an effect for an id it cannot look up would make every game write the
+%% same guard.
+-spec apply_effects(module(), [{binary(), map()}], map(), map()) -> map().
+apply_effects(_GameMod, [], Entities, _State) ->
+    Entities;
+apply_effects(GameMod, Effects, Entities, State) ->
+    case [E || {Id, _} = E <- Effects, is_map_key(Id, Entities)] of
+        [] ->
+            Entities;
+        Live ->
+            case erlang:function_exported(GameMod, handle_effects, 2) of
+                true ->
+                    effects_result(GameMod:handle_effects(Live, Entities), Entities, State);
+                false ->
+                    log_no_effect_handler(State),
+                    Entities
+            end
+    end.
+
+effects_result({ok, Entities1}, _Prev, _State) when is_map(Entities1) -> Entities1;
+effects_result(Entities1, _Prev, _State) when is_map(Entities1) -> Entities1;
+effects_result(_Other, Prev, State) ->
+    log_bad_effects_return(State),
+    Prev.
+
+%% --- Cold/hot classification (widgrensit/asobi#543) ---
+
+%% A zone with no entities, no queued input, no live entity timer and no
+%% pending respawn has nothing to simulate, and on a Lua world its tick is
+%% almost entirely the bridge's fixed per-callback cost rather than game logic.
+%% Ticking it at `cold_tick_divisor` is what `cold_tick_divisor` has always
+%% promised; until #543 nothing ever demoted a zone, so no zone was ever cold.
+%%
+%% Subscribers deliberately do not count. A player watching a neighbouring
+%% empty zone creates no work in it: there are no entities to move and no
+%% deltas to send. That is exactly the "watched but empty" case #543 asks about.
+-spec zone_idle(map()) -> boolean().
+%% `input_queue` and `effect_queue` are always `[]` where reclassify/1 calls
+%% this - do_tick/2 empties both before it runs - so those two conditions never
+%% decide anything at that call site. They are kept because this states what
+%% "idle" means for a zone rather than what happens to be true at one caller,
+%% and warm_up/1 is what actually handles a queue filling between ticks.
+zone_idle(#{
+    entities := Entities,
+    input_queue := Queue,
+    effect_queue := Effects,
+    entity_timers := ET,
+    spawner := Spawner
+}) ->
+    map_size(Entities) =:= 0 andalso
+        Queue =:= [] andalso
+        Effects =:= [] andalso
+        asobi_entity_timer:active_count(ET) =:= 0 andalso
+        not asobi_zone_spawner:has_pending(Spawner).
+
+-spec clamp_border_band(term()) -> number().
+clamp_border_band(Band) when is_number(Band), Band >= 0, Band =< ?MAX_BORDER_BAND ->
+    Band;
+clamp_border_band(Band) ->
+    ?LOG_WARNING(#{
+        msg => ~"border_band must be a fraction of zone_size between 0 and 1; ignoring",
+        value => Band
+    }),
+    ?DEFAULT_BORDER_BAND.
+
+%% Demotion is decided on the tick, where the cost is. Promotion is not: see
+%% warm_up/1.
+-spec reclassify(map()) -> map().
+reclassify(#{cold := Cold, ticker_pid := TickerPid} = State) ->
+    case zone_idle(State) of
+        Cold ->
+            State;
+        true ->
+            asobi_world_ticker:demote_zone(TickerPid, self()),
+            announce(cold, State),
+            State#{cold => true};
+        false ->
+            warm(State)
+    end.
+
+%% Promote from the message that created the work rather than from the next
+%% tick. A cold zone only ticks once every `cold_tick_divisor` ticks, so
+%% waiting for its own tick to notice a player arrived would put that whole
+%% divisor of latency on the first frame of every zone entry.
+-spec warm_up(map()) -> map().
+warm_up(#{cold := true} = State) ->
+    warm(State);
+warm_up(State) ->
+    State.
+
+%% Emitted on the transition only, never per tick: a zone that is merely busy is
+%% the normal case and says nothing an operator can act on.
+-spec warm(map()) -> map().
+warm(#{ticker_pid := TickerPid} = State) ->
+    asobi_world_ticker:promote_zone(TickerPid, self()),
+    announce(hot, State),
+    State#{cold => false}.
+
+%% Both events carry the same identity, and both are emitted from a plain state
+%% map, so the narrowing lives in one place rather than at each call.
+-spec announce(cold | hot, map()) -> ok.
+announce(Which, #{world_id := WorldId, coords := {CX, CY} = Coords}) when
+    is_binary(WorldId), is_integer(CX), is_integer(CY)
+->
+    case Which of
+        cold -> asobi_telemetry:zone_cold(WorldId, Coords);
+        hot -> asobi_telemetry:zone_hot(WorldId, Coords)
+    end;
+announce(_Which, _State) ->
     ok.
 
 has_tickable_entities(Entities) ->

--- a/src/world/asobi_zone_border.erl
+++ b/src/world/asobi_zone_border.erl
@@ -1,0 +1,214 @@
+-module(asobi_zone_border).
+-moduledoc """
+A read-only mirror of each zone's edge band, so a zone can see what its
+neighbours own near their shared seam.
+
+`asobi_spatial`'s zone-based queries search the calling zone's own entity map
+and nothing else, which makes anything just past a boundary permanently
+invisible rather than invisible for the tick it takes to cross
+(`guides/world-server.md`). An NPC parked one unit before a seam never sees the
+pilot two units past it, and a projectile resolved in the shooter's zone can
+never hit a target the neighbour owns.
+
+Every zone publishes the entities inside `border_band` of its own rectangle
+here once per tick, keyed by its coords. Neighbouring zones read the eight
+touching rows. What comes back is a **copy**: ownership never moves, and
+writing to what you read changes nothing.
+
+Writing to the *table*, however, changes `owner/4`'s answer, which is the
+sender-side half of `game.zone.apply`'s authorisation. The half that cannot be
+forged is the receiver's: `asobi_zone` applies an effect only to an entity it
+currently owns, so a forged row buys the ability to *address* an entity, never
+the ability to invent one. See `asobi_world_sup` for the trust model this sits
+inside.
+
+The band is bounded by the zone's perimeter rather than its area, which is what
+keeps this from being "every zone holds every neighbour's entity map". Set
+`border_band` to `0` to publish nothing.
+
+**One table per world, owned by that world's `asobi_world_instance`
+supervisor.** Nothing here has to be swept: no asobi process traps exits, so
+`terminate/2` does not run on a supervisor shutdown, and any cleanup hung off
+it would leak a whole grid of rows every time a world ended. Tying the table's
+lifetime to the world's own supervisor makes teardown exact rather than
+best-effort, and makes one world's rows unreachable from another by
+construction rather than by a key convention.
+""".
+
+-export([new/0]).
+-export([write_band/3, clear/2]).
+-export([neighbours/2, band_entities/4]).
+-export([query_radius/5, query_radius/6, query_rect/5, query_rect/6]).
+-export([owner/4]).
+
+-type coords() :: {integer(), integer()}.
+-type tab() :: ets:table() | undefined.
+
+-export_type([tab/0]).
+
+-doc """
+A world's mirror. Call from the process that should own it - the world's
+instance supervisor - so it dies exactly when the world does.
+""".
+-spec new() -> ets:table().
+new() ->
+    %% Both concurrency options, deliberately: every zone writes its own row
+    %% each tick while its neighbours read theirs, so the table is hot from both
+    %% sides at once.
+    ets:new(asobi_zone_border, [
+        public,
+        set,
+        {read_concurrency, true},
+        {write_concurrency, true}
+    ]).
+
+-doc """
+Write a band this zone has already computed.
+
+`asobi_zone` computes the band itself rather than handing the whole entity map
+over, so it can tell an empty band from an absent row and skip the write
+entirely: on a grid where most zones are empty most of the time, re-deleting a
+row that is not there is the whole per-tick cost of this feature.
+""".
+-spec write_band(tab(), coords(), map()) -> ok.
+write_band(undefined, _Coords, _Entities) ->
+    ok;
+write_band(Tab, Coords, Entities) ->
+    true = ets:insert(Tab, {Coords, Entities}),
+    ok.
+
+-doc "Drop this zone's row, if it has one.".
+-spec clear(tab(), coords()) -> ok.
+clear(undefined, _Coords) ->
+    ok;
+clear(Tab, Coords) ->
+    true = ets:delete(Tab, Coords),
+    ok.
+
+-doc "The entities of `Entities` lying within `Band` of any edge of this zone.".
+-spec band_entities(coords(), pos_integer(), number(), map()) -> map().
+band_entities({ZX, ZY}, ZoneSize, Band, Entities) ->
+    XLo = ZX * ZoneSize,
+    YLo = ZY * ZoneSize,
+    maps:filter(
+        fun(Id, Entity) ->
+            is_binary(Id) andalso is_map(Entity) andalso
+                in_band(pos(Entity), XLo, YLo, ZoneSize, Band)
+        end,
+        Entities
+    ).
+
+-doc "The up-to-eight in-grid coords touching `Coords`.".
+-spec neighbours(coords(), pos_integer()) -> [coords()].
+neighbours({ZX, ZY}, GridSize) ->
+    [
+        {X, Y}
+     || DX <- [-1, 0, 1],
+        DY <- [-1, 0, 1],
+        {DX, DY} =/= {0, 0},
+        X <- [ZX + DX],
+        Y <- [ZY + DY],
+        X >= 0,
+        Y >= 0,
+        X < GridSize,
+        Y < GridSize
+    ].
+
+-doc """
+Radius query over the eight zones touching `Coords`, never over `Coords`
+itself - the caller already holds its own entity map, and searching both here
+would return every in-zone entity twice.
+""".
+-spec query_radius(tab(), coords(), pos_integer(), {number(), number()}, number()) ->
+    [{binary(), map(), float()}].
+query_radius(Tab, Coords, GridSize, Center, Radius) ->
+    query_radius(Tab, Coords, GridSize, Center, Radius, #{}).
+
+-spec query_radius(
+    tab(), coords(), pos_integer(), {number(), number()}, number(), asobi_spatial:query_opts()
+) -> [{binary(), map(), float()}].
+query_radius(Tab, Coords, GridSize, Center, Radius, Opts) ->
+    asobi_spatial:query_radius(neighbour_entities(Tab, Coords, GridSize), Center, Radius, Opts).
+
+-spec query_rect(tab(), coords(), pos_integer(), {number(), number()}, {number(), number()}) ->
+    [{binary(), map()}].
+query_rect(Tab, Coords, GridSize, TopLeft, BottomRight) ->
+    query_rect(Tab, Coords, GridSize, TopLeft, BottomRight, #{}).
+
+-spec query_rect(
+    tab(),
+    coords(),
+    pos_integer(),
+    {number(), number()},
+    {number(), number()},
+    asobi_spatial:query_opts()
+) -> [{binary(), map()}].
+query_rect(Tab, Coords, GridSize, TopLeft, BottomRight, Opts) ->
+    asobi_spatial:query_rect(
+        neighbour_entities(Tab, Coords, GridSize), TopLeft, BottomRight, Opts
+    ).
+
+-doc """
+Which neighbour of `Coords` currently publishes `EntityId`.
+
+This is the sender-side authorisation gate for `game.zone.apply` as much as it
+is a lookup: a zone can only address an entity it can already see, so "what may
+I affect" and "what may I read" are the same set rather than two that can drift
+apart.
+""".
+-spec owner(tab(), coords(), pos_integer(), binary()) -> {ok, coords()} | error.
+owner(undefined, _Coords, _GridSize, _EntityId) ->
+    error;
+owner(Tab, Coords, GridSize, EntityId) when is_binary(EntityId) ->
+    find_owner(neighbours(Coords, GridSize), Tab, EntityId);
+owner(_Tab, _Coords, _GridSize, _EntityId) ->
+    error.
+
+%% --- Internal ---
+
+find_owner([], _Tab, _EntityId) ->
+    error;
+find_owner([Coords | Rest], Tab, EntityId) ->
+    case publishes(Tab, Coords, EntityId) of
+        true -> {ok, Coords};
+        false -> find_owner(Rest, Tab, EntityId)
+    end.
+
+%% A map pattern matches a map *containing* the key, so this answers membership
+%% inside ETS. `ets:lookup/2` would copy the neighbour's whole band out to the
+%% caller's heap to run one `maps:is_key/2` on it and throw the rest away -
+%% measured 4.6x slower at a 60-entity band, and unlike this it gets worse as
+%% the band grows.
+publishes(Tab, Coords, EntityId) ->
+    ets:select_count(Tab, [{{Coords, #{EntityId => '_'}}, [], [true]}]) > 0.
+
+neighbour_entities(undefined, _Coords, _GridSize) ->
+    #{};
+neighbour_entities(Tab, Coords, GridSize) ->
+    merge_rows(neighbours(Coords, GridSize), Tab, #{}).
+
+merge_rows([], _Tab, Acc) ->
+    Acc;
+merge_rows([Coords | Rest], Tab, Acc) ->
+    merge_rows(Rest, Tab, maps:merge(Acc, row(Tab, Coords))).
+
+row(Tab, Coords) ->
+    case ets:lookup(Tab, Coords) of
+        [{_, Entities}] when is_map(Entities) -> Entities;
+        _ -> #{}
+    end.
+
+in_band(undefined, _XLo, _YLo, _ZoneSize, _Band) ->
+    false;
+in_band({X, Y}, XLo, YLo, ZoneSize, Band) ->
+    X - XLo < Band orelse
+        XLo + ZoneSize - X < Band orelse
+        Y - YLo < Band orelse
+        YLo + ZoneSize - Y < Band.
+
+%% Entity maps are game-supplied and reach the zone with either atom keys (an
+%% Erlang game module) or binary ones (the Lua bridge), so both shapes have to
+%% be read here for the same reason asobi_zone:entity_pos/1 reads both.
+pos(#{x := X, y := Y}) when is_number(X), is_number(Y) -> {X, Y};
+pos(#{~"x" := X, ~"y" := Y}) when is_number(X), is_number(Y) -> {X, Y};
+pos(_) -> undefined.

--- a/src/world/asobi_zone_manager.erl
+++ b/src/world/asobi_zone_manager.erl
@@ -369,6 +369,14 @@ cleanup_zone(
         true -> asobi_telemetry:zone_closed(WorldId, Coords);
         false -> ok
     end,
+    %% The zone's own terminate/2 clears this too, but it does not run when the
+    %% zone is killed rather than stopped - and a stale band row keeps a dead
+    %% entity visible to every neighbour until the coords are next occupied.
+    %% Clearing it here covers the reaped and the crashed alike, and it is
+    %% idempotent.
+    asobi_zone_border:clear(
+        maps:get(border_tab, maps:get(zone_config, State, #{}), undefined), Coords
+    ),
     ets:delete(Tab, Coords),
     Monitors1 =
         case maps:get(Coords, Monitors, undefined) of

--- a/src/world/asobi_zone_spawner.erl
+++ b/src/world/asobi_zone_spawner.erl
@@ -6,7 +6,7 @@
 -export([new/1, new/0]).
 -export([spawn_entity/3, spawn_entity/4, spawn_entity/5]).
 -export([entity_removed/3, tick/2]).
--export([get_templates/1, get_spawn_count/2, info/1]).
+-export([get_templates/1, get_spawn_count/2, info/1, has_pending/1]).
 -export([set_templates/2]).
 -export([serialise/1, deserialise/1]).
 
@@ -200,6 +200,18 @@ set_templates(Templates, State) ->
 -spec get_spawn_count(binary(), state()) -> non_neg_integer().
 get_spawn_count(TemplateId, #{spawn_counts := C}) ->
     maps:get(TemplateId, C, 0).
+
+-doc """
+Whether any respawn is waiting to fire.
+
+A boolean rather than a count, and separate from `info/1`, because it is read on
+the hot path: `asobi_zone` asks every tick whether the zone has anything to do,
+and neither building the whole info map nor walking the queue with `length/1` is
+work worth doing to decide not to do work.
+""".
+-spec has_pending(state()) -> boolean().
+has_pending(#{respawn_queue := []}) -> false;
+has_pending(#{respawn_queue := _}) -> true.
 
 -spec info(state()) -> map().
 info(#{respawn_queue := Q, spawn_counts := C, entity_templates := ET}) ->

--- a/src/world/asobi_zone_sup.erl
+++ b/src/world/asobi_zone_sup.erl
@@ -19,9 +19,14 @@ init([]) ->
         intensity => 50,
         period => 60
     },
+    %% Explicit rather than defaulted: a zone traps exits so its terminate/2 can
+    %% write a final snapshot, and the shutdown budget is what gives it time to.
+    %% simple_one_for_one terminates its children concurrently, so this is the
+    %% wall-clock ceiling for the whole grid, not per zone.
     ChildSpec = #{
         id => asobi_zone,
         start => {asobi_zone, start_link, []},
-        restart => transient
+        restart => transient,
+        shutdown => 5_000
     },
     {ok, {SupFlags, [ChildSpec]}}.

--- a/test/asobi_game_modes_tests.erl
+++ b/test/asobi_game_modes_tests.erl
@@ -13,7 +13,10 @@ world_config_test_() ->
         {"a match mode is refused, not built into a world (#480)", fun match_mode_refused/0},
         {"a mode with no type is a match, so it is refused too (#480)", fun untyped_mode_refused/0},
         {"an unknown mode is still not_found, not wrong_mode_type (#480)",
-            fun unknown_mode_still_not_found/0}
+            fun unknown_mode_still_not_found/0},
+        {"the zone-lifecycle knobs reach the world server config (#543)",
+            fun zone_knobs_forwarded/0},
+        {"a mode that declares none of them forwards none", fun zone_knobs_absent/0}
     ]}.
 
 setup() ->
@@ -26,6 +29,17 @@ setup() ->
         },
         ~"arena" => #{type => world, module => some_game, chat => #{global => [~"trade"]}},
         ~"quiet" => #{type => world, module => some_game},
+        ~"tuned" => #{
+            type => world,
+            module => some_game,
+            lazy_zones => true,
+            zone_idle_timeout => 20000,
+            max_active_zones => 64,
+            spatial_grid_cell_size => 32,
+            cold_tick_divisor => 20,
+            rehome_margin => 0.25,
+            border_band => 0.15
+        },
         ~"duel" => #{type => match, module => some_game},
         ~"untyped" => #{module => some_game}
     }),
@@ -43,6 +57,33 @@ chat_forwarded() ->
 chat_absent() ->
     {ok, Config} = asobi_game_modes:world_config(~"quiet"),
     ?assertNot(maps:is_key(chat, Config)).
+
+%% widgrensit/asobi#543: every one of these is read downstream and was
+%% silently dropped here, so a world declaring `lazy_zones = true` pre-spawned
+%% its whole grid anyway and `cold_tick_divisor` never reached the ticker.
+zone_knobs_forwarded() ->
+    {ok, Config} = asobi_game_modes:world_config(~"tuned"),
+    ?assertEqual(true, maps:get(lazy_zones, Config)),
+    ?assertEqual(20000, maps:get(zone_idle_timeout, Config)),
+    ?assertEqual(64, maps:get(max_active_zones, Config)),
+    ?assertEqual(32, maps:get(spatial_grid_cell_size, Config)),
+    ?assertEqual(20, maps:get(cold_tick_divisor, Config)),
+    ?assertEqual(0.25, maps:get(rehome_margin, Config)),
+    ?assertEqual(0.15, maps:get(border_band, Config)).
+
+zone_knobs_absent() ->
+    {ok, Config} = asobi_game_modes:world_config(~"quiet"),
+    lists:foreach(
+        fun(Key) -> ?assertNot(maps:is_key(Key, Config)) end,
+        [
+            lazy_zones,
+            zone_idle_timeout,
+            max_active_zones,
+            spatial_grid_cell_size,
+            cold_tick_divisor,
+            border_band
+        ]
+    ).
 
 global_union() ->
     ?assertEqual([~"general", ~"trade"], asobi_game_modes:global_chat_channels()).

--- a/test/asobi_lua_api_tests.erl
+++ b/test/asobi_lua_api_tests.erl
@@ -85,6 +85,19 @@ api_test_() ->
         {"game.spatial.query_radius zone-based", fun spatial_zone_query_radius/0},
         {"game.spatial.query_rect zone-based", fun spatial_zone_query_rect/0},
         {"game.spatial.query_rect errors without zone", fun spatial_query_rect_no_zone/0},
+        {"game.spatial.neighbours_radius reads the touching zones",
+            fun spatial_neighbours_radius/0},
+        {"game.spatial.neighbours_radius honours opts", fun spatial_neighbours_radius_opts/0},
+        {"game.spatial.neighbours_rect reads the touching zones", fun spatial_neighbours_rect/0},
+        {"game.spatial.neighbours_* error without grid context", fun spatial_neighbours_no_grid/0},
+        {"game.zone.apply reaches the owning zone", fun zone_apply_delivers/0},
+        {"game.zone.apply refuses an entity no neighbour publishes",
+            fun zone_apply_refuses_unseen/0},
+        {"game.zone.apply errors without grid context", fun zone_apply_no_grid/0},
+        {"game.zone.apply refuses a non-table event", fun zone_apply_bad_event/0},
+        {"game.zone.apply refuses an oversized event", fun zone_apply_oversized_event/0},
+        {"game.zone.apply is bounded per tick", fun zone_apply_send_budget/0},
+        {"game.spatial.neighbours_* reject bad arity", fun spatial_neighbours_bad_args/0},
         {"game.terrain.get_chunk returns data", fun terrain_get_chunk/0},
         {"game.terrain.get_chunk errors without store", fun terrain_get_chunk_no_store/0},
         {"game.terrain.preload forwards coords", fun terrain_preload/0},
@@ -118,6 +131,14 @@ api_test_() ->
     ]}.
 
 setup() ->
+    %% Created here rather than in the test body: an ETS table dies with the
+    %% process that made it, and a eunit test body is a throwaway process, so a
+    %% table made there is already going away by the next test. In production
+    %% the owner is the world's instance supervisor.
+    case persistent_term:get({?MODULE, border_tab}, undefined) of
+        undefined -> persistent_term:put({?MODULE, border_tab}, asobi_zone_border:new());
+        Tab -> ets:delete_all_objects(Tab)
+    end,
     meck:new(asobi_id, [no_link]),
     meck:expect(asobi_id, generate, fun() -> ~"test-uuid-v7" end),
     meck:new(asobi_match_server, [no_link]),
@@ -172,6 +193,8 @@ setup() ->
     meck:expect(asobi_zone, query_rect, fun(_, _, _) ->
         [{~"e1", {5.0, 5.0}}]
     end),
+    meck:expect(asobi_zone, whereis_zone, fun(_, Coords) -> {ok, spawn_zone_stub(Coords)} end),
+    meck:expect(asobi_zone, apply_effect, fun(_, _, _) -> ok end),
     meck:new(asobi_terrain_store, [no_link]),
     meck:expect(asobi_terrain_store, get_chunk, fun(_, _) ->
         {ok, #{~"tiles" => [1, 2, 3]}}
@@ -656,6 +679,153 @@ zone_despawn() ->
     {ok, [true | _], _} = eval(Code, St),
     ?assert(meck:called(asobi_zone, despawn_entity, '_')).
 
+%% widgrensit/asobi#544. The caller is zone (1,1) of a 5x5 grid of 100-unit
+%% zones; (2,1) touches it and publishes a pirate just past the seam.
+install_api_with_grid() ->
+    {ok, St0} = asobi_lua_loader:new(fixture("test_match.lua")),
+    Ctx = #{
+        vm => zone,
+        match_id => ~"nb-world",
+        match_pid => self(),
+        zone_pid => self(),
+        world_id => ~"nb-world",
+        coords => {1, 1},
+        zone_size => 100,
+        grid_size => 5,
+        border_tab => border_tab()
+    },
+    asobi_lua_api:install(Ctx, St0).
+
+border_tab() -> persistent_term:get({?MODULE, border_tab}).
+
+publish_pirate() ->
+    asobi_zone_border:write_band(border_tab(), {2, 1}, #{
+        ~"pirate" => #{type => ~"npc", x => 205.0, y => 150.0},
+        ~"rock" => #{type => ~"debris", x => 206.0, y => 150.0}
+    }).
+
+spatial_neighbours_radius() ->
+    St = install_api_with_grid(),
+    publish_pirate(),
+    Code =
+        "local r = game.spatial.neighbours_radius(195.0, 150.0, 30.0)\n"
+        "local ids = {}\n"
+        "for _, h in ipairs(r) do ids[#ids + 1] = h.id end\n"
+        "table.sort(ids)\n"
+        "return #r, ids[1], ids[2]",
+    {ok, [N, First, Second | _], _} = eval(Code, St),
+    ?assertEqual(2, trunc(N)),
+    %% Sorted in Lua: asobi_spatial:query_radius/4 with no `sort` opt returns
+    %% maps:fold order, so asserting on r[1] alone would be asserting on a
+    %% nondeterminism.
+    ?assertEqual(~"pirate", First),
+    ?assertEqual(~"rock", Second).
+
+spatial_neighbours_radius_opts() ->
+    St = install_api_with_grid(),
+    publish_pirate(),
+    Code =
+        "local r = game.spatial.neighbours_radius(195.0, 150.0, 30.0, { type = 'npc' })\n"
+        "return #r, r[1].id",
+    {ok, [N, Id | _], _} = eval(Code, St),
+    ?assertEqual(1, trunc(N)),
+    ?assertEqual(~"pirate", Id).
+
+spatial_neighbours_rect() ->
+    St = install_api_with_grid(),
+    publish_pirate(),
+    Code = "return #game.spatial.neighbours_rect(190.0, 140.0, 210.0, 160.0)",
+    {ok, [N | _], _} = eval(Code, St),
+    ?assertEqual(2, trunc(N)).
+
+spatial_neighbours_no_grid() ->
+    St = install_api_with_zone(),
+    {ok, [Err | _], _} = eval("return game.spatial.neighbours_radius(0.0, 0.0, 1.0).error", St),
+    ?assertNotEqual(nomatch, binary:match(Err, ~"zone context")).
+
+%% Stands in for the zone that owns the addressed entity; `whereis_zone` is
+%% mecked to hand it back so this test stays about the API rather than about pg.
+spawn_zone_stub(_Coords) ->
+    spawn(fun() ->
+        receive
+            _ -> ok
+        end
+    end).
+
+zone_apply_delivers() ->
+    St = install_api_with_grid(),
+    publish_pirate(),
+    asobi_lua_api:reset_effect_sends(),
+    %% Lua numbers are floats: `12` on the Lua side is 12.0 by the time it is a
+    %% decoded Erlang term, and asserting on the integer would be asserting on
+    %% something the wire cannot produce.
+    {ok, [true | _], _} = eval("return game.zone.apply('pirate', { damage = 12.0 })", St),
+    ?assert(meck:called(asobi_zone, whereis_zone, [~"nb-world", {2, 1}])),
+    [{_, {_, _, [_, ~"pirate", Event]}, ok} | _] = lists:filter(
+        fun
+            ({_, {asobi_zone, apply_effect, _}, _}) -> true;
+            (_) -> false
+        end,
+        meck:history(asobi_zone)
+    ),
+    ?assertEqual(#{~"damage" => 12.0}, Event).
+
+zone_apply_refuses_unseen() ->
+    St = install_api_with_grid(),
+    publish_pirate(),
+    %% `false`, not an error: "I cannot see that entity from here" is an
+    %% ordinary outcome a script branches on, and it is also the authorisation
+    %% rule - see asobi_zone_border:owner/4.
+    {ok, [Result | _], _} = eval("return game.zone.apply('nobody', {})", St),
+    ?assertEqual(false, Result).
+
+zone_apply_bad_event() ->
+    St = install_api_with_grid(),
+    publish_pirate(),
+    {ok, [Err | _], _} = eval("return game.zone.apply('pirate', 7).error", St),
+    ?assertNotEqual(nomatch, binary:match(Err, ~"event_table")).
+
+%% A cross-zone event is a verb, not a payload, and the size bound is spent on
+%% the caller because past that point the term is already on another process's
+%% heap and in its mailbox.
+zone_apply_oversized_event() ->
+    St = install_api_with_grid(),
+    publish_pirate(),
+    Code =
+        "local big = {}\n"
+        "for i = 1, 5000 do big['k' .. i] = i end\n"
+        "return game.zone.apply('pirate', big)",
+    {ok, [Result | _], _} = eval(Code, St),
+    ?assertEqual(false, Result),
+    ?assertNot(meck:called(asobi_zone, apply_effect, '_')).
+
+zone_apply_send_budget() ->
+    St = install_api_with_grid(),
+    publish_pirate(),
+    asobi_lua_api:reset_effect_sends(),
+    Code =
+        "local sent = 0\n"
+        "for _ = 1, 500 do if game.zone.apply('pirate', { d = 1 }) then sent = sent + 1 end end\n"
+        "return sent",
+    try
+        {ok, [Sent | _], _} = eval(Code, St),
+        ?assertEqual(64, trunc(Sent))
+    after
+        asobi_lua_api:reset_effect_sends()
+    end.
+
+spatial_neighbours_bad_args() ->
+    St = install_api_with_grid(),
+    {ok, [E1 | _], _} = eval("return game.spatial.neighbours_radius(1.0).error", St),
+    ?assertNotEqual(nomatch, binary:match(E1, ~"x, y, radius")),
+    {ok, [E2 | _], _} = eval("return game.spatial.neighbours_rect(1.0, 2.0).error", St),
+    ?assertNotEqual(nomatch, binary:match(E2, ~"x1, y1, x2, y2")).
+
+zone_apply_no_grid() ->
+    St = install_api_with_zone(),
+    {ok, [Err | _], _} = eval("return game.zone.apply('x', {}).error", St),
+    ?assertNotEqual(nomatch, binary:match(Err, ~"zone context")).
+
 spatial_zone_query_radius() ->
     St = install_api_with_zone(),
     Code =
@@ -689,22 +859,39 @@ spatial_query_radius_with_opts() ->
     St = install_api(),
     %% A regression that drops the opts arg would break entity-type
     %% filtering — meck_history confirms the 4-arg variant fires.
+    %%
+    %% Unloaded in an `after`: meck:expect/3 on a module nothing called
+    %% meck:new/2 for mecks it implicitly, and the foreach setup/cleanup here
+    %% does not know about it - so without this the stub outlives this test and
+    %% answers every later one that reaches asobi_spatial (it did, for
+    %% game.spatial.neighbours_radius).
     meck:expect(asobi_spatial, query_radius, fun(_, _, _, _) ->
         [{~"e1", #{type => ~"npc"}, 4.0}]
     end),
-    Code =
-        "local entities = { a = { x = 0.0, y = 0.0, type = 'npc' } }\n"
-        "local r = game.spatial.query_radius(entities, 0.0, 0.0, 10.0, { type = 'npc' })\n"
-        "return #r",
-    {ok, [Count | _], _} = eval(Code, St),
-    ?assertEqual(1, trunc(Count)),
-    ?assert(meck:called(asobi_spatial, query_radius, '_')).
+    try
+        Code =
+            "local entities = { a = { x = 0.0, y = 0.0, type = 'npc' } }\n"
+            "local r = game.spatial.query_radius(entities, 0.0, 0.0, 10.0, { type = 'npc' })\n"
+            "return #r",
+        {ok, [Count | _], _} = eval(Code, St),
+        ?assertEqual(1, trunc(Count)),
+        ?assert(meck:called(asobi_spatial, query_radius, '_'))
+    after
+        meck:unload(asobi_spatial)
+    end.
 
 spatial_nearest_with_opts() ->
     St = install_api(),
     meck:expect(asobi_spatial, nearest, fun(_, _, _, _) ->
         [{~"e1", #{type => ~"npc"}, 1.0}]
     end),
+    try
+        spatial_nearest_with_opts_body(St)
+    after
+        meck:unload(asobi_spatial)
+    end.
+
+spatial_nearest_with_opts_body(St) ->
     Code =
         "local entities = { a = { x = 0.0, y = 0.0, type = 'npc' } }\n"
         "local r = game.spatial.nearest(entities, 0.0, 0.0, 1, { max_results = 1 })\n"

--- a/test/asobi_lua_reload_tests.erl
+++ b/test/asobi_lua_reload_tests.erl
@@ -7,8 +7,62 @@ reload_mode_test_() ->
         {"reload_mode = auto polls mtime", fun auto_polls/0},
         {"unknown env value falls back to auto", fun unknown_env_is_auto/0},
         {"reload_mode = off clears a stale just_reloaded flag",
-            fun off_clears_stale_just_reloaded_flag/0}
+            fun off_clears_stale_just_reloaded_flag/0},
+        {"auto polls at most once per interval", fun auto_throttles_the_stat/0},
+        {"an interval of 0 polls every call", fun zero_interval_polls_always/0}
     ].
+
+%% widgrensit/asobi#543: `auto` used to stat the script on every tick, which at
+%% 80 Hz across 225 zones is 18,000 syscalls a second to notice an edit a human
+%% makes every few minutes. The stamp is what proves the second call did not
+%% reach the stat.
+auto_throttles_the_stat() ->
+    with_auto(fun() ->
+        Old = application:get_env(asobi_lua, reload_poll_interval_ms),
+        application:set_env(asobi_lua, reload_poll_interval_ms, 60_000),
+        try
+            State = #{
+                script => "/nonexistent.lua",
+                script_mtime => {{1970, 1, 1}, {0, 0, 0}},
+                lua_state => fake_lua_state
+            },
+            First = asobi_lua_reload:maybe_hot_reload(State),
+            Deadline = maps:get(reload_poll_at, First),
+            Second = asobi_lua_reload:maybe_hot_reload(First),
+            %% Same deadline means maybe_poll/1 took the "too soon" branch: it
+            %% only re-stamps when it actually polls.
+            ?assertEqual(Deadline, maps:get(reload_poll_at, Second))
+        after
+            restore(reload_poll_interval_ms, Old)
+        end
+    end).
+
+zero_interval_polls_always() ->
+    with_auto(fun() ->
+        Old = application:get_env(asobi_lua, reload_poll_interval_ms),
+        application:set_env(asobi_lua, reload_poll_interval_ms, 0),
+        try
+            State = #{
+                script => "/nonexistent.lua",
+                script_mtime => {{1970, 1, 1}, {0, 0, 0}},
+                lua_state => fake_lua_state
+            },
+            %% No stamp at all on this path - the old per-tick behaviour, byte
+            %% for byte.
+            ?assertEqual(State, asobi_lua_reload:maybe_hot_reload(State))
+        after
+            restore(reload_poll_interval_ms, Old)
+        end
+    end).
+
+with_auto(Fun) ->
+    OldEnv = application:get_env(asobi_lua, reload_mode),
+    application:set_env(asobi_lua, reload_mode, auto),
+    try
+        Fun()
+    after
+        restore(reload_mode, OldEnv)
+    end.
 
 %% When reload_mode is `off`, the function returns the state unchanged
 %% even if the script's mtime has actually moved. Set up a state where
@@ -27,6 +81,13 @@ off_short_circuits() ->
         restore(reload_mode, OldEnv)
     end.
 
+%% `auto` stamps the poll deadline into the state, so an auto run is never
+%% byte-identical to its input. Compare everything else.
+assert_unchanged_but_stamped(State) ->
+    Out = asobi_lua_reload:maybe_hot_reload(State),
+    ?assert(maps:is_key(reload_poll_at, Out)),
+    ?assertEqual(State, maps:remove(reload_poll_at, Out)).
+
 %% When reload_mode is `auto`, the function actually consults
 %% filelib:last_modified on the path. We can't easily induce a real
 %% reload here without a fixture script + mtime bump, but we can prove
@@ -41,7 +102,7 @@ auto_polls() ->
             script_mtime => {{1970, 1, 1}, {0, 0, 0}},
             lua_state => fake_lua_state
         },
-        ?assertEqual(State, asobi_lua_reload:maybe_hot_reload(State))
+        assert_unchanged_but_stamped(State)
     after
         restore(reload_mode, OldEnv)
     end.
@@ -61,7 +122,7 @@ unknown_env_is_auto() ->
             script_mtime => {{1970, 1, 1}, {0, 0, 0}},
             lua_state => fake_lua_state
         },
-        ?assertEqual(State, asobi_lua_reload:maybe_hot_reload(State))
+        assert_unchanged_but_stamped(State)
     after
         restore(reload_mode, OldEnv),
         case OldOs of

--- a/test/asobi_lua_vm_tests.erl
+++ b/test/asobi_lua_vm_tests.erl
@@ -1,0 +1,183 @@
+-module(asobi_lua_vm_tests).
+-include_lib("eunit/include/eunit.hrl").
+
+%% ADR 0015. The point of these is parity plus the one behaviour that genuinely
+%% differs: under `owned` a runaway callback costs the state, not the tick.
+
+-spec fixture(string()) -> file:filename_all().
+fixture(Name) ->
+    Dir =
+        case code:lib_dir(asobi) of
+            {error, bad_name} -> error(asobi_not_loaded);
+            D -> D
+        end,
+    filename:absname(filename:join([Dir, "test", "fixtures", "lua", Name])).
+
+with_mode(Mode, Fun) ->
+    Prev = application:get_env(asobi, lua_vm_mode),
+    application:set_env(asobi, lua_vm_mode, Mode),
+    try
+        Fun()
+    after
+        case Prev of
+            {ok, V} -> application:set_env(asobi, lua_vm_mode, V);
+            undefined -> application:unset_env(asobi, lua_vm_mode)
+        end
+    end.
+
+zone_state(Script) ->
+    Config = #{game_config => #{lua_script => Script}},
+    ZS = asobi_lua_world:init_zone_state(Config, #{}),
+    erlang:erase({asobi_lua_world, zone_state}),
+    ZS.
+
+vm_test_() ->
+    [
+        {"copy mode hands back a raw Luerl state", fun copy_mode_is_unchanged/0},
+        {"owned mode hands back a VM handle", fun owned_mode_returns_a_handle/0},
+        {"both modes tick a zone identically", fun both_modes_agree/0},
+        {"both modes apply input identically", fun both_modes_agree_on_input/0},
+        {"a dead VM reports vm_down rather than crashing", fun dead_vm_is_reported/0},
+        {"release stops the VM", fun release_stops_the_vm/0},
+        {"a throwaway probe never starts a VM", fun probe_states_are_copied/0},
+        {"the mode defaults to copy", fun default_mode_is_copy/0}
+    ].
+
+default_mode_is_copy() ->
+    Prev = application:get_env(asobi, lua_vm_mode),
+    application:unset_env(asobi, lua_vm_mode),
+    try
+        ?assertEqual(copy, asobi_lua_loader:vm_mode())
+    after
+        case Prev of
+            {ok, V} -> application:set_env(asobi, lua_vm_mode, V);
+            undefined -> ok
+        end
+    end.
+
+copy_mode_is_unchanged() ->
+    with_mode(copy, fun() ->
+        #{lua_state := St} = zone_state(fixture("config_move_world.lua")),
+        ?assertNot(asobi_lua_vm:is_handle(St))
+    end).
+
+owned_mode_returns_a_handle() ->
+    with_mode(owned, fun() ->
+        #{lua_state := St} = ZS = zone_state(fixture("config_move_world.lua")),
+        ?assert(asobi_lua_vm:is_handle(St)),
+        ?assert(asobi_lua_vm:is_alive(St)),
+        asobi_lua_loader:release(maps:get(lua_state, ZS))
+    end).
+
+%% The load-bearing assertion of the whole change: a bridge cannot tell.
+both_modes_agree() ->
+    Script = fixture("config_move_world.lua"),
+    Entities = #{~"p1" => #{type => ~"player", x => 1.0, y => 2.0}},
+    Copy = with_mode(copy, fun() -> tick_once(Script, Entities) end),
+    Owned = with_mode(owned, fun() -> tick_once(Script, Entities) end),
+    ?assertEqual(Copy, Owned).
+
+tick_once(Script, Entities) ->
+    ZS = zone_state(Script),
+    {Ents, ZS1} = asobi_lua_world:zone_tick(Entities, ZS),
+    asobi_lua_loader:release(maps:get(lua_state, ZS1)),
+    erlang:erase({asobi_lua_world, zone_state}),
+    Ents.
+
+both_modes_agree_on_input() ->
+    Script = fixture("config_move_world.lua"),
+    Input = #{~"kind" => ~"move", ~"x" => 42, ~"y" => 7},
+    Copy = with_mode(copy, fun() -> input_once(Script, Input) end),
+    Owned = with_mode(owned, fun() -> input_once(Script, Input) end),
+    ?assertMatch(#{~"p1" := #{x := 42, y := 7}}, Owned),
+    ?assertEqual(Copy, Owned).
+
+input_once(Script, Input) ->
+    ZS = zone_state(Script),
+    {_, ZS1} = asobi_lua_world:zone_tick(#{}, ZS),
+    {ok, Entities} = asobi_lua_world:handle_input(~"p1", Input, #{}),
+    asobi_lua_loader:release(maps:get(lua_state, ZS1)),
+    erlang:erase({asobi_lua_world, zone_state}),
+    Entities.
+
+%% A handle whose VM has died is still a handle. Dispatching on liveness instead
+%% of shape would hand the tuple to luerl:encode/2 and crash the zone.
+dead_vm_is_reported() ->
+    with_mode(owned, fun() ->
+        #{lua_state := St} = zone_state(fixture("config_move_world.lua")),
+        asobi_lua_loader:release(St),
+        ?assert(asobi_lua_vm:is_handle(St)),
+        ?assertNot(asobi_lua_vm:is_alive(St)),
+        ?assertEqual({nil, St}, asobi_lua_loader:encode(#{~"a" => 1}, St)),
+        ?assertEqual(nil, asobi_lua_loader:decode(nil, St)),
+        ?assertEqual({error, vm_down}, asobi_lua_loader:call(zone_tick, [nil, nil], St, 100)),
+        ?assertNot(asobi_lua_loader:is_defined(zone_tick, St))
+    end).
+
+release_stops_the_vm() ->
+    with_mode(owned, fun() ->
+        #{lua_state := {asobi_lua_vm, Pid} = St} = zone_state(fixture("config_move_world.lua")),
+        ?assert(is_process_alive(Pid)),
+        asobi_lua_loader:release(St),
+        ?assertNot(is_process_alive(Pid))
+    end).
+
+%% A probe state answers one question and is dropped, so an owned VM there would
+%% be a process nothing ever stops.
+probe_states_are_copied() ->
+    with_mode(owned, fun() ->
+        Before = erlang:system_info(process_count),
+        Config = #{
+            mode => ~"test",
+            game_config => #{lua_script => fixture("config_game_type_world.lua")}
+        },
+        {ok, _} = asobi_lua_world:generate_world(0, Config),
+        ?assert(erlang:system_info(process_count) =< Before + 2)
+    end).
+
+%% A refused join must not advance the game state - otherwise a client drives a
+%% script by being turned away over and over. Under `copy` that revert is free
+%% (the mutated state is simply dropped); under `owned` the mutation has already
+%% happened inside the VM, and this is the test that caught it not being undone.
+join_refusal_reverts_test_() ->
+    [
+        {"copy mode reverts a refused join", fun() -> assert_refusal_reverts(copy) end},
+        {"owned mode reverts a refused join", fun() -> assert_refusal_reverts(owned) end}
+    ].
+
+assert_refusal_reverts(Mode) ->
+    with_mode(Mode, fun() ->
+        {ok, State0} = asobi_lua_match:init(#{lua_script => fixture("join_refuse.lua")}),
+        {error, _} = asobi_lua_match:join(~"silent", State0),
+        {error, _} = asobi_lua_match:join(~"silent", State0),
+        {ok, State1} = asobi_lua_match:join(~"p1", #{~"code" => ~"OPEN"}, State0),
+        #{~"attempts" := Attempts} = asobi_lua_match:get_state(~"p1", State1),
+        ?assertEqual(1, Attempts),
+        asobi_lua_loader:release(maps:get(lua_state, State1))
+    end).
+
+%% The same property one level down, so a regression is diagnosed at the
+%% primitive rather than through a match.
+revert_undoes_the_last_call_test_() ->
+    [
+        {"copy mode: dropping the state is the revert", fun() -> assert_revert(copy) end},
+        {"owned mode: the VM is asked to revert", fun() -> assert_revert(owned) end}
+    ].
+
+assert_revert(Mode) ->
+    with_mode(Mode, fun() ->
+        %% new/3, not new/1: new/1 is always the copying path, so an "owned"
+        %% case built on it would silently test copy twice.
+        {ok, St} = asobi_lua_loader:new(fixture("counter.lua"), 2000, fun(S) -> S end),
+        ?assertEqual(Mode =:= owned, asobi_lua_vm:is_handle(St)),
+        {ok, [One | _], St1} = asobi_lua_loader:call(bump, [], St, 1000),
+        ?assertEqual(1, trunc(One)),
+        {ok, [Two | _], _St2} = asobi_lua_loader:call(bump, [], St1, 1000),
+        ?assertEqual(2, trunc(Two)),
+        %% Undo the second bump. Under `copy` that means carrying on with St1;
+        %% under `owned` St1 and St2 are the same handle and only the VM can do it.
+        Reverted = asobi_lua_loader:revert(St1),
+        {ok, [Again | _], St3} = asobi_lua_loader:call(bump, [], Reverted, 1000),
+        ?assertEqual(2, trunc(Again)),
+        asobi_lua_loader:release(St3)
+    end).

--- a/test/asobi_lua_world_tests.erl
+++ b/test/asobi_lua_world_tests.erl
@@ -738,6 +738,13 @@ hot_reload_post_tick_survives_syntax_error_test() ->
     end.
 
 hot_reload_zone_tick_picks_up_global_change_test() ->
+    %% asobi#543 throttles the mtime stat to once per
+    %% `reload_poll_interval_ms`, and this test writes v2 and ticks again
+    %% inside that window. 0 is the documented "poll every call" setting; the
+    %% throttle itself is covered in asobi_lua_reload_tests.
+    with_every_tick_polling(fun hot_reload_zone_tick_picks_up_global_change_test_body/0).
+
+hot_reload_zone_tick_picks_up_global_change_test_body() ->
     %% Per-zone reload: each zone holds its own lua_state + script + mtime,
     %% and zone_tick checks the file at the start of every tick. We observe
     %% the reload by having zone_tick stamp a global value into the entities
@@ -822,6 +829,13 @@ hot_reload_zone_tick_survives_syntax_error_test() ->
     end.
 
 hot_reload_zone_tick_signals_spawn_templates_hint_test() ->
+    %% asobi#543 throttles the mtime stat to once per
+    %% `reload_poll_interval_ms`, and this test writes v2 and ticks again
+    %% inside that window. 0 is the documented "poll every call" setting; the
+    %% throttle itself is covered in asobi_lua_reload_tests.
+    with_every_tick_polling(fun hot_reload_zone_tick_signals_spawn_templates_hint_test_body/0).
+
+hot_reload_zone_tick_signals_spawn_templates_hint_test_body() ->
     %% asobi#253: a script edited on disk can add spawn templates that
     %% weren't present when the zone was created. spawn_templates_hint/1
     %% is how asobi_zone finds out, without polling every tick itself.
@@ -1094,3 +1108,50 @@ zone_bridge_identity() ->
         #{kind => zone, world_id => ~"w1", coords => {2, 3}},
         maps:get(lua_bridge, ZoneState)
     ).
+
+%% widgrensit/asobi#544: cross-zone effects reach the script batched, and the
+%% map it returns is what the zone keeps.
+handle_effects_applies_events_test() ->
+    Script = fixture("effects_world.lua"),
+    Config = #{game_config => #{lua_script => Script}},
+    ZoneState = asobi_lua_world:init_zone_state(Config, #{}),
+    erlang:erase({asobi_lua_world, zone_state}),
+    Entities = #{~"npc" => #{type => ~"npc", x => 1.0, y => 1.0, hp => 100}},
+    {_, _} = asobi_lua_world:zone_tick(Entities, ZoneState),
+    {ok, Out} = asobi_lua_world:handle_effects(
+        [{~"npc", #{~"hp_delta" => -30}}, {~"npc", #{~"hp_delta" => -5}}], Entities
+    ),
+    ?assertMatch(#{~"npc" := #{hp := 65}}, Out),
+    erlang:erase({asobi_lua_world, zone_state}).
+
+%% A script with no handle_effects must not be reported as a crashing one, and
+%% must leave the entities exactly as they were.
+handle_effects_without_a_handler_is_a_noop_test() ->
+    Script = fixture("config_move_world.lua"),
+    Config = #{game_config => #{lua_script => Script}},
+    {ok, ZoneStates} = asobi_lua_world:generate_world(0, Config),
+    ZoneState = asobi_lua_world:init_zone_state(Config, maps:get({0, 0}, ZoneStates)),
+    erlang:erase({asobi_lua_world, zone_state}),
+    {_, _} = asobi_lua_world:zone_tick(#{}, ZoneState),
+    Entities = #{~"npc" => #{type => ~"npc", x => 1.0, y => 1.0, hp => 100}},
+    ?assertEqual({ok, Entities}, asobi_lua_world:handle_effects([{~"npc", #{}}], Entities)),
+    erlang:erase({asobi_lua_world, zone_state}).
+
+%% No zone_tick has run, so there is no stashed lua_state: the bridge must hand
+%% the entities straight back rather than crash the zone.
+handle_effects_without_a_bridge_state_test() ->
+    erlang:erase({asobi_lua_world, zone_state}),
+    Entities = #{~"npc" => #{type => ~"npc"}},
+    ?assertEqual({ok, Entities}, asobi_lua_world:handle_effects([{~"npc", #{}}], Entities)).
+
+with_every_tick_polling(Fun) ->
+    Old = application:get_env(asobi_lua, reload_poll_interval_ms),
+    application:set_env(asobi_lua, reload_poll_interval_ms, 0),
+    try
+        Fun()
+    after
+        case Old of
+            {ok, V} -> application:set_env(asobi_lua, reload_poll_interval_ms, V);
+            undefined -> application:unset_env(asobi_lua, reload_poll_interval_ms)
+        end
+    end.

--- a/test/asobi_world_server_tests.erl
+++ b/test/asobi_world_server_tests.erl
@@ -775,3 +775,38 @@ ensure_vote_sup() ->
         _ ->
             ok
     end.
+
+%% widgrensit/asobi#543 review: `persistent` is the public global a game
+%% declares and `persistence` is the key every zone-side reader wants. Nothing
+%% translated between them, so no zone ever had persistence on and the whole
+%% snapshot path was dead - while `persistent = true` still made the world keep
+%% the snapshots it had never written.
+persistent_reaches_the_zone_config_test() ->
+    setup(),
+    try
+        #{instance_pid := InstancePid} = start_world(#{persistent => true}),
+        try
+            ZoneManager = asobi_world_instance:get_child(InstancePid, asobi_zone_manager),
+            #{zone_config := ZoneConfig} = sys:get_state(ZoneManager),
+            ?assertEqual(true, maps:get(persistence, ZoneConfig))
+        after
+            exit(InstancePid, shutdown)
+        end
+    after
+        cleanup(ok)
+    end.
+
+a_world_that_did_not_ask_is_not_persistent_test() ->
+    setup(),
+    try
+        #{instance_pid := InstancePid} = start_world(),
+        try
+            ZoneManager = asobi_world_instance:get_child(InstancePid, asobi_zone_manager),
+            #{zone_config := ZoneConfig} = sys:get_state(ZoneManager),
+            ?assertEqual(false, maps:get(persistence, ZoneConfig))
+        after
+            exit(InstancePid, shutdown)
+        end
+    after
+        cleanup(ok)
+    end.

--- a/test/asobi_world_ticker_tests.erl
+++ b/test/asobi_world_ticker_tests.erl
@@ -43,8 +43,116 @@ ticker_test_() ->
             {"a healthy world emits no skip events", fun healthy_world_emits_no_skips/0},
             {"post_tick never runs backwards", fun post_tick_is_monotonic/0},
             {"the world keeps posting while saturated", fun post_tick_survives_saturation/0},
-            {"set_zones twice arms one timer", fun set_zones_twice_arms_one_timer/0}
+            {"set_zones twice arms one timer", fun set_zones_twice_arms_one_timer/0},
+            {"a demoted zone stays cold under a zone manager", fun manager_honours_cold_zones/0},
+            {"a cold zone is skipped on an off-divisor tick", fun cold_zone_skipped/0},
+            {"a reaped cold zone drops out of the cold set", fun cold_set_prunes_dead_zones/0}
         ]}.
+
+%% widgrensit/asobi#543: with a zone manager the ticker used to overwrite its
+%% own hot/cold split with "every active zone is hot", which made
+%% cold_tick_divisor inert for every world running lazy zones.
+manager_honours_cold_zones() ->
+    Z1 = idle_proc(),
+    Z2 = idle_proc(),
+    Manager = fake_manager([Z1, Z2]),
+    Pid = start_ticker(#{tick_rate => 20}),
+    asobi_world_ticker:set_zone_manager(Pid, Manager, self()),
+    asobi_world_ticker:demote_zone(Pid, Z1),
+    timer:sleep(80),
+    State = get_state_map(Pid),
+    ?assertEqual([Z1], maps:get(cold_zones, State)),
+    ?assertEqual([Z2], maps:get(hot_zones, State)).
+
+cold_zone_skipped() ->
+    Z1 = counting_proc(),
+    Z2 = counting_proc(),
+    Manager = fake_manager([Z1, Z2]),
+    Pid = start_ticker(#{tick_rate => 10, cold_tick_divisor => 100}),
+    %% Each stand-in must retire its tick, or the ticker's saturation guard
+    %% skips it from the second tick onwards and both counts stay at 1.
+    Z1 ! {ticker, Pid},
+    Z2 ! {ticker, Pid},
+    asobi_world_ticker:set_zone_manager(Pid, Manager, self()),
+    asobi_world_ticker:demote_zone(Pid, Z1),
+    timer:sleep(150),
+    Hot = tick_count(Z2),
+    %% Exact rather than "fewer": with a divisor of 100 and at most ~15 world
+    %% ticks in the window, the cold zone should not have been reached once.
+    ?assertEqual(0, tick_count(Z1)),
+    %% Deliberately loose: this box runs eunit modules in parallel, so a 10ms
+    %% ticker's dispatch count over 150ms is not something to assert tightly.
+    ?assert(Hot >= 3).
+
+cold_set_prunes_dead_zones() ->
+    Z1 = idle_proc(),
+    Manager = fake_manager([Z1]),
+    Pid = start_ticker(#{tick_rate => 20}),
+    asobi_world_ticker:set_zone_manager(Pid, Manager, self()),
+    asobi_world_ticker:demote_zone(Pid, Z1),
+    timer:sleep(60),
+    ?assertEqual([Z1], maps:get(cold_zones, get_state_map(Pid))),
+    %% The manager stops listing it (the zone was reaped). Nothing sends
+    %% remove_zone, so the cold set has to prune itself or it grows for the
+    %% life of the world.
+    set_manager_zones(Manager, []),
+    timer:sleep(80),
+    ?assertEqual([], maps:get(cold_zones, get_state_map(Pid))).
+
+idle_proc() ->
+    spawn(fun() ->
+        receive
+            stop -> ok
+        end
+    end).
+
+%% Answers get_active_zones and counts nothing else; the zone list is
+%% swappable so a test can simulate a reap.
+fake_manager(Zones) ->
+    spawn(fun() -> manager_loop(Zones) end).
+
+manager_loop(Zones) ->
+    receive
+        {'$gen_call', {From, Tag}, get_active_zones} ->
+            From ! {Tag, Zones},
+            manager_loop(Zones);
+        {set_zones, New} ->
+            manager_loop(New);
+        stop ->
+            ok
+    end.
+
+set_manager_zones(Manager, Zones) ->
+    Manager ! {set_zones, Zones},
+    ok.
+
+%% A zone stand-in that counts the ticks it is sent.
+counting_proc() ->
+    spawn(fun() -> counting_loop(0, undefined) end).
+
+counting_loop(N, Ticker) ->
+    receive
+        {ticker, Pid} ->
+            counting_loop(N, Pid);
+        {'$gen_cast', {tick, T}} ->
+            case Ticker of
+                undefined -> ok;
+                _ -> asobi_world_ticker:tick_done(Ticker, self(), T)
+            end,
+            counting_loop(N + 1, Ticker);
+        {count, From} ->
+            From ! {count, N},
+            counting_loop(N, Ticker);
+        stop ->
+            ok
+    end.
+
+tick_count(Pid) ->
+    Pid ! {count, self()},
+    receive
+        {count, N} -> N
+    after 1000 -> error(no_count)
+    end.
 
 get_tick_starts_at_zero() ->
     Pid = start_ticker(),

--- a/test/asobi_zone_border_tests.erl
+++ b/test/asobi_zone_border_tests.erl
@@ -1,0 +1,159 @@
+-module(asobi_zone_border_tests).
+-include_lib("eunit/include/eunit.hrl").
+
+%% A 100-unit zone at (1,1) covers [100,200) on both axes; a band of 10 is
+%% therefore x<110, x>=190, y<110 or y>=190.
+-define(ZS, 100).
+-define(GRID, 5).
+-define(TAB, {?MODULE, tab}).
+
+%% One table per world in production, owned by the world's instance supervisor.
+%% Here the eunit foreach parent owns it, which is the same lifetime property:
+%% it outlives the individual test bodies.
+setup() ->
+    case persistent_term:get(?TAB, undefined) of
+        undefined -> persistent_term:put(?TAB, asobi_zone_border:new());
+        Tab -> ets:delete_all_objects(Tab)
+    end.
+
+tab() -> persistent_term:get(?TAB).
+
+e(X, Y) -> #{type => ~"npc", x => X, y => Y}.
+
+%% Mirrors what asobi_zone:publish_border/1 actually does - compute the band,
+%% then write it - rather than a convenience wrapper src/ does not call. A test
+%% driving a second implementation of the production path is a test that cannot
+%% catch the production path being wrong.
+publish(Tab, Coords, ZoneSize, Band, Entities) ->
+    case asobi_zone_border:band_entities(Coords, ZoneSize, Band, Entities) of
+        Empty when map_size(Empty) =:= 0 -> asobi_zone_border:clear(Tab, Coords);
+        InBand -> asobi_zone_border:write_band(Tab, Coords, InBand)
+    end.
+
+border_test_() ->
+    {foreach, fun setup/0, fun(_) -> setup() end, [
+        {"the band keeps only entities near an edge", fun band_selects_edges/0},
+        {"an entity with no position is never in the band", fun band_skips_unpositioned/0},
+        {"binary-keyed entities are read too", fun band_reads_binary_keys/0},
+        {"a corner zone has three neighbours", fun neighbours_clamped_to_grid/0},
+        {"a middle zone has eight", fun neighbours_middle/0},
+        {"a zone never neighbours itself", fun neighbours_excludes_self/0},
+        {"a radius query reads the neighbours, not the caller", fun radius_reads_neighbours/0},
+        {"query opts are honoured", fun radius_honours_opts/0},
+        {"a rect query reads the neighbours", fun rect_reads_neighbours/0},
+        {"owner finds the publishing zone", fun owner_finds_zone/0},
+        {"owner refuses an entity no neighbour publishes", fun owner_refuses_unseen/0},
+        {"clear removes the row", fun clear_removes/0},
+        {"one world never reads another's band", fun worlds_are_isolated/0},
+        {"no table at all degrades to empty, never crashes", fun no_table_is_empty/0}
+    ]}.
+
+band_selects_edges() ->
+    Entities = #{
+        ~"near_left" => e(105.0, 150.0),
+        ~"near_right" => e(195.0, 150.0),
+        ~"near_top" => e(150.0, 102.0),
+        ~"middle" => e(150.0, 150.0)
+    },
+    InBand = asobi_zone_border:band_entities({1, 1}, ?ZS, 10, Entities),
+    ?assertEqual(
+        [~"near_left", ~"near_right", ~"near_top"], lists:sort(maps:keys(InBand))
+    ).
+
+band_skips_unpositioned() ->
+    Entities = #{~"ghost" => #{type => ~"npc"}, ~"real" => e(105.0, 150.0)},
+    ?assertEqual([~"real"], maps:keys(asobi_zone_border:band_entities({1, 1}, ?ZS, 10, Entities))).
+
+band_reads_binary_keys() ->
+    %% The Lua bridge decodes entities to binary keys; asobi_zone reads both
+    %% shapes and so must this, or the mirror is silently empty for every Lua
+    %% world.
+    Entities = #{~"lua" => #{~"type" => ~"npc", ~"x" => 105.0, ~"y" => 150.0}},
+    ?assertEqual([~"lua"], maps:keys(asobi_zone_border:band_entities({1, 1}, ?ZS, 10, Entities))).
+
+neighbours_clamped_to_grid() ->
+    ?assertEqual(
+        [{0, 1}, {1, 0}, {1, 1}], lists:sort(asobi_zone_border:neighbours({0, 0}, ?GRID))
+    ).
+
+neighbours_middle() ->
+    ?assertEqual(8, length(asobi_zone_border:neighbours({2, 2}, ?GRID))).
+
+neighbours_excludes_self() ->
+    ?assertNot(lists:member({2, 2}, asobi_zone_border:neighbours({2, 2}, ?GRID))).
+
+radius_reads_neighbours() ->
+    %% The caller is (1,1). (2,1) owns a pirate just past the shared seam at
+    %% x=200; (1,1) owns a pilot of its own at x=195. A radius query from the
+    %% caller must return the neighbour's pirate and NOT its own pilot - the
+    %% caller already holds its own entity map, and returning both would double
+    %% every in-zone entity.
+    publish(tab(), {2, 1}, ?ZS, 10, #{~"pirate" => e(205.0, 150.0)}),
+    publish(tab(), {1, 1}, ?ZS, 10, #{~"pilot" => e(195.0, 150.0)}),
+    Results = asobi_zone_border:query_radius(tab(), {1, 1}, ?GRID, {195.0, 150.0}, 20.0),
+    ?assertMatch([{~"pirate", _, _}], Results).
+
+radius_honours_opts() ->
+    publish(tab(), {2, 1}, ?ZS, 10, #{
+        ~"pirate" => e(205.0, 150.0),
+        ~"rock" => (e(206.0, 150.0))#{type => ~"debris"}
+    }),
+    Results = asobi_zone_border:query_radius(
+        tab(), {1, 1}, ?GRID, {195.0, 150.0}, 20.0, #{type => ~"npc"}
+    ),
+    ?assertMatch([{~"pirate", _, _}], Results).
+
+rect_reads_neighbours() ->
+    publish(tab(), {2, 1}, ?ZS, 10, #{~"pirate" => e(205.0, 150.0)}),
+    Results = asobi_zone_border:query_rect(
+        tab(), {1, 1}, ?GRID, {190.0, 140.0}, {210.0, 160.0}
+    ),
+    ?assertMatch([{~"pirate", _}], Results).
+
+owner_finds_zone() ->
+    publish(tab(), {2, 1}, ?ZS, 10, #{~"pirate" => e(205.0, 150.0)}),
+    ?assertEqual({ok, {2, 1}}, asobi_zone_border:owner(tab(), {1, 1}, ?GRID, ~"pirate")).
+
+owner_refuses_unseen() ->
+    %% (3,1) does not touch (1,1). Publishing there must not make its entities
+    %% addressable from (1,1): "what I may affect" is "what I can see".
+    publish(tab(), {3, 1}, ?ZS, 10, #{~"far" => e(305.0, 150.0)}),
+    ?assertEqual(error, asobi_zone_border:owner(tab(), {1, 1}, ?GRID, ~"far")),
+    ?assertEqual(error, asobi_zone_border:owner(tab(), {1, 1}, ?GRID, ~"nobody")),
+    ?assertEqual(error, asobi_zone_border:owner(tab(), {1, 1}, ?GRID, not_a_binary)).
+
+clear_removes() ->
+    publish(tab(), {2, 1}, ?ZS, 10, #{~"pirate" => e(205.0, 150.0)}),
+    asobi_zone_border:clear(tab(), {2, 1}),
+    ?assertEqual([], asobi_zone_border:query_radius(tab(), {1, 1}, ?GRID, {200.0, 150.0}, 50.0)).
+
+%% One table per world is the whole cross-tenant story for this mirror: there is
+%% no key convention to get wrong, because a zone in world A is never handed
+%% world B's table in the first place.
+worlds_are_isolated() ->
+    Other = asobi_zone_border:new(),
+    asobi_zone_border:write_band(Other, {2, 1}, #{~"theirs" => e(205.0, 150.0)}),
+    try
+        ?assertEqual(
+            [], asobi_zone_border:query_radius(tab(), {1, 1}, ?GRID, {205.0, 150.0}, 50.0)
+        ),
+        ?assertEqual(error, asobi_zone_border:owner(tab(), {1, 1}, ?GRID, ~"theirs")),
+        ?assertMatch(
+            [{~"theirs", _, _}],
+            asobi_zone_border:query_radius(Other, {1, 1}, ?GRID, {205.0, 150.0}, 50.0)
+        )
+    after
+        ets:delete(Other)
+    end.
+
+%% A zone started outside a world instance (every unit test that starts one
+%% bare) has no table at all. Every entry point must degrade to empty rather
+%% than crash the zone mid-tick.
+no_table_is_empty() ->
+    ?assertEqual([], asobi_zone_border:query_radius(undefined, {1, 1}, ?GRID, {0.0, 0.0}, 10.0)),
+    ?assertEqual(
+        [], asobi_zone_border:query_rect(undefined, {1, 1}, ?GRID, {0.0, 0.0}, {9.9, 9.9})
+    ),
+    ?assertEqual(error, asobi_zone_border:owner(undefined, {1, 1}, ?GRID, ~"x")),
+    ?assertEqual(ok, asobi_zone_border:clear(undefined, {1, 1})),
+    ?assertEqual(ok, asobi_zone_border:write_band(undefined, {1, 1}, #{~"a" => e(1.0, 1.0)})).

--- a/test/asobi_zone_cold_tests.erl
+++ b/test/asobi_zone_cold_tests.erl
@@ -1,0 +1,185 @@
+-module(asobi_zone_cold_tests).
+-include_lib("eunit/include/eunit.hrl").
+
+%% widgrensit/asobi#543: a zone with nothing to simulate should stop paying the
+%% full per-tick cost. These assert the classification and, more importantly,
+%% the two directions of the transition - a zone that never promotes again is a
+%% zone that stops responding to players.
+
+-export([zone_tick/2, handle_input/3]).
+
+zone_tick(E, ZS) -> {E, ZS}.
+handle_input(_P, _I, E) -> {ok, E}.
+
+setup() ->
+    case ets:info(asobi_world_state) of
+        undefined -> ets:new(asobi_world_state, [named_table, public, set]);
+        _ -> ok
+    end,
+    case pg:start(nova_scope) of
+        {ok, _} -> ok;
+        {error, {already_started, _}} -> ok
+    end,
+    ok.
+
+start_zone() ->
+    {ok, Pid} = asobi_zone:start_link(#{
+        world_id => ~"cold-world",
+        coords => {1, 1},
+        ticker_pid => self(),
+        zone_size => 100,
+        grid_size => 5,
+        game_module => ?MODULE
+    }),
+    Pid.
+
+tick(Pid, N) ->
+    asobi_zone:tick(Pid, N),
+    _ = sys:get_state(Pid),
+    ok.
+
+is_cold(Pid) ->
+    case sys:get_state(Pid) of
+        #{cold := Cold} -> Cold
+    end.
+
+%% The zone casts promote/demote at its ticker_pid, which is this process.
+drain_ticker_casts() ->
+    receive
+        {'$gen_cast', {promote_zone, _}} -> [promote | drain_ticker_casts()];
+        {'$gen_cast', {demote_zone, _}} -> [demote | drain_ticker_casts()];
+        {'$gen_cast', {tick_done, _, _}} -> drain_ticker_casts()
+    after 0 -> []
+    end.
+
+cold_test_() ->
+    {foreach, fun setup/0, fun(_) -> ok end, [
+        {"a zone starts hot", fun starts_hot/0},
+        {"an empty zone goes cold on its first tick", fun empties_go_cold/0},
+        {"going cold is announced once", fun demote_announced_once/0},
+        {"an entity warms the zone before its next tick", fun entity_warms/0},
+        {"an input warms the zone before its next tick", fun input_warms/0},
+        {"an effect warms the zone", fun effect_warms/0},
+        {"an occupied zone stays hot", fun occupied_stays_hot/0},
+        {"a subscriber alone does not keep a zone hot", fun subscriber_does_not_warm/0},
+        {"going cold and warming again are each announced once", fun transitions_emit_telemetry/0}
+    ]}.
+
+%% An operator watching a world needs to see a zone stop simulating - a zone
+%% that goes cold and never comes back is one that has stopped responding to the
+%% players in it, and before this there was no signal for it at all.
+transitions_emit_telemetry() ->
+    {ok, _} = application:ensure_all_started(telemetry),
+    Ref = make_ref(),
+    Self = self(),
+    ok = telemetry:attach_many(
+        {?MODULE, Ref},
+        [[asobi, zone, cold], [asobi, zone, hot]],
+        fun(Event, _Measure, Meta, _) -> Self ! {telemetry, Event, Meta} end,
+        []
+    ),
+    try
+        Pid = start_zone(),
+        tick(Pid, 1),
+        ?assertEqual(
+            {[asobi, zone, cold], {1, 1}}, next_event()
+        ),
+        %% A second idle tick must not re-announce: this is a transition, not a
+        %% state, or a large empty world emits one event per zone per tick.
+        tick(Pid, 2),
+        asobi_zone:add_entity(Pid, ~"npc", #{type => ~"npc", x => 150.0, y => 150.0}),
+        _ = sys:get_state(Pid),
+        ?assertEqual({[asobi, zone, hot], {1, 1}}, next_event()),
+        gen_server:stop(Pid)
+    after
+        telemetry:detach({?MODULE, Ref})
+    end.
+
+next_event() ->
+    receive
+        {telemetry, Event, #{coords := Coords}} -> {Event, Coords}
+    after 1000 -> timeout
+    end.
+
+starts_hot() ->
+    Pid = start_zone(),
+    ?assertNot(is_cold(Pid)),
+    gen_server:stop(Pid).
+
+empties_go_cold() ->
+    Pid = start_zone(),
+    tick(Pid, 1),
+    ?assert(is_cold(Pid)),
+    gen_server:stop(Pid).
+
+demote_announced_once() ->
+    Pid = start_zone(),
+    tick(Pid, 1),
+    ?assertEqual([demote], drain_ticker_casts()),
+    tick(Pid, 2),
+    tick(Pid, 3),
+    ?assertEqual([], drain_ticker_casts()),
+    gen_server:stop(Pid).
+
+entity_warms() ->
+    Pid = start_zone(),
+    tick(Pid, 1),
+    _ = drain_ticker_casts(),
+    ?assert(is_cold(Pid)),
+    %% Promotion must happen on the message that created the work, not on the
+    %% zone's own next tick - a cold zone ticks once every cold_tick_divisor
+    %% ticks, so waiting would put that whole divisor of latency on entering a
+    %% zone.
+    asobi_zone:add_entity(Pid, ~"npc", #{type => ~"npc", x => 150.0, y => 150.0}),
+    _ = sys:get_state(Pid),
+    ?assertNot(is_cold(Pid)),
+    ?assertEqual([promote], drain_ticker_casts()),
+    gen_server:stop(Pid).
+
+input_warms() ->
+    Pid = start_zone(),
+    tick(Pid, 1),
+    _ = drain_ticker_casts(),
+    asobi_zone:player_input(Pid, ~"p1", #{~"kind" => ~"move"}),
+    _ = sys:get_state(Pid),
+    ?assertNot(is_cold(Pid)),
+    ?assertEqual([promote], drain_ticker_casts()),
+    gen_server:stop(Pid).
+
+effect_warms() ->
+    Pid = start_zone(),
+    tick(Pid, 1),
+    _ = drain_ticker_casts(),
+    asobi_zone:apply_effect(Pid, ~"someone", #{~"hp_delta" => -1}),
+    _ = sys:get_state(Pid),
+    ?assertNot(is_cold(Pid)),
+    ?assertEqual([promote], drain_ticker_casts()),
+    gen_server:stop(Pid).
+
+occupied_stays_hot() ->
+    Pid = start_zone(),
+    asobi_zone:add_entity(Pid, ~"npc", #{type => ~"npc", x => 150.0, y => 150.0}),
+    tick(Pid, 1),
+    tick(Pid, 2),
+    ?assertNot(is_cold(Pid)),
+    %% Not merely "the flag stayed false": reclassify/1 must take its no-op
+    %% branch rather than cast promote on every one of the world's ticks.
+    ?assertEqual([], drain_ticker_casts()),
+    gen_server:stop(Pid).
+
+subscriber_does_not_warm() ->
+    %% This is the "watched but empty" case #543 asks about: a pilot in a
+    %% neighbouring zone subscribes to this one, but there is nothing here to
+    %% simulate and nothing to send, so it does not need a full-rate tick.
+    Pid = start_zone(),
+    Player = spawn(fun() ->
+        receive
+            stop -> ok
+        end
+    end),
+    asobi_zone:subscribe(Pid, {~"p1", Player}),
+    _ = sys:get_state(Pid),
+    tick(Pid, 1),
+    ?assert(is_cold(Pid)),
+    Player ! stop,
+    gen_server:stop(Pid).

--- a/test/asobi_zone_effects_bad_return_game.erl
+++ b/test/asobi_zone_effects_bad_return_game.erl
@@ -1,0 +1,9 @@
+-module(asobi_zone_effects_bad_return_game).
+
+%% A game module whose handle_effects/2 breaks its contract. asobi must keep the
+%% entity map it already had rather than write the garbage back.
+-export([zone_tick/2, handle_input/3, handle_effects/2]).
+
+zone_tick(E, ZS) -> {E, ZS}.
+handle_input(_P, _I, E) -> {ok, E}.
+handle_effects(_Effects, _Entities) -> not_an_entity_map.

--- a/test/asobi_zone_effects_tests.erl
+++ b/test/asobi_zone_effects_tests.erl
@@ -1,0 +1,271 @@
+-module(asobi_zone_effects_tests).
+-include_lib("eunit/include/eunit.hrl").
+
+-define(LOG, asobi_zone_effects_log).
+
+%% Game module under test: records every effects batch it is handed and applies
+%% each event's `hp_delta`, so a test can assert both what arrived and that the
+%% zone wrote the result back.
+-export([zone_tick/2, handle_input/3, handle_effects/2]).
+-export([zone_tick_no_effects/2]).
+
+zone_tick(E, ZS) -> {E, ZS}.
+handle_input(_P, _I, E) -> {ok, E}.
+zone_tick_no_effects(E, ZS) -> {E, ZS}.
+
+%% Recorded in ETS rather than sent to the test process: eunit runs a `foreach`
+%% setup in a different process from the test body, so `self()` captured in
+%% setup is not the process that would receive the message.
+handle_effects(Effects, Entities) ->
+    ets:insert(?LOG, {erlang:unique_integer([monotonic]), Effects}),
+    {ok, apply_deltas(Effects, Entities)}.
+
+apply_deltas([], Entities) ->
+    Entities;
+apply_deltas([{Id, Event} | Rest], Entities) ->
+    #{Id := E} = Entities,
+    Hp = maps:get(hp, E, 0) + maps:get(~"hp_delta", Event, 0),
+    apply_deltas(Rest, Entities#{Id => E#{hp => Hp}}).
+
+setup() ->
+    case ets:whereis(?LOG) of
+        undefined -> ets:new(?LOG, [named_table, public, ordered_set]);
+        _ -> ets:delete_all_objects(?LOG)
+    end,
+    case ets:info(asobi_world_state) of
+        undefined -> ets:new(asobi_world_state, [named_table, public, set]);
+        _ -> ok
+    end,
+    case pg:start(nova_scope) of
+        {ok, _} -> ok;
+        {error, {already_started, _}} -> ok
+    end,
+    case persistent_term:get({?MODULE, tab}, undefined) of
+        undefined -> persistent_term:put({?MODULE, tab}, asobi_zone_border:new());
+        Tab -> ets:delete_all_objects(Tab)
+    end,
+    ok.
+
+tab() -> persistent_term:get({?MODULE, tab}).
+
+start_zone(GameMod) ->
+    {ok, Pid} = asobi_zone:start_link(#{
+        world_id => ~"effects-world",
+        coords => {1, 1},
+        ticker_pid => self(),
+        zone_size => 100,
+        grid_size => 5,
+        border_band => 0.1,
+        border_tab => tab(),
+        game_module => GameMod
+    }),
+    Pid.
+
+tick(Pid, N) ->
+    asobi_zone:tick(Pid, N),
+    _ = sys:get_state(Pid),
+    ok.
+
+effects_test_() ->
+    {foreach, fun setup/0, fun(_) -> ok end, [
+        {"an effect reaches the owning zone's handler", fun effect_delivered/0},
+        {"the handler's entity map is written back", fun effect_result_applied/0},
+        {"an effect for an entity the zone lost is dropped", fun effect_for_missing_entity/0},
+        {"the queue is drained every tick", fun queue_drains/0},
+        {"the queue is capped by count", fun queue_capped/0},
+        {"the queue is capped by size", fun queue_capped_by_size/0},
+        {"a module with no handler drops effects and survives", fun no_handler_survives/0},
+        {"a zone publishes its band as it ticks", fun zone_publishes_band/0},
+        {"a zone clears its band on stop", fun zone_clears_band_on_stop/0},
+        {"a killed zone's band does not outlive it", fun band_does_not_survive_a_kill/0},
+        {"a handler returning a non-map leaves the entities alone", fun bad_return_is_a_noop/0},
+        {"a spawn warms a cold zone", fun spawn_warms/0},
+        {"an entity timer warms a cold zone", fun timer_warms/0},
+        {"effects run after inputs, and timers after effects", fun effect_ordering/0}
+    ]}.
+
+effect_delivered() ->
+    Pid = start_zone(?MODULE),
+    asobi_zone:add_entity(Pid, ~"target", #{type => ~"npc", x => 150.0, y => 150.0, hp => 100}),
+    asobi_zone:apply_effect(Pid, ~"target", #{~"hp_delta" => -30}),
+    tick(Pid, 1),
+    ?assertEqual([[{~"target", #{~"hp_delta" => -30}}]], logged()),
+    gen_server:stop(Pid).
+
+logged() -> [E || {_, E} <- ets:tab2list(?LOG)].
+
+effect_result_applied() ->
+    Pid = start_zone(?MODULE),
+    asobi_zone:add_entity(Pid, ~"target", #{type => ~"npc", x => 150.0, y => 150.0, hp => 100}),
+    asobi_zone:apply_effect(Pid, ~"target", #{~"hp_delta" => -30}),
+    tick(Pid, 1),
+    ?assertMatch(#{~"target" := #{hp := 70}}, asobi_zone:get_entities(Pid)),
+    gen_server:stop(Pid).
+
+effect_for_missing_entity() ->
+    %% The target crossed away or died between the neighbour reading the band
+    %% and this tick. The handler must not be asked to look up a nil id.
+    Pid = start_zone(?MODULE),
+    asobi_zone:apply_effect(Pid, ~"ghost", #{~"hp_delta" => -30}),
+    tick(Pid, 1),
+    ?assertEqual([], logged()),
+    gen_server:stop(Pid).
+
+queue_drains() ->
+    Pid = start_zone(?MODULE),
+    asobi_zone:add_entity(Pid, ~"target", #{type => ~"npc", x => 150.0, y => 150.0, hp => 100}),
+    asobi_zone:apply_effect(Pid, ~"target", #{~"hp_delta" => -10}),
+    tick(Pid, 1),
+    ?assertEqual(1, length(logged())),
+    tick(Pid, 2),
+    ?assertEqual(1, length(logged())),
+    ?assertMatch(#{~"target" := #{hp := 90}}, asobi_zone:get_entities(Pid)),
+    gen_server:stop(Pid).
+
+queue_capped() ->
+    Pid = start_zone(?MODULE),
+    asobi_zone:add_entity(Pid, ~"target", #{type => ~"npc", x => 150.0, y => 150.0, hp => 0}),
+    lists:foreach(
+        fun(_) -> asobi_zone:apply_effect(Pid, ~"target", #{~"hp_delta" => 1}) end,
+        lists:seq(1, 400)
+    ),
+    tick(Pid, 1),
+    ?assertMatch([Effects] when length(Effects) =:= 256, logged()),
+    gen_server:stop(Pid).
+
+%% A count alone bounds nothing that matters: 256 entries of an arbitrary table
+%% is an arbitrary number of megabytes on the zone's heap.
+queue_capped_by_size() ->
+    Pid = start_zone(?MODULE),
+    asobi_zone:add_entity(Pid, ~"target", #{type => ~"npc", x => 150.0, y => 150.0, hp => 0}),
+    Big = maps:from_keys([integer_to_binary(I) || I <- lists:seq(1, 2_000)], 1),
+    lists:foreach(
+        fun(_) -> asobi_zone:apply_effect(Pid, ~"target", Big#{~"hp_delta" => 1}) end,
+        lists:seq(1, 200)
+    ),
+    tick(Pid, 1),
+    [Effects] = logged(),
+    %% Well under both the 200 sent and the 256-entry count cap: the byte cap is
+    %% what stopped it, which is the only cap that bounds the zone's heap.
+    ?assert(length(Effects) > 0),
+    ?assert(length(Effects) < 100),
+    gen_server:stop(Pid).
+
+no_handler_survives() ->
+    Pid = start_zone(asobi_zone_spatial_test_game),
+    asobi_zone:add_entity(Pid, ~"target", #{type => ~"npc", x => 150.0, y => 150.0, hp => 100}),
+    asobi_zone:apply_effect(Pid, ~"target", #{~"hp_delta" => -30}),
+    tick(Pid, 1),
+    ?assert(is_process_alive(Pid)),
+    ?assertMatch(#{~"target" := #{hp := 100}}, asobi_zone:get_entities(Pid)),
+    gen_server:stop(Pid).
+
+zone_publishes_band() ->
+    %% band = 0.1 * 100 = 10, so [100,110) is in the band for zone (1,1).
+    Pid = start_zone(?MODULE),
+    asobi_zone:add_entity(Pid, ~"edge", #{type => ~"npc", x => 105.0, y => 150.0}),
+    asobi_zone:add_entity(Pid, ~"middle", #{type => ~"npc", x => 150.0, y => 150.0}),
+    tick(Pid, 1),
+    Seen = asobi_zone_border:query_radius(tab(), {0, 1}, 5, {105.0, 150.0}, 50.0),
+    ?assertMatch([{~"edge", _, _}], Seen),
+    gen_server:stop(Pid).
+
+%% asobi_zone does not trap exits, so terminate/2 does not run on a supervisor
+%% shutdown or a linked crash. terminate/2 alone therefore cannot be where the
+%% band row is reclaimed, or a crashed zone leaves a dead entity visible to
+%% every neighbour for the life of the node.
+%% Nothing else in the suite pins this: every other test here would pass with
+%% effects applied before inputs, or after entity timers.
+effect_ordering() ->
+    Pid = start_zone(asobi_zone_order_game),
+    asobi_zone:add_entity(Pid, ~"t", #{
+        type => ~"npc", x => 150.0, y => 150.0, trace => []
+    }),
+    asobi_zone:player_input(Pid, ~"p1", #{~"kind" => ~"move"}),
+    asobi_zone:apply_effect(Pid, ~"t", #{~"hp_delta" => -1}),
+    asobi_zone:start_entity_timer(Pid, #{
+        entity_id => ~"t",
+        timer_id => ~"t1",
+        duration => 0,
+        on_complete => #{~"type" => ~"noop"}
+    }),
+    tick(Pid, 1),
+    #{~"t" := Entity} = asobi_zone:get_entities(Pid),
+    ?assertEqual([tick, input, effect], maps:get(trace, Entity)),
+    %% The timer ran after the effect: apply_timer_events/2 is fed the map
+    %% handle_effects/2 returned, so the completion is on the stamped entity.
+    ?assertMatch(#{~"completed_timers" := [_ | _]}, Entity),
+    gen_server:stop(Pid).
+
+band_does_not_survive_a_kill() ->
+    process_flag(trap_exit, true),
+    P1 = start_zone(?MODULE),
+    asobi_zone:add_entity(P1, ~"edge", #{type => ~"npc", x => 105.0, y => 150.0}),
+    tick(P1, 1),
+    ?assertMatch(
+        [_], asobi_zone_border:query_radius(tab(), {0, 1}, 5, {105.0, 150.0}, 50.0)
+    ),
+    exit(P1, kill),
+    receive
+        {'EXIT', P1, _} -> ok
+    after 1000 -> error(no_exit)
+    end,
+    %% The ETS crash backup would otherwise hand the replacement the same entity
+    %% and republish it, which would pass this test for the wrong reason.
+    ets:delete(asobi_world_state, {~"effects-world", {1, 1}}),
+    P2 = start_zone(?MODULE),
+    tick(P2, 1),
+    ?assertEqual(
+        [], asobi_zone_border:query_radius(tab(), {0, 1}, 5, {105.0, 150.0}, 50.0)
+    ),
+    process_flag(trap_exit, false),
+    gen_server:stop(P2).
+
+bad_return_is_a_noop() ->
+    Pid = start_zone(asobi_zone_effects_bad_return_game),
+    asobi_zone:add_entity(Pid, ~"target", #{type => ~"npc", x => 150.0, y => 150.0, hp => 100}),
+    asobi_zone:apply_effect(Pid, ~"target", #{~"hp_delta" => -30}),
+    tick(Pid, 1),
+    ?assert(is_process_alive(Pid)),
+    ?assertMatch(#{~"target" := #{hp := 100}}, asobi_zone:get_entities(Pid)),
+    gen_server:stop(Pid).
+
+%% warm_up/1 has to fire on every message that creates work for a cold zone, not
+%% just the ones a player sends: a zone that spawns from its own script or arms a
+%% timer has work to do at full rate.
+spawn_warms() ->
+    Pid = start_zone(?MODULE),
+    tick(Pid, 1),
+    ?assert(is_cold(Pid)),
+    asobi_zone:spawn_entities(Pid, []),
+    _ = sys:get_state(Pid),
+    ?assertNot(is_cold(Pid)),
+    gen_server:stop(Pid).
+
+timer_warms() ->
+    Pid = start_zone(?MODULE),
+    tick(Pid, 1),
+    ?assert(is_cold(Pid)),
+    asobi_zone:start_entity_timer(Pid, #{
+        entity_id => ~"t", timer_id => ~"t1", duration => 60_000
+    }),
+    _ = sys:get_state(Pid),
+    ?assertNot(is_cold(Pid)),
+    gen_server:stop(Pid).
+
+is_cold(Pid) ->
+    case sys:get_state(Pid) of
+        #{cold := Cold} -> Cold
+    end.
+
+zone_clears_band_on_stop() ->
+    Pid = start_zone(?MODULE),
+    asobi_zone:add_entity(Pid, ~"edge", #{type => ~"npc", x => 105.0, y => 150.0}),
+    tick(Pid, 1),
+    ?assertMatch(
+        [_], asobi_zone_border:query_radius(tab(), {0, 1}, 5, {105.0, 150.0}, 50.0)
+    ),
+    gen_server:stop(Pid),
+    ?assertEqual(
+        [], asobi_zone_border:query_radius(tab(), {0, 1}, 5, {105.0, 150.0}, 50.0)
+    ).

--- a/test/asobi_zone_order_game.erl
+++ b/test/asobi_zone_order_game.erl
@@ -1,0 +1,17 @@
+-module(asobi_zone_order_game).
+
+%% Every callback stamps its own name onto every entity, so the entity carries
+%% the order asobi ran them in. Pins the tick contract widgrensit/asobi#544
+%% depends on: an effect must land on the same tick's post-input state, and an
+%% entity timer must fire after it.
+-export([zone_tick/2, handle_input/3, handle_effects/2]).
+
+zone_tick(Entities, ZoneState) -> {stamp(Entities, tick), ZoneState}.
+handle_input(_PlayerId, _Input, Entities) -> {ok, stamp(Entities, input)}.
+handle_effects(_Effects, Entities) -> {ok, stamp(Entities, effect)}.
+
+stamp(Entities, What) ->
+    maps:map(
+        fun(_Id, Entity) -> Entity#{trace => maps:get(trace, Entity, []) ++ [What]} end,
+        Entities
+    ).

--- a/test/asobi_zone_shutdown_tests.erl
+++ b/test/asobi_zone_shutdown_tests.erl
@@ -1,0 +1,98 @@
+-module(asobi_zone_shutdown_tests).
+-include_lib("eunit/include/eunit.hrl").
+
+%% widgrensit/asobi#543 review: asobi_zone's terminate/2 is where the final
+%% snapshot, the ETS crash-backup clear, the limiter-key forget and the border
+%% row drop all live - and none of it ran on a supervisor shutdown, because a
+%% gen_server that does not trap exits is killed outright by the shutdown
+%% signal. That is the one moment a final snapshot exists for.
+
+-export([zone_tick/2, handle_input/3, dump_zone_state/1]).
+
+zone_tick(E, ZS) -> {E, ZS}.
+handle_input(_P, _I, E) -> {ok, E}.
+dump_zone_state(ZS) -> ZS.
+
+setup() ->
+    case ets:info(asobi_world_state) of
+        undefined -> ets:new(asobi_world_state, [named_table, public, set]);
+        _ -> ok
+    end,
+    case pg:start(nova_scope) of
+        {ok, _} -> ok;
+        {error, {already_started, _}} -> ok
+    end,
+    meck:new(asobi_zone_snapshotter, [no_link, non_strict]),
+    meck:expect(asobi_zone_snapshotter, snapshot, fun(_) -> ok end),
+    meck:expect(asobi_zone_snapshotter, snapshot_sync, fun(Snap) ->
+        ets:insert(?MODULE, {snapshot, Snap}),
+        ok
+    end),
+    meck:expect(asobi_zone_snapshotter, load_snapshot, fun(_, _) -> {error, not_found} end),
+    case ets:whereis(?MODULE) of
+        undefined -> ets:new(?MODULE, [named_table, public, set]);
+        _ -> ets:delete_all_objects(?MODULE)
+    end,
+    ok.
+
+cleanup(_) ->
+    meck:unload(asobi_zone_snapshotter).
+
+zone_config(Sup) ->
+    #{
+        world_id => ~"shutdown-world",
+        coords => {1, 1},
+        ticker_pid => self(),
+        zone_size => 100,
+        grid_size => 5,
+        border_band => 0.1,
+        border_tab => persistent_term:get({?MODULE, tab}),
+        persistence => true,
+        snapshot_interval => 600,
+        zone_sup => Sup,
+        game_module => ?MODULE
+    }.
+
+shutdown_test_() ->
+    {foreach, fun setup/0, fun cleanup/1, [
+        {"a zone snapshots when its supervisor shuts it down", fun snapshots_on_shutdown/0},
+        {"a zone drops its border row when its supervisor shuts it down",
+            fun clears_border_on_shutdown/0}
+    ]}.
+
+start_supervised_zone() ->
+    persistent_term:put({?MODULE, tab}, asobi_zone_border:new()),
+    {ok, Sup} = asobi_zone_sup:start_link(),
+    unlink(Sup),
+    {ok, Zone} = asobi_zone_sup:start_zone(Sup, zone_config(Sup)),
+    {Sup, Zone}.
+
+stop_sup(Sup, Zone) ->
+    Ref = monitor(process, Zone),
+    exit(Sup, shutdown),
+    receive
+        {'DOWN', Ref, process, Zone, _} -> ok
+    after 5000 -> error(zone_never_stopped)
+    end.
+
+snapshots_on_shutdown() ->
+    {Sup, Zone} = start_supervised_zone(),
+    asobi_zone:add_entity(Zone, ~"keep", #{
+        type => ~"npc", x => 150.0, y => 150.0, persistent => true
+    }),
+    asobi_zone:tick(Zone, 1),
+    _ = sys:get_state(Zone),
+    ?assertEqual([], ets:lookup(?MODULE, snapshot)),
+    stop_sup(Sup, Zone),
+    [{snapshot, Snap}] = ets:lookup(?MODULE, snapshot),
+    ?assertMatch(#{coords := {1, 1}, entities := #{~"keep" := _}}, Snap).
+
+clears_border_on_shutdown() ->
+    {Sup, Zone} = start_supervised_zone(),
+    Tab = persistent_term:get({?MODULE, tab}),
+    asobi_zone:add_entity(Zone, ~"edge", #{type => ~"npc", x => 105.0, y => 150.0}),
+    asobi_zone:tick(Zone, 1),
+    _ = sys:get_state(Zone),
+    ?assertMatch([_], asobi_zone_border:query_radius(Tab, {0, 1}, 5, {105.0, 150.0}, 50.0)),
+    stop_sup(Sup, Zone),
+    ?assertEqual([], asobi_zone_border:query_radius(Tab, {0, 1}, 5, {105.0, 150.0}, 50.0)).

--- a/test/fixtures/lua/counter.lua
+++ b/test/fixtures/lua/counter.lua
@@ -1,0 +1,8 @@
+-- Minimal mutable global, for asserting that a revert really puts the Lua heap
+-- back rather than only the value the caller happened to be holding.
+count = 0
+
+function bump()
+  count = count + 1
+  return count
+end

--- a/test/fixtures/lua/effects_world.lua
+++ b/test/fixtures/lua/effects_world.lua
@@ -1,0 +1,21 @@
+game_type = "world"
+match_size = 1
+grid_size = 3
+zone_size = 100
+border_band = 0.1
+
+function init(config) return {} end
+function generate_world(seed, config) return { ["0,0"] = {} } end
+function zone_tick(entities, zone_state) return entities, zone_state end
+
+function handle_input(player_id, input, entities)
+  return entities
+end
+
+function handle_effects(effects, entities)
+  for _, e in ipairs(effects) do
+    local target = entities[e.entity_id]
+    target.hp = (target.hp or 0) + (e.event.hp_delta or 0)
+  end
+  return entities
+end


### PR DESCRIPTION
Closes #544. Closes #543.

Both issues came from the same reporter, and measuring them turned up three
defects that were larger than either.

## #544 — seeing and acting across a seam

`border_band` publishes each zone's edge entities where its neighbours can read
them. Off by default.

```lua
border_band = 0.15   -- fraction of zone_size; 0 (the default) publishes nothing

local hit = game.spatial.neighbours_radius(shot.x, shot.y, 4.0, { type = "npc" })[1]
if hit then game.zone.apply(hit.id, { kind = "damage", amount = 12 }) end
```

`neighbours_radius` / `neighbours_rect` read the eight touching zones and return
read-only copies. `game.zone.apply` asks the owning zone, which applies it in
its own tick through a new optional `handle_effects/2`.

Off by default because publishing costs a filter plus a copy of the band every
tick whether or not anything reads it: **10,998 reductions/tick against 8,231**
on a zone holding 200 entities inside the band.

One ETS table per world, owned by that world's instance supervisor, so it is
reclaimed exactly when the world ends and one world can never read another's.

## #543 — the per-tick floor

An empty zone with an inert `zone_tick` cost ~2,200 reductions, ~90% of it the
Lua bridge. Three silent defects underneath it:

| | |
|---|---|
| `asobi_game_modes` dropped six config keys | a world declaring `lazy_zones = true` pre-spawned its whole grid anyway |
| `cold_tick_divisor` never reached the ticker | the knob read a value nothing set |
| nothing ever called `promote_zone`/`demote_zone` | no zone in any world was ever cold |

A zone with nothing to simulate now ticks once every `cold_tick_divisor` ticks.
Subscribers deliberately do not count — a player watching an empty neighbouring
zone creates no work in it, which is the reporter's "watched but empty" case.
Promotion happens on the message that creates the work, so entering a zone costs
no extra latency. Both transitions emit telemetry.

The hot-reload mtime poll is throttled to 200 ms: at 80 Hz across 225 zones it
was 18,000 `stat()` calls a second.

## ADR 0015 — the Luerl state stops being copied

`asobi_lua_vm` owns the state; the bridge holds a handle. Behind `lua_vm_mode`,
**default `copy`**, which is ADR 0015's own decision item 6.

| state | `copy` µs/tick | `owned` µs/tick |
|---|---|---|
| 0.1 MB | 151 | 16 |
| 3.2 MB | 3,733 | 18 |
| 15.7 MB | 20,385 | 16 |
| 62.6 MB | 111,444 | 19 |

Flat, not merely faster. It is a much smaller win where the per-tick work itself
grows with the state — a zone encoding 8,000 entities every tick measures 1.4x,
because there the encode is real work and the copy is a minority of it.

Running the suite under `owned` caught a rollback the copying path gave away for
free: a refused `join` and an input returning nothing usable are both undone by
discarding the mutated state, which an owned VM cannot do. A refused join left
the game state advanced — which is how a client drives a script by being turned
away over and over. `asobi_lua_vm` keeps the pre-call state (free — it shares
structure with the new one) and `asobi_lua_loader:revert/1` puts it back,
asserted in both modes.

## Persistent worlds have never persisted

`persistent` is the public global; `persistence` is what every zone-side reader
wants. Nothing translated between them, so the snapshot path was dead for every
world — while `persistent = true` still kept the snapshots it had never written.

Fixing that alone would ship persistence that loses its last snapshot, because
no asobi process traps exits: `asobi_zone:terminate/2` did not run on a
supervisor shutdown, i.e. not on world teardown. The zone now traps exits with a
`shutdown` budget, and bare `shutdown` gets the orderly terminate clause it was
falling past.

## Review

Ran the full gate: architecture guardian, BEAM security reviewer, Erlang code
reviewer. Findings applied, including two that mattered:

- **A killed zone left a permanent ghost row** in the border mirror (reproduced
  with a probe). Fixed by making the table per-world and supervisor-owned rather
  than hanging cleanup off a `terminate/2` that does not run.
- **`game.zone.apply` could write unbounded terms into another process's
  mailbox**, from `handle_input`, which has no budget at all. Bounded on the
  sender (4 KB, 64 sends/tick) and on the receiver (256 entries, 1 MB).

Also applied: `select_count` instead of copying whole bands out of ETS for the
owner lookup (4.6x), per-tick drop telemetry rather than per-message, and the
tautological and flaky tests rewritten.

## Checks

`fmt` · `xref` · `dialyzer` · `elp eqwalize` · `elp lint` · `ex_doc` — clean, no
new findings. **2,329 eunit, 389 CT, 0 failures.**

The Lua-relevant suites also pass under `lua_vm_mode = owned` (848 tests). The
*full* suite cannot run green there: a Lua timeout kills the VM, which is linked
to its owner, and ~6 timeout-exercising tests kill their own non-trapping test
process. In production that owner is the zone, which restarts into its snapshot —
ADR 0015 decisions 4 and 5. Copy mode is the default and the gate.

## Open, deliberately not decided here

- **`zone_busy/1`.** Both the architecture guardian and the code reviewer flagged
  the same gap: a script that drives spawning from `zone_tick` on an *empty* zone
  is invisible to idle detection and silently drops to 1/10 rate. Escape hatch is
  documented (`cold_tick_divisor = 1`) but it is world-wide, not per-zone.
- **The Lua surface shape.** The guardian argues `neighbours_*` should fold into
  `query_radius` opts and `apply` should self-cast locally, so a script never has
  to know which side of a seam a target is on. Explicit names were kept to avoid
  arity ambiguity.
- **ADRs 0016 / 0017** for cold zones and the border mirror are not written.
