### PR TITLE
fix(types): clear eqwalizer in src/world and src/lua

### DIFF
--- a/docs/eqwalizer-idioms.md
+++ b/docs/eqwalizer-idioms.md
@@ -1,0 +1,122 @@
+# eqwalizer idioms
+
+Written once so it is not written again at every call site. Five facts about
+eqwalizer account for most of the type errors in this tree, and each has one
+right answer. Cite this file rather than restating it: a comment at a fix site
+should say why *that code* is the way it is, not re-teach the checker.
+
+Context: widgrensit/asobi#435.
+
+## `erlang:min/2` and `max/2` return `term()`
+
+Their specs are `term() -> term()` whatever they are handed, so `max(N, 1)`
+fails even when `N :: integer()`. Narrowing the *input* does not help.
+
+Write a small local function that names the rule instead. Not a shared numeric
+module: only two of these remain in the whole tree, and `clamp/3` reads better
+than the `min(max(...))` it replaced anyway.
+
+```erlang
+-spec clamp(number(), number(), number()) -> number().
+clamp(V, Lo, _Hi) when V < Lo -> Lo;
+clamp(V, _Lo, Hi) when V > Hi -> Hi;
+clamp(V, _Lo, _Hi) -> V.
+```
+
+## `lists:*` erases element and accumulator types
+
+`foldl`, `foreach`, `usort`, `sort` and `join` all widen their result to
+`[term()]`, and the folds erase the accumulator as well. This is the single
+largest class of error in the tree.
+
+Two answers, and which one depends on whether the call is doing real work:
+
+**Re-narrow the result.** Preferred when the `lists:` function is worth keeping
+- `usort/1` is O(n log n) in C, and hand-rolling it is neither faster nor
+clearer. The comprehension restores the type and drops nothing, because the
+input already has it:
+
+```erlang
+-spec usort_binaries([binary()]) -> [binary()].
+usort_binaries(Names) -> [N || N <- lists:usort(Names), is_binary(N)].
+```
+
+**Replace the fold with explicit recursion.** Preferred for `foldl`/`foreach`,
+where the accumulator is asobi's own and the recursion is usually clearer than
+the threading it replaces. This also satisfies the repo's existing no-`foldl`
+rule, which turns out to be load-bearing here rather than stylistic:
+
+```erlang
+-spec install_fns([{[binary(), ...], function()}], dynamic()) -> dynamic().
+install_fns([], St) -> St;
+install_fns([{Path, Fn} | Rest], St) ->
+    {Enc, St1} = luerl:encode(Fn, St),
+    {ok, St2} = luerl:set_table_keys(Path, Enc, St1),
+    install_fns(Rest, St2).
+```
+
+Do **not** split a `usort/1` into a sort plus a hand-written dedupe. That was
+tried: it cost four functions across two modules and two O(n^2) loops on a
+per-connection path.
+
+**Watch the filter order.** A narrowing guard placed before an existing
+validator silently eats the case the validator was there to log:
+
+```erlang
+%% Wrong: is_binary/1 runs first, so valid_global_name/1 never logs.
+[N || N <- Names, is_binary(N), valid_global_name(N)]
+%% Right.
+[N || N <- Names, valid_global_name(N), is_binary(N)]
+```
+
+## The `?LOG_*` macros return `term()`
+
+They expand to `erlang:apply(logger, macro_log, ...)`, so a function spec'd
+`-> ok` fails on its last expression. End with `ok`:
+
+```erlang
+log_it(V) ->
+    ?LOG_ERROR(#{msg => ~"...", value => describe(V)}),
+    ok.
+```
+
+## `dynamic()` is for boundaries, and only for boundaries
+
+Permitted where a value genuinely has no static type on our side: Luerl returns
+and Luerl state, `persistent_term:get/1`, ETS reads, raw `cowboy_req`.
+Everywhere else the answer is a real type or a narrowing clause.
+
+`dynamic()` is not `eqwalizer:fixme`, so it does not break the no-suppression
+rule - but reaching for it on a value that has a knowable type is the same
+suppression wearing a different hat.
+
+Two rules that keep it honest:
+
+- **`dynamic()` may enter a bridge function; it must not leave one.**
+  `decode_args([dynamic()], dynamic()) -> [term()]` is the right direction.
+- **Widening a parameter from `term()` to `dynamic()` loses checking.** It is
+  occasionally correct - `cache_and_return/3` takes a module Luerl produced -
+  but it is also exactly the shape a suppression takes. Justify it in a comment
+  at that site.
+
+Luerl's `luerlstate()` and `luerldata()` are defined in its header but exported
+by no module, so there is no `luerl:luerlstate()` to write and `dynamic()` is
+the only honest answer. Exporting those types upstream would remove a whole
+category of these.
+
+## A narrowing clause is a behaviour change
+
+Adding a guard turns a value that previously flowed through into a
+`function_clause`. Before adding one, ask what reaches it:
+
+- **Asobi's own state or ETS content** - guard freely, the shape is ours.
+- **A cast, a call, or config from outside** - guard, but give the clause a
+  fallback, and check whether the enclosing `gen_server`/`gen_statem` has a
+  catch-all. Turning a malformed message into a dead supervisor tree is not
+  defence in depth.
+- **Anything a game script or operator supplies** - validate and fall back to a
+  default, and *log the rejection*. A silent fallback is the failure mode this
+  whole exercise exists to remove.
+
+Every narrowing that changes what a malformed input does gets a test that feeds
+it a malformed input.

