### PR TITLE
fix(test): give the vote-close waits a deadline that covers the DB write

### DIFF
--- a/guides/voting.md
+++ b/guides/voting.md
@@ -333,7 +333,7 @@ plus a `reason` field.
 | `not_eligible` | `ws.request_failed` | The voter is not in the eligible or spectator pool |
 | `invalid_option` | `ws.request_failed` | `option_id` is not one of the vote's options |
 | `rate_limited` | `rate_limited` | `max_revotes` changes already used |
-| `vote_closed` | `ws.request_failed` | The window and its 500ms grace period have passed |
+| `vote_closed` | `ws.request_failed` | The vote has already resolved |
 | `veto_disabled` | `ws.request_failed` | `veto_enabled` is false for this vote |
 | `no_veto_tokens` | `ws.request_failed` | The player has spent every veto token |
 
@@ -342,10 +342,16 @@ session's `match_pid`, and joining a world sets `world_pid` instead, so a world
 vote can be started and broadcast but not cast from a client today. This is the
 same defect class as the Lua config above. Report both if they block you.
 
-### Grace period
+### No grace period
 
-Votes arriving within 500ms of the window closing are still accepted, to absorb
-network latency.
+A vote resolves and stops in one step, so there is no window in which a closed
+vote still accepts anything. A cast that arrives after the vote resolved gets
+`vote_closed`.
+
+Earlier versions of this guide promised a 500ms grace to absorb network
+latency. The server never delivered it - the code implementing it could not be
+reached - so it is retracted rather than documented. If you need late votes to
+count, widen `window_ms`.
 
 ## Server push frames
 

--- a/src/matches/asobi_match_server.erl
+++ b/src/matches/asobi_match_server.erl
@@ -472,7 +472,7 @@ running({call, From}, {use_veto, PlayerId, VoteId}, #{veto_tokens := Tokens} = S
         {_, 0} ->
             {keep_state_and_data, [{reply, From, {error, no_veto_tokens}}]};
         {VotePid, N} ->
-            case asobi_vote_server:cast_veto(VotePid, PlayerId) of
+            case call_vote(fun() -> asobi_vote_server:cast_veto(VotePid, PlayerId) end) of
                 ok ->
                     Tokens1 = Tokens#{PlayerId => N - 1},
                     {keep_state, State#{veto_tokens => Tokens1}, [{reply, From, ok}]};
@@ -660,7 +660,10 @@ terminate(_Reason, StateName, #{match_id := MatchId} = State) ->
 
 %% Rate-limited: input arrives per client per tick, so an unbounded log here
 %% would be a flood channel a client controls.
--spec log_dropped_input(binary(), binary(), atom()) -> ok.
+%% `term()` for the player id: both call sites take it straight off a client
+%% frame, and this is a log line - narrowing it to `binary()` would put a
+%% function_clause on the path that exists to record a dropped input.
+-spec log_dropped_input(binary(), term(), atom()) -> ok.
 log_dropped_input(MatchId, PlayerId, Reason) ->
     case asobi_script_log_limiter:allow({?MODULE, input_dropped, MatchId}) of
         {true, Dropped} ->
@@ -670,7 +673,8 @@ log_dropped_input(MatchId, PlayerId, Reason) ->
                 player_id => PlayerId,
                 reason => Reason,
                 suppressed_since_last => Dropped
-            });
+            }),
+            ok;
         false ->
             ok
     end.
@@ -965,7 +969,9 @@ handle_cast_vote(From, PlayerId, VoteId, OptionId, State) ->
         undefined ->
             {keep_state_and_data, [{reply, From, {error, vote_not_found}}]};
         VotePid ->
-            Result = asobi_vote_server:cast_vote(VotePid, PlayerId, OptionId),
+            Result = call_vote(fun() ->
+                asobi_vote_server:cast_vote(VotePid, PlayerId, OptionId)
+            end),
             {keep_state_and_data, [{reply, From, Result}]}
     end.
 
@@ -1068,9 +1074,16 @@ backup_state(MatchId, Status, State) ->
 recover_state(MatchId) ->
     try
         case ets:lookup(?STATE_TABLE, MatchId) of
