### PR TITLE
fix(types): narrow the boundary reads across src

### DIFF
--- a/src/asobi_discovery.erl
+++ b/src/asobi_discovery.erl
@@ -71,8 +71,10 @@ direct (the table is protected) so a browse costs no round-trip.
 -spec cache_lookup(term(), integer()) -> {hit, [map()]} | miss.
 cache_lookup(Key, Now) ->
     try ets:lookup(?LIST_CACHE_TAB, Key) of
-        [{_, Listing, ExpiresAt}] when ExpiresAt > Now -> {hit, Listing};
-        _ -> miss
+        [{_, Listing, ExpiresAt}] when is_list(Listing), ExpiresAt > Now ->
+            {hit, [L || L <- Listing, is_map(L)]};
+        _ ->
+            miss
     catch
         error:badarg -> miss
     end.

--- a/src/asobi_discovery.erl
+++ b/src/asobi_discovery.erl
@@ -68,6 +68,9 @@ The table is owned and written by `asobi_world_lobby_server`; reads are
 direct (the table is protected) so a browse costs no round-trip.
 `badarg` before the owner has started is a miss, not a crash.
 """.
+%% [map()] holds because asobi_world_lobby_server checks every element before
+%% it writes. Checking on the read instead would either drop a world from a
+%% browse silently or rebuild the list on every hit.
 -spec cache_lookup(term(), integer()) -> {hit, [map()]} | miss.
 cache_lookup(Key, Now) ->
     try ets:lookup(?LIST_CACHE_TAB, Key) of

--- a/src/asobi_game_config.erl
+++ b/src/asobi_game_config.erl
@@ -70,7 +70,21 @@ auth posture at runtime.
 -doc "The effective game modes: the script layer with the operator layer on top.".
 -spec modes() -> modes().
 modes() ->
-    maps:merge(env_modes(script_game_modes), env_modes(game_modes)).
+    %% Shadowed by the operator's DECLARED names, not by the entries this module
+    %% can use. Dropping a malformed operator entry before the merge would let
+    %% the bundle's definition of that mode go live, and the guarantee above is
+    %% that no bundle reload can redefine or drop an operator mode. A malformed
+    %% operator entry still wins, and still fails closed at mode_config/1.
+    Declared = declared_names(game_modes),
+    Script = maps:without(Declared, env_modes(script_game_modes)),
+    maps:merge(Script, env_modes(game_modes)).
+
+-spec declared_names(atom()) -> [binary()].
+declared_names(Key) ->
+    case application:get_env(asobi, Key, #{}) of
+        Modes when is_map(Modes) -> [K || K <- maps:keys(Modes), is_binary(K)];
+        _ -> []
+    end.
 
 -doc "The effective guest-auth flag: the operator's key when set, else the game's.".
 -spec guest_auth() -> boolean().

--- a/src/asobi_game_config.erl
+++ b/src/asobi_game_config.erl
@@ -117,6 +117,9 @@ write_modes(_) ->
 -spec env_modes(atom()) -> modes().
 env_modes(Key) ->
     case application:get_env(asobi, Key, #{}) of
-        Modes when is_map(Modes) -> Modes;
-        _ -> #{}
+        Modes when is_map(Modes) ->
+            %% modes() is keyed by binary, and each value is a map or a module.
+            #{K => V || K := V <- Modes, is_binary(K), is_map(V) orelse is_atom(V)};
+        _ ->
+            #{}
     end.

--- a/src/asobi_guest_reaper.erl
+++ b/src/asobi_guest_reaper.erl
@@ -58,7 +58,10 @@
 %% lazily also self-corrects when the flag is set later, e.g. a bundle reload.
 -spec start_link() -> {ok, pid()} | {error, term()}.
 start_link() ->
-    gen_server:start_link({local, ?MODULE}, ?MODULE, [], []).
+    case gen_server:start_link({local, ?MODULE}, ?MODULE, [], []) of
+        {ok, Pid} when is_pid(Pid) -> {ok, Pid};
+        {error, _} = Error -> Error
+    end.
 
 %% For tests/ops: run a sweep synchronously.
 -spec sweep_now() -> {ok, non_neg_integer()}.
@@ -99,7 +102,11 @@ cached_unlinked_count() ->
             live_unlinked_count();
         _ ->
             case ets:lookup(?COUNT_CACHE, count) of
-                [{count, N, Expiry}] when Expiry > Now -> N;
+                %% `unknown` is a cached FAILURE, and caching it is the point:
+                %% asobi_guest_SUITE asserts a failing count is asked once per
+                %% TTL, not once per call. is_integer/1 alone rejected it and
+                %% re-queried every time.
+                [{count, N, Expiry}] when Expiry > Now, is_integer(N) orelse N =:= unknown -> N;
                 _ -> refresh_count(Now)
             end
     end.

--- a/src/asobi_guest_reaper.erl
+++ b/src/asobi_guest_reaper.erl
@@ -106,7 +106,8 @@ cached_unlinked_count() ->
                 %% asobi_guest_SUITE asserts a failing count is asked once per
                 %% TTL, not once per call. is_integer/1 alone rejected it and
                 %% re-queried every time.
-                [{count, N, Expiry}] when Expiry > Now, is_integer(N) orelse N =:= unknown -> N;
+                [{count, N, Expiry}] when Expiry > Now, is_integer(N), N >= 0 -> N;
+                [{count, unknown, Expiry}] when Expiry > Now -> unknown;
                 _ -> refresh_count(Now)
             end
     end.

--- a/src/console/asobi_console_controller.erl
+++ b/src/console/asobi_console_controller.erl
@@ -64,7 +64,7 @@ The binding is a map key, never a path segment joined onto a directory - see
 typo or a traversal attempt.
 """.
 -spec asset(cowboy_req:req()) -> response().
