### PR TITLE
docs(security): name the second unbudgeted callback, and scope the budget table to copy mode

### DIFF
--- a/docs/adr/0017-border-mirror-for-cross-zone-reads-and-effects.md
+++ b/docs/adr/0017-border-mirror-for-cross-zone-reads-and-effects.md
@@ -79,13 +79,23 @@ per-world mirror. Neighbours read copies. To act on one, address its owner.**
   `src/lua/asobi_lua_api.erl:1253-1254`) and on the receiver (256 entries, 1 MB,
   `asobi_zone.erl:57-58`). The sender-side bound is the load-bearing one: past it
   the term is already on another process's heap and in its mailbox, and
-  `handle_input` - the one callback with no wall-clock, heap or reduction budget -
+  `handle_input` - a callback with no wall-clock, heap or reduction budget -
   can call `apply` in a loop.
 - A reader can see an entity under two owners for at most one tick, because the
   old owner's row is refreshed on its own next tick. The receiver's ownership
   filter is what makes that harmless.
 - One more thing a game can get wrong: a `handle_effects` that raises on a `nil`
   field drops the whole tick's batch, not one effect.
+- **`handle_effects/2` is itself unbudgeted, and this ADR is what made it so.**
+  It goes through `asobi_lua_loader:call/3` rather than `call/4`
+  (`asobi_lua_world.erl:395`), deliberately, for the batching reason above: one
+  spawn per effect would pay the marshalling cost of asobi#543 per projectile.
+  So under the default `lua_vm_mode = copy` it has no wall-clock, heap or
+  reduction bound, and unlike `handle_input/3` the work it runs was sent by a
+  *neighbouring* zone. `guides/security-trust-model.md` was not amended when this
+  shipped and kept naming `handle_input/3` as the only such callback until
+  widgrensit/asobi#550 corrected it. Recorded here because this ADR owns the
+  callback.
 
 ## Alternatives considered
 

--- a/docs/adr/0019-zone-tick-returns-whether-it-is-busy.md
+++ b/docs/adr/0019-zone-tick-returns-whether-it-is-busy.md
@@ -83,7 +83,13 @@ Two further problems with the field shape, independent of the security one:
 - `zone_tick/2`'s contract widens. A game module that returns a three-tuple on
   an older asobi gets a `badmatch` and a dead zone, so this is forward-only.
 - `guides/security-trust-model.md`'s statement that `handle_input/3` is the only
-  unbudgeted callback is true again.
+  unbudgeted callback is **still wrong, and this bullet was wrong when written.**
+  Removing `_keep_hot` removed the entry point this ADR added, but ADR 0017 had
+  already added another: `handle_effects/2` also goes through
+  `asobi_lua_loader:call/3` (`asobi_lua_world.erl:395`). The guide named one
+  callback until widgrensit/asobi#550. Left in place rather than quietly edited,
+  because this ADR accuses ADR 0018 of exactly the sin it then committed itself -
+  changing what the sandbox promises and not amending the guide.
 
 ## Alternatives considered
 

