### PR TITLE
feat(world): let a game veto its own zone's demotion

### DIFF
--- a/docs/adr/0016-idle-zones-tick-at-the-cold-divisor.md
+++ b/docs/adr/0016-idle-zones-tick-at-the-cold-divisor.md
@@ -71,7 +71,9 @@ independent breaks, none of which produced an error:
   weather, a zone-level timer. The escape hatch is `cold_tick_divisor = 1`, and
   it is world-wide rather than per-zone. Both reviewers on asobi#545 asked for an
   optional `zone_busy/1` veto instead; that is a later decision, deliberately not
-  taken here.
+  taken here. **Taken since, in
+  `docs/adr/0018-zone-busy-vetoes-demotion.md`**, which closes this gap without
+  changing anything above.
 - Fixing the forwarding turns on five other knobs that games have been declaring
   and not getting, `lazy_zones` most consequentially. A world that has been
   pre-spawning its whole grid will start loading zones on demand.

--- a/docs/adr/0018-zone-busy-vetoes-demotion.md
+++ b/docs/adr/0018-zone-busy-vetoes-demotion.md
@@ -1,0 +1,83 @@
+# ADR 0018: A game may veto its own zone's demotion
+
+Date: 2026-08-22
+
+## Status
+
+**Accepted, and shipped.** Takes the decision
+`docs/adr/0016-idle-zones-tick-at-the-cold-divisor.md` names as "a later
+decision, deliberately not taken here". ADR 0016 stands: this closes the gap its
+Consequences record, it does not reverse it.
+
+Recorded because it adds an optional behaviour callback, which ADR 0000 names as
+ADR-worthy.
+
+## Context
+
+ADR 0016 demotes a zone with no entities, no queued input, no live entity timer
+and no pending respawn to `cold_tick_divisor`. That test reads asobi's own
+bookkeeping, and asobi's bookkeeping cannot see work a script keeps in its zone
+state: a wave spawner counting down between waves, weather, a zone-level phase
+timer. Such a zone holds nothing by design, so it is demoted, and the countdown
+then runs at a tenth of the rate it was written for - silently, because nothing
+about it looks like a failure.
+
+The escape hatch ADR 0016 shipped is `cold_tick_divisor = 1`, which turns the
+feature off for the whole world to protect one zone shape. Both reviewers on
+asobi#545 asked for something narrower.
+
+The obvious answer - an optional `zone_busy/1` callback - has a cost problem
+that is easy to miss. asobi consults it whenever it believes a zone is idle, and
+for a zone that keeps answering "busy" that is **every tick**. On a Lua world a
+callback is exactly the marshalled crossing asobi#543 is about, so the naive
+shape puts one extra callback per tick on precisely the zones the feature exists
+to make cheaper, in order to decide whether to skip a callback.
+
+## Decision
+
+**An optional `zone_busy/1` on the behaviour, consulted only after asobi's own
+test has already said idle - and for Lua, a field rather than a callback.**
+
+1. `asobi_zone:zone_idle/1` splits: `asobi_idle/1` is everything asobi can see
+   for itself, and only if that is true is `script_busy/3` consulted. A zone
+   holding entities never reaches the callback, so the common case pays nothing.
+2. **Fail-safe is "keep the zone hot".** A raising or non-boolean answer is
+   treated as `true` and logged rate-limited. Demoting a zone that has work is
+   the harmful direction; the cost of erring the other way is one zone ticking
+   at full rate.
+3. **Lua scripts set `_keep_hot` on their zone state**, read with one
+   `get_table_key`. It joins `_finished`, `_result` and `_vote` as fields a
+   script sets to tell asobi something, and it costs a table read rather than a
+   marshalled call - which is the whole reason the Lua half is not a function.
+4. A script that never sets it demotes exactly as it did before ADR 0018, so
+   this is additive.
+
+## Consequences
+
+- The zone shape ADR 0016 silently slowed can opt out without disabling the
+  feature for every other zone in the world.
+- One more magic field on the Lua side. `_keep_hot` is discoverable only from
+  the guides, like the three that precede it - a real cost, and the reason the
+  Erlang half is an ordinary declared callback.
+- A zone that answers "busy" forever never demotes. That is the game's decision
+  to make and asobi does not second-guess it, but it means a buggy veto is
+  indistinguishable from a busy zone. The telemetry from ADR 0016 is what makes
+  it visible: such a zone simply never emits `[asobi, zone, cold]`.
+- The split in `zone_idle/1` fixes the order of evaluation as load-bearing
+  rather than incidental. Consulting the script first would work and would cost
+  a callback on every busy zone.
+
+## Alternatives considered
+
+- **`zone_busy/1` as a Lua callback too**, for symmetry with every other hook.
+  Rejected on cost: one extra marshalled callback per idle tick, on the zones
+  asobi#543 is about, to decide whether to skip a callback.
+- **Infer it from `zone_state` changing between ticks.** Rejected: it makes any
+  script that stamps a tick counter permanently busy, which is most of them, and
+  the failure is invisible.
+- **Leave it at `cold_tick_divisor = 1`.** Rejected: it protects one zone by
+  turning the feature off for a whole grid, which is the trade ADR 0016 exists
+  to avoid.
+- **Demote anyway and let the script notice.** Rejected: a script cannot notice.
+  It sees `zone_tick` called, with no indication that it is being called a tenth
+  as often as it asked for.

