### PR TITLE
fix(test): stop tests borrowing each other's player sessions

### DIFF
--- a/test/asobi_match_server_tests.erl
+++ b/test/asobi_match_server_tests.erl
@@ -371,7 +371,7 @@ disconnect_starts_grace() ->
             max_offline_total => infinity
         }
     }),
-    SessionPid = fake_session(~"p1"),
+    SessionPid = asobi_test_helpers:fake_session(~"p1"),
     ok = asobi_match_server:join(Pid, ~"p1"),
     timer:sleep(50),
     %% Match transitioned to running; player count is 1.
@@ -389,7 +389,7 @@ disconnect_no_policy_leaves() ->
     Pid = start_match(#{min_players => 1, max_players => 2}),
     unlink(Pid),
     PidRef = monitor(process, Pid),
-    SessionPid = fake_session(~"p1"),
+    SessionPid = asobi_test_helpers:fake_session(~"p1"),
     ok = asobi_match_server:join(Pid, ~"p1"),
     timer:sleep(50),
 
@@ -416,7 +416,7 @@ reconnect_within_grace_keeps() ->
             max_offline_total => infinity
         }
     }),
-    SessionPid1 = fake_session(~"p1"),
+    SessionPid1 = asobi_test_helpers:fake_session(~"p1"),
     ok = asobi_match_server:join(Pid, ~"p1"),
     timer:sleep(50),
 
@@ -424,19 +424,31 @@ reconnect_within_grace_keeps() ->
     timer:sleep(30),
     %% Replace the registered session with a fresh fake.
     catch pg:leave(nova_scope, {player, ~"p1"}, SessionPid1),
-    _SessionPid2 = fake_session(~"p1"),
-    ?assertEqual(ok, asobi_match_server:reconnect(Pid, ~"p1")),
-    timer:sleep(30),
-    ?assertEqual(1, maps:get(player_count, asobi_match_server:get_info(Pid))),
-    stop(Pid).
+    SessionPid2 = asobi_test_helpers:fake_session(~"p1"),
+    try
+        ?assertEqual(ok, asobi_match_server:reconnect(Pid, ~"p1")),
+        timer:sleep(30),
+        ?assertEqual(1, maps:get(player_count, asobi_match_server:get_info(Pid)))
+    after
+        %% Left alive, this session stayed registered under `{player, <<"p1">>}`
+        %% in the SHARED nova_scope for the rest of the run, and later modules
+        %% using the same id silently borrowed it. That is how
+        %% asobi_world_zone_integration_tests came to pass only in a full run.
+        exit(SessionPid2, kill),
+        stop(Pid)
+    end.
 
 reconnect_no_policy_errors() ->
     Pid = start_match(#{min_players => 1, max_players => 2}),
-    _SessionPid = fake_session(~"p1"),
-    ok = asobi_match_server:join(Pid, ~"p1"),
-    timer:sleep(50),
-    ?assertMatch({error, no_reconnect_policy}, asobi_match_server:reconnect(Pid, ~"p1")),
-    stop(Pid).
+    SessionPid = asobi_test_helpers:fake_session(~"p1"),
+    try
+        ok = asobi_match_server:join(Pid, ~"p1"),
+        timer:sleep(50),
+        ?assertMatch({error, no_reconnect_policy}, asobi_match_server:reconnect(Pid, ~"p1"))
+    after
+        exit(SessionPid, kill),
+        stop(Pid)
+    end.
 
 %% Regression for widgrensit/asobi#280: find_player_pid/1 used to fall back
 %% to self() when a player had no live pg registration, which would have
@@ -478,7 +490,7 @@ reconnect_with_no_live_session_returns_error() ->
     %% nova_scope pg group, which would make find_player_pid/1 see a stray
     %% live pid instead of the empty-group case this test needs.
     PlayerId = ~"reconnect_no_session_280",
-    SessionPid = fake_session(PlayerId),
+    SessionPid = asobi_test_helpers:fake_session(PlayerId),
     ok = asobi_match_server:join(Pid, PlayerId),
     timer:sleep(50),
     exit(SessionPid, kill),
@@ -507,7 +519,7 @@ failed_reconnect_leaves_grace_intact() ->
     }),
     %% Unique player id - see reconnect_with_no_live_session_returns_error/0.
     PlayerId = ~"retry_after_no_session_280",
-    SessionPid1 = fake_session(PlayerId),
+    SessionPid1 = asobi_test_helpers:fake_session(PlayerId),
     ok = asobi_match_server:join(Pid, PlayerId),
     timer:sleep(50),
     exit(SessionPid1, kill),
@@ -515,7 +527,7 @@ failed_reconnect_leaves_grace_intact() ->
     ?assertEqual({error, no_live_session}, asobi_match_server:reconnect(Pid, PlayerId)),
     {_StateName, #{reconnect_state := #{disconnected := #{PlayerId := _}}}} = sys:get_state(Pid),
     catch pg:leave(nova_scope, {player, PlayerId}, SessionPid1),
-    _SessionPid2 = fake_session(PlayerId),
+    _SessionPid2 = asobi_test_helpers:fake_session(PlayerId),
     ?assertEqual(ok, asobi_match_server:reconnect(Pid, PlayerId)),
     timer:sleep(30),
     ?assertEqual(1, maps:get(player_count, asobi_match_server:get_info(Pid))),
@@ -529,7 +541,7 @@ failed_reconnect_leaves_grace_intact() ->
 %% under {player, ~"p1"} in the shared nova_scope pg group.
 waiting_down_removes_player() ->
     Pid = start_match(#{min_players => 3, max_players => 4}),
-    SessionPid1 = fake_session(~"p285_waiting_1"),
+    SessionPid1 = asobi_test_helpers:fake_session(~"p285_waiting_1"),
     ok = asobi_match_server:join(Pid, ~"p285_waiting_1"),
     ok = asobi_match_server:join(Pid, ~"p285_waiting_2"),
     timer:sleep(50),
@@ -554,7 +566,7 @@ paused_down_no_policy_leaves() ->
     Pid = start_match(#{min_players => 1, max_players => 2}),
     unlink(Pid),
     Ref = monitor(process, Pid),
-    SessionPid = fake_session(~"p285_paused_nopolicy"),
+    SessionPid = asobi_test_helpers:fake_session(~"p285_paused_nopolicy"),
     ok = asobi_match_server:join(Pid, ~"p285_paused_nopolicy"),
     timer:sleep(50),
     ok = asobi_match_server:pause(Pid),
@@ -594,7 +606,7 @@ paused_down_starts_grace() ->
     }),
     unlink(Pid),
     Ref = monitor(process, Pid),
-    SessionPid = fake_session(~"p285_paused_policy"),
+    SessionPid = asobi_test_helpers:fake_session(~"p285_paused_policy"),
     ok = asobi_match_server:join(Pid, ~"p285_paused_policy"),
     timer:sleep(50),
     ok = asobi_match_server:pause(Pid),
@@ -637,7 +649,7 @@ grace_expiry_of_last_player_stops_match() ->
     unlink(Pid),
     Ref = monitor(process, Pid),
     PlayerId = ~"p292_grace_last",
-    SessionPid = fake_session(PlayerId),
+    SessionPid = asobi_test_helpers:fake_session(PlayerId),
     ok = asobi_match_server:join(Pid, PlayerId),
     timer:sleep(50),
     ?assertEqual(1, maps:get(player_count, asobi_match_server:get_info(Pid))),
@@ -664,7 +676,7 @@ grace_expiry_with_players_left_keeps_match() ->
             max_offline_total => infinity
         }
     }),
-    SessionPid = fake_session(~"p292_grace_gone"),
+    SessionPid = asobi_test_helpers:fake_session(~"p292_grace_gone"),
     ok = asobi_match_server:join(Pid, ~"p292_grace_gone"),
     ok = asobi_match_server:join(Pid, ~"p292_grace_stays"),
     timer:sleep(50),
@@ -698,7 +710,7 @@ reconnect_while_paused_succeeds() ->
         }
     }),
     PlayerId = ~"p285_reconnect_paused",
-    SessionPid1 = fake_session(PlayerId),
+    SessionPid1 = asobi_test_helpers:fake_session(PlayerId),
     ok = asobi_match_server:join(Pid, PlayerId),
     timer:sleep(50),
     ok = asobi_match_server:pause(Pid),
@@ -706,7 +718,7 @@ reconnect_while_paused_succeeds() ->
     timer:sleep(100),
     %% Grace active (see paused_down_starts_grace/0) - a real session
     %% arriving now must be able to reconnect before resume/1 is called.