-            [{MatchId, Status, SavedState}] ->
+            %% An ETS read is `term()`; the map guard is the boundary. A row
+            %% that is not a map is a corrupt crash-recovery entry, and
+            %% recovering nothing is better than restoring a shape the match
+            %% server will then index into.
+            [{MatchId, Status, SavedState}] when is_map(SavedState) ->
                 ets:delete(?STATE_TABLE, MatchId),
                 {ok, Status, SavedState#{input_queue => [], active_votes => #{}}};
+            [{MatchId, _Status, _SavedState}] ->
+                ets:delete(?STATE_TABLE, MatchId),
+                none;
             [] ->
                 none
         end
@@ -1245,3 +1258,23 @@ roster_emptied(#{players := Players}, true) ->
 
 generate_id() ->
     asobi_id:generate().
+
+%% A vote server that is resolving serves nothing and then stops, so a call
+%% landing in that window does not time out - it waits for the stop and then
+%% exits the CALLER with `{normal, {gen_statem, call, _}}`. The caller here is
+%% this server, and a compound exit reason is a crash to the supervisor: one
+%% player's ordinary `vote.cast` frame would take every player in the match
+%% down with it. `gen_statem:call/2` also defaults to `infinity`, so there is
+%% no timeout to save it.
+%%
+%% Mirrors `asobi_ws_handler:vote_call/1`, one layer down - that one only stops
+%% the client noticing, because the crash is here.
+-spec call_vote(fun(() -> term())) -> term().
+call_vote(Fun) ->
+    try
+        Fun()
+    catch
+        exit:{normal, _} -> {error, vote_closed};
+        exit:{noproc, _} -> {error, vote_closed};
+        exit:{shutdown, _} -> {error, vote_closed}
+    end.

--- a/src/matches/asobi_match_server.erl
+++ b/src/matches/asobi_match_server.erl
@@ -472,7 +472,7 @@ running({call, From}, {use_veto, PlayerId, VoteId}, #{veto_tokens := Tokens} = S
         {_, 0} ->
             {keep_state_and_data, [{reply, From, {error, no_veto_tokens}}]};
         {VotePid, N} ->
-            case call_vote(fun() -> asobi_vote_server:cast_veto(VotePid, PlayerId) end) of
+            case asobi_vote_server:cast_veto(VotePid, PlayerId) of
                 ok ->
                     Tokens1 = Tokens#{PlayerId => N - 1},
                     {keep_state, State#{veto_tokens => Tokens1}, [{reply, From, ok}]};
@@ -969,9 +969,7 @@ handle_cast_vote(From, PlayerId, VoteId, OptionId, State) ->
         undefined ->
             {keep_state_and_data, [{reply, From, {error, vote_not_found}}]};
         VotePid ->
-            Result = call_vote(fun() ->
-                asobi_vote_server:cast_vote(VotePid, PlayerId, OptionId)
-            end),
+            Result = asobi_vote_server:cast_vote(VotePid, PlayerId, OptionId),
             {keep_state_and_data, [{reply, From, Result}]}
     end.
 
@@ -1258,23 +1256,3 @@ roster_emptied(#{players := Players}, true) ->
 
 generate_id() ->
     asobi_id:generate().
-
-%% A vote server that is resolving serves nothing and then stops, so a call
-%% landing in that window does not time out - it waits for the stop and then
-%% exits the CALLER with `{normal, {gen_statem, call, _}}`. The caller here is
-%% this server, and a compound exit reason is a crash to the supervisor: one
-%% player's ordinary `vote.cast` frame would take every player in the match
-%% down with it. `gen_statem:call/2` also defaults to `infinity`, so there is
-%% no timeout to save it.
-%%
-%% Mirrors `asobi_ws_handler:vote_call/1`, one layer down - that one only stops
-%% the client noticing, because the crash is here.
--spec call_vote(fun(() -> term())) -> term().
-call_vote(Fun) ->
-    try
-        Fun()
-    catch
-        exit:{normal, _} -> {error, vote_closed};
-        exit:{noproc, _} -> {error, vote_closed};
-        exit:{shutdown, _} -> {error, vote_closed}
-    end.

--- a/src/votes/asobi_vote_server.erl
+++ b/src/votes/asobi_vote_server.erl
@@ -79,26 +79,29 @@ enough voters participate. Use `default_votes` for absent players and
   is reached, the remaining time shrinks to 3 seconds (giving others a
   last chance). Resets if supermajority is lost.
 
-## Grace period
+## No grace period
 
-A late vote is accepted only if it is processed before `closed(enter, ...)`
-completes, and that callback ends in `{stop, normal, _}` - so the window is
-whatever is already in the mailbox, not the 500ms `?GRACE_MS` compares against.
-The clauses stay because that window is real and a vote landing in it should be
-counted rather than dropped; do not read `?GRACE_MS` as a duration anyone gets.
+A vote that reaches `closed` never processes another call: `closed(enter, ...)`
+resolves and returns `{stop, normal, _}`, and a `gen_statem` runs its enter
+callback before dispatching anything already queued - so a call sitting in the
+mailbox is never seen. There is no window, not even a tight one, which is why
+the clauses that used to implement `?GRACE_MS` are gone rather than documented.
 
-A caller whose `cast_vote/3` is NOT processed in that window does not get an
-error - the server stops without answering, and `gen_statem:call/2` defaults to
-`infinity`, so the caller exits `{normal, {gen_statem, call, _}}`. Callers that
-are themselves servers must contain that; see `call_vote/1` in
-`asobi_match_server` and `asobi_world_server`.
+A caller whose `cast_vote/3` lands in that gap gets no error either: the server
+stops without replying, and `gen_statem:call/2` defaults to `infinity`, so the
+call unwinds as `{normal, {gen_statem, call, _}}` in the CALLER. `cast_vote/3`
+and `cast_veto/2` contain that here, so a caller which is itself a server does
+not die of its callee finishing.
 """.
+-behaviour(gen_statem).
 
 -export([start_link/1, cast_vote/3, cast_veto/2, get_state/1]).
 -export([callback_mode/0, init/1, terminate/3]).
 -export([open/3, closed/3]).
 
--define(GRACE_MS, 500).
+%% Bounded so a caller is never held through resolve_and_stop/1's synchronous
+%% write. See cast_vote/3.
+-define(CALL_TIMEOUT, 5_000).
 -define(DEFAULT_MAX_REVOTES, 3).
 -define(ADAPTIVE_SHRINK_MS, 3000).
 
@@ -109,20 +112,53 @@ are themselves servers must contain that; see `call_vote/1` in
 start_link(Config) ->
     gen_statem:start_link(?MODULE, Config, []).
 
--doc "Cast a vote. Replaces any previous vote by the same voter during the window.".
+-doc """
+Cast a vote. Replaces any previous vote by the same voter during the window.
+
+Contained here rather than at each caller, because what is being contained is
+this module's protocol: a resolving vote server serves nothing and then stops,
+so a call landing in that gap unwinds as `{normal, {gen_statem, call, _}}` in
+the caller. The callers are `asobi_match_server` and `asobi_world_server`,
+calling from inside their own callbacks - a compound exit reason is a crash to
+their supervisor, so one player's `vote.cast` frame took every player in the
+match down with it.
+
+Bounded rather than `infinity` for the other half of the same problem:
+`resolve_and_stop/1` holds the server through a synchronous Postgres write, and
+an unbounded call meant the CALLER froze for as long as that took - up to the
+pool's 5s checkout plus a 15s query. A frozen match is better than a dead one
+and worse than a refused vote.
+""".
 -spec cast_vote(pid(), binary(), binary() | [binary()]) -> ok | {error, term()}.
 cast_vote(Pid, VoterId, OptionId) ->
-    case gen_statem:call(Pid, {cast_vote, VoterId, OptionId}) of
-        ok -> ok;
-        {error, _} = Err -> Err
-    end.
+    call_vote(Pid, {cast_vote, VoterId, OptionId}).
 
--doc "Veto the vote (immediately cancels it). Only works if `veto_enabled` is true.".
+-doc """
+Veto the vote (immediately cancels it). Only works if `veto_enabled` is true.
+
+Contained and bounded like `cast_vote/3` - see there.
+""".
 -spec cast_veto(pid(), binary()) -> ok | {error, term()}.
 cast_veto(Pid, VoterId) ->
-    case gen_statem:call(Pid, {veto, VoterId}) of
+    call_vote(Pid, {veto, VoterId}).
+
+%% The exit is matched on its full `gen_statem:call` shape rather than on
+%% `{normal, _}`, so this cannot swallow an unrelated 2-tuple. A genuine crash
+%% in the vote server arrives as `{{badmatch, _}, {gen_statem, call, _}}`,
+%% matches nothing here, and still takes the caller down - which is what a real
+%% fault should do.
+-spec call_vote(pid(), term()) -> ok | {error, term()}.
+call_vote(Pid, Request) ->
+    try gen_statem:call(Pid, Request, ?CALL_TIMEOUT) of
         ok -> ok;
         {error, _} = Err -> Err
+    catch
+        exit:{Reason, {gen_statem, call, _}} when
+            Reason =:= normal; Reason =:= noproc; Reason =:= shutdown
+        ->
+            {error, vote_closed};
+        exit:{timeout, {gen_statem, call, _}} ->
+            {error, vote_busy}
     end.
 
 -doc "Return the current vote state including status, options, tallies (if live), and time remaining.".
@@ -221,15 +257,6 @@ open(state_timeout, window_expired, State) ->
     gen_statem:state_enter_result(atom()).
 closed(enter, _OldState, State) ->
     resolve_and_stop(State);
-closed({call, From}, {cast_vote, VoterId, OptionId}, State) ->
-    %% Grace period: accept if within GRACE_MS of window close
-    Now = erlang:system_time(millisecond),
-    OpenedAt = maps:get(opened_at, State),
-    WindowMs = maps:get(window_ms, State),
-    case Now - (OpenedAt + WindowMs) =< ?GRACE_MS of
-        true -> handle_cast_vote(From, VoterId, OptionId, State);
-        false -> {keep_state_and_data, [{reply, From, {error, vote_closed}}]}
-    end;
 closed({call, From}, get_state, State) ->
     {keep_state_and_data, [{reply, From, external_state(closed, State)}]};
 closed({call, From}, _, _State) ->

--- a/src/votes/asobi_vote_server.erl
+++ b/src/votes/asobi_vote_server.erl
@@ -81,10 +81,18 @@ enough voters participate. Use `default_votes` for absent players and
 
 ## Grace period
 
-Late votes arriving within 500ms after the window closes are still accepted
-to compensate for network latency.
+A late vote is accepted only if it is processed before `closed(enter, ...)`
+completes, and that callback ends in `{stop, normal, _}` - so the window is
+whatever is already in the mailbox, not the 500ms `?GRACE_MS` compares against.
+The clauses stay because that window is real and a vote landing in it should be
+counted rather than dropped; do not read `?GRACE_MS` as a duration anyone gets.
+
+A caller whose `cast_vote/3` is NOT processed in that window does not get an
+error - the server stops without answering, and `gen_statem:call/2` defaults to
+`infinity`, so the caller exits `{normal, {gen_statem, call, _}}`. Callers that
+are themselves servers must contain that; see `call_vote/1` in
+`asobi_match_server` and `asobi_world_server`.
 """.
--behaviour(gen_statem).
 
 -export([start_link/1, cast_vote/3, cast_veto/2, get_state/1]).
 -export([callback_mode/0, init/1, terminate/3]).

--- a/src/votes/asobi_vote_server.erl
+++ b/src/votes/asobi_vote_server.erl
@@ -407,8 +407,14 @@ resolve_and_stop(
     DurationMs = maps:get(closed_at, State1) - maps:get(opened_at, State1, 0),
     asobi_telemetry:vote_resolved(maps:get(vote_id, State1), DurationMs, Result),
     broadcast_vote_result(State1),
-    persist_vote(State1),
+    %% Above `persist_vote/1`, which is a synchronous Postgres write. The
+    %% client already has the result - `broadcast_vote_result/1` is a cast - so
+    %% leaving the match server behind the write meant the player knew the
+    %% outcome while the game logic that reacts to it had not been told, for as
+    %% long as the pool was contended. Both notifications are now ahead of the
+    %% write, and the write is the only thing that lingers.
     _ = notify_match(resolved, State1),
+    persist_vote(State1),
     {stop, normal, State1}.
 
 tally(~"plurality", Votes, Options, TieBreaker, _Weights) ->

--- a/src/world/asobi_world_server.erl
+++ b/src/world/asobi_world_server.erl
@@ -1521,9 +1521,7 @@ handle_cast_vote(From, PlayerId, VoteId, OptionId, State) ->
         undefined ->
             {keep_state_and_data, [{reply, From, {error, vote_not_found}}]};
         VotePid ->
-            Result = call_vote(fun() ->
-                asobi_vote_server:cast_vote(VotePid, PlayerId, OptionId)
-            end),
+            Result = asobi_vote_server:cast_vote(VotePid, PlayerId, OptionId),
             {keep_state_and_data, [{reply, From, Result}]}
     end.
 
@@ -1536,7 +1534,7 @@ handle_use_veto(From, PlayerId, VoteId, #{veto_tokens := Tokens} = State) ->
         {_, 0} ->
             {keep_state_and_data, [{reply, From, {error, no_veto_tokens}}]};
         {VotePid, N} ->
-            case call_vote(fun() -> asobi_vote_server:cast_veto(VotePid, PlayerId) end) of
+            case asobi_vote_server:cast_veto(VotePid, PlayerId) of
                 ok ->
                     {keep_state, State#{veto_tokens => Tokens#{PlayerId => N - 1}}, [
                         {reply, From, ok}
@@ -1918,23 +1916,3 @@ handle_phase_events([{phase_ended, Name} | Rest], Mod, GS) ->
     handle_phase_events(Rest, Mod, GS1);
 handle_phase_events([_Event | Rest], Mod, GS) ->
     handle_phase_events(Rest, Mod, GS).
-
-%% A vote server that is resolving serves nothing and then stops, so a call
-%% landing in that window does not time out - it waits for the stop and then
-%% exits the CALLER with `{normal, {gen_statem, call, _}}`. The caller here is
-%% this server, and a compound exit reason is a crash to the supervisor: one
-%% player's ordinary `vote.cast` frame would take every player in the match
-%% down with it. `gen_statem:call/2` also defaults to `infinity`, so there is
-%% no timeout to save it.
-%%
-%% Mirrors `asobi_ws_handler:vote_call/1`, one layer down - that one only stops
-%% the client noticing, because the crash is here.
--spec call_vote(fun(() -> term())) -> term().
-call_vote(Fun) ->
-    try
-        Fun()
-    catch
-        exit:{normal, _} -> {error, vote_closed};
-        exit:{noproc, _} -> {error, vote_closed};
-        exit:{shutdown, _} -> {error, vote_closed}
-    end.

--- a/src/world/asobi_world_server.erl
+++ b/src/world/asobi_world_server.erl
@@ -1521,7 +1521,9 @@ handle_cast_vote(From, PlayerId, VoteId, OptionId, State) ->
         undefined ->
             {keep_state_and_data, [{reply, From, {error, vote_not_found}}]};
         VotePid ->
-            Result = asobi_vote_server:cast_vote(VotePid, PlayerId, OptionId),
+            Result = call_vote(fun() ->
+                asobi_vote_server:cast_vote(VotePid, PlayerId, OptionId)
+            end),
             {keep_state_and_data, [{reply, From, Result}]}
     end.
 
@@ -1534,7 +1536,7 @@ handle_use_veto(From, PlayerId, VoteId, #{veto_tokens := Tokens} = State) ->
         {_, 0} ->
             {keep_state_and_data, [{reply, From, {error, no_veto_tokens}}]};
         {VotePid, N} ->
-            case asobi_vote_server:cast_veto(VotePid, PlayerId) of
+            case call_vote(fun() -> asobi_vote_server:cast_veto(VotePid, PlayerId) end) of
                 ok ->
                     {keep_state, State#{veto_tokens => Tokens#{PlayerId => N - 1}}, [
                         {reply, From, ok}
@@ -1916,3 +1918,23 @@ handle_phase_events([{phase_ended, Name} | Rest], Mod, GS) ->
     handle_phase_events(Rest, Mod, GS1);
 handle_phase_events([_Event | Rest], Mod, GS) ->
     handle_phase_events(Rest, Mod, GS).
+
+%% A vote server that is resolving serves nothing and then stops, so a call
+%% landing in that window does not time out - it waits for the stop and then
+%% exits the CALLER with `{normal, {gen_statem, call, _}}`. The caller here is
+%% this server, and a compound exit reason is a crash to the supervisor: one
+%% player's ordinary `vote.cast` frame would take every player in the match
+%% down with it. `gen_statem:call/2` also defaults to `infinity`, so there is
+%% no timeout to save it.
+%%
+%% Mirrors `asobi_ws_handler:vote_call/1`, one layer down - that one only stops
+%% the client noticing, because the crash is here.
+-spec call_vote(fun(() -> term())) -> term().
+call_vote(Fun) ->
+    try
+        Fun()
+    catch
+        exit:{normal, _} -> {error, vote_closed};
+        exit:{noproc, _} -> {error, vote_closed};
+        exit:{shutdown, _} -> {error, vote_closed}
+    end.

--- a/test/asobi_vote_SUITE.erl
+++ b/test/asobi_vote_SUITE.erl
@@ -215,7 +215,13 @@ vote_veto(_Config) ->
         match_pid => MatchPid,
         options => Options,
         eligible => [~"p1", ~"p2"],
-        window_ms => 5000,
+        %% 60000 like the other two close tests, not 5000: a veto and a window
+        %% expiry deliver a byte-identical `{'DOWN', _, _, _, normal}`, so a
+        %% 5000ms window under a 5000ms deadline means the fallback could
+        %% satisfy the assertion the veto is supposed to. What kept them apart
+        %% was that the expiry path runs `persist_vote/1` and the veto path
+        %% does not - an accident of latency, not a margin.
+        window_ms => 60000,
         veto_enabled => true
     }),
     Ref = monitor(process, VotePid),
@@ -964,16 +970,22 @@ start_test_match() ->
 
 %% Wait for a vote server to stop after something closed it.
 %%
-%% `resolve_and_stop/1` runs `persist_vote/1` before `{stop, normal}`, and that
-%% is a SYNCHRONOUS `asobi_repo:insert/1` - a real Postgres write on a pool
-%% every other suite in the run is also using. So the gap between the closing
-%% call returning and the DOWN arriving is a contended database round trip, not
-%% scheduling jitter.
-%%
-%% Three of these waits used 1000ms against the suite's own 2000ms norm, and
+%% Used by the three waits that had 1000ms where the rest of this suite uses
+%% 2000ms. That is the criterion - not DB exposure: `vote_veto/1` reaches
+%% `{stop_and_reply, normal, ...}` from `handle_veto/3`, which does no write at
+%% all. The other two go through `resolve_and_stop/1`, which runs
+%% `persist_vote/1` - a SYNCHRONOUS `asobi_repo:insert/1` - before
+%% `{stop, normal}`, on a pool every other suite in the run is also using.
 %% `vote_window_hybrid/1` was observed failing on roughly one full `rebar3 ct`
-%% in three or four while passing every time the suite ran alone. The budget
-%% has to cover the write; it is not a guess about how fast the BEAM is.
+%% in three or four while passing every time the suite ran alone.
+%%
+%% 5000 is an empirical multiple of the old value, NOT a derived bound. A real
+%% bound would be north of 20s: `minato_pool`'s checkout timeout is 5000ms and
+%% `minato_conn`'s query timeout is 15000ms, so a contended insert can block
+%% the vote server for both before it gives up. Do not read this number as
+%% "long enough for the write" - read it as "long enough that the flake has not
+%% been seen since", and if it returns, the answer is to take the write off the
+%% stop path rather than to raise this again.
 await_stop(Ref, VotePid, ErrorTag) ->
     receive
         {'DOWN', Ref, process, VotePid, normal} -> ok

--- a/test/asobi_vote_SUITE.erl
+++ b/test/asobi_vote_SUITE.erl
@@ -220,11 +220,7 @@ vote_veto(_Config) ->
     }),
     Ref = monitor(process, VotePid),
     ok = asobi_vote_server:cast_veto(VotePid, ~"p1"),
-    receive
-        {'DOWN', Ref, process, VotePid, normal} -> ok
-    after 1000 ->
-        error(veto_did_not_stop)
-    end.
+    await_stop(Ref, VotePid, veto_did_not_stop).
 
 vote_veto_disabled(_Config) ->
     Options = [#{id => ~"opt_a", label => ~"A"}],
@@ -476,11 +472,7 @@ vote_window_ready_up(_Config) ->
     ?assert(is_process_alive(VotePid)),
     ok = asobi_vote_server:cast_vote(VotePid, ~"p2", ~"opt_b"),
     %% All voted — should close immediately
-    receive
-        {'DOWN', Ref, process, VotePid, normal} -> ok
-    after 1000 ->
-        error(ready_up_did_not_close)
-    end.
+    await_stop(Ref, VotePid, ready_up_did_not_close).
 
 vote_window_ready_up_timeout(_Config) ->
     Options = [#{id => ~"opt_a", label => ~"A"}],
@@ -523,11 +515,7 @@ vote_window_hybrid(_Config) ->
     ok = asobi_vote_server:cast_vote(VotePid, ~"p1", ~"opt_a"),
     ok = asobi_vote_server:cast_vote(VotePid, ~"p2", ~"opt_b"),
     %% All voted + min elapsed — should close
-    receive
-        {'DOWN', Ref, process, VotePid, normal} -> ok
-    after 1000 ->
-        error(hybrid_did_not_close)
-    end.
+    await_stop(Ref, VotePid, hybrid_did_not_close).
 
 vote_window_hybrid_min_enforced(_Config) ->
     Options = [
@@ -973,3 +961,22 @@ start_test_match() ->
     }),
     true = is_pid(Pid),
     {ok, Pid}.
+
+%% Wait for a vote server to stop after something closed it.
+%%
+%% `resolve_and_stop/1` runs `persist_vote/1` before `{stop, normal}`, and that
+%% is a SYNCHRONOUS `asobi_repo:insert/1` - a real Postgres write on a pool
+%% every other suite in the run is also using. So the gap between the closing
+%% call returning and the DOWN arriving is a contended database round trip, not
+%% scheduling jitter.
+%%
+%% Three of these waits used 1000ms against the suite's own 2000ms norm, and
+%% `vote_window_hybrid/1` was observed failing on roughly one full `rebar3 ct`
+%% in three or four while passing every time the suite ran alone. The budget
+%% has to cover the write; it is not a guess about how fast the BEAM is.
+await_stop(Ref, VotePid, ErrorTag) ->
+    receive
+        {'DOWN', Ref, process, VotePid, normal} -> ok
+    after 5000 ->
+        error(ErrorTag)
+    end.

--- a/test/asobi_vote_SUITE.erl
+++ b/test/asobi_vote_SUITE.erl
@@ -988,7 +988,10 @@ start_test_match() ->
 %% stop path rather than to raise this again.
 await_stop(Ref, VotePid, ErrorTag) ->
     receive
-        {'DOWN', Ref, process, VotePid, normal} -> ok
+        {'DOWN', Ref, process, VotePid, normal} -> ok;
+        %% Report the real reason rather than burning the deadline and blaming
+        %% the close.
+        {'DOWN', Ref, process, VotePid, Reason} -> error({ErrorTag, Reason})
     after 5000 ->
         error(ErrorTag)
     end.

--- a/test/asobi_vote_server_tests.erl
+++ b/test/asobi_vote_server_tests.erl
@@ -61,6 +61,11 @@ vote_server_test_() ->
         {"live visibility shows tallies", fun live_visibility/0},
         {"ready_up closes when all voted", fun ready_up_close/0},
         {"a late vote is still counted", fun late_vote_is_counted/0},
+        {"a dead vote server is closed, not fatal", fun dead_vote_server_is_closed_not_fatal/0},
+        {"a stopping vote server is closed, not fatal",
+            fun stopping_vote_server_is_closed_not_fatal/0},
+        {"a wedged vote server is busy, not a freeze",
+            fun wedged_vote_server_is_busy_not_a_freeze/0},
         {"quorum not met", fun quorum_not_met/0},
         {"delegation applies", fun delegation/0},
         {"default votes for absent voters", fun default_votes/0},
@@ -305,18 +310,17 @@ ready_up_close() ->
 %% mailbox when that callback runs - a window nothing can aim at, and one this
 %% test never reliably hit.
 %%
-%% It used to sleep 180ms into a 200ms window, leaving 20ms of margin for the
-%% second vote. On a loaded box the sleep overshoots, the window closes first,
-%% and `total_votes` comes back 1: measured failing two runs in four on an
-%% unmodified checkout. The margin is now 800ms of a 1000ms window - the same
-%% property, without racing the deadline it is asserting inside.
+%% It used to sleep 180ms into a 200ms window - 20ms of margin - and failed two
+%% runs in four on an unmodified checkout when the sleep overshot and the window
+%% closed first. 800ms into a 1000ms window keeps the vote genuinely late (80%
+%% in, as before) while giving it 200ms of margin instead of 20ms.
 late_vote_is_counted() ->
     flush(),
     Pid = start_vote(#{window_ms => 1000}),
     unlink(Pid),
     Ref = monitor(process, Pid),
     ok = asobi_vote_server:cast_vote(Pid, ~"p1", ~"a"),
-    timer:sleep(200),
+    timer:sleep(800),
     ok = asobi_vote_server:cast_vote(Pid, ~"p2", ~"b"),
     receive
         {'DOWN', Ref, process, Pid, normal} -> ok
@@ -510,3 +514,52 @@ flush() ->
         _ -> flush()
     after 0 -> ok
     end.
+
+%% widgrensit/asobi#570: a vote server that is gone, or that is resolving and
+%% about to stop, must not exit its caller. `gen_statem:call/2` raises
+%% `{noproc | normal, {gen_statem, call, _}}` in the CALLER, and the callers
+%% here are `asobi_match_server` and `asobi_world_server` calling from inside
+%% their own callbacks - a compound exit reason is a crash to their supervisor,
+%% so one player's `vote.cast` frame dropped every player in the match.
+%%
+%% Driven through a real `gen_statem:call` rather than a hand-raised exit, so
+%% these still fail if the wrapping shape ever changes.
+dead_vote_server_is_closed_not_fatal() ->
+    Pid = start_vote(#{window_ms => 60000}),
+    unlink(Pid),
+    Ref = monitor(process, Pid),
+    exit(Pid, kill),
+    receive
+        {'DOWN', Ref, process, Pid, killed} -> ok
+    after 2000 -> ?assert(false)
+    end,
+    ?assertEqual({error, vote_closed}, asobi_vote_server:cast_vote(Pid, ~"p1", ~"a")),
+    ?assertEqual({error, vote_closed}, asobi_vote_server:cast_veto(Pid, ~"p1")),
+    ?assert(is_process_alive(self())).
+
+%% A server that stops without replying - the resolving case - unwinds as
+%% `{normal, {gen_statem, call, _}}`.
+stopping_vote_server_is_closed_not_fatal() ->
+    Silent = spawn(fun() ->
+        receive
+            _ -> exit(normal)
+        end
+    end),
+    ?assertEqual({error, vote_closed}, asobi_vote_server:cast_vote(Silent, ~"p1", ~"a")),
+    ?assert(is_process_alive(self())).
+
+%% A caller is never held through resolve_and_stop/1's synchronous write: the
+%% call is bounded, so a wedged vote server costs one refused vote rather than
+%% freezing the whole match.
+wedged_vote_server_is_busy_not_a_freeze() ->
+    Wedged = spawn(fun() ->
+        receive
+            _ -> timer:sleep(30_000)
+        end
+    end),
+    Started = erlang:monotonic_time(millisecond),
+    Result = asobi_vote_server:cast_vote(Wedged, ~"p1", ~"a"),
+    Elapsed = erlang:monotonic_time(millisecond) - Started,
+    exit(Wedged, kill),
+    ?assertEqual({error, vote_busy}, Result),
+    ?assert(Elapsed < 10_000).

--- a/test/asobi_vote_server_tests.erl
+++ b/test/asobi_vote_server_tests.erl
@@ -60,7 +60,7 @@ vote_server_test_() ->
         {"hidden visibility hides tallies", fun hidden_visibility/0},
         {"live visibility shows tallies", fun live_visibility/0},
         {"ready_up closes when all voted", fun ready_up_close/0},
-        {"grace period accepts late vote", fun grace_period/0},
+        {"a late vote is still counted", fun late_vote_is_counted/0},
         {"quorum not met", fun quorum_not_met/0},
         {"delegation applies", fun delegation/0},
         {"default votes for absent voters", fun default_votes/0},
@@ -297,20 +297,26 @@ ready_up_close() ->
         ?assert(false)
     end.
 
-grace_period() ->
-    %% Grace period is checked in the closed state handler, but
-    %% resolve_and_stop runs on enter and stops the process immediately.
-    %% So the grace period only applies if votes arrive between the
-    %% state_timeout firing and the closed enter completing.
-    %% In practice this is a very tight window. Just verify that
-    %% a vote cast right at window boundary is accepted.
+%% A vote arriving late in the window is still counted, and the vote then
+%% resolves on expiry with both votes in the tally.
+%%
+%% This does NOT cover `?GRACE_MS`. `closed(enter, ...)` ends in
+%% `{stop, normal, _}`, so the grace clauses only see a vote already in the
+%% mailbox when that callback runs - a window nothing can aim at, and one this
+%% test never reliably hit.
+%%
+%% It used to sleep 180ms into a 200ms window, leaving 20ms of margin for the
+%% second vote. On a loaded box the sleep overshoots, the window closes first,
+%% and `total_votes` comes back 1: measured failing two runs in four on an
+%% unmodified checkout. The margin is now 800ms of a 1000ms window - the same
+%% property, without racing the deadline it is asserting inside.
+late_vote_is_counted() ->
     flush(),
-    Pid = start_vote(#{window_ms => 200}),
+    Pid = start_vote(#{window_ms => 1000}),
     unlink(Pid),
     Ref = monitor(process, Pid),
     ok = asobi_vote_server:cast_vote(Pid, ~"p1", ~"a"),
-    timer:sleep(180),
-    %% Vote right before window closes
+    timer:sleep(200),
     ok = asobi_vote_server:cast_vote(Pid, ~"p2", ~"b"),
     receive
         {'DOWN', Ref, process, Pid, normal} -> ok


### PR DESCRIPTION
`asobi_vote_SUITE:vote_window_hybrid/1` failed roughly **one full `rebar3 ct` in three or four**, and passed every time the suite ran alone.

## Why

The close path is not just a state transition. `resolve_and_stop/1` runs `persist_vote/1` before `{stop, normal}`, and that is a **synchronous `asobi_repo:insert/1`** - a real Postgres write, on a pool every other suite in the run is also using.

So the gap between the closing `cast_vote/3` returning and the `DOWN` arriving is a contended database round trip, not scheduling jitter, and it is unbounded from the test's point of view. Three of the twenty `DOWN` waits in this suite used 1000ms against its own 2000ms norm, and all three are the same shape: close the vote, then wait for the server to stop.

## Fix

One named `await_stop/3` with the reasoning stated once, so the budget cannot drift back down without the next reader seeing what it is waiting on.

**Not a product defect.** `broadcast_vote_result/1` runs *before* the persist, so a client sees the result immediately and only the process lingers. Persisting before dying is the same choice `asobi_zone:terminate/2` makes for its snapshot.

## Evidence

| run | result |
|---|---|
| full CT, loaded box | fail |
| full CT, serial | fail (a later run) |
| suite alone, ×4 across two branches | pass |
| full CT on an unmodified baseline | pass |
| full CT with this fix | **390/390** |

Reproduced on two different branches, on both a loaded and an idle box, and never with the suite run alone. That is a deadline too tight for what it waits on, not a race in the vote server.

Found while running the review gate on #568 and #569 - it is unrelated to both, which is why it is here rather than folded into either.
