### PR TITLE
fix(types): narrow the lists:* widening across the tree

### DIFF
--- a/docs/eqwalizer-idioms.md
+++ b/docs/eqwalizer-idioms.md
@@ -10,7 +10,11 @@ Context: widgrensit/asobi#435.
 ## `erlang:min/2` and `max/2` return `term()`
 
 Their specs are `term() -> term()` whatever they are handed, so `max(N, 1)`
-fails even when `N :: integer()`. Narrowing the *input* does not help.
+fails when the result flows into a typed context, even with `N :: integer()`.
+Narrowing the *input* does not help. The result can still flow into another
+`term()` position unremarked - `min(Offset, Total)` inside `lists:nthtail/2`
+eqwalizes clean - so the error appears where the value is *used*, not where it
+is produced.
 
 Write a small local function that names the rule instead. Not a shared numeric
 module: only two of these remain in the whole tree, and `clamp/3` reads better
@@ -31,7 +35,19 @@ largest class of error in the tree.
 
 Two answers, and which one depends on whether the call is doing real work:
 
-**Re-narrow the result.** Preferred when the `lists:` function is worth keeping
+**Re-narrow the result — but only when the producer already guarantees the
+type.** A re-narrowing comprehension is by construction a *silent drop*: it is
+free when nothing can fail the guard, and a bug when something can. If the
+producer does not guarantee it, widen the *consumer's* spec to `[term()]` and
+let the existing validator run. **Never filter ahead of a validator.**
+
+That mistake shipped twice in this cleanup. `asobi_world_chat` put an
+`is_binary/1` in front of the function that logs a malformed channel name;
+`asobi_console` filtered non-string manifest paths out before the function
+whose entire job is refusing them by name, which turned "console refuses to
+load" into "console loads with a screen missing".
+
+Otherwise, preferred when the `lists:` function is worth keeping
 - `usort/1` is O(n log n) in C, and hand-rolling it is neither faster nor
 clearer. The comprehension restores the type and drops nothing, because the
 input already has it:
@@ -40,6 +56,10 @@ input already has it:
 -spec usort_binaries([binary()]) -> [binary()].
 usort_binaries(Names) -> [N || N <- lists:usort(Names), is_binary(N)].
 ```
+
+`foldr/3` short-circuits from the *right*, so replacing one with left-to-right
+recursion changes which of several errors is reported. Same result list, first
+failure instead of last.
 
 **Replace the fold with explicit recursion.** Preferred for `foldl`/`foreach`,
 where the accumulator is asobi's own and the recursion is usually clearer than
@@ -54,6 +74,10 @@ install_fns([{Path, Fn} | Rest], St) ->
     {ok, St2} = luerl:set_table_keys(Path, Enc, St1),
     install_fns(Rest, St2).
 ```
+
+`lists:reverse/1` widens as well, and the accumulate-then-reverse shape above
+always ends in one - so an explicit-recursion rewrite usually needs a second
+re-narrow at the end, subject to the same precondition.
 
 Do **not** split a `usort/1` into a sort plus a hand-written dedupe. That was
 tried: it cost four functions across two modules and two O(n^2) loops on a
@@ -108,8 +132,14 @@ in one step:
 
 ```erlang
 %% was: {profiles, Profiles} = lists:keyfind(profiles, 1, Terms)
-[Profiles] = [V || {K, V} <- Terms, K =:= profiles, is_list(V)],
+[Profiles | _] = [V || {K, V} <- Terms, K =:= profiles, is_list(V)],
 ```
+
+`[X | _]` preserves `keyfind/3`'s first-wins semantics. `[X] =` adds a
+uniqueness assertion the original did not have - sometimes an improvement, but
+only use it where you mean it, and say so at the site. Give the empty case a
+named error (`[] -> error({missing_config, Key})`) rather than leaving a bare
+`{badmatch, []}` that does not say which key was absent.
 
 ## `dynamic()` is for boundaries, and only for boundaries
 
@@ -134,6 +164,23 @@ Luerl's `luerlstate()` and `luerldata()` are defined in its header but exported
 by no module, so there is no `luerl:luerlstate()` to write and `dynamic()` is
 the only honest answer. Exporting those types upstream would remove a whole
 category of these.
+
+## A pattern in a generator is a filter, not a match
+
+This is the likeliest way to break something while rewriting a fold, because
+the fold body's hard matches become silent drops:
+
+```erlang
+%% Asserts. A non-zero saturation count crashes and names itself.
+{Records, 0} = asobi_dgram_pose:records(...),
+
+%% Filters. A non-zero count is skipped and the test still passes.
+{Records, 0} <- [asobi_dgram_pose:records(...)],
+```
+
+Same for `#{slot := S} <- Records`, which drops a record with no `slot` where
+a function head would have raised. When the match was load-bearing, keep it in
+a named helper with a spec and generate over *that*.
 
 ## A narrowing clause is a behaviour change
 

--- a/docs/eqwalizer-idioms.md
+++ b/docs/eqwalizer-idioms.md
@@ -69,6 +69,25 @@ validator silently eats the case the validator was there to log:
 [N || N <- Names, valid_global_name(N), is_binary(N)]
 ```
 
+## `maybe ... end` needs an explicit `else`
+
+Without one, eqwalizer cannot type the short circuit and reports the *first*
+`?=` as returning the wrong type. Adding the clause the block already implies
+fixes it, and is behaviour-identical when every `?=` answers
+`{ok, _} | {error, _}` - which is the only shape that can reach it:
+
+```erlang
+maybe
+    {ok, Raw} ?= read_manifest(Dir),
+    ...
+else
+    {error, _} = Error -> Error
+end.
+```
+
+Verified with a probe: the same block without `else` fails, with `else` is
+clean.
+
 ## The `?LOG_*` macros return `term()`
 
 They expand to `erlang:apply(logger, macro_log, ...)`, so a function spec'd
@@ -78,6 +97,18 @@ They expand to `erlang:apply(logger, macro_log, ...)`, so a function spec'd
 log_it(V) ->
     ?LOG_ERROR(#{msg => ~"...", value => describe(V)}),
     ok.
+```
+
+## `lists:keyfind/3` cannot narrow, a comprehension can
+
+`keyfind/3` wants `[tuple()]`, and the term lists it is usually pointed at -
+`file:consult/1` output, a decoded Lua table, a literal config table - are
+`[term()]`. A tuple pattern in a generator narrows both the list and the value
+in one step:
+
+```erlang
+%% was: {profiles, Profiles} = lists:keyfind(profiles, 1, Terms)
+[Profiles] = [V || {K, V} <- Terms, K =:= profiles, is_list(V)],
 ```
 
 ## `dynamic()` is for boundaries, and only for boundaries

--- a/src/asobi_error.erl
+++ b/src/asobi_error.erl
@@ -382,7 +382,10 @@ is what asobi itself defines.
 """.
 -spec codes() -> [code()].
 codes() ->
-    core_codes() ++ lists:sort(maps:keys(asobi_extensions:error_codes())).
+    %% lists:sort/1 widens to [term()]; re-narrowed against code().
+    %% See docs/eqwalizer-idioms.md.
+    Extension = [C || C <- lists:sort(maps:keys(asobi_extensions:error_codes())), is_binary(C)],
+    core_codes() ++ Extension.
 
 -doc """
 The codes asobi itself defines.
@@ -472,9 +475,9 @@ register_handler() ->
 
 -spec entry(code()) -> {code(), pos_integer(), binary()} | false.
 entry(Code) ->
-    case lists:keyfind(Code, 1, ?CODES) of
-        false -> extension_entry(Code);
-        Entry -> Entry
+    case [E || {C, _, _} = E <- ?CODES, C =:= Code] of
+        [Entry | _] -> Entry;
+        [] -> extension_entry(Code)
     end.
 
 extension_entry(Code) ->
@@ -489,6 +492,9 @@ extension_entry(Code) ->
 -spec log_undefined(code()) -> ok.
 log_undefined(Code) ->
     case entry(Code) of