--- a/guides/performance-tuning.md
+++ b/guides/performance-tuning.md
@@ -119,10 +119,32 @@ spending most of a core on empty space and spending a tenth of it.
 Recorded in `docs/adr/0016-idle-zones-tick-at-the-cold-divisor.md`, which also
 says what it deliberately does not solve.
 
-Set `cold_tick_divisor = 1` if your game drives spawning from `zone_tick` on
-zones that hold nothing - that is the one shape this changes, because such a
-zone's `zone_tick` now runs at a tenth of the rate until something appears in
-it.
+**If your game drives work from `zone_tick` on a zone that holds nothing** - a
+wave spawner counting down between waves, weather, a zone-level timer - asobi
+cannot see it, and such a zone is demoted to a tenth of the rate it was written
+for. Say so and it stays hot:
+
+```lua
+function zone_tick(entities, zone_state)
+  zone_state.next_wave = zone_state.next_wave - 1
+  zone_state._keep_hot = zone_state.next_wave > 0
+  return entities, zone_state
+end
+```
+
+An Erlang game module exports `zone_busy/1` instead. Either way it is consulted
+**only when asobi already believes the zone is idle**, so a zone with entities
+never pays for it, and it fails safe: a raise or a non-boolean keeps the zone
+hot and is logged.
+
+`_keep_hot` is a field rather than a Lua callback on purpose. asobi asks on every
+idle tick, so a callback would put one extra marshalled call per tick on exactly
+the zones this section is about, to decide whether to skip a call. It joins
+`_finished`, `_result` and `_vote` as fields a script sets on its state to tell
+asobi something.
+
+`cold_tick_divisor = 1` disables the whole thing world-wide if you would rather
+not think about it.
 
 What does happen automatically:
 

