### PR TITLE
feat(world): cut the per-tick cost of a populated zone

### DIFF
--- a/docs/adr/0016-idle-zones-tick-at-the-cold-divisor.md
+++ b/docs/adr/0016-idle-zones-tick-at-the-cold-divisor.md
@@ -12,6 +12,24 @@ Recorded because it changes when a documented callback fires. `zone_tick/2` is
 a public behaviour callback and this makes it run 1-in-N ticks for some zones,
 which ADR 0000 names as "optimisations that change observable semantics".
 
+## Amended by later work
+
+- **Decision 3 no longer describes the code.** widgrensit/asobi#560 removed the
+  per-tick partition against the zone manager's active list: the ticker owns
+  its hot and cold sets outright, is told when a zone opens, and prunes a dead
+  zone from its own monitor rather than by the zone's absence from a list it
+  re-reads. The *effect* decision 3 describes - a reaped zone drops out without
+  a `remove_zone` cast - still holds, by a different mechanism.
+- **Decision 1's "subscribers deliberately do not count" holds for
+  classification, and no longer holds for reaping.**
+  `docs/adr/0021-a-zone-with-nothing-to-simulate-may-not-tick-at-all.md`
+  decision 4 makes a zone with subscribers decline `reap`. A watched empty zone
+  is still demoted; it is just not torn down.
+- ADR 0021 extends this one with `cold_tick_divisor = 0`.
+
+The file:line citations below were accurate at the time and are not now.
+Function names are the durable reference; treat the numbers as historical.
+
 ## Context
 
 A reporter measured an empty zone - zero entities, an inert `zone_tick`, no

--- a/docs/adr/0021-a-zone-with-nothing-to-simulate-may-not-tick-at-all.md
+++ b/docs/adr/0021-a-zone-with-nothing-to-simulate-may-not-tick-at-all.md
@@ -5,7 +5,9 @@ Date: 2026-08-25
 ## Status
 
 **Accepted, and shipped.** Extends
-`docs/adr/0016-idle-zones-tick-at-the-cold-divisor.md`, which stands. Closes
+`docs/adr/0016-idle-zones-tick-at-the-cold-divisor.md`, whose decision 3 is
+superseded by widgrensit/asobi#560 and whose decision 1 is amended by decision
+4 below; both are recorded in that file's own "Amended by later work". Closes
 widgrensit/asobi#561. **Off by default**: the divisor is still 10, and a world
 has to ask for 0.
 
@@ -54,13 +56,21 @@ the only transition back.**
    lost: it demoted before it went silent, and message-driven promotion is the
    only transition left. That is ADR 0016's decision 2, load-bearing rather
    than an optimisation.
-4. **A zone with subscribers declines `reap` and re-stamps itself.** This was
-   already true in effect - an empty watched zone re-stamped itself on the
-   `map_size(Subs) > 0` branch of every tick, so the reap cast never arrived -
-   but it was emergent from the tick rather than stated, and a zone that stops
-   ticking stops stamping. Without the guard, turning the knob on would tear a
-   watched zone out from under subscribers who are not re-subscribed until they
-   next move, and they would silently stop seeing anything that happens there.
+4. **A zone with subscribers declines `reap` and re-stamps itself.** Mostly a
+   statement of emergent behaviour - an empty watched zone re-stamped itself on
+   the `map_size(Subs) > 0` branch of every tick, so the reap cast never
+   arrived - made necessary because a zone that stops ticking stops stamping.
+   Without the guard, turning the knob on would tear a watched zone out from
+   under subscribers who are not re-subscribed until they next move, and they
+   would silently stop seeing anything that happens there.
+
+   **It also closes a race that existed at every divisor.** `release_zone/2`
+   backdates the stamp the moment a zone empties, and the sweep runs every
+   `?REAP_INTERVAL`. A sweep landing between that backdate and the zone's next
+   tick re-stamping it - a 20ms window when hot, 200ms when cold - fell through
+   to the `map_size(Entities) =:= 0` clause and stopped a *watched* zone. Small,
+   but real, and the same shape as the widgrensit/asobi#283 nightly flake. So
+   this is not purely a restatement.
 5. A `busy` zone is never idle, so a script driving wave logic from `zone_tick`
    keeps its full rate at 0 exactly as it does at 10 (ADR 0019).
 
@@ -76,6 +86,16 @@ the only transition back.**
 - The reap guard changes behaviour at every divisor, not only at 0. It makes an
   existing emergent behaviour explicit; no zone that used to be reaped is
   reaped less often, because a watched zone was never reachable by the sweep.
+- A dormant zone does not run `maybe_apply_spawn_templates_hint/5`, so it does
+  not pick up a hot-reloaded spawn template until it next warms. Self-corrects
+  on the first warm tick, and hot reload is a stated differentiator, so it is
+  worth knowing rather than a defect.
+- **The escape hatch is all-or-nothing.** A script with zone-level time - a
+  wave countdown, weather, a capture timer - must return `busy = true`
+  continuously, which pins the zone at full rate. There is no "wake me in N
+  ms". The missing primitive is a zone-level timer wheel, the zone equivalent
+  of `asobi_entity_timer`, which `zone_idle/1` already consults. That is what
+  would make this knob broadly safe, and it is a follow-up.
 - Declined: making 0 the default. The failure mode of a game that quietly needs
   the cold tick is silent and slow to attribute, and there is no way for asobi
   to detect it. An operator turning a knob on a large lazy world has the