-asset(#{bindings := #{~"file" := Name}} = Req) ->
+asset(#{bindings := #{~"file" := Name}} = Req) when is_binary(Name) ->
     case asobi_console:enabled() andalso asobi_console:asset(Name) of
         {ok, Asset} -> serve(Asset, Req);
         _ -> {asobi_error, ~"console.not_found"}
@@ -132,7 +132,12 @@ login(Req) ->
 authenticate(#{json := #{~"secret" := Secret} = Body} = Req) ->
     case asobi_ops_auth:verify_secret(Secret) of
         true ->
-            {ok, Session} = asobi_console_session:create(maps:get(~"label", Body, ~"operator")),
+            Label =
+                case maps:get(~"label", Body, ~"operator") of
+                    L when is_binary(L) -> L;
+                    _ -> ~"operator"
+                end,
+            {ok, Session} = asobi_console_session:create(Label),
             granted(Session, Req);
         false ->
             rejected(Req)
@@ -292,6 +297,6 @@ actor(#{display := Display, source := Source, caps := Caps, attested := Attested
 -spec version() -> binary().
 version() ->
     case application:get_key(asobi, vsn) of
-        {ok, Vsn} when is_list(Vsn) -> list_to_binary(Vsn);
+        {ok, Vsn} when is_list(Vsn) -> list_to_binary([C || C <- Vsn, is_integer(C)]);
         _ -> ~"unknown"
     end.

--- a/src/console/asobi_console_controller.erl
+++ b/src/console/asobi_console_controller.erl
@@ -132,12 +132,12 @@ login(Req) ->
 authenticate(#{json := #{~"secret" := Secret} = Body} = Req) ->
     case asobi_ops_auth:verify_secret(Secret) of
         true ->
-            Label =
-                case maps:get(~"label", Body, ~"operator") of
-                    L when is_binary(L) -> L;
-                    _ -> ~"operator"
-                end,
-            {ok, Session} = asobi_console_session:create(Label),
+            %% asobi_console_session:label/1 already normalises every
+            %% non-binary, empty, over-long and non-printable label to
+            %% "operator"; a second copy here would only drift from it.
+            {ok, Session} = asobi_console_session:create(
+                maps:get(~"label", Body, ~"operator")
+            ),
             granted(Session, Req);
         false ->
             rejected(Req)
@@ -297,6 +297,6 @@ actor(#{display := Display, source := Source, caps := Caps, attested := Attested
 -spec version() -> binary().
 version() ->
     case application:get_key(asobi, vsn) of
-        {ok, Vsn} when is_list(Vsn) -> list_to_binary([C || C <- Vsn, is_integer(C)]);
+        {ok, Vsn} when is_list(Vsn) -> asobi_ops_features:vsn_binary(Vsn);
         _ -> ~"unknown"
     end.

--- a/src/console/asobi_console_env.erl
+++ b/src/console/asobi_console_env.erl
@@ -64,13 +64,15 @@ resolve() ->
                 detail =>
                     ~"enabled but nothing could sign in - set ASOBI_OPS_SECRET_FILE (preferred) or ASOBI_OPS_SECRET, or provision ASOBI_OPS_TOKEN_SECRET and GAME_ID for the managed minted-token path",
                 effect => ~"the console stays off; the node is unaffected"
-            });
+            }),
+            ok;
         {true, true} ->
             ?LOG_NOTICE(#{
                 msg => ~"console_enabled",
                 path => ~"/console",
                 detail => ~"Shares the game port. Put it behind TLS and restrict who can reach it."
-            });
+            }),
+            ok;
         _ ->
             ok
     end.

--- a/src/console/asobi_console_session.erl
+++ b/src/console/asobi_console_session.erl
@@ -116,7 +116,13 @@ put the decision in two places.
 """.
 -spec create(binary(), [asobi_ops_caps:class()], integer()) -> {ok, session()}.
 create(Label, Caps, NotAfter) ->
-    gen_server:call(?MODULE, {create, label(Label), Caps, NotAfter}).
+    %% gen_server:call/2 answers term(). See docs/eqwalizer-idioms.md.
+    case gen_server:call(?MODULE, {create, label(Label), Caps, NotAfter}) of
+        {ok, #{id := I, csrf := C, label := L, caps := Cs, expires_at := E}} when
+            is_binary(I), is_binary(C), is_binary(L), is_list(Cs), is_integer(E)
+        ->
+            {ok, #{id => I, csrf => C, label => L, caps => caps(Cs), expires_at => E}}
+    end.
 
 -doc """
 Spend a minted token, so it can open exactly one session.