--- a/guides/world-server.md
+++ b/guides/world-server.md
@@ -212,6 +212,7 @@ end
 | `zone_tick(entities, zone_state)` | no | Per-zone simulation; return both |
 | `handle_input(player_id, input, entities)` | no | Apply one player's input to that zone's entities. A second return value is the client seq you consumed - see [Batched input and the ack](websocket-protocol.md#client-side-prediction). Every input in a tick is handed the same table rather than a copy, but returning nothing still discards whatever that call mutated - see [Players in one zone](performance-tuning.md#players-in-one-zone) |
 | `handle_effects(effects, entities)` | no | This tick's cross-zone effects, batched. See [Seeing across a seam](#seeing-across-a-seam) |
+| `_keep_hot` on your zone state | no | Not a callback: set it truthy in `zone_tick` to stop an entity-less zone being demoted. See [Performance tuning](performance-tuning.md#zone-tick-hibernation-and-reaping) |
 | `generate_world(seed, config)` | no | Return a table keyed by `"x,y"` strings |
 | `get_state(player_id, state)` | no | Player-visible state |
 | `spawn_templates(config)` | no | See [Spawn templates](#spawn-templates) |
@@ -325,6 +326,7 @@ post_tick(_TickN, State) ->
 | `handle_input/3` | one of | Process player input within a zone's entities. Return `{ok, Entities, ConsumedSeq}` to ack what you *ran* rather than what arrived - see [Batched input and the ack](websocket-protocol.md#client-side-prediction) |
 | `handle_input_batch/2` | one of | The whole tick's inputs in one call, returning one entity map plus one outcome per input. Export it instead of `handle_input/3` when your per-input cost is dominated by marshalling the entity map rather than by the input. Exporting it shadows `handle_input/3` entirely. asobi still owns the ack policy: you return one outcome per input - see [Players in one zone](performance-tuning.md#players-in-one-zone) |
 | `handle_effects/2` | no | This tick's cross-zone effects: `([{EntityId, Event}], Entities) -> {ok, Entities}`. Delivered after inputs, already filtered to entities this zone still owns. See [Seeing across a seam](#seeing-across-a-seam) |
+| `zone_busy/1` | no | `(ZoneState) -> boolean()`. Veto demotion of an entity-less zone that still has work asobi cannot see. Consulted only when asobi already believes the zone is idle; a raise or non-boolean keeps the zone hot |
 | `post_tick/2` | yes | Global post-tick: return `{ok, State}`, `{vote, Config, State}`, or `{finished, Result, State}` |
 | `generate_world/2` | no | Procedural generation: `(Seed, Config) -> {ok, #{Coords => ZoneState}}` |
 | `get_state/2` | no | Per-player state view |

--- a/src/asobi_telemetry.erl
+++ b/src/asobi_telemetry.erl
@@ -45,7 +45,8 @@
     | invalid_consumed_seq
     | effect_queue_full
     | no_effect_handler
-    | bad_effects_return.
+    | bad_effects_return
+    | bad_zone_busy.
 -export_type([game_error_kind/0]).
 -export([economy_transaction/4, store_purchase/3]).
 -export([chat_message_sent/2]).

--- a/src/lua/asobi_lua_world.erl
+++ b/src/lua/asobi_lua_world.erl
@@ -46,6 +46,7 @@ of hot reloads.
 
 -export([init/1, join/2, join/3, leave/2, spawn_position/2]).
 -export([zone_tick/2, handle_input/3, handle_input_batch/2, handle_effects/2, post_tick/2]).
+-export([zone_busy/1]).
 -ifdef(TEST).
 -export([zone_ctx/2, make_ctx/1]).
 -endif.
@@ -330,6 +331,43 @@ handle_input(PlayerId, Input, Entities) ->
         _ ->
             {ok, Entities}
     end.
+
+-doc """
+Reads the script's `_keep_hot` veto off the zone's `game_state`.
+
+A field rather than a callback, deliberately. asobi consults this whenever it
+believes a zone is idle, and on a hot zone that is every tick - so a `zone_busy`
+Lua *function* would put one extra marshalled callback per tick on exactly the
+zones widgrensit/asobi#543 is about, to decide whether to skip a callback. One
+table read is affordable; a second callback is the disease.
+
+`_keep_hot` joins `_finished`, `_result` and `_vote` as a field a script sets on
+its state to tell asobi something (`check_post_tick_result/2`).
+
+```lua
+function zone_tick(entities, zone_state)
+  zone_state.next_wave = zone_state.next_wave - 1
+  zone_state._keep_hot = zone_state.next_wave > 0   -- still counting down
+  return entities, zone_state
+end
+```
+
+Anything other than a literal `true` reads as "not busy", so a script that never
+sets it demotes exactly as before.
+""".
+-spec zone_busy(term()) -> boolean().
+zone_busy(#{lua_state := LuaSt, game_state := GS}) when GS =/= nil, GS =/= undefined ->
+    try asobi_lua_loader:get_table_key(GS, ~"_keep_hot", LuaSt) of
+        {ok, true, _} -> true;
+        _ -> false
+    catch
+        %% A game_state that is not a table at all. asobi_zone treats a raise as
+        %% "keep the zone hot", which would latch every such world to full rate,
+        %% so answer it here instead: a script with no table has no veto.
+        _:_ -> false
+    end;
+zone_busy(_ZoneState) ->
+    false.
 
 -doc """
 Delegates a tick's cross-zone effects to the script's `handle_effects`.

--- a/src/world/asobi_world.erl
+++ b/src/world/asobi_world.erl
@@ -199,6 +199,25 @@ dropped effect is indistinguishable from a delivery bug from the game's side.
 ) ->
     {ok, Entities1 :: map()} | Entities1 :: map().
 
+-doc """
+Optional: does this zone still have work asobi cannot see?
+
+A zone with no entities, no queued input, no live entity timer and no pending
+respawn is demoted and ticks once every `cold_tick_divisor` ticks
+(widgrensit/asobi#543). That test reads asobi's own bookkeeping, which is blind
+to work a script keeps in its zone state - a wave spawner counting down between
+waves, weather, a zone-level phase timer. Such a zone holds nothing, so it is
+demoted, and the countdown then runs at a tenth of the rate it was written for.
+
+Export this to veto that. It is consulted **only when asobi already believes the
+zone is idle**, so a zone with entities never pays for it, and a zone answering
+`true` is doing work in `zone_tick` and paying for that anyway.
+
+Fail-safe is "keep the zone hot": a raising or non-boolean answer is treated as
+`true` and logged. Demoting a zone that has work is the harmful direction.
+""".
+-callback zone_busy(ZoneState :: term()) -> boolean().
+
 -doc "Global post-tick hook: continue, trigger a vote, or finish the world.".
 -callback post_tick(Tick :: non_neg_integer(), GameState :: term()) ->
     {ok, GameState1 :: term()}
@@ -299,5 +318,6 @@ plain terms. The inverse of `init_zone_state`'s restore path.
     dump_zone_state/1,
     handle_input/3,
     handle_input_batch/2,
-    handle_effects/2
+    handle_effects/2,
+    zone_busy/1
 ]).

--- a/src/world/asobi_zone.erl
+++ b/src/world/asobi_zone.erl
@@ -2400,7 +2400,8 @@ forget_log_keys(WorldId, Coords) ->
     asobi_script_log_limiter:forget(no_input_handler_log_key(Zone)),
     asobi_script_log_limiter:forget(effect_log_key(Zone, effect_queue_full)),
     asobi_script_log_limiter:forget(effect_log_key(Zone, no_effect_handler)),
-    asobi_script_log_limiter:forget(effect_log_key(Zone, bad_effects_return)).
+    asobi_script_log_limiter:forget(effect_log_key(Zone, bad_effects_return)),
+    asobi_script_log_limiter:forget(effect_log_key(Zone, bad_zone_busy)).
 
 backup_zone_state(WorldId, Coords, Entities) ->
     case ets:info(asobi_world_state) of
@@ -2527,12 +2528,20 @@ effects_result(_Other, Prev, State) ->
 %% empty zone creates no work in it: there are no entities to move and no
 %% deltas to send. That is exactly the "watched but empty" case #543 asks about.
 -spec zone_idle(map()) -> boolean().
+-spec asobi_idle(map()) -> boolean().
+zone_idle(#{game_module := GameMod, zone_state := ZoneState} = State) ->
+    asobi_idle(State) andalso not script_busy(GameMod, ZoneState, State).
+
+%% Everything asobi can see for itself. Kept separate from the script's own
+%% answer because this half is free and that half is not, and the order matters:
+%% a zone holding entities never reaches `zone_busy/1` at all.
+%%
 %% `input_queue` and `effect_queue` are always `[]` where reclassify/1 calls
 %% this - do_tick/2 empties both before it runs - so those two conditions never
 %% decide anything at that call site. They are kept because this states what
 %% "idle" means for a zone rather than what happens to be true at one caller,
 %% and warm_up/1 is what actually handles a queue filling between ticks.
-zone_idle(#{
+asobi_idle(#{
     entities := Entities,
     input_queue := Queue,
     effect_queue := Effects,
@@ -2554,6 +2563,60 @@ clamp_border_band(Band) ->
         value => Band
     }),
     ?DEFAULT_BORDER_BAND.
+
+-doc """
+Whether the game says this zone still has work asobi cannot see.
+
+`asobi_idle/1` reads entities, queues, timers and the respawn queue - asobi's
+own bookkeeping - and that is blind to work a script keeps in its zone state: a
+wave spawner counting down, weather, a zone-level phase timer. Such a zone holds
+nothing, so asobi calls it idle and ticks it at `cold_tick_divisor`, and the
+countdown runs at a tenth of the rate it was written for.
+
+Consulted **only when asobi already believes the zone is idle**, which is what
+keeps it affordable: a zone with entities never reaches it, and a zone that
+answers `true` is by definition doing work in `zone_tick` and paying for that
+anyway.
+
+Fail-safe is `true` - a raising or out-of-shape answer keeps the zone hot.
+Demoting a zone that might have work is the harmful direction; the cost of
+getting it wrong the other way is one zone ticking at full rate.
+""".
+-spec script_busy(module(), term(), map()) -> boolean().
+script_busy(GameMod, ZoneState, State) ->
+    case erlang:function_exported(GameMod, zone_busy, 1) of
+        false ->
+            false;
+        true ->
+            try GameMod:zone_busy(ZoneState) of
+                Busy when is_boolean(Busy) ->
+                    Busy;
+                Other ->
+                    log_bad_zone_busy(State, Other),
+                    true
+            catch
+                Class:Reason ->
+                    log_bad_zone_busy(State, {Class, Reason}),
+                    true
+            end
+    end.
+
+log_bad_zone_busy(State, Detail) ->
+    Zone = log_zone(State),
+    asobi_telemetry:game_error(bad_zone_busy, #{
+        game_module => maps:get(game_module, State, undefined)
+    }),
+    case asobi_script_log_limiter:allow(effect_log_key(Zone, bad_zone_busy)) of
+        {true, SuppressedSinceLast} ->
+            ?LOG_ERROR(#{
+                msg => ~"zone_busy/1 did not return a boolean; keeping the zone hot",
+                coords => maps:get(coords, State, undefined),
+                detail => io_lib:format("~0p", [Detail]),
+                suppressed_since_last => SuppressedSinceLast
+            });
+        false ->
+            ok
+    end.
 
 %% Demotion is decided on the tick, where the cost is. Promotion is not: see
 %% warm_up/1.

--- a/test/asobi_lua_world_tests.erl
+++ b/test/asobi_lua_world_tests.erl
@@ -1155,3 +1155,39 @@ with_every_tick_polling(Fun) ->
             undefined -> application:unset_env(asobi_lua, reload_poll_interval_ms)
         end
     end.
+
+%% widgrensit/asobi#543 follow-up: a script counting down between waves holds no
+%% entities, so asobi's own bookkeeping calls the zone idle and demotes it to a
+%% tenth of the tick rate. `_keep_hot` is how the script says otherwise - a field
+%% rather than a callback, because asobi asks on every idle tick.
+keep_hot_vetoes_demotion_test() ->
+    Script = fixture("keep_hot_world.lua"),
+    Config = #{game_config => #{lua_script => Script}},
+    ZoneState = asobi_lua_world:init_zone_state(Config, #{}),
+    erlang:erase({asobi_lua_world, zone_state}),
+    %% next_wave: 3 -> 2 -> 1 -> 0, so the veto holds for two ticks and lifts.
+    {_, ZS1} = asobi_lua_world:zone_tick(#{}, ZoneState),
+    ?assert(asobi_lua_world:zone_busy(ZS1)),
+    {_, ZS2} = asobi_lua_world:zone_tick(#{}, ZS1),
+    ?assert(asobi_lua_world:zone_busy(ZS2)),
+    {_, ZS3} = asobi_lua_world:zone_tick(#{}, ZS2),
+    ?assertNot(asobi_lua_world:zone_busy(ZS3)),
+    erlang:erase({asobi_lua_world, zone_state}).
+
+%% A script that never sets the field demotes exactly as it did before.
+no_keep_hot_field_is_not_busy_test() ->
+    Script = fixture("config_move_world.lua"),
+    Config = #{game_config => #{lua_script => Script}},
+    {ok, ZoneStates} = asobi_lua_world:generate_world(0, Config),
+    ZoneState = asobi_lua_world:init_zone_state(Config, maps:get({0, 0}, ZoneStates)),
+    erlang:erase({asobi_lua_world, zone_state}),
+    {_, ZS1} = asobi_lua_world:zone_tick(#{}, ZoneState),
+    ?assertNot(asobi_lua_world:zone_busy(ZS1)),
+    erlang:erase({asobi_lua_world, zone_state}).
+
+%% No lua_state and no game_state: the bridge must answer, not raise, because
+%% asobi_zone treats a raise as "keep hot" and would latch the zone to full rate.
+zone_busy_without_a_bridge_state_test() ->
+    ?assertNot(asobi_lua_world:zone_busy(#{})),
+    ?assertNot(asobi_lua_world:zone_busy(#{lua_state => undefined, game_state => nil})),
+    ?assertNot(asobi_lua_world:zone_busy(not_a_map)).

--- a/test/asobi_zone_busy_game.erl
+++ b/test/asobi_zone_busy_game.erl
@@ -1,0 +1,13 @@
+-module(asobi_zone_busy_game).
+
+%% Vetoes demotion when its zone state says so, which is the shape a wave
+%% spawner has: no entities between waves, and a countdown asobi cannot see.
+-export([zone_tick/2, handle_input/3, zone_busy/1]).
+
+zone_tick(E, ZS) -> {E, ZS}.
+handle_input(_P, _I, E) -> {ok, E}.
+
+zone_busy(#{busy := bad_return}) -> not_a_boolean;
+zone_busy(#{busy := raises}) -> error(deliberate);
+zone_busy(#{busy := Busy}) when is_boolean(Busy) -> Busy;
+zone_busy(_) -> false.

--- a/test/asobi_zone_cold_tests.erl
+++ b/test/asobi_zone_cold_tests.erl
@@ -62,8 +62,68 @@ cold_test_() ->
         {"an effect warms the zone", fun effect_warms/0},
         {"an occupied zone stays hot", fun occupied_stays_hot/0},
         {"a subscriber alone does not keep a zone hot", fun subscriber_does_not_warm/0},
-        {"going cold and warming again are each announced once", fun transitions_emit_telemetry/0}
+        {"going cold and warming again are each announced once", fun transitions_emit_telemetry/0},
+        {"zone_busy vetoes demotion", fun zone_busy_keeps_a_zone_hot/0},
+        {"a zone that stops being busy is demoted", fun zone_busy_released/0},
+        {"zone_busy is not consulted while entities are present",
+            fun zone_busy_skipped_when_occupied/0},
+        {"a non-boolean zone_busy keeps the zone hot", fun bad_zone_busy_fails_safe/0},
+        {"a raising zone_busy keeps the zone hot", fun raising_zone_busy_fails_safe/0}
     ]}.
+
+start_busy_zone(ZoneState) ->
+    {ok, Pid} = asobi_zone:start_link(#{
+        world_id => ~"cold-world",
+        coords => {1, 1},
+        ticker_pid => self(),
+        zone_size => 100,
+        grid_size => 5,
+        zone_state => ZoneState,
+        game_module => asobi_zone_busy_game
+    }),
+    Pid.
+
+%% The gap ADR 0016 recorded and did not close: a script counting down between
+%% waves holds no entities, so asobi's own bookkeeping calls the zone idle.
+zone_busy_keeps_a_zone_hot() ->
+    Pid = start_busy_zone(#{busy => true}),
+    tick(Pid, 1),
+    tick(Pid, 2),
+    ?assertNot(is_cold(Pid)),
+    ?assertEqual([], drain_ticker_casts()),
+    gen_server:stop(Pid).
+
+zone_busy_released() ->
+    Pid = start_busy_zone(#{busy => true}),
+    tick(Pid, 1),
+    ?assertNot(is_cold(Pid)),
+    sys:replace_state(Pid, fun(S) -> S#{zone_state => #{busy => false}} end),
+    tick(Pid, 2),
+    ?assert(is_cold(Pid)),
+    gen_server:stop(Pid).
+
+%% Order matters for cost, not just for correctness: a zone holding entities must
+%% never reach the callback at all.
+zone_busy_skipped_when_occupied() ->
+    Pid = start_busy_zone(#{busy => raises}),
+    asobi_zone:add_entity(Pid, ~"npc", #{type => ~"npc", x => 150.0, y => 150.0}),
+    tick(Pid, 1),
+    ?assert(is_process_alive(Pid)),
+    ?assertNot(is_cold(Pid)),
+    gen_server:stop(Pid).
+
+bad_zone_busy_fails_safe() ->
+    Pid = start_busy_zone(#{busy => bad_return}),
+    tick(Pid, 1),
+    ?assertNot(is_cold(Pid)),
+    gen_server:stop(Pid).
+
+raising_zone_busy_fails_safe() ->
+    Pid = start_busy_zone(#{busy => raises}),
+    tick(Pid, 1),
+    ?assert(is_process_alive(Pid)),
+    ?assertNot(is_cold(Pid)),
+    gen_server:stop(Pid).
 
 %% An operator watching a world needs to see a zone stop simulating - a zone
 %% that goes cold and never comes back is one that has stopped responding to the

--- a/test/fixtures/lua/keep_hot_world.lua
+++ b/test/fixtures/lua/keep_hot_world.lua
@@ -1,0 +1,17 @@
+game_type = "world"
+match_size = 1
+grid_size = 3
+zone_size = 100
+
+function init(config) return {} end
+function generate_world(seed, config) return { ["0,0"] = {} } end
+function spawn_position(player_id, state) return { x = 10, y = 10 } end
+function handle_input(player_id, input, entities) return entities end
+
+-- A wave spawner: no entities between waves, and a countdown asobi cannot see.
+function zone_tick(entities, zone_state)
+  zone_state = zone_state or {}
+  zone_state.next_wave = (zone_state.next_wave or 3) - 1
+  zone_state._keep_hot = zone_state.next_wave > 0
+  return entities, zone_state
+end


### PR DESCRIPTION
Closes the gap ADR 0016 recorded and deliberately left open. Recorded as
`docs/adr/0018-zone-busy-vetoes-demotion.md`; ADR 0016 stands and now points at
it.

### The problem

ADR 0016 demotes a zone with no entities, no queued input, no live entity timer
and no pending respawn. That test reads asobi's own bookkeeping, which is blind
to work a script keeps in its zone state — a wave spawner counting down between
waves, weather, a zone-level phase timer. Such a zone holds nothing *by design*,
so it was demoted and its countdown ran at a tenth of the rate it was written
for. Silently: nothing about it looks like a failure.

The only escape hatch was `cold_tick_divisor = 1`, which protects one zone by
turning the feature off for a whole grid.

### The shape, and why it isn't the obvious one

An optional `zone_busy/1` on the behaviour, consulted **only after asobi's own
test has already said idle**. A zone holding entities never reaches it, and a
zone that answers "busy" is doing work in `zone_tick` and paying for that anyway.
Fail-safe is *keep the zone hot* — a raise or a non-boolean is treated as `true`
and logged rate-limited, because demoting a zone that has work is the harmful
direction.

**Lua scripts set `_keep_hot` on their zone state instead of exporting a
function**, joining `_finished` / `_result` / `_vote`:

```lua
function zone_tick(entities, zone_state)
  zone_state.next_wave = zone_state.next_wave - 1
  zone_state._keep_hot = zone_state.next_wave > 0
  return entities, zone_state
end
```

asobi asks on every idle tick, so a Lua *callback* would put one extra marshalled
call per tick on exactly the zones #543 is about, in order to decide whether to
skip a call. One table read is affordable; a second callback is the disease.

Additive — a game that sets neither demotes exactly as it did before.

### Tests

Both halves, including the ones that pin the reasoning rather than the happy
path: that a zone holding entities never reaches the callback at all (order of
evaluation is load-bearing for cost, not just correctness), that a non-boolean
and a raising `zone_busy` both keep the zone hot, and that a bridge with no
`game_state` answers rather than raising — a raise there would latch every such
world to full rate.

### Checks

`fmt` · `xref` · `dialyzer` · `elp eqwalize` · `elp lint` · doc-anchor and
telemetry drift — clean, no new findings. **2,337 eunit, 389 CT, 0 failures.**