### PR TITLE
feat(world): return busy from zone_tick instead of reading it back

### DIFF
--- a/docs/adr/0016-idle-zones-tick-at-the-cold-divisor.md
+++ b/docs/adr/0016-idle-zones-tick-at-the-cold-divisor.md
@@ -72,8 +72,11 @@ independent breaks, none of which produced an error:
   it is world-wide rather than per-zone. Both reviewers on asobi#545 asked for an
   optional `zone_busy/1` veto instead; that is a later decision, deliberately not
   taken here. **Taken since, in
-  `docs/adr/0018-zone-busy-vetoes-demotion.md`**, which closes this gap without
-  changing anything above.
+  `docs/adr/0019-zone-tick-returns-whether-it-is-busy.md`** (via
+  `docs/adr/0018-zone-busy-vetoes-demotion.md`, superseded). Note that 0019 does
+  redefine `zone_idle/1`, which decision item 1 above names: what is described
+  there is now `asobi_idle/1`, and `zone_idle/1` is that plus the game's own
+  answer. The line references above are from before those changes.
 - Fixing the forwarding turns on five other knobs that games have been declaring
   and not getting, `lazy_zones` most consequentially. A world that has been
   pre-spawning its whole grid will start loading zones on demand.

--- a/docs/adr/0018-zone-busy-vetoes-demotion.md
+++ b/docs/adr/0018-zone-busy-vetoes-demotion.md
@@ -4,13 +4,17 @@ Date: 2026-08-22
 
 ## Status
 
-**Accepted, and shipped.** Takes the decision
-`docs/adr/0016-idle-zones-tick-at-the-cold-divisor.md` names as "a later
-decision, deliberately not taken here". ADR 0016 stands: this closes the gap its
-Consequences record, it does not reverse it.
+**Superseded by `docs/adr/0019-zone-tick-returns-whether-it-is-busy.md`.**
 
-Recorded because it adds an optional behaviour callback, which ADR 0000 names as
-ADR-worthy.
+The decision below is right about the problem and wrong about the mechanism.
+Its cost argument - "one table read is affordable; a second callback is the
+disease" - rested on `luerl:get_table_key/3` being a raw read. It is not: an
+absent key on a table with an `__index` runs the metamethod inline on the zone
+process, unbudgeted, and `_keep_hot` was absent from almost every zone state.
+ADR 0019 removes the read rather than making it safe, and records the rest.
+
+Retained as the record of why the veto exists at all, and of a premise worth not
+re-deriving.
 
 ## Context
 

--- a/docs/adr/0019-zone-tick-returns-whether-it-is-busy.md
+++ b/docs/adr/0019-zone-tick-returns-whether-it-is-busy.md
@@ -1,0 +1,106 @@
+# ADR 0019: `zone_tick/2` returns whether its zone is busy
+
+Date: 2026-08-23
+
+## Status
+
+**Accepted, and shipped.** Supersedes
+`docs/adr/0018-zone-busy-vetoes-demotion.md`, which shipped the same intent
+through a `zone_busy/1` callback and a `_keep_hot` field on the zone state. Both
+are removed. ADR 0016 stands.
+
+`_keep_hot` existed only in v0.97.0, released hours earlier on 2026-08-22, so
+nothing had time to depend on it.
+
+## Context
+
+ADR 0018 gave a game a way to say "this zone has work asobi cannot see", so an
+entity-less wave spawner would not be demoted to `cold_tick_divisor`. Its
+central argument was cost: asobi consults the answer on every idle tick, so a
+Lua *callback* would add one marshalled crossing per tick to exactly the zones
+ADR 0016 exists to make cheaper. It therefore chose a field, `_keep_hot`, read
+with one `get_table_key`, on the reasoning that "one table read is affordable; a
+second callback is the disease".
+
+**That reasoning rested on a false premise, and a retrospective security review
+found it.** `luerl:get_table_key/3` is not a raw read. When the key is absent
+and the table has an `__index`, `luerl_emul:get_table_key/3` calls the
+metamethod (`luerl_emul.erl:167`). `_keep_hot` is absent from almost every zone
+state, so that was the *ordinary* path, not an edge case - and the metamethod ran
+inline on the zone `gen_server`, with no wall-clock timeout, no `max_heap_size`,
+no reduction budget and the whole `game.*` API in scope.
+
+`setmetatable(zone_state, Zone)` with a function `__index` is ordinary OOP Lua.
+It needed no adversary. Measured on the shipped build: a metamethod looping
+2,000,000 times cost 345 ms on the zone process, and `while true do end` never
+returned from `handle_cast` at all - the world ticker kept casting into a
+mailbox that never drained, with no supervisor intervention because the process
+was neither dead nor idle.
+
+`guides/security-trust-model.md` names `handle_input/3` as the single
+unbudgeted callback. ADR 0018 silently added a second entry point, at tick
+cadence, and did not amend that guide.
+
+Two further problems with the field shape, independent of the security one:
+
+- **A field latches; a value cannot.** `_keep_hot` persists in the Lua table
+  until overwritten, so "vetoes forever" was the default failure of anyone who
+  set it at the start of a wave and forgot to clear it.
+- **The two halves did not agree.** `asobi_zone` failed safe (keep hot) on a
+  raise; the Lua bridge caught everything and returned `false`, so it failed
+  *cold and silent*, and `bad_zone_busy` telemetry was unreachable for every Lua
+  game. The guides promised the Erlang behaviour to a Lua-first audience.
+
+## Decision
+
+**The answer rides on `zone_tick/2`'s return value.**
+
+1. `zone_tick/2` may return `{Entities, ZoneState, Busy :: boolean()}`. Lua
+   scripts `return entities, zone_state, true`. The ordinary two-tuple means
+   "not busy", so this is additive.
+2. `asobi_zone:reclassify/1` runs immediately after `zone_tick/2` in the same
+   `handle_cast`, so the value is wanted at exactly the instant the callback
+   already returns. **Nothing is read to obtain it**, which is what makes the
+   metamethod class impossible rather than merely guarded.
+3. Lua truthiness decides (`nil` and `false` are not busy), so returning a
+   countdown works as well as returning a comparison. `_keep_hot` required a
+   literal `true`, and `_keep_hot = 1` reading as "not busy" was a silent
+   failure the guides actively invited.
+4. Fail-safe stays "keep the zone hot" for a non-boolean, logged with the
+   module's bounded formatter rather than an unbounded `~0p` of a game term.
+5. **A busy zone is not hibernated and not reaped.** ADR 0018 accounted for
+   neither: an entity-less zone at full rate hibernates every tick, which is a
+   full-sweep GC of the whole Luerl state per tick, and the idle sweep would
+   still tear the zone down mid-countdown at `zone_idle_timeout`.
+
+## Consequences
+
+- The unbudgeted script-execution path is gone, not bounded. There is no read,
+  so there is no metamethod, in either VM mode.
+- One less magic field, and no Erlang/Lua asymmetry: both halves are one return
+  value with one meaning.
+- A veto cannot latch by accident. It must be produced on the tick it applies to.
+- `zone_tick/2`'s contract widens. A game module that returns a three-tuple on
+  an older asobi gets a `badmatch` and a dead zone, so this is forward-only.
+- `guides/security-trust-model.md`'s statement that `handle_input/3` is the only
+  unbudgeted callback is true again.
+
+## Alternatives considered
+
+- **Keep `_keep_hot`, read it with `luerl_heap:raw_get_table_key/3`.** Rejected,
+  though it does close the security hole: it keeps the latching failure, keeps
+  the asymmetry, keeps the literal-`true` trap, and still costs a read per idle
+  tick - a `gen_server` round trip under ADR 0015's `owned` mode. Removing the
+  read is strictly better than making the read safe.
+- **A `zone_busy/1` callback in both languages.** Rejected on ADR 0018's own
+  cost argument, which is correct even though its conclusion was not: a Lua
+  callback copies the whole Luerl state under the default `copy` mode.
+- **Infer it from `zone_state` changing between ticks.** Rejected as in ADR
+  0018: any script stamping a tick counter is permanently busy. Under `owned`
+  the handle does not change when the state does, so the comparison is not
+  merely wrong but impossible.
+- **A zone-level timer reachable from Lua**, so `asobi_idle/1` could see the
+  countdown itself. Not rejected - it is the better answer for the countdown
+  *shape* specifically, and `asobi_entity_timer` already exists with no `game.*`
+  surface. It does not cover conditional or accumulating work, so a veto is
+  still wanted. Left as follow-up.