-    _SessionPid2 = fake_session(PlayerId),
+    _SessionPid2 = asobi_test_helpers:fake_session(PlayerId),
     ?assertEqual(ok, gen_statem:call(Pid, {reconnect, PlayerId}, 2000)),
     ?assertMatch(#{status := paused}, asobi_match_server:get_info(Pid)),
     ?assertEqual(1, maps:get(player_count, asobi_match_server:get_info(Pid))),
@@ -806,18 +818,6 @@ join_while_paused_errors() ->
     stop(Pid).
 
 %% --- Helpers ---
-
-fake_session(PlayerId) ->
-    %% Spawn a tiny process and register it as the player's session in the
-    %% nova_scope pg group so asobi_match_server:find_player_pid/1 returns it.
-    Pid = spawn(fun L() ->
-        receive
-            stop -> ok;
-            _ -> L()
-        end
-    end),
-    ok = pg:join(nova_scope, {player, PlayerId}, Pid),
-    Pid.
 
 %% --- session notification, joinable, backfill ---
 

--- a/test/asobi_match_server_tests.erl
+++ b/test/asobi_match_server_tests.erl
@@ -457,11 +457,15 @@ reconnect_no_policy_errors() ->
 %% registered first is exactly that case.
 join_with_no_live_session_does_not_crash() ->
     Pid = start_match(#{min_players => 2, max_players => 2}),
-    ok = asobi_match_server:join(Pid, ~"no_session"),
+    %% Asserts the SESSION-LESS path, so it is only meaningful while nobody is
+    %% registered under this id - see the world-server twin, which shared this
+    %% literal until now.
+    ok = asobi_test_helpers:assert_no_session(~"no_session_match"),
+    ok = asobi_match_server:join(Pid, ~"no_session_match"),
     ?assert(is_process_alive(Pid)),
     ?assertEqual(1, maps:get(player_count, asobi_match_server:get_info(Pid))),
     {_StateName, #{
-        players := #{~"no_session" := #{session_pid := SessionPid, monitor_ref := MonRef}}
+        players := #{~"no_session_match" := #{session_pid := SessionPid, monitor_ref := MonRef}}
     }} = sys:get_state(Pid),
     ?assertEqual(undefined, SessionPid),
     ?assertEqual(undefined, MonRef),
@@ -527,10 +531,11 @@ failed_reconnect_leaves_grace_intact() ->
     ?assertEqual({error, no_live_session}, asobi_match_server:reconnect(Pid, PlayerId)),
     {_StateName, #{reconnect_state := #{disconnected := #{PlayerId := _}}}} = sys:get_state(Pid),
     catch pg:leave(nova_scope, {player, PlayerId}, SessionPid1),
-    _SessionPid2 = asobi_test_helpers:fake_session(PlayerId),
-    ?assertEqual(ok, asobi_match_server:reconnect(Pid, PlayerId)),
-    timer:sleep(30),
-    ?assertEqual(1, maps:get(player_count, asobi_match_server:get_info(Pid))),
+    asobi_test_helpers:with_session(PlayerId, fun() ->
+        ?assertEqual(ok, asobi_match_server:reconnect(Pid, PlayerId)),
+        timer:sleep(30),
+        ?assertEqual(1, maps:get(player_count, asobi_match_server:get_info(Pid)))
+    end),
     stop(Pid).
 
 %% Regression for widgrensit/asobi#285: waiting/3 had no clause for a
@@ -718,10 +723,11 @@ reconnect_while_paused_succeeds() ->
     timer:sleep(100),
     %% Grace active (see paused_down_starts_grace/0) - a real session
     %% arriving now must be able to reconnect before resume/1 is called.
-    _SessionPid2 = asobi_test_helpers:fake_session(PlayerId),
-    ?assertEqual(ok, gen_statem:call(Pid, {reconnect, PlayerId}, 2000)),
-    ?assertMatch(#{status := paused}, asobi_match_server:get_info(Pid)),
-    ?assertEqual(1, maps:get(player_count, asobi_match_server:get_info(Pid))),
+    asobi_test_helpers:with_session(PlayerId, fun() ->
+        ?assertEqual(ok, gen_statem:call(Pid, {reconnect, PlayerId}, 2000)),
+        ?assertMatch(#{status := paused}, asobi_match_server:get_info(Pid)),
+        ?assertEqual(1, maps:get(player_count, asobi_match_server:get_info(Pid)))
+    end),
     stop(Pid).
 
 %% Regression for widgrensit/asobi#285: waiting/3 had no {call, reconnect}

--- a/test/asobi_match_server_tests.erl
+++ b/test/asobi_match_server_tests.erl
@@ -356,6 +356,11 @@ generate_id_format() ->
 %% --- Reconnect tests ---
 
 disconnect_starts_grace() ->
+    %% Unique id, not `p1`: this test registers a session in the shared
+    %% `nova_scope`, and it kills that session mid-body on purpose - so an
+    %% assertion failing before the kill leaves it registered. Under `p1`
+    %% that survivor is borrowable by any later test; under this id it is
+    %% inert.
     %% With a reconnect policy, killing the player session must NOT remove
     %% the player from the match — the grace timer holds them in place
     %% until reconnect/2 returns or grace expires.
@@ -371,8 +376,8 @@ disconnect_starts_grace() ->
             max_offline_total => infinity
         }
     }),
-    SessionPid = asobi_test_helpers:fake_session(~"p1"),
-    ok = asobi_match_server:join(Pid, ~"p1"),
+    SessionPid = asobi_test_helpers:fake_session(~"disconnect_starts_grace_p1"),
+    ok = asobi_match_server:join(Pid, ~"disconnect_starts_grace_p1"),
     timer:sleep(50),
     %% Match transitioned to running; player count is 1.
     ?assertEqual(1, maps:get(player_count, asobi_match_server:get_info(Pid))),
@@ -384,13 +389,18 @@ disconnect_starts_grace() ->
     stop(Pid).
 
 disconnect_no_policy_leaves() ->
+    %% Unique id, not `p1`: this test registers a session in the shared
+    %% `nova_scope`, and it kills that session mid-body on purpose - so an
+    %% assertion failing before the kill leaves it registered. Under `p1`
+    %% that survivor is borrowable by any later test; under this id it is
+    %% inert.
     %% Without a reconnect policy, session DOWN goes through handle_leave —
     %% same as an explicit leave/2.
     Pid = start_match(#{min_players => 1, max_players => 2}),
     unlink(Pid),
     PidRef = monitor(process, Pid),
-    SessionPid = asobi_test_helpers:fake_session(~"p1"),
-    ok = asobi_match_server:join(Pid, ~"p1"),
+    SessionPid = asobi_test_helpers:fake_session(~"disconnect_no_policy_leaves_p1"),
+    ok = asobi_match_server:join(Pid, ~"disconnect_no_policy_leaves_p1"),
     timer:sleep(50),
 
     exit(SessionPid, kill),
@@ -402,6 +412,11 @@ disconnect_no_policy_leaves() ->
     end.
 
 reconnect_within_grace_keeps() ->
+    %% Unique id, not `p1`: this test registers a session in the shared
+    %% `nova_scope`, and it kills that session mid-body on purpose - so an
+    %% assertion failing before the kill leaves it registered. Under `p1`
+    %% that survivor is borrowable by any later test; under this id it is
+    %% inert.
     %% Disconnect → reconnect inside the grace window leaves the player
     %% counted and re-monitors the new session.
     Pid = start_match(#{
@@ -416,17 +431,17 @@ reconnect_within_grace_keeps() ->
             max_offline_total => infinity
         }
     }),
-    SessionPid1 = asobi_test_helpers:fake_session(~"p1"),
-    ok = asobi_match_server:join(Pid, ~"p1"),
+    SessionPid1 = asobi_test_helpers:fake_session(~"reconnect_within_grace_keeps_p1"),
+    ok = asobi_match_server:join(Pid, ~"reconnect_within_grace_keeps_p1"),
     timer:sleep(50),
 
     exit(SessionPid1, kill),
     timer:sleep(30),
     %% Replace the registered session with a fresh fake.
-    catch pg:leave(nova_scope, {player, ~"p1"}, SessionPid1),
-    SessionPid2 = asobi_test_helpers:fake_session(~"p1"),
+    catch pg:leave(nova_scope, {player, ~"reconnect_within_grace_keeps_p1"}, SessionPid1),
+    SessionPid2 = asobi_test_helpers:fake_session(~"reconnect_within_grace_keeps_p1"),
     try
-        ?assertEqual(ok, asobi_match_server:reconnect(Pid, ~"p1")),
+        ?assertEqual(ok, asobi_match_server:reconnect(Pid, ~"reconnect_within_grace_keeps_p1")),
         timer:sleep(30),
         ?assertEqual(1, maps:get(player_count, asobi_match_server:get_info(Pid)))
     after
@@ -439,12 +454,20 @@ reconnect_within_grace_keeps() ->
     end.
 
 reconnect_no_policy_errors() ->
