### PR TITLE
docs(adr): record the cold-zone divisor and the border mirror

### DIFF
--- a/docs/adr/0016-idle-zones-tick-at-the-cold-divisor.md
+++ b/docs/adr/0016-idle-zones-tick-at-the-cold-divisor.md
@@ -1,0 +1,98 @@
+# ADR 0016: A zone with nothing to simulate ticks at `cold_tick_divisor`
+
+Date: 2026-08-22
+
+## Status
+
+**Accepted, and shipped.** Landed in asobi#545, closing asobi#543. On by
+default at a divisor of 10, which is the value `cold_tick_divisor` has
+documented since it was written.
+
+Recorded because it changes when a documented callback fires. `zone_tick/2` is
+a public behaviour callback and this makes it run 1-in-N ticks for some zones,
+which ADR 0000 names as "optimisations that change observable semantics".
+
+## Context
+
+A reporter measured an empty zone - zero entities, an inert `zone_tick`, no
+client in it - at roughly 5,300 reductions per tick on a 225-zone grid at
+`tick_rate = 80` (asobi#543). Reproduced here at ~2,200, of which ~90% is the
+Lua bridge rather than anything the game asked for, and most of that is the
+per-callback state copy ADR 0015 addresses. The floor is paid per zone, and a
+world is the scaling unit, so it sets what one world can hold.
+
+`cold_tick_divisor` was supposed to be the answer and did nothing. Three
+independent breaks, none of which produced an error:
+
+- `asobi_game_modes:world_config_1/2` forwarded a whitelist from the mode
+  config to the world and `lazy_zones`, `zone_idle_timeout`,
+  `max_active_zones`, `spatial_grid_cell_size`, `cold_tick_divisor` and
+  `rehome_margin` were all absent from it. A world declaring
+  `lazy_zones = true` pre-spawned its whole grid anyway.
+- `asobi_world_instance` built the ticker's config without
+  `cold_tick_divisor`, so the ticker read its own default.
+- Nothing in `src/` ever called `asobi_world_ticker:promote_zone/2` or
+  `demote_zone/2`, and `set_zones/3` - the only path that fills the static
+  lists - has no caller either. No zone in any world was ever cold. Under a
+  zone manager the tick handler also overwrote its own split with "every active
+  zone is hot", which would have kept it inert for lazy worlds even once
+  something did classify.
+
+## Decision
+
+**A zone classifies itself, and the ticker honours it.**
+
+1. `asobi_zone:zone_idle/1` (`src/world/asobi_zone.erl:2535`) is true when the
+   zone has no entities, no queued input, no queued cross-zone effect, no live
+   entity timer and no pending respawn. **Subscribers deliberately do not
+   count**: a player watching an empty neighbouring zone creates no work in it,
+   and that is the "watched but empty" case asobi#543 asks about.
+2. Demotion is decided on the tick, where the cost is (`reclassify/1`, `:2561`).
+   **Promotion is not**: `warm_up/1` (`:2578`) fires on the message that creates
+   the work - an input, an entity arriving, a spawn, a timer, an effect - so
+   entering a zone costs no extra latency. Waiting for a cold zone's own next
+   tick would put the whole divisor on the first frame of every zone entry.
+3. The ticker partitions the zone manager's active list against its own cold set
+   (`src/world/asobi_world_ticker.erl:182`), which also prunes reaped pids
+   without needing a `remove_zone` cast to arrive.
+4. Both transitions emit telemetry (`[asobi, zone, cold]` / `[asobi, zone, hot]`,
+   `announce/2` at `asobi_zone.erl:2594`), on the transition rather than per
+   tick.
+5. The six dropped config keys are forwarded (`asobi_game_modes.erl:157-163`).
+
+## Consequences
+
+- An empty zone costs a tenth of what it did. On the reporter's grid that is the
+  difference between a world spending most of a core on empty space and a tenth
+  of it.
+- **A script that drives spawning from `zone_tick` on a zone holding nothing now
+  runs at a tenth of the rate.** `zone_idle/1` reads asobi's own bookkeeping and
+  cannot see work a script keeps in `zone_state` - a wave spawner counting down,
+  weather, a zone-level timer. The escape hatch is `cold_tick_divisor = 1`, and
+  it is world-wide rather than per-zone. Both reviewers on asobi#545 asked for an
+  optional `zone_busy/1` veto instead; that is a later decision, deliberately not
+  taken here.
+- Fixing the forwarding turns on five other knobs that games have been declaring
+  and not getting, `lazy_zones` most consequentially. A world that has been
+  pre-spawning its whole grid will start loading zones on demand.
+- A cold zone touches the zone manager 1-in-N ticks rather than every tick.
+  `zone_idle_timeout` defaults to 30s against a worst case of ten ticks, so the
+  reaper is unaffected.
+- This does not make an *occupied* zone cheaper. Only ADR 0015 does.
+
+## Alternatives considered
+
+- **Leave `cold_tick_divisor` inert and document the floor.** Rejected: the knob
+  is already documented as working, so the honest options were to delete it or
+  make it true.
+- **Count subscribers as work.** Rejected: it inverts the result. The reporter's
+  zones are empty *and* watched, because `view_radius` keeps a ring loaded around
+  every player, so counting subscribers would leave exactly the zones this is for
+  running at full rate.
+- **Promote on the zone's own next tick** rather than on the arriving message.
+  Rejected: simpler, and it puts `cold_tick_divisor` ticks of latency on entering
+  any zone - a regression a player feels, to save a cast.
+- **Skip the Lua callback rather than the whole tick.** Rejected: the skip
+  condition is asobi's (input queue, timers, spawner) and lives in `asobi_zone`,
+  while the callback is the bridge's. Ticking at a divisor keeps one mechanism
+  and leaves hot reload landing within N ticks rather than never.

--- a/docs/adr/0017-border-mirror-for-cross-zone-reads-and-effects.md
+++ b/docs/adr/0017-border-mirror-for-cross-zone-reads-and-effects.md
@@ -1,0 +1,111 @@
+# ADR 0017: Zones publish an edge band, and address effects at its owner
+
+Date: 2026-08-22
+
+## Status
+
+**Accepted, and shipped.** Landed in asobi#545, closing asobi#544. **Off by
+default** (`border_band = 0`).
+
+Recorded because it adds a behaviour callback (`handle_effects/2`) and two
+`game.*` namespaces' worth of surface, both of which ADR 0000 names as
+ADR-worthy.
+
+## Context
+
+`game.spatial.query_radius/rect` search the calling zone's own entity map and
+nothing else. Combined with the rehome margin - an entity may sit up to
+`rehome_margin * zone_size` outside the rectangle of the zone that still owns it
+- an area geometrically inside zone A can be occupied by an entity zone B owns,
+and a query from A misses it. `guides/world-server.md` has documented this since
+the margin shipped.
+
+The gap is not transient. A reporter running a space shooter (asobi#544) hit
+both halves: a hostile parks on the line and never chases, because
+`nearest_player` cannot see a pilot two units past the seam; and a player
+shooting across a boundary sees their client predict damage the server never
+applies, because the projectile is resolved in the shooter's zone and the target
+belongs to the neighbour. The second reads to players as a bug and took them a
+while to trace to the zone model rather than to their own hit tests.
+
+They built the read half themselves - each zone publishing its pilots' positions
+into a small ETS table on the occupancy cadence, neighbours reading the eight
+touching entries. It works, it duplicates data the engine already holds, it
+answers only "where are the players", and it does nothing for damage. Every game
+that puts an NPC near a boundary writes some version of it.
+
+Zone size is also a CPU knob, and the two constraints pull against each other:
+smaller zones are cheaper per tick and worse for anything near an edge.
+
+## Decision
+
+**Each zone publishes the entities inside `border_band` of its own edges into a
+per-world mirror. Neighbours read copies. To act on one, address its owner.**
+
+1. `asobi_zone_border` holds one ETS table per world. Each zone writes its band
+   once per tick, after crossings resolve (`asobi_zone:publish_border/1`,
+   `src/world/asobi_zone.erl:2444`), and skips the write when the band is empty
+   and no row exists - which is most zones most of the time.
+2. `game.spatial.neighbours_radius/rect` read the eight touching zones and never
+   the caller's own, which it already holds. What comes back is a **copy**;
+   ownership never moves.
+3. `game.zone.apply(entity_id, event)` resolves the owner out of the mirror and
+   casts to that zone, which applies it in its own tick through a new optional
+   `handle_effects/2` (`src/world/asobi_world.erl:196`), batched, after inputs,
+   already filtered to entities the zone still owns.
+4. **The band, not whole neighbour maps.** It is bounded by the zone's perimeter
+   rather than its area, and it is exactly the set the guide names as invisible.
+5. **Off by default.** Publishing costs a filter plus a copy of the band every
+   tick whether or not anything reads it: measured 10,998 reductions/tick against
+   8,231 with it off, on a zone holding 200 entities all inside the band.
+6. **The table is owned by the world's instance supervisor**
+   (`src/world/asobi_world_instance.erl:43`), so it dies exactly when the world
+   does. No asobi process traps exits except where it must, so cleanup hung off a
+   `terminate/2` would strand a grid of rows on every teardown.
+
+## Consequences
+
+- An NPC can chase across a seam and a shot can land across one, without a game
+  reimplementing either.
+- `zone_size` becomes a CPU knob again rather than a trade against correctness at
+  the edges.
+- **"What I may affect" is "what I can see"**, because both read the same rows.
+  The sender-side check is a convenience gate: the mirror is a public table, so
+  anything in the BEAM can write a row and authorise itself to address an entity.
+  The check that cannot be forged is the receiver's - a zone applies an effect
+  only to an entity it currently owns - so a forged row buys the ability to
+  address an entity, never to invent one.
+- Effects are bounded on the sender (4 KB per event, 64 sends per tick,
+  `src/lua/asobi_lua_api.erl:1253-1254`) and on the receiver (256 entries, 1 MB,
+  `asobi_zone.erl:57-58`). The sender-side bound is the load-bearing one: past it
+  the term is already on another process's heap and in its mailbox, and
+  `handle_input` - the one callback with no wall-clock, heap or reduction budget -
+  can call `apply` in a loop.
+- A reader can see an entity under two owners for at most one tick, because the
+  old owner's row is refreshed on its own next tick. The receiver's ownership
+  filter is what makes that harmless.
+- One more thing a game can get wrong: a `handle_effects` that raises on a `nil`
+  field drops the whole tick's batch, not one effect.
+
+## Alternatives considered
+
+- **A neighbour-aware query over whole neighbouring entity maps** (the
+  reporter's first preference). Rejected: cost scales with area rather than
+  perimeter, and it is paid every tick whether or not anything reads it.
+  Widening the band later is a config change; narrowing it once games depend on
+  it is not.
+- **Visibility only, no effect path.** Rejected: it closes the chase case and
+  leaves the damage case exactly where it was. Without it a game either forbids
+  cross-boundary interaction or reimplements ownership.
+- **Let a zone write a neighbour's entity directly.** Rejected: single-writer
+  ownership is what makes the zone model work at all, and a second writer
+  reintroduces every race the model exists to avoid.
+- **Synchronous fan-out to eight zones per query.** Rejected: a `gen_server:call`
+  from a callback into a neighbour mid-tick is a deadlock hazard and serialises
+  the grid; the reporter explicitly did not ask for it.
+- **One global table keyed by `{WorldId, Coords}`.** Rejected after review: it
+  makes teardown a sweep that must be remembered rather than a lifetime that
+  cannot be forgotten, and it leaves cross-world isolation resting on a key
+  convention instead of on there being no shared table at all.
+- **On by default.** Rejected on the measurement above: a third more per tick on
+  an occupied zone, to serve a query most games never make.

--- a/guides/performance-tuning.md
+++ b/guides/performance-tuning.md
@@ -116,6 +116,9 @@ tick, of which roughly 90% is the bridge and most of that is the state copy. At
 `tick_rate = 80` on a 225-zone grid that is the difference between a world
 spending most of a core on empty space and spending a tenth of it.
 
+Recorded in `docs/adr/0016-idle-zones-tick-at-the-cold-divisor.md`, which also
+says what it deliberately does not solve.
+
 Set `cold_tick_divisor = 1` if your game drives spawning from `zone_tick` on
 zones that hold nothing - that is the one shape this changes, because such a
 zone's `zone_tick` now runs at a tenth of the rate until something appears in

--- a/guides/world-server.md
+++ b/guides/world-server.md
@@ -475,6 +475,9 @@ The band is bounded by the zone's perimeter rather than its area, so a smaller
 `border_band` is cheaper; an empty zone pays nothing. Leave it at 0 unless the
 game reads the mirror.
 
+The decision, and the alternatives ruled out, are recorded in
+`docs/adr/0017-border-mirror-for-cross-zone-reads-and-effects.md`.
+
 **What it is not.** It is not a general cross-zone query: it answers only for
 entities inside the band, only for the eight touching zones, and only at the
 last tick's positions. A zone still owns its own entities outright, and nothing


### PR DESCRIPTION
Follow-up to #545, which shipped both decisions without recording either. ADR
0000 names what makes them ADR-worthy: **0016** changes when a public callback
fires, **0017** adds a behaviour callback and new `game.*` surface.

Docs only. No source changes.

### 0016 — a zone with nothing to simulate ticks at `cold_tick_divisor`

Records the three independent breaks that made the knob inert (config keys
dropped in `asobi_game_modes`, the divisor never reaching the ticker, nothing
ever calling `promote_zone`/`demote_zone`), why subscribers deliberately do not
count as work, and why promotion fires on the arriving message rather than on
the zone's own next tick.

The consequence worth being able to find later: `zone_idle/1` reads asobi's own
bookkeeping and cannot see work a script keeps in `zone_state`, so a tick-driven
spawner on an empty zone silently runs at a tenth of the rate. The escape hatch
is world-wide, and the optional `zone_busy/1` veto both reviewers asked for on
#545 is written down as deliberately not taken rather than quietly dropped.

### 0017 — zones publish an edge band, and address effects at its owner

Records why the band rather than whole neighbour maps (perimeter, not area), why
it is off by default (10,998 reductions/tick against 8,231 on a zone holding 200
entities in the band), and why the mirror is one table per world owned by that
world's supervisor rather than one global table swept by hand.

Also states which half of the authorisation is load-bearing: the sender-side
"you can only affect what you can see" check reads a public table anything in the
BEAM can write, so the check that cannot be forged is the receiving zone's — a
forged row buys the ability to *address* an entity, never to invent one.

### Checks

All four drift scripts pass locally (`check-doc-anchors`, `check-telemetry-drift`,
`check-error-drift`, `check-archived-refs`); anchors resolve across 160 links.
Every `file:line` citation was verified against merged `main`.