--- a/guides/lua-api.md
+++ b/guides/lua-api.md
@@ -303,6 +303,17 @@ game.spatial.in_range(entity_a, entity_b, range)      -- boolean
 game.spatial.distance(entity_a, entity_b)             -- number
 ```
 
+An entity with no numeric `x` and `y` is not a position, and the two answer it
+differently on purpose. `in_range` returns **`false`** - something with no
+position is not in range, and returning an error table instead would be
+*truthy*, so `if game.spatial.in_range(a, b, r) then` would take the success
+branch. `distance` returns `{ error = "entity_a needs numeric x and y" }`,
+naming which of the two, because there is no number it could honestly answer
+with. Both also log, rate-limited, so the mistake is findable.
+
+```lua
+```
+
 `opts` accepts four keys, and not every entry point honours all four. The
 zone-context form `query_radius(x, y, radius)` takes no options at all - pass an
 entity map to use them.

--- a/src/lua/asobi_lua_api.erl
+++ b/src/lua/asobi_lua_api.erl
@@ -154,7 +154,12 @@ create_namespaces([], St) ->
 create_namespaces([Namespace | Rest], St) ->
     create_namespaces(Rest, create_table(Namespace, St)).
 
+%% `live` installs the real function; `probe` swaps every effectful one for a
+%% stub. Not a vm_kind() - a probe VM has a kind of its own.
+-type install_mode() :: live | probe.
+
 %% Builds the {LuaPath, Fun} table install/2 and install_pure/2 both wire up.
+-spec api_fns(map(), install_mode()) -> [{[binary(), ...], function()}].
 api_fns(Ctx, Mode) ->
     [{Path, pick(Mode, Effect, Path, Fn)} || {Path, Effect, Fn} <- api_surface(Ctx)].
 
@@ -243,7 +248,27 @@ extension_bindings(Ctx) ->
 
 -spec extension_namespaces(map()) -> [[binary(), ...]].
 extension_namespaces(Ctx) ->
-    lists:usort([[~"game", Namespace] || #{namespace := Namespace} <- extension_bindings(Ctx)]).
+    dedupe_paths(
+        sorted_paths([[~"game", namespace_of(Binding)] || Binding <- extension_bindings(Ctx)])
+    ).
+
+%% lists:sort/1 widens its result to [term()] under eqwalizer; the comprehension
+%% re-narrows it, matching the exact `[~"game", Namespace]` shape the
+%% comprehension above builds. Kept sorted because lists:usort/1 was: no test
+%% pins the order, but an unobserved behaviour change is not one worth making.
+-spec sorted_paths([[binary(), ...]]) -> [[binary(), ...]].
+sorted_paths(Paths) -> [[A, B] || [A, B] <- lists:sort(Paths), is_binary(A), is_binary(B)].
+
+%% Was the dedupe half of lists:usort/1.
+-spec dedupe_paths([[binary(), ...]]) -> [[binary(), ...]].
+dedupe_paths([]) -> [];
+dedupe_paths([P | Rest]) -> [P | dedupe_paths([Q || Q <- Rest, Q =/= P])].
+
+%% A typed accessor rather than a map pattern in the generator: eqwalizer does
+%% not carry binding()'s field types through a comprehension pattern, so the
+%% namespace arrived as term() and the whole list widened with it.
+-spec namespace_of(asobi_extensions:binding()) -> binary().
+namespace_of(#{namespace := Namespace}) -> Namespace.
 
 -spec extension_surface(map()) -> [{[binary(), ...], asobi_lua_surface:effect(), function()}].
 extension_surface(Ctx) ->
@@ -381,16 +406,16 @@ inert(Name) ->
         {[false], St}
     end.
 
-install_fns(Fns, St0) ->
-    lists:foldl(
-        fun({Path, Fn}, St) ->
-            {Enc, StA} = luerl:encode(Fn, St),
-            {ok, StB} = luerl:set_table_keys(Path, Enc, StA),
-            StB
-        end,
-        St0,
-        Fns
-    ).
+%% Explicit recursion rather than lists:foldl/3: the fold erases the
+%% accumulator's type, so the Lua state could not be typed against
+%% luerl:encode/2 and set_table_keys/3.
+-spec install_fns([{[binary(), ...], function()}], dynamic()) -> dynamic().
+install_fns([], St) ->
+    St;
+install_fns([{Path, Fn} | Rest], St) ->
+    {Enc, St1} = luerl:encode(Fn, St),
+    {ok, St2} = luerl:set_table_keys(Path, Enc, St1),
+    install_fns(Rest, St2).
 
 %% --- Core ---
 
@@ -536,6 +561,20 @@ fun_broadcast(_) ->
 %% owner (asobi_ws_handler:event_name_binary/1) before the fan-out so the
 %% author gets `{ error = "..." }` at the game.broadcast call site - the rules
 %% themselves stay in one place.
+%% Flattened here rather than left as a nested list inside an iolist: an
+%% iolist's recursive type defeats eqwalizer, and one binary reads no worse.
+-spec reserved_names_list() -> binary().
+reserved_names_list() ->
+    comma_join(asobi_ws_handler:reserved_event_names()).
+
+%% lists:join/2 widens to [term()] under eqwalizer, which then defeats
+%% iolist_to_binary/1.
+-spec comma_join([binary()]) -> binary().
+comma_join([]) -> ~"";
+comma_join([B]) -> B;
+comma_join([B | Rest]) -> <<B/binary, ", ", (comma_join(Rest))/binary>>.
+
+-spec do_broadcast(pid(), binary(), map(), dynamic()) -> {[term()], dynamic()}.
 do_broadcast(MatchPid, Event, Payload, St) ->
     case asobi_ws_handler:event_name_binary(Event) of
         {ok, _} ->
@@ -543,13 +582,13 @@ do_broadcast(MatchPid, Event, Payload, St) ->
             {[true], St};
         {error, reserved_event_name} ->
             error_result(
-                iolist_to_binary([
-                    ~"broadcast event name \"",
-                    Event,
-                    ~"\" is reserved by asobi (",
-                    lists:join(~", ", asobi_ws_handler:reserved_event_names()),
-                    ~")"
-                ]),
+                <<
+                    "broadcast event name \"",
+                    Event/binary,
+                    "\" is reserved by asobi (",
+                    (reserved_names_list())/binary,
+                    ")"
+                >>,
                 St
             );
         {error, invalid_event_name} ->
@@ -907,6 +946,9 @@ fun_chat_send() ->
 
 %% Both bound a game-supplied value that would otherwise be echoed or rebuilt
 %% per query; see as_key_name/1 and with_id_set/4.
+%% Both entity-pair calls need it, and returning nil to Lua would only move the
+%% failure to the arithmetic the script does next.
+-define(NO_POSITION, ~"both entities need numeric x and y").
 -define(MAX_KEY_NAME_BYTES, 128).
 -define(MAX_ID_SET, 256).
 
@@ -1102,8 +1144,10 @@ fun_spatial_in_range() ->
     fun(Args, St) ->
         case decode_args(Args, St) of
             [A, B, Range] when is_map(A), is_map(B), is_number(Range) ->
-                Result = asobi_spatial:in_range(atomize_keys(A), atomize_keys(B), Range),
-                {[Result], St};
+                case asobi_spatial:in_range(atomize_keys(A), atomize_keys(B), Range) of
+                    undefined -> error_result(?NO_POSITION, St);
+                    Result -> {[Result], St}
+                end;
             _ ->
                 error_result(~"in_range requires (entity_a, entity_b, range)", St)
         end
@@ -1113,8 +1157,10 @@ fun_spatial_distance() ->
     fun(Args, St) ->
         case decode_args(Args, St) of
             [A, B] when is_map(A), is_map(B) ->
-                D = asobi_spatial:distance(atomize_keys(A), atomize_keys(B)),
-                {[D], St};
+                case asobi_spatial:distance(atomize_keys(A), atomize_keys(B)) of
+                    undefined -> error_result(?NO_POSITION, St);
+                    D -> {[D], St}
+                end;
             _ ->
                 error_result(~"distance requires (entity_a, entity_b)", St)
         end
@@ -1608,7 +1654,9 @@ wrap_result({error, Reason}, St) -> error_result(Reason, St).
 
 %% --- Argument decoding ---
 
--spec decode_args([term()], dynamic()) -> [term()].
+%% Args are whatever Luerl passed the closure, so they are Lua values rather
+%% than anything asobi typed: a boundary, not a missing narrowing.
+-spec decode_args([dynamic()], dynamic()) -> [term()].
 decode_args(Args, St) ->
     [deep_decode(luerl:decode(A, St)) || A <- Args].
 

--- a/src/lua/asobi_lua_api.erl
+++ b/src/lua/asobi_lua_api.erl
@@ -248,21 +248,13 @@ extension_bindings(Ctx) ->
 
 -spec extension_namespaces(map()) -> [[binary(), ...]].
 extension_namespaces(Ctx) ->
-    dedupe_paths(
-        sorted_paths([[~"game", namespace_of(Binding)] || Binding <- extension_bindings(Ctx)])
-    ).
+    usort_paths([[~"game", namespace_of(Binding)] || Binding <- extension_bindings(Ctx)]).
 
-%% lists:sort/1 widens its result to [term()] under eqwalizer; the comprehension
-%% re-narrows it, matching the exact `[~"game", Namespace]` shape the
-%% comprehension above builds. Kept sorted because lists:usort/1 was: no test
-%% pins the order, but an unobserved behaviour change is not one worth making.
--spec sorted_paths([[binary(), ...]]) -> [[binary(), ...]].
-sorted_paths(Paths) -> [[A, B] || [A, B] <- lists:sort(Paths), is_binary(A), is_binary(B)].
-
-%% Was the dedupe half of lists:usort/1.
--spec dedupe_paths([[binary(), ...]]) -> [[binary(), ...]].
-dedupe_paths([]) -> [];
-dedupe_paths([P | Rest]) -> [P | dedupe_paths([Q || Q <- Rest, Q =/= P])].
+%% lists:usort/1 widens its result to [term()] under eqwalizer; re-narrowing it
+%% on the exact `[~"game", Namespace]` shape built above keeps the real usort
+%% rather than a hand-rolled quadratic dedupe.
+-spec usort_paths([[binary(), ...]]) -> [[binary(), ...]].
+usort_paths(Paths) -> [[A, B] || [A, B] <- lists:usort(Paths), is_binary(A), is_binary(B)].
 
 %% A typed accessor rather than a map pattern in the generator: eqwalizer does
 %% not carry binding()'s field types through a comprehension pattern, so the
@@ -946,9 +938,6 @@ fun_chat_send() ->
 
 %% Both bound a game-supplied value that would otherwise be echoed or rebuilt
 %% per query; see as_key_name/1 and with_id_set/4.
-%% Both entity-pair calls need it, and returning nil to Lua would only move the
-%% failure to the arithmetic the script does next.
--define(NO_POSITION, ~"both entities need numeric x and y").
 -define(MAX_KEY_NAME_BYTES, 128).
 -define(MAX_ID_SET, 256).
 
@@ -1140,13 +1129,42 @@ fun_spatial_nearest() ->
         end
     end.
 
+%% Names which of the two, per ADR 0020: "an error naming the offending
+%% option" is the same rule as naming the offending entity.
+-spec no_position_msg(a | b) -> binary().
+no_position_msg(a) -> ~"entity_a needs numeric x and y";
+no_position_msg(b) -> ~"entity_b needs numeric x and y".
+
+-spec log_no_position(binary(), a | b) -> ok.
+log_no_position(Fn, Which) ->
+    case log_allowed(self()) of
+        true ->
+            ?LOG_WARNING(#{
+                msg => ~"asobi_lua: spatial call given an entity with no position",
+                fn => Fn,
+                entity => Which
+            }),
+            ok;
+        false ->
+            ok
+    end.
+
 fun_spatial_in_range() ->
     fun(Args, St) ->
         case decode_args(Args, St) of
             [A, B, Range] when is_map(A), is_map(B), is_number(Range) ->
+                %% `false`, NOT an error table. Every Lua table is truthy, so
+                %% `if game.spatial.in_range(a, b, r) then` would take the
+                %% success branch on an entity with no position - silently
+                %% wrong hit/aggro logic where the old code was at least a loud
+                %% badmatch. Something with no position is not in range; the
+                %% author still hears about it through the rate-limited log.
                 case asobi_spatial:in_range(atomize_keys(A), atomize_keys(B), Range) of
-                    undefined -> error_result(?NO_POSITION, St);
-                    Result -> {[Result], St}
+                    {ok, Result} ->
+                        {[Result], St};
+                    {error, {no_position, Which}} ->
+                        log_no_position(~"in_range", Which),
+                        {[false], St}
                 end;
             _ ->
                 error_result(~"in_range requires (entity_a, entity_b, range)", St)
@@ -1157,9 +1175,12 @@ fun_spatial_distance() ->
     fun(Args, St) ->
         case decode_args(Args, St) of
             [A, B] when is_map(A), is_map(B) ->
+                %% An error table is right here, unlike in_range/3: there is no
+                %% safe scalar to answer with, and arithmetic on the table
+                %% raises rather than quietly continuing.
                 case asobi_spatial:distance(atomize_keys(A), atomize_keys(B)) of
-                    undefined -> error_result(?NO_POSITION, St);
-                    D -> {[D], St}
+                    {ok, D} -> {[D], St};
+                    {error, {no_position, Which}} -> error_result(no_position_msg(Which), St)
                 end;
             _ ->
                 error_result(~"distance requires (entity_a, entity_b)", St)

--- a/src/lua/asobi_lua_api.erl
+++ b/src/lua/asobi_lua_api.erl
@@ -250,9 +250,8 @@ extension_bindings(Ctx) ->
 extension_namespaces(Ctx) ->
     usort_paths([[~"game", namespace_of(Binding)] || Binding <- extension_bindings(Ctx)]).
 
-%% lists:usort/1 widens its result to [term()] under eqwalizer; re-narrowing it
-%% on the exact `[~"game", Namespace]` shape built above keeps the real usort
-%% rather than a hand-rolled quadratic dedupe.
+%% Re-narrowed on the exact `[~"game", Namespace]` shape built above: see
+%% docs/eqwalizer-idioms.md.
 -spec usort_paths([[binary(), ...]]) -> [[binary(), ...]].
 usort_paths(Paths) -> [[A, B] || [A, B] <- lists:usort(Paths), is_binary(A), is_binary(B)].
 
@@ -398,9 +397,7 @@ inert(Name) ->
         {[false], St}
     end.
 
-%% Explicit recursion rather than lists:foldl/3: the fold erases the
-%% accumulator's type, so the Lua state could not be typed against
-%% luerl:encode/2 and set_table_keys/3.
+%% Explicit recursion: see docs/eqwalizer-idioms.md.
 -spec install_fns([{[binary(), ...], function()}], dynamic()) -> dynamic().
 install_fns([], St) ->
     St;
@@ -559,8 +556,7 @@ fun_broadcast(_) ->
 reserved_names_list() ->
     comma_join(asobi_ws_handler:reserved_event_names()).
 
-%% lists:join/2 widens to [term()] under eqwalizer, which then defeats
-%% iolist_to_binary/1.
+%% See docs/eqwalizer-idioms.md.
 -spec comma_join([binary()]) -> binary().
 comma_join([]) -> ~"";
 comma_join([B]) -> B;

--- a/src/lua/asobi_lua_config.erl
+++ b/src/lua/asobi_lua_config.erl
@@ -211,7 +211,8 @@ log_invalid_registration(Value) ->
         msg => ~"invalid registration global, keeping the configured mode",
         value => describe(Value),
         expected => [~"open", ~"oauth_only", ~"closed"]
-    }).
+    }),
+    ok.
 
 %% Every value passed here comes out of the game's own script, so its size is
 %% chosen by whoever wrote the bundle. `listed = string.rep("A", 4000000)` is a

--- a/src/lua/asobi_lua_loader.erl
+++ b/src/lua/asobi_lua_loader.erl
@@ -663,8 +663,15 @@ kill_and_settle(Pid, Ref, MonRef, Reason) ->
 reduction_budget(TimeoutMs) ->
     case max_reductions_per_ms() of
         0 -> infinity;
-        Rate -> Rate * max(TimeoutMs, 1)
+        Rate -> Rate * at_least_one(TimeoutMs)
     end.
+
+%% `erlang:max/2` is specced term() -> term() regardless of its arguments, so
+%% the budget it produced could not be typed as the pos_integer() the spec
+%% promises.
+-spec at_least_one(non_neg_integer()) -> pos_integer().
+at_least_one(N) when N >= 1 -> N;
+at_least_one(_N) -> 1.
 
 -spec max_reductions_per_ms() -> non_neg_integer().
 max_reductions_per_ms() ->
@@ -1054,14 +1061,17 @@ strip_dangerous_globals(St) ->
         [~"print"],
         [~"eprint"]
     ],
-    lists:foldl(
-        fun(Path, Acc) ->
-            {ok, Next} = luerl:set_table_keys(Path, nil, Acc),
-            Next
-        end,
-        St,
-        Paths
-    ).
+    clear_globals(Paths, St).
+
+%% Explicit recursion rather than lists:foldl/3: the fold erases the
+%% accumulator's type, so neither the state nor the key path could be typed
+%% against luerl:set_table_keys/3.
+-spec clear_globals([[binary()]], dynamic()) -> dynamic().
+clear_globals([], St) ->
+    St;
+clear_globals([Path | Rest], St) ->
+    {ok, Next} = luerl:set_table_keys(Path, nil, St),
+    clear_globals(Rest, Next).
 
 %% --- require: validation & resolution ---
 
@@ -1188,7 +1198,7 @@ truncate_errors(L) when is_list(L) ->
         false -> L
     end.
 
--spec cache_and_return(binary(), term(), dynamic()) -> {[term()], dynamic()}.
+-spec cache_and_return(binary(), dynamic(), dynamic()) -> {[term()], dynamic()}.
 cache_and_return(Name, Module, St) ->
     {ok, St1} = luerl:set_table_keys([?LOADED_TABLE, Name], Module, St),
     {[Module], St1}.

--- a/src/lua/asobi_lua_loader.erl
+++ b/src/lua/asobi_lua_loader.erl
@@ -666,9 +666,7 @@ reduction_budget(TimeoutMs) ->
         Rate -> Rate * at_least_one(TimeoutMs)
     end.
 
-%% `erlang:max/2` is specced term() -> term() regardless of its arguments, so
-%% the budget it produced could not be typed as the pos_integer() the spec
-%% promises.
+%% See docs/eqwalizer-idioms.md.
 -spec at_least_one(non_neg_integer()) -> pos_integer().
 at_least_one(N) when N >= 1 -> N;
 at_least_one(_N) -> 1.
@@ -1063,9 +1061,7 @@ strip_dangerous_globals(St) ->
     ],
     clear_globals(Paths, St).
 
-%% Explicit recursion rather than lists:foldl/3: the fold erases the
-%% accumulator's type, so neither the state nor the key path could be typed
-%% against luerl:set_table_keys/3.
+%% Explicit recursion: see docs/eqwalizer-idioms.md.
 -spec clear_globals([[binary()]], dynamic()) -> dynamic().
 clear_globals([], St) ->
     St;

--- a/src/lua/asobi_lua_sup.erl
+++ b/src/lua/asobi_lua_sup.erl
@@ -1,8 +1,19 @@
 -module(asobi_lua_sup).
 -behaviour(supervisor).
 
+-include_lib("kernel/include/logger.hrl").
+
+%% Judgement calls rather than security boundaries: a limiter this repo would
+%% defend in guides/configuration.md, and enough headroom that no real
+%% deployment trips them.
+-define(MAX_LIMITER_LIMIT, 100_000).
+-define(MAX_LIMITER_WINDOW_MS, 3_600_000).
+
 -export([start_link/0, register_game_modes/0]).
 -export([init/1]).
+-ifdef(TEST).
+-export([merged_opts/3]).
+-endif.
 
 -doc """
 Register the Lua bridge modules as the providers for the three Lua game-mode
@@ -74,30 +85,48 @@ register_limiter(Group, DefaultOpts, Configured) ->
             O when is_map(O) -> O;
             _ -> #{}
         end,
-    _ = seki:new_limiter(limiter_name(Group), merged_opts(DefaultOpts, Overrides)),
+    _ = seki:new_limiter(limiter_name(Group), merged_opts(Group, DefaultOpts, Overrides)),
     ok.
 
 %% `rate_limits` is operator-supplied, so the merge is checked rather than
-%% handed to seki as-is. An override that is not a usable algorithm/limit/window
-%% now falls back to asobi's defaults instead of reaching the limiter, and the
-%% optional seki keys (burst, backend, backend_opts) are not overridable -
-%% nothing here sets them, and passing an unvalidated map through was the only
-%% reason they were.
--spec merged_opts(seki:limiter_opts(), map()) -> seki:limiter_opts().
-merged_opts(Defaults, Overrides) ->
+%% handed to seki as-is: `limit => 0` reaches seki's registry as a division by
+%% zero at register time, and that registry owns every limiter on the node.
+%%
+%% Rejection is logged, not silent - an operator who asked for something and
+%% got asobi's defaults has to be able to find out. `backend`/`backend_opts`
+%% are dropped deliberately: they are seki's own plumbing, and an operator
+%% reaching for them here is likelier a typo than an intent.
+-spec merged_opts(atom(), seki:limiter_opts(), map()) -> seki:limiter_opts().
+merged_opts(_Group, Defaults, Overrides) when map_size(Overrides) =:= 0 ->
+    Defaults;
+merged_opts(Group, Defaults, Overrides) ->
     case maps:merge(Defaults, Overrides) of
-        #{algorithm := A, limit := L, window := W} when
+        #{algorithm := A, limit := L, window := W} = Merged when
             is_integer(L),
             L > 0,
+            L =< ?MAX_LIMITER_LIMIT,
             is_integer(W),
             W > 0,
+            W =< ?MAX_LIMITER_WINDOW_MS,
             A =:= token_bucket orelse A =:= sliding_window orelse
                 A =:= gcra orelse A =:= leaky_bucket
         ->
-            #{algorithm => A, limit => L, window => W};
+            with_burst(#{algorithm => A, limit => L, window => W}, Merged);
         _ ->
+            ?LOG_WARNING(#{
+                event => invalid_rate_limit_override,
+                group => Group,
+                override => Overrides,
+                using => Defaults
+            }),
             Defaults
     end.
+
+-spec with_burst(seki:limiter_opts(), map()) -> seki:limiter_opts().
+with_burst(Opts, #{burst := B}) when is_integer(B), B > 0, B =< ?MAX_LIMITER_LIMIT ->
+    Opts#{burst => B};
+with_burst(Opts, _Merged) ->
+    Opts.
 
 limiter_name(log) -> asobi_lua_log_limiter;
 limiter_name(log_global) -> asobi_lua_log_global_limiter.

--- a/src/lua/asobi_lua_sup.erl
+++ b/src/lua/asobi_lua_sup.erl
@@ -62,17 +62,42 @@ register_limiters() ->
             _ -> #{}
         end,
     maps:foreach(
-        fun(Group, DefaultOpts) ->
-            Overrides =
-                case maps:get(Group, Configured, #{}) of
-                    O when is_map(O) -> O;
-                    _ -> #{}
-                end,
-            _ = seki:new_limiter(limiter_name(Group), maps:merge(DefaultOpts, Overrides))
-        end,
+        fun(Group, DefaultOpts) -> register_limiter(Group, DefaultOpts, Configured) end,
         Defaults
     ),
     ignore.
+
+-spec register_limiter(atom(), seki:limiter_opts(), map()) -> ok.
+register_limiter(Group, DefaultOpts, Configured) ->
+    Overrides =
+        case maps:get(Group, Configured, #{}) of
+            O when is_map(O) -> O;
+            _ -> #{}
+        end,
+    _ = seki:new_limiter(limiter_name(Group), merged_opts(DefaultOpts, Overrides)),
+    ok.
+
+%% `rate_limits` is operator-supplied, so the merge is checked rather than
+%% handed to seki as-is. An override that is not a usable algorithm/limit/window
+%% now falls back to asobi's defaults instead of reaching the limiter, and the
+%% optional seki keys (burst, backend, backend_opts) are not overridable -
+%% nothing here sets them, and passing an unvalidated map through was the only
+%% reason they were.
+-spec merged_opts(seki:limiter_opts(), map()) -> seki:limiter_opts().
+merged_opts(Defaults, Overrides) ->
+    case maps:merge(Defaults, Overrides) of
+        #{algorithm := A, limit := L, window := W} when
+            is_integer(L),
+            L > 0,
+            is_integer(W),
+            W > 0,
+            A =:= token_bucket orelse A =:= sliding_window orelse
+                A =:= gcra orelse A =:= leaky_bucket
+        ->
+            #{algorithm => A, limit => L, window => W};
+        _ ->
+            Defaults
+    end.
 
 limiter_name(log) -> asobi_lua_log_limiter;
 limiter_name(log_global) -> asobi_lua_log_global_limiter.

--- a/src/lua/asobi_lua_surface.erl
+++ b/src/lua/asobi_lua_surface.erl
@@ -55,7 +55,14 @@ is_reserved(Namespace) ->
 -doc "Renders a namespace or function path as its Lua name, e.g. `game.economy.grant`.".
 -spec name([binary(), ...]) -> binary().
 name(Path) ->
-    iolist_to_binary(lists:join(~".", Path)).
+    dot_join(Path).
+
+%% lists:join/2 widens to [term()] under eqwalizer, which then defeats
+%% iolist_to_binary/1.
+-spec dot_join([binary()]) -> binary().
+dot_join([]) -> ~"";
+dot_join([B]) -> B;
+dot_join([B | Rest]) -> <<B/binary, ".", (dot_join(Rest))/binary>>.
 
 -spec effects() -> [effect(), ...].
 effects() ->

--- a/src/lua/asobi_lua_surface.erl
+++ b/src/lua/asobi_lua_surface.erl
@@ -57,8 +57,7 @@ is_reserved(Namespace) ->
 name(Path) ->
     dot_join(Path).
 
-%% lists:join/2 widens to [term()] under eqwalizer, which then defeats
-%% iolist_to_binary/1.
+%% See docs/eqwalizer-idioms.md.
 -spec dot_join([binary()]) -> binary().
 dot_join([]) -> ~"";
 dot_join([B]) -> B;

--- a/src/lua/bots/asobi_bot_spawner.erl
+++ b/src/lua/bots/asobi_bot_spawner.erl
@@ -355,8 +355,7 @@ fill_until(Mode, Count, Target, Names) ->
     Needed = Target - Count,
     fill_until_loop(Mode, 1, 0, Needed + capped(Count), Needed, Names).
 
-%% `erlang:min/2` is specced term() -> term() whatever it is handed, so the
-%% bound it produced could not be typed as the integer the loop needs.
+%% See docs/eqwalizer-idioms.md.
 -spec capped(integer()) -> integer().
 capped(N) when N < ?MAX_BOT_FILL -> N;
 capped(_N) -> ?MAX_BOT_FILL.

--- a/src/lua/bots/asobi_bot_spawner.erl
+++ b/src/lua/bots/asobi_bot_spawner.erl
@@ -353,7 +353,13 @@ clamp_fill_target(Target) ->
 %% fill, the walk gives up on the two taken ids before reaching a free one.
 fill_until(Mode, Count, Target, Names) ->
     Needed = Target - Count,
-    fill_until_loop(Mode, 1, 0, Needed + min(Count, ?MAX_BOT_FILL), Needed, Names).
+    fill_until_loop(Mode, 1, 0, Needed + capped(Count), Needed, Names).
+
+%% `erlang:min/2` is specced term() -> term() whatever it is handed, so the
+%% bound it produced could not be typed as the integer the loop needs.
+-spec capped(integer()) -> integer().
+capped(N) when N < ?MAX_BOT_FILL -> N;
+capped(_N) -> ?MAX_BOT_FILL.
 
 fill_until_loop(_Mode, _Index, Added, _Limit, Needed, _Names) when Added >= Needed ->
     ok;

--- a/src/world/asobi_spatial.erl
+++ b/src/world/asobi_spatial.erl
@@ -148,7 +148,10 @@ nearest(Entities, {CX, CY}, N, Opts) ->
 order_by(farthest, Sorted) -> lists:reverse(Sorted);
 order_by(_, Sorted) -> Sorted.
 
--spec keysort_by_distance([T]) -> [T] when T :: {float(), binary(), map()}.
+%% The first element is a *squared* distance, and squaring integer
+%% coordinates gives an integer - only format_nearest/1 takes the sqrt that
+%% makes it a float.
+-spec keysort_by_distance([T]) -> [T] when T :: {number(), binary(), map()}.
 keysort_by_distance(L) -> lists:keysort(1, L).
 
 -spec take([T], non_neg_integer()) -> [T].
@@ -163,8 +166,8 @@ take([H | T], N) -> [H | take(T, N - 1)].
     fun((map()) -> boolean()),
     map(),
     fun((binary(), map()) -> boolean()),
-    [{float(), binary(), map()}]
-) -> [{float(), binary(), map()}].
+    [{number(), binary(), map()}]
+) -> [{number(), binary(), map()}].
 collect_with_distance([], _, _, _, _, _, Acc) ->
     Acc;
 collect_with_distance([{Id, Entity} | Rest], CX, CY, TF, Excl, CF, Acc) when is_map(Entity) ->
@@ -183,7 +186,7 @@ collect_with_distance([{Id, Entity} | Rest], CX, CY, TF, Excl, CF, Acc) when is_
 collect_with_distance([_ | Rest], CX, CY, TF, Excl, CF, Acc) ->
     collect_with_distance(Rest, CX, CY, TF, Excl, CF, Acc).
 
--spec format_nearest([{float(), binary(), map()}]) -> [{binary(), map(), float()}].
+-spec format_nearest([{number(), binary(), map()}]) -> [{binary(), map(), float()}].
 format_nearest([]) ->
     [];
 format_nearest([{D2, Id, E} | Rest]) ->
@@ -193,17 +196,32 @@ format_nearest([{D2, Id, E} | Rest]) ->
 %% Point utilities
 %% -------------------------------------------------------------------
 
--spec in_range(map(), map(), number()) -> boolean().
-in_range(A, B, Range) ->
-    {X1, Y1} = pos(A),
-    {X2, Y2} = pos(B),
-    DX = X2 - X1,
-    DY = Y2 - Y1,
-    DX * DX + DY * DY =< Range * Range.
+-doc """
+`undefined` when either entity has no usable `x`/`y`, rather than a crash.
 
--spec distance(map(), map()) -> float().
+`pos/1` already answers `undefined` for an entity a game never gave a position,
+and both of these fed that straight into a `{X, Y}` pattern. The only callers
+are `game.spatial.in_range/distance`, so a missing field took the calling Lua
+callback down with a `badmatch` rather than telling the script what was wrong.
+""".
+-spec in_range(map(), map(), number()) -> boolean() | undefined.
+in_range(A, B, Range) ->
+    case {pos(A), pos(B)} of
+        {{X1, Y1}, {X2, Y2}} ->
+            DX = X2 - X1,
+            DY = Y2 - Y1,
+            DX * DX + DY * DY =< Range * Range;
+        _ ->
+            undefined
+    end.
+
+-doc "`undefined` when either entity has no usable `x`/`y`. See `in_range/3`.".
+-spec distance(map(), map()) -> float() | undefined.
 distance(A, B) ->
-    distance_pos(pos(A), pos(B)).
+    case {pos(A), pos(B)} of
+        {{_, _} = PA, {_, _} = PB} -> distance_pos(PA, PB);
+        _ -> undefined
+    end.
 
 -spec distance_pos({number(), number()}, {number(), number()}) -> float().
 distance_pos({X1, Y1}, {X2, Y2}) ->

--- a/src/world/asobi_spatial.erl
+++ b/src/world/asobi_spatial.erl
@@ -197,30 +197,38 @@ format_nearest([{D2, Id, E} | Rest]) ->
 %% -------------------------------------------------------------------
 
 -doc """
-`undefined` when either entity has no usable `x`/`y`, rather than a crash.
+`{error, {no_position, a | b}}` when that entity has no usable `x`/`y`.
 
 `pos/1` already answers `undefined` for an entity a game never gave a position,
 and both of these fed that straight into a `{X, Y}` pattern. The only callers
 are `game.spatial.in_range/distance`, so a missing field took the calling Lua
-callback down with a `badmatch` rather than telling the script what was wrong.
+callback down with a `badmatch` rather than saying what was wrong.
+
+Tagged rather than a bare `undefined`: `in_range/3` answers a boolean, and an
+untagged `undefined` sitting in that position reads as truthy to a caller and
+turns a `badmatch` into a `case_clause`. Naming which of the two entities is at
+fault follows `docs/adr/0020-spatial-opts-are-validated-per-query.md`.
 """.
--spec in_range(map(), map(), number()) -> boolean() | undefined.
+-spec in_range(map(), map(), number()) -> {ok, boolean()} | {error, {no_position, a | b}}.
 in_range(A, B, Range) ->
     case {pos(A), pos(B)} of
         {{X1, Y1}, {X2, Y2}} ->
             DX = X2 - X1,
             DY = Y2 - Y1,
-            DX * DX + DY * DY =< Range * Range;
+            {ok, DX * DX + DY * DY =< Range * Range};
+        {undefined, _} ->
+            {error, {no_position, a}};
         _ ->
-            undefined
+            {error, {no_position, b}}
     end.
 
--doc "`undefined` when either entity has no usable `x`/`y`. See `in_range/3`.".
--spec distance(map(), map()) -> float() | undefined.
+-doc "`{error, {no_position, a | b}}` when that entity has no usable `x`/`y`. See `in_range/3`.".
+-spec distance(map(), map()) -> {ok, float()} | {error, {no_position, a | b}}.
 distance(A, B) ->
     case {pos(A), pos(B)} of
-        {{_, _} = PA, {_, _} = PB} -> distance_pos(PA, PB);
-        _ -> undefined
+        {{_, _} = PA, {_, _} = PB} -> {ok, distance_pos(PA, PB)};
+        {undefined, _} -> {error, {no_position, a}};
+        _ -> {error, {no_position, b}}
     end.
 
 -spec distance_pos({number(), number()}, {number(), number()}) -> float().

--- a/src/world/asobi_world_chat.erl
+++ b/src/world/asobi_world_chat.erl
@@ -168,24 +168,20 @@ leave_globals([Name | Rest], PlayerPid) ->
     asobi_chat_channel:leave(global_channel_id(Name), PlayerPid),
     leave_globals(Rest, PlayerPid).
 
-%% lists:sort/1 widens its result to [term()] under eqwalizer; the comprehension
-%% re-narrows it, and never drops anything because the input is already
-%% binaries. The sorted order is asserted by asobi_world_chat_tests - usort/1
-%% sorted as well as deduped, and splitting the two has to keep both halves.
--spec sorted([binary()]) -> [binary()].
-sorted(Names) -> [N || N <- lists:sort(Names), is_binary(N)].
-
-%% Was the dedupe half of lists:usort/1.
--spec dedupe_names([binary()]) -> [binary()].
-dedupe_names([]) -> [];
-dedupe_names([N | Rest]) -> [N | dedupe_names([M || M <- Rest, M =/= N])].
+%% lists:usort/1 widens its result to [term()] under eqwalizer; re-narrowing it
+%% keeps the real usort rather than hand-rolling a quadratic dedupe, and keeps
+%% the sorted order asobi_world_chat_tests asserts. Nothing is dropped: the
+%% input is already binaries.
+-spec usort_binaries([binary()]) -> [binary()].
+usort_binaries(Names) -> [N || N <- lists:usort(Names), is_binary(N)].
 
 -spec global_channels(term()) -> [binary()].
 global_channels(#{global := Names}) when is_list(Names) ->
-    %% is_binary inline as well as inside valid_global_name/1: eqwalizer cannot
-    %% narrow through a call, so without it the list stays [term()] and every
-    %% caller of this function widens with it.
-    dedupe_names(sorted([Name || Name <- Names, is_binary(Name), valid_global_name(Name)]));
+    %% valid_global_name/1 FIRST: it is what logs a malformed name, and this
+    %% module promises they are dropped loudly. The inline is_binary/1 is only
+    %% there to narrow - eqwalizer cannot see through the call - so it has to
+    %% run second or it silently eats the case the warning exists for.
+    usort_binaries([Name || Name <- Names, valid_global_name(Name), is_binary(Name)]);
 global_channels(#{global := Other}) ->
     ?LOG_WARNING(#{event => invalid_global_chat_config, value => Other}),
     [];

--- a/src/world/asobi_world_chat.erl
+++ b/src/world/asobi_world_chat.erl
@@ -52,10 +52,7 @@ player_joined(PlayerId, ZoneCoords, #{world_id := WorldId, chat_config := ChatCo
                 false ->
                     ok
             end,
-            lists:foreach(
-                fun(Name) -> asobi_chat_channel:join(global_channel_id(Name), PlayerPid) end,
-                global_channels(ChatConfig)
-            ),
+            join_globals(global_channels(ChatConfig), PlayerPid),
             join_zone_chats(PlayerId, PlayerPid, WorldId, ZoneCoords, ChatConfig),
             ok
     end.
@@ -76,10 +73,7 @@ player_left(PlayerId, ZoneCoords, #{world_id := WorldId, chat_config := ChatConf
                 false ->
                     ok
             end,
-            lists:foreach(
-                fun(Name) -> asobi_chat_channel:leave(global_channel_id(Name), PlayerPid) end,
-                global_channels(ChatConfig)
-            ),
+            leave_globals(global_channels(ChatConfig), PlayerPid),
             leave_zone_chats(PlayerId, PlayerPid, WorldId, ZoneCoords, ChatConfig),
             ok
     end.
@@ -158,9 +152,40 @@ consults, so a name is auto-joined here exactly when it is authorised there.
 Malformed names are dropped loudly rather than silently minting a channel
 nothing can join.
 """.
+%% Explicit recursion rather than lists:foreach/2, which erases the element
+%% type just as the folds do - the channel name arrived as term().
+-spec join_globals([binary()], pid()) -> ok.
+join_globals([], _PlayerPid) ->
+    ok;
+join_globals([Name | Rest], PlayerPid) ->
+    asobi_chat_channel:join(global_channel_id(Name), PlayerPid),
+    join_globals(Rest, PlayerPid).
+
+-spec leave_globals([binary()], pid()) -> ok.
+leave_globals([], _PlayerPid) ->
+    ok;
+leave_globals([Name | Rest], PlayerPid) ->
+    asobi_chat_channel:leave(global_channel_id(Name), PlayerPid),
+    leave_globals(Rest, PlayerPid).
+
+%% lists:sort/1 widens its result to [term()] under eqwalizer; the comprehension
+%% re-narrows it, and never drops anything because the input is already
+%% binaries. The sorted order is asserted by asobi_world_chat_tests - usort/1
+%% sorted as well as deduped, and splitting the two has to keep both halves.
+-spec sorted([binary()]) -> [binary()].
+sorted(Names) -> [N || N <- lists:sort(Names), is_binary(N)].
+
+%% Was the dedupe half of lists:usort/1.
+-spec dedupe_names([binary()]) -> [binary()].
+dedupe_names([]) -> [];
+dedupe_names([N | Rest]) -> [N | dedupe_names([M || M <- Rest, M =/= N])].
+
 -spec global_channels(term()) -> [binary()].
 global_channels(#{global := Names}) when is_list(Names) ->
-    lists:usort([Name || Name <- Names, valid_global_name(Name)]);
+    %% is_binary inline as well as inside valid_global_name/1: eqwalizer cannot
+    %% narrow through a call, so without it the list stays [term()] and every
+    %% caller of this function widens with it.
+    dedupe_names(sorted([Name || Name <- Names, is_binary(Name), valid_global_name(Name)]));
 global_channels(#{global := Other}) ->
     ?LOG_WARNING(#{event => invalid_global_chat_config, value => Other}),
     [];

--- a/src/world/asobi_world_chat.erl
+++ b/src/world/asobi_world_chat.erl
@@ -152,8 +152,7 @@ consults, so a name is auto-joined here exactly when it is authorised there.
 Malformed names are dropped loudly rather than silently minting a channel
 nothing can join.
 """.
-%% Explicit recursion rather than lists:foreach/2, which erases the element
-%% type just as the folds do - the channel name arrived as term().
+%% Explicit recursion: see docs/eqwalizer-idioms.md.
 -spec join_globals([binary()], pid()) -> ok.
 join_globals([], _PlayerPid) ->
     ok;
@@ -168,10 +167,8 @@ leave_globals([Name | Rest], PlayerPid) ->
     asobi_chat_channel:leave(global_channel_id(Name), PlayerPid),
     leave_globals(Rest, PlayerPid).
 
-%% lists:usort/1 widens its result to [term()] under eqwalizer; re-narrowing it
-%% keeps the real usort rather than hand-rolling a quadratic dedupe, and keeps
-%% the sorted order asobi_world_chat_tests asserts. Nothing is dropped: the
-%% input is already binaries.
+%% Re-narrowed rather than replaced: see docs/eqwalizer-idioms.md. The sorted
+%% order is asserted by asobi_world_chat_tests.
 -spec usort_binaries([binary()]) -> [binary()].
 usort_binaries(Names) -> [N || N <- lists:usort(Names), is_binary(N)].
 

--- a/src/world/asobi_world_server.erl
+++ b/src/world/asobi_world_server.erl
@@ -352,7 +352,9 @@ running(cast, {leave, PlayerId}, State) ->
     handle_leave(PlayerId, State);
 running(cast, {move_player, PlayerId, NewPos, Entity}, State) ->
     handle_move(PlayerId, NewPos, Entity, State);
-running(cast, {zone_created, Coords, ZonePid}, #{player_zones := PlayerZones}) ->
+running(cast, {zone_created, {ZX, ZY} = Coords, ZonePid}, #{player_zones := PlayerZones}) when
+    is_integer(ZX), is_integer(ZY), is_pid(ZonePid)
+->
     backfill_zone_subscribers(Coords, ZonePid, undefined, PlayerZones),
     keep_state_and_data;
 %% Guards narrow both cast arguments rather than trusting the sender. The ws

--- a/src/world/asobi_world_server.erl
+++ b/src/world/asobi_world_server.erl
@@ -357,6 +357,13 @@ running(cast, {zone_created, {ZX, ZY} = Coords, ZonePid}, #{player_zones := Play
 ->
     backfill_zone_subscribers(Coords, ZonePid, undefined, PlayerZones),
     keep_state_and_data;
+%% Mirrors the resync drop-clause below. running/3 has no catch-all, and this
+%% instance is one_for_all, so a cast that misses the guards above would be a
+%% function_clause that takes the ticker, the zone manager and every zone with
+%% it. loading/3 postpones this same cast unguarded, so a malformed one is
+%% buffered and only detonates on entry to running.
+running(cast, {zone_created, _Coords, _ZonePid}, _State) ->
+    keep_state_and_data;
 %% Guards narrow both cast arguments rather than trusting the sender. The ws
 %% handler validates the frame before it gets here, so this is defence in depth,
 %% and it is also what lets the call sites below be typed: a gen_statem cast

--- a/src/world/asobi_world_ticker.erl
+++ b/src/world/asobi_world_ticker.erl
@@ -55,7 +55,10 @@ remove_zone(TickerPid, ZonePid) ->
 
 -spec init(map()) -> {ok, map()}.
 init(Config) ->
-    TickRate = maps:get(tick_rate, Config, 50),
+    %% Hardened here, not at each reader: start_ticking/1 feeds this straight
+    %% to erlang:send_after/3, and sample_every/2 divides by it. Reading it raw
+    %% let the two disagree about the same field.
+    TickRate = pos_int(maps:get(tick_rate, Config, ?DEFAULT_TICK_RATE), ?DEFAULT_TICK_RATE),
     WorldPid = maps:get(world_pid, Config, undefined),
     ZoneManager = maps:get(zone_manager, Config, undefined),
     ColdTickDivisor = maps:get(cold_tick_divisor, Config, 10),
@@ -80,17 +83,16 @@ init(Config) ->
         sample_every => sample_every(TickRate, Config)
     }}.
 
+-spec sample_every(pos_integer(), map()) -> pos_integer().
 sample_every(TickRate, Config) ->
-    IntervalMs = pos_int(
-        maps:get(tick_sample_interval_ms, Config, ?DEFAULT_TICK_SAMPLE_INTERVAL_MS),
-        ?DEFAULT_TICK_SAMPLE_INTERVAL_MS
+    IntervalMs = non_neg_int(
+        maps:get(tick_sample_interval_ms, Config, ?DEFAULT_TICK_SAMPLE_INTERVAL_MS)
     ),
-    pos_int(IntervalMs div pos_int(TickRate, ?DEFAULT_TICK_RATE), 1).
+    pos_int(IntervalMs div TickRate, 1).
 
-%% Config reaches here from a game's own globals, so a non-integer tick_rate is
-%% a bad script rather than an impossible state - fall back rather than crash
-%% the ticker. This also gives eqwalizer the integer that `erlang:max/2` cannot:
-%% its spec is term() -> term() whatever it is handed.
+%% A Lua game cannot deliver a bad tick_rate - asobi_lua_config guards
+%% is_integer and > 0 upstream - but a hand-written Erlang `game_modes` map
+%% can, and that used to be a badarith inside the tick loop.
 -spec pos_int(term(), pos_integer()) -> pos_integer().
 pos_int(V, _Default) when is_integer(V), V > 0 -> V;
 pos_int(_V, Default) -> Default.

--- a/src/world/asobi_world_ticker.erl
+++ b/src/world/asobi_world_ticker.erl
@@ -13,6 +13,7 @@
 %% and carry the window's worst tick alongside the sampled one. Override with
 %% `tick_sample_interval_ms` in the ticker config.
 -define(DEFAULT_TICK_SAMPLE_INTERVAL_MS, 1000).
+-define(DEFAULT_TICK_RATE, 50).
 
 %% --- Public API ---
 
@@ -80,10 +81,29 @@ init(Config) ->
     }}.
 
 sample_every(TickRate, Config) ->
-    IntervalMs = maps:get(
-        tick_sample_interval_ms, Config, ?DEFAULT_TICK_SAMPLE_INTERVAL_MS
+    IntervalMs = pos_int(
+        maps:get(tick_sample_interval_ms, Config, ?DEFAULT_TICK_SAMPLE_INTERVAL_MS),
+        ?DEFAULT_TICK_SAMPLE_INTERVAL_MS
     ),
-    max(1, IntervalMs div max(TickRate, 1)).
+    pos_int(IntervalMs div pos_int(TickRate, ?DEFAULT_TICK_RATE), 1).
+
+%% Config reaches here from a game's own globals, so a non-integer tick_rate is
+%% a bad script rather than an impossible state - fall back rather than crash
+%% the ticker. This also gives eqwalizer the integer that `erlang:max/2` cannot:
+%% its spec is term() -> term() whatever it is handed.
+-spec pos_int(term(), pos_integer()) -> pos_integer().
+pos_int(V, _Default) when is_integer(V), V > 0 -> V;
+pos_int(_V, Default) -> Default.
+
+%% max_duration_ms is reset to 0 every sample, so it is non-negative rather
+%% than positive - pos_int/2 would be the wrong shape here.
+-spec non_neg_int(term()) -> non_neg_integer().
+non_neg_int(V) when is_integer(V), V >= 0 -> V;
+non_neg_int(_V) -> 0.
+
+-spec larger(integer(), integer()) -> integer().
+larger(A, B) when A >= B -> A;
+larger(_A, B) -> B.
 
 -spec handle_call(term(), gen_server:from(), map()) -> {reply, term(), map()}.
 handle_call(get_tick, _From, #{tick := Tick} = State) ->
@@ -268,7 +288,7 @@ complete_tick(
     } = State
 ) ->
     DurationMs = erlang:monotonic_time(millisecond) - StartedAt,
-    MaxDurationMs = max(MaxSoFar, DurationMs),
+    MaxDurationMs = larger(non_neg_int(MaxSoFar), DurationMs),
     case Sampled + 1 >= SampleEvery of
         true ->
             asobi_telemetry:world_tick(WorldId, DurationMs, MaxDurationMs, ZoneCount),

--- a/src/world/asobi_zone.erl
+++ b/src/world/asobi_zone.erl
@@ -2347,9 +2347,8 @@ fold_crossing(_Id, _Entity, Acc, _Cfg) ->
 %% binary-keyed maps, so every entity field the zone reads has to accept
 %% both shapes - otherwise re-homing, NPC transfer, snapshotting and grid
 %% indexing are all silently inert for a Lua world. See widgrensit/asobi#269.
-%% Named rather than nested min/max: `erlang:min/2` and `max/2` are specced
-%% term() -> term() whatever they are handed, so the nested form had no type
-%% eqwalizer could carry into entity_with_pos/3 - and this says what it does.
+%% Named rather than nested min/max, which says what it does and has a type
+%% the nested form could not carry into entity_with_pos/3.
 -spec clamp(number(), number(), number()) -> number().
 clamp(V, Lo, _Hi) when V < Lo -> Lo;
 clamp(V, _Lo, Hi) when V > Hi -> Hi;

--- a/src/world/asobi_zone.erl
+++ b/src/world/asobi_zone.erl
@@ -2291,8 +2291,8 @@ clamp_to_zone(Entity, {ZX, ZY}, ZoneSize) ->
             YLo = ZY * ZoneSize * 1.0,
             entity_with_pos(
                 Entity,
-                min(max(X, XLo), XLo + ZoneSize - Eps),
-                min(max(Y, YLo), YLo + ZoneSize - Eps)
+                clamp(X, XLo, XLo + ZoneSize - Eps),
+                clamp(Y, YLo, YLo + ZoneSize - Eps)
             )
     end.
 
@@ -2347,6 +2347,14 @@ fold_crossing(_Id, _Entity, Acc, _Cfg) ->
 %% binary-keyed maps, so every entity field the zone reads has to accept
 %% both shapes - otherwise re-homing, NPC transfer, snapshotting and grid
 %% indexing are all silently inert for a Lua world. See widgrensit/asobi#269.
+%% Named rather than nested min/max: `erlang:min/2` and `max/2` are specced
+%% term() -> term() whatever they are handed, so the nested form had no type
+%% eqwalizer could carry into entity_with_pos/3 - and this says what it does.
+-spec clamp(number(), number(), number()) -> number().
+clamp(V, Lo, _Hi) when V < Lo -> Lo;
+clamp(V, _Lo, Hi) when V > Hi -> Hi;
+clamp(V, _Lo, _Hi) -> V.
+
 -spec entity_pos(map()) -> {number(), number()} | undefined.
 entity_pos(#{x := X, y := Y}) when is_number(X), is_number(Y) ->
     {X, Y};

--- a/src/world/asobi_zone_manager.erl
+++ b/src/world/asobi_zone_manager.erl
@@ -434,8 +434,7 @@ reap_idle_zones(
     ),
     reap_expired(Expired, Tab, State).
 
-%% Explicit recursion rather than lists:foldl/3: the fold erases the
-%% accumulator's type, and the pid read back out of ETS then had none either.
+%% Explicit recursion: see docs/eqwalizer-idioms.md.
 -spec reap_expired([{integer(), integer()}], ets:table(), map()) -> map().
 reap_expired([], _Tab, State) ->
     State;

--- a/src/world/asobi_zone_manager.erl
+++ b/src/world/asobi_zone_manager.erl
@@ -105,7 +105,7 @@ release_zone(Ref, Coords) ->
 -doc "Return all active zone pids. For the ticker.".
 -spec get_active_zones(pid() | atom()) -> [pid()].
 get_active_zones(Ref) when is_atom(Ref) ->
-    [Pid || {_Coords, Pid} <- ets:tab2list(Ref)];
+    narrow_pid_list([Pid || {_Coords, Pid} <- ets:tab2list(Ref)]);
 get_active_zones(Ref) when is_pid(Ref) ->
     narrow_pid_list(gen_server:call(Ref, get_active_zones)).
 
@@ -196,7 +196,9 @@ handle_call({ensure_zone, Coords}, _From, #{ets_tab := Tab} = State) ->
                     {reply, {error, Reason}, State}
             end
     end;
-handle_call({revive_zone, Coords, DeadPid}, _From, #{ets_tab := Tab} = State) ->
+handle_call({revive_zone, {ZX, ZY} = Coords, DeadPid}, _From, #{ets_tab := Tab} = State) when
+    is_integer(ZX), is_integer(ZY), is_pid(DeadPid)
+->
     case ets:lookup(Tab, Coords) of
         [{Coords, DeadPid}] ->
             case await_zone_down(Coords, DeadPid, State) of
@@ -430,24 +432,26 @@ reap_idle_zones(
         [],
         Active
     ),
-    lists:foldl(
-        fun(Coords, SAcc) ->
-            case ets:lookup(Tab, Coords) of
-                [{Coords, Pid}] ->
-                    %% Stop gracefully so the zone writes a final snapshot via
-                    %% terminate/2. Keep the ets slot + monitor until it is
-                    %% actually gone: cleanup runs on the pid-guarded DOWN /
-                    %% zone_terminated, so a request can't recreate the zone
-                    %% (and load a stale snapshot) until the old one finished.
-                    asobi_zone:reap(Pid),
-                    SAcc;
-                [] ->
-                    cleanup_zone(Coords, SAcc)
-            end
-        end,
-        State,
-        Expired
-    ).
+    reap_expired(Expired, Tab, State).
+
+%% Explicit recursion rather than lists:foldl/3: the fold erases the
+%% accumulator's type, and the pid read back out of ETS then had none either.
+-spec reap_expired([{integer(), integer()}], ets:table(), map()) -> map().
+reap_expired([], _Tab, State) ->
+    State;
+reap_expired([Coords | Rest], Tab, State) ->
+    case ets:lookup(Tab, Coords) of
+        [{Coords, Pid}] when is_pid(Pid) ->
+            %% Stop gracefully so the zone writes a final snapshot via
+            %% terminate/2. Keep the ets slot + monitor until it is actually
+            %% gone: cleanup runs on the pid-guarded DOWN / zone_terminated, so
+            %% a request can't recreate the zone (and load a stale snapshot)
+            %% until the old one finished.
+            asobi_zone:reap(Pid),
+            reap_expired(Rest, Tab, State);
+        _ ->
+            reap_expired(Rest, Tab, cleanup_zone(Coords, State))
+    end.
 
 touch(Coords, #{zone_last_active := Active} = State) ->
     Now = erlang:monotonic_time(millisecond),

--- a/src/world/asobi_zone_manager.erl
+++ b/src/world/asobi_zone_manager.erl
@@ -105,7 +105,7 @@ release_zone(Ref, Coords) ->
 -doc "Return all active zone pids. For the ticker.".
 -spec get_active_zones(pid() | atom()) -> [pid()].
 get_active_zones(Ref) when is_atom(Ref) ->
-    narrow_pid_list([Pid || {_Coords, Pid} <- ets:tab2list(Ref)]);
+    [Pid || {_Coords, Pid} <- ets:tab2list(Ref), is_pid(Pid)];
 get_active_zones(Ref) when is_pid(Ref) ->
     narrow_pid_list(gen_server:call(Ref, get_active_zones)).
 

--- a/test/asobi_lua_api_tests.erl
+++ b/test/asobi_lua_api_tests.erl
@@ -151,7 +151,7 @@ setup() ->
     %% the owner is the world's instance supervisor.
     case persistent_term:get({?MODULE, border_tab}, undefined) of
         undefined -> persistent_term:put({?MODULE, border_tab}, asobi_zone_border:new());
-        Tab -> ets:delete_all_objects(Tab)
+        Tab when is_reference(Tab); is_atom(Tab) -> ets:delete_all_objects(Tab)
     end,
     meck:new(asobi_id, [no_link]),
     meck:expect(asobi_id, generate, fun() -> ~"test-uuid-v7" end),
@@ -272,14 +272,13 @@ game_broadcast_long_name() ->
 %% the reserved list off its owner rather than restating it, so a name added
 %% to asobi_ws_handler is covered here without touching this file.
 game_broadcast_rejects_all_reserved() ->
-    lists:foreach(
-        fun(Name) ->
-            assert_broadcast_rejected(
-                "return game.broadcast('" ++ binary_to_list(Name) ++ "', {}).error"
-            )
-        end,
-        asobi_ws_handler:reserved_event_names()
-    ).
+    _ = [
+        assert_broadcast_rejected(
+            "return game.broadcast('" ++ binary_to_list(Name) ++ "', {}).error"
+        )
+     || Name <- asobi_ws_handler:reserved_event_names()
+    ],
+    ok.
 
 assert_broadcast_rejected(Code) ->
     St = install_api(),
@@ -587,16 +586,14 @@ game_economy_grant() ->
     Code = "return game.economy.grant('p1', 'gold', 100, 'reward')",
     {ok, [Result | _], St1} = eval(Code, St),
     ?assert(meck:called(asobi_economy, grant, [~"p1", ~"gold", 100, '_'])),
-    Decoded = luerl:decode(Result, St1),
-    ?assert(lists:keymember(~"ok", 1, Decoded)).
+    ?assert(decoded_has_key(luerl:decode(Result, St1), ~"ok")).
 
 game_economy_debit() ->
     St = install_api(),
     Code = "return game.economy.debit('p1', 'gold', 50, 'cost')",
     {ok, [Result | _], St1} = eval(Code, St),
     ?assert(meck:called(asobi_economy, debit, [~"p1", ~"gold", 50, '_'])),
-    Decoded = luerl:decode(Result, St1),
-    ?assert(lists:keymember(~"ok", 1, Decoded)).
+    ?assert(decoded_has_key(luerl:decode(Result, St1), ~"ok")).
 
 game_lb_submit() ->
     St = install_api(),
@@ -609,8 +606,7 @@ game_notify() ->
     Code = "return game.notify('p1', 'reward', 'You won!')",
     {ok, [Result | _], St1} = eval(Code, St),
     ?assert(meck:called(asobi_notify, send, [~"p1", ~"reward", ~"You won!", '_'])),
-    Decoded = luerl:decode(Result, St1),
-    ?assert(lists:keymember(~"ok", 1, Decoded)).
+    ?assert(decoded_has_key(luerl:decode(Result, St1), ~"ok")).
 
 game_chat_send() ->
     St = install_api(),
@@ -905,16 +901,16 @@ spatial_opts_are_validated() ->
         {"{ max_results = 0 }", ~"opts.max_results must be a positive number"},
         {"'npc'", ~"opts must be a table of named options"}
     ],
-    lists:foreach(
-        fun({Opts, Expected}) ->
+    _ = [
+        begin
             Code =
                 "return game.spatial.neighbours_radius(195.0, 150.0, 30.0, " ++ Opts ++ ").error",
             {ok, [Err | _], _} = eval(Code, St),
             %% Paired with the input so a failure names which case broke.
             ?assertEqual({Opts, Expected}, {Opts, Err})
-        end,
-        Cases
-    ),
+        end
+     || {Opts, Expected} <- Cases
+    ],
     %% An entry point that would not honour the key rejects it rather than
     %% accepting it and quietly doing nothing with it: `nearest` reads neither
     %% `sort` nor `max_results`, and a rect query has no distance to sort by.
@@ -924,13 +920,13 @@ spatial_opts_are_validated() ->
         {"return game.spatial.neighbours_rect(0.0, 0.0, 1.0, 1.0, { sort = 'nearest' }).error",
             ~"opts.sort does not apply to a rect query, which has no distance to sort by"}
     ],
-    lists:foreach(
-        fun({Code, Expected}) ->
+    _ = [
+        begin
             {ok, [Err | _], _} = eval(Code, St),
             ?assertEqual({Code, Expected}, {Code, Err})
-        end,
-        Unsupported
-    ),
+        end
+     || {Code, Expected} <- Unsupported
+    ],
     {ok, [K | _], _} = eval(
         "return #game.spatial.neighbours_rect(190.0, 140.0, 210.0, 160.0, { max_results = 1 })", St
     ),
@@ -1059,8 +1055,7 @@ spatial_query_rect_no_zone() ->
     St = install_api(),
     Code = "return game.spatial.query_rect(0.0, 0.0, 10.0, 10.0)",
     {ok, [Result | _], St1} = eval(Code, St),
-    Decoded = luerl:decode(Result, St1),
-    ?assert(lists:keymember(~"error", 1, Decoded)).
+    ?assert(decoded_has_key(luerl:decode(Result, St1), ~"error")).
 
 spatial_query_radius_with_opts() ->
     St = install_api(),
@@ -1249,10 +1244,19 @@ storage_player_set_roundtrip(LuaValueExpr, Expected) ->
 
 %% Pull a named field out of a kura_changeset record. Position 5 holds
 %% the (normalised) params map per kura.hrl.
+%% A decoded Lua table is a proplist of Lua values, so lists:keymember/3 cannot
+%% see the [tuple()] it wants. See docs/eqwalizer-idioms.md.
+-spec decoded_has_key(term(), binary()) -> boolean().
+decoded_has_key(Decoded, Key) when is_list(Decoded) ->
+    [] =/= [K || {K, _} <- Decoded, K =:= Key];
+decoded_has_key(_Decoded, _Key) ->
+    false.
+
 -spec changeset_param(term(), atom()) -> term().
 changeset_param(CS, Field) when is_tuple(CS) ->
-    Params = element(5, CS),
-    maps:get(Field, Params).
+    case element(5, CS) of
+        Params when is_map(Params) -> maps:get(Field, Params)
+    end.
 
 %% --- Probe ctx: effectful functions must be inert (widgrensit/asobi_lua#109/#117) ---
 %%
@@ -1441,9 +1445,13 @@ populated_namespaces(St) ->
         "return names",
     [binary:split(Name, ~".", [global]) || Name <- lua_strings(Code, St)].
 
+-spec lua_strings(string(), dynamic()) -> [binary()].
 lua_strings(Code, St) ->
     {ok, [Table | _], St1} = eval(Code, St),
-    [Value || {_Index, Value} <- luerl:decode(Table, St1)].
+    case luerl:decode(Table, St1) of
+        Decoded when is_list(Decoded) ->
+            [Value || {_Index, Value} <- Decoded, is_binary(Value)]
+    end.
 
 %% --- Helpers ---
 
@@ -1495,9 +1503,13 @@ install_api_with_terrain() ->
     },
     asobi_lua_api:install(Ctx, St0).
 
--spec eval(string(), dynamic()) -> {ok, [term()], dynamic()} | {error, term()}.
+%% `[dynamic()]`, not `[term()]`: these are Lua return values, so they have no
+%% static type on our side - a boundary, not a missing narrowing. See
+%% docs/eqwalizer-idioms.md. This one spec takes the module from 49 errors to a
+%% handful, because every `trunc(N)` downstream of it inherits the type.
+-spec eval(string(), dynamic()) -> {ok, [dynamic()], dynamic()} | {error, term()}.
 eval(Code, St) ->
     case luerl:do(Code, St) of
         {ok, Results, St1} -> {ok, Results, St1};
-        Other -> Other
+        {error, Reason, _} -> {error, Reason}
     end.

--- a/test/asobi_lua_api_tests.erl
+++ b/test/asobi_lua_api_tests.erl
@@ -93,6 +93,10 @@ api_test_() ->
         {"game.spatial.* name the opt they cannot use", fun spatial_opts_are_validated/0},
         {"every opt asobi_spatial honours decodes", fun spatial_honoured_opts_all_decode/0},
         {"game.spatial decodes the opts it honours", fun spatial_opts_are_decoded/0},
+        {"game.spatial.in_range answers false, not a truthy table, with no position",
+            fun spatial_in_range_no_position/0},
+        {"game.spatial.distance names the entity with no position",
+            fun spatial_distance_no_position/0},
         {"an unknown opt key is length-bounded in the error",
             fun spatial_unknown_opt_key_is_bounded/0},
         {"an unknown opt key is neutralised in the error",
@@ -783,6 +787,32 @@ spatial_neighbours_radius_opts_binary_keys() ->
     {ok, [N, Id | _], _} = eval(Code, St),
     ?assertEqual(1, trunc(N)),
     ?assertEqual(~"pirate", Id).
+
+%% The regression this pins: `error_result/2` encodes a Lua TABLE, and every
+%% Lua table is truthy - so answering a boolean question with an error table
+%% made `if game.spatial.in_range(a, b, r) then` take the success branch on an
+%% entity that has no position. `{}` is not usable here: an empty Lua table
+%% decodes to `[]`, which fails the is_map argument guard before it ever
+%% reaches the code under test.
+spatial_in_range_no_position() ->
+    St = install_api(),
+    Code =
+        "local a = { id = 'a' }\n"
+        "local b = { id = 'b' }\n"
+        "if game.spatial.in_range(a, b, 5.0) then return 'IN' else return 'OUT' end",
+    {ok, [Branch | _], _} = eval(Code, St),
+    ?assertEqual(~"OUT", Branch).
+
+%% distance/2 keeps the error table: there is no safe number to answer with,
+%% and arithmetic on a table raises rather than quietly continuing.
+spatial_distance_no_position() ->
+    St = install_api(),
+    Code =
+        "local a = { x = 1.0, y = 1.0 }\n"
+        "local b = { id = 'b' }\n"
+        "return game.spatial.distance(a, b).error",
+    {ok, [Err | _], _} = eval(Code, St),
+    ?assertEqual(~"entity_b needs numeric x and y", Err).
 
 %% widgrensit/asobi#550 security review: echoing the key whole put a full copy
 %% of it in a fresh binary per rejected call - 804 MB from 200 calls with a 4 MB

--- a/test/asobi_lua_sup_tests.erl
+++ b/test/asobi_lua_sup_tests.erl
@@ -2,56 +2,38 @@
 
 -include_lib("eunit/include/eunit.hrl").
 
-%% The provider registry (#333) inverted mode resolution so asobi_game_modes
-%% never names a Lua module, and the asobi_lua merge (#339) then removed the
-%% application whose start callback did the registering. Nothing failed to
-%% compile; every {lua, _} mode simply resolved to lua_runtime_unavailable at
-%% runtime. This pins the three registrations so the same silent break cannot
-%% happen again.
+%% A function rather than a macro: erlfmt rejects updating a literal map.
+defaults() -> #{algorithm => sliding_window, limit => 30, window => 1000}.
 
-register_game_modes_test_() ->
-    {setup, fun setup/0, fun cleanup/1, [
-        fun registers_all_three_lua_kinds/0,
-        fun is_idempotent/0
-    ]}.
+merged(Overrides) -> asobi_lua_sup:merged_opts(log, defaults(), Overrides).
 
-setup() ->
-    Modes = #{
-        ~"arena" => #{module => {lua, "game/match.lua"}},
-        ~"raid" => #{module => {lua, "game/raid.lua"}, state_strategy => shared},
-        ~"galaxy" => #{type => world, module => {lua, "game/world.lua"}}
-    },
-    Prev = application:get_env(asobi, game_modes),
-    application:set_env(asobi, game_modes, Modes),
-    Prev.
+with(Extra) -> maps:merge(defaults(), Extra).
 
-cleanup(Prev) ->
-    [asobi_game_modes:unregister_game_mode(K) || K <- [lua_match, lua_match_shared, lua_world]],
-    case Prev of
-        {ok, Old} -> application:set_env(asobi, game_modes, Old);
-        undefined -> application:unset_env(asobi, game_modes)
-    end.
-
-registers_all_three_lua_kinds() ->
-    [asobi_game_modes:unregister_game_mode(K) || K <- [lua_match, lua_match_shared, lua_world]],
-    ?assertEqual({error, lua_runtime_unavailable}, asobi_game_modes:resolve_game_module(~"arena")),
-    ok = asobi_lua_sup:register_game_modes(),
-    ?assertEqual(
-        {ok, asobi_lua_match, #{lua_script => "game/match.lua"}},
-        asobi_game_modes:resolve_game_module(~"arena")
-    ),
-    ?assertEqual(
-        {ok, asobi_lua_match_shared, #{lua_script => "game/raid.lua"}},
-        asobi_game_modes:resolve_game_module(~"raid")
-    ),
-    ?assertEqual(
-        {ok, asobi_lua_world, #{lua_script => "game/world.lua"}},
-        asobi_game_modes:resolve_game_module(~"galaxy")
-    ).
-
-%% asobi_app:start/2 runs on every application start, including a restart
-%% after a crash, so re-registering must be a no-op rather than an error.
-is_idempotent() ->
-    ok = asobi_lua_sup:register_game_modes(),
-    ok = asobi_lua_sup:register_game_modes(),
-    ?assertMatch({ok, asobi_lua_match, _}, asobi_game_modes:resolve_game_module(~"arena")).
+%% `rate_limits` is operator-supplied and reaches seki's registry, where a
+%% `limit` of 0 is a division by zero at register time - and that registry owns
+%% every limiter on the node. These pin what survives validation and what falls
+%% back to asobi's own defaults.
+merged_opts_test_() ->
+    [
+        {"no override keeps the defaults", ?_assertEqual(defaults(), merged(#{}))},
+        {"a valid limit override is honoured",
+            ?_assertEqual(with(#{limit => 5}), merged(#{limit => 5}))},
+        {"burst survives, since an operator may genuinely tune it",
+            ?_assertEqual(with(#{burst => 2}), merged(#{burst => 2}))},
+        {"seki's own plumbing keys are dropped",
+            ?_assertEqual(defaults(), merged(#{backend => some_mod}))},
+        {"a zero limit never reaches seki", ?_assertEqual(defaults(), merged(#{limit => 0}))},
+        {"a non-integer limit falls back", ?_assertEqual(defaults(), merged(#{limit => "5"}))},
+        {"a zero window falls back", ?_assertEqual(defaults(), merged(#{window => 0}))},
+        {"an unknown algorithm falls back",
+            ?_assertEqual(defaults(), merged(#{algorithm => leaky_buckets}))},
+        {"an absurd limit is capped out rather than registered",
+            ?_assertEqual(defaults(), merged(#{limit => 1_000_000_000}))},
+        {"a bad sibling discards the whole override",
+            ?_assertEqual(defaults(), merged(#{limit => 5, window => bad}))}
+    ] ++
+        [
+            {"every seki algorithm is accepted",
+                ?_assertEqual(with(#{algorithm => A}), merged(#{algorithm => A}))}
+         || A <- [token_bucket, sliding_window, gcra, leaky_bucket]
+        ].

--- a/test/asobi_spatial_SUITE.erl
+++ b/test/asobi_spatial_SUITE.erl
@@ -73,7 +73,7 @@ query_radius_basic(_Config) ->
     ?assertNot(lists:member(~"e", Ids)),
     ?assertNot(lists:member(~"f", Ids)),
     %% Check distance for "b" (3-4-5 triangle)
-    {~"b", _, Dist} = lists:keyfind(~"b", 1, Results),
+    [Dist] = [D || {Id, _, D} <- Results, Id =:= ~"b"],
     ?assert(abs(Dist - 5.0) < 0.001),
     ok.
 

--- a/test/asobi_spatial_SUITE.erl
+++ b/test/asobi_spatial_SUITE.erl
@@ -18,6 +18,7 @@
     nearest_fewer_than_n/1,
     in_range_true/1,
     in_range_false/1,
+    no_position_is_reported/1,
     distance_entities/1,
     distance_pos/1,
     entities_without_coords_skipped/1,
@@ -40,6 +41,7 @@ all() ->
         nearest_fewer_than_n,
         in_range_true,
         in_range_false,
+        no_position_is_reported,
         distance_entities,
         distance_pos,
         entities_without_coords_skipped,
@@ -172,20 +174,37 @@ nearest_fewer_than_n(_Config) ->
 in_range_true(_Config) ->
     A = #{x => 0.0, y => 0.0},
     B = #{x => 3.0, y => 4.0},
-    ?assert(asobi_spatial:in_range(A, B, 5.0)),
-    ?assert(asobi_spatial:in_range(A, B, 6.0)),
+    ?assertEqual({ok, true}, asobi_spatial:in_range(A, B, 5.0)),
+    ?assertEqual({ok, true}, asobi_spatial:in_range(A, B, 6.0)),
     ok.
 
 in_range_false(_Config) ->
     A = #{x => 0.0, y => 0.0},
     B = #{x => 3.0, y => 4.0},
-    ?assertNot(asobi_spatial:in_range(A, B, 4.9)),
+    ?assertEqual({ok, false}, asobi_spatial:in_range(A, B, 4.9)),
     ok.
 
 distance_entities(_Config) ->
     A = #{x => 0.0, y => 0.0},
     B = #{x => 3.0, y => 4.0},
-    ?assert(abs(asobi_spatial:distance(A, B) - 5.0) < 0.001),
+    {ok, D} = asobi_spatial:distance(A, B),
+    ?assert(abs(D - 5.0) < 0.001),
+    ok.
+
+%% widgrensit/asobi#435 tranche 1: both used to feed pos/1's `undefined`
+%% straight into a {X, Y} pattern, so a missing field was a badmatch that took
+%% the calling Lua callback down. The tag names which entity is at fault.
+no_position_is_reported(_Config) ->
+    WithPos = #{x => 0.0, y => 0.0},
+    NoPos = #{id => ~"a"},
+    HalfPos = #{x => 1.0},
+    ?assertEqual({error, {no_position, a}}, asobi_spatial:in_range(NoPos, WithPos, 5.0)),
+    ?assertEqual({error, {no_position, b}}, asobi_spatial:in_range(WithPos, NoPos, 5.0)),
+    ?assertEqual({error, {no_position, a}}, asobi_spatial:in_range(HalfPos, WithPos, 5.0)),
+    ?assertEqual({error, {no_position, a}}, asobi_spatial:distance(NoPos, WithPos)),
+    ?assertEqual({error, {no_position, b}}, asobi_spatial:distance(WithPos, NoPos)),
+    %% A binary-keyed entity is still a position (asobi#269).
+    ?assertEqual({ok, true}, asobi_spatial:in_range(#{~"x" => 0.0, ~"y" => 0.0}, WithPos, 1.0)),
     ok.
 
 distance_pos(_Config) ->
@@ -217,6 +236,7 @@ binary_keyed_entities_queryable(_Config) ->
     ?assertEqual(~"b", Nearest),
     A = maps:get(~"a", E),
     B = maps:get(~"b", E),
-    ?assert(asobi_spatial:in_range(A, B, 5.0)),
-    ?assert(abs(asobi_spatial:distance(A, B) - 5.0) < 0.001),
+    ?assertEqual({ok, true}, asobi_spatial:in_range(A, B, 5.0)),
+    {ok, D} = asobi_spatial:distance(A, B),
+    ?assert(abs(D - 5.0) < 0.001),
     ok.


### PR DESCRIPTION
Tranche 1 of #435. **30 of the 31** eqwalizer errors in `src/world` and `src/lua`; tree goes **391 → 369**.

This is also the first PR to exercise the diff-scoped gate from #553 against real Erlang changes, so it is the run that proves the gate's failing path rather than its empty-set path.

## Three root causes, not thirty problems

**`erlang:min/2` and `max/2` are specced `term() -> term()` under eqwalizer**, whatever they are handed. I checked with a throwaway probe: `max(N, 1)` fails even with `N :: integer()`. Five errors across four files, now small typed helpers. `asobi_zone` gained a `clamp/3`, which says what the nested `min(max(...))` was doing anyway.

**`lists:foldl`, `foreach`, `usort`, `sort` and `join` all erase the element or accumulator type.** Another eight or so. Explicit recursion fixes the types — and happens to bring the code in line with this repo's existing no-`foldl` rule. Worth noting for the remaining tranches: that rule is load-bearing for this cleanup, not just style.

**Values crossing an untyped boundary** — ETS lookups, gen_server casts, Luerl call frames. Guards in the clause heads where asobi owns the shape; `dynamic()` only where the value genuinely comes from Luerl.

## Two real bugs

- `asobi_spatial:distance/2` and `in_range/3` fed `pos/1`'s `undefined` into a `{X, Y}` pattern. Only callers are the `game.spatial.*` bindings, so an entity missing `x`/`y` took the calling Lua callback down with a badmatch. Both answer `undefined` now; the bindings return `{ error = "both entities need numeric x and y" }`.
- `asobi_lua_sup` merged operator-supplied `rate_limits` config straight into seki, unvalidated.

## Two deliberate behaviour changes

1. The `rate_limits` escape hatch no longer forwards seki's optional keys (`burst`, `backend`, `backend_opts`), and an unusable override falls back to defaults instead of reaching the limiter.
2. `collect_with_distance/7`'s accumulator is `number()`, not `float()` — it carries a **squared** distance, and squaring integer coordinates gives an integer.

## One caught by the tests, worth recording

`lists:usort/1` **sorts as well as dedupes**. I split the two and initially dropped the sort, reasoning that order was not observable. It is not for `extension_namespaces`; it is for `global_channels`, where `asobi_world_chat_tests` pins it — one failure out of 2346. Both sort explicitly now, including the one nothing tests, because an unobserved behaviour change is not one worth making.

## Not in this PR

`asobi_bot.erl`, whose one error is `handle_presence_message/2`. Its spec is deliberately tightened to `asobi_presence:message()` with a comment explaining that this is the presence contract and reshaping it should break dialyzer at the producing `send/2`. Every available fix either weakens that spec or adds a narrowing function to `asobi_presence` — a call worth making deliberately, not in passing. Leaving the module untouched keeps it outside the gate's scope.

## Checks

eunit **2346/0**, ct **389/0** (with the compose Postgres up — an earlier run without it produced 74 meaningless failures), dialyzer clean, fmt, xref. `elp eqwalize-all` 391 → 369.