--- a/guides/performance-tuning.md
+++ b/guides/performance-tuning.md
@@ -122,26 +122,35 @@ says what it deliberately does not solve.
 **If your game drives work from `zone_tick` on a zone that holds nothing** - a
 wave spawner counting down between waves, weather, a zone-level timer - asobi
 cannot see it, and such a zone is demoted to a tenth of the rate it was written
-for. Say so and it stays hot:
+for. Say so with a third return value:
 
 ```lua
 function zone_tick(entities, zone_state)
-  zone_state.next_wave = zone_state.next_wave - 1
-  zone_state._keep_hot = zone_state.next_wave > 0
-  return entities, zone_state
+  zone_state.next_wave = (zone_state.next_wave or 30) - 1
+  return entities, zone_state, zone_state.next_wave > 0
 end
 ```
 
-An Erlang game module exports `zone_busy/1` instead. Either way it is consulted
-**only when asobi already believes the zone is idle**, so a zone with entities
-never pays for it, and it fails safe: a raise or a non-boolean keeps the zone
-hot and is logged.
+An Erlang game module returns `{Entities, ZoneState, Busy}` from `zone_tick/2`.
+Returning the ordinary two-tuple means "not busy", so this is additive and a
+game that never uses it behaves exactly as before.
 
-`_keep_hot` is a field rather than a Lua callback on purpose. asobi asks on every
-idle tick, so a callback would put one extra marshalled call per tick on exactly
-the zones this section is about, to decide whether to skip a call. It joins
-`_finished`, `_result` and `_vote` as fields a script sets on its state to tell
-asobi something.
+Lua truthiness decides: `nil` and `false` are not busy, everything else is - so
+returning the countdown itself works as well as returning a comparison.
+
+While a zone says it is busy it keeps its full tick rate, is **not** hibernated
+between ticks, and is **not** reaped by the idle sweep. A non-boolean from an
+Erlang module keeps the zone hot and is logged; demoting a zone that has work is
+the harmful direction.
+
+It rides on `zone_tick`'s return rather than being a separate callback or a
+field on the zone state, and that is not only about tidiness: asobi wants the
+answer at exactly the instant `zone_tick` returns, a second callback would cost
+a marshalled crossing on every idle tick, and a field would cost a Luerl read -
+which is *not* raw, so an absent key on a table with an `__index` runs the
+metamethod inline on the zone process with no timeout and no heap cap. A
+returned value reads nothing. See
+`docs/adr/0019-zone-tick-returns-whether-it-is-busy.md`.
 
 `cold_tick_divisor = 1` disables the whole thing world-wide if you would rather
 not think about it.