@@ -169,7 +175,7 @@ resolve(_Id, _Csrf) ->
 -doc "End a session. Unknown ids are `ok` - logging out twice is not an error.".
 -spec delete(binary()) -> ok.
 delete(Id) when is_binary(Id) ->
-    gen_server:call(?MODULE, {delete, Id});
+    ok = gen_server:call(?MODULE, {delete, Id});
 delete(_Id) ->
     ok.
 
@@ -183,9 +189,16 @@ csrf(Id) ->
 -spec ttl_seconds() -> pos_integer().
 ttl_seconds() ->
     case application:get_env(asobi, console_session_ttl) of
-        {ok, Ttl} when is_integer(Ttl) -> min(max(Ttl, ?MIN_TTL), ?MAX_TTL);
+        {ok, Ttl} when is_integer(Ttl) -> clamp(Ttl, ?MIN_TTL, ?MAX_TTL);
         _ -> ?DEFAULT_TTL
     end.
+
+%% erlang:min/2 and max/2 are specced term() -> term() whatever they are handed.
+%% See docs/eqwalizer-idioms.md.
+-spec clamp(integer(), pos_integer(), pos_integer()) -> pos_integer().
+clamp(V, Lo, _Hi) when V < Lo -> Lo;
+clamp(V, _Lo, Hi) when V > Hi -> Hi;
+clamp(V, Lo, _Hi) when V >= Lo -> V.
 
 -spec init([]) -> {ok, #{}}.
 init([]) ->
@@ -267,8 +280,12 @@ sweep_expired() ->
 -spec lookup(binary()) -> {ok, session()} | {error, reason()}.
 lookup(Id) ->
     try ets:lookup(?TABLE, Id) of
-        [{Id, ExpiresAt, Label, Caps}] -> live(Id, ExpiresAt, Label, Caps);
-        [] -> {error, unknown}
+        [{Id, ExpiresAt, Label, Caps}] when
+            is_integer(ExpiresAt), is_binary(Label), is_list(Caps)
+        ->
+            live(Id, ExpiresAt, Label, caps(Caps));
+        [] ->
+            {error, unknown}
     catch
         %% The table is gone only while the owner is restarting. That is a
         %% logged-out console, not a crashed request.
@@ -304,9 +321,17 @@ checked(#{csrf := Expected} = Session, Presented) ->
 constant_equal(Expected, Presented) ->
     crypto:hash_equals(crypto:hash(sha256, Expected), crypto:hash(sha256, Presented)).
 
+%% ETS content is this module's own, but the read is still a boundary the
+%% checker cannot see through. See docs/eqwalizer-idioms.md.
+-spec caps([term()]) -> [asobi_ops_caps:class()].
+caps(Caps) ->
+    [C || C <- Caps, C =:= read orelse C =:= player_data orelse C =:= config orelse C =:= erasure].
+
 -spec secret() -> binary().
 secret() ->
-    persistent_term:get(?SECRET_KEY, <<>>).
+    case persistent_term:get(?SECRET_KEY, <<>>) of
+        Secret when is_binary(Secret) -> Secret
+    end.
 
 -spec label(term()) -> binary().
 label(Label) when is_binary(Label), Label =/= ~"", byte_size(Label) =< ?MAX_LABEL_BYTES ->
@@ -322,13 +347,16 @@ printable(Label) ->
     lists:all(fun(Char) -> Char >= 32 andalso Char =< 126 end, binary_to_list(Label)).
 
 -spec log_sweep(non_neg_integer()) -> ok.
-log_sweep(0) -> ok;
-log_sweep(Removed) -> ?LOG_INFO(#{msg => ~"console sessions expired", removed => Removed}).
+log_sweep(0) ->
+    ok;
+log_sweep(Removed) ->
+    ?LOG_INFO(#{msg => ~"console sessions expired", removed => Removed}),
+    ok.
 
 -ifdef(TEST).
 -spec expire(binary()) -> ok.
-expire(Id) -> gen_server:call(?MODULE, {expire, Id}).
+expire(Id) -> ok = gen_server:call(?MODULE, {expire, Id}).
 
 -spec sweep() -> ok.
-sweep() -> gen_server:call(?MODULE, sweep).
+sweep() -> ok = gen_server:call(?MODULE, sweep).
 -endif.

--- a/src/console/asobi_console_session.erl
+++ b/src/console/asobi_console_session.erl
@@ -90,7 +90,9 @@ somewhere the operator never meant to - and an erasure is the one ops action
 no follow-up call can undo. Same secret, different blast radius, different
 default. Set `console_erasure` to `true` to erase from the console anyway.
 """.
--spec create(binary()) -> {ok, session()}.
+%% term(), because label/1 normalises every shape a caller can hand it. The
+%% controller used to re-implement that check; one normaliser is enough.
+-spec create(term()) -> {ok, session()}.
 create(Label) ->
     create(Label, console_caps(), erlang:system_time(second) + ttl_seconds()).
 
@@ -114,7 +116,7 @@ Nothing is subtracted here, unlike `create/1`: a minted token carries exactly
 the classes the control plane decided to mint, and second-guessing that would
 put the decision in two places.
 """.
--spec create(binary(), [asobi_ops_caps:class()], integer()) -> {ok, session()}.
+-spec create(term(), [asobi_ops_caps:class()], integer()) -> {ok, session()}.
 create(Label, Caps, NotAfter) ->
     %% gen_server:call/2 answers term(). See docs/eqwalizer-idioms.md.
     case gen_server:call(?MODULE, {create, label(Label), Caps, NotAfter}) of
@@ -198,7 +200,7 @@ ttl_seconds() ->
 -spec clamp(integer(), pos_integer(), pos_integer()) -> pos_integer().
 clamp(V, Lo, _Hi) when V < Lo -> Lo;
 clamp(V, _Lo, Hi) when V > Hi -> Hi;
-clamp(V, Lo, _Hi) when V >= Lo -> V.
+clamp(V, _Lo, _Hi) -> V.
 
 -spec init([]) -> {ok, #{}}.
 init([]) ->
@@ -325,11 +327,15 @@ constant_equal(Expected, Presented) ->
 %% checker cannot see through. See docs/eqwalizer-idioms.md.
 -spec caps([term()]) -> [asobi_ops_caps:class()].
 caps(Caps) ->
-    [C || C <- Caps, C =:= read orelse C =:= player_data orelse C =:= config orelse C =:= erasure].
+    [Class || Cap <- Caps, {ok, Class} <- [asobi_ops_caps:class_of(Cap)]].
 
 -spec secret() -> binary().
 secret() ->
-    case persistent_term:get(?SECRET_KEY, <<>>) of
+    %% No default. A session cannot exist without the secret that derives its
+    %% CSRF token, and an empty key makes that token publicly computable from
+    %% the session id - which is exactly what this module's second layer is
+    %% supposed to prevent.
+    case persistent_term:get(?SECRET_KEY) of
         Secret when is_binary(Secret) -> Secret
     end.
 

--- a/src/controllers/asobi_storage_controller.erl
+++ b/src/controllers/asobi_storage_controller.erl
@@ -308,7 +308,12 @@ do_delete_storage(
         {error, Reason} ->
             log_storage_query_failed(Col, Key, Reason),
             {asobi_error, ~"storage.query_failed"}
-    end.
+    end;
+do_delete_storage(_Req) ->
+    %% Same reasoning as do_get_storage/1: a binding that is not a binary is not
+    %% a key this collection can hold, and guarded/2 does not catch, so without
+    %% this the guard above turns a 404 into a 500.
+    {asobi_error, ~"storage.not_found"}.
 
 -spec list_storage(cowboy_req:req()) -> response().
 list_storage(Req) ->

--- a/src/controllers/asobi_storage_controller.erl
+++ b/src/controllers/asobi_storage_controller.erl
@@ -147,7 +147,7 @@ get_storage(Req) ->
 do_get_storage(
     #{bindings := #{~"collection" := Col, ~"key" := Key}, auth_data := #{player_id := PlayerId}} =
         _Req
-) ->
+) when is_binary(Col), is_binary(Key) ->
     Q = kura_query:where(
         kura_query:where(
             kura_query:where(kura_query:from(asobi_storage), {collection, Col}),
@@ -170,7 +170,13 @@ do_get_storage(
         {error, Reason} ->
             log_storage_query_failed(Col, Key, Reason),
             {asobi_error, ~"storage.query_failed"}
-    end.
+    end;
+do_get_storage(_Req) ->
+    %% A binding that is not a binary is not a key this collection can hold.
+    %% Answering not_found keeps the shape the unguarded version produced by
+    %% querying for it and finding nothing; guarded/2 does not catch, so a bare
+    %% guard would have turned that 404 into a 500.
+    {asobi_error, ~"storage.not_found"}.
 
 -spec put_storage(cowboy_req:req()) -> response().
 put_storage(Req) ->
@@ -277,7 +283,7 @@ delete_storage(Req) ->
 do_delete_storage(
     #{bindings := #{~"collection" := Col, ~"key" := Key}, auth_data := #{player_id := PlayerId}} =
         _Req
-) ->
+) when is_binary(Col), is_binary(Key) ->
     Q = kura_query:where(
         kura_query:where(
             kura_query:where(kura_query:from(asobi_storage), {collection, Col}),
@@ -342,7 +348,8 @@ log_storage_invariant_violation(Col, Key, RowCount) ->
         collection => Col,
         key => Key,
         row_count => RowCount
-    }).
+    }),
+    ok.
 
 -spec log_storage_query_failed(binary(), binary(), term()) -> ok.
 log_storage_query_failed(Col, Key, Reason) ->
@@ -351,7 +358,8 @@ log_storage_query_failed(Col, Key, Reason) ->
         collection => Col,
         key => Key,
         reason => Reason
-    }).
+    }),
+    ok.
 
 -spec data_within_limit(dynamic()) -> boolean().
 data_within_limit(Data) ->

--- a/src/extensions/asobi_extension_watch.erl
+++ b/src/extensions/asobi_extension_watch.erl
@@ -22,7 +22,10 @@ It monitors rather than links: a monitor cannot influence what it watches.
 
 -spec start_link([asobi_extension:name()]) -> {ok, pid()} | {error, term()}.
 start_link(Names) ->
-    gen_server:start_link({local, ?MODULE}, ?MODULE, Names, []).
+    case gen_server:start_link({local, ?MODULE}, ?MODULE, Names, []) of
+        {ok, Pid} when is_pid(Pid) -> {ok, Pid};
+        {error, _} = Error -> Error
+    end.
 
 %% Monitoring happens in handle_continue, not init: `which_children` is a call
 %% into the parent supervisor, and the parent is still inside its own init
@@ -51,12 +54,17 @@ handle_info({'DOWN', Ref, process, _Pid, Reason}, #{monitors := Monitors} = Stat
                 reason => Reason,
                 detail => ~"this extension is no longer running; the node is otherwise unaffected"
             }),