--- a/guides/security-lua-known-limitations.md
+++ b/guides/security-lua-known-limitations.md
@@ -37,7 +37,7 @@ Two limits are worth knowing:
 `handle_input/3` is the exception: it runs inline in the calling process with
 no child, so none of the three bounds apply. Its cost is a hung match or zone
 process, not a supervisor event - see [handle-input is not a sandbox
-boundary](security-trust-model.md#handle-input-is-not-a-sandbox-boundary).
+boundary](security-trust-model.md#handle-input-and-handle-effects-are-not-sandbox-boundaries).
 
 ### The heap cap is per eval, not per script
 

--- a/guides/security-sandbox.md
+++ b/guides/security-sandbox.md
@@ -68,7 +68,7 @@ where each macro lives.
 
 `handle_input/3` is the exception. It runs inline in the calling process, so
 none of the three bounds apply to it. See [what that
-costs](security-trust-model.md#handle-input-is-not-a-sandbox-boundary).
+costs](security-trust-model.md#handle-input-and-handle-effects-are-not-sandbox-boundaries).
 
 The same wrapper covers the three places script-author-controlled code is
 evaluated rather than called:

--- a/guides/security-trust-model.md
+++ b/guides/security-trust-model.md
@@ -51,6 +51,16 @@ allocation kills
 the child, the parent gen_server sees `{error, timeout | heap_exhausted |
 reductions_exhausted}`, and the match or zone continues on its previous state.
 
+**This table describes the default `lua_vm_mode = copy`.** Under `owned` the
+callback runs in the VM process rather than a spawned child, so `bounded_eval`
+is never entered and only the wall-clock column survives - as the VM's
+`gen_server:call` timeout. There is no reduction budget at all, and the heap cap
+is `vm_max_heap_words`, which defaults to `0`, meaning disabled. The failure
+mode inverts as well: under `copy` an overrun costs a tick, because the process
+killed is a throwaway; under `owned` the only killable process is the one
+holding the state, so the zone dies with its VM and restarts into its last
+snapshot.
+
 | Callback | Bridge | Bounded | Budget |
 |---|---|---|---|
 | `init/1` | match, world | yes | 1000 ms match, 2000 ms world |
@@ -68,6 +78,7 @@ reductions_exhausted}`, and the match or zone continues on its previous state.
 | `terrain_provider/1` | world | yes | 2000 ms |
 | bot `think/2` | bot | yes | 50 ms |
 | `handle_input/3` | match, world | **no** | see below |
+| `handle_effects/2` | world | **no** | see below |
 
 The macros are not all in one place. Match budgets are `?*_TIMEOUT` in
 `asobi_lua_match.erl` and world budgets are `?*_TIMEOUT` in
@@ -108,9 +119,10 @@ be intercepted - and a batch whose anchor has gone abandons the tick's inputs
 and hands the zone back the entity map it started with. The cost of tampering
 falls on the script that tampered.
 
-## handle-input is not a sandbox boundary
+## handle-input and handle-effects are not sandbox boundaries
 
-`handle_input/3` is the one callback that does not spawn-isolate. At realistic
+`handle_input/3` and `handle_effects/2` are the two callbacks that do not
+spawn-isolate. At realistic
 input rates - one tick times N players times the message rate - the per-call
 spawn cost dominated the actual Lua work: roughly 30 to 50 microseconds of
 spawn, monitor and heap-cap setup against 50 to 200 microseconds of input
@@ -125,6 +137,21 @@ by `apply_inputs/3` in `asobi_match_server` and in `asobi_zone`. There is no
 zone process indefinitely: the tick stops, no supervisor restart happens, and
 every later call against that process times out in its own caller. Blast radius
 is one match or one zone. Recovery is manual.
+
+`handle_effects/2` is unbudgeted for the same reason and is batched for it: one
+spawn per effect would pay the marshalling cost on every projectile. It matters
+more than `handle_input/3` does, because the work it runs arrives from a
+*neighbouring zone* rather than from a player of its own. The bound that makes
+that safe is on the sending side, not here - an event is capped at 4 KB and a
+caller at 64 sends per tick, and the receiving zone caps its queue by count and
+by bytes. A `while true do end` in `handle_effects` still hangs the zone that
+owns it.
+
+Both are unbudgeted only under the default `lua_vm_mode = copy`. Under
+`lua_vm_mode = owned` the callback runs in the VM process behind a
+`gen_server:call`, so its timeout is a wall-clock bound - one that kills the VM
+and takes the zone's Lua state with it. See
+[Performance tuning](performance-tuning.md) for that trade.
 
 `game.zone.apply` is the one call that can send from inside `handle_input` into
 a *different* process, so it carries its own bound rather than relying on the


### PR DESCRIPTION
Split out of #550 on the architecture guardian's review: this changes what the
sandbox promises about untrusted code, and that deserves reading on its own
rather than as a rider on a spatial-opts validation fix.

Two separate wrong statements, both verified against source rather than
inferred.

## `handle_input/3` is not the only unbudgeted callback

`guides/security-trust-model.md` said it was "the one callback that does not
spawn-isolate". `handle_effects/2` goes through `asobi_lua_loader:call/3` as
well (`src/lua/asobi_lua_world.erl:395`), which is the path with no
`bounded_eval` wrapper, so under the default `lua_vm_mode = copy` it has no
wall-clock, heap or reduction bound either.

It is the wider of the two surfaces. The work `handle_effects/2` runs was sent
by a **neighbouring zone**, not by a player of its own. A `while true do end` in
it hangs the zone that owns the target, with no supervisor event.

It is unbudgeted deliberately - ADR 0017 batched it precisely so a per-effect
callback would not pay the asobi#543 marshalling cost on every projectile - so
this is a documentation fix, not a request to change the runtime. The complete
no-timeout `call/3` set is `asobi_lua_world.erl:328`, `:395`, `:496` and
`asobi_lua_match.erl:227`; every other call site passes a timeout.

## The budget table's intro is only true under `copy`

Found in the security review of #550. The intro promised, for **every** row,
a child process with a wall-clock timeout, `max_heap_size` with `kill => true`,
and a reduction budget. Under `lua_vm_mode = owned` none of that holds:

| bound | `copy` (default) | `owned` |
|---|---|---|
| wall clock | `bounded_eval` deadline | `gen_server:call` timeout |
| heap | `2*Base + max_heap_words` | `vm_max_heap_words`, **default 0 = disabled** |
| reductions | `max_reductions_per_ms` | **none at all** |

`call/4` under `owned` routes to `vm_call/4` and never enters `bounded_eval`, so
the reduction poll does not exist - `reduction_budget/1` is reachable only from
`bounded_eval/2`. `asobi_lua_loader:vm_max_heap_words/0` returns `0` unless
configured and `asobi_lua_vm:cap_heap(0)` is a no-op. The failure mode inverts
as well: under `copy` an overrun costs a tick because the killed process is a
throwaway, under `owned` it kills the process holding the state.

An operator reading this table to decide whether `owned` is safe to enable was
getting the wrong answer. `owned` is the mode asobi#543's reporter has now
adopted in production.

## ADRs

ADR 0017 and ADR 0019 both assert the single-callback claim.

- **0017** owns `handle_effects/2` and introduced the second unbudgeted entry
  point without amending the guide. Corrected, with the reason it is unbudgeted
  recorded next to it.
- **0019** restated the claim in its Consequences. Left visible and marked wrong
  rather than quietly rewritten, because that ADR accuses ADR 0018 of exactly
  this - "silently added a second entry point, at tick cadence, and did not
  amend that guide" - while 0017 had already done it.

## Checks

Docs-only. `scripts/check-doc-anchors.sh` passes (two inbound anchors repointed
to the renamed heading), plus the other three drift scripts.