--- a/guides/world-server.md
+++ b/guides/world-server.md
@@ -212,7 +212,7 @@ end
 | `zone_tick(entities, zone_state)` | no | Per-zone simulation; return both |
 | `handle_input(player_id, input, entities)` | no | Apply one player's input to that zone's entities. A second return value is the client seq you consumed - see [Batched input and the ack](websocket-protocol.md#client-side-prediction). Every input in a tick is handed the same table rather than a copy, but returning nothing still discards whatever that call mutated - see [Players in one zone](performance-tuning.md#players-in-one-zone) |
 | `handle_effects(effects, entities)` | no | This tick's cross-zone effects, batched. See [Seeing across a seam](#seeing-across-a-seam) |
-| `_keep_hot` on your zone state | no | Not a callback: set it truthy in `zone_tick` to stop an entity-less zone being demoted. See [Performance tuning](performance-tuning.md#zone-tick-hibernation-and-reaping) |
+| a third return from `zone_tick` | no | `return entities, zone_state, true` stops an entity-less zone being demoted. See [Performance tuning](performance-tuning.md#zone-tick-hibernation-and-reaping) |
 | `generate_world(seed, config)` | no | Return a table keyed by `"x,y"` strings |
 | `get_state(player_id, state)` | no | Player-visible state |
 | `spawn_templates(config)` | no | See [Spawn templates](#spawn-templates) |
@@ -326,7 +326,7 @@ post_tick(_TickN, State) ->
 | `handle_input/3` | one of | Process player input within a zone's entities. Return `{ok, Entities, ConsumedSeq}` to ack what you *ran* rather than what arrived - see [Batched input and the ack](websocket-protocol.md#client-side-prediction) |
 | `handle_input_batch/2` | one of | The whole tick's inputs in one call, returning one entity map plus one outcome per input. Export it instead of `handle_input/3` when your per-input cost is dominated by marshalling the entity map rather than by the input. Exporting it shadows `handle_input/3` entirely. asobi still owns the ack policy: you return one outcome per input - see [Players in one zone](performance-tuning.md#players-in-one-zone) |
 | `handle_effects/2` | no | This tick's cross-zone effects: `([{EntityId, Event}], Entities) -> {ok, Entities}`. Delivered after inputs, already filtered to entities this zone still owns. See [Seeing across a seam](#seeing-across-a-seam) |
-| `zone_busy/1` | no | `(ZoneState) -> boolean()`. Veto demotion of an entity-less zone that still has work asobi cannot see. Consulted only when asobi already believes the zone is idle; a raise or non-boolean keeps the zone hot |
+| `zone_tick/2`'s third element | no | `{Entities, ZoneState, Busy :: boolean()}` vetoes demotion of an entity-less zone that still has work asobi cannot see. A two-tuple means "not busy"; a non-boolean keeps the zone hot and is logged |
 | `post_tick/2` | yes | Global post-tick: return `{ok, State}`, `{vote, Config, State}`, or `{finished, Result, State}` |
 | `generate_world/2` | no | Procedural generation: `(Seed, Config) -> {ok, #{Coords => ZoneState}}` |
 | `get_state/2` | no | Per-player state view |

--- a/src/lua/asobi_lua_world.erl
+++ b/src/lua/asobi_lua_world.erl
@@ -46,7 +46,6 @@ of hot reloads.
 
 -export([init/1, join/2, join/3, leave/2, spawn_position/2]).
 -export([zone_tick/2, handle_input/3, handle_input_batch/2, handle_effects/2, post_tick/2]).
--export([zone_busy/1]).
 -ifdef(TEST).
 -export([zone_ctx/2, make_ctx/1]).
 -endif.
@@ -208,7 +207,7 @@ spawn_position(PlayerId, #{lua_state := LuaSt, game_state := GS} = State) ->
 %% exactly the write/read split here.
 -define(TEMPLATES_KEY, known).
 
--spec zone_tick(map(), term()) -> {map(), term()}.
+-spec zone_tick(map(), term()) -> {map(), term()} | {map(), term(), boolean()}.
 zone_tick(Entities, ZoneState0) when is_map(ZoneState0) ->
     %% Pick up any lua_state updates that handle_input stashed earlier this
     %% tick. The dev-error rate-limit stamp must ride along too: asobi_zone's
@@ -266,6 +265,9 @@ zone_tick(Entities, ZoneState0) when is_map(ZoneState0) ->
                         zone_tick, [EncEntities, GS], LuaSt1, ?TICK_TIMEOUT
                     )
                 of
+                    {ok, [Ents1, ZS1, Busy | _], LuaSt2} ->
+                        Ents2 = asobi_lua_api:atomize_entities(decode_to_map(Ents1, LuaSt2)),
+                        {Ents2, ZoneState#{lua_state => LuaSt2, game_state => ZS1}, truthy(Busy)};
                     {ok, [Ents1, ZS1 | _], LuaSt2} ->
                         Ents2 = asobi_lua_api:atomize_entities(decode_to_map(Ents1, LuaSt2)),
                         {Ents2, ZoneState#{lua_state => LuaSt2, game_state => ZS1}};
@@ -277,11 +279,22 @@ zone_tick(Entities, ZoneState0) when is_map(ZoneState0) ->
                         {Entities, ZoneState}
                 end
         end,
-    {_, NewZoneState} = Result,
-    erlang:put(?PD_KEY, NewZoneState),
+    erlang:put(?PD_KEY, result_zone_state(Result)),
     Result;
 zone_tick(Entities, ZoneState) ->
     {Entities, ZoneState}.
+
+result_zone_state({_Entities, ZoneState}) -> ZoneState;
+result_zone_state({_Entities, ZoneState, _Busy}) -> ZoneState.
+
+%% Lua truthiness, not Erlang's: `nil` and `false` are the only falsey values, so
+%% `return entities, zone_state, wave_countdown > 0` works and so does returning
+%% a number. Reading a bare returned value can run no metamethod, which is the
+%% whole reason this is a return value and not a field - see asobi_zone's
+%% zone_tick_result/2.
+truthy(nil) -> false;
+truthy(false) -> false;
+truthy(_) -> true.
 
 -doc """
 Delegates to the script's `handle_input`.
@@ -331,43 +344,6 @@ handle_input(PlayerId, Input, Entities) ->
         _ ->
             {ok, Entities}
     end.
-
--doc """
-Reads the script's `_keep_hot` veto off the zone's `game_state`.
-
-A field rather than a callback, deliberately. asobi consults this whenever it
-believes a zone is idle, and on a hot zone that is every tick - so a `zone_busy`
-Lua *function* would put one extra marshalled callback per tick on exactly the
-zones widgrensit/asobi#543 is about, to decide whether to skip a callback. One
-table read is affordable; a second callback is the disease.
-
-`_keep_hot` joins `_finished`, `_result` and `_vote` as a field a script sets on
-its state to tell asobi something (`check_post_tick_result/2`).
-
-```lua
-function zone_tick(entities, zone_state)
-  zone_state.next_wave = zone_state.next_wave - 1
-  zone_state._keep_hot = zone_state.next_wave > 0   -- still counting down
-  return entities, zone_state
-end
-```
-
-Anything other than a literal `true` reads as "not busy", so a script that never
-sets it demotes exactly as before.
-""".
--spec zone_busy(term()) -> boolean().
-zone_busy(#{lua_state := LuaSt, game_state := GS}) when GS =/= nil, GS =/= undefined ->
-    try asobi_lua_loader:get_table_key(GS, ~"_keep_hot", LuaSt) of
-        {ok, true, _} -> true;
-        _ -> false
-    catch
-        %% A game_state that is not a table at all. asobi_zone treats a raise as
-        %% "keep the zone hot", which would latch every such world to full rate,
-        %% so answer it here instead: a script with no table has no veto.
-        _:_ -> false
-    end;
-zone_busy(_ZoneState) ->
-    false.
 
 -doc """
 Delegates a tick's cross-zone effects to the script's `handle_effects`.

--- a/src/world/asobi_world.erl
+++ b/src/world/asobi_world.erl
@@ -59,9 +59,30 @@ behind the join.
 -callback spawn_position(PlayerId :: binary(), GameState :: term()) ->
     {ok, {X :: number(), Y :: number()}}.
 
--doc "Per-zone tick: advance the entities in one zone from its zone_state.".
+-doc """
+Per-zone tick: advance the entities in one zone from its zone_state.
+
+The optional third element answers "does this zone still have work asobi cannot
+see?". A zone with no entities, no queued input, no live entity timer and no
+pending respawn is demoted and ticks once every `cold_tick_divisor` ticks
+(widgrensit/asobi#543). That test reads asobi's own bookkeeping, which is blind
+to work a script keeps in its zone state - a wave spawner counting down between
+waves, weather, a zone-level phase timer. Return `true` and the zone stays hot,
+is not hibernated between ticks, and is not reaped while it says so.
+
+It rides on `zone_tick/2`'s return rather than being asked for separately
+because that is the instant asobi wants it, so anything else is strictly worse:
+a second callback costs a marshalled crossing per idle tick, and a field on the
+zone state costs a Luerl read that is not raw - see `asobi_zone`'s
+`zone_tick_result/2`. Returning a plain two-tuple means "not busy", so this is
+additive.
+
+A non-boolean third element keeps the zone hot and is logged: demoting a zone
+that has work is the harmful direction.
+""".
 -callback zone_tick(Entities :: map(), ZoneState :: term()) ->
-    {Entities1 :: map(), ZoneState1 :: term()}.
+    {Entities1 :: map(), ZoneState1 :: term()}
+    | {Entities1 :: map(), ZoneState1 :: term(), Busy :: boolean()}.
 
 -doc """
 Apply a player input to a zone's entities.
@@ -199,25 +220,6 @@ dropped effect is indistinguishable from a delivery bug from the game's side.
 ) ->
     {ok, Entities1 :: map()} | Entities1 :: map().
 
--doc """
-Optional: does this zone still have work asobi cannot see?
-
-A zone with no entities, no queued input, no live entity timer and no pending
-respawn is demoted and ticks once every `cold_tick_divisor` ticks
-(widgrensit/asobi#543). That test reads asobi's own bookkeeping, which is blind
-to work a script keeps in its zone state - a wave spawner counting down between
-waves, weather, a zone-level phase timer. Such a zone holds nothing, so it is
-demoted, and the countdown then runs at a tenth of the rate it was written for.
-
-Export this to veto that. It is consulted **only when asobi already believes the
-zone is idle**, so a zone with entities never pays for it, and a zone answering
-`true` is doing work in `zone_tick` and paying for that anyway.
-
-Fail-safe is "keep the zone hot": a raising or non-boolean answer is treated as
-`true` and logged. Demoting a zone that has work is the harmful direction.
-""".
--callback zone_busy(ZoneState :: term()) -> boolean().
-
 -doc "Global post-tick hook: continue, trigger a vote, or finish the world.".
 -callback post_tick(Tick :: non_neg_integer(), GameState :: term()) ->
     {ok, GameState1 :: term()}
@@ -318,6 +320,5 @@ plain terms. The inverse of `init_zone_state`'s restore path.
     dump_zone_state/1,
     handle_input/3,
     handle_input_batch/2,
-    handle_effects/2,
-    zone_busy/1
+    handle_effects/2
 ]).

--- a/src/world/asobi_zone.erl
+++ b/src/world/asobi_zone.erl
@@ -326,6 +326,9 @@ init(Config) ->
             %% drop path more expensive for the victim than the accept path -
             %% which inverts the point of a cap. Emitted once per tick instead.
             effect_dropped => 0,
+            %% zone_tick/2's last third return value. Starts false: the zone has
+            %% not ticked, so the game has not claimed anything.
+            script_busy => false,
             %% A zone with nothing to simulate is demoted to the ticker's cold
             %% set, which runs it once every `cold_tick_divisor` ticks instead
             %% of every tick (widgrensit/asobi#543). Starts hot: the zone has
@@ -559,6 +562,18 @@ handle_call(_Request, _From, State) ->
 
 -spec handle_cast(term(), map()) ->
     {noreply, map()} | {noreply, map(), hibernate} | {stop, normal, map()}.
+handle_cast(reap, #{entities := Entities, script_busy := true} = State) when
+    map_size(Entities) =:= 0
+->
+    %% "This zone has work" has to mean it is not torn down, or a wave spawner
+    %% counting down between waves is reaped mid-countdown at
+    %% `zone_idle_timeout` and the wave never comes. Declined the same way an
+    %% occupied zone declines below.
+    case maps:get(zone_manager_pid, State, undefined) of
+        undefined -> ok;
+        ZMPid -> asobi_zone_manager:touch_zone(ZMPid, maps:get(coords, State))
+    end,
+    {noreply, State};
 handle_cast(reap, #{entities := Entities} = State) when map_size(Entities) =:= 0 ->
     %% Graceful stop so terminate/2 writes a final snapshot. Transient restart
     %% means a normal stop is not respawned.
@@ -584,7 +599,10 @@ handle_cast({tick, TickN}, State) ->
     #{subscribers := Subs, entities := Ents, zone_manager_pid := ZMPid, coords := Coords} = State3,
     case map_size(Subs) of
         0 ->
-            case has_tickable_entities(Ents) of
+            %% A zone that says it is busy is not idle between its ticks, so
+            %% hibernating it would pay a full-sweep GC of the whole Luerl state
+            %% at tick rate - more per tick than an occupied zone costs.
+            case has_tickable_entities(Ents) orelse maps:get(script_busy, State3, false) of
                 false -> {noreply, State3, hibernate};
                 true -> {noreply, State3}
             end;
@@ -977,7 +995,9 @@ do_tick(
     %% the previous order; broadcasts still reflect this tick's input because
     %% the broadcast step runs after both.
     ZoneStateWithTick = ZoneState#{tick => TickN},
-    {Entities0, ZoneState1} = GameMod:zone_tick(Entities, ZoneStateWithTick),
+    {Entities0, ZoneState1, ScriptBusy} = zone_tick_result(
+        GameMod:zone_tick(Entities, ZoneStateWithTick), State
+    ),
     %% input_queue is built newest-first via [Input | Queue], so reverse it
     %% before applying so handle_input sees inputs in arrival order. Without
     %% this, a burst of moves arriving in one tick window collapses to the
@@ -1088,8 +1108,43 @@ do_tick(
         entity_timers => ET1,
         spawner => Spawner1,
         spatial_grid => Grid1,
+        script_busy => ScriptBusy,
         tick => TickN
     }.
+
+-doc """
+Reads `zone_tick/2`'s optional third return value: does the game say this zone
+still has work asobi cannot see?
+
+A return value rather than a callback or a state field, and that is the whole
+design. `reclassify/1` runs immediately after `zone_tick/2` in the same
+`handle_cast`, so the answer is wanted at exactly the instant the callback
+already returns - which makes any *separate* way of asking strictly worse:
+
+- a second callback costs a marshalled crossing per idle tick, on the zones
+  widgrensit/asobi#543 exists to make cheaper;
+- a field on the zone state costs a table read, and a Luerl table read is not
+  raw - an absent key on a table with an `__index` runs the metamethod inline on
+  this process, with no timeout, no heap cap and no reduction budget. `_keep_hot`
+  was absent from almost every zone state, so that was the ordinary path, and
+  ordinary OOP Lua (`setmetatable(zone_state, Zone)`) was enough to hang a zone
+  forever. That is what this replaced, in v0.98.0.
+
+A value cannot do either: it is already here, and nothing is read to get it.
+
+Fail-safe is `true`. Demoting a zone that has work is silent and harmful;
+keeping one hot is loud and costs one zone.
+""".
+-spec zone_tick_result(term(), map()) -> {map(), term(), boolean()}.
+zone_tick_result({Entities, ZoneState}, _State) when is_map(Entities) ->
+    {Entities, ZoneState, false};
+zone_tick_result({Entities, ZoneState, Busy}, _State) when
+    is_map(Entities), is_boolean(Busy)
+->
+    {Entities, ZoneState, Busy};
+zone_tick_result({Entities, ZoneState, Other}, State) when is_map(Entities) ->
+    log_bad_zone_busy(State, Other),
+    {Entities, ZoneState, true}.
 
 apply_timer_events([], Entities) ->
     Entities;
@@ -2529,12 +2584,12 @@ effects_result(_Other, Prev, State) ->
 %% deltas to send. That is exactly the "watched but empty" case #543 asks about.
 -spec zone_idle(map()) -> boolean().
 -spec asobi_idle(map()) -> boolean().
-zone_idle(#{game_module := GameMod, zone_state := ZoneState} = State) ->
-    asobi_idle(State) andalso not script_busy(GameMod, ZoneState, State).
+zone_idle(State) ->
+    asobi_idle(State) andalso not maps:get(script_busy, State, false).
 
-%% Everything asobi can see for itself. Kept separate from the script's own
-%% answer because this half is free and that half is not, and the order matters:
-%% a zone holding entities never reaches `zone_busy/1` at all.
+%% Everything asobi can see for itself. `script_busy` - the game's own answer,
+%% from zone_tick_result/2 - is the other half, and it is a stored value rather
+%% than a question asked here, so neither half costs anything to consult.
 %%
 %% `input_queue` and `effect_queue` are always `[]` where reclassify/1 calls
 %% this - do_tick/2 empties both before it runs - so those two conditions never
@@ -2564,54 +2619,24 @@ clamp_border_band(Band) ->
     }),
     ?DEFAULT_BORDER_BAND.
 
--doc """
-Whether the game says this zone still has work asobi cannot see.
-
-`asobi_idle/1` reads entities, queues, timers and the respawn queue - asobi's
-own bookkeeping - and that is blind to work a script keeps in its zone state: a
-wave spawner counting down, weather, a zone-level phase timer. Such a zone holds
-nothing, so asobi calls it idle and ticks it at `cold_tick_divisor`, and the
-countdown runs at a tenth of the rate it was written for.
-
-Consulted **only when asobi already believes the zone is idle**, which is what
-keeps it affordable: a zone with entities never reaches it, and a zone that
-answers `true` is by definition doing work in `zone_tick` and paying for that
-anyway.
-
-Fail-safe is `true` - a raising or out-of-shape answer keeps the zone hot.
-Demoting a zone that might have work is the harmful direction; the cost of
-getting it wrong the other way is one zone ticking at full rate.
-""".
--spec script_busy(module(), term(), map()) -> boolean().
-script_busy(GameMod, ZoneState, State) ->
-    case erlang:function_exported(GameMod, zone_busy, 1) of
-        false ->
-            false;
-        true ->
-            try GameMod:zone_busy(ZoneState) of
-                Busy when is_boolean(Busy) ->
-                    Busy;
-                Other ->
-                    log_bad_zone_busy(State, Other),
-                    true
-            catch
-                Class:Reason ->
-                    log_bad_zone_busy(State, {Class, Reason}),
-                    true
-            end
-    end.
-
+%% `Detail` is whatever the game returned, so it is bounded and binarised the
+%% way every other game-supplied term in this module is - an unbounded `~0p` of
+%% a zone state is both a 200KB log line and a way to print a secret the game
+%% keeps in it.
 log_bad_zone_busy(State, Detail) ->
     Zone = log_zone(State),
     asobi_telemetry:game_error(bad_zone_busy, #{
-        game_module => maps:get(game_module, State, undefined)
+        game_module => maps:get(game_module, State, undefined),
+        world_id => maps:get(world_id, State, undefined),
+        coords => maps:get(coords, State, undefined)
     }),
     case asobi_script_log_limiter:allow(effect_log_key(Zone, bad_zone_busy)) of
         {true, SuppressedSinceLast} ->
             ?LOG_ERROR(#{
-                msg => ~"zone_busy/1 did not return a boolean; keeping the zone hot",
+                msg =>
+                    ~"zone_tick/2's third return value was not a boolean; keeping the zone hot",
                 coords => maps:get(coords, State, undefined),
-                detail => io_lib:format("~0p", [Detail]),
+                detail => bound_debug_term(Detail),
                 suppressed_since_last => SuppressedSinceLast
             });
         false ->

--- a/test/asobi_lua_world_tests.erl
+++ b/test/asobi_lua_world_tests.erl
@@ -1158,36 +1158,56 @@ with_every_tick_polling(Fun) ->
 
 %% widgrensit/asobi#543 follow-up: a script counting down between waves holds no
 %% entities, so asobi's own bookkeeping calls the zone idle and demotes it to a
-%% tenth of the tick rate. `_keep_hot` is how the script says otherwise - a field
-%% rather than a callback, because asobi asks on every idle tick.
-keep_hot_vetoes_demotion_test() ->
+%% tenth of the tick rate. The third return value from `zone_tick` is how the
+%% script says otherwise - a returned value rather than a field, because reading
+%% a field is a Luerl read that can run an `__index` metamethod on the zone
+%% process with no budget.
+third_return_value_vetoes_demotion_test() ->
     Script = fixture("keep_hot_world.lua"),
     Config = #{game_config => #{lua_script => Script}},
     ZoneState = asobi_lua_world:init_zone_state(Config, #{}),
     erlang:erase({asobi_lua_world, zone_state}),
     %% next_wave: 3 -> 2 -> 1 -> 0, so the veto holds for two ticks and lifts.
-    {_, ZS1} = asobi_lua_world:zone_tick(#{}, ZoneState),
-    ?assert(asobi_lua_world:zone_busy(ZS1)),
-    {_, ZS2} = asobi_lua_world:zone_tick(#{}, ZS1),
-    ?assert(asobi_lua_world:zone_busy(ZS2)),
-    {_, ZS3} = asobi_lua_world:zone_tick(#{}, ZS2),
-    ?assertNot(asobi_lua_world:zone_busy(ZS3)),
+    {_, ZS1, Busy1} = asobi_lua_world:zone_tick(#{}, ZoneState),
+    ?assert(Busy1),
+    {_, ZS2, Busy2} = asobi_lua_world:zone_tick(#{}, ZS1),
+    ?assert(Busy2),
+    ?assertMatch({_, _, false}, asobi_lua_world:zone_tick(#{}, ZS2)),
     erlang:erase({asobi_lua_world, zone_state}).
 
-%% A script that never sets the field demotes exactly as it did before.
-no_keep_hot_field_is_not_busy_test() ->
+%% A script returning two values gets the two-tuple it always did.
+two_return_values_stay_a_two_tuple_test() ->
     Script = fixture("config_move_world.lua"),
     Config = #{game_config => #{lua_script => Script}},
     {ok, ZoneStates} = asobi_lua_world:generate_world(0, Config),
     ZoneState = asobi_lua_world:init_zone_state(Config, maps:get({0, 0}, ZoneStates)),
     erlang:erase({asobi_lua_world, zone_state}),
-    {_, ZS1} = asobi_lua_world:zone_tick(#{}, ZoneState),
-    ?assertNot(asobi_lua_world:zone_busy(ZS1)),
+    ?assertMatch({_, _}, asobi_lua_world:zone_tick(#{}, ZoneState)),
     erlang:erase({asobi_lua_world, zone_state}).
 
-%% No lua_state and no game_state: the bridge must answer, not raise, because
-%% asobi_zone treats a raise as "keep hot" and would latch the zone to full rate.
-zone_busy_without_a_bridge_state_test() ->
-    ?assertNot(asobi_lua_world:zone_busy(#{})),
-    ?assertNot(asobi_lua_world:zone_busy(#{lua_state => undefined, game_state => nil})),
-    ?assertNot(asobi_lua_world:zone_busy(not_a_map)).
+%% Lua truthiness, not Erlang's: a countdown returning a number is the natural
+%% thing to write, and `_keep_hot = 1` reading as "not busy" was the silent
+%% failure this replaced.
+lua_truthiness_decides_busy_test() ->
+    Script = fixture("truthy_busy_world.lua"),
+    Config = #{game_config => #{lua_script => Script}},
+    ZoneState = asobi_lua_world:init_zone_state(Config, #{}),
+    erlang:erase({asobi_lua_world, zone_state}),
+    ?assertMatch({_, _, true}, asobi_lua_world:zone_tick(#{}, ZoneState)),
+    erlang:erase({asobi_lua_world, zone_state}).
+
+%% The bug this design removes: a zone_state carrying an __index metamethod used
+%% to run that metamethod inline on the zone process, unbudgeted, because the
+%% veto was read as an absent table key. A returned value reads nothing.
+hostile_metatable_cannot_run_on_the_zone_test() ->
+    Script = fixture("metatable_zone_state.lua"),
+    Config = #{game_config => #{lua_script => Script}},
+    ZoneState = asobi_lua_world:init_zone_state(Config, #{}),
+    erlang:erase({asobi_lua_world, zone_state}),
+    {Us, Result} = timer:tc(fun() -> asobi_lua_world:zone_tick(#{}, ZoneState) end),
+    %% Two-tuple: the script returned no third value, and asobi read no key off
+    %% the zone state to find one out.
+    ?assertMatch({_, _}, Result),
+    %% The metamethod burns ~2e6 iterations if anything invokes it.
+    ?assert(Us < 200_000),
+    erlang:erase({asobi_lua_world, zone_state}).

--- a/test/asobi_zone_busy_game.erl
+++ b/test/asobi_zone_busy_game.erl
@@ -1,13 +1,13 @@
 -module(asobi_zone_busy_game).
 
-%% Vetoes demotion when its zone state says so, which is the shape a wave
-%% spawner has: no entities between waves, and a countdown asobi cannot see.
--export([zone_tick/2, handle_input/3, zone_busy/1]).
+%% Answers zone_tick/2's optional third element from its own zone state, which
+%% is the shape a wave spawner has: no entities between waves, and a countdown
+%% asobi cannot see.
+-export([zone_tick/2, handle_input/3]).
 
-zone_tick(E, ZS) -> {E, ZS}.
 handle_input(_P, _I, E) -> {ok, E}.
 
-zone_busy(#{busy := bad_return}) -> not_a_boolean;
-zone_busy(#{busy := raises}) -> error(deliberate);
-zone_busy(#{busy := Busy}) when is_boolean(Busy) -> Busy;
-zone_busy(_) -> false.
+%% A two-tuple means "not busy", so this also covers the additive case.
+zone_tick(E, #{busy := quiet} = ZS) -> {E, ZS};
+zone_tick(E, #{busy := Busy} = ZS) -> {E, ZS, Busy};
+zone_tick(E, ZS) -> {E, ZS}.

--- a/test/asobi_zone_cold_tests.erl
+++ b/test/asobi_zone_cold_tests.erl
@@ -63,12 +63,12 @@ cold_test_() ->
         {"an occupied zone stays hot", fun occupied_stays_hot/0},
         {"a subscriber alone does not keep a zone hot", fun subscriber_does_not_warm/0},
         {"going cold and warming again are each announced once", fun transitions_emit_telemetry/0},
-        {"zone_busy vetoes demotion", fun zone_busy_keeps_a_zone_hot/0},
+        {"a busy third return value vetoes demotion", fun zone_busy_keeps_a_zone_hot/0},
         {"a zone that stops being busy is demoted", fun zone_busy_released/0},
-        {"zone_busy is not consulted while entities are present",
-            fun zone_busy_skipped_when_occupied/0},
-        {"a non-boolean zone_busy keeps the zone hot", fun bad_zone_busy_fails_safe/0},
-        {"a raising zone_busy keeps the zone hot", fun raising_zone_busy_fails_safe/0}
+        {"a two-tuple return still means not busy", fun two_tuple_is_not_busy/0},
+        {"a non-boolean third element keeps the zone hot", fun bad_zone_busy_fails_safe/0},
+        {"a busy zone is not reaped", fun busy_zone_declines_reap/0},
+        {"a busy zone is not hibernated", fun busy_zone_does_not_hibernate/0}
     ]}.
 
 start_busy_zone(ZoneState) ->
@@ -85,82 +85,6 @@ start_busy_zone(ZoneState) ->
 
 %% The gap ADR 0016 recorded and did not close: a script counting down between
 %% waves holds no entities, so asobi's own bookkeeping calls the zone idle.
-zone_busy_keeps_a_zone_hot() ->
-    Pid = start_busy_zone(#{busy => true}),
-    tick(Pid, 1),
-    tick(Pid, 2),
-    ?assertNot(is_cold(Pid)),
-    ?assertEqual([], drain_ticker_casts()),
-    gen_server:stop(Pid).
-
-zone_busy_released() ->
-    Pid = start_busy_zone(#{busy => true}),
-    tick(Pid, 1),
-    ?assertNot(is_cold(Pid)),
-    sys:replace_state(Pid, fun(S) -> S#{zone_state => #{busy => false}} end),
-    tick(Pid, 2),
-    ?assert(is_cold(Pid)),
-    gen_server:stop(Pid).
-
-%% Order matters for cost, not just for correctness: a zone holding entities must
-%% never reach the callback at all.
-zone_busy_skipped_when_occupied() ->
-    Pid = start_busy_zone(#{busy => raises}),
-    asobi_zone:add_entity(Pid, ~"npc", #{type => ~"npc", x => 150.0, y => 150.0}),
-    tick(Pid, 1),
-    ?assert(is_process_alive(Pid)),
-    ?assertNot(is_cold(Pid)),
-    gen_server:stop(Pid).
-
-bad_zone_busy_fails_safe() ->
-    Pid = start_busy_zone(#{busy => bad_return}),
-    tick(Pid, 1),
-    ?assertNot(is_cold(Pid)),
-    gen_server:stop(Pid).
-
-raising_zone_busy_fails_safe() ->
-    Pid = start_busy_zone(#{busy => raises}),
-    tick(Pid, 1),
-    ?assert(is_process_alive(Pid)),
-    ?assertNot(is_cold(Pid)),
-    gen_server:stop(Pid).
-
-%% An operator watching a world needs to see a zone stop simulating - a zone
-%% that goes cold and never comes back is one that has stopped responding to the
-%% players in it, and before this there was no signal for it at all.
-transitions_emit_telemetry() ->
-    {ok, _} = application:ensure_all_started(telemetry),
-    Ref = make_ref(),
-    Self = self(),
-    ok = telemetry:attach_many(
-        {?MODULE, Ref},
-        [[asobi, zone, cold], [asobi, zone, hot]],
-        fun(Event, _Measure, Meta, _) -> Self ! {telemetry, Event, Meta} end,
-        []
-    ),
-    try
-        Pid = start_zone(),
-        tick(Pid, 1),
-        ?assertEqual(
-            {[asobi, zone, cold], {1, 1}}, next_event()
-        ),
-        %% A second idle tick must not re-announce: this is a transition, not a
-        %% state, or a large empty world emits one event per zone per tick.
-        tick(Pid, 2),
-        asobi_zone:add_entity(Pid, ~"npc", #{type => ~"npc", x => 150.0, y => 150.0}),
-        _ = sys:get_state(Pid),
-        ?assertEqual({[asobi, zone, hot], {1, 1}}, next_event()),
-        gen_server:stop(Pid)
-    after
-        telemetry:detach({?MODULE, Ref})
-    end.
-
-next_event() ->
-    receive
-        {telemetry, Event, #{coords := Coords}} -> {Event, Coords}
-    after 1000 -> timeout
-    end.
-
 starts_hot() ->
     Pid = start_zone(),
     ?assertNot(is_cold(Pid)),
@@ -243,3 +167,99 @@ subscriber_does_not_warm() ->
     ?assert(is_cold(Pid)),
     Player ! stop,
     gen_server:stop(Pid).
+
+%% An operator watching a world needs to see a zone stop simulating - a zone
+%% that goes cold and never comes back is one that has stopped responding to the
+%% players in it, and before this there was no signal for it at all.
+transitions_emit_telemetry() ->
+    {ok, _} = application:ensure_all_started(telemetry),
+    Ref = make_ref(),
+    Self = self(),
+    ok = telemetry:attach_many(
+        {?MODULE, Ref},
+        [[asobi, zone, cold], [asobi, zone, hot]],
+        fun(Event, _Measure, Meta, _) -> Self ! {telemetry, Event, Meta} end,
+        []
+    ),
+    try
+        Pid = start_zone(),
+        tick(Pid, 1),
+        ?assertEqual({[asobi, zone, cold], {1, 1}}, next_event()),
+        %% A second idle tick must not re-announce: this is a transition, not a
+        %% state, or a large empty world emits one event per zone per tick.
+        tick(Pid, 2),
+        asobi_zone:add_entity(Pid, ~"npc", #{type => ~"npc", x => 150.0, y => 150.0}),
+        _ = sys:get_state(Pid),
+        ?assertEqual({[asobi, zone, hot], {1, 1}}, next_event()),
+        gen_server:stop(Pid)
+    after
+        telemetry:detach({?MODULE, Ref})
+    end.
+
+next_event() ->
+    receive
+        {telemetry, Event, #{coords := Coords}} -> {Event, Coords}
+    after 1000 -> timeout
+    end.
+
+zone_busy_keeps_a_zone_hot() ->
+    Pid = start_busy_zone(#{busy => true}),
+    tick(Pid, 1),
+    tick(Pid, 2),
+    ?assertNot(is_cold(Pid)),
+    ?assertEqual([], drain_ticker_casts()),
+    gen_server:stop(Pid).
+
+zone_busy_released() ->
+    Pid = start_busy_zone(#{busy => true}),
+    tick(Pid, 1),
+    ?assertNot(is_cold(Pid)),
+    sys:replace_state(Pid, fun(S) -> S#{zone_state => #{busy => false}} end),
+    tick(Pid, 2),
+    ?assert(is_cold(Pid)),
+    gen_server:stop(Pid).
+
+%% The two-tuple is the whole pre-existing contract, so this is what makes the
+%% third element additive rather than a change.
+two_tuple_is_not_busy() ->
+    Pid = start_busy_zone(#{busy => quiet}),
+    tick(Pid, 1),
+    ?assert(is_cold(Pid)),
+    gen_server:stop(Pid).
+
+bad_zone_busy_fails_safe() ->
+    Pid = start_busy_zone(#{busy => not_a_boolean}),
+    tick(Pid, 1),
+    ?assertNot(is_cold(Pid)),
+    gen_server:stop(Pid).
+
+%% "This zone has work" has to keep it alive, or a wave spawner is torn down
+%% mid-countdown at zone_idle_timeout and the wave never comes.
+busy_zone_declines_reap() ->
+    Pid = start_busy_zone(#{busy => true}),
+    tick(Pid, 1),
+    asobi_zone:reap(Pid),
+    _ = sys:get_state(Pid),
+    ?assert(is_process_alive(Pid)),
+    gen_server:stop(Pid).
+
+%% An entity-less zone normally hibernates between ticks. A busy one must not:
+%% at full tick rate that is a full-sweep GC of the whole Luerl state per tick,
+%% which costs more than an occupied zone does.
+busy_zone_does_not_hibernate() ->
+    Quiet = start_busy_zone(#{busy => quiet}),
+    asobi_zone:tick(Quiet, 1),
+    _ = sys:get_state(Quiet),
+    ?assertMatch(
+        {current_function, {gen_server, loop_hibernate, 4}},
+        process_info(Quiet, current_function)
+    ),
+    gen_server:stop(Quiet),
+    Busy = start_busy_zone(#{busy => true}),
+    asobi_zone:tick(Busy, 1),
+    _ = sys:get_state(Busy),
+    ?assertNotMatch(
+        {current_function, {gen_server, loop_hibernate, 4}},
+        process_info(Busy, current_function)
+    ),
+    gen_server:stop(Busy).

--- a/test/fixtures/lua/metatable_zone_state.lua
+++ b/test/fixtures/lua/metatable_zone_state.lua
@@ -8,10 +8,16 @@ function generate_world(seed, config) return { ["0,0"] = {} } end
 function spawn_position(player_id, state) return { x = 10, y = 10 } end
 function handle_input(player_id, input, entities) return entities end
 
--- A wave spawner: no entities between waves, and a countdown asobi cannot see.
--- The third return value is what keeps the zone at full tick rate.
+-- Ordinary OOP Lua. Under the field design this __index ran inline on the zone
+-- process for every absent-key read, with no timeout and no heap cap.
+local Zone = {}
+Zone.__index = function(_t, _k)
+  local n = 0
+  for i = 1, 2000000 do n = n + i end
+  return n
+end
+
 function zone_tick(entities, zone_state)
-  zone_state = zone_state or {}
-  zone_state.next_wave = (zone_state.next_wave or 3) - 1
-  return entities, zone_state, zone_state.next_wave > 0
+  zone_state = zone_state or setmetatable({}, Zone)
+  return entities, zone_state
 end

--- a/test/fixtures/lua/truthy_busy_world.lua
+++ b/test/fixtures/lua/truthy_busy_world.lua
@@ -8,10 +8,8 @@ function generate_world(seed, config) return { ["0,0"] = {} } end
 function spawn_position(player_id, state) return { x = 10, y = 10 } end
 function handle_input(player_id, input, entities) return entities end
 
--- A wave spawner: no entities between waves, and a countdown asobi cannot see.
--- The third return value is what keeps the zone at full tick rate.
+-- Returns a number, which is truthy in Lua. A countdown written the obvious way
+-- produces exactly this.
 function zone_tick(entities, zone_state)
-  zone_state = zone_state or {}
-  zone_state.next_wave = (zone_state.next_wave or 3) - 1
-  return entities, zone_state, zone_state.next_wave > 0
+  return entities, zone_state or {}, 3
 end


### PR DESCRIPTION
Replaces v0.97.0's `zone_busy/1` callback and `_keep_hot` field. Found by the
retrospective gate on #547 (guardian, security reviewer, code reviewer, all
three). ADR 0019 supersedes 0018; ADR 0016 stands.

## The security finding

**`luerl:get_table_key/3` is not a raw read.** When the key is absent and the
table has an `__index`, `luerl_emul:get_table_key/3` calls the metamethod:

```erlang
{meta,Meth,Args,St1} ->
    {Ret,St2} = functioncall(Meth, Args, St1),
```

`_keep_hot` was absent from almost every zone state, so that was the **ordinary
path**, not an edge case. The metamethod ran inline on the zone `gen_server`
with no wall-clock timeout, no `max_heap_size`, no reduction budget, and the
whole `game.*` API in scope.

`setmetatable(zone_state, Zone)` with a function `__index` is ordinary OOP Lua.
It needed no adversary. Measured on the shipped build:

| zone_state metatable | result |
|---|---|
| `__index` looping 2e6 times | **345 ms** on the zone process |
| `__index = function() while true do end end` | **never returns from `handle_cast`** |

The second leaves the world ticker casting into a mailbox that never drains, with
no supervisor intervention because the process is neither dead nor idle.
`guides/security-trust-model.md` names `handle_input/3` as the *single*
unbudgeted callback; #547 silently added a second, at tick cadence.

## The fix, and why it's not "read it raw"

`luerl_heap:raw_get_table_key/3` exists and would close the hole. It was
rejected: it keeps everything else the field shape got wrong. The answer now
rides on `zone_tick/2`'s return value —

```lua
function zone_tick(entities, zone_state)
  zone_state.next_wave = (zone_state.next_wave or 30) - 1
  return entities, zone_state, zone_state.next_wave > 0
end
```

`reclassify/1` runs immediately after `zone_tick/2` in the same `handle_cast`,
so that is the instant asobi wants the answer. **Nothing is read to obtain it**,
which makes the metamethod class impossible rather than guarded. A two-tuple
means "not busy", so this is additive.

Three things the field could not avoid and a value cannot have:

- **It latched.** `_keep_hot` persists until overwritten, so "vetoes forever"
  was the default failure of anyone setting it at the start of a wave.
- **The halves disagreed.** `asobi_zone` failed safe on a raise; the bridge
  caught everything and returned `false`. Lua worlds failed *cold and silent*,
  and `bad_zone_busy` telemetry was dead code for every one of them.
- **`_keep_hot = 1` read as "not busy"** while `guides/world-server.md` said to
  set it "truthy". Lua truthiness now decides.

## Also from the same review

- A busy zone is no longer **hibernated** — at full rate that was a full-sweep GC
  of the whole Luerl state per tick, costing more than an occupied zone.
- A busy zone is no longer **reaped** mid-countdown by the idle sweep. "This zone
  has work" now means it stays alive.
- The bad-return log goes through the module's own bounded formatter. The
  unbounded `~0p` echoed a 2000-entity zone state — including an `api_key` — into
  an ERROR log at 215 KB per line, rate-limited per zone, with the fail-safe
  keeping every such zone hot and maximising its own rate.

## Tests

Includes `metatable_zone_state.lua` — a zone state carrying a 2e6-iteration
`__index` — asserting the tick stays under 200 ms, i.e. that nothing invokes it.
Plus Lua truthiness, the additive two-tuple, the non-boolean fail-safe, and the
reap and hibernate behaviours.

The old order-of-evaluation test is gone rather than fixed: the code reviewer
proved it passed in both orderings (mutation: flip the `andalso`, 14/14 still
green), and with a return value there is no call to order.

## Checks

`fmt` · `xref` · `dialyzer` · `elp eqwalize` · `elp lint` · doc-anchor and
telemetry drift — clean, no new findings. **2,339 eunit, 389 CT, 0 failures.**