-            {noreply, State#{monitors => Rest}};
+            {noreply, State#{monitors => monitors(Rest)}};
         error ->
             {noreply, State}
     end;
 handle_info(_Message, State) ->
     {noreply, State}.
+
+%% The monitor map is this module's own, but maps:remove/2 answers a widened
+%% map. See docs/eqwalizer-idioms.md.
+-spec monitors(term()) -> #{reference() => atom()}.
+monitors(M) when is_map(M) -> #{R => N || R := N <- M, is_reference(R), is_atom(N)}.
 
 -spec handle_call(term(), gen_server:from(), state()) -> {reply, ok, state()}.
 handle_call(_Request, _From, State) ->

--- a/src/leaderboards/asobi_leaderboard_server.erl
+++ b/src/leaderboards/asobi_leaderboard_server.erl
@@ -204,7 +204,13 @@ handle_cast({evict, PlayerId}, #{table := Table, player_index := Idx, dirty := D
         [{PlayerId, Score}] when is_number(Score) ->
             ets:delete(Table, {-Score, PlayerId}),
             ets:delete(Idx, PlayerId);
-        _ ->
+        [{PlayerId, _Unusable}] ->
+            %% Unreachable today - both writers guard is_number - but this is
+            %% the erasure path (asobi_player_erase), and a board never re-reads
+            %% Postgres, so leaving the row would keep serving an erased player
+            %% from top/rank/around indefinitely.
+            ets:delete(Idx, PlayerId);
+        [] ->
             ok
     end,
     %% Unconditionally, even when the board never held them: `dirty` and the

--- a/src/leaderboards/asobi_leaderboard_server.erl
+++ b/src/leaderboards/asobi_leaderboard_server.erl
@@ -98,15 +98,14 @@ live_boards() ->
 %% are already gone from.
 -spec evict_player(binary()) -> ok.
 evict_player(PlayerId) ->
-    lists:foreach(
-        fun(BoardId) ->
-            case whereis_board_optional(BoardId) of
-                {ok, Pid} -> gen_server:cast(Pid, {evict, PlayerId});
-                not_found -> ok
-            end
-        end,
-        live_boards()
-    ).
+    _ = [
+        case whereis_board_optional(BoardId) of
+            {ok, Pid} -> gen_server:cast(Pid, {evict, PlayerId});
+            not_found -> ok
+        end
+     || BoardId <- live_boards()
+    ],
+    ok.
 
 -spec validate_entries([term()]) -> [{binary(), number(), pos_integer()}].
 validate_entries(Entries) ->
@@ -164,7 +163,7 @@ handle_call({top, N}, _From, #{table := Table} = State) ->
     {reply, Entries, State};
 handle_call({rank, PlayerId}, _From, #{table := Table, player_index := Idx} = State) ->
     case ets:lookup(Idx, PlayerId) of
-        [{PlayerId, Score}] ->
+        [{PlayerId, Score}] when is_number(Score) ->
             Key = {-Score, PlayerId},
             Pos = count_before(Table, Key) + 1,
             {reply, {ok, Pos}, State};
@@ -173,7 +172,7 @@ handle_call({rank, PlayerId}, _From, #{table := Table, player_index := Idx} = St
     end;
 handle_call({around, PlayerId, N}, _From, #{table := Table, player_index := Idx} = State) ->
     case ets:lookup(Idx, PlayerId) of
-        [{PlayerId, Score}] ->
+        [{PlayerId, Score}] when is_number(Score) ->
             Key = {-Score, PlayerId},
             Entries = entries_around(Table, Key, N),
             {reply, Entries, State};
@@ -190,7 +189,7 @@ handle_cast(
     is_number(Score)
 ->
     case ets:lookup(Idx, PlayerId) of
-        [{PlayerId, OldScore}] ->
+        [{PlayerId, OldScore}] when is_number(OldScore) ->
             ets:delete(Table, {-OldScore, PlayerId});
         [] ->
             ok
@@ -202,10 +201,10 @@ handle_cast({evict, PlayerId}, #{table := Table, player_index := Idx, dirty := D
     is_binary(PlayerId)
 ->
     case ets:lookup(Idx, PlayerId) of
-        [{PlayerId, Score}] ->
+        [{PlayerId, Score}] when is_number(Score) ->
             ets:delete(Table, {-Score, PlayerId}),
             ets:delete(Idx, PlayerId);
-        [] ->
+        _ ->
             ok
     end,
     %% Unconditionally, even when the board never held them: `dirty` and the

--- a/src/ops/asobi_ops_caps.erl
+++ b/src/ops/asobi_ops_caps.erl
@@ -25,7 +25,7 @@ A route with no entry in `classes/0` has no class and `authorised/2` denies
 it, so an untagged or mis-mounted route is closed rather than open.
 """.
 
--export([classes/0, class/2, authorised/2, class_names/0]).
+-export([classes/0, class/2, authorised/2, class_names/0, class_of/1]).
 
 -type class() :: read | player_data | config | erasure.
 -type segment() :: binary() | '_'.
@@ -96,6 +96,21 @@ authorised(Class, Caps) -> lists:member(Class, Caps).
 -spec class_names() -> [class()].
 class_names() ->
     [read, player_data, config, erasure].
+
+-doc """
+Narrow an untrusted term to a capability class, or refuse it.
+
+Exported so a consumer does not keep a second copy of the class list. A copy
+drifts the moment a class is added, and it drifts silently: the new class
+passes validation wherever it is minted and is then dropped here, which is the
+403-far-from-the-cause that asobi_ops_token:caps/1 exists to avoid.
+""".
+-spec class_of(term()) -> {ok, class()} | error.
+class_of(Term) ->
+    case [C || C <- class_names(), C =:= Term] of
+        [Class | _] -> {ok, Class};
+        [] -> error
+    end.
 
 -spec lookup(atom(), [binary()]) -> class() | undefined.
 lookup(undefined, _Segments) ->

--- a/src/ops/asobi_ops_features.erl
+++ b/src/ops/asobi_ops_features.erl
@@ -34,7 +34,7 @@ It stays in the list so a console rendering against a stripped custom release
 still gets an answer rather than an absent key.
 """.
 
--export([features/0, extensions/0, capabilities/0]).
+-export([features/0, extensions/0, capabilities/0, vsn_binary/1]).
 
 -spec features() -> map().
 features() ->
@@ -103,15 +103,28 @@ ships_console(App) ->
 -spec app_version(atom()) -> binary().
 app_version(App) ->
     case application:get_key(App, vsn) of
-        {ok, Vsn} when is_list(Vsn) -> list_to_binary([C || C <- Vsn, is_integer(C)]);
+        {ok, Vsn} when is_list(Vsn) -> vsn_binary(Vsn);
         _ -> ~"unknown"
+    end.
+
+%% A vsn is whatever the .app file holds, so an iolist like ["1.0", ".0"] is
+%% legitimate and must still render as "1.0.0". Filtering the list for integers
+%% would silently truncate it; application:get_key/2 is a boundary, so the
+%% conversion is made total instead. See docs/eqwalizer-idioms.md.
+-spec vsn_binary(dynamic()) -> binary().
+vsn_binary(Vsn) ->
+    try unicode:characters_to_binary(Vsn) of
+        Binary when is_binary(Binary) -> Binary;
+        _ -> ~"unknown"
+    catch
+        _:_ -> ~"unknown"
     end.
 
 -doc "Core capabilities, sorted by name so the response is stable.".
 -spec capabilities() -> [#{name := binary(), enabled := boolean()}].
 capabilities() ->
     [
-        #{name => Name, enabled => Enabled}
+        #{name => Name, enabled => Enabled =:= true}
      || {Name, Enabled} <- lists:sort([
             {~"clustering", configured(cluster)},
             {~"guest_auth", asobi_guest_controller:enabled()},
@@ -124,17 +137,17 @@ capabilities() ->
             {~"storage", asobi_storage:enabled()},
             {~"worlds", any_mode(fun is_world_mode/1)}
         ]),
-        %% lists:sort/1 widens the pairs to term(). See
-        %% docs/eqwalizer-idioms.md; nothing is dropped, the list above is a
-        %% literal of {binary(), boolean()}.
-        is_binary(Name),
-        is_boolean(Enabled)
+        %% lists:sort/1 widens the pairs to term(). The keys are literals; the
+        %% values are ten calls, so `enabled` is normalised rather than
+        %% filtered - a capability that answered oddly should report false on
+        %% this diagnostic surface, not vanish from it.
+        is_binary(Name)
     ].
 
 -spec version() -> binary().
 version() ->
     case application:get_key(asobi, vsn) of
-        {ok, Vsn} when is_list(Vsn) -> list_to_binary([C || C <- Vsn, is_integer(C)]);
+        {ok, Vsn} when is_list(Vsn) -> vsn_binary(Vsn);
         _ -> ~"unknown"
     end.
 

--- a/src/ops/asobi_ops_features.erl
+++ b/src/ops/asobi_ops_features.erl
@@ -103,7 +103,7 @@ ships_console(App) ->
 -spec app_version(atom()) -> binary().
 app_version(App) ->
     case application:get_key(App, vsn) of
-        {ok, Vsn} when is_list(Vsn) -> list_to_binary(Vsn);
+        {ok, Vsn} when is_list(Vsn) -> list_to_binary([C || C <- Vsn, is_integer(C)]);
         _ -> ~"unknown"
     end.
 
@@ -123,13 +123,18 @@ capabilities() ->
             {~"steam", configured(steam_api_key)},
             {~"storage", asobi_storage:enabled()},
             {~"worlds", any_mode(fun is_world_mode/1)}
-        ])
+        ]),
+        %% lists:sort/1 widens the pairs to term(). See
+        %% docs/eqwalizer-idioms.md; nothing is dropped, the list above is a
+        %% literal of {binary(), boolean()}.
+        is_binary(Name),
+        is_boolean(Enabled)
     ].
 
 -spec version() -> binary().
 version() ->
     case application:get_key(asobi, vsn) of
-        {ok, Vsn} when is_list(Vsn) -> list_to_binary(Vsn);
+        {ok, Vsn} when is_list(Vsn) -> list_to_binary([C || C <- Vsn, is_integer(C)]);
         _ -> ~"unknown"
     end.
 

--- a/src/world/asobi_world_lobby_server.erl
+++ b/src/world/asobi_world_lobby_server.erl
@@ -24,6 +24,8 @@ listings for both worlds and matches. Callers read the table directly
 """.
 -behaviour(gen_server).
 
+-include_lib("kernel/include/logger.hrl").
+
 -export([start_link/0, find_or_create/1, find_or_create/2, cache_listing/3]).
 -export([find_or_create_match/2]).
 -export([init/1, handle_call/3, handle_cast/2]).
@@ -135,7 +137,20 @@ handle_call(_Other, _From, State) ->
 handle_cast({cache_listing, Key, Listing, ExpiresAt}, State) when
     is_tuple(Key), is_list(Listing), is_integer(ExpiresAt)
 ->
-    ets:insert(?LIST_CACHE_TAB, {Key, Listing, ExpiresAt}),
+    %% Every element checked here, once per cache fill, rather than on every
+    %% read: asobi_discovery:cache_lookup/2 promises [map()], and the elements
+    %% come from a ServerMod:listing_info/1 callback implemented outside this
+    %% module - including by extensions. A bad element refuses the write, so a
+    %% browse never serves a listing that is quietly short one world.
+    case lists:all(fun is_map/1, Listing) of
+        true ->
+            ets:insert(?LIST_CACHE_TAB, {Key, Listing, ExpiresAt});
+        false ->
+            ?LOG_WARNING(#{
+                msg => ~"discovery listing not cached: an entry is not a map",
+                key => Key
+            })
+    end,
     {noreply, State};
 handle_cast(_Msg, State) ->
     {noreply, State}.

--- a/test/asobi_game_config_tests.erl
+++ b/test/asobi_game_config_tests.erl
@@ -18,8 +18,27 @@ game_config_test_() ->
         {"a non-boolean operator guest_auth pins it off",
             fun non_boolean_operator_guest_auth_pins_off/0},
         {"a non-map operator env is ignored, not crashed on", fun non_map_operator_env_ignored/0},
+        {"a malformed operator mode still shadows the script's",
+            fun malformed_operator_mode_still_shadows/0},
         {"script modes resolve through asobi_game_modes", fun script_mode_resolves/0}
     ]}.
+
+%% asobi#435 tranche 3 re-narrowed env_modes/1 for the type checker, which
+%% dropped an operator entry this module cannot use BEFORE the merge - so the
+%% bundle's definition of that name went live instead. This module's guarantee
+%% is that no bundle reload can redefine or drop an operator mode, so a
+%% malformed one must still shadow, and still fail closed when resolved.
+malformed_operator_mode_still_shadows() ->
+    application:set_env(asobi, game_modes, #{~"arena" => [{module, operator_mod}]}),
+    ok = asobi_game_config:apply_config(#{
+        modes => #{~"arena" => #{module => script_mod, match_size => 8}}
+    }),
+    %% The mode fails closed either way. What must not happen is the SCRIPT's
+    %% definition going live under a name the operator pinned - that is the
+    %% guarantee, and re-narrowing env_modes/1 broke it by dropping the
+    %% operator's entry before the merge instead of after.
+    ?assertEqual(undefined, maps:get(~"arena", asobi_game_config:modes(), undefined)),
+    ?assertEqual({error, not_found}, asobi_game_modes:resolve_game_module(~"arena")).
 
 setup() ->
     Saved = [{Key, application:get_env(asobi, Key)} || Key <- keys()],

--- a/test/asobi_storage_controller_tests.erl
+++ b/test/asobi_storage_controller_tests.erl
@@ -12,8 +12,33 @@
 controller_test_() ->
     {foreach, fun setup/0, fun cleanup/1, [
         fun each_route_answers_its_family_not_found_when_disabled/0,
-        fun routes_reach_their_handler_when_enabled/0
+        fun routes_reach_their_handler_when_enabled/0,
+        fun a_malformed_binding_answers_the_same_on_every_handler/0
     ]}.
+
+%% asobi#435 tranche 3 added `when is_binary(Col), is_binary(Key)` to these
+%% handlers. guarded/2 checks whether storage is enabled; it does not catch, so
+%% a guard without a fallback clause turns a 404 into a 500 - and the first
+%% version of that change gave do_get_storage/1 a fallback and do_delete_storage/1
+%% only the guard.
+a_malformed_binding_answers_the_same_on_every_handler() ->
+    application:set_env(asobi, storage, true),
+    Req = #{
+        bindings => #{~"collection" => 123, ~"key" => ~"theme"},
+        json => #{~"value" => #{}},
+        qs => ~"",
+        auth_data => #{player_id => ?PID}
+    },
+    Crashed = [
+        Name
+     || {Name, Result} <- [
+            {get, catch asobi_storage_controller:get_storage(Req)},
+            {put, catch asobi_storage_controller:put_storage(Req)},
+            {delete, catch asobi_storage_controller:delete_storage(Req)}
+        ],
+        element(1, Result) =:= 'EXIT'
+    ],
+    ?assertEqual([], Crashed).
 
 setup() ->
     Was = application:get_env(asobi, storage),

--- a/test/asobi_storage_controller_tests.erl
+++ b/test/asobi_storage_controller_tests.erl
@@ -29,16 +29,20 @@ a_malformed_binding_answers_the_same_on_every_handler() ->
         qs => ~"",
         auth_data => #{player_id => ?PID}
     },
-    Crashed = [
-        Name
-     || {Name, Result} <- [
-            {get, catch asobi_storage_controller:get_storage(Req)},
-            {put, catch asobi_storage_controller:put_storage(Req)},
-            {delete, catch asobi_storage_controller:delete_storage(Req)}
-        ],
-        element(1, Result) =:= 'EXIT'
+    Handlers = [
+        {get, fun asobi_storage_controller:get_storage/1},
+        {put, fun asobi_storage_controller:put_storage/1},
+        {delete, fun asobi_storage_controller:delete_storage/1}
     ],
+    Crashed = [Name || {Name, Fn} <- Handlers, crashes(Fn, Req)],
     ?assertEqual([], Crashed).
+
+crashes(Fn, Req) ->
+    try Fn(Req) of
+        _ -> false
+    catch
+        _:_ -> true
+    end.
 
 setup() ->
     Was = application:get_env(asobi, storage),


### PR DESCRIPTION
Tranche 3 of #435, scoped to the **boundary class**: a value crossing something the checker cannot see through — an ETS row, a `gen_server:call`/`start_link` result, `persistent_term`, `application:get_key/env` — reaching a typed context.

**Tree: 209 → 170.** Ten modules.

## What a boundary narrowing means here

Not a cast. Each read is narrowed to the shape *the writer put there*, so a clobbered key or an unexpected row is a legible `function_clause` rather than a value flowing on as the wrong type. `asobi_console_session` is the clearest example: it now checks all five fields of `session()` and validates cap atoms against the four `class()` values, where before it returned whatever the `gen_server:call` handed back.

## Three places this needed care, not a guard

**`asobi_storage_controller`.** `Col` and `Key` come out of cowboy's untyped `bindings`, so the head wants `is_binary/1`. But `guarded/2` turned out to only check whether storage is *enabled* — it does not catch — so a bare guard would have turned a malformed binding from a 404 into a **500**. Both handlers get an explicit fallback answering `storage.not_found`, which is the shape the unguarded version produced anyway by querying and finding nothing.

**`asobi_guest_reaper` — a regression I introduced, caught by CT.** The live-guest count is cached with a TTL, and `unknown` is a cached *failure*; caching it is the point, so a failing count is asked once per TTL rather than once per call, which `asobi_guest_SUITE` asserts. Guarding with `is_integer/1` alone rejected it and re-queried every time. The expected type had said so all along: `'unknown' | integer()`.

That is the third narrowing in this cleanup to change behaviour where the old code passed a value through, after `asobi_fixture_erase` (#555) and `asobi_console` (#555). All three were caught by a test, none by reading. I now run the affected suites per module rather than per tranche.

**`asobi_ops_features`** had two `list_to_binary(Vsn)` sites; I fixed one and only the re-check found the sibling.

## Two modules deliberately left alone

Not deferred vaguely — each has a reason the gate would otherwise force me to fudge:

- **`asobi_extensions`**: its `persistent_term` reads narrow cleanly, but the remaining error needs `[problem()]` — an eleven-member tuple union — threaded out of `validate/1`, and every spec added to a producer pushed the checking a layer deeper into untyped internals. Its own piece of work.
- **`asobi_body_cap_plugin`**: one error, `json:encode/1` on an `asobi_error:object()` whose `details()` carries `term()`. The honest fix is tightening that type across modules, not casting at the call site.

Reverted both to untouched so the gate does not demand them here.

## Checks

eunit **2362/0**, ct **390/0**, dialyzer clean, fmt, and `elp eqwalize` `NO ERRORS` on every touched module.