+    %% Unique id, not `p1`: this test registers a session in the shared
+    %% `nova_scope`, and it kills that session mid-body on purpose - so an
+    %% assertion failing before the kill leaves it registered. Under `p1`
+    %% that survivor is borrowable by any later test; under this id it is
+    %% inert.
     Pid = start_match(#{min_players => 1, max_players => 2}),
-    SessionPid = asobi_test_helpers:fake_session(~"p1"),
+    SessionPid = asobi_test_helpers:fake_session(~"reconnect_no_policy_errors_p1"),
     try
-        ok = asobi_match_server:join(Pid, ~"p1"),
+        ok = asobi_match_server:join(Pid, ~"reconnect_no_policy_errors_p1"),
         timer:sleep(50),
-        ?assertMatch({error, no_reconnect_policy}, asobi_match_server:reconnect(Pid, ~"p1"))
+        ?assertMatch(
+            {error, no_reconnect_policy},
+            asobi_match_server:reconnect(Pid, ~"reconnect_no_policy_errors_p1")
+        )
     after
         exit(SessionPid, kill),
         stop(Pid)

--- a/test/asobi_match_server_tests.erl
+++ b/test/asobi_match_server_tests.erl
@@ -389,11 +389,6 @@ disconnect_starts_grace() ->
     stop(Pid).
 
 disconnect_no_policy_leaves() ->
-    %% Unique id, not `p1`: this test registers a session in the shared
-    %% `nova_scope`, and it kills that session mid-body on purpose - so an
-    %% assertion failing before the kill leaves it registered. Under `p1`
-    %% that survivor is borrowable by any later test; under this id it is
-    %% inert.
     %% Without a reconnect policy, session DOWN goes through handle_leave —
     %% same as an explicit leave/2.
     Pid = start_match(#{min_players => 1, max_players => 2}),
@@ -412,11 +407,6 @@ disconnect_no_policy_leaves() ->
     end.
 
 reconnect_within_grace_keeps() ->
-    %% Unique id, not `p1`: this test registers a session in the shared
-    %% `nova_scope`, and it kills that session mid-body on purpose - so an
-    %% assertion failing before the kill leaves it registered. Under `p1`
-    %% that survivor is borrowable by any later test; under this id it is
-    %% inert.
     %% Disconnect → reconnect inside the grace window leaves the player
     %% counted and re-monitors the new session.
     Pid = start_match(#{
@@ -454,11 +444,6 @@ reconnect_within_grace_keeps() ->
     end.
 
 reconnect_no_policy_errors() ->
-    %% Unique id, not `p1`: this test registers a session in the shared
-    %% `nova_scope`, and it kills that session mid-body on purpose - so an
-    %% assertion failing before the kill leaves it registered. Under `p1`
-    %% that survivor is borrowable by any later test; under this id it is
-    %% inert.
     Pid = start_match(#{min_players => 1, max_players => 2}),
     SessionPid = asobi_test_helpers:fake_session(~"reconnect_no_policy_errors_p1"),
     try

--- a/test/asobi_test_helpers.erl
+++ b/test/asobi_test_helpers.erl
@@ -2,6 +2,7 @@
 
 -export([start/1, unique_username/1, unique_id/1, binary_join/2]).
 -export([fake_session/1, fake_session/2, unique_session/1, assert_no_session/1]).
+-export([with_session/2, with_session/3, with_unique_session/2]).
 -export([http_routes/1, routes_missing_options/1, preflight_targets/1, sample_path/1]).
 
 -spec start(list()) -> list().
@@ -86,6 +87,36 @@ forward(Owner, PlayerId, Msg) ->
     ok.
 
 -doc """
+Run `Fun` with a session registered, and release it whatever happens.
+
+`fake_session/1,2` gives you a pid and leaves the pairing to discipline, which
+is how three of them ended up bound to `_`-prefixed variables and registered
+for the rest of the run. An `_` prefix says the author is discarding the pid;
+the pg group is not. Prefer these where the shape allows it, so the release is
+structural rather than remembered.
+""".
+-spec with_session(binary(), fun(() -> R)) -> R.
+with_session(PlayerId, Fun) ->
+    with_session(PlayerId, undefined, Fun).
+
+-spec with_session(binary(), pid() | undefined, fun(() -> R)) -> R.
+with_session(PlayerId, Owner, Fun) ->
+    Pid = fake_session(PlayerId, Owner),
+    try
+        Fun()
+    after
+        exit(Pid, kill)
+    end.
+
+-doc """
+As `with_session/2` under an id nothing can collide with. `Fun` receives it.
+""".
+-spec with_unique_session(binary(), fun((binary()) -> R)) -> R.
+with_unique_session(Prefix, Fun) ->
+    PlayerId = unique_id(Prefix),
+    with_session(PlayerId, fun() -> Fun(PlayerId) end).
+
+-doc """
 A session under an id no other run or module can collide with.
 
 `unique_id/1` rather than a hand-picked name: a distinctive id works only
@@ -107,8 +138,15 @@ which is exactly how the bug this helper documents stayed hidden.
 assert_no_session(PlayerId) ->
     case pg:get_members(nova_scope, {player, PlayerId}) of
         [] -> ok;
-        Members -> error({session_already_registered, PlayerId, Members})
+        Members -> error({session_already_registered, PlayerId, [who(M) || M <- Members]})
     end.
+
+%% In a full run the module that fails this assertion is the one that did
+%% nothing wrong, and a bare pid does not say who registered it - by the time
+%% anyone reads the output the process may be gone. Name the leaker.
+-spec who(pid()) -> {pid(), term()}.
+who(Pid) ->
+    {Pid, erlang:process_info(Pid, [initial_call, current_function])}.
 
 %% --- Router enumeration ---
 %%

--- a/test/asobi_test_helpers.erl
+++ b/test/asobi_test_helpers.erl
@@ -1,6 +1,7 @@
 -module(asobi_test_helpers).
 
 -export([start/1, unique_username/1, unique_id/1, binary_join/2]).
+-export([fake_session/1, fake_session/2, unique_session/1, assert_no_session/1]).
 -export([http_routes/1, routes_missing_options/1, preflight_targets/1, sample_path/1]).
 
 -spec start(list()) -> list().
@@ -31,6 +32,83 @@ run concurrently with itself.
 unique_id(Prefix) ->
     Hex = binary:encode_hex(crypto:strong_rand_bytes(8), lowercase),
     <<Prefix/binary, "_", Hex/binary>>.
+
+%% --- Player sessions ---
+
+-doc """
+A live, pg-registered session for a player.
+
+`asobi_world_server` and `asobi_match_server` both resolve a player's session
+through `pg:get_members(nova_scope, {player, PlayerId})`. With no member the
+pid is `undefined` and the caller degrades: no interest subscriptions, no
+monitor. A test that asserts on subscriptions therefore needs a real member,
+or it asserts on the degraded path without saying so.
+
+Hand-copied into five test modules before this lived here, in two variants
+that differed only in whether they forwarded messages.
+
+**`nova_scope` is shared by the whole run and `{player, Id}` is not
+namespaced**, so a module that leaves one of these alive lends it to every
+later test that happens to use the same id. That has now been found three
+times, most recently as a test that passed only in a full run because it
+borrowed another module's session and subscribed it to four zones. Prefer
+`unique_session/1`; if you must name the player, kill the session in an
+`after`.
+""".
+-spec fake_session(binary()) -> pid().
+fake_session(PlayerId) ->
+    fake_session(PlayerId, undefined).
+
+-doc """
+As `fake_session/1`, forwarding every message to `Owner` as `{PlayerId, Msg}`
+so a test can assert on actual delivery rather than on subscriber-map
+bookkeeping.
+""".
+-spec fake_session(binary(), pid() | undefined) -> pid().
+fake_session(PlayerId, Owner) ->
+    Pid = spawn(fun Loop() ->
+        receive
+            stop ->
+                ok;
+            Msg ->
+                forward(Owner, PlayerId, Msg),
+                Loop()
+        end
+    end),
+    ok = pg:join(nova_scope, {player, PlayerId}, Pid),
+    Pid.
+
+-spec forward(pid() | undefined, binary(), term()) -> ok.
+forward(undefined, _PlayerId, _Msg) ->
+    ok;
+forward(Owner, PlayerId, Msg) ->
+    Owner ! {PlayerId, Msg},
+    ok.
+
+-doc """
+A session under an id no other run or module can collide with.
+
+`unique_id/1` rather than a hand-picked name: a distinctive id works only
+until someone else picks it, which is the same guarantee `p1` had.
+""".
+-spec unique_session(binary()) -> {binary(), pid()}.
+unique_session(Prefix) ->
+    PlayerId = unique_id(Prefix),
+    {PlayerId, fake_session(PlayerId)}.
+
+-doc """
+Assert that nobody is registered as this player before the test relies on it.
+
+For the tests that want the SESSION-LESS path. Without this, a leftover
+session from another module silently turns that test into a different one -
+which is exactly how the bug this helper documents stayed hidden.
+""".
+-spec assert_no_session(binary()) -> ok.
+assert_no_session(PlayerId) ->
+    case pg:get_members(nova_scope, {player, PlayerId}) of
+        [] -> ok;
+        Members -> error({session_already_registered, PlayerId, Members})
+    end.
 
 %% --- Router enumeration ---
 %%

--- a/test/asobi_test_helpers.erl
+++ b/test/asobi_test_helpers.erl
@@ -1,8 +1,8 @@
 -module(asobi_test_helpers).
 
 -export([start/1, unique_username/1, unique_id/1, binary_join/2]).
--export([fake_session/1, fake_session/2, unique_session/1, assert_no_session/1]).
--export([with_session/2, with_session/3, with_unique_session/2, release_session/2]).
+-export([fake_session/1, fake_session/2, assert_no_session/1]).
+-export([with_session/2, with_session/3, release_session/2]).
 -export([http_routes/1, routes_missing_options/1, preflight_targets/1, sample_path/1]).
 
 -spec start(list()) -> list().
@@ -52,9 +52,12 @@ that differed only in whether they forwarded messages.
 namespaced**, so a module that leaves one of these alive lends it to every
 later test that happens to use the same id. That has now been found three
 times, most recently as a test that passed only in a full run because it
-borrowed another module's session and subscribed it to four zones. Prefer
-`unique_session/1`; if you must name the player, kill the session in an
-`after`.
+borrowed another module's session and subscribed it to four zones.
+
+Prefer `with_session/2` - it releases in an `after`, so a failing assertion
+cannot strand the registration. Take the pid directly only where the test kills
+the session mid-body on purpose (the dominant shape in these suites, which
+`with_session/2` cannot express), and pair it with `release_session/2`.
 """.
 -spec fake_session(binary()) -> pid().
 fake_session(PlayerId) ->
@@ -74,15 +77,14 @@ fake_session(PlayerId, Owner) ->
     %% cannot use. `initial_call` never helped - it is `{erlang,apply,2}` for a
     %% plain spawn and `{proc_lib,init_p,5}` for a real session.
     Caller = caller_frame(),
-    Pid = spawn(fun Loop() ->
+    Pid = spawn(fun() ->
+        %% Above the loop, not inside it: re-entering would re-apply the label
+        %% on every forwarded message, which for a zone session is once per
+        %% world.tick. Applied BY the spawned process, so it is not readable
+        %% the instant this returns - `assert_no_session/1`'s targets are
+        %% long-lived leakers, so that is fine, but a test of `who/1` must wait.
         proc_lib:set_label({fake_session, PlayerId, Caller}),
-        receive
-            stop ->
-                ok;
-            Msg ->
-                forward(Owner, PlayerId, Msg),
-                Loop()
-        end
+        session_loop(PlayerId, Owner)
     end),
     ok = pg:join(nova_scope, {player, PlayerId}, Pid),
     Pid.
@@ -108,6 +110,16 @@ first_foreign_frame([]) ->
 frame_line([{line, L} | _]) when is_integer(L), L > 0 -> L;
 frame_line([_ | Rest]) -> frame_line(Rest);
 frame_line([]) -> undefined.
+
+-spec session_loop(binary(), pid() | undefined) -> ok.
+session_loop(PlayerId, Owner) ->
+    receive
+        stop ->
+            ok;
+        Msg ->
+            forward(Owner, PlayerId, Msg),
+            session_loop(PlayerId, Owner)
+    end.
 
 -spec forward(pid() | undefined, binary(), term()) -> ok.
 forward(undefined, _PlayerId, _Msg) ->
@@ -153,8 +165,18 @@ themselves from a stale one if an id ever repeats.
 """.
 -spec release_session(binary(), pid()) -> ok.
 release_session(PlayerId, Pid) ->
+    %% `_ =` and not `ok =`: the dominant shape in these suites kills the
+    %% session mid-body on purpose to trigger a DOWN, so `not_joined` here is
+    %% ordinary rather than a double release.
     _ = pg:leave(nova_scope, {player, PlayerId}, Pid),
+    Ref = monitor(process, Pid),
     Pid ! stop,
+    receive
+        {'DOWN', Ref, process, Pid, _} -> ok
+    after 1_000 ->
+        demonitor(Ref, [flush]),
+        exit(Pid, kill)
+    end,
     drain_forwarded(PlayerId).
 
 -spec drain_forwarded(binary()) -> ok.
@@ -163,25 +185,6 @@ drain_forwarded(PlayerId) ->
         {PlayerId, _} -> drain_forwarded(PlayerId)
     after 0 -> ok
     end.
-
--doc """
-As `with_session/2` under an id nothing can collide with. `Fun` receives it.
-""".
--spec with_unique_session(binary(), fun((binary()) -> R)) -> R.
-with_unique_session(Prefix, Fun) ->
-    PlayerId = unique_id(Prefix),
-    with_session(PlayerId, fun() -> Fun(PlayerId) end).
-
--doc """
-A session under an id no other run or module can collide with.
-
-`unique_id/1` rather than a hand-picked name: a distinctive id works only
-until someone else picks it, which is the same guarantee `p1` had.
-""".
--spec unique_session(binary()) -> {binary(), pid()}.
-unique_session(Prefix) ->
-    PlayerId = unique_id(Prefix),
-    {PlayerId, fake_session(PlayerId)}.
 
 -doc """
 Assert that nobody is registered as this player before the test relies on it.

--- a/test/asobi_test_helpers.erl
+++ b/test/asobi_test_helpers.erl
@@ -2,7 +2,7 @@
 
 -export([start/1, unique_username/1, unique_id/1, binary_join/2]).
 -export([fake_session/1, fake_session/2, unique_session/1, assert_no_session/1]).
--export([with_session/2, with_session/3, with_unique_session/2]).
+-export([with_session/2, with_session/3, with_unique_session/2, release_session/2]).
 -export([http_routes/1, routes_missing_options/1, preflight_targets/1, sample_path/1]).
 
 -spec start(list()) -> list().
@@ -67,7 +67,15 @@ bookkeeping.
 """.
 -spec fake_session(binary(), pid() | undefined) -> pid().
 fake_session(PlayerId, Owner) ->
+    %% Labelled with the CALLER's frame, read from `self()` before the spawn.
+    %% `current_function` used to name the test module because the fun was
+    %% written there; extracting it here made every leaker report
+    %% `asobi_test_helpers`, which is the one answer `assert_no_session/1`
+    %% cannot use. `initial_call` never helped - it is `{erlang,apply,2}` for a
+    %% plain spawn and `{proc_lib,init_p,5}` for a real session.
+    Caller = caller_frame(),
     Pid = spawn(fun Loop() ->
+        proc_lib:set_label({fake_session, PlayerId, Caller}),
         receive
             stop ->
                 ok;
@@ -78,6 +86,28 @@ fake_session(PlayerId, Owner) ->
     end),
     ok = pg:join(nova_scope, {player, PlayerId}, Pid),
     Pid.
+
+-spec caller_frame() -> {module(), atom(), arity(), term()} | unknown.
+caller_frame() ->
+    case erlang:process_info(self(), current_stacktrace) of
+        {current_stacktrace, Stack} -> first_foreign_frame(Stack);
+        _ -> unknown
+    end.
+
+-spec first_foreign_frame([term()]) -> {module(), atom(), arity(), term()} | unknown.
+first_foreign_frame([{M, F, A, Loc} | _]) when
+    is_atom(M), M =/= ?MODULE, is_atom(F), is_integer(A), is_list(Loc)
+->
+    {M, F, A, frame_line(Loc)};
+first_foreign_frame([_ | Rest]) ->
+    first_foreign_frame(Rest);
+first_foreign_frame([]) ->
+    unknown.
+
+-spec frame_line([term()]) -> pos_integer() | undefined.
+frame_line([{line, L} | _]) when is_integer(L), L > 0 -> L;
+frame_line([_ | Rest]) -> frame_line(Rest);
+frame_line([]) -> undefined.
 
 -spec forward(pid() | undefined, binary(), term()) -> ok.
 forward(undefined, _PlayerId, _Msg) ->
@@ -105,7 +135,33 @@ with_session(PlayerId, Owner, Fun) ->
     try
         Fun()
     after
-        exit(Pid, kill)
+        release_session(PlayerId, Pid)
+    end.
+
+-doc """
+Release a session: leave the group, stop the process, drain what it forwarded.
+
+`pg:leave/3` rather than relying on the process dying, because a killed pid
+lingers in the group for tens of milliseconds - long enough for an immediately
+following `assert_no_session/1` to fail naming a dead pid, and long enough for
+production code reading that group to get one.
+
+The drain matters because the owner is the SAME process for every test in a
+module: undrained `{PlayerId, Msg}` forwards outlive the test that caused them,
+and `received_entity/2`-style selective receives would happily satisfy
+themselves from a stale one if an id ever repeats.
+""".
+-spec release_session(binary(), pid()) -> ok.
+release_session(PlayerId, Pid) ->
+    _ = pg:leave(nova_scope, {player, PlayerId}, Pid),
+    Pid ! stop,
+    drain_forwarded(PlayerId).
+
+-spec drain_forwarded(binary()) -> ok.
+drain_forwarded(PlayerId) ->
+    receive
+        {PlayerId, _} -> drain_forwarded(PlayerId)
+    after 0 -> ok
     end.
 
 -doc """
@@ -144,9 +200,23 @@ assert_no_session(PlayerId) ->
 %% In a full run the module that fails this assertion is the one that did
 %% nothing wrong, and a bare pid does not say who registered it - by the time
 %% anyone reads the output the process may be gone. Name the leaker.
--spec who(pid()) -> {pid(), term()}.
+%% `proc_lib:get_label/1` is the useful half - see fake_session/2. It answers
+%% `undefined` for an unlabelled or dead pid rather than raising.
+%%
+%% `process_info/2` RAISES on a remote pid, and pg is a distributed registry:
+%% the day asobi is not single-node, an unguarded call here turns the leak
+%% report into a badarg that hides the leak it was written to find.
+%%
+%% Deliberately not `dictionary`, `messages` or `backtrace`: asobi_lua_world
+%% stores the whole zone state - Luerl VM included - in its process
+%% dictionary, so a leaked zone process would dump the entire scripting VM and
+%% every entity map into CI output. `current_function` is an MFA; arity, not
+%% arguments.
+-spec who(pid()) -> tuple().
+who(Pid) when node(Pid) =/= node() ->
+    {Pid, {remote, node(Pid)}};
 who(Pid) ->
-    {Pid, erlang:process_info(Pid, [initial_call, current_function])}.
+    {Pid, proc_lib:get_label(Pid), erlang:process_info(Pid, [current_function, registered_name])}.
 
 %% --- Router enumeration ---
 %%

--- a/test/asobi_test_helpers_tests.erl
+++ b/test/asobi_test_helpers_tests.erl
@@ -16,5 +16,88 @@ unique_id_draws_from_a_large_space_test() ->
     ?assertEqual(1000, length(lists:usort(Ids))),
     %% 8 random bytes, hex-encoded: the suffix has to be wide enough that two
     %% runs colliding is not a thing that happens.
-    [Suffix] = tl(binary:split(hd(Ids), ~"_")),
-    ?assertEqual(16, byte_size(Suffix)).
+    ?assertEqual(16, byte_size(id_suffix(Ids))).
+
+%% `unique_id/1` is spec'd `-> binary()`, but a list comprehension erases the
+%% element type, so the ids come back `term()`. Narrow once rather than
+%% indexing an unknown shape.
+-spec id_suffix([term()]) -> binary().
+id_suffix([Id | _]) when is_binary(Id) ->
+    case binary:split(Id, ~"_") of
+        [_Prefix, Suffix] when is_binary(Suffix) -> Suffix
+    end.
+
+%% Five test modules depend on these, and `who/1` already regressed once inside
+%% the PR that added it - caught by review rather than by a test. That is what
+%% these pin.
+session_helpers_test_() ->
+    {setup, fun ensure_pg/0, fun(_) -> ok end, [
+        {"with_session releases on a raising body", fun with_session_releases_on_raise/0},
+        {"release_session leaves the group before it returns", fun release_is_synchronous/0},
+        {"release_session drains what it forwarded", fun release_drains/0},
+        {"assert_no_session passes on an empty group", fun assert_no_session_empty/0},
+        {"assert_no_session names the calling module", fun assert_no_session_names_caller/0}
+    ]}.
+
+ensure_pg() ->
+    case whereis(nova_scope) of
+        undefined ->
+            {ok, _} = pg:start(nova_scope),
+            ok;
+        _ ->
+            ok
+    end.
+
+%% The whole thesis: the release is structural, so it happens on the path a
+%% failing assertion takes.
+with_session_releases_on_raise() ->
+    Id = asobi_test_helpers:unique_id(~"wsr"),
+    ?assertError(boom, asobi_test_helpers:with_session(Id, fun() -> error(boom) end)),
+    ?assertEqual([], pg:get_members(nova_scope, {player, Id})).
+
+%% No sleep: `pg:leave/3` is a call, which is why it replaced `exit/2` here - a
+%% killed pid lingers in the group long enough for a reader to get a dead one.
+release_is_synchronous() ->
+    Id = asobi_test_helpers:unique_id(~"rsl"),
+    Pid = asobi_test_helpers:fake_session(Id),
+    ?assertEqual([Pid], pg:get_members(nova_scope, {player, Id})),
+    ok = asobi_test_helpers:release_session(Id, Pid),
+    ?assertEqual([], pg:get_members(nova_scope, {player, Id})).
+
+release_drains() ->
+    Id = asobi_test_helpers:unique_id(~"rsd"),
+    Pid = asobi_test_helpers:fake_session(Id, self()),
+    Pid ! one,
+    Pid ! two,
+    timer:sleep(50),
+    ok = asobi_test_helpers:release_session(Id, Pid),
+    receive
+        {Id, _} = Stale -> erlang:error({undrained, Stale})
+    after 0 -> ok
+    end.
+
+assert_no_session_empty() ->
+    Id = asobi_test_helpers:unique_id(~"ans"),
+    ?assertEqual(ok, asobi_test_helpers:assert_no_session(Id)).
+
+%% Regression pin: `who/1` must name the module that SPAWNED the leaker. When
+%% fake_session was extracted into asobi_test_helpers, `current_function` began
+%% naming the shared helper for every leaker - the one answer this cannot use.
+%% The sleep is required: the label is applied by the spawned process.
+assert_no_session_names_caller() ->
+    Id = asobi_test_helpers:unique_id(~"leak"),
+    Pid = asobi_test_helpers:fake_session(Id),
+    try
+        timer:sleep(50),
+        Reason =
+            try asobi_test_helpers:assert_no_session(Id) of
+                ok -> no_error
+            catch
+                error:R -> R
+            end,
+        ?assertMatch({session_already_registered, Id, [_ | _]}, Reason),
+        {session_already_registered, _, [{_, Label, _} | _]} = Reason,
+        ?assertMatch({fake_session, Id, {?MODULE, _, _, _}}, Label)
+    after
+        asobi_test_helpers:release_session(Id, Pid)
+    end.

--- a/test/asobi_world_chat_tests.erl
+++ b/test/asobi_world_chat_tests.erl
@@ -73,90 +73,102 @@ cleanup(_) ->
     meck:unload(asobi_repo),
     ok.
 
-register_player() ->
-    pg:join(nova_scope, {player, ~"p1"}, self()).
-
-unregister_player() ->
-    pg:leave(nova_scope, {player, ~"p1"}, self()).
+%% Registers THIS process (the eunit runner, alive for the whole run) under a
+%% shared-scope key, so leaving is not optional: `nova_scope` and `{player,
+%% Id}` are global across every module in the run, and a registration that
+%% outlives its test is lent to any later test using the same id. That is how
+%% asobi_world_zone_integration_tests came to pass only in a full run - it
+%% found a session it never created and subscribed it to four zones.
+%%
+%% Paired via `try ... after` rather than a trailing call: these tests assert
+%% in the middle, and a failing assertion used to skip the unregister and
+%% strand the runner in the group for the rest of the run.
+with_registered_player(Fun) ->
+    ok = pg:join(nova_scope, {player, ~"p1"}, self()),
+    try
+        Fun()
+    after
+        pg:leave(nova_scope, {player, ~"p1"}, self())
+    end.
 
 join_world_chat() ->
-    register_player(),
-    ChatState = asobi_world_chat:init(~"wc1", #{chat => #{world => true}}),
-    asobi_world_chat:player_joined(~"p1", {0, 0}, ChatState),
-    ChannelId = asobi_world_chat:channel_id(~"wc1", world, undefined),
-    Members = pg:get_members(nova_scope, {chat, ChannelId}),
-    ?assert(lists:member(self(), Members)),
-    unregister_player().
+    with_registered_player(fun() ->
+        ChatState = asobi_world_chat:init(~"wc1", #{chat => #{world => true}}),
+        asobi_world_chat:player_joined(~"p1", {0, 0}, ChatState),
+        ChannelId = asobi_world_chat:channel_id(~"wc1", world, undefined),
+        Members = pg:get_members(nova_scope, {chat, ChannelId}),
+        ?assert(lists:member(self(), Members))
+    end).
 
 join_zone_chat() ->
-    register_player(),
-    ChatState = asobi_world_chat:init(~"wc2", #{chat => #{zone => true}}),
-    asobi_world_chat:player_joined(~"p1", {2, 3}, ChatState),
-    ChannelId = asobi_world_chat:channel_id(~"wc2", zone, {2, 3}),
-    Members = pg:get_members(nova_scope, {chat, ChannelId}),
-    ?assert(lists:member(self(), Members)),
-    unregister_player().
+    with_registered_player(fun() ->
+        ChatState = asobi_world_chat:init(~"wc2", #{chat => #{zone => true}}),
+        asobi_world_chat:player_joined(~"p1", {2, 3}, ChatState),
+        ChannelId = asobi_world_chat:channel_id(~"wc2", zone, {2, 3}),
+        Members = pg:get_members(nova_scope, {chat, ChannelId}),
+        ?assert(lists:member(self(), Members))
+    end).
 
 leave_cleans_up() ->
-    register_player(),
-    ChatState = asobi_world_chat:init(~"wc3", #{chat => #{world => true, zone => true}}),
-    asobi_world_chat:player_joined(~"p1", {1, 1}, ChatState),
-    asobi_world_chat:player_left(~"p1", {1, 1}, ChatState),
-    WorldChannel = asobi_world_chat:channel_id(~"wc3", world, undefined),
-    ZoneChannel = asobi_world_chat:channel_id(~"wc3", zone, {1, 1}),
-    ?assertNot(lists:member(self(), pg:get_members(nova_scope, {chat, WorldChannel}))),
-    ?assertNot(lists:member(self(), pg:get_members(nova_scope, {chat, ZoneChannel}))),
-    unregister_player().
+    with_registered_player(fun() ->
+        ChatState = asobi_world_chat:init(~"wc3", #{chat => #{world => true, zone => true}}),
+        asobi_world_chat:player_joined(~"p1", {1, 1}, ChatState),
+        asobi_world_chat:player_left(~"p1", {1, 1}, ChatState),
+        WorldChannel = asobi_world_chat:channel_id(~"wc3", world, undefined),
+        ZoneChannel = asobi_world_chat:channel_id(~"wc3", zone, {1, 1}),
+        ?assertNot(lists:member(self(), pg:get_members(nova_scope, {chat, WorldChannel}))),
+        ?assertNot(lists:member(self(), pg:get_members(nova_scope, {chat, ZoneChannel})))
+    end).
 
 zone_change_swaps_chat() ->
-    register_player(),
-    ChatState = asobi_world_chat:init(~"wc4", #{chat => #{zone => true, grid_size => 10}}),
-    asobi_world_chat:player_joined(~"p1", {1, 1}, ChatState),
-    OldChannel = asobi_world_chat:channel_id(~"wc4", zone, {1, 1}),
-    ?assert(lists:member(self(), pg:get_members(nova_scope, {chat, OldChannel}))),
-    asobi_world_chat:player_zone_changed(~"p1", {1, 1}, {2, 2}, 10, ChatState),
-    NewChannel = asobi_world_chat:channel_id(~"wc4", zone, {2, 2}),
-    ?assertNot(lists:member(self(), pg:get_members(nova_scope, {chat, OldChannel}))),
-    ?assert(lists:member(self(), pg:get_members(nova_scope, {chat, NewChannel}))),
-    unregister_player().
+    with_registered_player(fun() ->
+        ChatState = asobi_world_chat:init(~"wc4", #{chat => #{zone => true, grid_size => 10}}),
+        asobi_world_chat:player_joined(~"p1", {1, 1}, ChatState),
+        OldChannel = asobi_world_chat:channel_id(~"wc4", zone, {1, 1}),
+        ?assert(lists:member(self(), pg:get_members(nova_scope, {chat, OldChannel}))),
+        asobi_world_chat:player_zone_changed(~"p1", {1, 1}, {2, 2}, 10, ChatState),
+        NewChannel = asobi_world_chat:channel_id(~"wc4", zone, {2, 2}),
+        ?assertNot(lists:member(self(), pg:get_members(nova_scope, {chat, OldChannel}))),
+        ?assert(lists:member(self(), pg:get_members(nova_scope, {chat, NewChannel})))
+    end).
 
 proximity_chat() ->
-    register_player(),
-    ChatState = asobi_world_chat:init(~"wc5", #{chat => #{proximity => 1, grid_size => 5}}),
-    asobi_world_chat:player_joined(~"p1", {2, 2}, ChatState),
-    Center = asobi_world_chat:channel_id(~"wc5", proximity, {2, 2}),
-    Corner = asobi_world_chat:channel_id(~"wc5", proximity, {1, 1}),
-    Far = asobi_world_chat:channel_id(~"wc5", proximity, {4, 4}),
-    ?assert(lists:member(self(), pg:get_members(nova_scope, {chat, Center}))),
-    ?assert(lists:member(self(), pg:get_members(nova_scope, {chat, Corner}))),
-    ?assertNot(lists:member(self(), pg:get_members(nova_scope, {chat, Far}))),
-    unregister_player().
+    with_registered_player(fun() ->
+        ChatState = asobi_world_chat:init(~"wc5", #{chat => #{proximity => 1, grid_size => 5}}),
+        asobi_world_chat:player_joined(~"p1", {2, 2}, ChatState),
+        Center = asobi_world_chat:channel_id(~"wc5", proximity, {2, 2}),
+        Corner = asobi_world_chat:channel_id(~"wc5", proximity, {1, 1}),
+        Far = asobi_world_chat:channel_id(~"wc5", proximity, {4, 4}),
+        ?assert(lists:member(self(), pg:get_members(nova_scope, {chat, Center}))),
+        ?assert(lists:member(self(), pg:get_members(nova_scope, {chat, Corner}))),
+        ?assertNot(lists:member(self(), pg:get_members(nova_scope, {chat, Far})))
+    end).
 
 no_chat_config() ->
-    register_player(),
-    ChatState = asobi_world_chat:init(~"wc6", #{}),
-    asobi_world_chat:player_joined(~"p1", {0, 0}, ChatState),
-    WorldChannel = asobi_world_chat:channel_id(~"wc6", world, undefined),
-    ZoneChannel = asobi_world_chat:channel_id(~"wc6", zone, {0, 0}),
-    ?assertNot(lists:member(self(), pg:get_members(nova_scope, {chat, WorldChannel}))),
-    ?assertNot(lists:member(self(), pg:get_members(nova_scope, {chat, ZoneChannel}))),
-    unregister_player().
+    with_registered_player(fun() ->
+        ChatState = asobi_world_chat:init(~"wc6", #{}),
+        asobi_world_chat:player_joined(~"p1", {0, 0}, ChatState),
+        WorldChannel = asobi_world_chat:channel_id(~"wc6", world, undefined),
+        ZoneChannel = asobi_world_chat:channel_id(~"wc6", zone, {0, 0}),
+        ?assertNot(lists:member(self(), pg:get_members(nova_scope, {chat, WorldChannel}))),
+        ?assertNot(lists:member(self(), pg:get_members(nova_scope, {chat, ZoneChannel})))
+    end).
 
 %% #299: the global tier carries no world id, so two worlds of the same game
 %% resolve the same channel process.
 global_chat_joined_and_left() ->
-    register_player(),
-    ChatState = asobi_world_chat:init(~"wc8", #{chat => #{global => [~"general"]}}),
-    ChatState2 = asobi_world_chat:init(~"wc9", #{chat => #{global => [~"general"]}}),
-    ChannelId = asobi_world_chat:global_channel_id(~"general"),
-    ?assertEqual(~"global:general", ChannelId),
-    asobi_world_chat:player_joined(~"p1", {0, 0}, ChatState),
-    ?assert(lists:member(self(), pg:get_members(nova_scope, {chat, ChannelId}))),
-    asobi_world_chat:player_joined(~"p1", {0, 0}, ChatState2),
-    asobi_world_chat:player_left(~"p1", {0, 0}, ChatState2),
-    asobi_world_chat:player_left(~"p1", {0, 0}, ChatState),
-    ?assertNot(lists:member(self(), pg:get_members(nova_scope, {chat, ChannelId}))),
-    unregister_player().
+    with_registered_player(fun() ->
+        ChatState = asobi_world_chat:init(~"wc8", #{chat => #{global => [~"general"]}}),
+        ChatState2 = asobi_world_chat:init(~"wc9", #{chat => #{global => [~"general"]}}),
+        ChannelId = asobi_world_chat:global_channel_id(~"general"),
+        ?assertEqual(~"global:general", ChannelId),
+        asobi_world_chat:player_joined(~"p1", {0, 0}, ChatState),
+        ?assert(lists:member(self(), pg:get_members(nova_scope, {chat, ChannelId}))),
+        asobi_world_chat:player_joined(~"p1", {0, 0}, ChatState2),
+        asobi_world_chat:player_left(~"p1", {0, 0}, ChatState2),
+        asobi_world_chat:player_left(~"p1", {0, 0}, ChatState),
+        ?assertNot(lists:member(self(), pg:get_members(nova_scope, {chat, ChannelId})))
+    end).
 
 global_channels_test_() ->
     [

--- a/test/asobi_world_chat_tests.erl
+++ b/test/asobi_world_chat_tests.erl
@@ -96,22 +96,36 @@ with_registered_player(Fun) ->
 %% of `player_joined/3`, and only leave them on the success path. World-scoped
 %% ids bound the damage, but the global tier deliberately carries NO world id
 %% (widgrensit/asobi#299) - `global:general` is the single most shared key in
-%% the system - so a failing assertion strands the eunit runner in it for the
-%% rest of the run, where nothing today would detect it.
+%% the system.
+%%
+%% The strand lasts for the rest of this MODULE, not the whole run: the eunit
+%% runner is per module group and pg reaps its memberships when it dies. That
+%% is still worth closing - a membership from one test was measured visible in
+%% a later test of the same module - but the cross-MODULE vector is a spawned
+%% session outliving its creator, not this.
+%%
+%% Drains rather than leaving once. `pg:join` twice registers twice and one
+%% `pg:leave` removes one, and `global_chat_joined_and_left/0` deliberately
+%% joins `global:general` through two worlds - so a single leave would
+%% under-clean in exactly the case that motivates the sweep.
 leave_chat_channels() ->
     Self = self(),
     lists:foreach(
         fun
-            ({chat, _} = Group) ->
-                case lists:member(Self, pg:get_members(nova_scope, Group)) of
-                    true -> pg:leave(nova_scope, Group, Self);
-                    false -> ok
-                end;
-            (_Group) ->
-                ok
+            ({chat, _} = Group) -> drain_membership(Group, Self);
+            (_Group) -> ok
         end,
         pg:which_groups(nova_scope)
     ).
+
+drain_membership(Group, Self) ->
+    case lists:member(Self, pg:get_members(nova_scope, Group)) of
+        true ->
+            _ = pg:leave(nova_scope, Group, Self),
+            drain_membership(Group, Self);
+        false ->
+            ok
+    end.
 
 join_world_chat() ->
     with_registered_player(fun() ->
@@ -226,6 +240,11 @@ global_channels_test_() ->
 %% calling register_player/0 here - a player with no session must not join,
 %% leave, or move any channel using the calling process's own pid.
 no_live_session_does_not_join_as_caller() ->
+    %% Same class as the two #277/#280 twins: this asserts the SESSION-LESS
+    %% path, and `find_player_pid/1` takes the head of the group - so a leaked
+    %% session under this id would be joined instead, and the assertion would
+    %% still pass while the degraded path went untested.
+    ok = asobi_test_helpers:assert_no_session(~"ghost"),
     ChatState = asobi_world_chat:init(~"wc7", #{
         chat => #{world => true, zone => true, proximity => 1, grid_size => 5}
     }),

--- a/test/asobi_world_chat_tests.erl
+++ b/test/asobi_world_chat_tests.erl
@@ -73,16 +73,17 @@ cleanup(_) ->
     meck:unload(asobi_repo),
     ok.
 
-%% Registers THIS process (the eunit runner, alive for the whole run) under a
-%% shared-scope key, so leaving is not optional: `nova_scope` and `{player,
-%% Id}` are global across every module in the run, and a registration that
-%% outlives its test is lent to any later test using the same id. That is how
-%% asobi_world_zone_integration_tests came to pass only in a full run - it
-%% found a session it never created and subscribed it to four zones.
+%% Registers THIS process under a shared-scope key, so leaving is not optional:
+%% `nova_scope` and `{player, Id}` are global across every module in the run,
+%% and a registration that outlives its test is lent to any later test using
+%% the same id.
 %%
-%% Paired via `try ... after` rather than a trailing call: these tests assert
-%% in the middle, and a failing assertion used to skip the unregister and
-%% strand the runner in the group for the rest of the run.
+%% This module was NOT the donor for the zone-integration false pass - every
+%% `unregister_player()` here was paired, so a green run left nothing behind.
+%% That was `asobi_match_server_tests`, which had two `_`-prefixed sessions on
+%% the same id that were never killed at all. What this module had was the
+%% failure path: these tests assert in the middle, and a failing assertion
+%% skipped a trailing unregister. Hence `try ... after`.
 with_registered_player(Fun) ->
     ok = pg:join(nova_scope, {player, ~"p1"}, self()),
     try

--- a/test/asobi_world_chat_tests.erl
+++ b/test/asobi_world_chat_tests.erl
@@ -88,8 +88,30 @@ with_registered_player(Fun) ->
     try
         Fun()
     after
-        pg:leave(nova_scope, {player, ~"p1"}, self())
+        pg:leave(nova_scope, {player, ~"p1"}, self()),
+        leave_chat_channels()
     end.
+
+%% The bodies join this process to `{chat, ChannelId}` groups as a side effect
+%% of `player_joined/3`, and only leave them on the success path. World-scoped
+%% ids bound the damage, but the global tier deliberately carries NO world id
+%% (widgrensit/asobi#299) - `global:general` is the single most shared key in
+%% the system - so a failing assertion strands the eunit runner in it for the
+%% rest of the run, where nothing today would detect it.
+leave_chat_channels() ->
+    Self = self(),
+    lists:foreach(
+        fun
+            ({chat, _} = Group) ->
+                case lists:member(Self, pg:get_members(nova_scope, Group)) of
+                    true -> pg:leave(nova_scope, Group, Self);
+                    false -> ok
+                end;
+            (_Group) ->
+                ok
+        end,
+        pg:which_groups(nova_scope)
+    ).
 
 join_world_chat() ->
     with_registered_player(fun() ->

--- a/test/asobi_world_server_tests.erl
+++ b/test/asobi_world_server_tests.erl
@@ -462,7 +462,12 @@ join_three_sets_zone_pid() ->
 %% join/2 (test-only, no session registered) is exactly that case.
 join_with_no_live_session_does_not_crash() ->
     Ctx = #{world_pid := Pid, instance_pid := InstancePid} = start_world(),
-    PlayerId = ~"no_session",
+    %% This test asserts the SESSION-LESS path, so the assertion below is only
+    %% meaningful while nobody is registered under this id. A leftover session
+    %% from another module would silently turn it into a different test - and
+    %% the id was shared verbatim with asobi_match_server_tests until now.
+    PlayerId = ~"no_session_world",
+    ok = asobi_test_helpers:assert_no_session(PlayerId),
     ?assertEqual(ok, asobi_world_server:join(Pid, PlayerId)),
     ?assert(is_process_alive(Pid)),
     ?assertEqual(1, maps:get(player_count, asobi_world_server:get_info(Pid))),
@@ -512,9 +517,10 @@ failed_reconnect_leaves_grace_intact() ->
     timer:sleep(100),
     ?assertEqual({error, no_live_session}, asobi_world_server:reconnect(Pid, PlayerId)),
     {_StateName, #{reconnect_state := #{disconnected := #{PlayerId := _}}}} = sys:get_state(Pid),
-    _S2 = asobi_test_helpers:fake_session(PlayerId),
-    ?assertEqual(ok, asobi_world_server:reconnect(Pid, PlayerId)),
-    ?assertEqual(1, maps:get(player_count, asobi_world_server:get_info(Pid))),
+    asobi_test_helpers:with_session(PlayerId, fun() ->
+        ?assertEqual(ok, asobi_world_server:reconnect(Pid, PlayerId)),
+        ?assertEqual(1, maps:get(player_count, asobi_world_server:get_info(Pid)))
+    end),
     stop_world(Ctx).
 
 %% --- listing_info/1 (pure projection, no world needed) ---
@@ -803,6 +809,10 @@ a_world_that_did_not_ask_is_not_persistent_test() ->
 
 %% sys:get_state/1 is term(); narrow before indexing rather than reading a
 %% field out of an unknown shape.
+%% `pid() | undefined` and not `pid()`: the caller hands this
+%% `asobi_world_instance:get_child/2`, which can answer `undefined`. The guard
+%% then makes that a loud function_clause rather than a defaulted read - what
+%% the spec must not do is claim an input the call site cannot guarantee.
 -spec zone_config(pid() | undefined) -> map().
 zone_config(ZoneManager) when is_pid(ZoneManager) ->
     case sys:get_state(ZoneManager) of

--- a/test/asobi_world_server_tests.erl
+++ b/test/asobi_world_server_tests.erl
@@ -393,22 +393,12 @@ empty_phases_does_not_finish() ->
 %% Spawn a fake player session and register it in the pg group the world
 %% server monitors via find_player_pid/1. Killing this pid triggers the
 %% world_server's 'DOWN' handler.
-fake_session(PlayerId) ->
-    Pid = spawn(fun Loop() ->
-        receive
-            stop -> ok;
-            _ -> Loop()
-        end
-    end),
-    ok = pg:join(nova_scope, {player, PlayerId}, Pid),
-    Pid.
-
 player_ttl_zero_removes_on_down() ->
     %% Default behavior: WS drop with no reconnect policy should fully clean
     %% up the player. Without this, the zone accumulates zombie entities.
     Ctx = #{world_pid := Pid} = start_world(),
     PlayerId = <<"ttl0">>,
-    SessionPid = fake_session(PlayerId),
+    SessionPid = asobi_test_helpers:fake_session(PlayerId),
     asobi_world_server:join(Pid, PlayerId),
     ?assertEqual(1, maps:get(player_count, asobi_world_server:get_info(Pid))),
     exit(SessionPid, kill),
@@ -421,7 +411,7 @@ player_ttl_minus_one_keeps_on_down() ->
     %% The game module manages reconnection state itself.
     Ctx = #{world_pid := Pid} = start_world(#{player_ttl_ms => -1}),
     PlayerId = <<"ttlneg">>,
-    SessionPid = fake_session(PlayerId),
+    SessionPid = asobi_test_helpers:fake_session(PlayerId),
     asobi_world_server:join(Pid, PlayerId),
     ?assertEqual(1, maps:get(player_count, asobi_world_server:get_info(Pid))),
     exit(SessionPid, kill),
@@ -434,7 +424,7 @@ player_ttl_grace_starts_grace() ->
     %% grace flow; player count stays at 1 during the grace window.
     Ctx = #{world_pid := Pid} = start_world(#{player_ttl_ms => 5_000}),
     PlayerId = <<"ttlgrace">>,
-    SessionPid = fake_session(PlayerId),
+    SessionPid = asobi_test_helpers:fake_session(PlayerId),
     asobi_world_server:join(Pid, PlayerId),
     ?assertEqual(1, maps:get(player_count, asobi_world_server:get_info(Pid))),
     exit(SessionPid, kill),
@@ -499,7 +489,7 @@ join_with_no_live_session_does_not_crash() ->
 reconnect_with_no_live_session_returns_error() ->
     Ctx = #{world_pid := Pid} = start_world(#{player_ttl_ms => 5_000}),
     PlayerId = ~"reconnect_no_session",
-    SessionPid = fake_session(PlayerId),
+    SessionPid = asobi_test_helpers:fake_session(PlayerId),
     ?assertEqual(ok, asobi_world_server:join(Pid, PlayerId)),
     ?assertEqual(1, maps:get(player_count, asobi_world_server:get_info(Pid))),
     exit(SessionPid, kill),
@@ -516,13 +506,13 @@ reconnect_with_no_live_session_returns_error() ->
 failed_reconnect_leaves_grace_intact() ->
     Ctx = #{world_pid := Pid} = start_world(#{player_ttl_ms => 5_000}),
     PlayerId = ~"retry_after_no_session",
-    S1 = fake_session(PlayerId),
+    S1 = asobi_test_helpers:fake_session(PlayerId),
     ?assertEqual(ok, asobi_world_server:join(Pid, PlayerId)),
     exit(S1, kill),
     timer:sleep(100),
     ?assertEqual({error, no_live_session}, asobi_world_server:reconnect(Pid, PlayerId)),
     {_StateName, #{reconnect_state := #{disconnected := #{PlayerId := _}}}} = sys:get_state(Pid),
-    _S2 = fake_session(PlayerId),
+    _S2 = asobi_test_helpers:fake_session(PlayerId),
     ?assertEqual(ok, asobi_world_server:reconnect(Pid, PlayerId)),
     ?assertEqual(1, maps:get(player_count, asobi_world_server:get_info(Pid))),
     stop_world(Ctx).
@@ -787,7 +777,7 @@ persistent_reaches_the_zone_config_test() ->
         #{instance_pid := InstancePid} = start_world(#{persistent => true}),
         try
             ZoneManager = asobi_world_instance:get_child(InstancePid, asobi_zone_manager),
-            #{zone_config := ZoneConfig} = sys:get_state(ZoneManager),
+            ZoneConfig = zone_config(ZoneManager),
             ?assertEqual(true, maps:get(persistence, ZoneConfig))
         after
             exit(InstancePid, shutdown)
@@ -802,11 +792,19 @@ a_world_that_did_not_ask_is_not_persistent_test() ->
         #{instance_pid := InstancePid} = start_world(),
         try
             ZoneManager = asobi_world_instance:get_child(InstancePid, asobi_zone_manager),
-            #{zone_config := ZoneConfig} = sys:get_state(ZoneManager),
+            ZoneConfig = zone_config(ZoneManager),
             ?assertEqual(false, maps:get(persistence, ZoneConfig))
         after
             exit(InstancePid, shutdown)
         end
     after
         cleanup(ok)
+    end.
+
+%% sys:get_state/1 is term(); narrow before indexing rather than reading a
+%% field out of an unknown shape.
+-spec zone_config(pid() | undefined) -> map().
+zone_config(ZoneManager) when is_pid(ZoneManager) ->
+    case sys:get_state(ZoneManager) of
+        #{zone_config := Config} when is_map(Config) -> Config
     end.

--- a/test/asobi_world_zone_integration_tests.erl
+++ b/test/asobi_world_zone_integration_tests.erl
@@ -115,14 +115,14 @@ default_prespawns_all() ->
 broadcast_interval_reaches_the_zone() ->
     Ctx = #{zone_mgr := Mgr} = start_world(#{broadcast_interval => 1}),
     {ok, ZonePid} = asobi_zone_manager:get_zone(Mgr, {0, 0}),
-    ?assertEqual(1, maps:get(broadcast_interval, sys:get_state(ZonePid))),
+    ?assertEqual(1, maps:get(broadcast_interval, zone_state(ZonePid))),
     stop_world(Ctx).
 
 %% The default is unchanged: a world that sets nothing runs on 3.
 broadcast_interval_defaults_to_three() ->
     Ctx = #{zone_mgr := Mgr} = start_world(),
     {ok, ZonePid} = asobi_zone_manager:get_zone(Mgr, {0, 0}),
-    ?assertEqual(3, maps:get(broadcast_interval, sys:get_state(ZonePid))),
+    ?assertEqual(3, maps:get(broadcast_interval, zone_state(ZonePid))),
     stop_world(Ctx).
 
 %% lazy_zones=true means no zones spawned at startup
@@ -443,23 +443,51 @@ world_input_crossing_touches_only_ring_delta() ->
     %% just because it's in view) - lazy_zones=false pre-spawns the whole
     %% grid so every ring zone is subscribable at join time.
     Ctx = #{world_pid := Pid, zone_mgr := Mgr} = start_world(#{grid_size => 5}),
-    ?assertEqual(ok, asobi_world_server:join(Pid, ~"p1")),
-    timer:sleep(20),
-    %% Spawns at {100.0, 100.0} => zone {1,1}.
-    {ok, Z11} = asobi_zone_manager:get_zone(Mgr, {1, 1}),
-    ?assertEqual(1, asobi_zone:get_subscriber_count(Z11)),
-    {ok, Z00} = asobi_zone_manager:get_zone(Mgr, {0, 0}),
-    ?assertEqual(1, asobi_zone:get_subscriber_count(Z00)),
-    {ok, Z30} = asobi_zone_manager:get_zone(Mgr, {3, 0}),
-    ?assertEqual(0, asobi_zone:get_subscriber_count(Z30)),
+    %% A pg-registered session, like every other test in this module that
+    %% asserts on subscriptions. `subscribe_interest_zones/4` resolves the
+    %% player through `find_player_pid/1`, which reads
+    %% `pg:get_members(nova_scope, {player, PlayerId})` - with no member the
+    %% pid is `undefined` and asobi_world_server skips the subscribe
+    %% entirely, so every count below is 0.
+    %%
+    %% Without this the test passed only in a full eunit run, by finding a
+    %% live process ANOTHER module had left registered under `{player,
+    %% <<"p1">>}` in the shared scope - so it was green for a reason that had
+    %% nothing to do with the ring diff it exists to prove, and red whenever
+    %% the module was run on its own. Hence the distinctive id: `p1` is what
+    %% made it borrowable.
+    Player = ~"ring275_p1",
+    SessionPid = fake_session(Player, self()),
+    %% The session and the world are released by the outer `after`, so it has
+    %% to open BEFORE the join and the asserts below - the first of which is
+    %% the one this test used to fail on. Releasing them only from a block the
+    %% failure jumps over would leak a pg-registered session and a ticking
+    %% world into the rest of the run, which is the class of contamination
+    %% this commit exists to remove.
+    try
+        ?assertEqual(ok, asobi_world_server:join(Pid, Player)),
+        timer:sleep(20),
+        %% Spawns at {100.0, 100.0} => zone {1,1}.
+        {ok, Z11} = asobi_zone_manager:get_zone(Mgr, {1, 1}),
+        ?assertEqual(1, asobi_zone:get_subscriber_count(Z11)),
+        {ok, Z00} = asobi_zone_manager:get_zone(Mgr, {0, 0}),
+        ?assertEqual(1, asobi_zone:get_subscriber_count(Z00)),
+        {ok, Z30} = asobi_zone_manager:get_zone(Mgr, {3, 0}),
+        ?assertEqual(0, asobi_zone:get_subscriber_count(Z30)),
+        ring_delta_crossing(Mgr, Player, Z11, Z00, Z30)
+    after
+        exit(SessionPid, kill),
+        stop_world(Ctx)
+    end.
 
-    %% Reaching the same end state doesn't prove the ring diff ran instead of
-    %% a full unsubscribe-everything/resubscribe-everything pass - both reach
-    %% identical final counts. Count the actual subscribe/unsubscribe calls:
-    %% only 3 zones left the ring and 3 entered it (not all 9), plus one more
-    %% unconditional subscribe to the destination zone itself (asobi#275: the
-    %% crossing player is always (re-)subscribed to the zone they land in,
-    %% even though it stayed in the ring and so is never in the ring diff).
+%% Reaching the same end state doesn't prove the ring diff ran instead of
+%% a full unsubscribe-everything/resubscribe-everything pass - both reach
+%% identical final counts. Count the actual subscribe/unsubscribe calls:
+%% only 3 zones left the ring and 3 entered it (not all 9), plus one more
+%% unconditional subscribe to the destination zone itself (asobi#275: the
+%% crossing player is always (re-)subscribed to the zone they land in,
+%% even though it stayed in the ring and so is never in the ring diff).
+ring_delta_crossing(Mgr, Player, Z11, Z00, Z30) ->
     Self = self(),
     meck:new(asobi_zone, [passthrough]),
     try
@@ -474,7 +502,7 @@ world_input_crossing_touches_only_ring_delta() ->
 
         %% x=225 clears zone {1,1}'s margin (edge at 200 + 15% of 100), landing
         %% in zone {2,1}.
-        asobi_zone:player_input(Z11, ~"p1", #{
+        asobi_zone:player_input(Z11, Player, #{
             ~"action" => ~"move", ~"x" => 225.0, ~"y" => 100.0
         }),
         timer:sleep(150),
@@ -494,8 +522,7 @@ world_input_crossing_touches_only_ring_delta() ->
         {ok, Z21} = asobi_zone_manager:get_zone(Mgr, {2, 1}),
         ?assertEqual(1, asobi_zone:get_subscriber_count(Z21))
     after
-        meck:unload(asobi_zone),
-        stop_world(Ctx)
+        meck:unload(asobi_zone)
     end.
 
 count_messages(Tag) ->
@@ -862,3 +889,11 @@ reap_first_zone_at(Target, Coords, {ok, ZonePid, _Status} = Result, Ctr) when Co
     end;
 reap_first_zone_at(_Target, _Coords, Result, _Ctr) ->
     Result.
+
+%% sys:get_state/1 is term(); a test reading a field out of a zone's state
+%% narrows first rather than indexing an unknown shape.
+-spec zone_state(pid()) -> map().
+zone_state(ZonePid) ->
+    case sys:get_state(ZonePid) of
+        State when is_map(State) -> State
+    end.

--- a/test/asobi_world_zone_integration_tests.erl
+++ b/test/asobi_world_zone_integration_tests.erl
@@ -476,7 +476,7 @@ world_input_crossing_touches_only_ring_delta() ->
         ?assertEqual(0, asobi_zone:get_subscriber_count(Z30)),
         ring_delta_crossing(Mgr, Player, Z11, Z00, Z30)
     after
-        exit(SessionPid, kill),
+        asobi_test_helpers:release_session(Player, SessionPid),
         stop_world(Ctx)
     end.
 
@@ -623,8 +623,8 @@ crossing_into_a_lazily_created_zone_backfills_stationary_neighbours() ->
         %% receives the crossing player's entity.
         ?assert(received_entity(Ada, Bob))
     after
-        exit(AdaPid, kill),
-        exit(BobPid, kill),
+        asobi_test_helpers:release_session(Ada, AdaPid),
+        asobi_test_helpers:release_session(Bob, BobPid),
         stop_world(Ctx)
     end.
 
@@ -659,7 +659,7 @@ npc_crossing_into_an_unloaded_zone_creates_it_and_backfills() ->
         ?assertMatch(#{subscribers := #{Ada := {AdaPid, _}}}, sys:get_state(Z21)),
         ?assert(received_entity(Ada, ~"npc271"))
     after
-        exit(AdaPid, kill),
+        asobi_test_helpers:release_session(Ada, AdaPid),
         stop_world(Ctx)
     end.
 
@@ -690,7 +690,7 @@ script_spawn_into_a_lazily_created_zone_backfills_neighbours() ->
         {ok, Z21} = asobi_zone_manager:get_zone(Mgr, {2, 1}),
         ?assertMatch(#{subscribers := #{Ada := {AdaPid, _}}}, sys:get_state(Z21))
     after
-        exit(AdaPid, kill),
+        asobi_test_helpers:release_session(Ada, AdaPid),
         stop_world(Ctx)
     end.
 
@@ -761,8 +761,8 @@ crossing_out_of_ring_removes_stationary_neighbour() ->
         ?assertEqual(1, asobi_zone:get_subscriber_count(Z11)),
         ?assert(received_removal(Bob, Ada))
     after
-        exit(AdaPid, kill),
-        exit(BobPid, kill),
+        asobi_test_helpers:release_session(Ada, AdaPid),
+        asobi_test_helpers:release_session(Bob, BobPid),
         stop_world(Ctx)
     end.
 

--- a/test/asobi_world_zone_integration_tests.erl
+++ b/test/asobi_world_zone_integration_tests.erl
@@ -457,7 +457,7 @@ world_input_crossing_touches_only_ring_delta() ->
     %% the module was run on its own. Hence the distinctive id: `p1` is what
     %% made it borrowable.
     Player = ~"ring275_p1",
-    SessionPid = fake_session(Player, self()),
+    SessionPid = asobi_test_helpers:fake_session(Player, self()),
     %% The session and the world are released by the outer `after`, so it has
     %% to open BEFORE the join and the asserts below - the first of which is
     %% the one this test used to fail on. Releasing them only from a block the
@@ -531,24 +531,6 @@ count_messages(Tag) ->
     after 0 -> 0
     end.
 
-%% A live, pg-registered session for a player, so find_player_pid/1 and
-%% backfill_zone_subscribers/4 (both pg-based) resolve to a real process
-%% instead of silently falling through to not_loaded/self()-fallback
-%% behaviour. Forwards every asobi_message to Owner so a test can assert on
-%% actual delivery, not just zone subscriber-map bookkeeping.
-fake_session(PlayerId, Owner) ->
-    Pid = spawn(fun Loop() ->
-        receive
-            stop ->
-                ok;
-            Msg ->
-                Owner ! {PlayerId, Msg},
-                Loop()
-        end
-    end),
-    ok = pg:join(nova_scope, {player, PlayerId}, Pid),
-    Pid.
-
 %% Blocks until PlayerId's forwarded messages mention EntityId in ANY of the
 %% three world.tick carriers, or the timeout elapses.
 %%
@@ -607,8 +589,8 @@ crossing_into_a_lazily_created_zone_backfills_stationary_neighbours() ->
         }),
     Ada = ~"bf275_ada",
     Bob = ~"bf275_bob",
-    AdaPid = fake_session(Ada, self()),
-    BobPid = fake_session(Bob, self()),
+    AdaPid = asobi_test_helpers:fake_session(Ada, self()),
+    BobPid = asobi_test_helpers:fake_session(Bob, self()),
     try
         %% Ada joins and stays put. Spawns at {100.0,100.0} => zone {1,1};
         %% with view_radius=1 that ring already covers {2,1} - but {2,1} is
@@ -658,7 +640,7 @@ npc_crossing_into_an_unloaded_zone_creates_it_and_backfills() ->
             lazy_zones => true, grid_size => 5
         }),
     Ada = ~"npc271_ada",
-    AdaPid = fake_session(Ada, self()),
+    AdaPid = asobi_test_helpers:fake_session(Ada, self()),
     try
         %% Ada joins at {100.0,100.0} => zone {1,1}; {2,1} is in her ring but
         %% not loaded, so her ring-subscribe to it no-ops.
@@ -694,7 +676,7 @@ script_spawn_into_a_lazily_created_zone_backfills_neighbours() ->
             lazy_zones => true, grid_size => 5
         }),
     Ada = ~"bf275_spawn_ada",
-    AdaPid = fake_session(Ada, self()),
+    AdaPid = asobi_test_helpers:fake_session(Ada, self()),
     try
         ?assertEqual(ok, asobi_world_server:join(Pid, Ada)),
         timer:sleep(20),
@@ -757,8 +739,8 @@ crossing_out_of_ring_removes_stationary_neighbour() ->
         }),
     Ada = ~"leave_ring_ada",
     Bob = ~"leave_ring_bob",
-    AdaPid = fake_session(Ada, self()),
-    BobPid = fake_session(Bob, self()),
+    AdaPid = asobi_test_helpers:fake_session(Ada, self()),
+    BobPid = asobi_test_helpers:fake_session(Bob, self()),
     try
         %% Both spawn at {100.0, 100.0} => zone {1,1}.
         ?assertEqual(ok, asobi_world_server:join(Pid, Ada)),

--- a/test/prop_chat_zone_routing.erl
+++ b/test/prop_chat_zone_routing.erl
@@ -237,13 +237,20 @@ positions_with_neighbors(Positions) ->
 ensure_listeners(Players, WorldId) ->
     %% One spawned process per player, registered in pg as the player's session.
     %% The world_chat module subscribes the pg-registered pid to channels.
-    maps:from_list([{P, ensure_listener(P, WorldId)} || P <- Players]).
+    _ = WorldId,
+    maps:from_list([{P, asobi_test_helpers:fake_session(P)} || P <- Players]).
 
-ensure_listener(P, _WorldId) ->
-    asobi_test_helpers:fake_session(P).
-
+%% `release_session/2` rather than `exit/2`: these ids are unnamespaced and the
+%% next PropEr iteration re-joins them, so a killed pid still sitting in the
+%% group is one the world can resolve. pg:leave/3 is synchronous.
 cleanup_listeners(Listeners) ->
-    maps:foreach(fun(_, Pid) -> catch exit(Pid, kill) end, Listeners),
+    maps:foreach(fun release_one/2, Listeners),
+    ok.
+
+-spec release_one(term(), term()) -> ok.
+release_one(PlayerId, Pid) when is_binary(PlayerId), is_pid(Pid) ->
+    asobi_test_helpers:release_session(PlayerId, Pid);
+release_one(_PlayerId, _Pid) ->
     ok.
 
 -spec narrow_list(term()) -> [term()].

--- a/test/prop_chat_zone_routing.erl
+++ b/test/prop_chat_zone_routing.erl
@@ -240,14 +240,7 @@ ensure_listeners(Players, WorldId) ->
     maps:from_list([{P, ensure_listener(P, WorldId)} || P <- Players]).
 
 ensure_listener(P, _WorldId) ->
-    Pid = spawn(fun L() ->
-        receive
-            stop -> ok;
-            _ -> L()
-        end
-    end),
-    ok = pg:join(nova_scope, {player, P}, Pid),
-    Pid.
+    asobi_test_helpers:fake_session(P).
 
 cleanup_listeners(Listeners) ->
     maps:foreach(fun(_, Pid) -> catch exit(Pid, kill) end, Listeners),

--- a/test/prop_reconnect_lifecycle.erl
+++ b/test/prop_reconnect_lifecycle.erl
@@ -125,7 +125,7 @@ step({join, P}, #{world_pid := Pid}, #{joined := J, sessions := Ss} = S) ->
         true ->
             S;
         false ->
-            SessionPid = fake_session(P),
+            SessionPid = asobi_test_helpers:fake_session(P),
             case asobi_world_server:join(Pid, P) of
                 ok ->
                     S#{
@@ -149,7 +149,7 @@ step({disconnect, P}, _Ctx, #{joined := J, sessions := Ss} = S) ->
 step({reconnect, P}, #{world_pid := Pid}, #{joined := J, sessions := Ss} = S) ->
     case sets:is_element(P, J) andalso not maps:is_key(P, Ss) of
         true ->
-            SessionPid = fake_session(P),
+            SessionPid = asobi_test_helpers:fake_session(P),
             case asobi_world_server:reconnect(Pid, P) of
                 ok ->
                     S#{sessions => Ss#{P => SessionPid}};
@@ -204,16 +204,6 @@ start_world() ->
     timer:sleep(40),
     ServerPid = asobi_world_instance:get_child(InstancePid, asobi_world_server),
     #{instance_pid => InstancePid, world_pid => ServerPid}.
-
-fake_session(PlayerId) ->
-    Pid = spawn(fun L() ->
-        receive
-            stop -> ok;
-            _ -> L()
-        end
-    end),
-    ok = pg:join(nova_scope, {player, PlayerId}, Pid),
-    Pid.
 
 -spec narrow_list(term()) -> [term()].
 narrow_list(L) when is_list(L) -> L.

--- a/test/prop_reconnect_lifecycle.erl
+++ b/test/prop_reconnect_lifecycle.erl
@@ -111,8 +111,29 @@ player_id() ->
 run_iteration(Ctx, Cmds) ->
     cleanup_world(Ctx),
     Final = lists:foldl(fun(C, S) -> step(C, Ctx, S) end, init_state(), Cmds),
-    timer:sleep(20),
-    check(Ctx, Final).
+    try
+        timer:sleep(20),
+        check(Ctx, Final)
+    after
+        %% The player ids are drawn from a fixed set of five, so a session left
+        %% alive here is still registered when the NEXT iteration joins the
+        %% same id - and `find_player_pid/1` takes the head of the group, so
+        %% the world would monitor a session this test no longer controls.
+        %% Nothing in `check/2` would notice: it compares player_count against
+        %% the model, and a disconnected player stays joined during grace.
+        release_sessions(Final)
+    end.
+
+%% `lists:foldl/3` erases the accumulator, so the model comes back `term()`.
+-spec release_sessions(term()) -> ok.
+release_sessions(#{sessions := Sessions}) when is_map(Sessions) ->
+    maps:foreach(fun release_one/2, Sessions).
+
+-spec release_one(term(), term()) -> ok.
+release_one(PlayerId, Pid) when is_binary(PlayerId), is_pid(Pid) ->
+    asobi_test_helpers:release_session(PlayerId, Pid);
+release_one(_PlayerId, _Pid) ->
+    ok.
 
 init_state() ->
     %% joined = players currently expected to be in the world (whether


### PR DESCRIPTION
`world_input_crossing_touches_only_ring_delta/0` passed in a full eunit run and failed whenever the module was run on its own. That is the worse way round of the two: it was green for a reason that had nothing to do with the ring diff it exists to prove.

## Cause

`subscribe_interest_zones/4` resolves a player through `find_player_pid/1`, which reads `pg:get_members(nova_scope, {player, PlayerId})`. The test joined `p1` without registering anything under that key, so the pid came back `undefined`, `asobi_world_server` skipped the subscribe entirely (`asobi_world_server.erl:1056-1059`), and every subscriber count in the test was 0.

In a full run it found a live process **another module** had left registered under `{player, <<"p1">>}` in the shared `nova_scope`, and passed on that.

## Fix

The module already has `fake_session/2` for exactly this, and its own documentation says so - "a live, pg-registered session for a player, so `find_player_pid/1` ... resolve to a real process instead of silently falling through". Six other tests in the module use it. This one now does too, with a distinctive player id, since `p1` is what made it borrowable in the first place.

## Verification

By substitution rather than by the test simply going green: swapping the pg-registered session for a plain unregistered process reproduces the original failure exactly (`expected: 1, got: 0`). The assertion is now carried by the subscribe path rather than by whatever else happens to be running.

Also narrows two `sys:get_state/1` reads in the same module - they are `term()`, and touching the module brings it into CI's `EQW_SCOPE=diff` gate, which requires zero errors in every module a PR touches. `eqwalize-all`: 195, from 197.

## Checks

`fmt --check`, `xref`, `dialyzer`, `elp lint` (no new findings), eunit **2,398/0**, CT **390/0**, and the module now passes standalone.

Found during the review gate on #566.


---

## Second commit: fix the mechanism, not just this test

`nova_scope` is shared by every module in a run and `{player, Id}` is not namespaced, so a registration that outlives its test is lent to any later test using the same id. That has now cost two silent wrong-reason passes, so the second commit fixes the mechanism.

`fake_session/1,2` was hand-copied into four modules in two variants that differed only in whether they forwarded messages. It now lives in `asobi_test_helpers`, alongside:

- **`unique_session/1`**, deriving the id from `unique_id/1`. A distinctive id works only until someone else picks it - the same guarantee `p1` had.
- **`assert_no_session/1`**, for tests that want the session-*less* path. Without it a leftover registration silently turns such a test into a different one, which is how this class stayed hidden.

**The donor.** `asobi_world_chat_tests` registers `self()` - the eunit runner, alive for the whole run - under `{player, <<"p1">>}` in seven tests, with the `pg:leave` as a trailing call rather than an `after`. Those tests assert in the middle, so a failing assertion skipped the leave and stranded the runner in the group for the rest of the run. `with_registered_player/1` makes the pairing unconditional.

`asobi_match_server_tests` had two sessions spawned and never killed at all; both now released in an `after`.

Also narrows two `sys:get_state/1` reads in `asobi_world_server_tests`, since CI eqwalizes every module a PR touches. `eqwalize-all`: **193**, from 212 on main.

**eunit 2,398/0, CT 390/0.**

## Gate

Architecture guardian: **ACCEPT**, and it caught a real flaw in the first commit - the session and world were released only from a block the failing assertion jumped over, recreating the leak class on the failure path. Fixed in `80b1229`.

Security reviewer: the diff is clean; it found the production defect underneath, now fixed separately in #569.

**A correction to an earlier version of this description.** It said the donor was `asobi_world_chat_tests` and that the guardian had misattributed it. That is backwards. Every `unregister_player()` in the chat module was paired, so a green run left nothing behind - what that module had was the *failure* path. The donor was `asobi_match_server_tests`, which had two `_`-prefixed sessions on `p1` and killed neither, permanently registered, in a module that sorts first. The guardian had it right; the security review did not, and this description repeated the security review.

Code reviewer: found that the helper five modules now depend on had no tests - and that `who/1` had already regressed inside this PR, caught by review rather than by a test. Also that `release_session/2` had no callers outside `with_session/3`, and that `prop_reconnect_lifecycle` was accumulating up to ~125 registered sessions per run. All worked in the final commit.