--- a/docs/adr/0021-a-zone-with-nothing-to-simulate-may-not-tick-at-all.md
+++ b/docs/adr/0021-a-zone-with-nothing-to-simulate-may-not-tick-at-all.md
@@ -1,0 +1,89 @@
+# ADR 0021: `cold_tick_divisor = 0` stops ticking an idle zone entirely
+
+Date: 2026-08-25
+
+## Status
+
+**Accepted, and shipped.** Extends
+`docs/adr/0016-idle-zones-tick-at-the-cold-divisor.md`, which stands. Closes
+widgrensit/asobi#561. **Off by default**: the divisor is still 10, and a world
+has to ask for 0.
+
+Recorded for the same reason ADR 0016 was: `zone_tick/2` is a public behaviour
+callback, and this makes it stop firing for some zones rather than merely fire
+less often. ADR 0000 names that as an observable-semantics change.
+
+## Context
+
+ADR 0016 removed 90% of the idle floor by ticking a zone with nothing to
+simulate 1-in-10. The remaining 10% is not free:
+
+- A cold tick is a full `do_tick` - the `zone_tick` bridge call with its
+  encode/decode round trip, the crossing scan, reclassification.
+- A zone that hibernates between cold ticks pays a full-sweep GC of the whole
+  process on every hibernate/wake cycle. At divisor 10 and `tick_rate = 50`
+  that is 2 Hz of whole-heap collection on a zone doing nothing.
+
+The aggregate of "loaded but idle" scales with map size rather than with player
+activity, so on a 2000x2000-capable lazy world where an operator keeps
+`max_active_zones` high it is a per-world cost nobody asked for.
+
+The correctness machinery for "safe to skip" already exists. `zone_idle/1` is
+precise about what "nothing to simulate" means - no entities, no queued input,
+no queued cross-zone effect, no live entity timer, no pending respawn - and ADR
+0019 lets a script veto with `busy`.
+
+## Decision
+
+**`cold_tick_divisor = 0` means an idle zone is not ticked, and `warm_up/1` is
+the only transition back.**
+
+1. `asobi_world_ticker` folds a divisor of 0 - and any non-positive or
+   non-integer value - into "never tick the cold set" (`tick_cold/2`). Hot
+   zones are unaffected: this is not a world-wide off switch.
+2. **Nothing has to be caught up on warm-up, and that is a property of
+   `zone_idle/1` rather than an omission.** A zone is only demoted when its
+   entity-timer wheel is empty and its respawn queue is empty, so a dormant
+   zone holds no elapsed deadline. What it can acquire while dormant - a spawn,
+   a timer, an entity, an input, an effect - arrives as a message, and every
+   one of those messages already runs `warm_up/1`. `asobi_zone_spawner:tick/2`
+   and `asobi_entity_timer:tick/2` are both driven by the `Now` the resumed
+   tick passes them, so a window that opened during the silence fires on the
+   first tick after warm-up rather than a divisor later.
+3. A zone at divisor 0 never runs `reclassify/1`, so no demotion decision is
+   lost: it demoted before it went silent, and message-driven promotion is the
+   only transition left. That is ADR 0016's decision 2, load-bearing rather
+   than an optimisation.
+4. **A zone with subscribers declines `reap` and re-stamps itself.** This was
+   already true in effect - an empty watched zone re-stamped itself on the
+   `map_size(Subs) > 0` branch of every tick, so the reap cast never arrived -
+   but it was emergent from the tick rather than stated, and a zone that stops
+   ticking stops stamping. Without the guard, turning the knob on would tear a
+   watched zone out from under subscribers who are not re-subscribed until they
+   next move, and they would silently stop seeing anything that happens there.
+5. A `busy` zone is never idle, so a script driving wave logic from `zone_tick`
+   keeps its full rate at 0 exactly as it does at 10 (ADR 0019).
+
+## Consequences
+
+- A world that turns this on pays nothing for a loaded-but-idle zone. The
+  residual cost of a large lazy world scales with player activity rather than
+  with map size.
+- `zone_tick/2` can go arbitrarily long without firing for such a zone. A game
+  that keeps state in `zone_state` and advances it from the tick must either
+  return `busy` (ADR 0019) or not use this knob. The guides say so at both
+  ends.
+- The reap guard changes behaviour at every divisor, not only at 0. It makes an
+  existing emergent behaviour explicit; no zone that used to be reaped is
+  reaped less often, because a watched zone was never reachable by the sweep.
+- Declined: making 0 the default. The failure mode of a game that quietly needs
+  the cold tick is silent and slow to attribute, and there is no way for asobi
+  to detect it. An operator turning a knob on a large lazy world has the
+  context; a default does not.
+
+## Prior art
+
+Grid-based C++ emulators behave this way: a grid with no players near it gets
+no object updates at all, and respawns come from a time-ordered queue consulted
+at a coarse interval (AzerothCore's `ProcessRespawns`, every 5s) rather than
+from ticking dormant creatures slowly.

--- a/docs/adr/0022-zone-tick-may-declare-what-changed.md
+++ b/docs/adr/0022-zone-tick-may-declare-what-changed.md
@@ -1,0 +1,104 @@
+# ADR 0022: `zone_tick/2` may declare what changed
+
+Date: 2026-08-25
+
+## Status
+
+**Accepted, and shipped.** Closes widgrensit/asobi#557. Additive and opt-in:
+the two- and three-tuple returns keep today's semantics exactly, in both VM
+modes, and no existing game changes behaviour.
+
+Recorded because `zone_tick/2` is a public behaviour callback and this adds a
+way for a game to make asobi believe something false about its own state. ADR
+0000 names that class.
+
+## Context
+
+ADR 0015 removed the O(state) copy from every budgeted callback, and its own
+measurements name what it did not remove:
+
+> The win is much smaller when the per-tick work grows with the state - a zone
+> holding 8,000 entities and encoding all of them every tick measured 1.4x,
+> because there the encode is genuine work and the copy is a minority of it.
+> `owned` removes a term that is O(state); it does not make encoding cheaper.
+
+A populated zone paid O(all entities x fields) three times per tick to discover
+a usually-small changed set:
+
+- `asobi_lua_world:zone_tick/2` encoded every entity in and decoded and
+  atomised every one of them back out, on a tick where the script moved one NPC
+  or nothing at all.
+- Because the decode rebuilt every entity map, structural sharing with the
+  previous tick was destroyed, so `compute_deltas/2` deep-compared every field
+  of every entity at each broadcast to find out that most had not changed.
+- `sync_spatial_grid/3` walked all entities for the same reason: nothing told
+  it which ones moved.
+
+Measured here on one machine, a zone with an inert script that moves three
+entities, under `owned`:
+
+| entities | us/tick before | us/tick after | reductions in the zone before | after |
+|---|---|---|---|---|
+| 100 | 280 | 224 | 10,944 | 528 |
+| 500 | 1,773 | 1,152 | 53,289 | 692 |
+| 2,000 | 10,509 | 5,929 | 200,659 | 1,208 |
+
+Under `copy` at 2,000 entities: 13.1ms to 9.4ms.
+
+The reduction column is the one that matters for scheduling: the decode ran on
+the zone `gen_server` itself, so a 2,000-entity zone spent 200k reductions per
+tick marshalling before the game did anything.
+
+## Decision
+
+**A game may return a fourth value saying what it changed, and asobi merges it
+onto the map it handed in.**
+
+1. `{Entities, ZoneState, Busy, #{changed => #{Id => Entity}, removed => [Id]}}`.
+   `Entities` is the base; `changed` is merged over it and `removed` deleted
+   from it. Lua returns the same shape as a table.
+2. **The bridge stops decoding.** When a Lua script declares, `asobi_lua_world`
+   decodes only `changed` and passes the input map straight back as the base.
+   That is where most of the win is, and it is also what makes the sharing
+   real: the untouched entities are not merely equal, they are the same terms.
+3. **The declaration is the truth.** An entity the script mutated and did not
+   name is not changed, and the next tick re-encodes asobi's map over the top
+   of it - so the mutation is undone, not merely invisible. This is inherent to
+   any dirty contract and it is why this is opt-in per game rather than a mode.
+4. **Fail towards merging.** A malformed declaration is narrowed - non-binary
+   ids and non-map entities are dropped, a non-map declaration is ignored
+   entirely - and logged through the bounded formatter with a
+   `bad_zone_dirty` game error. Ignoring a declaration is always safe: it costs
+   the sharing and nothing else. Refusing the tick would not be.
+5. `sync_spatial_grid/3` matches the previous tick's entity term first, so an
+   entity nobody touched costs one pointer comparison rather than two position
+   extractions. `compute_deltas/2` already did this - it just never got a
+   shared term to do it on.
+
+## Consequences
+
+- A Lua zone's marshalling cost stops scaling with resident entity count and
+  starts scaling with activity. A zone of 500 NPCs of which 3 move pays for 3.
+- **The encode IN is unchanged and still O(N).** Removing it needs the VM to
+  hold the entities table across ticks and asobi to push only its own
+  mutations, which means tracking dirtiness across `handle_input`,
+  `handle_effects`, the timer wheel, the spawner, the crossing resolver and
+  five entity-bearing casts. That is a separate decision with a real hazard - a
+  missed mark is an entity that silently stops replicating - and it is not this
+  one. The tables above are with the encode still in.
+- Nothing in `asobi_zone` accumulates a dirty set across ticks, and no mutation
+  site outside `zone_tick_result/2` has to know this exists. That is deliberate:
+  it is what keeps the change unable to lose an entity.
+- Declined: a `game.mark_dirty(id)` API. It would put the bridge's per-call
+  cost on every marked entity and give a script a way to mark from outside
+  `zone_tick`, where asobi has no base map to merge onto.
+- Declined: making the declaration mandatory under `owned`. `owned` is a
+  deployment choice about where the state lives; this is a contract about what
+  the game promises. Coupling them would change a game's semantics when an
+  operator flipped a flag.
+
+## Prior art
+
+Standard in C++ MMO emulators - AzerothCore's `UpdateData`, where objects
+accumulate per-field dirty flags and replication packets are built from marked
+blocks only. Nothing there scans full state to derive deltas.

--- a/docs/adr/0022-zone-tick-may-declare-what-changed.md
+++ b/docs/adr/0022-zone-tick-may-declare-what-changed.md
@@ -39,11 +39,16 @@ entities, under `owned`:
 
 | entities | us/tick before | us/tick after | reductions in the zone before | after |
 |---|---|---|---|---|
-| 100 | 280 | 224 | 10,944 | 528 |
-| 500 | 1,773 | 1,152 | 53,289 | 692 |
-| 2,000 | 10,509 | 5,929 | 200,659 | 1,208 |
+| 100 | 299 | 181 | 10,945 | 526 |
+| 500 | 1,784 | 898 | 53,314 | 672 |
+| 2,000 | 9,292 | 4,569 | 200,466 | 1,209 |
 
-Under `copy` at 2,000 entities: 13.1ms to 9.4ms.
+Median of three runs each; the wall-clock column moves by 10-20% between runs
+on this machine and the reduction column does not, which is why both are here.
+
+Under `copy` at 2,000 entities: 14.6ms to 8.8ms, and 778k reductions to 452k.
+The reduction floor is higher there because the encode still runs on the zone
+process rather than in the VM.
 
 The reduction column is the one that matters for scheduling: the decode ran on
 the zone `gen_server` itself, so a 2,000-entity zone spent 200k reductions per
@@ -63,17 +68,64 @@ onto the map it handed in.**
    real: the untouched entities are not merely equal, they are the same terms.
 3. **The declaration is the truth.** An entity the script mutated and did not
    name is not changed, and the next tick re-encodes asobi's map over the top
-   of it - so the mutation is undone, not merely invisible. This is inherent to
-   any dirty contract and it is why this is opt-in per game rather than a mode.
-4. **Fail towards merging.** A malformed declaration is narrowed - non-binary
-   ids and non-map entities are dropped, a non-map declaration is ignored
-   entirely - and logged through the bounded formatter with a
-   `bad_zone_dirty` game error. Ignoring a declaration is always safe: it costs
-   the sharing and nothing else. Refusing the tick would not be.
-5. `sync_spatial_grid/3` matches the previous tick's entity term first, so an
-   entity nobody touched costs one pointer comparison rather than two position
-   extractions. `compute_deltas/2` already did this - it just never got a
-   shared term to do it on.
+   of it - so the mutation is undone, not merely invisible.
+
+   The first draft of this ADR called that "inherent to any dirty contract".
+   **It is not, and the prior art cited below contradicts it.** AzerothCore's
+   dirty flags govern *replication*: a missed flag means the client does not
+   see the change, the server's state still holds it, and the next marked write
+   carries it. Here a missed declaration REVERTS the mutation, because the
+   consumer of the declaration also owns the base state and re-encodes it over
+   the top. That is a strictly more destructive failure mode than the
+   precedent.
+
+   The honest claim is narrower: inherent to a dirty contract *where the base
+   state is re-pushed by the consumer* - a design choice made in decision 2,
+   not a law. And it has a consequence that decision 4 has to carry: because
+   the failure is worse than the prior art's, the reporting has to be better
+   than the prior art's, not equal.
+4. **Fail towards merging, and say so every time.** A malformed declaration is
+   narrowed - non-binary ids and non-map entities dropped, a non-map
+   declaration ignored - and *every* way of being malformed emits
+   `bad_zone_dirty` and a log line. Ignoring a declaration is always safe: it
+   costs the sharing and nothing else. Refusing the tick would not be.
+
+   Four ways of being malformed reported nothing in the first implementation,
+   and the review of widgrensit/asobi#557 found all four. They are recorded
+   because each one produces the same symptom - every entity in the zone stops
+   moving, forever, with no error - and because three of them are one line away
+   from an idiom the guide itself shows:
+
+   - a typo'd key (`#{chnaged => ...}`) read as an empty declaration;
+   - `changed` built as a Lua array (`changed[#changed + 1] = e`) was
+     normalised to `#{}` in the bridge, *before* core could complain;
+   - a table that declares neither half became a well-formed empty declaration,
+     because `decode_to_map/2` coerces an array-shaped decode to `#{}`;
+   - `narrow_ids/1` dropped bad ids silently while its sibling logged.
+
+   What is logged is a **count and the first offending key clipped to 64
+   bytes**, never the declaration. `changed` is script-controlled and
+   arbitrarily large, and the module's bounded formatter renders its whole
+   argument before truncating it - measured at ~10 seconds on the zone process
+   for a 32MB script binary, outside `bounded_eval`'s wall clock and invisible
+   to `max_heap_size` because a refc binary is. Three of those per limiter
+   window is a zone that never ticks again, with no crash to attribute it to.
+   The bound has to be on the way IN.
+5. **Only a table reference is a declaration.** Luerl represents every
+   non-scalar as a record, so `is_tuple/1` admits `#funref{}`, `#erl_func{}`,
+   `#erl_mfa{}` and `#usdref{}` as well as `#tref{}` - and each of those raises
+   out of the decode, on a callback `asobi_zone:do_tick/2` invokes with no
+   try/catch. The tag is checked, and the decode is wrapped anyway because a
+   `#tref{}` can be recursive.
+6. **`sync_spatial_grid/3` deliberately does NOT test entity identity.**
+   Matching the previous tick's term would settle an untouched entity in one
+   pointer comparison where sharing holds - but where it does not, `=:=` on two
+   maps is a structural walk *that can only fail*, and that is the common case:
+   every game that does not declare, plus every Lua game on a tick carrying
+   input. Two position lookups are O(1) whatever the entity holds.
+   `compute_deltas/2` is where the sharing pays, and it already tested
+   identity - it just never got a shared term to do it on.
+7. An id in both `changed` and `removed` is removed: the merge happens first.
 
 ## Consequences
 
@@ -89,6 +141,15 @@ onto the map it handed in.**
 - Nothing in `asobi_zone` accumulates a dirty set across ticks, and no mutation
   site outside `zone_tick_result/2` has to know this exists. That is deliberate:
   it is what keeps the change unable to lose an entity.
+- **The downstream half of the win is cancelled by input.** `handle_input/3`
+  and `handle_input_batch/2` encode the entity map and decode it back, so any
+  tick carrying at least one input rebuilds every entity and destroys the
+  sharing this preserved. The upstream half - not decoding the whole table in
+  `zone_tick` - survives, and decision 2 says that is the bigger half. But the
+  measurements in this ADR are taken with an inert script and no input, which
+  excludes the workload that holds the most entities: a populated zone with
+  players in it. Extending the declaration to `handle_input_batch/2` is where
+  it composes; that is a follow-up, not this ADR.
 - Declined: a `game.mark_dirty(id)` API. It would put the bridge's per-call
   cost on every marked entity and give a script a way to mark from outside
   `zone_tick`, where asobi has no base map to merge onto.

--- a/guides/performance-tuning.md
+++ b/guides/performance-tuning.md
@@ -119,6 +119,58 @@ spending most of a core on empty space and spending a tenth of it.
 Recorded in `docs/adr/0016-idle-zones-tick-at-the-cold-divisor.md`, which also
 says what it deliberately does not solve.
 
+### Telling asobi what changed
+
+An idle zone is cheap. A **populated** one has a different problem: its tick
+cost scales with how many entities it holds rather than with how many of them
+did anything. The entity map crosses the Lua bridge whole in both directions on
+every tick, and because the decode rebuilds every entity map, the delta diff and
+the spatial-grid sync then walk every field of every entity to discover that
+three NPCs moved.
+
+Say what changed and none of that happens:
+
+```lua
+function zone_tick(entities, zone_state)
+  local changed, removed = {}, {}
+  for id, e in pairs(entities) do
+    if e.target then
+      step(e)
+      changed[id] = e
+    end
+    if e.hp <= 0 then
+      removed[#removed + 1] = id
+    end
+  end
+  return entities, zone_state, false, { changed = changed, removed = removed }
+end
+```
+
+An Erlang game module returns the same fourth element as a map:
+`#{changed => #{Id => Entity}, removed => [Id]}`. Measured on one machine with
+an inert script moving three entities, under `lua_vm_mode = owned`:
+
+| entities | before | after |
+|----------|--------|-------|
+| 100 | 280us | 224us |
+| 500 | 1,773us | 1,152us |
+| 2,000 | 10,509us | 5,929us |
+
+The reductions the zone process itself burns per tick fall much further - 200k
+to 1.2k at 2,000 entities - because the decode used to run on the zone rather
+than in the VM.
+
+**The declaration is the truth.** An entity your script mutated and did not put
+in `changed` is not changed as far as asobi is concerned, and the next tick
+re-encodes asobi's map over the top of it, so the mutation is undone rather than
+merely invisible. That is the trade: it is opt-in per game for exactly this
+reason, and returning the ordinary two- or three-tuple keeps the
+full-comparison behaviour.
+
+What it does **not** remove is the encode in the other direction, which is still
+proportional to the entity count. See
+`docs/adr/0022-zone-tick-may-declare-what-changed.md`.
+
 **If your game drives work from `zone_tick` on a zone that holds nothing** - a
 wave spawner counting down between waves, weather, a zone-level timer - asobi
 cannot see it, and such a zone is demoted to a tenth of the rate it was written
@@ -154,6 +206,22 @@ returned value reads nothing. See
 
 `cold_tick_divisor = 1` disables the whole thing world-wide if you would rather
 not think about it.
+
+`cold_tick_divisor = 0` goes the other way: an idle zone is not ticked **at
+all**. It costs nothing at all until a message gives it work, and it also stops
+paying the full-sweep GC of a hibernate/wake cycle it would otherwise pay twice
+a second. Nothing time-based is lost by the silence - a zone is only demoted
+when it has no live entity timer and an empty respawn queue, and both the
+spawner and the timer wheel are driven by the wall clock the first tick after
+warm-up hands them, so a respawn window that opened while the zone was dormant
+fires on that tick rather than a divisor later. A zone that says it is `busy`
+is never idle, so a script driving wave logic from `zone_tick` keeps its full
+rate at 0 exactly as it does at 10.
+
+Worth turning on for a large lazy world where an operator keeps
+`max_active_zones` high and most loaded zones hold nothing: the residual cost
+of "loaded but idle" then scales with player activity rather than with map
+size. The default stays 10.
 
 What does happen automatically:
 

--- a/guides/performance-tuning.md
+++ b/guides/performance-tuning.md
@@ -138,7 +138,9 @@ function zone_tick(entities, zone_state)
       step(e)
       changed[id] = e
     end
-    if e.hp <= 0 then
+    -- `e.hp and` matters: an entity without an `hp` field compares nil with
+    -- a number, which raises and takes the whole zone_tick down.
+    if e.hp and e.hp <= 0 then
       removed[#removed + 1] = id
     end
   end
@@ -152,13 +154,15 @@ an inert script moving three entities, under `lua_vm_mode = owned`:
 
 | entities | before | after |
 |----------|--------|-------|
-| 100 | 280us | 224us |
-| 500 | 1,773us | 1,152us |
-| 2,000 | 10,509us | 5,929us |
+| 100 | 299us | 181us |
+| 500 | 1,784us | 898us |
+| 2,000 | 9,292us | 4,569us |
 
 The reductions the zone process itself burns per tick fall much further - 200k
 to 1.2k at 2,000 entities - because the decode used to run on the zone rather
-than in the VM.
+than in the VM. That is the number that decides whether a zone keeps up with
+its tick budget, and it is the stable one: the wall-clock column moves by
+10-20% between runs on the same machine.
 
 **The declaration is the truth.** An entity your script mutated and did not put
 in `changed` is not changed as far as asobi is concerned, and the next tick
@@ -167,9 +171,17 @@ merely invisible. That is the trade: it is opt-in per game for exactly this
 reason, and returning the ordinary two- or three-tuple keeps the
 full-comparison behaviour.
 
-What it does **not** remove is the encode in the other direction, which is still
-proportional to the entity count. See
-`docs/adr/0022-zone-tick-may-declare-what-changed.md`.
+Two things it does **not** do, both worth knowing before you reach for it:
+
+- The encode in the other direction is unchanged and still proportional to the
+  entity count. The table above is measured with it still in.
+- The numbers above are for a tick carrying **no player input**. `handle_input`
+  encodes the entity map and decodes it back, which rebuilds every entity and
+  undoes the structural sharing the declaration preserved - so on a populated
+  zone with players in it you keep the large half of the win (`zone_tick` not
+  decoding the whole table) and lose the smaller half (the cheaper delta diff).
+
+See `docs/adr/0022-zone-tick-may-declare-what-changed.md`.
 
 **If your game drives work from `zone_tick` on a zone that holds nothing** - a
 wave spawner counting down between waves, weather, a zone-level timer - asobi

--- a/guides/world-server.md
+++ b/guides/world-server.md
@@ -213,6 +213,7 @@ end
 | `handle_input(player_id, input, entities)` | no | Apply one player's input to that zone's entities. A second return value is the client seq you consumed - see [Batched input and the ack](websocket-protocol.md#client-side-prediction). Every input in a tick is handed the same table rather than a copy, but returning nothing still discards whatever that call mutated - see [Players in one zone](performance-tuning.md#players-in-one-zone) |
 | `handle_effects(effects, entities)` | no | This tick's cross-zone effects, batched. See [Seeing across a seam](#seeing-across-a-seam) |
 | a third return from `zone_tick` | no | `return entities, zone_state, true` stops an entity-less zone being demoted. See [Performance tuning](performance-tuning.md#zone-tick-hibernation-and-reaping) |
+| a fourth return from `zone_tick` | no | `return entities, zone_state, busy, { changed = ..., removed = ... }` says what actually changed, so asobi stops decoding the whole entity table every tick. See [Performance tuning](performance-tuning.md#telling-asobi-what-changed) |
 | `generate_world(seed, config)` | no | Return a table keyed by `"x,y"` strings |
 | `get_state(player_id, state)` | no | Player-visible state |
 | `spawn_templates(config)` | no | See [Spawn templates](#spawn-templates) |
@@ -327,6 +328,7 @@ post_tick(_TickN, State) ->
 | `handle_input_batch/2` | one of | The whole tick's inputs in one call, returning one entity map plus one outcome per input. Export it instead of `handle_input/3` when your per-input cost is dominated by marshalling the entity map rather than by the input. Exporting it shadows `handle_input/3` entirely. asobi still owns the ack policy: you return one outcome per input - see [Players in one zone](performance-tuning.md#players-in-one-zone) |
 | `handle_effects/2` | no | This tick's cross-zone effects: `([{EntityId, Event}], Entities) -> {ok, Entities}`. Delivered after inputs, already filtered to entities this zone still owns. See [Seeing across a seam](#seeing-across-a-seam) |
 | `zone_tick/2`'s third element | no | `{Entities, ZoneState, Busy :: boolean()}` vetoes demotion of an entity-less zone that still has work asobi cannot see. A two-tuple means "not busy"; a non-boolean keeps the zone hot and is logged |
+| `zone_tick/2`'s fourth element | no | `{Entities, ZoneState, Busy, #{changed => #{Id => Entity}, removed => [Id]}}` declares what changed, merged onto the returned map. An entity not named is not changed |
 | `post_tick/2` | yes | Global post-tick: return `{ok, State}`, `{vote, Config, State}`, or `{finished, Result, State}` |
 | `generate_world/2` | no | Procedural generation: `(Seed, Config) -> {ok, #{Coords => ZoneState}}` |
 | `get_state/2` | no | Per-player state view |
@@ -395,7 +397,7 @@ version they are facts of the deployment rather than knobs.
 | `max_active_zones` | 10,000 | See [Large worlds](large-worlds.md) for what happens at that ceiling |
 | `zone_idle_timeout` | 30,000 | Milliseconds an empty zone lingers before it is released |
 | `spatial_grid_cell_size` | unset | Cell side for the in-zone spatial index. Unset means no index is built |
-| `cold_tick_divisor` | 10 | Ticks between ticks of a zone with nothing to simulate - see [Performance tuning](performance-tuning.md) |
+| `cold_tick_divisor` | 10 | Ticks between ticks of a zone with nothing to simulate; `1` ticks it every tick, `0` never ticks it - see [Performance tuning](performance-tuning.md) |
 | `border_band` | 0 | Fraction of `zone_size` published to neighbours - see [Seeing across a seam](#seeing-across-a-seam) |
 
 `rehome_margin` (default 0.15 of `zone_size`, described below) is settable the

--- a/src/asobi_telemetry.erl
+++ b/src/asobi_telemetry.erl
@@ -549,4 +549,5 @@ handle_event(EventName, Measurements, Metadata, _Config) ->
         event => EventName,
         measurements => Measurements,
         metadata => Metadata
-    }).
+    }),
+    ok.

--- a/src/asobi_telemetry.erl
+++ b/src/asobi_telemetry.erl
@@ -46,7 +46,8 @@
     | effect_queue_full
     | no_effect_handler
     | bad_effects_return
-    | bad_zone_busy.
+    | bad_zone_busy
+    | bad_zone_dirty.
 -export_type([game_error_kind/0]).
 -export([economy_transaction/4, store_purchase/3]).
 -export([chat_message_sent/2]).

--- a/src/lua/asobi_lua_config.erl
+++ b/src/lua/asobi_lua_config.erl
@@ -49,7 +49,7 @@ lazy_zones              = true            -- optional, on-demand zone loading
 zone_idle_timeout       = 30000           -- optional, ms before idle zone is reaped
 max_active_zones        = 10000           -- optional, cap on concurrent zones
 spatial_grid_cell_size  = 64              -- optional, cell size for spatial grid indexing
-cold_tick_divisor       = 10              -- optional, tick rate divisor for cold (idle) zones
+cold_tick_divisor       = 10              -- optional, tick divisor for cold (idle) zones, 0 = never tick one
 border_band             = 0.15            -- optional, fraction of zone_size mirrored to neighbours (default 0 = off)
 empty_grace_ms          = 60000           -- optional, ms to keep an empty world alive before finishing
 player_ttl_ms           = 0               -- optional, 0=remove on disconnect, -1=keep forever, N=grace ms
@@ -365,7 +365,7 @@ read_match_globals(ScriptPath, St) ->
             Config3 = maybe_add_bots(Config2a, Bots, ScriptPath),
             Config4 = maybe_add_zone_config(Config3, LazyZones, ZoneIdleTimeout, MaxActiveZones),
             Config5 = maybe_add_int(Config4, spatial_grid_cell_size, SpatialGridCellSize),
-            Config6 = maybe_add_int(Config5, cold_tick_divisor, ColdTickDivisor),
+            Config6 = maybe_add_non_neg_int(Config5, cold_tick_divisor, ColdTickDivisor),
             Config6a = maybe_add_fraction(Config6, border_band, BorderBand),
             Config7 = maybe_add_int(Config6a, empty_grace_ms, EmptyGraceMs),
             Config8 = maybe_add_player_ttl(Config7, PlayerTtlMs),

--- a/src/lua/asobi_lua_world.erl
+++ b/src/lua/asobi_lua_world.erl
@@ -207,7 +207,8 @@ spawn_position(PlayerId, #{lua_state := LuaSt, game_state := GS} = State) ->
 %% exactly the write/read split here.
 -define(TEMPLATES_KEY, known).
 
--spec zone_tick(map(), term()) -> {map(), term()} | {map(), term(), boolean()}.
+-spec zone_tick(map(), term()) ->
+    {map(), term()} | {map(), term(), boolean()} | {map(), term(), boolean(), map()}.
 zone_tick(Entities, ZoneState0) when is_map(ZoneState0) ->
     %% Pick up any lua_state updates that handle_input stashed earlier this
     %% tick. The dev-error rate-limit stamp must ride along too: asobi_zone's
@@ -265,6 +266,20 @@ zone_tick(Entities, ZoneState0) when is_map(ZoneState0) ->
                         zone_tick, [EncEntities, GS], LuaSt1, ?TICK_TIMEOUT
                     )
                 of
+                    {ok, [Ents1, ZS1, Busy, Dirty | _], LuaSt2} ->
+                        ZS = ZoneState#{lua_state => LuaSt2, game_state => ZS1},
+                        case decode_dirty(Dirty, LuaSt2) of
+                            undefined ->
+                                Ents2 = asobi_lua_api:atomize_entities(
+                                    decode_to_map(Ents1, LuaSt2)
+                                ),
+                                {Ents2, ZS, truthy(Busy)};
+                            DirtySet ->
+                                %% `Entities` - what asobi handed IN - rather
+                                %% than a decode of what came back. That is the
+                                %% point: see decode_dirty/2.
+                                {Entities, ZS, truthy(Busy), DirtySet}
+                        end;
                     {ok, [Ents1, ZS1, Busy | _], LuaSt2} ->
                         Ents2 = asobi_lua_api:atomize_entities(decode_to_map(Ents1, LuaSt2)),
                         {Ents2, ZoneState#{lua_state => LuaSt2, game_state => ZS1}, truthy(Busy)};
@@ -285,7 +300,67 @@ zone_tick(Entities, ZoneState) ->
     {Entities, ZoneState}.
 
 result_zone_state({_Entities, ZoneState}) -> ZoneState;
-result_zone_state({_Entities, ZoneState, _Busy}) -> ZoneState.
+result_zone_state({_Entities, ZoneState, _Busy}) -> ZoneState;
+result_zone_state({_Entities, ZoneState, _Busy, _Dirty}) -> ZoneState.
+
+-doc """
+Reads `zone_tick`'s optional fourth return value: what actually changed.
+
+```lua
+function zone_tick(entities, zone_state)
+  local changed, removed = {}, {}
+  for id, e in pairs(entities) do
+    if wants_to_move(e) then step(e); changed[id] = e end
+    if e.hp <= 0 then removed[#removed + 1] = id end
+  end
+  return entities, zone_state, false, { changed = changed, removed = removed }
+end
+```
+
+Declaring it is what lets this bridge stop decoding the whole entities table.
+Without it a populated zone round-trips every entity across the boundary in
+both directions on every tick regardless of how many actually changed - a zone
+with 500 NPCs of which 3 move pays for 500, twenty times a second, and pays
+again downstream because the decode rebuilds every entity map and destroys the
+structural sharing `compute_deltas/2` and `sync_spatial_grid/3` rely on
+(widgrensit/asobi#557). Measured on a 2,000-entity zone with an inert script
+under `owned`, the round trip was ~9.9ms per tick.
+
+**The declaration is the truth.** An entity the script mutated and did not put
+in `changed` is not changed as far as asobi is concerned, and the next tick
+re-encodes asobi's map over the top of it - so the mutation is not merely
+invisible, it is undone. That is inherent to any dirty contract and it is why
+this is opt-in per script rather than a mode.
+
+Anything that is not a Lua table means "no declaration" and today's semantics,
+which is also what a three-value return gives. Malformed halves are narrowed
+away in `asobi_zone:apply_dirty/3` rather than here, so an Erlang game module
+declaring the same thing meets the same bar.
+""".
+-spec decode_dirty(term(), dynamic()) -> map() | undefined.
+%% `nil`, `true`, a number, a string: not a declaration. Only a Lua table is,
+%% and a table reference is a tuple in both VM modes - so anything else means
+%% "no declaration" and the caller falls back to decoding the whole map.
+decode_dirty(Ref, LuaSt) when is_tuple(Ref) ->
+    Decoded = decode_to_map(Ref, LuaSt),
+    #{
+        changed => asobi_lua_api:atomize_entities(
+            as_entity_map(maps:get(~"changed", Decoded, #{}))
+        ),
+        removed => as_id_list(maps:get(~"removed", Decoded, []))
+    };
+decode_dirty(_Other, _LuaSt) ->
+    undefined.
+
+%% An empty Lua table decodes to `[]`, not `#{}` - there is nothing in it to
+%% tell a record from an array.
+-spec as_entity_map(term()) -> map().
+as_entity_map(M) when is_map(M) -> M;
+as_entity_map(_Other) -> #{}.
+
+-spec as_id_list(term()) -> [binary()].
+as_id_list(L) when is_list(L) -> [Id || Id <- L, is_binary(Id)];
+as_id_list(_Other) -> [].
 
 %% Lua truthiness, not Erlang's: `nil` and `false` are the only falsey values, so
 %% `return entities, zone_state, wave_countdown > 0` works and so does returning

--- a/src/lua/asobi_lua_world.erl
+++ b/src/lua/asobi_lua_world.erl
@@ -303,64 +303,121 @@ result_zone_state({_Entities, ZoneState}) -> ZoneState;
 result_zone_state({_Entities, ZoneState, _Busy}) -> ZoneState;
 result_zone_state({_Entities, ZoneState, _Busy, _Dirty}) -> ZoneState.
 
--doc """
-Reads `zone_tick`'s optional fourth return value: what actually changed.
-
-```lua
-function zone_tick(entities, zone_state)
-  local changed, removed = {}, {}
-  for id, e in pairs(entities) do
-    if wants_to_move(e) then step(e); changed[id] = e end
-    if e.hp <= 0 then removed[#removed + 1] = id end
-  end
-  return entities, zone_state, false, { changed = changed, removed = removed }
-end
-```
-
-Declaring it is what lets this bridge stop decoding the whole entities table.
-Without it a populated zone round-trips every entity across the boundary in
-both directions on every tick regardless of how many actually changed - a zone
-with 500 NPCs of which 3 move pays for 500, twenty times a second, and pays
-again downstream because the decode rebuilds every entity map and destroys the
-structural sharing `compute_deltas/2` and `sync_spatial_grid/3` rely on
-(widgrensit/asobi#557). Measured on a 2,000-entity zone with an inert script
-under `owned`, the round trip was ~9.9ms per tick.
-
-**The declaration is the truth.** An entity the script mutated and did not put
-in `changed` is not changed as far as asobi is concerned, and the next tick
-re-encodes asobi's map over the top of it - so the mutation is not merely
-invisible, it is undone. That is inherent to any dirty contract and it is why
-this is opt-in per script rather than a mode.
-
-Anything that is not a Lua table means "no declaration" and today's semantics,
-which is also what a three-value return gives. Malformed halves are narrowed
-away in `asobi_zone:apply_dirty/3` rather than here, so an Erlang game module
-declaring the same thing meets the same bar.
-""".
+%% Reads `zone_tick`'s optional fourth return value: what actually changed.
+%%
+%% ```lua
+%% function zone_tick(entities, zone_state)
+%%   local changed, removed = {}, {}
+%%   for id, e in pairs(entities) do
+%%     if wants_to_move(e) then step(e); changed[id] = e end
+%%     if e.hp and e.hp <= 0 then removed[#removed + 1] = id end
+%%   end
+%%   return entities, zone_state, false, { changed = changed, removed = removed }
+%% end
+%% ```
+%%
+%% Declaring it is what lets this bridge stop decoding the whole entities table.
+%% Without it a populated zone round-trips every entity across the boundary in
+%% both directions on every tick regardless of how many actually changed - a zone
+%% with 500 NPCs of which 3 move pays for 500, twenty times a second, and pays
+%% again downstream because the decode rebuilds every entity map and destroys the
+%% structural sharing `compute_deltas/2` and `sync_spatial_grid/3` rely on
+%% (widgrensit/asobi#557). Measured on a 2,000-entity zone with an inert script
+%% under `owned`, the round trip was ~9.3ms per tick and 200k reductions on the
+%% zone process; declaring takes it to ~4.6ms and 1.2k.
+%%
+%% **The declaration is the truth.** An entity the script mutated and did not put
+%% in `changed` is not changed as far as asobi is concerned, and the next tick
+%% re-encodes asobi's map over the top of it - so the mutation is not merely
+%% invisible, it is undone. That is inherent to any dirty contract and it is why
+%% this is opt-in per script rather than a mode.
+%%
+%% Anything that is not a table declaring at least one of `changed` and `removed`
+%% means "no declaration" and today's semantics, which is also what a three-value
+%% return gives. That fallback is the safe direction in both places it is reached
+%% from: it costs a full decode and nothing else. Malformed HALVES are narrowed
+%% and reported in `asobi_zone:apply_dirty/3` rather than here, so an Erlang game
+%% module declaring the same thing meets the same bar.
 -spec decode_dirty(term(), dynamic()) -> map() | undefined.
-%% `nil`, `true`, a number, a string: not a declaration. Only a Lua table is,
-%% and a table reference is a tuple in both VM modes - so anything else means
-%% "no declaration" and the caller falls back to decoding the whole map.
-decode_dirty(Ref, LuaSt) when is_tuple(Ref) ->
-    Decoded = decode_to_map(Ref, LuaSt),
+%% Only a TABLE reference is a declaration, and `is_tuple/1` does not say that.
+%% Luerl represents every non-scalar as a record - `#tref{}`, `#funref{}`,
+%% `#erl_func{}`, `#erl_mfa{}`, `#usdref{}` - so `is_tuple/1` admitted all of
+%% them, and each one raises out of decode_to_map/2. `asobi_zone:do_tick/2`
+%% calls `zone_tick/2` with no try/catch, so `return entities, zone_state,
+%% false, print` killed the zone and everyone in it (widgrensit/asobi#557
+%% review). The record tag is the check; the try/catch is for a `#tref{}` that
+%% is recursive or stale, which decode_to_map/2 also raises on.
+decode_dirty(Ref, LuaSt) when is_tuple(Ref), element(1, Ref) =:= tref ->
+    try decode_to_map(Ref, LuaSt) of
+        Decoded -> narrow_dirty(Decoded)
+    catch
+        _:_ -> undefined
+    end;
+decode_dirty(_Other, _LuaSt) ->
+    undefined.
+
+%% A table has to actually declare something. `decode_to_map/2` coerces an
+%% array-shaped decode to `#{}`, so without this test `{"a","b"}` - or any
+%% table that is simply not a dirty set - became a well-formed EMPTY
+%% declaration, and an empty declaration means "nothing changed", every tick,
+%% forever. Falling back to the full decode is the only reading that cannot
+%% silently freeze a zone.
+-spec narrow_dirty(map()) -> map() | undefined.
+narrow_dirty(Decoded) when
+    is_map_key(~"changed", Decoded); is_map_key(~"removed", Decoded)
+->
     #{
         changed => asobi_lua_api:atomize_entities(
             as_entity_map(maps:get(~"changed", Decoded, #{}))
         ),
         removed => as_id_list(maps:get(~"removed", Decoded, []))
     };
-decode_dirty(_Other, _LuaSt) ->
+narrow_dirty(_NotADeclaration) ->
     undefined.
 
 %% An empty Lua table decodes to `[]`, not `#{}` - there is nothing in it to
-%% tell a record from an array.
+%% tell a record from an array - so `changed = {}` is the ordinary "I moved
+%% nothing this tick" case and passes through silently. A NON-empty list is a
+%% script that built `changed` as an array (`changed[#changed + 1] = e`), which
+%% is one line away from the idiom in the guide; asobi cannot use it, and
+%% saying nothing would revert every mutation the tick made.
 -spec as_entity_map(term()) -> map().
-as_entity_map(M) when is_map(M) -> M;
-as_entity_map(_Other) -> #{}.
+as_entity_map(M) when is_map(M) ->
+    M;
+as_entity_map([]) ->
+    #{};
+as_entity_map(Other) ->
+    report_bad_half(~"changed", Other),
+    #{}.
 
 -spec as_id_list(term()) -> [binary()].
-as_id_list(L) when is_list(L) -> [Id || Id <- L, is_binary(Id)];
-as_id_list(_Other) -> [].
+as_id_list(L) when is_list(L) ->
+    [Id || Id <- L, is_binary(Id)];
+as_id_list(#{} = Empty) when map_size(Empty) =:= 0 ->
+    [];
+as_id_list(Other) ->
+    report_bad_half(~"removed", Other),
+    [].
+
+%% Reported here rather than left to asobi_zone: by the time the bridge has
+%% normalised a malformed half away, core sees something well-formed and has
+%% nothing to complain about. That gap is what made this whole class silent.
+-spec report_bad_half(binary(), term()) -> ok.
+report_bad_half(Half, Other) ->
+    asobi_telemetry:game_error(bad_zone_dirty, #{callback => zone_tick}),
+    ?LOG_ERROR(#{
+        msg => ~"zone_tick's dirty declaration has a malformed half; ignoring it",
+        half => Half,
+        shape => dirty_half_shape(Other)
+    }),
+    ok.
+
+%% Shape, never the value: the value is the script's and so is its size.
+-spec dirty_half_shape(term()) -> tuple() | binary().
+dirty_half_shape(T) when is_list(T) -> {list, length(T)};
+dirty_half_shape(T) when is_map(T) -> {map, map_size(T)};
+dirty_half_shape(T) when is_binary(T) -> {binary, byte_size(T)};
+dirty_half_shape(T) -> iolist_to_binary(io_lib:format("~P", [T, 4])).
 
 %% Lua truthiness, not Erlang's: `nil` and `false` are the only falsey values, so
 %% `return entities, zone_state, wave_countdown > 0` works and so does returning

--- a/src/world/asobi_world.erl
+++ b/src/world/asobi_world.erl
@@ -65,7 +65,8 @@ Per-zone tick: advance the entities in one zone from its zone_state.
 The optional third element answers "does this zone still have work asobi cannot
 see?". A zone with no entities, no queued input, no live entity timer and no
 pending respawn is demoted and ticks once every `cold_tick_divisor` ticks
-(widgrensit/asobi#543). That test reads asobi's own bookkeeping, which is blind
+(widgrensit/asobi#543), or not at all where a world sets that to 0
+(widgrensit/asobi#561). That test reads asobi's own bookkeeping, which is blind
 to work a script keeps in its zone state - a wave spawner counting down between
 waves, weather, a zone-level phase timer. Return `true` and the zone stays hot,
 is not hibernated between ticks, and is not reaped while it says so.
@@ -79,10 +80,24 @@ additive.
 
 A non-boolean third element keeps the zone hot and is logged: demoting a zone
 that has work is the harmful direction.
+
+The optional fourth element says what actually changed:
+`#{changed => #{Id => Entity}, removed => [Id]}`, applied on top of the map
+returned as the first element. Declaring it is a promise that every entity NOT
+named is exactly what asobi handed in, which is what lets the untouched ones
+stay the same TERMS - `compute_deltas/2` and the spatial-grid sync then settle
+each of them with a pointer comparison instead of walking its fields, and a Lua
+zone stops decoding its whole entity table on every tick
+(widgrensit/asobi#557).
+
+The declaration is the truth: an entity mutated but not named is not changed as
+far as asobi is concerned. Return the ordinary two- or three-tuple to keep the
+full-comparison semantics, which is what every game gets by default.
 """.
 -callback zone_tick(Entities :: map(), ZoneState :: term()) ->
     {Entities1 :: map(), ZoneState1 :: term()}
-    | {Entities1 :: map(), ZoneState1 :: term(), Busy :: boolean()}.
+    | {Entities1 :: map(), ZoneState1 :: term(), Busy :: boolean()}
+    | {Entities1 :: map(), ZoneState1 :: term(), Busy :: boolean(), Dirty :: map()}.
 
 -doc """
 Apply a player input to a zone's entities.

--- a/src/world/asobi_world_ticker.erl
+++ b/src/world/asobi_world_ticker.erl
@@ -6,6 +6,8 @@
 -export([promote_zone/2, demote_zone/2, add_zone/2, remove_zone/2]).
 -export([init/1, handle_call/3, handle_cast/2, handle_info/2]).
 
+-include_lib("kernel/include/logger.hrl").
+
 %% #313: a world tick is the fan-out to every zone plus the fan-in of their
 %% tick_done replies, which is the saturation signal an operator watching a
 %% world server wants. At the default 50ms tick rate that is 20 events per
@@ -14,6 +16,7 @@
 %% `tick_sample_interval_ms` in the ticker config.
 -define(DEFAULT_TICK_SAMPLE_INTERVAL_MS, 1000).
 -define(DEFAULT_TICK_RATE, 50).
+-define(DEFAULT_COLD_DIVISOR, 10).
 
 %% --- Public API ---
 
@@ -80,18 +83,24 @@ init(Config) ->
     TickRate = pos_int(maps:get(tick_rate, Config, ?DEFAULT_TICK_RATE), ?DEFAULT_TICK_RATE),
     WorldPid = maps:get(world_pid, Config, undefined),
     ZoneManager = maps:get(zone_manager, Config, undefined),
-    ColdTickDivisor = maps:get(cold_tick_divisor, Config, 10),
+    ColdTickDivisor = cold_divisor(maps:get(cold_tick_divisor, Config, ?DEFAULT_COLD_DIVISOR)),
     {ok, #{
         tick => 0,
         tick_rate => TickRate,
         world_id => maps:get(world_id, Config, undefined),
         world_pid => WorldPid,
+        %% Diagnostic only since widgrensit/asobi#560 - the ticker owns its own
+        %% active set and never asks the manager for anything. Kept so
+        %% `sys:get_state/1` still says which manager this ticker belongs to.
+        %% `set_zone_manager/3`'s remaining effect is start_ticking/1, which is
+        %% what actually starts the world: do not delete that call as dead
+        %% plumbing on the strength of this field being unread.
         zone_manager => ZoneManager,
-        %% Maps rather than lists: the tick loop derives its candidate list
-        %% from these every tick, and `lists:uniq/1` on a list of thousands of
-        %% zones is per-tick work that a map's key set gives for nothing. Kept
-        %% disjoint by construction, so `maps:keys(Hot) ++ maps:keys(Cold)` has
-        %% no duplicates and needs no `uniq`.
+        %% Maps used as sets: the tick loop derives its candidate list from
+        %% these every tick, and `lists:uniq/1` on a list of thousands of zones
+        %% is per-tick work a map's key set gives for nothing. Kept disjoint by
+        %% construction, so `maps:keys(Hot) ++ maps:keys(Cold)` has no
+        %% duplicates and needs no `uniq`.
         hot_zones => #{},
         cold_zones => #{},
         %% One monitor per known zone, so a zone that dies leaves both sets
@@ -158,16 +167,20 @@ handle_cast({promote_zone, ZonePid}, #{hot_zones := Hot, cold_zones := Cold} = S
 ->
     State1 = watch(ZonePid, State),
     {noreply, State1#{
-        hot_zones => Hot#{ZonePid => []},
+        hot_zones => Hot#{ZonePid => ok},
         cold_zones => maps:remove(ZonePid, Cold)
     }};
+%% Demotion registers an unknown zone as COLD, which at `cold_tick_divisor = 0`
+%% means it never ticks. Safe because the only sender is `reclassify/1`, which
+%% runs inside the zone's own `do_tick` - so the ticker has already dispatched
+%% to it and therefore already knows it.
 handle_cast({demote_zone, ZonePid}, #{hot_zones := Hot, cold_zones := Cold} = State) when
     is_pid(ZonePid)
 ->
     State1 = watch(ZonePid, State),
     {noreply, State1#{
         hot_zones => maps:remove(ZonePid, Hot),
-        cold_zones => Cold#{ZonePid => []}
+        cold_zones => Cold#{ZonePid => ok}
     }};
 handle_cast({remove_zone, ZonePid}, State) when is_pid(ZonePid) ->
     {noreply, forget(ZonePid, State)};
@@ -219,10 +232,6 @@ handle_info(
     %% zones - plus, when the manager was addressed by pid, a `gen_server` call
     %% into the same process the join and crossing paths go through.
     %%
-    %% Before widgrensit/asobi#543 this branch discarded `cold_zones` outright.
-    %% That was not the only reason `cold_tick_divisor` was inert: nothing
-    %% anywhere called promote_zone/2 or demote_zone/2, so no world of any
-    %% shape ever had a cold zone.
     TickCold = tick_cold(NextTickCount, ColdTickDivisor),
     %% No `lists:uniq/1`: the two sets are disjoint map key sets.
     Candidates =
@@ -268,16 +277,33 @@ handle_info({'DOWN', MonRef, process, ZonePid, _Reason}, #{zone_monitors := Mons
 handle_info(_Info, State) ->
     {noreply, State}.
 
-%% `0` (and `infinity`) means an idle zone is not ticked at all: `warm_up/1`
-%% on the message that creates the work is then the only transition back, which
-%% is exactly ADR 0016's decision 2 doing the load-bearing job rather than an
-%% optimisation. See ADR 0021 and widgrensit/asobi#561. Any other non-positive
-%% value would be a division by zero or a `rem` that fires every tick, so it is
-%% folded into the same never-tick answer rather than crashing the loop.
--spec tick_cold(pos_integer(), term()) -> boolean().
-tick_cold(_TickCount, Divisor) when not is_integer(Divisor) -> false;
-tick_cold(_TickCount, Divisor) when Divisor =< 0 -> false;
+%% `0` means an idle zone is not ticked at all: `warm_up/1` on the message that
+%% creates the work is then the only transition back, which is ADR 0016's
+%% decision 2 doing a load-bearing job rather than an optimisation. See ADR
+%% 0021 and widgrensit/asobi#561.
+-spec tick_cold(pos_integer(), non_neg_integer()) -> boolean().
+tick_cold(_TickCount, 0) -> false;
 tick_cold(TickCount, Divisor) -> (TickCount rem Divisor) =:= 0.
+
+%% Hardened here rather than at the reader, for the same reason `tick_rate` is:
+%% a Lua game cannot deliver a bad value (`asobi_lua_config` guards it) but a
+%% hand-written Erlang `game_modes` map can.
+%%
+%% A bad value takes the DOCUMENTED DEFAULT, loudly - never the never-tick
+%% regime. Folding `"10"` or `-1` into 0 would hand a world the most aggressive
+%% setting in the system by typo, and ADR 0021 is explicit that at 0 the whole
+%% thing rests on `warm_up/1`: that is a property a world opts into, not one it
+%% lands in silently.
+-spec cold_divisor(term()) -> non_neg_integer().
+cold_divisor(D) when is_integer(D), D >= 0 ->
+    D;
+cold_divisor(D) ->
+    ?LOG_WARNING(#{
+        msg => ~"cold_tick_divisor must be a non-negative integer; using the default",
+        value => io_lib:format("~P", [D, 4]),
+        default => ?DEFAULT_COLD_DIVISOR
+    }),
+    ?DEFAULT_COLD_DIVISOR.
 
 %% Explicit recursion: see docs/eqwalizer-idioms.md.
 -spec add_all([term()], map()) -> map().
@@ -298,7 +324,7 @@ forget_all([_ | Rest], State) ->
 add_known(ZonePid, #{hot_zones := Hot, cold_zones := Cold} = State) when is_pid(ZonePid) ->
     case is_map_key(ZonePid, Hot) orelse is_map_key(ZonePid, Cold) of
         true -> State;
-        false -> (watch(ZonePid, State))#{hot_zones => Hot#{ZonePid => []}}
+        false -> (watch(ZonePid, State))#{hot_zones => Hot#{ZonePid => ok}}
     end;
 add_known(_ZonePid, State) ->
     State.

--- a/src/world/asobi_world_ticker.erl
+++ b/src/world/asobi_world_ticker.erl
@@ -3,7 +3,7 @@
 
 -export([start_link/1]).
 -export([tick_done/3, set_zones/3, set_zone_manager/3, get_tick/1]).
--export([promote_zone/2, demote_zone/2, remove_zone/2]).
+-export([promote_zone/2, demote_zone/2, add_zone/2, remove_zone/2]).
 -export([init/1, handle_call/3, handle_cast/2, handle_info/2]).
 
 %% #313: a world tick is the fan-out to every zone plus the fan-in of their
@@ -39,6 +39,25 @@ get_tick(TickerPid) ->
         N when is_integer(N), N >= 0 -> N
     end.
 
+-doc """
+Take ownership of a zone, hot, from the moment it exists.
+
+Before widgrensit/asobi#560 the ticker asked the zone manager for the active
+set on EVERY tick, and the manager answered with `ets:tab2list/1` - a full
+table copy plus a list rebuild, 20 times a second on a world with thousands of
+loaded zones, before a single zone had been ticked. The set only changes when
+a zone opens or closes, so it is pushed here instead and the manager is off
+the per-tick path entirely (with widgrensit/asobi#559, off the tick path full
+stop).
+
+The ticker monitors what it is told about, so a reaped or crashed zone drops
+out on its `DOWN` without needing `remove_zone/2` to arrive - which is the
+self-healing the old partition-against-the-manager's-list gave for free.
+""".
+-spec add_zone(pid(), pid()) -> ok.
+add_zone(TickerPid, ZonePid) ->
+    gen_server:cast(TickerPid, {add_zone, ZonePid}).
+
 -spec promote_zone(pid(), pid()) -> ok.
 promote_zone(TickerPid, ZonePid) ->
     gen_server:cast(TickerPid, {promote_zone, ZonePid}).
@@ -68,8 +87,16 @@ init(Config) ->
         world_id => maps:get(world_id, Config, undefined),
         world_pid => WorldPid,
         zone_manager => ZoneManager,
-        hot_zones => [],
-        cold_zones => [],
+        %% Maps rather than lists: the tick loop derives its candidate list
+        %% from these every tick, and `lists:uniq/1` on a list of thousands of
+        %% zones is per-tick work that a map's key set gives for nothing. Kept
+        %% disjoint by construction, so `maps:keys(Hot) ++ maps:keys(Cold)` has
+        %% no duplicates and needs no `uniq`.
+        hot_zones => #{},
+        cold_zones => #{},
+        %% One monitor per known zone, so a zone that dies leaves both sets
+        %% without anyone having to tell us.
+        zone_monitors => #{},
         cold_tick_divisor => ColdTickDivisor,
         tick_count => 0,
         pending => #{},
@@ -114,31 +141,36 @@ handle_call(_Request, _From, State) ->
     {reply, {error, unknown_request}, State}.
 
 -spec handle_cast(term(), map()) -> {noreply, map()}.
-handle_cast({set_zones, Zones, WorldPid}, State) ->
-    {noreply, start_ticking(State#{hot_zones => Zones, world_pid => WorldPid})};
+%% Replaces the set rather than adding to it, which is what "set" has always
+%% meant here - and now that the ticker holds a monitor per zone, the ones it
+%% is dropping have to be released too.
+handle_cast({set_zones, Zones, WorldPid}, State) when is_list(Zones) ->
+    State1 = forget_all(maps:keys(maps:get(zone_monitors, State)), State),
+    {noreply, start_ticking(add_all(Zones, State1#{world_pid => WorldPid}))};
 handle_cast({set_zone_manager, ZoneManagerPid, WorldPid}, State) ->
     {noreply, start_ticking(State#{zone_manager => ZoneManagerPid, world_pid => WorldPid})};
-handle_cast({promote_zone, ZonePid}, #{hot_zones := Hot, cold_zones := Cold} = State) ->
-    Cold1 = lists:delete(ZonePid, Cold),
-    Hot1 =
-        case lists:member(ZonePid, Hot) of
-            true -> Hot;
-            false -> [ZonePid | Hot]
-        end,
-    {noreply, State#{hot_zones => Hot1, cold_zones => Cold1}};
-handle_cast({demote_zone, ZonePid}, #{hot_zones := Hot, cold_zones := Cold} = State) ->
-    Hot1 = lists:delete(ZonePid, Hot),
-    Cold1 =
-        case lists:member(ZonePid, Cold) of
-            true -> Cold;
-            false -> [ZonePid | Cold]
-        end,
-    {noreply, State#{hot_zones => Hot1, cold_zones => Cold1}};
-handle_cast({remove_zone, ZonePid}, #{hot_zones := Hot, cold_zones := Cold} = State) ->
-    {noreply, State#{
-        hot_zones => lists:delete(ZonePid, Hot),
-        cold_zones => lists:delete(ZonePid, Cold)
+handle_cast({add_zone, ZonePid}, State) when is_pid(ZonePid) ->
+    {noreply, add_known(ZonePid, State)};
+%% Promotion doubles as registration: a zone that warms up before its opener's
+%% `add_zone` lands must not be left out of the tick.
+handle_cast({promote_zone, ZonePid}, #{hot_zones := Hot, cold_zones := Cold} = State) when
+    is_pid(ZonePid)
+->
+    State1 = watch(ZonePid, State),
+    {noreply, State1#{
+        hot_zones => Hot#{ZonePid => []},
+        cold_zones => maps:remove(ZonePid, Cold)
     }};
+handle_cast({demote_zone, ZonePid}, #{hot_zones := Hot, cold_zones := Cold} = State) when
+    is_pid(ZonePid)
+->
+    State1 = watch(ZonePid, State),
+    {noreply, State1#{
+        hot_zones => maps:remove(ZonePid, Hot),
+        cold_zones => Cold#{ZonePid => []}
+    }};
+handle_cast({remove_zone, ZonePid}, State) when is_pid(ZonePid) ->
+    {noreply, forget(ZonePid, State)};
 %% A reply frees the zone whatever tick it carries: a zone only ever has one
 %% tick in flight, so `tick_done` means "this zone is idle again". Matching the
 %% reply against the ticker's current tick instead - as this did before #426 -
@@ -172,45 +204,31 @@ handle_info(
         tick_rate := TickRate,
         tick_count := TickCount,
         cold_tick_divisor := ColdTickDivisor,
-        hot_zones := StaticHot,
-        cold_zones := StaticCold,
-        zone_manager := ZoneManager,
+        hot_zones := Hot,
+        cold_zones := Cold,
         pending := Pending,
         world_id := WorldId
     } = State
 ) ->
     NextTick = Tick + 1,
     NextTickCount = TickCount + 1,
-    %% Under a zone manager the active set is the manager's, but which of those
-    %% zones are cold is still this ticker's own bookkeeping - it is fed by
-    %% asobi_zone's promote/demote casts. Before widgrensit/asobi#543 this
-    %% branch discarded `cold_zones` outright. That was not the only reason
-    %% `cold_tick_divisor` was inert: nothing anywhere called promote_zone/2 or
-    %% demote_zone/2, and `set_zones/3` (the only path that populates the static
-    %% lists) has no caller in src/ either, so no world of any shape ever had a
-    %% cold zone. This branch is what would have kept it inert for a lazy world
-    %% even after the zone side started classifying itself.
+    %% The hot/cold split is this ticker's own bookkeeping, fed by asobi_zone's
+    %% add/promote/demote casts and pruned by the zones' own `DOWN`s
+    %% (widgrensit/asobi#560). It used to be re-derived from the zone manager
+    %% every tick, which cost a full `ets:tab2list/1` of the world's loaded
+    %% zones - plus, when the manager was addressed by pid, a `gen_server` call
+    %% into the same process the join and crossing paths go through.
     %%
-    %% Partitioning the manager's list also prunes the cold set: a zone that has
-    %% been reaped is absent from `AllZones` and so drops out of `cold_zones`
-    %% below without needing a `remove_zone` cast to arrive.
-    {Hot, Cold} =
-        case ZoneManager of
-            undefined ->
-                {StaticHot, StaticCold};
-            ZMPid ->
-                AllZones = asobi_zone_manager:get_active_zones(ZMPid),
-                ColdSet = maps:from_keys(StaticCold, []),
-                lists:partition(fun(Z) -> not is_map_key(Z, ColdSet) end, AllZones)
-        end,
-    TickCold = (NextTickCount rem ColdTickDivisor) =:= 0,
-    %% `uniq` because a zone dispatched twice in one tick replies twice, and
-    %% the second reply finds nothing left in `pending` to retire - the tick
-    %% would then never complete and the world would stop posting.
+    %% Before widgrensit/asobi#543 this branch discarded `cold_zones` outright.
+    %% That was not the only reason `cold_tick_divisor` was inert: nothing
+    %% anywhere called promote_zone/2 or demote_zone/2, so no world of any
+    %% shape ever had a cold zone.
+    TickCold = tick_cold(NextTickCount, ColdTickDivisor),
+    %% No `lists:uniq/1`: the two sets are disjoint map key sets.
     Candidates =
         case TickCold of
-            true -> lists:uniq(Hot ++ Cold);
-            false -> lists:uniq(Hot)
+            true -> maps:keys(Hot) ++ maps:keys(Cold);
+            false -> maps:keys(Hot)
         end,
     %% #426: a zone that has not retired its previous tick is skipped rather
     %% than sent another one. Without this the fan-out is open-loop - a zone
@@ -231,8 +249,6 @@ handle_info(
     State1 = State#{
         tick => NextTick,
         tick_count => NextTickCount,
-        hot_zones => Hot,
-        cold_zones => Cold,
         tick_started_at => erlang:monotonic_time(millisecond),
         tick_zone_count => length(ZonesToTick),
         pending => maps:merge(Pending0, maps:from_keys(ZonesToTick, NextTick)),
@@ -242,8 +258,73 @@ handle_info(
         [] -> {noreply, complete_tick(maybe_post_tick(NextTick, State1))};
         _ -> {noreply, State1}
     end;
+handle_info({'DOWN', MonRef, process, ZonePid, _Reason}, #{zone_monitors := Mons} = State) when
+    is_pid(ZonePid)
+->
+    case maps:get(ZonePid, Mons, undefined) of
+        MonRef -> {noreply, forget(ZonePid, State)};
+        _ -> {noreply, State}
+    end;
 handle_info(_Info, State) ->
     {noreply, State}.
+
+%% `0` (and `infinity`) means an idle zone is not ticked at all: `warm_up/1`
+%% on the message that creates the work is then the only transition back, which
+%% is exactly ADR 0016's decision 2 doing the load-bearing job rather than an
+%% optimisation. See ADR 0021 and widgrensit/asobi#561. Any other non-positive
+%% value would be a division by zero or a `rem` that fires every tick, so it is
+%% folded into the same never-tick answer rather than crashing the loop.
+-spec tick_cold(pos_integer(), term()) -> boolean().
+tick_cold(_TickCount, Divisor) when not is_integer(Divisor) -> false;
+tick_cold(_TickCount, Divisor) when Divisor =< 0 -> false;
+tick_cold(TickCount, Divisor) -> (TickCount rem Divisor) =:= 0.
+
+%% Explicit recursion: see docs/eqwalizer-idioms.md.
+-spec add_all([term()], map()) -> map().
+add_all([], State) -> State;
+add_all([ZonePid | Rest], State) -> add_all(Rest, add_known(ZonePid, State)).
+
+-spec forget_all([term()], map()) -> map().
+forget_all([], State) ->
+    State;
+forget_all([ZonePid | Rest], State) when is_pid(ZonePid) ->
+    forget_all(Rest, forget(ZonePid, State));
+forget_all([_ | Rest], State) ->
+    forget_all(Rest, State).
+
+%% A newly-known zone starts hot: it has not ticked, so it has not established
+%% that it is idle - the same reason asobi_zone's own `cold` starts false.
+-spec add_known(term(), map()) -> map().
+add_known(ZonePid, #{hot_zones := Hot, cold_zones := Cold} = State) when is_pid(ZonePid) ->
+    case is_map_key(ZonePid, Hot) orelse is_map_key(ZonePid, Cold) of
+        true -> State;
+        false -> (watch(ZonePid, State))#{hot_zones => Hot#{ZonePid => []}}
+    end;
+add_known(_ZonePid, State) ->
+    State.
+
+-spec watch(pid(), map()) -> map().
+watch(ZonePid, #{zone_monitors := Mons} = State) ->
+    case is_map_key(ZonePid, Mons) of
+        true -> State;
+        false -> State#{zone_monitors => Mons#{ZonePid => monitor(process, ZonePid)}}
+    end.
+
+-spec forget(pid(), map()) -> map().
+forget(ZonePid, #{hot_zones := Hot, cold_zones := Cold, zone_monitors := Mons} = State) ->
+    Mons1 =
+        case maps:take(ZonePid, Mons) of
+            {MonRef, Rest} ->
+                demonitor(MonRef, [flush]),
+                Rest;
+            error ->
+                Mons
+        end,
+    State#{
+        hot_zones => maps:remove(ZonePid, Hot),
+        cold_zones => maps:remove(ZonePid, Cold),
+        zone_monitors => Mons1
+    }.
 
 start_ticking(#{running := true} = State) ->
     State;

--- a/src/world/asobi_zone.erl
+++ b/src/world/asobi_zone.erl
@@ -300,6 +300,9 @@ init(Config) ->
             world_server_pid => WorldServerPid,
             spawn_templates => Templates,
             zone_manager_pid => ZoneManagerPid,
+            %% The manager's stamp table, when this zone was started by one.
+            %% See touch_manager/1.
+            zone_stamp_tab => maps:get(zone_stamp_tab, Config, undefined),
             terrain_store_pid => TerrainStorePid,
             zone_size => ZoneSize,
             grid_size => GridSize,
@@ -569,17 +572,27 @@ handle_cast(reap, #{entities := Entities, script_busy := true} = State) when
     %% counting down between waves is reaped mid-countdown at
     %% `zone_idle_timeout` and the wave never comes. Declined the same way an
     %% occupied zone declines below.
-    case maps:get(zone_manager_pid, State, undefined) of
-        undefined -> ok;
-        ZMPid -> asobi_zone_manager:touch_zone(ZMPid, maps:get(coords, State))
-    end,
+    touch_manager(State),
+    {noreply, State};
+%% A watched zone is in use even with nothing in it. This was already true in
+%% effect - an empty zone with subscribers re-stamps itself active on the
+%% `map_size(Subs) > 0` branch of every tick, so the reap cast never arrived -
+%% but it was emergent rather than stated, and at `cold_tick_divisor = 0` the
+%% zone stops ticking and stops stamping (widgrensit/asobi#561). Reaping it
+%% then would tear it out from under subscribers who are not re-subscribed
+%% until they next move, so they would silently stop seeing anything that
+%% happens there.
+handle_cast(reap, #{entities := Entities, subscribers := Subs} = State) when
+    map_size(Entities) =:= 0, map_size(Subs) > 0
+->
+    touch_manager(State),
     {noreply, State};
 handle_cast(reap, #{entities := Entities} = State) when map_size(Entities) =:= 0 ->
     %% Graceful stop so terminate/2 writes a final snapshot. Transient restart
     %% means a normal stop is not respawned.
     {stop, normal, State};
-handle_cast(reap, #{zone_manager_pid := ZMPid, coords := Coords} = State) ->
-    %% asobi#283: the manager decides to reap from its own zone_last_active
+handle_cast(reap, State) ->
+    %% asobi#283: the manager decides to reap from its own last-active
     %% bookkeeping, which can lag real occupancy - release_zone backdates it
     %% the moment a zone empties, and nothing re-touches it for an occupied
     %% zone with no live subscribers (this zone's own tick only touches on
@@ -587,16 +600,13 @@ handle_cast(reap, #{zone_manager_pid := ZMPid, coords := Coords} = State) ->
     %% an occupied zone out from under its entities. This zone is the one
     %% source of truth for its own occupancy at the moment it actually
     %% receives the cast, so decline and re-touch instead of stopping.
-    case ZMPid of
-        undefined -> ok;
-        _ -> asobi_zone_manager:touch_zone(ZMPid, Coords)
-    end,
+    touch_manager(State),
     {noreply, State};
 handle_cast({tick, TickN}, State) ->
     State1 = do_tick(TickN, State),
     State2 = publish_border(resolve_zone_crossings(State1)),
     State3 = reclassify(State2),
-    #{subscribers := Subs, entities := Ents, zone_manager_pid := ZMPid, coords := Coords} = State3,
+    #{subscribers := Subs, entities := Ents} = State3,
     case map_size(Subs) of
         0 ->
             %% A zone that says it is busy is not idle between its ticks, so
@@ -607,10 +617,7 @@ handle_cast({tick, TickN}, State) ->
                 true -> {noreply, State3}
             end;
         _ ->
-            case ZMPid of
-                undefined -> ok;
-                _ -> asobi_zone_manager:touch_zone(ZMPid, Coords)
-            end,
+            touch_manager(State3),
             {noreply, State3}
     end;
 handle_cast({input, PlayerId, Input, Seq}, #{input_queue := Queue} = State) ->
@@ -1142,9 +1149,70 @@ zone_tick_result({Entities, ZoneState, Busy}, _State) when
     is_map(Entities), is_boolean(Busy)
 ->
     {Entities, ZoneState, Busy};
+zone_tick_result({Entities, ZoneState, Busy, Dirty}, State) when
+    is_map(Entities), is_boolean(Busy)
+->
+    {apply_dirty(Entities, Dirty, State), ZoneState, Busy};
+zone_tick_result({Entities, ZoneState, Other, Dirty}, State) when is_map(Entities) ->
+    log_bad_zone_busy(State, Other),
+    {apply_dirty(Entities, Dirty, State), ZoneState, true};
 zone_tick_result({Entities, ZoneState, Other}, State) when is_map(Entities) ->
     log_bad_zone_busy(State, Other),
     {Entities, ZoneState, true}.
+
+-doc """
+Apply `zone_tick/2`'s optional fourth return value: what actually changed.
+
+`#{changed => #{Id => Entity}, removed => [Id]}` on top of the map the callback
+returned. A game that declares this is telling asobi that every entity it did
+NOT name is byte-for-byte what asobi handed in - so the unchanged ones stay the
+same TERMS, and structural sharing with the previous tick survives the callback
+(widgrensit/asobi#557).
+
+That sharing is the whole point, and it is worth more than the merge costs.
+`compute_deltas/2` short-circuits on an identical entity with one pointer
+comparison instead of walking its fields, and so does `sync_spatial_grid/3`.
+Without it a Lua zone rebuilds every entity map on every tick's decode, so both
+of those degrade to O(all entities x fields) to discover that three NPCs moved.
+The bigger half of the win is upstream, in the bridge: `asobi_lua_world` decodes
+only `changed` rather than the whole entities table.
+
+Ignoring the declaration entirely is always safe and never wrong - it only
+costs the sharing - so this fails towards "merge what is well-formed and log
+the rest" rather than towards refusing a tick.
+""".
+-spec apply_dirty(map(), term(), map()) -> map().
+apply_dirty(Entities, Dirty, State) when is_map(Dirty) ->
+    Changed = narrow_changed(maps:get(changed, Dirty, #{}), State),
+    Removed = narrow_ids(maps:get(removed, Dirty, [])),
+    maps:without(Removed, maps:merge(Entities, Changed));
+apply_dirty(Entities, Dirty, State) ->
+    log_bad_zone_dirty(State, Dirty),
+    Entities.
+
+%% Same bar every other id-bearing path in this module holds: a non-binary id
+%% reaches byte_size/1 in the encoder and kills the zone mid-tick (asobi#509).
+-spec narrow_changed(term(), map()) -> map().
+narrow_changed(Changed, State) when is_map(Changed) ->
+    Narrowed = maps:filter(
+        fun
+            (Id, E) when is_binary(Id), is_map(E) -> true;
+            (_Id, _E) -> false
+        end,
+        Changed
+    ),
+    case map_size(Narrowed) =:= map_size(Changed) of
+        true -> ok;
+        false -> log_bad_zone_dirty(State, Changed)
+    end,
+    Narrowed;
+narrow_changed(Changed, State) ->
+    log_bad_zone_dirty(State, Changed),
+    #{}.
+
+-spec narrow_ids(term()) -> [binary()].
+narrow_ids(Ids) when is_list(Ids) -> [Id || Id <- Ids, is_binary(Id)];
+narrow_ids(_Ids) -> [].
 
 apply_timer_events([], Entities) ->
     Entities;
@@ -2630,6 +2698,26 @@ clamp_border_band(Band) ->
 %% way every other game-supplied term in this module is - an unbounded `~0p` of
 %% a zone state is both a 200KB log line and a way to print a secret the game
 %% keeps in it.
+log_bad_zone_dirty(State, Detail) ->
+    Zone = log_zone(State),
+    asobi_telemetry:game_error(bad_zone_dirty, #{
+        game_module => maps:get(game_module, State, undefined),
+        world_id => maps:get(world_id, State, undefined),
+        coords => maps:get(coords, State, undefined)
+    }),
+    case asobi_script_log_limiter:allow(effect_log_key(Zone, bad_zone_dirty)) of
+        {true, SuppressedSinceLast} ->
+            ?LOG_ERROR(#{
+                msg =>
+                    ~"zone_tick/2's fourth return value was not a well-formed dirty set; ignoring it",
+                coords => maps:get(coords, State, undefined),
+                detail => bound_debug_term(Detail),
+                suppressed_since_last => SuppressedSinceLast
+            });
+        false ->
+            ok
+    end.
+
 log_bad_zone_busy(State, Detail) ->
     Zone = log_zone(State),
     asobi_telemetry:game_error(bad_zone_busy, #{
@@ -2668,12 +2756,43 @@ reclassify(#{cold := Cold, ticker_pid := TickerPid} = State) ->
 %% Promote from the message that created the work rather than from the next
 %% tick. A cold zone only ticks once every `cold_tick_divisor` ticks, so
 %% waiting for its own tick to notice a player arrived would put that whole
-%% divisor of latency on the first frame of every zone entry.
+%% divisor of latency on the first frame of every zone entry. At
+%% `cold_tick_divisor = 0` it never ticks at all, so this is the ONLY
+%% transition left and the whole thing rests on it (widgrensit/asobi#561).
+%%
+%% Nothing time-based has to be caught up here, and that is a property of
+%% `asobi_idle/1` rather than an omission: a zone is only demoted when it has
+%% no live entity timer and an empty respawn queue, so a dormant zone has no
+%% elapsed deadline to reconcile. What it can acquire while dormant - a spawn,
+%% a timer, an entity, an input, an effect - arrives as a message, and every
+%% one of those messages runs this. `asobi_zone_spawner:tick/2` and
+%% `asobi_entity_timer:tick/2` are both driven by the wall clock the resumed
+%% tick passes them, so a window that opened during the silence fires on the
+%% first tick after it rather than `cold_tick_divisor` ticks later.
 -spec warm_up(map()) -> map().
 warm_up(#{cold := true} = State) ->
     warm(State);
 warm_up(State) ->
     State.
+
+-doc """
+Tell the reaper this zone is still in use.
+
+Written straight into the manager's stamp table where the zone has one, which
+is every zone the manager started. An occupied zone does this on EVERY tick,
+and as a `gen_server` cast it made the zone manager a queue the whole world
+shared - the same process `ensure_zone/2` goes through on the join and
+crossing hot path, where a 1s timeout costs the crossing
+(widgrensit/asobi#559). The cast remains for a zone started outside the
+manager, which has no table to write to.
+""".
+-spec touch_manager(map()) -> ok.
+touch_manager(#{zone_stamp_tab := Tab, coords := Coords}) when Tab =/= undefined ->
+    asobi_zone_manager:stamp_active(Tab, Coords);
+touch_manager(#{zone_manager_pid := ZMPid, coords := Coords}) when is_pid(ZMPid) ->
+    asobi_zone_manager:touch_zone(ZMPid, Coords);
+touch_manager(_State) ->
+    ok.
 
 %% Emitted on the transition only, never per tick: a zone that is merely busy is
 %% the normal case and says nothing an operator can act on.
@@ -2886,6 +3005,27 @@ remove_from_grid(_Ids, undefined) ->
 remove_from_grid(Ids, Grid) ->
     remove_from_grid_do(Ids, Grid).
 
+%% Ids in `OldEntities` that `NewEntities` no longer has.
+%%
+%% A fold with `maps:is_key/2` rather than `maps:keys(Old) -- maps:keys(New)`
+%% (widgrensit/asobi#558). `--` is O(N*M): it rescans the right-hand list for
+%% every element of the left one, so with a spatial grid configured a zone
+%% holding N entities paid O(N^2) key comparisons EVERY tick to almost always
+%% produce `[]`. Measured on an inert 2,000-entity zone, `erlang:'--'/2` was
+%% 13% of the whole tick at ~500us a call. This is O(N) with O(1) lookups.
+-spec removed_ids(map(), map()) -> [term()].
+removed_ids(OldEntities, NewEntities) ->
+    maps:fold(
+        fun(Id, _Old, Acc) ->
+            case is_map_key(Id, NewEntities) of
+                true -> Acc;
+                false -> [Id | Acc]
+            end
+        end,
+        [],
+        OldEntities
+    ).
+
 -spec remove_from_grid_do([term()], asobi_spatial_grid:grid()) -> asobi_spatial_grid:grid().
 remove_from_grid_do([], Grid) ->
     Grid;
@@ -2897,26 +3037,21 @@ remove_from_grid_do([_ | Rest], Grid) ->
 sync_spatial_grid(_OldEntities, _NewEntities, undefined) ->
     undefined;
 sync_spatial_grid(OldEntities, NewEntities, Grid) when is_map(Grid) ->
-    %% Remove entities that no longer exist
-    Removed = maps:keys(OldEntities) -- maps:keys(NewEntities),
-    Grid1 = remove_from_grid_do(Removed, Grid),
+    Grid1 = remove_from_grid_do(removed_ids(OldEntities, NewEntities), Grid),
     %% Update/insert entities with changed or new positions
     maps:fold(
         fun
-            (Id, Entity, G) when is_map(Entity) ->
-                case entity_pos(Entity) of
-                    undefined ->
+            (Id, Entity, G) when is_binary(Id), is_map(Entity) ->
+                %% `{ok, Entity}` matches the bound entity, so an entity the
+                %% tick left alone settles in one pointer comparison rather
+                %% than two position extractions. Worth having only because a
+                %% tick can now preserve structural sharing - see apply_dirty/3
+                %% and widgrensit/asobi#557.
+                case maps:find(Id, OldEntities) of
+                    {ok, Entity} ->
                         G;
-                    Pos ->
-                        case maps:find(Id, OldEntities) of
-                            {ok, Old} when is_map(Old) ->
-                                case entity_pos(Old) of
-                                    Pos -> G;
-                                    _ -> asobi_spatial_grid:update(Id, Pos, G)
-                                end;
-                            _ ->
-                                asobi_spatial_grid:update(Id, Pos, G)
-                        end
+                    Found ->
+                        sync_moved_entity(Id, Entity, Found, G)
                 end;
             (_Id, _Entity, G) ->
                 G
@@ -2924,3 +3059,22 @@ sync_spatial_grid(OldEntities, NewEntities, Grid) when is_map(Grid) ->
         Grid1,
         NewEntities
     ).
+
+-spec sync_moved_entity(
+    binary(), map(), {ok, term()} | error, asobi_spatial_grid:grid()
+) -> asobi_spatial_grid:grid().
+sync_moved_entity(Id, Entity, Found, Grid) ->
+    case entity_pos(Entity) of
+        undefined ->
+            Grid;
+        Pos ->
+            case Found of
+                {ok, Old} when is_map(Old) ->
+                    case entity_pos(Old) of
+                        Pos -> Grid;
+                        _ -> asobi_spatial_grid:update(Id, Pos, Grid)
+                    end;
+                _ ->
+                    asobi_spatial_grid:update(Id, Pos, Grid)
+            end
+    end.

--- a/src/world/asobi_zone.erl
+++ b/src/world/asobi_zone.erl
@@ -1160,35 +1160,47 @@ zone_tick_result({Entities, ZoneState, Other}, State) when is_map(Entities) ->
     log_bad_zone_busy(State, Other),
     {Entities, ZoneState, true}.
 
--doc """
-Apply `zone_tick/2`'s optional fourth return value: what actually changed.
-
-`#{changed => #{Id => Entity}, removed => [Id]}` on top of the map the callback
-returned. A game that declares this is telling asobi that every entity it did
-NOT name is byte-for-byte what asobi handed in - so the unchanged ones stay the
-same TERMS, and structural sharing with the previous tick survives the callback
-(widgrensit/asobi#557).
-
-That sharing is the whole point, and it is worth more than the merge costs.
-`compute_deltas/2` short-circuits on an identical entity with one pointer
-comparison instead of walking its fields, and so does `sync_spatial_grid/3`.
-Without it a Lua zone rebuilds every entity map on every tick's decode, so both
-of those degrade to O(all entities x fields) to discover that three NPCs moved.
-The bigger half of the win is upstream, in the bridge: `asobi_lua_world` decodes
-only `changed` rather than the whole entities table.
-
-Ignoring the declaration entirely is always safe and never wrong - it only
-costs the sharing - so this fails towards "merge what is well-formed and log
-the rest" rather than towards refusing a tick.
-""".
+%% Apply `zone_tick/2`'s optional fourth return value: what actually changed.
+%%
+%% `#{changed => #{Id => Entity}, removed => [Id]}` on top of the map the callback
+%% returned. A game that declares this is telling asobi that every entity it did
+%% NOT name is byte-for-byte what asobi handed in - so the unchanged ones stay the
+%% same TERMS, and structural sharing with the previous tick survives the callback
+%% (widgrensit/asobi#557).
+%%
+%% That sharing is the whole point. `compute_deltas/2` settles an identical entity
+%% with one pointer comparison instead of walking its fields; without it a Lua zone
+%% rebuilds every entity map on every tick's decode, so the diff degrades to
+%% O(all entities x fields) to discover that three NPCs moved. `sync_spatial_grid/3`
+%% deliberately does NOT test identity - see the comment there. The bigger half of
+%% the win is upstream, in the bridge: `asobi_lua_world` decodes only `changed`
+%% rather than the whole entities table.
+%%
+%% Ignoring the declaration entirely is always safe and never wrong - it only
+%% costs the sharing - so this fails towards "merge what is well-formed and log
+%% the rest" rather than towards refusing a tick. Every way of being malformed is
+%% reported: a declaration that silently does nothing freezes every entity in the
+%% zone for as long as the zone lives, because the base map it merges onto is the
+%% one asobi handed the callback.
 -spec apply_dirty(map(), term(), map()) -> map().
 apply_dirty(Entities, Dirty, State) when is_map(Dirty) ->
+    report_unknown_dirty_keys(Dirty, State),
     Changed = narrow_changed(maps:get(changed, Dirty, #{}), State),
-    Removed = narrow_ids(maps:get(removed, Dirty, [])),
+    Removed = narrow_ids(maps:get(removed, Dirty, []), State),
     maps:without(Removed, maps:merge(Entities, Changed));
 apply_dirty(Entities, Dirty, State) ->
-    log_bad_zone_dirty(State, Dirty),
+    log_bad_zone_dirty(State, {not_a_map, dirty_shape(Dirty)}),
     Entities.
+
+%% A typo is the likeliest malformation and, until this reported it, the only
+%% one that produced neither a merge nor a word: `#{chnaged => ...}` reads as
+%% an empty declaration, which means "nothing changed this tick" - forever.
+-spec report_unknown_dirty_keys(map(), map()) -> ok.
+report_unknown_dirty_keys(Dirty, State) ->
+    case maps:keys(maps:without([changed, removed], Dirty)) of
+        [] -> ok;
+        Unknown -> log_bad_zone_dirty(State, {unknown_keys, [key_label(K) || K <- Unknown]})
+    end.
 
 %% Same bar every other id-bearing path in this module holds: a non-binary id
 %% reaches byte_size/1 in the encoder and kills the zone mid-tick (asobi#509).
@@ -1201,18 +1213,64 @@ narrow_changed(Changed, State) when is_map(Changed) ->
         end,
         Changed
     ),
-    case map_size(Narrowed) =:= map_size(Changed) of
-        true -> ok;
-        false -> log_bad_zone_dirty(State, Changed)
+    case map_size(Changed) - map_size(Narrowed) of
+        0 ->
+            ok;
+        Dropped ->
+            log_bad_zone_dirty(State, dirty_summary(dropped_changed, Dropped, Changed, Narrowed))
     end,
     Narrowed;
 narrow_changed(Changed, State) ->
-    log_bad_zone_dirty(State, Changed),
+    log_bad_zone_dirty(State, {changed_not_a_map, dirty_shape(Changed)}),
     #{}.
 
--spec narrow_ids(term()) -> [binary()].
-narrow_ids(Ids) when is_list(Ids) -> [Id || Id <- Ids, is_binary(Id)];
-narrow_ids(_Ids) -> [].
+%% Reports what it dropped, like its sibling. ADR 0022 decision 4 promises both
+%% halves are logged, and only one of them was.
+-spec narrow_ids(term(), map()) -> [binary()].
+narrow_ids(Ids, State) when is_list(Ids) ->
+    Narrowed = [Id || Id <- Ids, is_binary(Id)],
+    case length(Ids) - length(Narrowed) of
+        0 -> ok;
+        Dropped -> log_bad_zone_dirty(State, {dropped_removed, Dropped})
+    end,
+    Narrowed;
+narrow_ids(Ids, State) ->
+    log_bad_zone_dirty(State, {removed_not_a_list, dirty_shape(Ids)}),
+    [].
+
+%% A bounded description of a malformed declaration, never the declaration itself.
+%%
+%% `changed` is a script-controlled map of arbitrary size, and `bound_debug_term/1`
+%% renders its whole argument before it truncates - so handing it the map cost
+%% seconds of `io_lib:format/2` ON THE ZONE PROCESS for a script that put a 32MB
+%% string in it, outside `bounded_eval`'s wall clock and invisible to
+%% `max_heap_size` because a refc binary is. Three of those per limiter window is
+%% a zone that never ticks again, with no crash to attribute it to.
+%%
+%% So the bound is on the way in: a count, and the first offending key clipped to
+%% 64 bytes. That is what an operator needs to find the line in the script, and it
+%% cannot be made expensive by the script.
+-spec dirty_summary(atom(), non_neg_integer(), map(), map()) -> tuple().
+dirty_summary(Tag, Dropped, Changed, Narrowed) ->
+    Bad = maps:keys(maps:without(maps:keys(Narrowed), Changed)),
+    {Tag, Dropped, first_key(Bad)}.
+
+-spec first_key([term()]) -> binary().
+first_key([K | _]) -> key_label(K);
+first_key([]) -> ~"".
+
+-spec key_label(term()) -> binary().
+key_label(K) when is_binary(K) -> binary:part(K, 0, min(64, byte_size(K)));
+key_label(K) when is_atom(K) -> atom_to_binary(K, utf8);
+key_label(K) -> iolist_to_binary(io_lib:format("~P", [K, 4])).
+
+%% Shape only. Same reason as dirty_summary/4: the value is the script's, and
+%% its size is the script's choice.
+-spec dirty_shape(term()) -> tuple() | binary().
+dirty_shape(T) when is_binary(T) -> {binary, byte_size(T)};
+dirty_shape(T) when is_list(T) -> {list, length(T)};
+dirty_shape(T) when is_map(T) -> {map, map_size(T)};
+dirty_shape(T) -> iolist_to_binary(io_lib:format("~P", [T, 4])).
 
 apply_timer_events([], Entities) ->
     Entities;
@@ -2775,23 +2833,34 @@ warm_up(#{cold := true} = State) ->
 warm_up(State) ->
     State.
 
--doc """
-Tell the reaper this zone is still in use.
-
-Written straight into the manager's stamp table where the zone has one, which
-is every zone the manager started. An occupied zone does this on EVERY tick,
-and as a `gen_server` cast it made the zone manager a queue the whole world
-shared - the same process `ensure_zone/2` goes through on the join and
-crossing hot path, where a 1s timeout costs the crossing
-(widgrensit/asobi#559). The cast remains for a zone started outside the
-manager, which has no table to write to.
-""".
+%% Tell the reaper this zone is still in use.
+%%
+%% Written straight into the manager's stamp table where the zone has one, which
+%% is every zone the manager started. An occupied zone does this on EVERY tick,
+%% and as a `gen_server` cast it made the zone manager a queue the whole world
+%% shared - the same process `ensure_zone/2` goes through on the join and
+%% crossing hot path, where a 1s timeout costs the crossing
+%% (widgrensit/asobi#559). The cast remains for a zone started outside the
+%% manager, which has no table to write to.
 -spec touch_manager(map()) -> ok.
-touch_manager(#{zone_stamp_tab := Tab, coords := Coords}) when Tab =/= undefined ->
-    asobi_zone_manager:stamp_active(Tab, Coords);
-touch_manager(#{zone_manager_pid := ZMPid, coords := Coords}) when is_pid(ZMPid) ->
+touch_manager(#{zone_stamp_tab := Tab, coords := Coords} = State) when Tab =/= undefined ->
+    case asobi_zone_manager:stamp_active(Tab, Coords) of
+        ok ->
+            ok;
+        stamp_failed ->
+            %% A dead table during world teardown, or a handle a consumer got
+            %% wrong. The first is transient and the second is forever, and a
+            %% zone that silently never stamps is a zone the reaper takes - so
+            %% degrade to the pre-#559 cast rather than to nothing.
+            touch_via_manager(State)
+    end;
+touch_manager(State) ->
+    touch_via_manager(State).
+
+-spec touch_via_manager(map()) -> ok.
+touch_via_manager(#{zone_manager_pid := ZMPid, coords := Coords}) when is_pid(ZMPid) ->
     asobi_zone_manager:touch_zone(ZMPid, Coords);
-touch_manager(_State) ->
+touch_via_manager(_State) ->
     ok.
 
 %% Emitted on the transition only, never per tick: a zone that is merely busy is
@@ -2943,7 +3012,12 @@ bound_template_id(TemplateId) ->
 %% binary rather than a raw pid/reference/fun it cannot encode.
 -spec bound_debug_term(term()) -> binary().
 bound_debug_term(Term) ->
-    Formatted = iolist_to_binary(io_lib:format("~0p", [Term])),
+    %% `~P` with a depth rather than `~0p`: the depth cut happens DURING the
+    %% render, so a caller that hands this a large game-supplied term pays a
+    %% bounded cost instead of formatting the whole thing and then throwing
+    %% almost all of it away. That difference was measured at ~10 seconds on
+    %% the zone process for a 32MB script binary (widgrensit/asobi#557 review).
+    Formatted = iolist_to_binary(io_lib:format("~P", [Term, 6])),
     Head = binary:part(Formatted, 0, min(200, byte_size(Formatted))),
     case unicode:characters_to_binary(Head) of
         Valid when is_binary(Valid) -> Valid;
@@ -3038,20 +3112,30 @@ sync_spatial_grid(_OldEntities, _NewEntities, undefined) ->
     undefined;
 sync_spatial_grid(OldEntities, NewEntities, Grid) when is_map(Grid) ->
     Grid1 = remove_from_grid_do(removed_ids(OldEntities, NewEntities), Grid),
-    %% Update/insert entities with changed or new positions
+    %% Compares POSITIONS rather than whole entities, deliberately. Matching the
+    %% previous tick's entity term would settle an untouched entity in one
+    %% pointer comparison where a tick preserved structural sharing - but where
+    %% it did not, `=:=` on two maps is a structural walk THAT CAN ONLY FAIL,
+    %% and that is the common case: every game that does not declare a dirty
+    %% set, and every Lua game on any tick carrying input, because
+    %% `handle_input` rebuilds the map. Two position lookups are O(1) whatever
+    %% the entity holds (widgrensit/asobi#557 review).
     maps:fold(
         fun
-            (Id, Entity, G) when is_binary(Id), is_map(Entity) ->
-                %% `{ok, Entity}` matches the bound entity, so an entity the
-                %% tick left alone settles in one pointer comparison rather
-                %% than two position extractions. Worth having only because a
-                %% tick can now preserve structural sharing - see apply_dirty/3
-                %% and widgrensit/asobi#557.
-                case maps:find(Id, OldEntities) of
-                    {ok, Entity} ->
+            (Id, Entity, G) when is_map(Entity) ->
+                case entity_pos(Entity) of
+                    undefined ->
                         G;
-                    Found ->
-                        sync_moved_entity(Id, Entity, Found, G)
+                    Pos ->
+                        case maps:find(Id, OldEntities) of
+                            {ok, Old} when is_map(Old) ->
+                                case entity_pos(Old) of
+                                    Pos -> G;
+                                    _ -> asobi_spatial_grid:update(Id, Pos, G)
+                                end;
+                            _ ->
+                                asobi_spatial_grid:update(Id, Pos, G)
+                        end
                 end;
             (_Id, _Entity, G) ->
                 G
@@ -3059,22 +3143,3 @@ sync_spatial_grid(OldEntities, NewEntities, Grid) when is_map(Grid) ->
         Grid1,
         NewEntities
     ).
-
--spec sync_moved_entity(
-    binary(), map(), {ok, term()} | error, asobi_spatial_grid:grid()
-) -> asobi_spatial_grid:grid().
-sync_moved_entity(Id, Entity, Found, Grid) ->
-    case entity_pos(Entity) of
-        undefined ->
-            Grid;
-        Pos ->
-            case Found of
-                {ok, Old} when is_map(Old) ->
-                    case entity_pos(Old) of
-                        Pos -> Grid;
-                        _ -> asobi_spatial_grid:update(Id, Pos, Grid)
-                    end;
-                _ ->
-                    asobi_spatial_grid:update(Id, Pos, Grid)
-            end
-    end.

--- a/src/world/asobi_zone_manager.erl
+++ b/src/world/asobi_zone_manager.erl
@@ -19,6 +19,8 @@ Hot-path lookups go through ETS directly, bypassing the gen_server.
 -export([register_zone/3, set_zone_config/2, set_initial_zone_states/2]).
 -export([init/1, handle_call/3, handle_cast/2, handle_info/2, terminate/2]).
 
+-include_lib("kernel/include/logger.hrl").
+
 -define(REAP_INTERVAL, 10_000).
 -define(DEFAULT_IDLE_TIMEOUT, 30_000).
 -define(DEFAULT_MAX_ACTIVE, 10_000).
@@ -102,7 +104,7 @@ also what answers `ensure_zone/2` on the join and crossing hot path
 (widgrensit/asobi#559).
 """.
 -spec touch_zone(pid() | atom(), {integer(), integer()}) -> ok.
-touch_zone(Ref, Coords) ->
+touch_zone(Ref, {X, Y} = Coords) when is_integer(X), is_integer(Y) ->
     gen_server:cast(Ref, {touch_zone, Coords}).
 
 -doc """
@@ -125,23 +127,29 @@ manager (`register_zone/3`) keeps working through the cast.
 The table is owned by the manager and the instance supervisor stops the manager
 BEFORE the zone supervisor, so on world teardown a zone can still be ticking
 after the table has gone. A `gen_server` cast at a dead manager is a silent
-no-op and this has to be one too, or every world teardown ends in a burst of
-`badarg` crashes from zones that did nothing wrong.
+no-op and this must not crash either, or every world teardown ends in a burst
+of `badarg` crashes from zones that did nothing wrong.
+
+It answers `stamp_failed` rather than `ok` so the caller can tell the two apart:
+a teardown is transient and a wrong handle is forever, and a zone that silently
+never stamps is a zone the reaper will take. The zone's own touch helper falls
+back to `touch_zone/2` on `stamp_failed`, which degrades to the pre-#559 path
+instead of to nothing.
 """.
--spec stamp_active(ets:table() | undefined, {integer(), integer()}) -> ok.
+-spec stamp_active(ets:table() | undefined, {integer(), integer()}) -> ok | stamp_failed.
 stamp_active(undefined, _Coords) ->
-    ok;
-stamp_active(Tab, Coords) ->
+    stamp_failed;
+stamp_active(Tab, {X, Y} = Coords) when is_integer(X), is_integer(Y) ->
     try
         true = ets:insert(Tab, {Coords, erlang:monotonic_time(millisecond)}),
         ok
     catch
-        error:badarg -> ok
+        error:badarg -> stamp_failed
     end.
 
 -doc "Hint that zone can be unloaded.".
 -spec release_zone(pid() | atom(), {integer(), integer()}) -> ok.
-release_zone(Ref, Coords) ->
+release_zone(Ref, {X, Y} = Coords) when is_integer(X), is_integer(Y) ->
     gen_server:cast(Ref, {release_zone, Coords}).
 
 -doc "Return all active zone pids. For the ticker.".
@@ -481,11 +489,30 @@ reap_idle_zones(
     Expired = ets:select(StampTab, [
         {{'$1', '$2'}, [{'<', '$2', Cutoff}], ['$1']}
     ]),
-    reap_expired(narrow_coords(Expired), Tab, State).
+    reap_expired(narrow_coords(Expired, StampTab), Tab, State).
 
--spec narrow_coords(term()) -> [{integer(), integer()}].
-narrow_coords([]) -> [];
-narrow_coords([{X, Y} | Rest]) when is_integer(X), is_integer(Y) -> [{X, Y} | narrow_coords(Rest)].
+%% Drops a key that is not a coords pair rather than function_clausing on it.
+%% This manager is `transient` under a ONE_FOR_ALL supervisor, so a crash here
+%% restarts the zone supervisor, the ticker and the world server - every zone
+%% in the world dies. The code this replaced just handed whatever it found to
+%% `ets:lookup/2` and swept the miss, so failing loud here would have been a
+%% robustness regression, not an improvement (widgrensit/asobi#559 review).
+%%
+%% Deleted as well as dropped: `release_zone/2` writes an already-expired
+%% stamp, so a bad key lands in the very next sweep and would be re-found for
+%% the life of the world.
+-spec narrow_coords([term()], ets:table()) -> [{integer(), integer()}].
+narrow_coords([], _StampTab) ->
+    [];
+narrow_coords([{X, Y} = Coords | Rest], StampTab) when is_integer(X), is_integer(Y) ->
+    [Coords | narrow_coords(Rest, StampTab)];
+narrow_coords([Bad | Rest], StampTab) ->
+    ?LOG_WARNING(#{
+        msg => ~"non-coords key in the zone stamp table; dropping it",
+        key => io_lib:format("~P", [Bad, 4])
+    }),
+    ets:delete(StampTab, Bad),
+    narrow_coords(Rest, StampTab).
 
 %% Explicit recursion: see docs/eqwalizer-idioms.md.
 -spec reap_expired([{integer(), integer()}], ets:table(), map()) -> map().

--- a/src/world/asobi_zone_manager.erl
+++ b/src/world/asobi_zone_manager.erl
@@ -14,6 +14,7 @@ Hot-path lookups go through ETS directly, bypassing the gen_server.
 
 -export([start_link/1]).
 -export([ensure_zone/2, ensure_zone/3, get_zone/2, touch_zone/2, release_zone/2, revive_zone/3]).
+-export([stamp_active/2]).
 -export([get_active_zones/1, zone_terminated/3, pre_warm/1]).
 -export([register_zone/3, set_zone_config/2, set_initial_zone_states/2]).
 -export([init/1, handle_call/3, handle_cast/2, handle_info/2, terminate/2]).
@@ -92,10 +93,51 @@ revive_zone(Ref, Coords, DeadPid) when is_pid(DeadPid) ->
         {error, _} = Err -> Err
     end.
 
--doc "Reset idle timer for a zone. Fire-and-forget.".
+-doc """
+Reset idle timer for a zone. Fire-and-forget.
+
+For callers that hold the stamp table - every zone the manager itself started
+does - prefer `stamp_active/2`: this cast serialises on the manager, which is
+also what answers `ensure_zone/2` on the join and crossing hot path
+(widgrensit/asobi#559).
+""".
 -spec touch_zone(pid() | atom(), {integer(), integer()}) -> ok.
 touch_zone(Ref, Coords) ->
     gen_server:cast(Ref, {touch_zone, Coords}).
+
+-doc """
+Stamp a zone as active by writing the ETS row directly.
+
+The reaper needs last-active at `idle_timeout` resolution (30s by default) and
+only sweeps every 10s, so the information content of a stamp is tiny - but
+every occupied zone used to send it as a cast on EVERY tick, and the manager
+rebuilt a map per cast. At `tick_rate = 50` that is 20 casts per second per
+occupied zone through the one gen_server that also serves `ensure_zone/2` on
+the join and NPC-crossing path, where the crossing budget is 1s and a timeout
+costs the crossing. The manager's mailbox became a queue the whole world
+shared (widgrensit/asobi#559).
+
+Distinct keys take distinct locks under `write_concurrency`, so zones stamping
+concurrently do not contend with each other, and none of them touch the
+manager process at all. `undefined` is accepted so a zone started outside the
+manager (`register_zone/3`) keeps working through the cast.
+
+The table is owned by the manager and the instance supervisor stops the manager
+BEFORE the zone supervisor, so on world teardown a zone can still be ticking
+after the table has gone. A `gen_server` cast at a dead manager is a silent
+no-op and this has to be one too, or every world teardown ends in a burst of
+`badarg` crashes from zones that did nothing wrong.
+""".
+-spec stamp_active(ets:table() | undefined, {integer(), integer()}) -> ok.
+stamp_active(undefined, _Coords) ->
+    ok;
+stamp_active(Tab, Coords) ->
+    try
+        true = ets:insert(Tab, {Coords, erlang:monotonic_time(millisecond)}),
+        ok
+    catch
+        error:badarg -> ok
+    end.
 
 -doc "Hint that zone can be unloaded.".
 -spec release_zone(pid() | atom(), {integer(), integer()}) -> ok.
@@ -157,6 +199,13 @@ init(Opts) ->
             N when is_atom(N) ->
                 ets:new(N, [set, public, named_table, {read_concurrency, true}])
         end,
+    %% A separate table from the coords->pid one on purpose. That one is read
+    %% on every lookup and never written on the tick path; this one is written
+    %% by every occupied zone on its own tick and read only by the 10s reap
+    %% sweep, so it wants `write_concurrency` and the lookup table does not.
+    StampTab = ets:new(asobi_zone_stamps, [
+        set, public, {write_concurrency, auto}, {read_concurrency, true}
+    ]),
     ZoneSup =
         case maps:get(zone_sup, Opts, undefined) of
             undefined ->
@@ -172,7 +221,7 @@ init(Opts) ->
         instance_sup => maps:get(instance_sup, Opts, undefined),
         zone_sup => ZoneSup,
         ets_tab => Tab,
-        zone_last_active => #{},
+        stamp_tab => StampTab,
         zone_monitors => #{},
         idle_timeout => maps:get(idle_timeout, Opts, ?DEFAULT_IDLE_TIMEOUT),
         max_active_zones => maps:get(max_active_zones, Opts, ?DEFAULT_MAX_ACTIVE),
@@ -187,7 +236,8 @@ init(Opts) ->
 handle_call({ensure_zone, Coords}, _From, #{ets_tab := Tab} = State) ->
     case ets:lookup(Tab, Coords) of
         [{Coords, Pid}] ->
-            {reply, {ok, Pid, existing}, touch(Coords, State)};
+            touch(Coords, State),
+            {reply, {ok, Pid, existing}, State};
         [] ->
             case start_zone(Coords, State) of
                 {ok, Pid, State1} ->
@@ -211,7 +261,8 @@ handle_call({revive_zone, {ZX, ZY} = Coords, DeadPid}, _From, #{ets_tab := Tab} 
                     {reply, {error, zone_stopping}, State}
             end;
         [{Coords, Pid}] ->
-            {reply, {ok, Pid, existing}, touch(Coords, State)};
+            touch(Coords, State),
+            {reply, {ok, Pid, existing}, State};
         [] ->
             case start_zone(Coords, State) of
                 {ok, Pid, State1} -> {reply, {ok, Pid, created}, State1};
@@ -227,17 +278,14 @@ handle_call(
     _From,
     #{
         ets_tab := Tab,
-        zone_last_active := Active,
         zone_monitors := Monitors
     } = State
 ) when is_pid(ZonePid) ->
     ets:insert(Tab, {Coords, ZonePid}),
     MonRef = monitor(process, ZonePid),
-    Now = erlang:monotonic_time(millisecond),
-    State1 = State#{
-        zone_last_active => Active#{Coords => Now},
-        zone_monitors => Monitors#{MonRef => Coords, Coords => MonRef}
-    },
+    announce_zone(ZonePid, State),
+    touch(Coords, State),
+    State1 = State#{zone_monitors => Monitors#{MonRef => Coords, Coords => MonRef}},
     {reply, ok, State1};
 handle_call({set_zone_config, Config}, _From, State) ->
     {reply, ok, State#{zone_config => Config}};
@@ -257,10 +305,14 @@ handle_call(_Request, _From, State) ->
 
 -spec handle_cast(term(), map()) -> {noreply, map()}.
 handle_cast({touch_zone, Coords}, State) ->
-    {noreply, touch(Coords, State)};
-handle_cast({release_zone, Coords}, #{zone_last_active := Active, idle_timeout := Timeout} = State) ->
+    touch(Coords, State),
+    {noreply, State};
+handle_cast(
+    {release_zone, Coords}, #{stamp_tab := StampTab, idle_timeout := Timeout} = State
+) ->
     Stale = erlang:monotonic_time(millisecond) - Timeout - 1,
-    {noreply, State#{zone_last_active => Active#{Coords => Stale}}};
+    ets:insert(StampTab, {Coords, Stale}),
+    {noreply, State};
 handle_cast({zone_terminated, Coords, ZonePid}, #{ets_tab := Tab} = State) ->
     %% Only clean up if this coords still maps to the pid that terminated -
     %% a reaped zone's slot may already have been recreated.
@@ -308,8 +360,9 @@ handle_info(_Info, State) ->
 %% gauge from opened minus closed must key it on world_id and drop the world's
 %% counters when the world ends - see ADR 0005.
 -spec terminate(term(), map()) -> ok.
-terminate(_Reason, #{ets_tab := Tab}) ->
+terminate(_Reason, #{ets_tab := Tab, stamp_tab := StampTab}) ->
     ets:delete(Tab),
+    ets:delete(StampTab),
     ok.
 
 %% --- Internal ---
@@ -318,8 +371,8 @@ start_zone(
     Coords,
     #{
         ets_tab := Tab,
+        stamp_tab := StampTab,
         zone_sup := ZoneSup,
-        zone_last_active := Active,
         zone_monitors := Monitors,
         max_active_zones := MaxActive,
         zone_config := BaseConfig,
@@ -331,7 +384,9 @@ start_zone(
         true ->
             {error, max_zones_reached};
         false ->
-            Config0 = BaseConfig#{coords => Coords},
+            %% Handed to the zone so it can stamp itself active without a cast
+            %% at the manager - see stamp_active/2.
+            Config0 = BaseConfig#{coords => Coords, zone_stamp_tab => StampTab},
             Config =
                 case maps:get(Coords, InitialStates, undefined) of
                     undefined -> Config0;
@@ -339,13 +394,13 @@ start_zone(
                     _ -> Config0
                 end,
             case asobi_zone_sup:start_zone(ZoneSup, Config) of
-                {ok, Pid} ->
+                {ok, Pid} when is_pid(Pid) ->
                     ets:insert(Tab, {Coords, Pid}),
                     asobi_telemetry:zone_opened(WorldId, Coords),
+                    announce_zone(Pid, State),
                     MonRef = monitor(process, Pid),
-                    Now = erlang:monotonic_time(millisecond),
+                    touch(Coords, State),
                     State1 = State#{
-                        zone_last_active => Active#{Coords => Now},
                         zone_monitors => Monitors#{MonRef => Coords, Coords => MonRef}
                     },
                     {ok, Pid, State1};
@@ -358,7 +413,7 @@ cleanup_zone(
     Coords,
     #{
         ets_tab := Tab,
-        zone_last_active := Active,
+        stamp_tab := StampTab,
         zone_monitors := Monitors,
         world_id := WorldId
     } = State
@@ -380,6 +435,7 @@ cleanup_zone(
         maps:get(border_tab, maps:get(zone_config, State, #{}), undefined), Coords
     ),
     ets:delete(Tab, Coords),
+    ets:delete(StampTab, Coords),
     Monitors1 =
         case maps:get(Coords, Monitors, undefined) of
             undefined ->
@@ -388,10 +444,7 @@ cleanup_zone(
                 demonitor(MonRef, [flush]),
                 maps:without([Coords, MonRef], Monitors)
         end,
-    State#{
-        zone_last_active => maps:remove(Coords, Active),
-        zone_monitors => Monitors1
-    }.
+    State#{zone_monitors => Monitors1}.
 
 %% The manager owns a monitor on every zone it has in ETS, so the DOWN for a
 %% zone a caller has just seen die is either already in this mailbox or on its
@@ -416,23 +469,23 @@ await_zone_down(Coords, ZonePid, #{zone_monitors := Monitors} = State) ->
 
 reap_idle_zones(
     #{
-        zone_last_active := Active,
+        stamp_tab := StampTab,
         idle_timeout := Timeout,
         ets_tab := Tab
     } = State
 ) ->
-    Now = erlang:monotonic_time(millisecond),
-    Expired = maps:fold(
-        fun(Coords, LastActive, Acc) ->
-            case Now - LastActive > Timeout of
-                true -> [Coords | Acc];
-                false -> Acc
-            end
-        end,
-        [],
-        Active
-    ),
-    reap_expired(Expired, Tab, State).
+    Cutoff = erlang:monotonic_time(millisecond) - Timeout,
+    %% Selected in ETS rather than folded in the manager's own state: the
+    %% stamps live in the table zones write to directly (widgrensit/asobi#559),
+    %% and this runs once every ?REAP_INTERVAL rather than per tick.
+    Expired = ets:select(StampTab, [
+        {{'$1', '$2'}, [{'<', '$2', Cutoff}], ['$1']}
+    ]),
+    reap_expired(narrow_coords(Expired), Tab, State).
+
+-spec narrow_coords(term()) -> [{integer(), integer()}].
+narrow_coords([]) -> [];
+narrow_coords([{X, Y} | Rest]) when is_integer(X), is_integer(Y) -> [{X, Y} | narrow_coords(Rest)].
 
 %% Explicit recursion: see docs/eqwalizer-idioms.md.
 -spec reap_expired([{integer(), integer()}], ets:table(), map()) -> map().
@@ -452,9 +505,23 @@ reap_expired([Coords | Rest], Tab, State) ->
             reap_expired(Rest, Tab, cleanup_zone(Coords, State))
     end.
 
-touch(Coords, #{zone_last_active := Active} = State) ->
-    Now = erlang:monotonic_time(millisecond),
-    State#{zone_last_active => Active#{Coords => Now}}.
+touch(Coords, #{stamp_tab := StampTab}) ->
+    stamp_active(StampTab, Coords).
+
+%% The ticker owns its own active set rather than re-reading this manager's
+%% table every tick (widgrensit/asobi#560), so a zone has to be handed to it
+%% when it opens. Removal needs no counterpart: the ticker monitors what it is
+%% told about, so a reaped or crashed zone drops out on its own `DOWN`.
+%%
+%% The ticker pid rides in the zone config the world server sets, which is the
+%% same map every zone is started from - so a manager configured for a world
+%% has it, and one that has not been configured yet has started no zones.
+-spec announce_zone(pid(), map()) -> ok.
+announce_zone(ZonePid, #{zone_config := ZoneConfig}) ->
+    case maps:get(ticker_pid, ZoneConfig, undefined) of
+        TickerPid when is_pid(TickerPid) -> asobi_world_ticker:add_zone(TickerPid, ZonePid);
+        _ -> ok
+    end.
 
 schedule_reap() ->
     Ref = make_ref(),

--- a/test/asobi_leaderboard_api_SUITE.erl
+++ b/test/asobi_leaderboard_api_SUITE.erl
@@ -56,12 +56,15 @@ init_per_suite(Config) ->
         lists:seq(1, 5)
     ),
     [{P1Id, P1Token} | _] = Players,
-    BoardId = iolist_to_binary([
-        ~"test_board_", integer_to_binary(erlang:unique_integer([positive]))
-    ]),
-    DisabledBoardId = iolist_to_binary([
-        ~"test_board_disabled_", integer_to_binary(erlang:unique_integer([positive]))
-    ]),
+    %% asobi_test_helpers:unique_id/1, not erlang:unique_integer/1: the latter
+    %% is unique within ONE runtime instance and every `rebar3 ct` is a new
+    %% one, so two runs hand out the same low integers. The local database
+    %% persists between runs, so the second run inherited the first run's rows
+    %% on the same board id - `get_top_empty` found scores and
+    %% `ops_board_listing` counted 6 entries where it seeds 3. Exactly the
+    %% failure asobi#357 recorded and unique_id/1 was written for.
+    BoardId = asobi_test_helpers:unique_id(~"test_board"),
+    DisabledBoardId = asobi_test_helpers:unique_id(~"test_board_disabled"),
     {ok, _} = asobi_leaderboard_sup:start_board(BoardId),
     %% Whitelist this board for client submits — submit_score_disabled
     %% deliberately uses an un-whitelisted board to confirm the gate.
@@ -69,9 +72,7 @@ init_per_suite(Config) ->
     %% The ops reads are database reads. Seed rows straight into the table
     %% rather than waiting out the 30s flush, and out of rank order so the
     %% ranking is proven rather than inherited from the insert order.
-    OpsBoardId = iolist_to_binary([
-        ~"ops_board_", integer_to_binary(erlang:unique_integer([positive]))
-    ]),
+    OpsBoardId = asobi_test_helpers:unique_id(~"ops_board"),
     [{Pa, _}, {Pb, _}, {Pc, _} | _] = Players,
     ok = seed_entry(OpsBoardId, Pb, 100),
     ok = seed_entry(OpsBoardId, Pa, 300),

--- a/test/asobi_lua_config_tests.erl
+++ b/test/asobi_lua_config_tests.erl
@@ -42,6 +42,8 @@ config_test_() ->
         {"bot names: falls back to defaults", fun bot_names_fallback/0},
         {"world config: reads zone settings", fun world_config_zone_settings/0},
         {"world config: reads phase 2 settings", fun world_config_phase2_settings/0},
+        {"world config: cold_tick_divisor = 0 survives parsing",
+            fun world_config_cold_divisor_zero/0},
         {"game_type world selects world bridge", fun game_type_world_selects_world_bridge/0},
         {"game_type absent defaults to match bridge", fun game_type_absent_defaults_to_match/0},
         {"empty_grace_ms global is forwarded to mode config", fun empty_grace_ms_forwarded/0},
@@ -447,6 +449,21 @@ world_config_phase2_settings() ->
     ?assertEqual(64, maps:get(spatial_grid_cell_size, Mode)),
     ?assertEqual(5, maps:get(cold_tick_divisor, Mode)),
     ?assertEqual(true, maps:get(lazy_zones, Mode)),
+    cleanup_temp_dir(TmpDir).
+
+%% widgrensit/asobi#561: 0 is meaningful - an idle zone is never ticked - so it
+%% cannot go through maybe_add_int/3, which requires `Val > 0` and would drop it
+%% back to the default of 10 without a word. This one token is the whole
+%% user-facing entry point for ADR 0021 on a Lua game, and asobi's docs are
+%% Lua-first. `maps:get/2` raises badkey when the value is dropped.
+world_config_cold_divisor_zero() ->
+    TmpDir = make_temp_dir(),
+    {ok, Content} = file:read_file(fixture("config_world_cold_zero.lua")),
+    ok = file:write_file(filename:join(TmpDir, "match.lua"), Content),
+    application:set_env(asobi, game_dir, TmpDir),
+    ok = asobi_lua_config:maybe_load_game_config(),
+    Mode = maps:get(~"default", get_game_modes()),
+    ?assertEqual(0, maps:get(cold_tick_divisor, Mode)),
     cleanup_temp_dir(TmpDir).
 
 game_type_world_selects_world_bridge() ->

--- a/test/asobi_lua_world_tests.erl
+++ b/test/asobi_lua_world_tests.erl
@@ -856,7 +856,7 @@ hot_reload_zone_tick_signals_spawn_templates_hint_test_body() ->
         Zone0 = asobi_lua_world:init_zone_state(Config, maps:get({0, 0}, ZoneStates)),
         erlang:erase({asobi_lua_world, zone_state}),
         {_Ents0, Zone1} = asobi_lua_world:zone_tick(#{}, Zone0),
-        ?assertEqual(unchanged, asobi_lua_world:spawn_templates_hint(Zone1)),
+        ?assertEqual(unchanged, asobi_lua_world:spawn_templates_hint(zone_state(Zone1))),
 
         ok = file:write_file(
             Path,
@@ -877,12 +877,12 @@ hot_reload_zone_tick_signals_spawn_templates_hint_test_body() ->
         {_Ents1, Zone2} = asobi_lua_world:zone_tick(#{}, Zone1),
         ?assertMatch(
             {changed, #{~"goblin" := _, ~"dragon" := _}},
-            asobi_lua_world:spawn_templates_hint(Zone2)
+            asobi_lua_world:spawn_templates_hint(zone_state(Zone2))
         ),
 
         %% The signal is one-tick only - it must not leak into the next tick.
         {_Ents2, Zone3} = asobi_lua_world:zone_tick(#{}, Zone2),
-        ?assertEqual(unchanged, asobi_lua_world:spawn_templates_hint(Zone3))
+        ?assertEqual(unchanged, asobi_lua_world:spawn_templates_hint(zone_state(Zone3)))
     after
         erlang:erase({asobi_lua_world, zone_state}),
         file:delete(Path)
@@ -926,7 +926,7 @@ hot_reload_broken_spawn_templates_does_not_wipe_hint_test() ->
         bump_mtime(Path),
 
         {_Ents1, Zone2} = asobi_lua_world:zone_tick(#{}, Zone1),
-        ?assertEqual(unchanged, asobi_lua_world:spawn_templates_hint(Zone2))
+        ?assertEqual(unchanged, asobi_lua_world:spawn_templates_hint(zone_state(Zone2)))
     after
         erlang:erase({asobi_lua_world, zone_state}),
         file:delete(Path)
@@ -1042,8 +1042,9 @@ game_namespace_visible_in_zone_tick_and_handle_input_test() ->
     {_Ents, ZoneState1} = asobi_lua_world:zone_tick(#{}, ZoneState),
     %% ZoneState1.game_state holds the script's zone_state luerl tref;
     %% decode it to inspect the flag.
+    ZoneState1Map = zone_state(ZoneState1),
     ZoneTickGS = asobi_lua_api:decode_to_map(
-        maps:get(game_state, ZoneState1), maps:get(lua_state, ZoneState1)
+        maps:get(game_state, ZoneState1Map), maps:get(lua_state, ZoneState1Map)
     ),
     ?assertEqual(true, maps:get(~"zone_tick_saw_game", ZoneTickGS, false)),
 
@@ -1355,3 +1356,9 @@ zone_tick_malformed_half_is_reported_test() ->
     after
         telemetry:detach(Handler)
     end.
+
+%% `zone_tick/2` returns the zone state as `term()` - the callback contract is
+%% game-defined - so a test reading fields out of it narrows first.
+-spec zone_state(term()) -> map().
+zone_state(ZoneState) when is_map(ZoneState) ->
+    ZoneState.

--- a/test/asobi_lua_world_tests.erl
+++ b/test/asobi_lua_world_tests.erl
@@ -1258,3 +1258,100 @@ zone_tick_without_dirty_declaration_test() ->
     after 5_000 ->
         ?assert(false)
     end.
+
+%% widgrensit/asobi#557 review: `is_tuple/1` is not a Luerl-table check. Luerl
+%% represents every non-scalar as a record - #tref{}, #funref{}, #erl_func{},
+%% #erl_mfa{}, #usdref{} - so a script returning a function or a recursive
+%% table as its fourth value raised out of decode_to_map/2, and asobi_zone
+%% calls zone_tick/2 with no try/catch: the zone died with everyone in it.
+%%
+%% Each mode runs in its own process because zone_tick/2 stashes its zone state
+%% in the process dictionary and reads lua_state back from it.
+zone_tick_hostile_fourth_value_test_() ->
+    [
+        {binary_to_list(Mode), fun() -> assert_survives(Mode, ExpectedX) end}
+     || {Mode, ExpectedX} <- [
+            %% Not a declaration at all, so the safe answer is the full decode
+            %% and the script's mutation lands.
+            {~"function", 2.0},
+            {~"recursive", 2.0},
+            {~"number", 2.0},
+            {~"nil_fourth", 2.0},
+            {~"not_a_declaration", 2.0},
+            %% This one DOES declare - it has a `changed` key - but the half is
+            %% array-shaped and unusable. The declaration stands and the
+            %% malformed half is reported, so the base map is what survives.
+            {~"array", 1.0}
+        ]
+    ].
+
+%% Two assertions, and the first is the one that matters: the bridge must not
+%% raise. The second separates "asobi decoded what the script returned" from
+%% "asobi kept the map it handed in", which is the difference between a
+%% fallback and a silent freeze.
+assert_survives(Mode, ExpectedX) ->
+    case run_fourth_value(Mode) of
+        {raised, Crash} ->
+            erlang:error({zone_tick_raised, Mode, Crash});
+        {ok, Result} ->
+            ?assert(is_tuple(Result)),
+            Entities = element(1, Result),
+            ?assert(is_map(Entities)),
+            ?assertEqual(ExpectedX, maps:get(x, maps:get(~"a", Entities)))
+    end.
+
+run_fourth_value(Mode) ->
+    Script = fixture("dirty_bad_world.lua"),
+    Self = self(),
+    Pid = spawn(fun() ->
+        Config = #{game_config => #{lua_script => Script}},
+        {ok, ZoneStates} = asobi_lua_world:generate_world(0, Config),
+        ZoneState = asobi_lua_world:init_zone_state(Config, maps:get({0, 0}, ZoneStates)),
+        Entities = #{
+            ~"a" => #{type => ~"npc", x => 1.0, y => 1.0},
+            ~"probe" => #{type => ~"npc", mode => Mode, x => 0.0, y => 0.0}
+        },
+        Self !
+            {result,
+                try asobi_lua_world:zone_tick(Entities, ZoneState) of
+                    R -> {ok, R}
+                catch
+                    C:E -> {raised, {C, E}}
+                end}
+    end),
+    MonRef = monitor(process, Pid),
+    receive
+        {result, Result} ->
+            demonitor(MonRef, [flush]),
+            Result;
+        {'DOWN', MonRef, process, Pid, Reason} ->
+            {raised, {down, Reason}}
+    after 5_000 ->
+        {raised, timeout}
+    end.
+
+%% The array-shaped half is the one the guide's own idiom invites -
+%% `changed[#changed + 1] = e` - and until widgrensit/asobi#557's review it was
+%% normalised to #{} in this bridge BEFORE asobi_zone could complain, so every
+%% mutation the tick made was reverted with no log and no telemetry. Assert the
+%% report, not just the outcome: the outcome alone looks identical to silence.
+zone_tick_malformed_half_is_reported_test() ->
+    {ok, _} = application:ensure_all_started(telemetry),
+    Self = self(),
+    Handler = ?FUNCTION_NAME,
+    ok = telemetry:attach(
+        Handler,
+        [asobi, error],
+        fun(_E, _M, Meta, _C) -> Self ! {game_error, Meta} end,
+        undefined
+    ),
+    try
+        {ok, _} = run_fourth_value(~"array"),
+        receive
+            {game_error, #{kind := bad_zone_dirty}} -> ok
+        after 1_000 ->
+            ?assert(false)
+        end
+    after
+        telemetry:detach(Handler)
+    end.

--- a/test/asobi_lua_world_tests.erl
+++ b/test/asobi_lua_world_tests.erl
@@ -1211,3 +1211,50 @@ hostile_metatable_cannot_run_on_the_zone_test() ->
     %% The metamethod burns ~2e6 iterations if anything invokes it.
     ?assert(Us < 200_000),
     erlang:erase({asobi_lua_world, zone_state}).
+
+%% widgrensit/asobi#557: a script that says what it changed lets the bridge
+%% skip decoding the whole entities table, and asobi merges the declaration
+%% onto the map it handed in - so untouched entities stay the same terms.
+zone_tick_dirty_declaration_test() ->
+    Script = fixture("dirty_world.lua"),
+    Config = #{game_config => #{lua_script => Script}},
+    {ok, ZoneStates} = asobi_lua_world:generate_world(0, Config),
+    ZoneState = asobi_lua_world:init_zone_state(Config, maps:get({0, 0}, ZoneStates)),
+    Entities = #{
+        ~"a" => #{type => ~"npc", x => 1.0, y => 1.0},
+        ~"b" => #{type => ~"npc", x => 2.0, y => 2.0},
+        ~"c" => #{type => ~"npc", x => 3.0, y => 3.0}
+    },
+    {Base, _ZS, false, Dirty} = asobi_lua_world:zone_tick(Entities, ZoneState),
+    %% The bridge passes the INPUT map straight back rather than a decode of
+    %% what the script returned. That is what preserves sharing.
+    ?assertEqual(Entities, Base),
+    ?assertMatch(#{changed := #{~"a" := #{x := 11.0}}, removed := [~"c"]}, Dirty),
+    #{changed := Changed} = Dirty,
+    %% "b" was mutated by the script but not declared, so it is not changed.
+    ?assertNot(maps:is_key(~"b", Changed)),
+    ?assertEqual(1, map_size(Changed)).
+
+%% A script that returns three values (or two) keeps the old contract: the
+%% whole table is decoded and there is no fourth element.
+%%
+%% In its own process: zone_tick/2 stashes its zone state in the process
+%% dictionary and reads `lua_state` back from it, so a test running after
+%% another one in the same process would call the OTHER script's zone_tick.
+zone_tick_without_dirty_declaration_test() ->
+    Script = fixture("config_move_world.lua"),
+    Self = self(),
+    Pid = spawn(fun() ->
+        Config = #{game_config => #{lua_script => Script}},
+        {ok, ZoneStates} = asobi_lua_world:generate_world(0, Config),
+        ZoneState = asobi_lua_world:init_zone_state(Config, maps:get({0, 0}, ZoneStates)),
+        Self ! {result, asobi_lua_world:zone_tick(#{}, ZoneState)}
+    end),
+    MonRef = monitor(process, Pid),
+    receive
+        {result, Result} ->
+            demonitor(MonRef, [flush]),
+            ?assertEqual(2, tuple_size(Result))
+    after 5_000 ->
+        ?assert(false)
+    end.

--- a/test/asobi_world_ticker_tests.erl
+++ b/test/asobi_world_ticker_tests.erl
@@ -45,30 +45,39 @@ ticker_test_() ->
             {"the world keeps posting while saturated", fun post_tick_survives_saturation/0},
             {"set_zones twice arms one timer", fun set_zones_twice_arms_one_timer/0},
             {"a demoted zone stays cold under a zone manager", fun manager_honours_cold_zones/0},
+            {"cold_tick_divisor 0 never ticks a cold zone", fun cold_divisor_zero_never_ticks/0},
+            {"a divisor of 0 still ticks hot zones", fun cold_divisor_zero_ticks_hot/0},
+            {"a warmed zone at divisor 0 ticks again", fun cold_divisor_zero_warms_back/0},
             {"a cold zone is skipped on an off-divisor tick", fun cold_zone_skipped/0},
             {"a reaped cold zone drops out of the cold set", fun cold_set_prunes_dead_zones/0}
         ]}.
 
 %% widgrensit/asobi#543: with a zone manager the ticker used to overwrite its
 %% own hot/cold split with "every active zone is hot", which made
-%% cold_tick_divisor inert for every world running lazy zones.
+%% cold_tick_divisor inert for every world running lazy zones. Since
+%% widgrensit/asobi#560 the split IS the active set - the manager pushes zones
+%% in as they open and never gets asked for the list again.
 manager_honours_cold_zones() ->
     Z1 = idle_proc(),
     Z2 = idle_proc(),
     Manager = fake_manager([Z1, Z2]),
     Pid = start_ticker(#{tick_rate => 20}),
     asobi_world_ticker:set_zone_manager(Pid, Manager, self()),
+    asobi_world_ticker:add_zone(Pid, Z1),
+    asobi_world_ticker:add_zone(Pid, Z2),
     asobi_world_ticker:demote_zone(Pid, Z1),
     timer:sleep(80),
     State = get_state_map(Pid),
-    ?assertEqual([Z1], maps:get(cold_zones, State)),
-    ?assertEqual([Z2], maps:get(hot_zones, State)).
+    ?assertEqual([Z1], maps:keys(maps:get(cold_zones, State))),
+    ?assertEqual([Z2], maps:keys(maps:get(hot_zones, State))).
 
 cold_zone_skipped() ->
     Z1 = counting_proc(),
     Z2 = counting_proc(),
     Manager = fake_manager([Z1, Z2]),
     Pid = start_ticker(#{tick_rate => 10, cold_tick_divisor => 100}),
+    asobi_world_ticker:add_zone(Pid, Z1),
+    asobi_world_ticker:add_zone(Pid, Z2),
     %% Each stand-in must retire its tick, or the ticker's saturation guard
     %% skips it from the second tick onwards and both counts stay at 1.
     Z1 ! {ticker, Pid},
@@ -84,20 +93,62 @@ cold_zone_skipped() ->
     %% ticker's dispatch count over 150ms is not something to assert tightly.
     ?assert(Hot >= 3).
 
+%% widgrensit/asobi#561: the opt-in last step past ADR 0016. At a divisor of
+%% 10 an idle zone still pays a full do_tick twice a second, plus a
+%% full-sweep GC per hibernate/wake cycle; at 0 it pays nothing until a
+%% message gives it work.
+cold_divisor_zero_never_ticks() ->
+    Z = counting_proc(),
+    Pid = start_ticker(#{tick_rate => 10, cold_tick_divisor => 0}),
+    Z ! {ticker, Pid},
+    asobi_world_ticker:set_zones(Pid, [], self()),
+    asobi_world_ticker:add_zone(Pid, Z),
+    asobi_world_ticker:demote_zone(Pid, Z),
+    timer:sleep(150),
+    ?assertEqual(0, tick_count(Z)).
+
+%% The knob must not be a world-wide off switch: only the cold set is skipped.
+cold_divisor_zero_ticks_hot() ->
+    Z = counting_proc(),
+    Pid = start_ticker(#{tick_rate => 10, cold_tick_divisor => 0}),
+    Z ! {ticker, Pid},
+    asobi_world_ticker:set_zones(Pid, [], self()),
+    asobi_world_ticker:add_zone(Pid, Z),
+    timer:sleep(150),
+    ?assert(tick_count(Z) >= 3).
+
+%% Promotion is the only transition left for a zone that never ticks, so if
+%% warming did not bring it back it would be dead rather than dormant.
+cold_divisor_zero_warms_back() ->
+    Z = counting_proc(),
+    Pid = start_ticker(#{tick_rate => 10, cold_tick_divisor => 0}),
+    Z ! {ticker, Pid},
+    asobi_world_ticker:set_zones(Pid, [], self()),
+    asobi_world_ticker:add_zone(Pid, Z),
+    asobi_world_ticker:demote_zone(Pid, Z),
+    timer:sleep(100),
+    ?assertEqual(0, tick_count(Z)),
+    asobi_world_ticker:promote_zone(Pid, Z),
+    timer:sleep(150),
+    ?assert(tick_count(Z) >= 3).
+
 cold_set_prunes_dead_zones() ->
     Z1 = idle_proc(),
     Manager = fake_manager([Z1]),
     Pid = start_ticker(#{tick_rate => 20}),
     asobi_world_ticker:set_zone_manager(Pid, Manager, self()),
+    asobi_world_ticker:add_zone(Pid, Z1),
     asobi_world_ticker:demote_zone(Pid, Z1),
     timer:sleep(60),
-    ?assertEqual([Z1], maps:get(cold_zones, get_state_map(Pid))),
-    %% The manager stops listing it (the zone was reaped). Nothing sends
-    %% remove_zone, so the cold set has to prune itself or it grows for the
-    %% life of the world.
-    set_manager_zones(Manager, []),
+    ?assertEqual([Z1], maps:keys(maps:get(cold_zones, get_state_map(Pid)))),
+    %% The zone is reaped. Nothing sends remove_zone, so the ticker's own
+    %% monitor has to prune it or both sets grow for the life of the world -
+    %% which is what re-deriving them from the manager's list used to do for
+    %% free (widgrensit/asobi#560).
+    Z1 ! stop,
     timer:sleep(80),
-    ?assertEqual([], maps:get(cold_zones, get_state_map(Pid))).
+    ?assertEqual(#{}, maps:get(cold_zones, get_state_map(Pid))),
+    ?assertEqual(#{}, maps:get(hot_zones, get_state_map(Pid))).
 
 idle_proc() ->
     spawn(fun() ->
@@ -116,15 +167,9 @@ manager_loop(Zones) ->
         {'$gen_call', {From, Tag}, get_active_zones} ->
             From ! {Tag, Zones},
             manager_loop(Zones);
-        {set_zones, New} ->
-            manager_loop(New);
         stop ->
             ok
     end.
-
-set_manager_zones(Manager, Zones) ->
-    Manager ! {set_zones, Zones},
-    ok.
 
 %% A zone stand-in that counts the ticks it is sent.
 counting_proc() ->
@@ -173,8 +218,8 @@ set_zones_all_hot() ->
     asobi_world_ticker:set_zones(Pid, [Z1, Z2], self()),
     timer:sleep(10),
     State = get_state_map(Pid),
-    ?assertEqual([Z1, Z2], maps:get(hot_zones, State)),
-    ?assertEqual([], maps:get(cold_zones, State)).
+    ?assertEqual(lists:sort([Z1, Z2]), lists:sort(maps:keys(maps:get(hot_zones, State)))),
+    ?assertEqual(#{}, maps:get(cold_zones, State)).
 
 promote_zone_adds_to_hot() ->
     Pid = start_ticker(),
@@ -186,8 +231,8 @@ promote_zone_adds_to_hot() ->
     asobi_world_ticker:promote_zone(Pid, Z1),
     timer:sleep(10),
     State = get_state_map(Pid),
-    ?assert(lists:member(Z1, maps:get(hot_zones, State))),
-    ?assertNot(lists:member(Z1, maps:get(cold_zones, State))).
+    ?assert(is_map_key(Z1, maps:get(hot_zones, State))),
+    ?assertNot(is_map_key(Z1, maps:get(cold_zones, State))).
 
 demote_zone_moves_to_cold() ->
     Pid = start_ticker(),
@@ -201,8 +246,8 @@ demote_zone_moves_to_cold() ->
     asobi_world_ticker:demote_zone(Pid, Z1),
     timer:sleep(10),
     State = get_state_map(Pid),
-    ?assertNot(lists:member(Z1, maps:get(hot_zones, State))),
-    ?assert(lists:member(Z1, maps:get(cold_zones, State))).
+    ?assertNot(is_map_key(Z1, maps:get(hot_zones, State))),
+    ?assert(is_map_key(Z1, maps:get(cold_zones, State))).
 
 remove_zone_removes() ->
     Pid = start_ticker(),
@@ -216,8 +261,8 @@ remove_zone_removes() ->
     asobi_world_ticker:remove_zone(Pid, Z1),
     timer:sleep(10),
     State = get_state_map(Pid),
-    ?assertNot(lists:member(Z1, maps:get(hot_zones, State))),
-    ?assertNot(lists:member(Z1, maps:get(cold_zones, State))).
+    ?assertNot(is_map_key(Z1, maps:get(hot_zones, State))),
+    ?assertNot(is_map_key(Z1, maps:get(cold_zones, State))).
 
 promote_idempotent() ->
     Pid = start_ticker(),
@@ -231,8 +276,7 @@ promote_idempotent() ->
     asobi_world_ticker:promote_zone(Pid, Z1),
     timer:sleep(10),
     State = get_state_map(Pid),
-    Hot = maps:get(hot_zones, State),
-    ?assertEqual(1, length([Z || Z <- Hot, Z =:= Z1])).
+    ?assertEqual([Z1], maps:keys(maps:get(hot_zones, State))).
 
 demote_idempotent() ->
     Pid = start_ticker(),
@@ -246,8 +290,7 @@ demote_idempotent() ->
     asobi_world_ticker:demote_zone(Pid, Z1),
     timer:sleep(10),
     State = get_state_map(Pid),
-    Cold = maps:get(cold_zones, State),
-    ?assertEqual(1, length([Z || Z <- Cold, Z =:= Z1])).
+    ?assertEqual([Z1], maps:keys(maps:get(cold_zones, State))).
 
 cold_divisor_default() ->
     Pid = start_ticker(),

--- a/test/asobi_world_ticker_tests.erl
+++ b/test/asobi_world_ticker_tests.erl
@@ -44,7 +44,10 @@ ticker_test_() ->
             {"post_tick never runs backwards", fun post_tick_is_monotonic/0},
             {"the world keeps posting while saturated", fun post_tick_survives_saturation/0},
             {"set_zones twice arms one timer", fun set_zones_twice_arms_one_timer/0},
-            {"a demoted zone stays cold under a zone manager", fun manager_honours_cold_zones/0},
+            {"a demoted zone stays cold while its neighbour stays hot",
+                fun demoted_zone_stays_cold/0},
+            {"set_zones releases the monitors it drops", fun set_zones_releases_monitors/0},
+            {"a non-integer cold_tick_divisor takes the default", fun bad_cold_divisor_defaults/0},
             {"cold_tick_divisor 0 never ticks a cold zone", fun cold_divisor_zero_never_ticks/0},
             {"a divisor of 0 still ticks hot zones", fun cold_divisor_zero_ticks_hot/0},
             {"a warmed zone at divisor 0 ticks again", fun cold_divisor_zero_warms_back/0},
@@ -52,29 +55,53 @@ ticker_test_() ->
             {"a reaped cold zone drops out of the cold set", fun cold_set_prunes_dead_zones/0}
         ]}.
 
-%% widgrensit/asobi#543: with a zone manager the ticker used to overwrite its
-%% own hot/cold split with "every active zone is hot", which made
-%% cold_tick_divisor inert for every world running lazy zones. Since
-%% widgrensit/asobi#560 the split IS the active set - the manager pushes zones
-%% in as they open and never gets asked for the list again.
-manager_honours_cold_zones() ->
+%% widgrensit/asobi#543: the ticker used to overwrite its own hot/cold split
+%% with "every active zone is hot", which made cold_tick_divisor inert for
+%% every world running lazy zones. Since widgrensit/asobi#560 the split IS the
+%% active set - nothing asks a manager for a list any more, which is why this
+%% no longer involves one.
+demoted_zone_stays_cold() ->
     Z1 = idle_proc(),
     Z2 = idle_proc(),
-    Manager = fake_manager([Z1, Z2]),
     Pid = start_ticker(#{tick_rate => 20}),
-    asobi_world_ticker:set_zone_manager(Pid, Manager, self()),
-    asobi_world_ticker:add_zone(Pid, Z1),
-    asobi_world_ticker:add_zone(Pid, Z2),
+    asobi_world_ticker:set_zones(Pid, [Z1, Z2], self()),
     asobi_world_ticker:demote_zone(Pid, Z1),
     timer:sleep(80),
     State = get_state_map(Pid),
     ?assertEqual([Z1], maps:keys(maps:get(cold_zones, State))),
     ?assertEqual([Z2], maps:keys(maps:get(hot_zones, State))).
 
+%% "set" replaces, and since widgrensit/asobi#560 the ticker holds a monitor
+%% per zone - so a zone it drops has to lose its monitor too, or the ticker
+%% leaks one per zone for the life of the world.
+set_zones_releases_monitors() ->
+    Z1 = idle_proc(),
+    Z2 = idle_proc(),
+    Pid = start_ticker(),
+    asobi_world_ticker:add_zone(Pid, Z1),
+    timer:sleep(10),
+    asobi_world_ticker:set_zones(Pid, [Z2], self()),
+    timer:sleep(10),
+    State = get_state_map(Pid),
+    ?assertEqual([Z2], maps:keys(maps:get(hot_zones, State))),
+    ?assertEqual([Z2], maps:keys(maps:get(zone_monitors, State))),
+    %% Dropped means dropped: Z1 dying is now a DOWN the ticker must ignore.
+    Z1 ! stop,
+    timer:sleep(40),
+    ?assertEqual([Z2], maps:keys(maps:get(hot_zones, get_state_map(Pid)))).
+
+%% A bad divisor must take the documented default, not the never-tick regime -
+%% landing in ADR 0021's semantics by typo is exactly what the hardening in
+%% cold_divisor/1 exists to stop.
+bad_cold_divisor_defaults() ->
+    Pid = start_ticker(#{cold_tick_divisor => ~"10"}),
+    ?assertEqual(10, maps:get(cold_tick_divisor, get_state_map(Pid))),
+    Neg = start_ticker(#{cold_tick_divisor => -1}),
+    ?assertEqual(10, maps:get(cold_tick_divisor, get_state_map(Neg))).
+
 cold_zone_skipped() ->
     Z1 = counting_proc(),
     Z2 = counting_proc(),
-    Manager = fake_manager([Z1, Z2]),
     Pid = start_ticker(#{tick_rate => 10, cold_tick_divisor => 100}),
     asobi_world_ticker:add_zone(Pid, Z1),
     asobi_world_ticker:add_zone(Pid, Z2),
@@ -82,7 +109,7 @@ cold_zone_skipped() ->
     %% skips it from the second tick onwards and both counts stay at 1.
     Z1 ! {ticker, Pid},
     Z2 ! {ticker, Pid},
-    asobi_world_ticker:set_zone_manager(Pid, Manager, self()),
+    asobi_world_ticker:set_zones(Pid, [Z1, Z2], self()),
     asobi_world_ticker:demote_zone(Pid, Z1),
     timer:sleep(150),
     Hot = tick_count(Z2),
@@ -134,10 +161,8 @@ cold_divisor_zero_warms_back() ->
 
 cold_set_prunes_dead_zones() ->
     Z1 = idle_proc(),
-    Manager = fake_manager([Z1]),
     Pid = start_ticker(#{tick_rate => 20}),
-    asobi_world_ticker:set_zone_manager(Pid, Manager, self()),
-    asobi_world_ticker:add_zone(Pid, Z1),
+    asobi_world_ticker:set_zones(Pid, [Z1], self()),
     asobi_world_ticker:demote_zone(Pid, Z1),
     timer:sleep(60),
     ?assertEqual([Z1], maps:keys(maps:get(cold_zones, get_state_map(Pid)))),
@@ -156,20 +181,6 @@ idle_proc() ->
             stop -> ok
         end
     end).
-
-%% Answers get_active_zones and counts nothing else; the zone list is
-%% swappable so a test can simulate a reap.
-fake_manager(Zones) ->
-    spawn(fun() -> manager_loop(Zones) end).
-
-manager_loop(Zones) ->
-    receive
-        {'$gen_call', {From, Tag}, get_active_zones} ->
-            From ! {Tag, Zones},
-            manager_loop(Zones);
-        stop ->
-            ok
-    end.
 
 %% A zone stand-in that counts the ticks it is sent.
 counting_proc() ->

--- a/test/asobi_zone_cold_tests.erl
+++ b/test/asobi_zone_cold_tests.erl
@@ -240,7 +240,7 @@ zone_busy_released() ->
     Pid = start_busy_zone(#{busy => true}),
     tick(Pid, 1),
     ?assertNot(is_cold(Pid)),
-    sys:replace_state(Pid, fun(S) -> S#{zone_state => #{busy => false}} end),
+    sys:replace_state(Pid, fun clear_busy/1),
     tick(Pid, 2),
     ?assert(is_cold(Pid)),
     gen_server:stop(Pid).
@@ -289,3 +289,9 @@ busy_zone_does_not_hibernate() ->
         process_info(Busy, current_function)
     ),
     gen_server:stop(Busy).
+
+%% sys:replace_state/2 hands the fun a term(), so the update needs a narrowing
+%% clause rather than a map update on an unknown shape.
+-spec clear_busy(term()) -> map().
+clear_busy(State) when is_map(State) ->
+    State#{zone_state => #{busy => false}}.

--- a/test/asobi_zone_cold_tests.erl
+++ b/test/asobi_zone_cold_tests.erl
@@ -68,8 +68,34 @@ cold_test_() ->
         {"a two-tuple return still means not busy", fun two_tuple_is_not_busy/0},
         {"a non-boolean third element keeps the zone hot", fun bad_zone_busy_fails_safe/0},
         {"a busy zone is not reaped", fun busy_zone_declines_reap/0},
-        {"a busy zone is not hibernated", fun busy_zone_does_not_hibernate/0}
+        {"a busy zone is not hibernated", fun busy_zone_does_not_hibernate/0},
+        {"a watched empty zone is not reaped", fun watched_zone_declines_reap/0},
+        {"an unwatched empty zone still is", fun unwatched_zone_accepts_reap/0}
     ]}.
+
+%% widgrensit/asobi#561: an empty zone with subscribers was only kept alive by
+%% re-stamping itself on every tick, so at `cold_tick_divisor = 0` - where it
+%% stops ticking entirely - the reaper would tear it out from under players
+%% who are not re-subscribed until they next move.
+watched_zone_declines_reap() ->
+    Pid = start_zone(),
+    asobi_zone:subscribe(Pid, {~"p1", self()}),
+    _ = sys:get_state(Pid),
+    asobi_zone:reap(Pid),
+    _ = sys:get_state(Pid),
+    ?assert(is_process_alive(Pid)),
+    gen_server:stop(Pid).
+
+unwatched_zone_accepts_reap() ->
+    Pid = start_zone(),
+    unlink(Pid),
+    MonRef = monitor(process, Pid),
+    asobi_zone:reap(Pid),
+    receive
+        {'DOWN', MonRef, process, Pid, normal} -> ok
+    after 1_000 ->
+        ?assert(false)
+    end.
 
 start_busy_zone(ZoneState) ->
     {ok, Pid} = asobi_zone:start_link(#{

--- a/test/asobi_zone_dirty_game.erl
+++ b/test/asobi_zone_dirty_game.erl
@@ -2,13 +2,22 @@
 
 -export([zone_tick/2, handle_input/3]).
 
-%% Declares what it changed instead of handing back a rebuilt map, which is
-%% what lets asobi keep the untouched entities as the same terms
-%% (widgrensit/asobi#557). `dirty` in the zone state is whatever the test wants
-%% the fourth return value to be, so a malformed declaration is testable too.
+%% `dirty` in the zone state is whatever the test wants the fourth return value
+%% to be, so a malformed declaration is testable too. Its ABSENCE means the
+%% two-tuple return - the compatibility path ADR 0022 claims is unchanged -
+%% which needs a test of its own rather than an empty declaration standing in
+%% for it.
 zone_tick(Entities, ZoneState) when is_map(ZoneState) ->
-    {Entities, ZoneState, false, maps:get(dirty, ZoneState, #{})};
+    case maps:get(dirty, ZoneState, no_declaration) of
+        no_declaration -> declared_arity(Entities, ZoneState);
+        Dirty -> {Entities, ZoneState, false, Dirty}
+    end;
 zone_tick(Entities, ZoneState) ->
+    {Entities, ZoneState}.
+
+declared_arity(Entities, #{arity := 3, busy := Busy} = ZoneState) ->
+    {Entities, ZoneState, Busy};
+declared_arity(Entities, ZoneState) ->
     {Entities, ZoneState}.
 
 handle_input(_PlayerId, _Input, Entities) ->

--- a/test/asobi_zone_dirty_game.erl
+++ b/test/asobi_zone_dirty_game.erl
@@ -1,0 +1,15 @@
+-module(asobi_zone_dirty_game).
+
+-export([zone_tick/2, handle_input/3]).
+
+%% Declares what it changed instead of handing back a rebuilt map, which is
+%% what lets asobi keep the untouched entities as the same terms
+%% (widgrensit/asobi#557). `dirty` in the zone state is whatever the test wants
+%% the fourth return value to be, so a malformed declaration is testable too.
+zone_tick(Entities, ZoneState) when is_map(ZoneState) ->
+    {Entities, ZoneState, false, maps:get(dirty, ZoneState, #{})};
+zone_tick(Entities, ZoneState) ->
+    {Entities, ZoneState}.
+
+handle_input(_PlayerId, _Input, Entities) ->
+    {ok, Entities}.

--- a/test/asobi_zone_dirty_tests.erl
+++ b/test/asobi_zone_dirty_tests.erl
@@ -1,0 +1,120 @@
+-module(asobi_zone_dirty_tests).
+-include_lib("eunit/include/eunit.hrl").
+
+%% widgrensit/asobi#557: a zone used to round-trip its whole entity map through
+%% zone_tick every tick whatever changed, and the rebuilt map destroyed the
+%% structural sharing every downstream diff depends on. A game may now say what
+%% it changed instead.
+
+setup() ->
+    case ets:info(asobi_world_state) of
+        undefined -> ets:new(asobi_world_state, [named_table, public, set]);
+        _ -> ok
+    end,
+    case pg:start(nova_scope) of
+        {ok, _} -> ok;
+        {error, {already_started, _}} -> ok
+    end,
+    ok.
+
+start_zone(Dirty) ->
+    {ok, Pid} = asobi_zone:start_link(#{
+        world_id => ~"dirty-world",
+        coords => {1, 1},
+        ticker_pid => self(),
+        zone_size => 1000,
+        grid_size => 5,
+        game_module => asobi_zone_dirty_game,
+        zone_state => #{dirty => Dirty}
+    }),
+    Pid.
+
+npc(X) ->
+    #{type => ~"npc", x => 1000.0 + X, y => 1000.0, hp => 100}.
+
+tick(Pid) ->
+    asobi_zone:tick(Pid, 1),
+    _ = sys:get_state(Pid),
+    ok.
+
+add(Pid, Id, E) ->
+    asobi_zone:add_entity(Pid, Id, E),
+    _ = sys:get_state(Pid),
+    ok.
+
+dirty_test_() ->
+    {foreach, fun setup/0, fun(_) -> ok end, [
+        {"a declared change lands", fun changed_lands/0},
+        {"a declared removal lands", fun removed_lands/0},
+        {"an undeclared entity keeps its identity", fun untouched_is_shared/0},
+        {"a malformed declaration is ignored, not fatal", fun malformed_is_ignored/0},
+        {"a non-binary id in changed is dropped", fun bad_id_dropped/0},
+        {"no declaration keeps today's semantics", fun no_declaration/0}
+    ]}.
+
+changed_lands() ->
+    Pid = start_zone(#{changed => #{~"a" => npc(9.0)}, removed => []}),
+    add(Pid, ~"a", npc(1.0)),
+    tick(Pid),
+    ?assertMatch(#{~"a" := #{x := 1009.0}}, asobi_zone:get_entities(Pid)),
+    gen_server:stop(Pid).
+
+removed_lands() ->
+    Pid = start_zone(#{changed => #{}, removed => [~"b"]}),
+    add(Pid, ~"a", npc(1.0)),
+    add(Pid, ~"b", npc(2.0)),
+    tick(Pid),
+    Entities = asobi_zone:get_entities(Pid),
+    ?assert(maps:is_key(~"a", Entities)),
+    ?assertNot(maps:is_key(~"b", Entities)),
+    gen_server:stop(Pid).
+
+%% The point of the whole contract: an entity nobody named is the SAME TERM it
+%% was before the callback, so compute_deltas/2 and sync_spatial_grid/3 settle
+%% it with a pointer comparison instead of walking its fields.
+%%
+%% Both halves of the comparison have to be read INSIDE the zone: a
+%% `get_entities/1` call copies the map out, and copying a term does not
+%% preserve sharing within it - two calls would compare two independent copies
+%% and the assertion would be vacuously false whatever the tick did.
+untouched_is_shared() ->
+    Pid = start_zone(#{changed => #{~"a" => npc(9.0)}, removed => []}),
+    add(Pid, ~"a", npc(1.0)),
+    add(Pid, ~"b", npc(2.0)),
+    _ = sys:replace_state(Pid, fun stash_probe/1),
+    tick(Pid),
+    _ = sys:replace_state(Pid, fun compare_probe/1),
+    ?assertMatch(#{probe_same := true}, sys:get_state(Pid)),
+    gen_server:stop(Pid).
+
+-spec stash_probe(term()) -> map().
+stash_probe(#{entities := #{~"b" := B}} = State) when is_map(State) ->
+    State#{probe => B}.
+
+-spec compare_probe(term()) -> map().
+compare_probe(#{entities := #{~"b" := B}, probe := Probe} = State) when is_map(State) ->
+    State#{probe_same => erts_debug:same(Probe, B)}.
+
+malformed_is_ignored() ->
+    Pid = start_zone(not_a_map),
+    add(Pid, ~"a", npc(1.0)),
+    tick(Pid),
+    ?assert(is_process_alive(Pid)),
+    ?assertMatch(#{~"a" := #{x := 1001.0}}, asobi_zone:get_entities(Pid)),
+    gen_server:stop(Pid).
+
+bad_id_dropped() ->
+    Pid = start_zone(#{changed => #{not_a_binary => npc(9.0)}, removed => [also_not]}),
+    add(Pid, ~"a", npc(1.0)),
+    tick(Pid),
+    Entities = asobi_zone:get_entities(Pid),
+    ?assertEqual([~"a"], maps:keys(Entities)),
+    ?assert(is_process_alive(Pid)),
+    gen_server:stop(Pid).
+
+no_declaration() ->
+    Pid = start_zone(#{}),
+    add(Pid, ~"a", npc(1.0)),
+    tick(Pid),
+    ?assertMatch(#{~"a" := #{x := 1001.0}}, asobi_zone:get_entities(Pid)),
+    gen_server:stop(Pid).

--- a/test/asobi_zone_dirty_tests.erl
+++ b/test/asobi_zone_dirty_tests.erl
@@ -15,9 +15,15 @@ setup() ->
         {ok, _} -> ok;
         {error, {already_started, _}} -> ok
     end,
+    %% The malformed-declaration tests assert on `[asobi, error]` rather than on
+    %% a log line, so the handler table has to exist.
+    {ok, _} = application:ensure_all_started(telemetry),
     ok.
 
 start_zone(Dirty) ->
+    start_zone_with(#{dirty => Dirty}).
+
+start_zone_with(ZoneState) ->
     {ok, Pid} = asobi_zone:start_link(#{
         world_id => ~"dirty-world",
         coords => {1, 1},
@@ -25,9 +31,27 @@ start_zone(Dirty) ->
         zone_size => 1000,
         grid_size => 5,
         game_module => asobi_zone_dirty_game,
-        zone_state => #{dirty => Dirty}
+        zone_state => ZoneState
     }),
     Pid.
+
+%% asobi_telemetry routes game errors through the `[asobi, error]` event.
+attach_game_error_handler(Id) ->
+    Self = self(),
+    telemetry:attach(
+        Id,
+        [asobi, error],
+        fun(_Event, _Measure, Meta, _Cfg) -> Self ! {game_error, Meta} end,
+        undefined
+    ).
+
+await_game_error(Kind) ->
+    receive
+        {game_error, #{kind := Kind}} -> ok;
+        {game_error, _Other} -> await_game_error(Kind)
+    after 1_000 ->
+        error({no_game_error, Kind})
+    end.
 
 npc(X) ->
     #{type => ~"npc", x => 1000.0 + X, y => 1000.0, hp => 100}.
@@ -49,7 +73,12 @@ dirty_test_() ->
         {"an undeclared entity keeps its identity", fun untouched_is_shared/0},
         {"a malformed declaration is ignored, not fatal", fun malformed_is_ignored/0},
         {"a non-binary id in changed is dropped", fun bad_id_dropped/0},
-        {"no declaration keeps today's semantics", fun no_declaration/0}
+        {"a two-tuple return keeps today's semantics", fun two_tuple_no_declaration/0},
+        {"a three-tuple return keeps today's semantics", fun three_tuple_no_declaration/0},
+        {"an unknown key in the declaration is reported", fun unknown_dirty_key_reported/0},
+        {"a non-binary removed id is reported", fun bad_removed_id_reported/0},
+        {"a non-map declaration is reported", fun non_map_declaration_reported/0},
+        {"a 4-tuple with a bad busy keeps the zone hot and still merges", fun bad_busy_with_dirty/0}
     ]}.
 
 changed_lands() ->
@@ -103,8 +132,13 @@ malformed_is_ignored() ->
     ?assertMatch(#{~"a" := #{x := 1001.0}}, asobi_zone:get_entities(Pid)),
     gen_server:stop(Pid).
 
+%% The `changed` half is the discriminating one: an atom sorts before a binary,
+%% so without narrow_changed/2 the keys would come back `[not_a_binary, <<"a">>]`.
+%% `removed` is tested separately in bad_removed_id_reported/0 - asserting it
+%% here would be vacuous, because maps:without/2 on an id that is not in the map
+%% is a no-op whether or not it was filtered.
 bad_id_dropped() ->
-    Pid = start_zone(#{changed => #{not_a_binary => npc(9.0)}, removed => [also_not]}),
+    Pid = start_zone(#{changed => #{not_a_binary => npc(9.0)}, removed => []}),
     add(Pid, ~"a", npc(1.0)),
     tick(Pid),
     Entities = asobi_zone:get_entities(Pid),
@@ -112,9 +146,67 @@ bad_id_dropped() ->
     ?assert(is_process_alive(Pid)),
     gen_server:stop(Pid).
 
-no_declaration() ->
-    Pid = start_zone(#{}),
+%% ADR 0022's headline compatibility claim: a game that never declares behaves
+%% exactly as before. The empty declaration is NOT this case - it goes through
+%% apply_dirty/3 - so both arities need their own test.
+two_tuple_no_declaration() ->
+    Pid = start_zone_with(#{}),
     add(Pid, ~"a", npc(1.0)),
     tick(Pid),
     ?assertMatch(#{~"a" := #{x := 1001.0}}, asobi_zone:get_entities(Pid)),
     gen_server:stop(Pid).
+
+three_tuple_no_declaration() ->
+    Pid = start_zone_with(#{arity => 3, busy => false}),
+    add(Pid, ~"a", npc(1.0)),
+    tick(Pid),
+    ?assertMatch(#{~"a" := #{x := 1001.0}}, asobi_zone:get_entities(Pid)),
+    gen_server:stop(Pid).
+
+%% The worst failure this contract can produce: a typo'd key reads as an empty
+%% declaration, which means "nothing changed" - and because the base map is
+%% what asobi handed in, every entity in the zone freezes for as long as it
+%% lives. It has to be loud.
+unknown_dirty_key_reported() ->
+    ok = attach_game_error_handler(?FUNCTION_NAME),
+    Pid = start_zone(#{chnaged => #{~"a" => npc(9.0)}}),
+    add(Pid, ~"a", npc(1.0)),
+    tick(Pid),
+    ok = await_game_error(bad_zone_dirty),
+    telemetry:detach(?FUNCTION_NAME),
+    gen_server:stop(Pid).
+
+%% ADR 0022 decision 4 promises both halves are narrowed AND logged. narrow_ids
+%% dropped silently until widgrensit/asobi#557's review.
+bad_removed_id_reported() ->
+    ok = attach_game_error_handler(?FUNCTION_NAME),
+    Pid = start_zone(#{changed => #{}, removed => [also_not]}),
+    add(Pid, ~"a", npc(1.0)),
+    tick(Pid),
+    ok = await_game_error(bad_zone_dirty),
+    telemetry:detach(?FUNCTION_NAME),
+    gen_server:stop(Pid).
+
+non_map_declaration_reported() ->
+    ok = attach_game_error_handler(?FUNCTION_NAME),
+    Pid = start_zone(not_a_map),
+    add(Pid, ~"a", npc(1.0)),
+    tick(Pid),
+    ok = await_game_error(bad_zone_dirty),
+    telemetry:detach(?FUNCTION_NAME),
+    gen_server:stop(Pid).
+
+%% The four-element twin of bad_zone_busy_fails_safe/0: a non-boolean third
+%% element keeps the zone hot, and the declaration is still applied.
+bad_busy_with_dirty() ->
+    Pid = start_zone(#{changed => #{~"a" => npc(9.0)}, removed => []}),
+    _ = sys:replace_state(Pid, fun set_bad_busy/1),
+    add(Pid, ~"a", npc(1.0)),
+    tick(Pid),
+    ?assertMatch(#{~"a" := #{x := 1009.0}}, asobi_zone:get_entities(Pid)),
+    ?assertMatch(#{cold := false}, sys:get_state(Pid)),
+    gen_server:stop(Pid).
+
+-spec set_bad_busy(term()) -> map().
+set_bad_busy(#{zone_state := ZS} = State) when is_map(State), is_map(ZS) ->
+    State#{zone_state => ZS#{busy => not_a_boolean, arity => 4}}.

--- a/test/asobi_zone_manager_tests.erl
+++ b/test/asobi_zone_manager_tests.erl
@@ -33,6 +33,15 @@ start_manager(Overrides) ->
     unlink(Pid),
     #{mgr => Pid, zone_sup => ZoneSup}.
 
+%% sys:get_state/1 is term(); the stamp table has to come out as an ets:table()
+%% or every use of it downstream is an untyped boundary read.
+-spec zone_state(pid()) -> #{zone_stamp_tab := ets:table(), coords := term()}.
+zone_state(ZonePid) ->
+    case sys:get_state(ZonePid) of
+        #{zone_stamp_tab := Tab, coords := Coords} when is_reference(Tab); is_atom(Tab) ->
+            #{zone_stamp_tab => Tab, coords => Coords}
+    end.
+
 stop_manager(#{mgr := Pid, zone_sup := ZoneSup}) ->
     catch exit(Pid, shutdown),
     catch exit(ZoneSup, shutdown),
@@ -66,7 +75,10 @@ zone_manager_test_() ->
         {"missing per-coord state leaves zone_state default", fun initial_zone_states_default/0},
         {"a zone start emits zone/opened", fun zone_open_emits_telemetry/0},
         {"a zone death emits exactly one zone/closed", fun zone_close_emits_telemetry_once/0},
-        {"manager shutdown emits no zone/closed", fun manager_shutdown_emits_no_close/0}
+        {"manager shutdown emits no zone/closed", fun manager_shutdown_emits_no_close/0},
+        {"a zone stamps itself active without a cast", fun zone_stamps_itself_active/0},
+        {"a zone that stamped itself is not reaped", fun stamped_zone_survives_sweep/0},
+        {"a new zone is announced to the ticker", fun zone_open_announced_to_ticker/0}
     ]}.
 
 %% --- #313: zone lifecycle telemetry ---
@@ -251,6 +263,46 @@ stale_zone_reaped_on_sweep() ->
     force_reap_sweep(Mgr),
     ?assertEqual(not_loaded, asobi_zone_manager:get_zone(Mgr, {0, 0})),
     ?assert(not is_process_alive(ZonePid)),
+    stop_manager(Ctx).
+
+%% widgrensit/asobi#559: an occupied zone used to cast `touch_zone` at the
+%% manager on EVERY tick, through the same gen_server that answers
+%% `ensure_zone/2` on the join and crossing hot path. The stamp is written
+%% straight into a public ETS table now, and the zone is handed that table in
+%% its config when the manager starts it.
+zone_stamps_itself_active() ->
+    Ctx = #{mgr := Mgr} = start_manager(),
+    {ok, ZonePid, created} = asobi_zone_manager:ensure_zone(Mgr, {0, 0}),
+    #{zone_stamp_tab := Tab, coords := Coords} = zone_state(ZonePid),
+    ?assertEqual({0, 0}, Coords),
+    ?assertMatch([{{0, 0}, _}], ets:lookup(Tab, {0, 0})),
+    stop_manager(Ctx).
+
+%% The other half of the same change: the reap sweep has to read the stamps
+%% the zones wrote, not a map the manager keeps for itself. A zone that
+%% stamped after being released is not idle any more.
+stamped_zone_survives_sweep() ->
+    Ctx = #{mgr := Mgr} = start_manager(#{idle_timeout => 20}),
+    {ok, ZonePid, created} = asobi_zone_manager:ensure_zone(Mgr, {0, 0}),
+    ok = asobi_zone_manager:release_zone(Mgr, {0, 0}),
+    #{zone_stamp_tab := Tab} = zone_state(ZonePid),
+    ok = asobi_zone_manager:stamp_active(Tab, {0, 0}),
+    force_reap_sweep(Mgr),
+    ?assertMatch({ok, ZonePid}, asobi_zone_manager:get_zone(Mgr, {0, 0})),
+    ?assert(is_process_alive(ZonePid)),
+    stop_manager(Ctx).
+
+%% widgrensit/asobi#560: the ticker owns its active set now, so a zone that
+%% opens has to be pushed to it - nothing asks the manager for the list any
+%% more. ?BASE_OPTS puts this test process in as the ticker.
+zone_open_announced_to_ticker() ->
+    Ctx = #{mgr := Mgr} = start_manager(),
+    {ok, ZonePid, created} = asobi_zone_manager:ensure_zone(Mgr, {0, 0}),
+    receive
+        {'$gen_cast', {add_zone, ZonePid}} -> ok
+    after 1_000 ->
+        ?assert(false)
+    end,
     stop_manager(Ctx).
 
 %% Regression widgrensit/asobi#283, found via the prop_input_never_dropped

--- a/test/asobi_zone_manager_tests.erl
+++ b/test/asobi_zone_manager_tests.erl
@@ -78,7 +78,10 @@ zone_manager_test_() ->
         {"manager shutdown emits no zone/closed", fun manager_shutdown_emits_no_close/0},
         {"a zone stamps itself active without a cast", fun zone_stamps_itself_active/0},
         {"a zone that stamped itself is not reaped", fun stamped_zone_survives_sweep/0},
-        {"a new zone is announced to the ticker", fun zone_open_announced_to_ticker/0}
+        {"a new zone is announced to the ticker", fun zone_open_announced_to_ticker/0},
+        {"stamping a dead table does not crash the zone", fun stamp_on_dead_table/0},
+        {"stamping without a table reports rather than pretends", fun stamp_without_table/0},
+        {"a junk stamp key is dropped, not fatal", fun junk_stamp_key_dropped/0}
     ]}.
 
 %% --- #313: zone lifecycle telemetry ---
@@ -305,8 +308,46 @@ zone_open_announced_to_ticker() ->
     end,
     stop_manager(Ctx).
 
+%% The manager owns the stamp table and the instance supervisor stops the
+%% manager BEFORE the zone supervisor, so on teardown a zone can still be
+%% ticking after the table has gone. That has to be as quiet as a cast at a
+%% dead gen_server was, or every world teardown ends in a burst of badarg
+%% crashes from zones that did nothing wrong (widgrensit/asobi#559).
+stamp_on_dead_table() ->
+    Tab = ets:new(stamp_probe, [set, public]),
+    true = ets:delete(Tab),
+    ?assertEqual(stamp_failed, asobi_zone_manager:stamp_active(Tab, {0, 0})).
+
+%% `undefined` is a zone the manager did not start. It answers stamp_failed
+%% rather than ok so asobi_zone:touch_manager/1 can fall back to the cast - a
+%% zone that silently never stamps is a zone the reaper takes.
+stamp_without_table() ->
+    ?assertEqual(stamp_failed, asobi_zone_manager:stamp_active(undefined, {0, 0})).
+
+%% The sweep reads keys straight out of a public table, and this manager is
+%% transient under a ONE_FOR_ALL supervisor - so a function_clause here would
+%% restart the zone supervisor, the ticker and the world server. The code this
+%% replaced swept an unknown key harmlessly; failing loud would have been a
+%% robustness regression (widgrensit/asobi#559 review).
+junk_stamp_key_dropped() ->
+    Ctx = #{mgr := Mgr} = start_manager(#{idle_timeout => 20}),
+    {ok, ZonePid, created} = asobi_zone_manager:ensure_zone(Mgr, {0, 0}),
+    #{zone_stamp_tab := Tab} = zone_state(ZonePid),
+    %% Genuinely stale, not literal 0: the clock is monotonic and starts deeply
+    %% negative, so 0 is in the FUTURE and the sweep would never select it.
+    Stale = erlang:monotonic_time(millisecond) - 100_000,
+    true = ets:insert(Tab, {{1.5, 2.5}, Stale}),
+    true = ets:insert(Tab, {not_even_a_pair, Stale}),
+    force_reap_sweep(Mgr),
+    ?assert(is_process_alive(Mgr)),
+    %% Dropped AND deleted: release_zone writes an already-expired stamp, so a
+    %% key that survived would be re-found on every sweep for the world's life.
+    ?assertEqual([], ets:lookup(Tab, {1.5, 2.5})),
+    ?assertEqual([], ets:lookup(Tab, not_even_a_pair)),
+    stop_manager(Ctx).
+
 %% Regression widgrensit/asobi#283, found via the prop_input_never_dropped
-%% nightly flake (asobi#282): release_zone/2 backdates zone_last_active as
+%% nightly flake (asobi#282): release_zone/2 backdates the zone's stamp as
 %% soon as a zone empties out, and nothing un-stales it on re-occupation - a
 %% zone's own tick only touches the manager when it has live subscribers
 %% (asobi_zone.erl, map_size(Subs) > 0), which this test's raw add_entity

--- a/test/asobi_zone_spatial_test_game.erl
+++ b/test/asobi_zone_spatial_test_game.erl
@@ -2,14 +2,19 @@
 
 -export([zone_tick/2, handle_input/3]).
 
-%% An entity marked `despawn` is dropped by the tick itself rather than by a
-%% `remove_entity` cast, which is the only way to reach sync_spatial_grid's
-%% removal path from a test (widgrensit/asobi#558).
+%% Two markers, both driven from the tick rather than from a cast, because a
+%% cast reaches the grid through spatial_grid_insert/remove and never through
+%% sync_spatial_grid/3 - which is the function widgrensit/asobi#557 and #558
+%% both rewrote.
 zone_tick(Entities, ZoneState) ->
-    {maps:filter(fun(_Id, E) -> not despawning(E) end, Entities), ZoneState}.
+    Kept = maps:filter(fun(_Id, E) -> not despawning(E) end, Entities),
+    {maps:map(fun(_Id, E) -> drift(E) end, Kept), ZoneState}.
 
 handle_input(_PlayerId, _Input, Entities) ->
     {ok, Entities}.
 
 despawning(E) when is_map(E) -> maps:get(despawn, E, false) =:= true;
 despawning(_E) -> false.
+
+drift(#{drift := D, x := X} = E) when is_number(D), is_number(X) -> E#{x => X + D};
+drift(E) -> E.

--- a/test/asobi_zone_spatial_test_game.erl
+++ b/test/asobi_zone_spatial_test_game.erl
@@ -2,8 +2,14 @@
 
 -export([zone_tick/2, handle_input/3]).
 
+%% An entity marked `despawn` is dropped by the tick itself rather than by a
+%% `remove_entity` cast, which is the only way to reach sync_spatial_grid's
+%% removal path from a test (widgrensit/asobi#558).
 zone_tick(Entities, ZoneState) ->
-    {Entities, ZoneState}.
+    {maps:filter(fun(_Id, E) -> not despawning(E) end, Entities), ZoneState}.
 
 handle_input(_PlayerId, _Input, Entities) ->
     {ok, Entities}.
+
+despawning(E) when is_map(E) -> maps:get(despawn, E, false) =:= true;
+despawning(_E) -> false.

--- a/test/asobi_zone_spatial_tests.erl
+++ b/test/asobi_zone_spatial_tests.erl
@@ -104,3 +104,17 @@ entity_without_position_ignored_by_grid_test() ->
     Result = asobi_zone:query_radius(Pid, {0.0, 0.0}, 1000.0),
     ?assertEqual([], Result),
     stop_zone(Pid).
+
+%% widgrensit/asobi#558: sync_spatial_grid derived its removals with `--`, and
+%% the O(N^2) that replaced covers exactly this path - an entity that the tick
+%% dropped, rather than one a `remove_entity` cast took out of the grid
+%% directly.
+tick_removal_reflected_in_grid_test() ->
+    Pid = start_zone(config_with_grid()),
+    asobi_zone:add_entity(Pid, ~"stays", #{x => 10.0, y => 10.0}),
+    asobi_zone:add_entity(Pid, ~"goes", #{x => 11.0, y => 11.0, despawn => true}),
+    asobi_zone:tick(Pid, 1),
+    _ = sys:get_state(Pid),
+    Result = asobi_zone:query_radius(Pid, {10.0, 10.0}, 5.0),
+    ?assertEqual([{~"stays", {10.0, 10.0}}], Result),
+    stop_zone(Pid).

--- a/test/asobi_zone_spatial_tests.erl
+++ b/test/asobi_zone_spatial_tests.erl
@@ -118,3 +118,22 @@ tick_removal_reflected_in_grid_test() ->
     Result = asobi_zone:query_radius(Pid, {10.0, 10.0}, 5.0),
     ?assertEqual([{~"stays", {10.0, 10.0}}], Result),
     stop_zone(Pid).
+
+%% The other half of tick_removal_reflected_in_grid_test: an entity the tick
+%% MOVED. That is the branch of sync_spatial_grid/3 on the hot path, and it had
+%% no coverage in eunit or CT before widgrensit/asobi#557's review.
+tick_movement_reflected_in_grid_test() ->
+    Pid = start_zone(config_with_grid()),
+    asobi_zone:add_entity(Pid, ~"mover", #{x => 10.0, y => 10.0, drift => 40.0}),
+    asobi_zone:add_entity(Pid, ~"still", #{x => 11.0, y => 11.0}),
+    asobi_zone:tick(Pid, 1),
+    _ = sys:get_state(Pid),
+    ?assertEqual(
+        [{~"still", {11.0, 11.0}}],
+        asobi_zone:query_radius(Pid, {10.0, 10.0}, 5.0)
+    ),
+    ?assertEqual(
+        [{~"mover", {50.0, 10.0}}],
+        asobi_zone:query_radius(Pid, {50.0, 10.0}, 5.0)
+    ),
+    stop_zone(Pid).

--- a/test/asobi_zone_tests.erl
+++ b/test/asobi_zone_tests.erl
@@ -397,9 +397,9 @@ world_ack_garbage_seq_does_not_kill_the_zone() ->
     asobi_zone:subscribe(Pid, {~"p1", self()}),
     timer:sleep(10),
     flush_messages(),
-    asobi_zone:player_input(Pid, ~"p1", #{}, ~"garbage"),
-    asobi_zone:player_input(Pid, ~"p1", #{}, {tuple, 1}),
-    asobi_zone:player_input(Pid, ~"p1", #{}, [1, 2, 3]),
+    asobi_zone:player_input(Pid, ~"p1", #{}, off_the_wire(~"garbage")),
+    asobi_zone:player_input(Pid, ~"p1", #{}, off_the_wire({tuple, 1})),
+    asobi_zone:player_input(Pid, ~"p1", #{}, off_the_wire([1, 2, 3])),
     asobi_zone:tick(Pid, 1),
     ?assertEqual(no_ack, recv_ack()),
     ?assert(is_process_alive(Pid)),
@@ -521,7 +521,7 @@ world_ack_survives_non_integer_seq() ->
     asobi_zone:subscribe(Pid, {~"p1", self()}),
     timer:sleep(10),
     flush_messages(),
-    asobi_zone:player_input(Pid, ~"p1", #{}, ~"not-a-seq"),
+    asobi_zone:player_input(Pid, ~"p1", #{}, off_the_wire(~"not-a-seq")),
     asobi_zone:tick(Pid, 1),
     ?assertEqual(no_ack, recv_ack()),
     ?assert(is_process_alive(Pid)),
@@ -1204,3 +1204,12 @@ flush_messages() ->
         _ -> flush_messages()
     after 0 -> ok
     end.
+
+%% The seq a client stamps on a world.input frame is whatever it sent, and
+%% `player_input/4` is exported - so proving the zone survives a spec-violating
+%% one means handing it a value the spec forbids. `dynamic()` is the honest
+%% type for a value that crossed the wire, and it is confined to this helper:
+%% it enters `player_input/4` and never leaves it (docs/eqwalizer-idioms.md).
+-spec off_the_wire(term()) -> dynamic().
+off_the_wire(Seq) ->
+    Seq.

--- a/test/asobi_zone_tests.erl
+++ b/test/asobi_zone_tests.erl
@@ -1120,7 +1120,7 @@ reap_stops_empty_zone() ->
     end.
 
 %% asobi#283, found via the nightly prop_input_never_dropped flake (#282):
-%% asobi_zone_manager:release_zone/2 backdates a zone's zone_last_active the
+%% asobi_zone_manager:release_zone/2 backdates a zone's last-active stamp the
 %% moment it empties out, so it becomes reap-eligible on the next sweep. But
 %% nothing un-stales that timestamp on re-occupation for a zone with no live
 %% subscribers - this zone's own tick only touches the manager on the

--- a/test/fixtures/lua/config_world_cold_zero.lua
+++ b/test/fixtures/lua/config_world_cold_zero.lua
@@ -1,0 +1,34 @@
+-- World mode declaring cold_tick_divisor = 0 (never tick an idle zone).
+match_size = 1
+max_players = 50
+lazy_zones = true
+zone_idle_timeout = 30000
+max_active_zones = 200
+spatial_grid_cell_size = 64
+cold_tick_divisor = 0
+
+function init(config)
+    return { players = {} }
+end
+
+function join(player_id, state)
+    state.players[player_id] = { x = 0, y = 0 }
+    return state
+end
+
+function leave(player_id, state)
+    state.players[player_id] = nil
+    return state
+end
+
+function handle_input(player_id, input, state)
+    return state
+end
+
+function tick(state)
+    return state
+end
+
+function get_state(player_id, state)
+    return state
+end

--- a/test/fixtures/lua/dirty_bad_world.lua
+++ b/test/fixtures/lua/dirty_bad_world.lua
@@ -1,0 +1,43 @@
+match_size = 1
+grid_size = 1
+zone_size = 1000
+
+zones = { ["0,0"] = {} }
+
+function generate_world(seed)
+  return zones
+end
+
+-- The mode rides on an entity rather than on zone_state: asobi hands the
+-- entity map to luerl:encode, whereas the second argument is passed through
+-- as-is, so a test cannot put a plain Erlang term there.
+--
+-- Each branch used to be a way to take the zone down or to silently freeze it
+-- (widgrensit/asobi#557 review).
+function zone_tick(entities, zone_state)
+  local mode = entities.probe and entities.probe.mode or "none"
+  -- Bumped so a caller can tell "asobi decoded what I returned" (x == 2) from
+  -- "asobi kept the map it handed me" (x == 1). Without a mutation the two
+  -- paths are byte-identical and nothing here would discriminate.
+  entities.a.x = entities.a.x + 1
+  if mode == "function" then
+    return entities, zone_state, false, function() return 1 end
+  elseif mode == "recursive" then
+    local d = {}
+    d.changed = d
+    return entities, zone_state, false, d
+  elseif mode == "array" then
+    return entities, zone_state, false, { changed = { "a", "b" } }
+  elseif mode == "not_a_declaration" then
+    return entities, zone_state, false, { "a", "b" }
+  elseif mode == "number" then
+    return entities, zone_state, false, 42
+  elseif mode == "nil_fourth" then
+    return entities, zone_state, false, nil
+  end
+  return entities, zone_state
+end
+
+function handle_input(player_id, input, entities)
+  return entities
+end

--- a/test/fixtures/lua/dirty_world.lua
+++ b/test/fixtures/lua/dirty_world.lua
@@ -1,0 +1,28 @@
+match_size = 1
+grid_size = 1
+zone_size = 1000
+
+zones = { ["0,0"] = {} }
+
+function generate_world(seed)
+  return zones
+end
+
+-- Moves "a", deletes "c", and mutates "b" WITHOUT declaring it. The
+-- undeclared mutation must not land: the declaration is the truth
+-- (widgrensit/asobi#557).
+function zone_tick(entities, zone_state)
+  local changed = {}
+  if entities["a"] then
+    entities["a"].x = entities["a"].x + 10
+    changed["a"] = entities["a"]
+  end
+  if entities["b"] then
+    entities["b"].x = 999
+  end
+  return entities, zone_state, false, { changed = changed, removed = { "c" } }
+end
+
+function handle_input(player_id, input, entities)
+  return entities
+end


### PR DESCRIPTION
Five issues on the zone tick hot path, measured before and after on one machine.

## asobi#558 - `--` on entity keys, every tick

`sync_spatial_grid/3` derived removals with `maps:keys(Old) -- maps:keys(New)`. `--` is O(N*M), so with a spatial grid configured a zone holding N entities paid O(N^2) key comparisons every tick to almost always produce `[]`. Profiled on an inert 2,000-entity zone, `erlang:'--'/2` was **13.4% of the whole tick at ~498us a call**. A fold with `is_map_key/2` is O(N). Tick wall time at 2,000 entities: **1,533us -> 910us**.

## asobi#559 - the zone manager was on the per-tick path

Every occupied zone cast `touch_zone` at the manager on every tick, and the manager rebuilt a map per cast. At `tick_rate = 50` that is 20 casts/sec/zone through the one gen_server that also answers `ensure_zone/2` on the join and NPC-crossing path, where the crossing budget is 1s and a timeout costs the crossing.

Stamps move to a public ETS table zones write directly; the reap sweep selects expired coords out of it. The cast stays for a zone started outside a manager. The write is guarded: the table dies with the manager, and the instance supervisor stops the manager *before* the zones, so an unguarded `ets:insert` would turn every world teardown into a burst of `badarg` crashes.

## asobi#560 - the ticker copied the whole zone table every tick

It asked the manager for the active set on every tick and got `ets:tab2list/1` back, plus a `gen_server` call when the manager was addressed by pid. The ticker now owns the set: the manager pushes a zone in when it opens, and the ticker monitors it, so a reaped or crashed zone drops out on its own `DOWN` - which is the self-healing the old partition-against-the-list gave for free. `hot`/`cold` become maps, retiring the per-tick `lists:uniq/1`.

With #559, the zone manager is off the tick path entirely.

## asobi#561 - `cold_tick_divisor = 0`

An idle zone is not ticked at all. Nothing has to be caught up on warm-up, and that is a property of `zone_idle/1` rather than an omission: a zone is only demoted when its timer wheel and respawn queue are both empty, and both are driven by the wall clock the resumed tick passes them.

A zone with subscribers now declines `reap` and re-stamps. Mostly a statement of emergent behaviour, but it also closes a real race at every divisor: `release_zone/2` backdates the stamp the moment a zone empties, and a sweep landing before the next re-stamp stopped a *watched* zone.

Default stays 10. ADR 0021.

## asobi#557 - `zone_tick/2` may declare what changed

`{Entities, ZoneState, Busy, #{changed => #{Id => Entity}, removed => [Id]}}`, merged onto the map the callback returned. A Lua script declaring it stops the bridge decoding the whole entities table, and the entities nobody named stay the same *terms*, so `compute_deltas/2` settles each with a pointer comparison instead of walking its fields.

Median of three runs, inert script moving three entities, `lua_vm_mode = owned`:

| entities | before | after | reductions on the zone before | after |
|---|---|---|---|---|
| 100 | 299us | 181us | 10,945 | 526 |
| 500 | 1,784us | 898us | 53,314 | 672 |
| 2,000 | 9,292us | 4,569us | 200,466 | 1,209 |

The reduction column is the one that decides whether a zone keeps up with its tick budget, and it is the stable one.

**The encode in the other direction is unchanged and still O(N).** Removing it needs the VM to hold the entities table across ticks and asobi to push only its own mutations, which means tracking dirtiness across eight entity-writing sites where a missed mark is an entity that silently stops replicating. ADR 0022 records that as a separate decision.

## Review gate

Architecture guardian -> security reviewer -> code reviewer, then a second commit working every finding. Highlights:

- `decode_dirty/2` guarded `is_tuple/1`, which is not a Luerl-table check - Luerl represents every non-scalar as a record, so `return entities, zone_state, false, function() end` raised on a callback invoked with no try/catch and killed the zone. Now checks the record tag, with a try/catch for recursive tables.
- The malformed-declaration log handed a script-controlled map to a formatter that renders before truncating - ~10s on the zone process for a 32MB script binary, outside `bounded_eval` and invisible to `max_heap_size`. The bound moved to the way in.
- Four silent-revert paths now report `bad_zone_dirty`. Each produced the same symptom - every entity in the zone frozen, forever, no error - and three were one line from an idiom the guide itself showed.
- `narrow_coords/1` filters and deletes rather than `function_clause`-ing the manager under `one_for_all`.
- Reverted the `sync_spatial_grid` identity match: on a miss it is a map `=:=` that can only fail, and the miss path is the default.
- ADR 0022's "inherent to any dirty contract" was overstated and its own cited prior art contradicts it. Narrowed, with the consequence stated.

## Tests

+19. The hostile-fourth-value cases were verified by reverting each fix and confirming the specific case fails - the first version of them passed against the unfixed code, because the mode rode on `game_state` (handed to Luerl unencoded, so it never reached the script) and because `print` is stripped from the sandbox.

The third commit fixes a CT failure that was **not** flake: `asobi_leaderboard_api_SUITE` built board ids with `erlang:unique_integer/1`, unique within one runtime instance, so a second `rebar3 ct` reused the ids and inherited the first run's rows. `asobi_test_helpers:unique_id/1` exists for this and says so, citing asobi#357.

## Gate status

`fmt --check`, `xref`, `dialyzer`, `elp lint` clean on changed files; `eqwalize-all` 209 vs 212 on main (no new); `ex_doc` unchanged at 6; drift checks pass; **eunit 2,398/0**; **CT 390/0 on two consecutive runs**.

## Known, not fixed here

`asobi_world_zone_integration_tests:world_input_crossing_touches_only_ring_delta` passes spuriously: `find_player_pid/1` reads `pg:get_members(nova_scope, {player, PlayerId})`, that module never registers the group, and in the full suite it borrows a live process another module left behind. Run alone it correctly reports 0 subscribers and fails. Unrelated to this change and it alters what the test asserts, so it wants its own PR.

Closes #557
Closes #558
Closes #559
Closes #560
Closes #561