-        false -> ?LOG_ERROR(#{event => undefined_error_code, code => Code});
-        _ -> ok
+        false ->
+            ?LOG_ERROR(#{event => undefined_error_code, code => Code}),
+            ok;
+        _ ->
+            ok
     end.

--- a/src/asobi_game_modes.erl
+++ b/src/asobi_game_modes.erl
@@ -179,12 +179,15 @@ what `asobi_chat_acl` authorises against.
 -spec global_chat_channels() -> [binary()].
 global_chat_channels() ->
     Modes = asobi_game_config:modes(),
-    lists:usort([
+    %% lists:usort/1 widens to [term()]; re-narrowed rather than replaced.
+    %% See docs/eqwalizer-idioms.md.
+    Names = [
         Name
      || Config <- maps:values(Modes),
         is_map(Config),
         Name <- asobi_world_chat:global_channels(maps:get(chat, Config, #{}))
-    ]).
+    ],
+    [N || N <- lists:usort(Names), is_binary(N)].
 
 -spec forward_optional(map(), [atom()], map()) -> map().
 forward_optional(_Src, [], Acc) ->

--- a/src/console/asobi_console.erl
+++ b/src/console/asobi_console.erl
@@ -96,8 +96,14 @@ bundle() ->
             persistent_term:put(?KEY, Result),
             Result;
         Result ->
-            Result
+            narrow_bundle(Result)
     end.
+
+%% persistent_term:get/2 answers persistent_term:value(). What went in is
+%% resolve/0's own result, put one clause up, so this is a boundary rather than
+%% a shape worth re-deriving. See docs/eqwalizer-idioms.md.
+-spec narrow_bundle(dynamic()) -> {ok, bundle()} | {error, problem()}.
+narrow_bundle(Result) -> Result.
 
 -doc """
 One asset by basename, or `error` for anything not in the bundle.
@@ -129,6 +135,12 @@ load(Dir) ->
         {ok, Served} ?= names(declared(Manifest)),
         {ok, Assets} ?= read_assets(Dir, Served),
         {ok, #{script => Script, styles => stylesheets(Served), assets => Assets}}
+    else
+        %% Behaviour-identical to the implicit short circuit - every `?=` above
+        %% answers `{ok, _} | {error, problem()}`, so this is the only shape
+        %% that can reach here. Written out because eqwalizer cannot type a
+        %% `maybe` block without it.
+        {error, _} = Error -> Error
     end.
 
 %% Everything the manifest names, and nothing else. Deriving the served set
@@ -137,7 +149,7 @@ load(Dir) ->
 %% only ever a map key.
 -spec declared(map()) -> [binary()].
 declared(Manifest) ->
-    lists:usort(
+    usort_binaries(
         lists:append([
             [
                 maps:get(~"file", Chunk)
@@ -150,7 +162,17 @@ declared(Manifest) ->
 
 -spec collect(binary(), map()) -> [binary()].
 collect(Key, Manifest) ->
-    lists:append([maps:get(Key, Chunk, []) || Chunk <- maps:values(Manifest), is_map(Chunk)]).
+    binaries(
+        lists:append([maps:get(Key, Chunk, []) || Chunk <- maps:values(Manifest), is_map(Chunk)])
+    ).
+
+%% lists:usort/1 and lists:append/1 both widen to [term()]; re-narrowing keeps
+%% the real call. See docs/eqwalizer-idioms.md.
+-spec usort_binaries([term()]) -> [binary()].
+usort_binaries(L) -> [B || B <- lists:usort(L), is_binary(B)].
+
+-spec binaries([term()]) -> [binary()].
+binaries(L) -> [B || B <- L, is_binary(B)].
 
 %% Which of the served names are stylesheets the shell has to link. Vite emits
 %% the entry's CSS as its own manifest chunk when code splitting is off, so
@@ -226,15 +248,16 @@ is_entry(_Chunk) -> false.
 
 -spec names([term()]) -> {ok, [binary()]} | {error, problem()}.
 names(Paths) ->
-    lists:foldr(fun accumulate_name/2, {ok, []}, Paths).
+    names(Paths, []).
 
--spec accumulate_name(term(), {ok, [binary()]} | {error, problem()}) ->
-    {ok, [binary()]} | {error, problem()}.
-accumulate_name(_Path, {error, _} = Error) ->
-    Error;
-accumulate_name(Path, {ok, Acc}) ->
+%% Explicit recursion: see docs/eqwalizer-idioms.md. Order is preserved, as
+%% lists:foldr/3 did.
+-spec names([term()], [binary()]) -> {ok, [binary()]} | {error, problem()}.
+names([], Acc) ->
+    {ok, binaries(lists:reverse(Acc))};
+names([Path | Rest], Acc) ->
     case name(Path) of
-        {ok, Name} -> {ok, [Name | Acc]};
+        {ok, Name} -> names(Rest, [Name | Acc]);
         {error, _} = Error -> Error
     end.
 
@@ -280,15 +303,26 @@ is_name_char(_Char) -> false.
 -spec mime(binary()) -> binary() | error.
 mime(Name) ->
     Ext = string:lowercase(filename:extension(Name)),
-    case lists:keyfind(Ext, 1, ?MIME) of
-        {_, Mime} -> Mime;
-        false -> error
+    case [M || {E, M} <- ?MIME, E =:= Ext, is_binary(M)] of
+        [Mime | _] -> Mime;
+        [] -> error
     end.
 
 -spec read_assets(file:filename_all(), [binary()]) ->
     {ok, #{binary() => asset()}} | {error, problem()}.
 read_assets(Dir, Names) ->
-    lists:foldr(fun(Name, Acc) -> read_asset(Dir, Name, Acc) end, {ok, #{}}, Names).
+    read_assets(Dir, Names, #{}).
+
+%% Explicit recursion: see docs/eqwalizer-idioms.md.
+-spec read_assets(file:filename_all(), [binary()], #{binary() => asset()}) ->
+    {ok, #{binary() => asset()}} | {error, problem()}.
+read_assets(_Dir, [], Acc) ->
+    {ok, Acc};
+read_assets(Dir, [Name | Rest], Acc) ->
+    case read_asset(Dir, Name, {ok, Acc}) of
+        {ok, Next} -> read_assets(Dir, Rest, Next);
+        {error, _} = Error -> Error
+    end.
 
 -spec read_asset(file:filename_all(), binary(), {ok, map()} | {error, problem()}) ->
     {ok, map()} | {error, problem()}.
@@ -319,12 +353,14 @@ log({ok, #{script := Script, assets := Assets}}) ->
         msg => ~"console bundle loaded",
         script => Script,
         assets => map_size(Assets)
-    });
+    }),
+    ok;
 log({error, Problem}) ->
     ?LOG_WARNING(#{
         msg => ~"console bundle unavailable; /console answers 503",
         problem => Problem
-    }).
+    }),
+    ok.
 
 -ifdef(TEST).
 -spec reset() -> ok.

--- a/src/console/asobi_console.erl
+++ b/src/console/asobi_console.erl
@@ -103,7 +103,8 @@ bundle() ->
 %% resolve/0's own result, put one clause up, so this is a boundary rather than
 %% a shape worth re-deriving. See docs/eqwalizer-idioms.md.
 -spec narrow_bundle(dynamic()) -> {ok, bundle()} | {error, problem()}.
-narrow_bundle(Result) -> Result.
+narrow_bundle({ok, #{script := _, styles := _, assets := _}} = Ok) -> Ok;
+narrow_bundle({error, _} = Error) -> Error.
 
 -doc """
 One asset by basename, or `error` for anything not in the bundle.
@@ -147,9 +148,12 @@ load(Dir) ->
 %% from the build's own output rather than from a directory listing means a
 %% stray file that lands in `priv/console` is not reachable, and a name is
 %% only ever a map key.
--spec declared(map()) -> [binary()].
+%% [term()], deliberately: names/1 is what refuses a manifest value that is not
+%% a string, and it can only do that if the value reaches it. Re-narrowing here
+%% would drop the bad value silently and load a console missing a screen.
+-spec declared(map()) -> [term()].
 declared(Manifest) ->
-    usort_binaries(
+    lists:usort(
         lists:append([
             [
                 maps:get(~"file", Chunk)
@@ -160,16 +164,9 @@ declared(Manifest) ->
         ])
     ).
 
--spec collect(binary(), map()) -> [binary()].
+-spec collect(binary(), map()) -> [term()].
 collect(Key, Manifest) ->
-    binaries(
-        lists:append([maps:get(Key, Chunk, []) || Chunk <- maps:values(Manifest), is_map(Chunk)])
-    ).
-
-%% lists:usort/1 and lists:append/1 both widen to [term()]; re-narrowing keeps
-%% the real call. See docs/eqwalizer-idioms.md.
--spec usort_binaries([term()]) -> [binary()].
-usort_binaries(L) -> [B || B <- lists:usort(L), is_binary(B)].
+    lists:append([maps:get(Key, Chunk, []) || Chunk <- maps:values(Manifest), is_map(Chunk)]).
 
 -spec binaries([term()]) -> [binary()].
 binaries(L) -> [B || B <- L, is_binary(B)].
@@ -342,7 +339,11 @@ read_asset(Dir, Name, Acc) ->
                 Mime when is_binary(Mime) ->
                     {ok, Acc#{Name => #{body => Body, mime => Mime, etag => etag(Body)}}};
                 error ->
-                    {error, {asset_unreadable, Name, unknown_media_type}}
+                    %% Unreachable: name/1 refuses a name whose extension has
+                    %% no mime, on the same basename this re-derives. Raised
+                    %% rather than returned so it does not read as an outcome
+                    %% callers should expect from problem().
+                    error({unreachable, {no_mime, Name}})
             end;
         {error, Reason} ->
             {error, {asset_unreadable, Name, Reason}}

--- a/src/console/asobi_console.erl
+++ b/src/console/asobi_console.erl
@@ -319,22 +319,31 @@ read_assets(Dir, Names) ->
 read_assets(_Dir, [], Acc) ->
     {ok, Acc};
 read_assets(Dir, [Name | Rest], Acc) ->
-    case read_asset(Dir, Name, {ok, Acc}) of
+    case read_asset(Dir, Name, Acc) of
         {ok, Next} -> read_assets(Dir, Rest, Next);
         {error, _} = Error -> Error
     end.
 
--spec read_asset(file:filename_all(), binary(), {ok, map()} | {error, problem()}) ->
-    {ok, map()} | {error, problem()}.
-read_asset(_Dir, _Name, {error, _} = Error) ->
-    Error;
-read_asset(Dir, Name, {ok, Acc}) ->
+%% Takes the accumulator itself rather than a `{ok, _} | {error, _}`: the fold
+%% this replaced threaded the error through every remaining element, and
+%% read_assets/3 short-circuits instead. Dialyzer caught the leftover clause.
+-spec read_asset(file:filename_all(), binary(), #{binary() => asset()}) ->
+    {ok, #{binary() => asset()}} | {error, problem()}.
+read_asset(Dir, Name, Acc) ->
     Path = filename:join([Dir, ~"assets", Name]),
     case file:read_file(Path) of
         {ok, Body} ->
-            {ok, Acc#{
-                Name => #{body => Body, mime => mime(Name), etag => etag(Body)}
-            }};
+            %% name/1 already refuses a name whose extension has no mime, so
+            %% this restates an invariant rather than adding a check. Worth
+            %% restating: asset()'s mime is a binary, and the controller puts
+            %% it straight into a content-type header, so the atom `error`
+            %% reaching here would be a malformed response rather than a crash.
+            case mime(Name) of
+                Mime when is_binary(Mime) ->
+                    {ok, Acc#{Name => #{body => Body, mime => Mime, etag => etag(Body)}}};
+                error ->
+                    {error, {asset_unreadable, Name, unknown_media_type}}
+            end;
         {error, Reason} ->
             {error, {asset_unreadable, Name, Reason}}
     end.

--- a/src/extensions/asobi_extension_reserved.erl
+++ b/src/extensions/asobi_extension_reserved.erl
@@ -79,7 +79,7 @@ kinds() ->
     [tables, rpc, lua, queues, http].
 
 -doc "Core's reserved token set, per namespace kind.".
--spec namespaces() -> #{kind() := [asobi_extension:token()]}.
+-spec namespaces() -> #{kind() => [asobi_extension:token()]}.
 namespaces() ->
     Modules = core_modules(),
     Lua = lua(),
@@ -87,7 +87,7 @@ namespaces() ->
         tables => schema_tables(Modules),
         queues => worker_queues(Modules),
         lua => Lua,
-        rpc => lists:usort(error_domains() ++ Lua ++ core_wire_prefixes()),
+        rpc => tokens(lists:usort(error_domains() ++ Lua ++ core_wire_prefixes())),
         http => core_route_paths()
     }.
 
@@ -180,13 +180,16 @@ core_wire_prefixes() ->
 %% on a later app's path (nova_resilience's /health) would silently hijack
 %% it. `nova:get_env/2` reads the bootstrap application's env, which is
 %% exactly where nova_sup reads `nova_apps` from.
+-spec core_route_paths() -> [asobi_extension:token()].
 core_route_paths() ->
-    lists:usort([
-        Path
-     || App <- co_mounted_apps(),
-        Group <- app_route_groups(App),
-        Path <- group_paths(Group)
-    ]).
+    tokens(
+        lists:usort([
+            Path
+         || App <- co_mounted_apps(),
+            Group <- app_route_groups(App),
+            Path <- group_paths(Group)
+        ])
+    ).
 
 co_mounted_apps() ->
     NovaApps =
@@ -251,12 +254,15 @@ schema_tables(Modules) ->
 worker_queues(Modules) ->
     exported_values(Modules, queue, {perform, 1}).
 
+-spec lua() -> [asobi_extension:token()].
 lua() ->
-    lists:usort([
-        Namespace
-     || Path <- asobi_lua_surface:reserved_namespaces(),
-        Namespace <- lua_namespace(Path)
-    ]).
+    tokens(
+        lists:usort([
+            Namespace
+         || Path <- asobi_lua_surface:reserved_namespaces(),
+            Namespace <- lua_namespace(Path)
+        ])
+    ).
 
 %% `game` itself is reserved: an extension owning it would claim the root
 %% table every other namespace hangs off.
@@ -264,8 +270,15 @@ lua_namespace([~"game"]) -> [~"game"];
 lua_namespace([~"game", Namespace]) -> [Namespace];
 lua_namespace(_) -> [].
 
+-spec error_domains() -> [asobi_extension:token()].
 error_domains() ->
-    lists:usort([Domain || Code <- asobi_error:core_codes(), Domain <- domain(Code)]).
+    tokens(lists:usort([Domain || Code <- asobi_error:core_codes(), Domain <- domain(Code)])).
+
+%% lists:usort/1 widens to [term()]. Safe to re-narrow here: every producer
+%% above yields binaries, and unlike asobi_console's manifest paths nothing
+%% downstream validates these by name. See docs/eqwalizer-idioms.md.
+-spec tokens([term()]) -> [asobi_extension:token()].
+tokens(L) -> [T || T <- L, is_binary(T)].
 
 domain(Code) ->
     case binary:split(Code, ~".") of

--- a/src/extensions/rebar3_asobi_check.erl
+++ b/src/extensions/rebar3_asobi_check.erl
@@ -26,7 +26,13 @@ Core's reserved names come from the plugin's copy of asobi, which is the
 version in `project_plugins`. Pin it to the same tag as the dependency.
 """.
 
--behaviour(provider).
+%% No `-behaviour(provider).`: rebar3 dispatches a provider on its exported
+%% init/1, do/1 and format_error/1, not on the attribute, and the `provider`
+%% behaviour lives in rebar3 rather than in anything asobi depends on. Declaring
+%% it bought no callback checking - the module is simply absent - while making
+%% every type checker report a behaviour that does not exist. rebar.config
+%% already excludes both providers from dialyzer for the same reason, and
+%% asobi_extension_reserved_tests asserts the three exports are present.
 
 -export([init/1, do/1, format_error/1]).
 -ifdef(TEST).

--- a/src/extensions/rebar3_asobi_console.erl
+++ b/src/extensions/rebar3_asobi_console.erl
@@ -72,7 +72,13 @@ disagreeing is loud.
 See `guides/console-extensions.md`.
 """.
 
--behaviour(provider).
+%% No `-behaviour(provider).`: rebar3 dispatches a provider on its exported
+%% init/1, do/1 and format_error/1, not on the attribute, and the `provider`
+%% behaviour lives in rebar3 rather than in anything asobi depends on. Declaring
+%% it bought no callback checking - the module is simply absent - while making
+%% every type checker report a behaviour that does not exist. rebar.config
+%% already excludes both providers from dialyzer for the same reason, and
+%% asobi_extension_reserved_tests asserts the three exports are present.
 
 -export([init/1, do/1, format_error/1]).
 
@@ -255,9 +261,12 @@ with_console(#{app := App, name := Name}, Dirs) ->
     end.
 
 output(State, Args, Dirs) ->
+    %% proplists:get_value/2 answers term(); rebar3 hands `--out` through as a
+    %% string. See docs/eqwalizer-idioms.md.
     case proplists:get_value(out, Args) of
-        undefined -> configured_output(State, Dirs);
-        Path -> {ok, filename:absname(Path)}
+        Path when is_binary(Path) -> {ok, filename:absname(Path)};
+        Path when is_list(Path) -> {ok, filename:absname([C || C <- Path, is_integer(C)])};
+        _ -> configured_output(State, Dirs)
     end.
 
 configured_output(State, Dirs) ->
@@ -372,7 +381,7 @@ host_config(Out, Args) ->
         " },\n",
         "  server: {\n",
         "    port: ",
-        integer_to_list(proplists:get_value(port, Args, ?DEFAULT_PORT)),
+        integer_to_list(port_of(Args)),
         ",\n",
         "    strictPort: true,\n",
         "    // Same-origin through the proxy, so config.js reads no api base and takes\n",
@@ -414,8 +423,20 @@ dev_document() ->
 %% Escaping only the quote left `--out 'x\'` closing the literal it was meant
 %% to sit inside, which put the rest of the argument in the generated config as
 %% JavaScript that `vite` then ran.
+-spec port_of([term()]) -> integer().
+port_of(Args) ->
+    case proplists:get_value(port, Args, ?DEFAULT_PORT) of
+        Port when is_integer(Port) -> Port;
+        _ -> ?DEFAULT_PORT
+    end.
+
 quote(Value) ->
-    json:encode(unicode:characters_to_binary(Value)).
+    %% characters_to_binary/1 can answer an error tuple on malformed input; a
+    %% provider argument that is not valid unicode is a bad invocation, and
+    %% failing here beats emitting it into the generated vite config.
+    case unicode:characters_to_binary(Value) of
+        Binary when is_binary(Binary) -> json:encode(Binary)
+    end.
 
 %%====================================================================
 %% npm and Vite
@@ -435,7 +456,7 @@ install(Workspace, Args) ->
 run(Workspace, Out, Args) ->
     case proplists:get_value(dev, Args, false) of
         true ->
-            Port = integer_to_list(proplists:get_value(port, Args, ?DEFAULT_PORT)),
+            Port = integer_to_list(port_of(Args)),
             Target = proplists:get_value(target, Args, ?DEFAULT_TARGET),
             rebar_api:info("asobi: dev server on http://localhost:~ts, ops API proxied at ~ts", [
                 Port, Target

--- a/src/ops/asobi_ops_page.erl
+++ b/src/ops/asobi_ops_page.erl
@@ -67,8 +67,21 @@ slice(Rows, Orders, #{limit := Limit, offset := Offset}, Project) when
     is_integer(Limit), Limit > 0, is_integer(Offset), Offset >= 0
 ->
     Total = length(Rows),
-    Sorted = lists:sort(fun(A, B) -> precedes(Orders, A, B) end, Rows),
-    Window = lists:sublist(lists:nthtail(min(Offset, Total), Sorted), Limit),
+    %% lists:sort/2 erases the element type; the comprehension restores it and
+    %% drops nothing, since Rows is already [map()].
+    %% See docs/eqwalizer-idioms.md.
+    Sorted = [
+        R
+     || R <- lists:sort(
+            fun
+                (A, B) when is_map(A), is_map(B) -> precedes(Orders, A, B);
+                (_A, _B) -> false
+            end,
+            Rows
+        ),
+        is_map(R)
+    ],
+    Window = [W || W <- lists:sublist(lists:nthtail(min(Offset, Total), Sorted), Limit), is_map(W)],
     #{
         data => [Project(Row) || Row <- Window],
         page => #{limit => Limit, offset => Offset, total => Total}

--- a/src/ops/asobi_ops_params.erl
+++ b/src/ops/asobi_ops_params.erl
@@ -97,9 +97,9 @@ the tie-breaker is named by the endpoint rather than assumed.
 sort(Params, Allowed, Default, TieBreak) ->
     case maps:get(~"sort", Params, undefined) of
         Field when is_binary(Field), Field =/= ~"" ->
-            case lists:keyfind(Field, 1, Allowed) of
-                {_, Column} -> sorted_by(Column, Params, TieBreak);
-                false -> {error, {unknown_sort, Field}}
+            case [C || {F, C} <- Allowed, F =:= Field, is_atom(C)] of
+                [Column | _] -> sorted_by(Column, Params, TieBreak);
+                [] -> {error, {unknown_sort, Field}}
             end;
         _ ->
             {ok, deterministic(Default, TieBreak)}

--- a/src/ws/asobi_ws_handler.erl
+++ b/src/ws/asobi_ws_handler.erl
@@ -533,7 +533,8 @@ log_unhandled_info(Info) ->
                 event => ws_unhandled_info,
                 tag => Tag,
                 suppressed_since_last => DroppedSinceLastLog
-            });
+            }),
+            ok;
         false ->
             ok
     end.
@@ -547,12 +548,19 @@ unhandled_tag(Info) -> plain_tag(Info).
 
 -spec plain_tag(term()) -> atom().
 plain_tag(Tag) when is_atom(Tag) -> Tag;
-plain_tag(Tuple) when is_tuple(Tuple), tuple_size(Tuple) > 0, is_atom(element(1, Tuple)) ->
-    element(1, Tuple);
+plain_tag(Tuple) when is_tuple(Tuple), tuple_size(Tuple) > 0 ->
+    case erlang:element(1, Tuple) of
+        Tag when is_atom(Tag) -> Tag;
+        _ -> unknown
+    end;
 plain_tag(_) ->
     unknown.
 
--spec terminate(term(), term(), map()) -> ok.
+%% `term()` for the state, not `map()`: the second clause below exists so that
+%% a shape terminate/3 was never designed for cannot crash the process on the
+%% way out, and asobi_ws_handler_tests asserts it. The narrower spec described
+%% the first clause rather than the function.
+-spec terminate(term(), term(), term()) -> ok.
 %% Decrements the connection gauge ONLY if this process incremented it, which is
 %% not every process that reaches here.
 %%
@@ -580,8 +588,8 @@ terminate(_Reason, _Req, State) when is_map(State) ->
     end,
     session_disconnected(State),
     case maps:get(session, State, undefined) of
-        undefined -> ok;
-        SessionPid -> asobi_player_session:stop(SessionPid)
+        SessionPid when is_pid(SessionPid) -> asobi_player_session:stop(SessionPid);
+        _ -> ok
     end,
     ok;
 terminate(_Reason, _Req, _State) ->

--- a/test/asobi_bot_spawner_tests.erl
+++ b/test/asobi_bot_spawner_tests.erl
@@ -87,7 +87,11 @@ bot_id_test_() ->
 bot_ids_are_distinct() ->
     Ids = [asobi_bot_spawner:bot_id(~"Spark") || _ <- lists:seq(1, 50)],
     ?assertEqual(50, length(lists:usort(Ids))),
-    ?assert(lists:all(fun(Id) -> asobi_bot_spawner:name_part(Id) =:= ~"Spark" end, Ids)).
+    ?assertEqual([], [Id || Id <- Ids, asobi_bot_spawner:name_part(Id) =/= ~"Spark"]).
+
+%% tl/1 erases the element type. See docs/eqwalizer-idioms.md.
+-spec all_but_first([binary()]) -> [binary()].
+all_but_first([_ | Rest]) -> Rest.
 
 name_round_trips() ->
     ?assertEqual(~"Spark", asobi_bot_spawner:name_part(asobi_bot_spawner:bot_id(~"Spark"))).
@@ -114,7 +118,7 @@ ceiling_boundary() ->
     ),
     ?assertEqual(
         ok,
-        asobi_bot_spawner:add_bot_refusal(~"TheLastOne", tl(Bots), 1000)
+        asobi_bot_spawner:add_bot_refusal(~"TheLastOne", all_but_first(Bots), 1000)
     ).
 
 second_match_bot_gets_an_ai() ->

--- a/test/asobi_console_routes_tests.erl
+++ b/test/asobi_console_routes_tests.erl
@@ -64,20 +64,18 @@ until(Quote, Rest) ->
 
 %% `${...}` is a bound segment, and nothing else in these paths is dynamic.
 normalise(Path) ->
-    iolist_to_binary(
-        lists:join(~"/", [
-            case binary:match(Segment, ~"${") of
-                nomatch -> Segment;
-                _ -> ~"_"
-            end
-         || Segment <- binary:split(Path, ~"/", [global])
-        ])
-    ).
+    asobi_test_helpers:binary_join(~"/", [
+        case binary:match(Segment, ~"${") of
+            nomatch -> Segment;
+            _ -> ~"_"
+        end
+     || Segment <- binary:split(Path, ~"/", [global])
+    ]).
 
 %% The same table, as the paths a caller writes.
 declared() ->
     lists:usort([
-        iolist_to_binary([~"/", lists:join(~"/", [segment(S) || S <- Segments])])
+        <<"/", (asobi_test_helpers:binary_join(~"/", [segment(S) || S <- Segments]))/binary>>
      || {get, Segments, _Class} <- asobi_ops_caps:classes()
     ]).
 

--- a/test/asobi_console_tests.erl
+++ b/test/asobi_console_tests.erl
@@ -53,7 +53,10 @@ refused(Json) ->
     end.
 
 committed() ->
-    asobi_console:load(filename:join(code:priv_dir(asobi), "console")).
+    %% code:priv_dir/1 answers file:filename() | {error, bad_name}.
+    case code:priv_dir(asobi) of
+        Priv when is_list(Priv) -> asobi_console:load(filename:join(Priv, "console"))
+    end.
 
 %%--------------------------------------------------------------------
 %% The happy path

--- a/test/asobi_console_tests.erl
+++ b/test/asobi_console_tests.erl
@@ -129,6 +129,29 @@ refuses_a_bare_dot_segment_test_() ->
     ),
     fixture(fun(Dir) -> ?_assertMatch({error, {bad_asset_name, _}}, Refused(Dir)) end).
 
+%% asobi#435 tranche 2: a manifest value that is not a string is refused BY
+%% NAME, not filtered out of the served set. Narrowing declared/1 and collect/2
+%% for the type checker dropped the bad value before names/1 could see it, and
+%% the console then loaded silently with a screen missing. See
+%% docs/eqwalizer-idioms.md on not filtering ahead of a validator.
+refuses_a_non_string_manifest_path_test_() ->
+    Refused = refused(
+        ~"""
+    {"src/main.jsx": {"file": "assets/main-Ca5kJxSg.js", "isEntry": true},
+     "src/late.jsx": {"file": 12345}}
+    """
+    ),
+    fixture(fun(Dir) -> ?_assertMatch({error, {bad_asset_name, _}}, Refused(Dir)) end).
+
+refuses_a_non_string_stylesheet_test_() ->
+    Refused = refused(
+        ~"""
+    {"src/main.jsx": {"file": "assets/main-Ca5kJxSg.js", "isEntry": true,
+                      "css": [67890]}}
+    """
+    ),
+    fixture(fun(Dir) -> ?_assertMatch({error, {bad_asset_name, _}}, Refused(Dir)) end).
+
 refuses_a_dotfile_test_() ->
     Refused = refused(
         ~"""

--- a/test/asobi_cors_SUITE.erl
+++ b/test/asobi_cors_SUITE.erl
@@ -113,7 +113,8 @@ assert_preflight_ok(Path, #{status := Status} = Resp) ->
 
 -spec header(binary(), nova_test:response()) -> binary() | undefined.
 header(Name, #{headers := Headers}) ->
-    case lists:keyfind(binary_to_list(Name), 1, Headers) of
-        {_, Value} -> list_to_binary(Value);
-        false -> undefined
+    Wanted = binary_to_list(Name),
+    case [V || {K, V} <- Headers, K =:= Wanted, is_list(V)] of
+        [Value | _] -> list_to_binary(Value);
+        [] -> undefined
     end.

--- a/test/asobi_dgram_gw_tests.erl
+++ b/test/asobi_dgram_gw_tests.erl
@@ -62,7 +62,7 @@ gw_role_starts_no_engine() ->
 %% boundary; a regression here is the security property gone, not a feature loss.
 gateway_application_is_minimal() ->
     _ = application:load(asobi_dgram_gw),
-    {ok, Deps} = application:get_key(asobi_dgram_gw, applications),
+    Deps = app_applications(asobi_dgram_gw),
     ?assertEqual([], Deps -- [kernel, stdlib, crypto, telemetry, seki]),
     [
         ?assertNot(lists:member(Heavy, Deps))
@@ -71,8 +71,15 @@ gateway_application_is_minimal() ->
     %% ...and the engine still depends on it, which is the direction that makes
     %% the codec shared without making the gateway carry the engine.
     _ = application:load(asobi),
-    {ok, AsobiDeps} = application:get_key(asobi, applications),
-    ?assert(lists:member(asobi_dgram_gw, AsobiDeps)).
+    ?assert(lists:member(asobi_dgram_gw, app_applications(asobi))).
+
+%% application:get_key/2 answers {ok, term()}. See docs/eqwalizer-idioms.md.
+-spec app_applications(atom()) -> [atom()].
+app_applications(App) ->
+    {ok, Value} = application:get_key(App, applications),
+    case Value of
+        List when is_list(List) -> [A || A <- List, is_atom(A)]
+    end.
 
 %% asobi#530: `asobi` lists `asobi_dgram_gw` in `applications` for the shared
 %% codec, so this supervisor's `init/1` runs on every engine. Returning the child

--- a/test/asobi_dgram_pose_tests.erl
+++ b/test/asobi_dgram_pose_tests.erl
@@ -147,14 +147,21 @@ axial_covers_everything() ->
     Entities = maps:from_keys(Ids, pos(1.0, 2.0)),
     {ok, Slots} = asobi_wire_slots:sync(Entities, asobi_wire_slots:new()),
     #{period_ticks := Period} = M,
-    Slotted = [
-        S
-     || Tick <- lists:seq(0, Period - 1),
-        {Records, 0} <- [asobi_dgram_pose:records(#{}, Entities, Slots, M, Tick)],
-        #{slot := S} <- Records
-    ],
+    Slotted = [S || Tick <- lists:seq(0, Period - 1), S <- tick_slots(Entities, Slots, M, Tick)],
     Seen = sets:from_list(Slotted, [{version, 2}]),
     ?assertEqual(40, sets:size(Seen)).
+
+%% A pattern in a GENERATOR is a filter, not a match: `{Records, 0} <- [...]`
+%% would silently skip a saturated tick, where the fold this replaced asserted
+%% on the count. asobi_dgram_pose treats saturation as something worth knowing
+%% before players report teleporting, so it stays a hard match.
+-spec tick_slots(map(), asobi_wire_slots:slots(), map(), non_neg_integer()) -> [integer()].
+tick_slots(Entities, Slots, M, Tick) ->
+    {Records, 0} = asobi_dgram_pose:records(#{}, Entities, Slots, M, Tick),
+    [slot_of(R) || R <- Records].
+
+-spec slot_of(map()) -> integer().
+slot_of(#{slot := S}) -> S.
 
 %% --- Edges ---
 

--- a/test/asobi_dgram_pose_tests.erl
+++ b/test/asobi_dgram_pose_tests.erl
@@ -147,14 +147,13 @@ axial_covers_everything() ->
     Entities = maps:from_keys(Ids, pos(1.0, 2.0)),
     {ok, Slots} = asobi_wire_slots:sync(Entities, asobi_wire_slots:new()),
     #{period_ticks := Period} = M,
-    Seen = lists:foldl(
-        fun(Tick, Acc) ->
-            {Records, 0} = asobi_dgram_pose:records(#{}, Entities, Slots, M, Tick),
-            lists:foldl(fun(#{slot := S}, A) -> sets:add_element(S, A) end, Acc, Records)
-        end,
-        sets:new([{version, 2}]),
-        lists:seq(0, Period - 1)
-    ),
+    Slotted = [
+        S
+     || Tick <- lists:seq(0, Period - 1),
+        {Records, 0} <- [asobi_dgram_pose:records(#{}, Entities, Slots, M, Tick)],
+        #{slot := S} <- Records
+    ],
+    Seen = sets:from_list(Slotted, [{version, 2}]),
     ?assertEqual(40, sets:size(Seen)).
 
 %% --- Edges ---

--- a/test/asobi_eunit_config_tests.erl
+++ b/test/asobi_eunit_config_tests.erl
@@ -6,7 +6,22 @@
 %% it and turning a green suite red at random.
 scale_timeouts_configured_test() ->
     {ok, Terms} = file:consult("rebar.config"),
-    {profiles, Profiles} = lists:keyfind(profiles, 1, Terms),
-    {test, TestProfile} = lists:keyfind(test, 1, Profiles),
-    {eunit_opts, EunitOpts} = lists:keyfind(eunit_opts, 1, TestProfile),
-    ?assert(proplists:get_value(scale_timeouts, EunitOpts, 1) >= 2).
+    Profiles = section(profiles, Terms),
+    TestProfile = section(test, Profiles),
+    EunitOpts = section(eunit_opts, TestProfile),
+    ?assert(int_opt(scale_timeouts, EunitOpts, 1) >= 2).
+
+%% A comprehension rather than lists:keyfind/3: file:consult/1 answers
+%% [term()], keyfind wants [tuple()], and the tuple pattern in a generator
+%% narrows where keyfind cannot. See docs/eqwalizer-idioms.md.
+-spec section(atom(), [term()]) -> [term()].
+section(Key, Terms) ->
+    [Section] = [V || {K, V} <- Terms, K =:= Key, is_list(V)],
+    Section.
+
+-spec int_opt(atom(), [term()], integer()) -> integer().
+int_opt(Key, Opts, Default) ->
+    case [V || {K, V} <- Opts, K =:= Key, is_integer(V)] of
+        [V | _] -> V;
+        [] -> Default
+    end.

--- a/test/asobi_game_modes_tests.erl
+++ b/test/asobi_game_modes_tests.erl
@@ -114,10 +114,10 @@ setup_lua() ->
     Prev.
 
 cleanup_lua(Prev) ->
-    lists:foreach(
-        fun(Kind) -> ok = asobi_game_modes:unregister_game_mode(Kind) end,
-        [lua_world, lua_match, lua_match_shared]
-    ),
+    _ = [
+        ok = asobi_game_modes:unregister_game_mode(Kind)
+     || Kind <- [lua_world, lua_match, lua_match_shared]
+    ],
     cleanup(Prev).
 
 lua_without_provider() ->

--- a/test/asobi_lua_bot_tests.erl
+++ b/test/asobi_lua_bot_tests.erl
@@ -103,11 +103,19 @@ think_returning_map_works_test() ->
     try
         {ok, St} = asobi_lua_loader:new(Path),
         {ok, [Result | _], St1} = asobi_lua_loader:call(think, [~"bot1", #{}], St, 50),
-        Decoded = luerl:decode(Result, St1),
+        Decoded = decode(Result, St1),
         ?assert(is_list(Decoded)),
-        ?assertEqual(true, proplists:get_value(~"right", Decoded))
+        ?assertEqual([true], [V || {K, V} <- Decoded, K =:= ~"right"])
     after
         file:delete(Path)
+    end.
+
+%% luerl:decode/2 takes and answers Lua values, so both sides are a boundary.
+%% See docs/eqwalizer-idioms.md.
+-spec decode(dynamic(), dynamic()) -> [{term(), term()}].
+decode(Value, St) ->
+    case luerl:decode(Value, St) of
+        Decoded when is_list(Decoded) -> [{K, V} || {K, V} <- Decoded]
     end.
 
 %% --- bot_names global ---
@@ -115,8 +123,7 @@ think_returning_map_works_test() ->
 names_global_decodes_test() ->
     {ok, St} = asobi_lua_loader:new(fixture("bots/named_bot.lua")),
     {ok, Val, St1} = luerl:get_table_keys([~"names"], St),
-    Names = luerl:decode(Val, St1),
-    NameList = [V || {_, V} <- Names, is_binary(V)],
+    NameList = [V || {_, V} <- decode(Val, St1), is_binary(V)],
     ?assertEqual([~"Spark", ~"Blitz", ~"Volt", ~"Neon", ~"Pulse"], NameList).
 
 names_absent_returns_nil_or_false_test() ->

--- a/test/asobi_lua_release_config_tests.erl
+++ b/test/asobi_lua_release_config_tests.erl
@@ -28,9 +28,9 @@ dev_config_declares_kura_backend_test() ->
 
 -spec kura_env([{atom(), term()}]) -> [{atom(), term()}].
 kura_env(Config) ->
-    case proplists:get_value(kura, Config) of
-        Env when is_list(Env) -> Env;
-        _ -> error(no_kura_app_in_config)
+    case [V || {K, V} <- Config, K =:= kura, is_list(V)] of
+        [Env | _] -> [{K, V} || {K, V} <- Env, is_atom(K)];
+        [] -> error(no_kura_app_in_config)
     end.
 
 -spec consult_config(string()) -> [{atom(), term()}].
@@ -41,7 +41,11 @@ consult_config(Name) ->
     ok = file:write_file(Tmp, Substituted),
     {ok, [Config]} = file:consult(Tmp),
     ok = file:delete(Tmp),
-    Config.
+    %% file:consult/1 answers [term()], so the term has to be narrowed to a
+    %% list before it can be walked. See docs/eqwalizer-idioms.md.
+    case Config of
+        Terms when is_list(Terms) -> [{K, V} || {K, V} <- Terms, is_atom(K)]
+    end.
 
 -spec locate(string()) -> file:filename_all().
 locate(Name) ->
@@ -49,7 +53,7 @@ locate(Name) ->
         filename:join(["config", Name]),
         filename:join([filename:dirname(?FILE), "..", "config", Name])
     ],
-    case lists:dropwhile(fun(P) -> not filelib:is_regular(P) end, Candidates) of
+    case [P || P <- Candidates, filelib:is_regular(P)] of
         [Path | _] -> Path;
         [] -> error({config_not_found, Name})
     end.

--- a/test/asobi_ops_leaderboards_tests.erl
+++ b/test/asobi_ops_leaderboards_tests.erl
@@ -45,6 +45,9 @@ enumeration_is_grouped_and_capped() ->
     expect_groups([]),
     meck:reset(asobi_repo),
     {ok, _} = asobi_leaderboards:boards(),
+    %% Exactly one call, which is what "grouped and capped" means and why
+    %% meck:reset/1 is above: an added asobi_repo:one/1 must fail here.
+    ?assertMatch([_], meck:history(asobi_repo)),
     [Query] = [
         Q
      || {_, {asobi_repo, all, [Q]}, _} <- meck:history(asobi_repo), is_record(Q, kura_query)

--- a/test/asobi_ops_leaderboards_tests.erl
+++ b/test/asobi_ops_leaderboards_tests.erl
@@ -45,7 +45,10 @@ enumeration_is_grouped_and_capped() ->
     expect_groups([]),
     meck:reset(asobi_repo),
     {ok, _} = asobi_leaderboards:boards(),
-    [{_, {asobi_repo, all, [Query]}, _}] = meck:history(asobi_repo),
+    [Query] = [
+        Q
+     || {_, {asobi_repo, all, [Q]}, _} <- meck:history(asobi_repo), is_record(Q, kura_query)
+    ],
     ?assertEqual([leaderboard_id], Query#kura_query.group_bys),
     ?assertEqual([{leaderboard_id, asc}], Query#kura_query.order_bys),
     ?assertEqual(1000, Query#kura_query.limit).
@@ -141,7 +144,10 @@ entries_default_order_is_the_board_order_test() ->
 entries_rank_window_matches_the_board_order_test() ->
     {ok, Query} = asobi_ops_leaderboards:entries_query(~"arena", #{}),
     {exprs, Exprs} = Query#kura_query.select,
-    {rank, {over, row_number, #{order_by := WindowOrder}}} = lists:keyfind(rank, 1, Exprs),
+    [#{order_by := WindowOrder}] = [
+        W
+     || {rank, {over, row_number, W}} <- Exprs, is_map(W)
+    ],
     ?assertEqual(asobi_leaderboards:board_order(), WindowOrder),
     ?assertEqual(WindowOrder, Query#kura_query.order_bys).
 

--- a/test/asobi_protocol_coverage_tests.erl
+++ b/test/asobi_protocol_coverage_tests.erl
@@ -302,7 +302,7 @@ scan_handled_inbound_types(Bin) ->
 scan_extension_frame_types(Bin) ->
     Re = "extension_frames\\(\\s*~\"([a-z][a-z._]*)\",\\s*~\"([a-z][a-z._]*)\"",
     case re:run(Bin, Re, [global, {capture, all_but_first, binary}]) of
-        {match, Matches} -> lists:append(Matches);
+        {match, Matches} -> [B || Group <- Matches, is_list(Group), B <- Group, is_binary(B)];
         nomatch -> []
     end.
 
@@ -424,8 +424,10 @@ guide_documents_the_reserved_event_names_test() ->
 scan_documented_reserved_names(Bin) ->
     Re = "BEGIN reserved-event-names.*?```\\s*(.*?)```",
     case re:run(Bin, Re, [dotall, {capture, all_but_first, binary}]) of
-        {match, [Block]} -> binary:split(Block, [~" ", ~"\n"], [global, trim_all]);
-        nomatch -> []
+        {match, [Block]} when is_binary(Block) ->
+            binary:split(Block, [~" ", ~"\n"], [global, trim_all]);
+        nomatch ->
+            []
     end.
 
 %% Every server->client frame family (the token before the first dot) must be a

--- a/test/asobi_social_api_SUITE.erl
+++ b/test/asobi_social_api_SUITE.erl
@@ -120,8 +120,8 @@ auth(Token) when is_binary(Token) ->
 %% --- Group API ---
 
 show_group(Config) ->
-    {group_id, GroupId} = lists:keyfind(group_id, 1, Config),
-    {player1_token, Token} = lists:keyfind(player1_token, 1, Config),
+    GroupId = cfg(group_id, Config),
+    Token = cfg(player1_token, Config),
     true = is_binary(GroupId),
     true = is_binary(Token),
     {ok, Resp} = nova_test:get(
@@ -135,7 +135,7 @@ show_group(Config) ->
     Config.
 
 show_group_not_found(Config) ->
-    {player1_token, Token} = lists:keyfind(player1_token, 1, Config),
+    Token = cfg(player1_token, Config),
     true = is_binary(Token),
     {ok, Resp} = nova_test:get(
         "/api/v1/groups/00000000-0000-0000-0000-000000000000",
@@ -146,8 +146,8 @@ show_group_not_found(Config) ->
     Config.
 
 leave_group(Config) ->
-    {group_id, GroupId} = lists:keyfind(group_id, 1, Config),
-    {player2_token, Token} = lists:keyfind(player2_token, 1, Config),
+    GroupId = cfg(group_id, Config),
+    Token = cfg(player2_token, Config),
     true = is_binary(GroupId),
     true = is_binary(Token),
     {ok, Resp} = nova_test:post(
@@ -160,8 +160,8 @@ leave_group(Config) ->
     Config.
 
 leave_group_not_member(Config) ->
-    {group_id, GroupId} = lists:keyfind(group_id, 1, Config),
-    {player2_token, Token} = lists:keyfind(player2_token, 1, Config),
+    GroupId = cfg(group_id, Config),
+    Token = cfg(player2_token, Config),
     true = is_binary(GroupId),
     true = is_binary(Token),
     {ok, Resp} = nova_test:post(
@@ -177,7 +177,7 @@ leave_group_not_member(Config) ->
 %% F-10: arbitrary channel ids that don't correspond to a group the
 %% requester is a member of must return 403, not leak history.
 chat_history_unauthorized_arbitrary_channel(Config) ->
-    {player1_token, Token} = lists:keyfind(player1_token, 1, Config),
+    Token = cfg(player1_token, Config),
     true = is_binary(Token),
     {ok, Resp} = nova_test:get(
         "/api/v1/chat/nonexistent_channel/history",
@@ -188,8 +188,8 @@ chat_history_unauthorized_arbitrary_channel(Config) ->
     Config.
 
 chat_history_with_messages(Config) ->
-    {channel_id, ChannelId} = lists:keyfind(channel_id, 1, Config),
-    {player1_token, Token} = lists:keyfind(player1_token, 1, Config),
+    ChannelId = cfg(channel_id, Config),
+    Token = cfg(player1_token, Config),
     true = is_binary(ChannelId),
     true = is_binary(Token),
     {ok, Resp} = nova_test:get(
@@ -206,8 +206,8 @@ chat_history_with_messages(Config) ->
 %% F-10: a player who is not a member of the group MUST not be able to
 %% read its chat history.
 chat_history_non_member_forbidden(Config) ->
-    {channel_id, ChannelId} = lists:keyfind(channel_id, 1, Config),
-    {player3_token, Token} = lists:keyfind(player3_token, 1, Config),
+    ChannelId = cfg(channel_id, Config),
+    Token = cfg(player3_token, Config),
     true = is_binary(ChannelId),
     true = is_binary(Token),
     {ok, Resp} = nova_test:get(
@@ -218,11 +218,19 @@ chat_history_non_member_forbidden(Config) ->
     ?assertStatus(403, Resp),
     Config.
 
+%% CT's config is a [tuple()] of term() values, so a lists:keyfind/3 result
+%% cannot be typed and every id or token read out of it widened. One accessor
+%% instead of twenty-four keyfinds. See docs/eqwalizer-idioms.md.
+-spec cfg(atom(), [tuple()]) -> binary().
+cfg(Key, Config) ->
+    [Value | _] = [V || {K, V} <- Config, K =:= Key, is_binary(V)],
+    Value.
+
 %% F-10: DM channels (`dm:A:B`) must only be readable by A or B.
 chat_history_dm_non_participant_forbidden(Config) ->
-    {player1_id, P1Id} = lists:keyfind(player1_id, 1, Config),
-    {player2_id, P2Id} = lists:keyfind(player2_id, 1, Config),
-    {player3_token, EavesdropToken} = lists:keyfind(player3_token, 1, Config),
+    P1Id = cfg(player1_id, Config),
+    P2Id = cfg(player2_id, Config),
+    EavesdropToken = cfg(player3_token, Config),
     DmChannel = asobi_dm:channel_id(P1Id, P2Id),
     true = is_binary(DmChannel),
     {ok, Resp} = nova_test:get(
@@ -234,9 +242,9 @@ chat_history_dm_non_participant_forbidden(Config) ->
     Config.
 
 chat_history_dm_participant_allowed(Config) ->
-    {player1_id, P1Id} = lists:keyfind(player1_id, 1, Config),
-    {player1_token, Token} = lists:keyfind(player1_token, 1, Config),
-    {player2_id, P2Id} = lists:keyfind(player2_id, 1, Config),
+    P1Id = cfg(player1_id, Config),
+    Token = cfg(player1_token, Config),
+    P2Id = cfg(player2_id, Config),
     DmChannel = asobi_dm:channel_id(P1Id, P2Id),
     {ok, Resp} = nova_test:get(
         "/api/v1/chat/" ++ binary_to_list(DmChannel) ++ "/history",
@@ -256,8 +264,8 @@ chat_history_dm_participant_allowed(Config) ->
 %% the earlier `leave_group` test case, and both groups share init_per_suite
 %% fixtures, so player1 is the only membership guaranteed still live here.
 room_channel_member_authorized(Config) ->
-    {group_id, GroupId} = lists:keyfind(group_id, 1, Config),
-    {player1_id, P1Id} = lists:keyfind(player1_id, 1, Config),
+    GroupId = cfg(group_id, Config),
+    P1Id = cfg(player1_id, Config),
     RoomChannel = <<"room:", GroupId/binary>>,
     ?assert(asobi_chat_acl:authorized(RoomChannel, P1Id)),
     Config.
@@ -265,8 +273,8 @@ room_channel_member_authorized(Config) ->
 %% Regression for #295: a non-member must still be rejected once the
 %% `room:` prefix is stripped correctly (closed by default).
 room_channel_non_member_rejected(Config) ->
-    {group_id, GroupId} = lists:keyfind(group_id, 1, Config),
-    {player3_id, P3Id} = lists:keyfind(player3_id, 1, Config),
+    GroupId = cfg(group_id, Config),
+    P3Id = cfg(player3_id, Config),
     RoomChannel = <<"room:", GroupId/binary>>,
     ?assertNot(asobi_chat_acl:authorized(RoomChannel, P3Id)),
     Config.
@@ -275,7 +283,7 @@ room_channel_non_member_rejected(Config) ->
 %% no group must be denied, not merely fall through to an empty membership
 %% lookup by coincidence.
 room_channel_nonexistent_group_denied(Config) ->
-    {player1_id, P1Id} = lists:keyfind(player1_id, 1, Config),
+    P1Id = cfg(player1_id, Config),
     Ghost = asobi_id:generate(),
     ?assertNot(asobi_chat_acl:authorized(<<"room:", Ghost/binary>>, P1Id)),
     Config.
@@ -284,7 +292,7 @@ room_channel_nonexistent_group_denied(Config) ->
 %% empty, or carrying injection-shaped garbage) must be denied outright by
 %% classify/1's uuid-shape check rather than reaching the DB query.
 room_channel_malformed_group_id_denied(Config) ->
-    {player1_id, P1Id} = lists:keyfind(player1_id, 1, Config),
+    P1Id = cfg(player1_id, Config),
     [
         ?assertNot(asobi_chat_acl:authorized(C, P1Id))
      || C <- [~"room:abc", ~"room:", ~"room:' OR 1=1 --"]

--- a/test/asobi_steam_tests.erl
+++ b/test/asobi_steam_tests.erl
@@ -82,8 +82,8 @@ outbound_call_sets_tls_options() ->
     _ = asobi_steam:validate_ticket(~"deadbeef"),
     receive
         {opts, Opts} ->
-            {ssl, Ssl} = lists:keyfind(ssl, 1, Opts),
-            ?assertEqual(verify_peer, proplists:get_value(verify, Ssl))
+            [Ssl] = [V || {K, V} <- Opts, K =:= ssl, is_list(V)],
+            ?assertEqual([verify_peer], [V || {K, V} <- Ssl, K =:= verify])
     after 1000 -> ?assert(false)
     end.
 

--- a/test/asobi_test_helpers.erl
+++ b/test/asobi_test_helpers.erl
@@ -1,6 +1,6 @@
 -module(asobi_test_helpers).
 
--export([start/1, unique_username/1, unique_id/1]).
+-export([start/1, unique_username/1, unique_id/1, binary_join/2]).
 -export([http_routes/1, routes_missing_options/1, preflight_targets/1, sample_path/1]).
 
 -spec start(list()) -> list().
@@ -60,7 +60,13 @@ routes_missing_options(Groups) ->
 %% carry a protocol handler (the WebSocket group) have no preflight to make.
 -spec preflight_targets([map()]) -> [{binary(), binary()}].
 preflight_targets(Groups) ->
-    lists:flatmap(fun first_http_route/1, Groups).
+    [Target || Group <- Groups, Target <- first_http_route(Group)].
+
+-doc "Join binaries with a separator. lists:join/2 widens to [term()], which then defeats iolist_to_binary/1 - see docs/eqwalizer-idioms.md.".
+-spec binary_join(binary(), [binary()]) -> binary().
+binary_join(_Sep, []) -> ~"";
+binary_join(_Sep, [B]) -> B;
+binary_join(Sep, [B | Rest]) -> <<B/binary, Sep/binary, (binary_join(Sep, Rest))/binary>>.
 
 -spec first_http_route(map()) -> [{binary(), binary()}].
 first_http_route(#{prefix := Prefix} = Group) ->
@@ -80,4 +86,4 @@ sample_path(Path) ->
         end
      || Segment <- binary:split(Path, ~"/", [global])
     ],
-    iolist_to_binary(lists:join(~"/", Segments)).
+    binary_join(~"/", Segments).

--- a/test/asobi_wire_tests.erl
+++ b/test/asobi_wire_tests.erl
@@ -110,18 +110,17 @@ atom_field_names_encode_as_their_text_form_test() ->
 encode_never_produces_bytes_decode_rejects_test() ->
     Long = binary:copy(~"a", 300),
     Huge = binary:copy(~"b", 70_000),
-    Frames = [
-        frame([#{op => update, slot => 1, gen => 0, fields => #{Long => 1.0}}]),
-        frame([#{op => add, slot => 1, gen => 0, id => Long, fields => #{~"x" => 1.0}}]),
-        frame([#{op => update, slot => 1, gen => 0, fields => #{~"s" => Huge}}])
-    ],
+    BadField = frame([#{op => update, slot => 1, gen => 0, fields => #{Long => 1.0}}]),
+    BadId = frame([#{op => add, slot => 1, gen => 0, id => Long, fields => #{~"x" => 1.0}}]),
+    TooLarge = frame([#{op => update, slot => 1, gen => 0, fields => #{~"s" => Huge}}]),
+    Frames = [BadField, BadId, TooLarge],
     [
         ?assertMatch({ok, _}, asobi_wire:decode(Bin))
      || F <- Frames, {ok, Bin} <- [asobi_wire:encode(F)]
     ],
-    ?assertEqual({error, bad_field_name}, asobi_wire:encode(hd(Frames))),
-    ?assertEqual({error, bad_entity_id}, asobi_wire:encode(lists:nth(2, Frames))),
-    ?assertEqual({error, value_too_large}, asobi_wire:encode(lists:nth(3, Frames))).
+    ?assertEqual({error, bad_field_name}, asobi_wire:encode(BadField)),
+    ?assertEqual({error, bad_entity_id}, asobi_wire:encode(BadId)),
+    ?assertEqual({error, value_too_large}, asobi_wire:encode(TooLarge)).
 
 %% The boundaries are where they say they are: the dictionary and the id both
 %% count their length in one byte, and a string value in two.
@@ -189,26 +188,26 @@ length_limits_are_inclusive_test() ->
 %% CHARACTERS can be four times that in UTF-8 - so the check has to be on the
 %% rendered text rather than on the atom.
 atom_field_name_past_the_limit_refuses_the_frame_test() ->
-    Wide = list_to_atom(lists:duplicate(200, 16#4E2D)),
+    Wide = list_to_atom(repeat(16#4E2D, 200)),
     F = frame([#{op => update, slot => 1, gen => 0, fields => #{Wide => 1.0}}]),
     ?assert(byte_size(atom_to_binary(Wide, utf8)) > 255),
     ?assertEqual({error, bad_field_name}, asobi_wire:encode(F)),
     %% The boundary is where it says it is, on the rendered bytes: 85 three-byte
     %% characters is exactly 255, one ASCII character more is 256.
-    Exact = list_to_atom(lists:duplicate(85, 16#4E2D)),
+    Exact = list_to_atom(repeat(16#4E2D, 85)),
     ?assertEqual(255, byte_size(atom_to_binary(Exact, utf8))),
     ?assertMatch(
         {ok, _},
         asobi_wire:encode(frame([#{op => update, slot => 1, gen => 0, fields => #{Exact => 1.0}}]))
     ),
-    Over = list_to_atom(lists:duplicate(85, 16#4E2D) ++ "a"),
+    Over = list_to_atom(repeat(16#4E2D, 85) ++ "a"),
     ?assertEqual(256, byte_size(atom_to_binary(Over, utf8))),
     ?assertEqual(
         {error, bad_field_name},
         asobi_wire:encode(frame([#{op => update, slot => 1, gen => 0, fields => #{Over => 1.0}}]))
     ),
     %% ...and one that fits still encodes, so the bound is on length not on atoms.
-    Narrow = list_to_atom(lists:duplicate(80, 16#4E2D)),
+    Narrow = list_to_atom(repeat(16#4E2D, 80)),
     ?assertMatch(
         {ok, _},
         asobi_wire:encode(frame([#{op => update, slot => 1, gen => 0, fields => #{Narrow => 1.0}}]))
@@ -440,6 +439,13 @@ fixture_corpus_round_trips_test() ->
 
 %% --- Helpers ---
 
+%% lists:duplicate/2 widens to [term()], which is not a string(), and
+%% list_to_atom/1 wants one. See docs/eqwalizer-idioms.md.
+-spec repeat(char(), non_neg_integer()) -> string().
+repeat(_Char, 0) -> [];
+repeat(Char, N) -> [Char | repeat(Char, N - 1)].
+
+-spec frame([map()]) -> asobi_wire:frame().
 frame(Records) ->
     #{
         kind => sequenced,

--- a/test/asobi_world_ticker_tests.erl
+++ b/test/asobi_world_ticker_tests.erl
@@ -512,8 +512,14 @@ with_subscription(Event, WorldId, Fun) ->
 collect_for(Ref, WindowMs) ->
     collect_until(Ref, erlang:monotonic_time(millisecond) + WindowMs, []).
 
+%% erlang:max/2 is specced term() -> term(); a receive timeout needs an
+%% integer. See docs/eqwalizer-idioms.md.
+-spec wait_ms(integer()) -> non_neg_integer().
+wait_ms(Ms) when Ms > 0 -> Ms;
+wait_ms(_Ms) -> 0.
+
 collect_until(Ref, Deadline, Acc) ->
-    Wait = max(0, Deadline - erlang:monotonic_time(millisecond)),
+    Wait = wait_ms(Deadline - erlang:monotonic_time(millisecond)),
     receive
         {Ref, M, Meta} -> collect_until(Ref, Deadline, [{M, Meta} | Acc])
     after Wait -> lists:reverse(Acc)

--- a/test/asobi_ws_handler_tests.erl
+++ b/test/asobi_ws_handler_tests.erl
@@ -71,7 +71,7 @@ world_event_non_ascii_name_is_rejected_and_logged_test() ->
 %% forwarded — same log-not-crash contract as the non-ASCII case.
 world_event_oversized_name_is_rejected_and_logged_test() ->
     ok = install_log_capture(),
-    TooLong = list_to_binary(lists:duplicate(65, $a)),
+    TooLong = binary:copy(~"a", 65),
     Msg = {asobi_message, {world_event, TooLong, #{}}},
     ?assertEqual({ok, #{}}, asobi_ws_handler:websocket_info(Msg, #{})),
     ?assertEqual(#{namespace => ~"world", reason => invalid_event_name}, await_rejection()),
@@ -181,10 +181,17 @@ nova_splices_a_list_reply_into_separate_commands_test() ->
 %% list-valued reply onto the command list as one cowboy command, so both
 %% frames arrived at cow_ws:frame/2 as a single frame and took the
 %% connection process down. Pin the frame count, not just the payloads -
+%% websocket_info/2 may answer one frame or a list of them, so the reply has to
+%% be narrowed to a list before it can be counted. See docs/eqwalizer-idioms.md.
+-spec frames(term()) -> [term()].
+frames(Frames) when is_list(Frames) -> Frames;
+frames(Frame) -> [Frame].
+
 %% a regression to a single frame is exactly what shipped in #330.
 extension_frames_are_two_separate_frames_test() ->
     Msg = {asobi_message, {game_message, ~"hi"}},
-    {reply, Frames, _State1} = asobi_ws_handler:websocket_info(Msg, #{}),
+    {reply, Frames0, _State1} = asobi_ws_handler:websocket_info(Msg, #{}),
+    Frames = frames(Frames0),
     ?assertEqual(2, length(Frames)),
     ?assertEqual([~"game.message", ~"module.message"], [type_of(F) || F <- Frames]).
 
@@ -211,7 +218,8 @@ legacy_game_frames_can_be_disabled_test() ->
 %% Nothing of the unencodable payload may reach the client either way.
 script_error_unencodable_payload_degrades_test() ->
     Msg = {asobi_message, {script_error, #{~"message" => {not_json}}}},
-    {reply, Frames, _State1} = asobi_ws_handler:websocket_info(Msg, #{}),
+    {reply, Frames0, _State1} = asobi_ws_handler:websocket_info(Msg, #{}),
+    Frames = frames(Frames0),
     ?assertEqual(1, length(Frames)),
     Payload = payload_of(~"error", Frames),
     ?assertEqual(~"internal", maps:get(~"reason", Payload)),

--- a/test/asobi_ws_handler_tests.erl
+++ b/test/asobi_ws_handler_tests.erl
@@ -181,12 +181,6 @@ nova_splices_a_list_reply_into_separate_commands_test() ->
 %% list-valued reply onto the command list as one cowboy command, so both
 %% frames arrived at cow_ws:frame/2 as a single frame and took the
 %% connection process down. Pin the frame count, not just the payloads -
-%% websocket_info/2 may answer one frame or a list of them, so the reply has to
-%% be narrowed to a list before it can be counted. See docs/eqwalizer-idioms.md.
--spec frames(term()) -> [term()].
-frames(Frames) when is_list(Frames) -> Frames;
-frames(Frame) -> [Frame].
-
 %% a regression to a single frame is exactly what shipped in #330.
 extension_frames_are_two_separate_frames_test() ->
     Msg = {asobi_message, {game_message, ~"hi"}},
@@ -614,3 +608,10 @@ binary_uplink_is_refused_out_loud_test() ->
         #{~"payload" := #{~"reason" := ~"binary_uplink_unsupported"}},
         decode(Frame)
     ).
+
+%% List-only on purpose: websocket_info/2 answers a list here (extension_frames/3
+%% is spec'd [{text, binary()}]), and wrapping a bare frame instead would make a
+%% regression to a single frame - the #330 / nova#399 shape these tests exist to
+%% pin - pass length/1 silently.
+-spec frames(term()) -> [term()].
+frames(Frames) when is_list(Frames) -> Frames.

--- a/test/extensions/asobi_extension_reserved_tests.erl
+++ b/test/extensions/asobi_extension_reserved_tests.erl
@@ -33,9 +33,26 @@ seasons_is_no_longer_reserved_test() ->
     #{tables := Reserved} = asobi_extension_reserved:namespaces(),
     ?assertNot(lists:member(~"seasons", Reserved)),
     _ = application:load(asobi),
-    {ok, Modules} = application:get_key(asobi, modules),
+    Modules = app_key(modules),
     ?assertNot(lists:member(asobi_season, Modules)),
     ?assertNot(lists:member(asobi_season_manager, Modules)).
+
+%% application:get_key/2 answers {ok, term()}, and proplists:get_value/2 the
+%% same. Narrowed once here rather than at each read.
+%% See docs/eqwalizer-idioms.md.
+-spec app_key(atom()) -> [term()].
+app_key(Key) ->
+    {ok, Value} = application:get_key(asobi, Key),
+    case Value of
+        List when is_list(List) -> List
+    end.
+
+-spec env_list(atom()) -> [term()].
+env_list(Key) ->
+    case [V || {K, V} <- app_key(env), K =:= Key, is_list(V)] of
+        [List | _] -> List;
+        [] -> []
+    end.
 
 queues_come_from_core_shigoto_workers_test() ->
     #{queues := Reserved} = asobi_extension_reserved:namespaces(),
@@ -116,9 +133,7 @@ core_wire_prefixes_are_reserved_rpc_prefixes_test() ->
 %% Deleting this env key silently removes `rebar3 asobi check` from every host.
 the_build_time_gate_is_declared_to_rebar3_test() ->
     _ = application:load(asobi),
-    {ok, Env} = application:get_key(asobi, env),
-    Providers = proplists:get_value(providers, Env),
-    ?assert(lists:member(rebar3_asobi_check, Providers)),
+    ?assert(lists:member(rebar3_asobi_check, env_list(providers))),
     Exports = rebar3_asobi_check:module_info(exports),
     [?assert(lists:member(E, Exports)) || E <- [{init, 1}, {do, 1}, {format_error, 1}]].
 
@@ -126,8 +141,6 @@ the_build_time_gate_is_declared_to_rebar3_test() ->
 %% silently remove `rebar3 asobi console` the same way.
 the_console_builder_is_declared_to_rebar3_test() ->
     _ = application:load(asobi),
-    {ok, Env} = application:get_key(asobi, env),
-    Providers = proplists:get_value(providers, Env),
-    ?assert(lists:member(rebar3_asobi_console, Providers)),
+    ?assert(lists:member(rebar3_asobi_console, env_list(providers))),
     Exports = rebar3_asobi_console:module_info(exports),
     [?assert(lists:member(E, Exports)) || E <- [{init, 1}, {do, 1}, {format_error, 1}]].

--- a/test/extensions/asobi_extensions_tests.erl
+++ b/test/extensions/asobi_extensions_tests.erl
@@ -657,7 +657,7 @@ an_unsatisfiable_requires_is_refused() ->
     tunable(#{requires => [does_not_exist]}),
     Problems = check_problems(),
     ?assert(lists:member({unsatisfied_requirement, ?TUNABLE, does_not_exist}, Problems)),
-    Text = iolist_to_binary(lists:join(~" ", asobi_extensions:describe(Problems))),
+    Text = asobi_test_helpers:binary_join(~" ", asobi_extensions:describe(Problems)),
     ?assertNotEqual(nomatch, binary:match(Text, atom_to_binary(?TUNABLE, utf8))),
     ?assertNotEqual(nomatch, binary:match(Text, ~"does_not_exist")),
     ?assertError({asobi_extensions, _}, asobi_extensions:resolve()).
@@ -697,7 +697,7 @@ a_self_requirement_is_named_as_such() ->
     Problems = check_problems(),
     ?assert(lists:member({self_requirement, ?TUNABLE, economy}, Problems)),
     ?assertNot(lists:member({requirement_out_of_order, ?TUNABLE, economy}, Problems)),
-    Text = iolist_to_binary(lists:join(~" ", asobi_extensions:describe(Problems))),
+    Text = asobi_test_helpers:binary_join(~" ", asobi_extensions:describe(Problems)),
     ?assertNotEqual(nomatch, binary:match(Text, ~"itself")).
 
 %% A two-cycle terminates with a legible problem, not a loop. clans requires
@@ -766,7 +766,7 @@ check_problems() ->
 assert_conflict(Kind, Token) ->
     Problems = check_problems(),
     ?assert(lists:member({namespace_conflict, Kind, Token, ?QUESTS, ?TUNABLE}, Problems)),
-    Text = iolist_to_binary(lists:join(~" ", asobi_extensions:describe(Problems))),
+    Text = asobi_test_helpers:binary_join(~" ", asobi_extensions:describe(Problems)),
     ?assertNotEqual(nomatch, binary:match(Text, atom_to_binary(?QUESTS, utf8))),
     ?assertNotEqual(nomatch, binary:match(Text, atom_to_binary(?TUNABLE, utf8))),
     ?assertNotEqual(nomatch, binary:match(Text, Token)).

--- a/test/extensions/asobi_fixture_erase.erl
+++ b/test/extensions/asobi_fixture_erase.erl
@@ -21,17 +21,35 @@ reset() ->
 -doc "Every `erase_player/1` call, in the order core made them.".
 -spec calls() -> [{atom(), binary()}].
 calls() ->
-    lists:reverse(persistent_term:get(?CALLS, [])).
+    %% persistent_term is a boundary; narrowed at the read, and lists:reverse/1
+    %% widens on the way back. See docs/eqwalizer-idioms.md.
+    case persistent_term:get(?CALLS, []) of
+        Calls when is_list(Calls) ->
+            [{N, P} || {N, P} <- lists:reverse(Calls), is_atom(N), is_binary(P)]
+    end.
 
 -doc "What this extension's erase path does: `ok`, `{error, R}` or `{raise, R}`.".
 -spec outcome(atom(), term()) -> ok.
 outcome(Name, Outcome) ->
-    persistent_term:put(?OUTCOMES, maps:put(Name, Outcome, persistent_term:get(?OUTCOMES, #{}))).
+    Current =
+        case persistent_term:get(?OUTCOMES, #{}) of
+            M when is_map(M) -> M
+        end,
+    persistent_term:put(?OUTCOMES, maps:put(Name, Outcome, Current)).
 
 -spec run(atom(), binary()) -> ok | {error, term()}.
 run(Name, PlayerId) ->
-    persistent_term:put(?CALLS, [{Name, PlayerId} | persistent_term:get(?CALLS, [])]),
-    case maps:get(Name, persistent_term:get(?OUTCOMES, #{}), ok) of
+    Calls =
+        case persistent_term:get(?CALLS, []) of
+            L when is_list(L) -> L
+        end,
+    persistent_term:put(?CALLS, [{Name, PlayerId} | Calls]),
+    Outcomes =
+        case persistent_term:get(?OUTCOMES, #{}) of
+            M when is_map(M) -> M
+        end,
+    case maps:get(Name, Outcomes, ok) of
         {raise, Reason} -> error(Reason);
-        Outcome -> Outcome
+        ok -> ok;
+        {error, _} = Error -> Error
     end.

--- a/test/extensions/asobi_fixture_erase.erl
+++ b/test/extensions/asobi_fixture_erase.erl
@@ -37,7 +37,13 @@ outcome(Name, Outcome) ->
         end,
     persistent_term:put(?OUTCOMES, maps:put(Name, Outcome, Current)).
 
--spec run(atom(), binary()) -> ok | {error, term()}.
+%% `term()`, not `ok | {error, _}`: this fixture exists to hand core values
+%% that are OUTSIDE the erase contract, so that core's own validation can be
+%% tested. asobi_extension_erase_tests configures `other` and asserts core
+%% answers `{bad_return, other}`. Narrowing the return here turned that into a
+%% case_clause inside the fixture - the trap docs/eqwalizer-idioms.md warns
+%% about, met in the wild.
+-spec run(atom(), binary()) -> term().
 run(Name, PlayerId) ->
     Calls =
         case persistent_term:get(?CALLS, []) of
@@ -50,6 +56,5 @@ run(Name, PlayerId) ->
         end,
     case maps:get(Name, Outcomes, ok) of
         {raise, Reason} -> error(Reason);
-        ok -> ok;
-        {error, _} = Error -> Error
+        Outcome -> Outcome
     end.

--- a/test/extensions/asobi_fixture_erase.erl
+++ b/test/extensions/asobi_fixture_erase.erl
@@ -19,13 +19,14 @@ reset() ->
     ok.
 
 -doc "Every `erase_player/1` call, in the order core made them.".
--spec calls() -> [{atom(), binary()}].
+-spec calls() -> [term()].
 calls() ->
-    %% persistent_term is a boundary; narrowed at the read, and lists:reverse/1
-    %% widens on the way back. See docs/eqwalizer-idioms.md.
+    %% No guards on the elements: this is the observation side of a fixture
+    %% whose whole job is catching a call core should not have made. Filtering
+    %% a malformed record out here would hide exactly what a test is looking
+    %% for, the same way narrowing run/2's return did.
     case persistent_term:get(?CALLS, []) of
-        Calls when is_list(Calls) ->
-            [{N, P} || {N, P} <- lists:reverse(Calls), is_atom(N), is_binary(P)]
+        Calls when is_list(Calls) -> lists:reverse(Calls)
     end.
 
 -doc "What this extension's erase path does: `ok`, `{error, R}` or `{raise, R}`.".

--- a/test/extensions/asobi_fixture_export.erl
+++ b/test/extensions/asobi_fixture_export.erl
@@ -20,13 +20,14 @@ reset() ->
     ok.
 
 -doc "Every `export_player/1` call, in the order core made them.".
--spec calls() -> [{atom(), binary()}].
+-spec calls() -> [term()].
 calls() ->
-    %% persistent_term is a boundary; narrowed at the read, and lists:reverse/1
-    %% widens on the way back. See docs/eqwalizer-idioms.md.
+    %% No guards on the elements: this is the observation side of a fixture
+    %% whose whole job is catching a call core should not have made. Filtering
+    %% a malformed record out here would hide exactly what a test is looking
+    %% for, the same way narrowing run/2's return did.
     case persistent_term:get(?CALLS, []) of
-        Calls when is_list(Calls) ->
-            [{N, P} || {N, P} <- lists:reverse(Calls), is_atom(N), is_binary(P)]
+        Calls when is_list(Calls) -> lists:reverse(Calls)
     end.
 
 -doc "What this extension's export path does: `{ok, Data}`, `{error, R}` or `{raise, R}`.".

--- a/test/extensions/asobi_fixture_export.erl
+++ b/test/extensions/asobi_fixture_export.erl
@@ -22,17 +22,34 @@ reset() ->
 -doc "Every `export_player/1` call, in the order core made them.".
 -spec calls() -> [{atom(), binary()}].
 calls() ->
-    lists:reverse(persistent_term:get(?CALLS, [])).
+    %% persistent_term is a boundary; narrowed at the read, and lists:reverse/1
+    %% widens on the way back. See docs/eqwalizer-idioms.md.
+    case persistent_term:get(?CALLS, []) of
+        Calls when is_list(Calls) ->
+            [{N, P} || {N, P} <- lists:reverse(Calls), is_atom(N), is_binary(P)]
+    end.
 
 -doc "What this extension's export path does: `{ok, Data}`, `{error, R}` or `{raise, R}`.".
 -spec outcome(atom(), term()) -> ok.
 outcome(Name, Outcome) ->
-    persistent_term:put(?OUTCOMES, maps:put(Name, Outcome, persistent_term:get(?OUTCOMES, #{}))).
+    Current =
+        case persistent_term:get(?OUTCOMES, #{}) of
+            M when is_map(M) -> M
+        end,
+    persistent_term:put(?OUTCOMES, maps:put(Name, Outcome, Current)).
 
 -spec run(atom(), binary()) -> term().
 run(Name, PlayerId) ->
-    persistent_term:put(?CALLS, [{Name, PlayerId} | persistent_term:get(?CALLS, [])]),
-    case maps:get(Name, persistent_term:get(?OUTCOMES, #{}), {ok, #{~"rows" => [PlayerId]}}) of
+    Calls =
+        case persistent_term:get(?CALLS, []) of
+            L when is_list(L) -> L
+        end,
+    persistent_term:put(?CALLS, [{Name, PlayerId} | Calls]),
+    Outcomes =
+        case persistent_term:get(?OUTCOMES, #{}) of
+            M when is_map(M) -> M
+        end,
+    case maps:get(Name, Outcomes, {ok, #{~"rows" => [PlayerId]}}) of
         {raise, Reason} -> error(Reason);
         Outcome -> Outcome
     end.

--- a/test/extensions/asobi_fixture_quests_ops.erl
+++ b/test/extensions/asobi_fixture_quests_ops.erl
@@ -38,7 +38,13 @@ reset() ->
 
 -spec calls() -> [term()].
 calls() ->
-    lists:reverse(persistent_term:get(?KEY, [])).
+    case persistent_term:get(?KEY, []) of
+        Calls when is_list(Calls) -> lists:reverse(Calls)
+    end.
 
 record(Call) ->
-    persistent_term:put(?KEY, [Call | persistent_term:get(?KEY, [])]).
+    Calls =
+        case persistent_term:get(?KEY, []) of
+            L when is_list(L) -> L
+        end,
+    persistent_term:put(?KEY, [Call | Calls]).


### PR DESCRIPTION
Tranche 2 of #435, scoped by **pattern rather than directory** — the measurement in tranche 1 showed the work clusters by idiom, not by folder.

**Tree: 317 → 217.** Twenty-six modules, one repeated set of idioms.

## Why this shape

After #554 I classified all 367 remaining errors by reading each one's source line rather than its sub-expression. `lists:*` was by far the largest identifiable class. The two agent recommendations from #554 both turned out to be aimed at smaller targets:

| what fixes it | count at the time |
|---|---|
| `lists:*` widening | **89** |
| long tail (untyped params, map-patterns in comprehensions, `?=` chains) | 188 |
| `maps:get` on untyped maps | 36 |
| `persistent_term:get` → boundary | 21 |
| `?LOG_` returning `term()` | 11 |
| `gen_server:call` result | 4 |
| **`min`/`max`** | **2** |

There are two `min`/`max` errors left in the whole tree, so the shared-numeric-module question from #554 was about two call sites. Keeping them per-module.

## The idioms

All in `docs/eqwalizer-idioms.md`, which this PR extends. Cited at the fix sites rather than restated.

- **Re-narrow, don't replace.** `usort/1` is O(n log n) in C; `[X || X <- lists:usort(L), is_binary(X)]` keeps it and restores the type.
- **Explicit recursion for folds**, which also satisfies the repo's existing no-`foldl` rule.
- **A comprehension generator narrows where `lists:keyfind/3` cannot** — that covers the 31 keyfind sites, mostly reads out of CT config, `file:consult/1` output and `application:get_key/2`.
- **`maybe ... end` needs an explicit `else`.** Probe-verified: the identical block fails without one, is clean with it.
- `lists:sort/2` erases its **comparator's arguments**, not only its result.

One shared helper earned its place: `asobi_test_helpers:binary_join/2`, after the `iolist_to_binary(lists:join(...))` shape appeared five times.

## Two findings that were not type errors

**A narrowing broke a deliberate test fixture.** `asobi_fixture_erase` exists to return values *outside* the erase contract so core's validation can be tested. Narrowing its return turned that into a `case_clause` inside the fixture. Only the test suite caught it — the exact trap the idioms doc warns about, met in the wild.

**Dialyzer found what eqwalizer could not.** Replacing a `foldr` left a clause unreachable; removing it tightened an accumulator, which exposed that `mime/1` answers `binary() | error` while `asset()` declares `mime := binary()` — and the controller puts that into a content-type header. Not live (`name/1` gates it), but the invariant is now restated where the asset is built.

Also widened `asobi_ws_handler:terminate/3`'s state to `term()`: its second clause exists so an unexpected shape cannot crash the process on the way out, and a test asserts that. The spec described the first clause rather than the function.

## Not in this PR

`src/extensions/rebar3_asobi_console.erl` — its last 2 sites sit alongside a `behaviour_does_not_exist` for `-behaviour(provider)`, which is an analysis-config question (rebar3 is not in the eqwalizer app graph), not a type fix. Touching the module would oblige the gate to demand a decision that is yours.

## Checks

eunit **2360/0**, ct **390/0**, dialyzer clean, fmt, xref. Every touched module reports `NO ERRORS`.