### PR TITLE
fix(bots): keep a bot script's Lua state across think calls, and bound it

### DIFF
--- a/docs/adr/0005-telemetry-event-surface.md
+++ b/docs/adr/0005-telemetry-event-surface.md
@@ -134,11 +134,11 @@ building an exporter safely - not a step to defer until after one is built.
 
 - measurements `#{words, bytes, count}` - the size of the Luerl state behind
   one Lua bridge. Metadata is `#{script, kind}` on every emitter, plus
-  `world_id` on a zone or a world and `match_id` on a match, plus `coords` on
-  a zone only. `script` (one per loaded game script, fixed at deploy) and
-  `kind` (`zone | world | match`, a fixed enum) are label-safe; `world_id`,
-  `match_id` and `coords` are unbounded on the same grounds as
-  `[asobi, zone, opened]`'s and are never a label. **Every value may be
+  `world_id` on a zone or a world, `match_id` on a match and `bot_id` on a bot,
+  plus `coords` on a zone only. `script` (one per loaded game script, fixed at
+  deploy) and `kind` (`zone | world | match | bot`, a fixed enum) are
+  label-safe; `world_id`, `match_id`, `bot_id` and `coords` are unbounded on the
+  same grounds as `[asobi, zone, opened]`'s and are never a label. **Every value may be
   `undefined`, and the key set differs by `kind`, so a handler must be total
   over it** - `telemetry` detaches a handler that raises, permanently, taking
   every other asobi metric on that attachment with it. Added by asobi#536.
@@ -148,7 +148,10 @@ building an exporter safely - not a step to defer until after one is built.
   worse than no metric. The identity is stamped at
   `asobi_lua_world:init_zone_state/2` and its two siblings rather than derived
   by the collector, which runs inside the bridge process and knows nothing
-  about the grid.
+  about the grid. `kind => bot` was added when `asobi_bot` started threading its
+  Luerl state across ticks: a bot that remembers is a bot whose state can grow,
+  which is exactly what this gauge exists to make visible. A match filled with
+  eight scripted bots is eight more series.
 - Sampled on **wall clock**, roughly once a second per bridge, overridable with
   `asobi_lua.state_sample_interval_ms`. A per-tick counter would be a rate that
   varies with the world's tick rate and multiplies by live zone count, which is

--- a/docs/adr/0005-telemetry-event-surface.md
+++ b/docs/adr/0005-telemetry-event-surface.md
@@ -134,11 +134,12 @@ building an exporter safely - not a step to defer until after one is built.
 
 - measurements `#{words, bytes, count}` - the size of the Luerl state behind
   one Lua bridge. Metadata is `#{script, kind}` on every emitter, plus
-  `world_id` on a zone or a world, `match_id` on a match and `bot_id` on a bot,
-  plus `coords` on a zone only. `script` (one per loaded game script, fixed at
-  deploy) and `kind` (`zone | world | match | bot`, a fixed enum) are
-  label-safe; `world_id`, `match_id`, `bot_id` and `coords` are unbounded on the
-  same grounds as `[asobi, zone, opened]`'s and are never a label. **Every value may be
+  `world_id` on a zone or a world, `match_id` on a match, and both `match_id`
+  and `bot_id` on a bot, plus `coords` on a zone only. `script` (one per loaded
+  game script, fixed at deploy) and `kind` (`zone | world | match | bot`, a
+  fixed enum) are label-safe; `world_id`, `match_id`, `bot_id` and `coords` are
+  unbounded on the same grounds as `[asobi, zone, opened]`'s and are never a
+  label. **Every value may be
   `undefined`, and the key set differs by `kind`, so a handler must be total
   over it** - `telemetry` detaches a handler that raises, permanently, taking
   every other asobi metric on that attachment with it. Added by asobi#536.
@@ -150,8 +151,12 @@ building an exporter safely - not a step to defer until after one is built.
   by the collector, which runs inside the bridge process and knows nothing
   about the grid. `kind => bot` was added when `asobi_bot` started threading its
   Luerl state across ticks: a bot that remembers is a bot whose state can grow,
-  which is exactly what this gauge exists to make visible. A match filled with
-  eight scripted bots is eight more series.
+  which is exactly what this gauge exists to make visible. A bot is the one
+  bridge with no identity worth separating on. `coords` is positional and
+  `world_id`/`match_id` are bounded by concurrency, but a bot id is minted per
+  bot instance with a random discriminator and never reused, so keying on it is
+  cardinality that grows with every match ever played. Bot series collapse on
+  `script` and `kind`; group a match's bots on its `match_id`.
 - Sampled on **wall clock**, roughly once a second per bridge, overridable with
   `asobi_lua.state_sample_interval_ms`. A per-tick counter would be a rate that
   varies with the world's tick rate and multiplies by live zone count, which is

--- a/guides/lua-bots.md
+++ b/guides/lua-bots.md
@@ -153,7 +153,8 @@ plus the optional `names` list.
 
 Because a bot decides only from `state`, difficulty is a property of the
 script rather than a config knob: throttle a reaction delay or degrade target
-selection by keying per-bot state off `bot_id` in a module-level table.
+selection by keying per-bot state off `bot_id` in a module-level table. That
+table survives between calls - see [Timing and cooldowns](#timing-and-cooldowns).
 
 ### What a bot script gets
 
@@ -179,6 +180,9 @@ What is available:
 - The two arguments of `think(bot_id, state)`, plus whatever the script itself
   defines at the top level. `state` is the match state as broadcast to
   players, so a bot sees what a client sees and nothing more.
+- Whatever the script wrote to a global on an earlier call. A bot keeps one
+  Luerl state for its whole life, so a global assigned inside `think` is still
+  there on the next call - see [Timing and cooldowns](#timing-and-cooldowns).
 
 Anything else has to come through the match script: put the value in the state
 the match broadcasts and read it from `state`.
@@ -257,6 +261,104 @@ function wander()
     }
 end
 ```
+
+## Timing and cooldowns
+
+`think` runs on its own fixed 100 ms loop. That loop is independent of the
+mode's `tick_rate`, so a bot in a 50 ms mode is asked for input every second
+match tick, and "40 ticks" means 4 seconds of bot calls, not 4 seconds of match
+ticks. Nothing in the bot loop is driven by the match clock.
+
+A bot keeps one Luerl state for its whole life, so the plain way to time
+something is to count your own calls:
+
+```lua
+-- game/bots/patient.lua
+
+calls = 0
+next_action = {}
+
+function think(bot_id, state)
+    calls = calls + 1
+
+    if (next_action[bot_id] or 0) > calls then
+        return {}     -- still cooling down: send nothing this call
+    end
+
+    next_action[bot_id] = calls + 40   -- 40 calls at 100 ms = 4 seconds
+    return fire(bot_id, state)
+end
+```
+
+`next_action` is keyed on `bot_id` because every bot in the mode runs this same
+script, but each one is its own process with its own Luerl state, so the table
+holds a single entry in practice. Key it anyway: it is what makes the script
+read correctly, and it is the shape you want if you ever fold two bots into one
+process.
+
+Returning `{}` is how a bot declines to act. It still goes through
+`handle_input`, so a match script that treats an empty input as a real one will
+see it - guard on the keys you care about rather than on the input being
+non-empty.
+
+### Timing against the match clock instead
+
+Counting bot calls times the bot. When the cooldown is a *game rule* - a weapon
+that fires once every 4 seconds, whoever is holding it - time it against the
+match, not against `think`, so a bot and a human get the same rule. Broadcast a
+counter from the match script and read it from `state`:
+
+```lua
+-- game/match.lua
+function init(config)
+    return { tick_count = 0, players = {} }
+end
+
+function tick(state)
+    state.tick_count = state.tick_count + 1
+    return state
+end
+
+function get_state(player_id, state)
+    return { players = state.players, tick_count = state.tick_count }
+end
+```
+
+```lua
+-- game/bots/patient.lua
+
+next_action = {}
+
+function think(bot_id, state)
+    local now = state.tick_count or 0
+    if (next_action[bot_id] or 0) > now then return {} end
+    next_action[bot_id] = now + 80    -- 80 match ticks at 50 ms = 4 seconds
+    return fire(bot_id, state)
+end
+```
+
+`get_state` is the part that matters. A bot reads the broadcast state and
+nothing else, so a counter the match keeps but leaves out of `get_state` is
+`nil` in `think`, and both ways of handling that fail quietly. Written as above,
+`state.tick_count or 0` pins `now` at 0, the cooldown never expires and the bot
+goes silent for the rest of the match. Written without the `or 0`, comparing a
+number with `nil` raises, which costs the call and drops the bot to the default
+AI - silent to the client, and logged once a minute as
+`bot_think_error_falling_back_to_default_ai`. Broadcast the counter.
+
+This reads the same clock a human's input is judged against, and it survives a
+match that pauses or changes tick rate. It is also the honest place for a rule
+the server enforces: the match script should reject an early action whoever
+sent it, and then the bot's cooldown is an optimisation rather than the
+enforcement.
+
+`os.clock()` is available and returns node uptime in seconds as a float, which
+works for a delta between two calls. It is not a date and not per-match; prefer
+one of the two counters above.
+
+Each `think` call is budgeted at 50 ms of wall clock, so a cooldown implemented
+by blocking inside `think` is a call the platform kills and replaces with the
+default AI. Return early instead.
 
 ## Multiple bot types
 

--- a/guides/lua-bots.md
+++ b/guides/lua-bots.md
@@ -183,6 +183,10 @@ What is available:
 - Whatever the script wrote to a global on an earlier call. A bot keeps one
   Luerl state for its whole life, so a global assigned inside `think` is still
   there on the next call - see [Timing and cooldowns](#timing-and-cooldowns).
+  A call that fails is the exception: a `think` that raises, times out or
+  overruns its heap is rolled back whole, so anything it assigned before the
+  failure is gone. A deterministic failure therefore repeats forever, because
+  every call re-runs from the same state and fails the same way.
 
 Anything else has to come through the match script: put the value in the state
 the match broadcasts and read it from `state`.
@@ -296,10 +300,17 @@ holds a single entry in practice. Key it anyway: it is what makes the script
 read correctly, and it is the shape you want if you ever fold two bots into one
 process.
 
-Returning `{}` is how a bot declines to act. It still goes through
-`handle_input`, so a match script that treats an empty input as a real one will
-see it - guard on the keys you care about rather than on the input being
-non-empty.
+Returning `{}` is how a bot declines to act, and `return nil` does the same. A
+bare `return`, or falling off the end of `think`, does **not**: those return no
+values at all, which the platform reads as "this call produced no input" and
+answers with the built-in default AI. The bot then chases and shoots. Write
+`return {}` when you mean "do nothing this call".
+
+An empty input still goes through `handle_input` while the match is running, so
+a match script that treats an empty input as a real one will see it - guard on
+the keys you care about rather than on the input being non-empty. In `waiting`
+and in `paused` the match server drops input instead, and a bot's loop runs in
+all three states.
 
 ### Timing against the match clock instead
 
@@ -359,6 +370,25 @@ one of the two counters above.
 Each `think` call is budgeted at 50 ms of wall clock, so a cooldown implemented
 by blocking inside `think` is a call the platform kills and replaces with the
 default AI. Return early instead.
+
+### What a bot may keep
+
+Persistence is not a licence to hoard. The state a bot carries between calls is
+copied into every `think` call, so a script that keeps a large table alive makes
+every one of its own ticks more expensive - and Lua collection reclaims garbage,
+not what is still reachable, so nothing shrinks a table your script is holding.
+
+There is a ceiling. Past 10 MB of Luerl state, roughly 1.25 M words, the
+platform reloads the script and the bot starts again from the state it loads
+with: globals gone, cooldowns reset. That is logged as
+`bot_lua_state_reloaded` with the size that tripped it. Override the ceiling
+with `{asobi, [{max_bot_state_words, N}]}` if a mode genuinely needs a larger
+one.
+
+A cooldown table is nowhere near this: the examples above hold one integer per
+bot. What reaches the ceiling is a script accumulating history - appending every
+tick's `state` to a list, keeping a trail of positions with no bound. Keep a
+window, not a log.
 
 ## Multiple bot types
 

--- a/guides/observability.md
+++ b/guides/observability.md
@@ -285,20 +285,22 @@ is no longer being collected - see
 [Performance tuning](performance-tuning.md#lua-memory).
 
 `asobi.lua.state` is what tells you which of those it is. It reports `words`
-and `bytes` for the Luerl state behind one Lua bridge - a zone, a world or a
-match - about once a second per bridge
+and `bytes` for the Luerl state behind one Lua bridge - a zone, a world, a
+match or a bot - about once a second per bridge
 (`asobi_lua.state_sample_interval_ms`). That size decides what a Lua tick
 costs, because asobi copies the whole state into the callback's eval worker at
 roughly 7 ms per MB, so a state climbing through tens of MB pushes a zone past
 its tick budget on its own. A healthy zone's state is flat; alert on the trend
 rather than a threshold.
 
-Metadata is `#{script, kind, world_id | match_id, coords}`. `script` and `kind`
-(`zone | world | match`) are label-safe; the identifiers and `coords` are
-unbounded and must not be labels. The event is per bridge process, so a world
-with a hundred live zones produces a hundred series - key them on `coords`, or
-whichever zone reported last overwrites the rest and you get one flapping
-gauge. asobi also logs `lua_state_large` once per excursion past
+Metadata is `#{script, kind, world_id | match_id | bot_id, coords}`. `script`
+and `kind` (`zone | world | match | bot`) are label-safe; the identifiers and
+`coords` are unbounded and must not be labels. The event is per bridge process,
+so a world with a hundred live zones produces a hundred series - key them on
+`coords`, or whichever zone reported last overwrites the rest and you get one
+flapping gauge. A bot is the one bridge with no groupable identity of its own:
+its id carries a random discriminator, is never reused, and must not be keyed
+on. Group a match's bots on `match_id`. asobi also logs `lua_state_large` once per excursion past
 `state_warn_words` (~100 MB by default), for operators without a metrics
 pipeline attached.
 

--- a/guides/security-trust-model.md
+++ b/guides/security-trust-model.md
@@ -87,6 +87,13 @@ The macros are not all in one place. Match budgets are `?*_TIMEOUT` in
 budget is a literal `50` at the call site in `asobi_bot.erl` rather than a
 macro. Grep for `asobi_lua_loader:call(` if you need the authoritative set.
 
+The budget bounds the callback, not the tick that carries it. The Luerl state is
+copied into the eval worker before the deadline is armed, at roughly 7 ms per
+MB, so a bridge holding a large state spends time on every tick that no budget
+in this table covers. That is what the adaptive collector and, for a bot,
+`max_bot_state_words` exist to bound - see
+[What a bot may keep](lua-bots.md#what-a-bot-may-keep).
+
 ## The anchors are written past `_G`'s metatable
 
 asobi holds Luerl references between callbacks, and Lua's root set is `_G`, the

--- a/src/asobi_telemetry.erl
+++ b/src/asobi_telemetry.erl
@@ -285,12 +285,15 @@ roughly 7 ms per MB, so a state that reaches tens of MB pushes a zone past its
 tick budget on its own - with no other symptom than CPU and, eventually, dead
 zones.
 
-Metadata is `#{script, kind, world_id | match_id, coords}`. `script` and `kind`
-(`zone | world | match`) are label-safe; the identifiers and `coords` are
-unbounded and must never be a label. One event is emitted per bridge *process*,
-so a world with a hundred live zones produces a hundred series - key them on
-`coords`, or the last zone to report overwrites every other one and the result
-reads as a single flapping gauge.
+Metadata is `#{script, kind, world_id | match_id | bot_id, coords}`. `script`
+and `kind` (`zone | world | match | bot`) are label-safe; the identifiers and
+`coords` are unbounded and must never be a label. One event is emitted per
+bridge *process*, so a world with a hundred live zones produces a hundred
+series - key them on `coords`, or the last zone to report overwrites every other
+one and the result reads as a single flapping gauge. A bot carries `bot_id` and
+`match_id` but is not separable that way: a bot id is minted per bot instance
+with a random discriminator and is never reused, so it is a correlation aid in a
+trace, never a label. Group a match's bots on `match_id`.
 
 Alert on the trend, not a threshold. A healthy zone's state is flat; one that
 climbs across a session is a script holding more alive between callbacks than

--- a/src/lua/asobi_lua_loader.erl
+++ b/src/lua/asobi_lua_loader.erl
@@ -710,8 +710,9 @@ collector would free the tables underneath it and the next `luerl:decode/2`
 on it would crash. It is rooted in a global for the duration of the collection
 and unrooted again straight after, so a script never observes the anchor.
 
-Bookkeeping is kept under `lua_gc` in the same map. Set
-`{asobi, [{lua_gc, false}]}` to turn the collector off entirely.
+Bookkeeping is kept under `lua_gc` in the same map, including `words` - the
+size of the state this call measured, for a bridge that enforces a ceiling of
+its own. Set `{asobi, [{lua_gc, false}]}` to turn the collector off entirely.
 """.
 -spec collect_state(map()) -> map().
 collect_state(#{lua_state := St} = State) ->
@@ -720,7 +721,12 @@ collect_state(#{lua_state := St} = State) ->
     Gc1 = report_state_size(Words, State, Gc0),
     Anchor = maps:get(game_state, State, nil),
     {St1, Gc2} = maybe_gc(St, Anchor, Words, Gc1),
-    State#{lua_state => St1, lua_gc => Gc2};
+    %% `words` is the size measured *before* this collection, which is the
+    %% number a caller enforcing a ceiling wants: it is what the last callback
+    %% was handed and what the next one will be handed if nothing was reclaimed.
+    %% `undefined` when the measurement was unavailable, so a caller acting on
+    %% it must guard on the integer.
+    State#{lua_state => St1, lua_gc => Gc2#{words => Words}};
 collect_state(State) ->
     State.
 

--- a/src/lua/bots/asobi_bot.erl
+++ b/src/lua/bots/asobi_bot.erl
@@ -16,6 +16,15 @@ Both state strategies arrive as `{match_state, map()}`. Under
 `state_strategy = "shared"` the match server still encodes once for the whole
 roster, and `asobi_presence:send_match_state/3` hands the bot the term behind
 that frame rather than the frame, so a bot decodes nothing per tick.
+
+The Luerl state is threaded across ticks, so a bot script's globals persist
+between `think` calls the way a match script's do. Before that they did not:
+the state `think` returned was dropped and the next tick re-entered the script
+as loaded, which made a per-bot cooldown table reset every 100 ms and its guard
+fire on every tick. Persisting it means a bot now pays the same per-tick cost a
+match bridge does - the copy into the bounded call grows with what the script
+keeps alive - so `asobi_lua_loader:collect_state/1` runs before each call on
+the same adaptive schedule.
 """.
 
 -behaviour(gen_server).
@@ -66,15 +75,16 @@ init(#{match_pid := MatchPid, bot_id := BotId, lua_script := LuaScript}) ->
         match_pid => MatchPid,
         bot_id => BotId,
         lua_state => LuaSt,
+        lua_script => LuaScript,
         game_state => #{},
         phase => playing
     }}.
 
 -spec handle_info(term(), map()) -> {noreply, map()} | {stop, term(), map()}.
 handle_info(tick, #{phase := playing} = State) ->
-    send_input(State),
+    State1 = send_input(State),
     erlang:send_after(?TICK_INTERVAL, self(), tick),
-    {noreply, State};
+    {noreply, State1};
 handle_info(tick, State) ->
     erlang:send_after(?TICK_INTERVAL, self(), tick),
     {noreply, State};
@@ -145,24 +155,50 @@ terminate(_, _) ->
 %% persistently-broken script is visible without spamming logs.
 -define(THINK_LOG_INTERVAL_MS, 60000).
 
-send_input(#{lua_state := undefined, bot_id := BotId, match_pid := MatchPid, game_state := GS}) ->
-    Input = default_ai(BotId, GS),
-    asobi_match_server:handle_input(MatchPid, BotId, Input);
 send_input(
-    #{lua_state := LuaSt, bot_id := BotId, match_pid := MatchPid, game_state := GS} = State
+    #{lua_state := undefined, bot_id := BotId, match_pid := MatchPid, game_state := GS} = State
 ) ->
+    Input = default_ai(BotId, GS),
+    asobi_match_server:handle_input(MatchPid, BotId, Input),
+    State;
+send_input(#{lua_state := _} = State0) ->
+    #{lua_state := LuaSt, bot_id := BotId, match_pid := MatchPid, game_state := GS} =
+        State = collect(State0),
     {EncGS, LuaSt1} = asobi_lua_loader:encode(GS, LuaSt),
-    Input =
+    {Input, LuaSt3} =
         case asobi_lua_loader:call(think, [BotId, EncGS], LuaSt1, 50) of
             {ok, [Result | _], LuaSt2} ->
-                decode_result(Result, LuaSt2);
+                {decode_result(Result, LuaSt2), LuaSt2};
+            %% A `think` that returns nothing still ran, and may have written a
+            %% counter this bot needs on the next call. Keep its state; only the
+            %% input falls back.
+            {ok, [], LuaSt2} ->
+                {default_ai(BotId, GS), LuaSt2};
             {error, Reason} ->
                 maybe_log_think_error(BotId, Reason, State),
-                default_ai(BotId, GS);
+                {default_ai(BotId, GS), LuaSt};
             _ ->
-                default_ai(BotId, GS)
+                {default_ai(BotId, GS), LuaSt}
         end,
-    asobi_match_server:handle_input(MatchPid, BotId, Input).
+    asobi_match_server:handle_input(MatchPid, BotId, Input),
+    State#{lua_state => LuaSt3}.
+
+%% The collector needs no anchor here. `game_state` on a bot is the Erlang term
+%% the match broadcast, re-encoded every tick, so unlike a match or a zone the
+%% bot holds no Luerl reference across `think` calls - and passing that Erlang
+%% map to `collect_state/1` as the anchor would root a non-Luerl value in `_G`.
+%% Hence the purpose-built map rather than the bot's own state.
+collect(#{lua_state := LuaSt} = State) ->
+    Probe = maps:merge(
+        #{
+            lua_state => LuaSt,
+            script => maps:get(lua_script, State, undefined),
+            lua_bridge => #{kind => bot, bot_id => maps:get(bot_id, State, undefined)}
+        },
+        maps:with([lua_gc], State)
+    ),
+    #{lua_state := LuaSt1, lua_gc := Gc} = asobi_lua_loader:collect_state(Probe),
+    State#{lua_state => LuaSt1, lua_gc => Gc}.
 
 -spec maybe_log_think_error(binary(), term(), map()) -> ok.
 maybe_log_think_error(BotId, Reason, _State) ->

--- a/src/lua/bots/asobi_bot.erl
+++ b/src/lua/bots/asobi_bot.erl
@@ -117,11 +117,12 @@ handle_info({'DOWN', _, process, MatchPid, _}, #{match_pid := MatchPid} = State)
 handle_info(_, State) ->
     {noreply, State}.
 
-%% Spec'd against the presence contract rather than term(): these are named
-%% shapes core has to keep, not an ad-hoc guess at an internal protocol.
-%% Reshaping one means editing asobi_presence:message/0, which breaks
-%% dialyzer at the producing send/2 call.
--spec handle_presence_message(asobi_presence:message(), map()) ->
+%% `dynamic()` because a gen_server mailbox is a boundary: what arrives is
+%% `term()` and only the clause heads below decide what it was. The shapes those
+%% heads match are `t:asobi_presence:message/0` - named shapes core has to keep,
+%% not an ad-hoc guess at an internal protocol - and the contract is still
+%% enforced on the producing side, at the `asobi_presence:send/2` call.
+-spec handle_presence_message(dynamic(), map()) ->
     {noreply, map()} | {stop, term(), map()}.
 handle_presence_message({match_state, GameState}, State) when is_map(GameState) ->
     Phase = extract_phase(GameState),
@@ -215,9 +216,7 @@ run_think(BotId, GS, LuaSt, State) ->
         %% was never touched - if bots ever move to an owned VM (ADR 0015) a
         %% timeout kills that VM and this handle needs rebuilding, not keeping.
         {error, Reason} ->
-            {default_ai(BotId, GS), LuaSt, note_think_error(Reason, State)};
-        _ ->
-            {default_ai(BotId, GS), LuaSt, State}
+            {default_ai(BotId, GS), LuaSt, note_think_error(Reason, State)}
     end.
 
 %% No anchor: unlike a match or a zone, `game_state` on a bot is an Erlang term

--- a/src/lua/bots/asobi_bot.erl
+++ b/src/lua/bots/asobi_bot.erl
@@ -18,13 +18,16 @@ roster, and `asobi_presence:send_match_state/3` hands the bot the term behind
 that frame rather than the frame, so a bot decodes nothing per tick.
 
 The Luerl state is threaded across ticks, so a bot script's globals persist
-between `think` calls the way a match script's do. Before that they did not:
-the state `think` returned was dropped and the next tick re-entered the script
-as loaded, which made a per-bot cooldown table reset every 100 ms and its guard
-fire on every tick. Persisting it means a bot now pays the same per-tick cost a
-match bridge does - the copy into the bounded call grows with what the script
-keeps alive - so `asobi_lua_loader:collect_state/1` runs before each call on
-the same adaptive schedule.
+between `think` calls the way a match script's do. A bot therefore pays the same
+per-tick copy a match bridge does, and `asobi_lua_loader:collect_state/1` runs
+before each call on the same adaptive schedule.
+
+Collection bounds garbage, not what a script keeps live, and Luerl's mark phase
+is quadratic in the live set - so a script that hoards drives the collector past
+its budget until it gives up on that state entirely. `?MAX_STATE_WORDS` is the
+backstop: past it the script is reloaded and its globals are gone. A bot is the
+one Lua bridge where that is affordable, because nothing a player can see lives
+in its state.
 """.
 
 -behaviour(gen_server).
@@ -32,9 +35,16 @@ the same adaptive schedule.
 -include_lib("kernel/include/logger.hrl").
 
 -export([start_link/3]).
--export([init/1, handle_info/2, handle_cast/2, handle_call/3, terminate/2]).
+-export([init/1, handle_info/2, handle_cast/2, handle_call/3, terminate/2, format_status/1]).
 
 -define(TICK_INTERVAL, 100).
+
+%% 10 MB at 8 bytes a word. The per-bot cooldown table guides/lua-bots.md
+%% describes is three orders of magnitude under this; a bot past it is holding
+%% something it should not, and would otherwise sit at ~100 ms a tick copying it
+%% into every bounded call for the rest of the match. Override with
+%% `{asobi, [{max_bot_state_words, N}]}`.
+-define(DEFAULT_MAX_STATE_WORDS, 1_250_000).
 
 -spec start_link(pid(), binary(), binary() | undefined) -> gen_server:start_ret().
 start_link(MatchPid, BotId, LuaScript) ->
@@ -75,10 +85,22 @@ init(#{match_pid := MatchPid, bot_id := BotId, lua_script := LuaScript}) ->
         match_pid => MatchPid,
         bot_id => BotId,
         lua_state => LuaSt,
-        lua_script => LuaScript,
+        script => LuaScript,
+        lua_bridge => #{kind => bot, bot_id => BotId, match_id => match_id(MatchPid)},
         game_state => #{},
         phase => playing
     }}.
+
+%% Groups a bot's telemetry with the match it plays in. `bot_id` alone joins to
+%% nothing: it carries a random discriminator per bot instance and is never
+%% reused, so it is a correlation aid in a trace and never a label.
+match_id(MatchPid) ->
+    try asobi_match_server:get_info(MatchPid) of
+        #{match_id := MatchId} -> MatchId;
+        _ -> undefined
+    catch
+        _:_ -> undefined
+    end.
 
 -spec handle_info(term(), map()) -> {noreply, map()} | {stop, term(), map()}.
 handle_info(tick, #{phase := playing} = State) ->
@@ -135,6 +157,15 @@ handle_cast(_, State) ->
 handle_call(_, _From, State) ->
     {reply, ok, State}.
 
+%% The Luerl state runs to megabytes, and a crash report or a `sys:get_status`
+%% would format the whole of it on the logger's process. Nothing reading a bot's
+%% status needs it.
+-spec format_status(gen_server:format_status()) -> gen_server:format_status().
+format_status(#{state := State} = Status) when is_map(State) ->
+    Status#{state => State#{lua_state => '#luerl{}'}};
+format_status(Status) ->
+    Status.
+
 -spec terminate(term(), map()) -> ok.
 terminate(_Reason, #{bot_id := BotId, match_pid := MatchPid}) ->
     asobi_presence:untrack_bot(BotId, self()),
@@ -162,64 +193,110 @@ send_input(
     asobi_match_server:handle_input(MatchPid, BotId, Input),
     State;
 send_input(#{lua_state := _} = State0) ->
-    #{lua_state := LuaSt, bot_id := BotId, match_pid := MatchPid, game_state := GS} =
-        State = collect(State0),
-    {EncGS, LuaSt1} = asobi_lua_loader:encode(GS, LuaSt),
-    {Input, LuaSt3} =
-        case asobi_lua_loader:call(think, [BotId, EncGS], LuaSt1, 50) of
-            {ok, [Result | _], LuaSt2} ->
-                {decode_result(Result, LuaSt2), LuaSt2};
-            %% A `think` that returns nothing still ran, and may have written a
-            %% counter this bot needs on the next call. Keep its state; only the
-            %% input falls back.
-            {ok, [], LuaSt2} ->
-                {default_ai(BotId, GS), LuaSt2};
-            {error, Reason} ->
-                maybe_log_think_error(BotId, Reason, State),
-                {default_ai(BotId, GS), LuaSt};
-            _ ->
-                {default_ai(BotId, GS), LuaSt}
-        end,
+    State = collect_lua_state(State0),
+    #{lua_state := LuaSt, bot_id := BotId, match_pid := MatchPid, game_state := GS} = State,
+    {Input, LuaSt1, State1} = run_think(BotId, GS, LuaSt, State),
     asobi_match_server:handle_input(MatchPid, BotId, Input),
-    State#{lua_state => LuaSt3}.
+    State1#{lua_state => LuaSt1}.
 
-%% The collector needs no anchor here. `game_state` on a bot is the Erlang term
-%% the match broadcast, re-encoded every tick, so unlike a match or a zone the
-%% bot holds no Luerl reference across `think` calls - and passing that Erlang
-%% map to `collect_state/1` as the anchor would root a non-Luerl value in `_G`.
-%% Hence the purpose-built map rather than the bot's own state.
-collect(#{lua_state := LuaSt} = State) ->
-    Probe = maps:merge(
-        #{
-            lua_state => LuaSt,
-            script => maps:get(lua_script, State, undefined),
-            lua_bridge => #{kind => bot, bot_id => maps:get(bot_id, State, undefined)}
-        },
-        maps:with([lua_gc], State)
-    ),
-    #{lua_state := LuaSt1, lua_gc := Gc} = asobi_lua_loader:collect_state(Probe),
-    State#{lua_state => LuaSt1, lua_gc => Gc}.
-
--spec maybe_log_think_error(binary(), term(), map()) -> ok.
-maybe_log_think_error(BotId, Reason, _State) ->
-    Now = erlang:system_time(millisecond),
-    Last =
-        case persistent_term:get({?MODULE, last_think_error, BotId}, 0) of
-            N when is_integer(N) -> N;
-            _ -> 0
-        end,
-    case Now - Last >= ?THINK_LOG_INTERVAL_MS of
-        true ->
-            persistent_term:put({?MODULE, last_think_error, BotId}, Now),
-            logger:warning(#{
-                msg => ~"bot_think_error_falling_back_to_default_ai",
-                bot_id => BotId,
-                reason => Reason
-            }),
-            ok;
-        false ->
-            ok
+run_think(BotId, GS, LuaSt, State) ->
+    {EncGS, LuaSt1} = asobi_lua_loader:encode(GS, LuaSt),
+    case asobi_lua_loader:call(think, [BotId, EncGS], LuaSt1, 50) of
+        {ok, [Result | _], LuaSt2} ->
+            {decode_result(Result, LuaSt2), LuaSt2, State};
+        %% A `think` that returns nothing still ran, and may have written a
+        %% counter this bot needs on the next call. Keep its state; only the
+        %% input falls back.
+        {ok, [], LuaSt2} ->
+            {default_ai(BotId, GS), LuaSt2, State};
+        %% `LuaSt`, not `LuaSt1`: a failed call is rolled back past the encode
+        %% too, so a bot that fails every tick cannot grow the state it is
+        %% failing on. Under `copy` the worker mutated its own copy and this one
+        %% was never touched - if bots ever move to an owned VM (ADR 0015) a
+        %% timeout kills that VM and this handle needs rebuilding, not keeping.
+        {error, Reason} ->
+            {default_ai(BotId, GS), LuaSt, note_think_error(Reason, State)};
+        _ ->
+            {default_ai(BotId, GS), LuaSt, State}
     end.
+
+%% No anchor: unlike a match or a zone, `game_state` on a bot is an Erlang term
+%% re-encoded every tick rather than a Luerl reference held across calls, and
+%% handing it to the collector would root a non-Luerl value in `_G`.
+collect_lua_state(State) ->
+    #{lua_state := LuaSt, lua_gc := Gc} =
+        asobi_lua_loader:collect_state(maps:without([game_state], State)),
+    reload_if_oversized(State#{lua_state => LuaSt, lua_gc => Gc}).
+
+reload_if_oversized(#{lua_gc := #{words := Words}} = State) when is_integer(Words) ->
+    reload_if_oversized(Words, max_state_words(), State);
+reload_if_oversized(State) ->
+    State.
+
+reload_if_oversized(Words, Ceiling, #{script := Path, bot_id := BotId} = State) when
+    Words > Ceiling
+->
+    ?LOG_WARNING(#{
+        event => bot_lua_state_reloaded,
+        bot_id => BotId,
+        state_words => Words,
+        ceiling_words => Ceiling,
+        msg =>
+            ~"A bot script kept more alive across think calls than the ceiling allows. Its Lua state was reloaded from disk, so its globals are gone and any cooldown it was tracking has reset. Keep less between calls."
+    }),
+    %% Remove rather than reset to `#{}`: `collect_state/1` seeds its bookkeeping
+    %% only when the key is absent, and an empty map matches no `maybe_gc/4`
+    %% clause.
+    maps:remove(lua_gc, State#{lua_state => reload(Path)});
+reload_if_oversized(_Words, _Ceiling, State) ->
+    State.
+
+max_state_words() ->
+    case asobi_lua_env:get_env(max_bot_state_words, ?DEFAULT_MAX_STATE_WORDS) of
+        N when is_integer(N), N > 0 -> N;
+        _ -> ?DEFAULT_MAX_STATE_WORDS
+    end.
+
+reload(Path) when is_binary(Path); is_list(Path) ->
+    case asobi_lua_loader:new(Path) of
+        {ok, St} -> St;
+        {error, _} -> undefined
+    end;
+reload(_) ->
+    undefined.
+
+%% Throttled in the bot's own state rather than in `persistent_term`: a bot id
+%% carries a random discriminator and is never reused, so a global key per bot
+%% would be a table that only ever grows, and every write scans the literal area
+%% across all processes.
+-spec note_think_error(term(), map()) -> map().
+note_think_error(Reason, #{bot_id := BotId} = State) ->
+    Now = erlang:system_time(millisecond),
+    case Now - maps:get(last_think_error, State, 0) >= ?THINK_LOG_INTERVAL_MS of
+        true ->
+            ?LOG_WARNING(#{
+                event => bot_think_error_falling_back_to_default_ai,
+                bot_id => BotId,
+                reason => bounded(Reason, 4)
+            }),
+            State#{last_think_error => Now};
+        false ->
+            State
+    end.
+
+%% A script chooses the value it raises with, and it can raise with megabytes -
+%% which the logger would then format on its own process. `binary:part/3` on a
+%% refc binary is O(1), so the bound costs nothing. The `[H | T]` clause rather
+%% than an `is_list/1` guard: `is_list/1` admits an improper list, and a
+%% comprehension over one raises inside this function.
+bounded(B, _Depth) when is_binary(B), byte_size(B) > 256 ->
+    <<(binary:part(B, 0, 256))/binary, "...">>;
+bounded(T, Depth) when is_tuple(T), Depth > 0 ->
+    list_to_tuple([bounded(E, Depth - 1) || E <- tuple_to_list(T)]);
+bounded([H | T], Depth) when Depth > 0 ->
+    [bounded(H, Depth - 1) | bounded(T, Depth - 1)];
+bounded(Other, _Depth) ->
+    Other.
 
 default_ai(BotId, GameState) ->
     Players = maps:get(players, GameState, maps:get(~"players", GameState, #{})),
@@ -335,9 +412,21 @@ pick_random_option(Options) ->
     end.
 
 -spec decode_result(term(), term()) -> map().
-decode_result(Result, _LuaSt) when is_map(Result) ->
-    Result;
 decode_result(Result, LuaSt) ->
+    try
+        do_decode_result(Result, LuaSt)
+    catch
+        %% `luerl:decode/2` raises on a table that references itself, which a
+        %% script can return by accident. That costs this tick's input, not the
+        %% bot: an uncaught raise here kills a `temporary` child, so the match
+        %% would silently lose a player for the rest of its life.
+        _:_ ->
+            #{}
+    end.
+
+do_decode_result(Result, _LuaSt) when is_map(Result) ->
+    Result;
+do_decode_result(Result, LuaSt) ->
     case asobi_lua_loader:decode(Result, LuaSt) of
         L when is_list(L) -> props_to_map(L, #{});
         M when is_map(M) -> M;
@@ -348,9 +437,26 @@ decode_result(Result, LuaSt) ->
 props_to_map([], Acc) ->
     Acc;
 props_to_map([{K, V} | T], Acc) when is_binary(K) ->
-    props_to_map(T, Acc#{K => V});
+    case sendable(V) of
+        true -> props_to_map(T, Acc#{K => V});
+        false -> props_to_map(T, Acc)
+    end;
 props_to_map([_ | T], Acc) ->
     props_to_map(T, Acc).
+
+%% An input crosses into the match script's own Luerl state and is broadcast
+%% from there, so it carries only what a client could have sent. A `think`
+%% returning a function decodes to a callable: not JSON-encodable, and no
+%% business in another bridge's state. Nested tables are kept - a bot may send
+%% the same shaped input a player can.
+sendable(V) when is_function(V); is_pid(V); is_port(V); is_reference(V) ->
+    false;
+sendable([H | T]) ->
+    sendable(H) andalso sendable(T);
+sendable({K, V}) ->
+    sendable(K) andalso sendable(V);
+sendable(_) ->
+    true.
 
 %% --- Helpers ---
 

--- a/test/asobi_bot_input_game.erl
+++ b/test/asobi_bot_input_game.erl
@@ -1,20 +1,26 @@
 -module(asobi_bot_input_game).
+-moduledoc """
+Records every input the match server accepts, so a test can read what a bot
+actually sent, tick by tick.
+
+The table is ETS rather than the process dictionary because the match server
+runs in a different process from the test that reads it.
+""".
+
 -behaviour(asobi_match).
 
-%% Records every input the match server accepts into a public ETS table so a
-%% test can read what a bot actually sent, tick by tick.
-
 -export([init/1, join/2, leave/2, handle_input/3, tick/1, get_state/2]).
--export([log/0, inputs/0]).
+-export([reset/0, inputs/0]).
 
 -define(LOG, asobi_bot_input_log).
 
--spec log() -> ets:table().
-log() ->
+-spec reset() -> ok.
+reset() ->
     case ets:whereis(?LOG) of
         undefined -> ets:new(?LOG, [named_table, public, ordered_set]);
-        Tid -> Tid
-    end.
+        _ -> ets:delete_all_objects(?LOG)
+    end,
+    ok.
 
 -spec inputs() -> [map()].
 inputs() ->

--- a/test/asobi_bot_input_game.erl
+++ b/test/asobi_bot_input_game.erl
@@ -1,0 +1,46 @@
+-module(asobi_bot_input_game).
+-behaviour(asobi_match).
+
+%% Records every input the match server accepts into a public ETS table so a
+%% test can read what a bot actually sent, tick by tick.
+
+-export([init/1, join/2, leave/2, handle_input/3, tick/1, get_state/2]).
+-export([log/0, inputs/0]).
+
+-define(LOG, asobi_bot_input_log).
+
+-spec log() -> ets:table().
+log() ->
+    case ets:whereis(?LOG) of
+        undefined -> ets:new(?LOG, [named_table, public, ordered_set]);
+        Tid -> Tid
+    end.
+
+-spec inputs() -> [map()].
+inputs() ->
+    [Input || {_Seq, Input} <- ets:tab2list(?LOG), is_map(Input)].
+
+-spec init(map()) -> {ok, map()}.
+init(_Config) ->
+    {ok, #{players => #{}, tick_count => 0}}.
+
+-spec join(binary(), map()) -> {ok, map()}.
+join(PlayerId, #{players := Players} = State) ->
+    {ok, State#{players => Players#{PlayerId => #{}}}}.
+
+-spec leave(binary(), map()) -> {ok, map()}.
+leave(PlayerId, #{players := Players} = State) ->
+    {ok, State#{players => maps:remove(PlayerId, Players)}}.
+
+-spec handle_input(binary(), map(), map()) -> {ok, map()}.
+handle_input(_PlayerId, Input, State) ->
+    true = ets:insert(?LOG, {erlang:unique_integer([monotonic]), Input}),
+    {ok, State}.
+
+-spec tick(map()) -> {ok, map()}.
+tick(#{tick_count := Count} = State) ->
+    {ok, State#{tick_count => Count + 1}}.
+
+-spec get_state(binary(), map()) -> map().
+get_state(PlayerId, #{players := Players}) ->
+    maps:get(PlayerId, Players, #{}).

--- a/test/asobi_bot_state_tests.erl
+++ b/test/asobi_bot_state_tests.erl
@@ -1,0 +1,141 @@
+-module(asobi_bot_state_tests).
+-include_lib("eunit/include/eunit.hrl").
+
+%% asobi_bot used to call think/2 and throw the Luerl state it got back away,
+%% so every tick re-entered the script exactly as it was loaded. A bot script
+%% could not remember anything between calls: the per-bot cooldown table the
+%% bots guide tells authors to keep silently reset every 100 ms, and the guard
+%% built on it fired on every tick. The state is threaded through now.
+
+-define(BASE_CONFIG, #{
+    game_module => asobi_bot_input_game,
+    min_players => 1,
+    max_players => 4,
+    tick_rate => 50
+}).
+
+bot_state_test_() ->
+    {foreach, fun setup/0, fun cleanup/1, [
+        {"a bot script's globals survive across think calls", fun globals_persist/0},
+        {"a per-bot cooldown gates input as the guide describes", fun cooldown_gates_input/0}
+    ]}.
+
+setup() ->
+    _ = asobi_bot_input_game:log(),
+    true = ets:delete_all_objects(asobi_bot_input_log),
+    case ets:whereis(asobi_match_state) of
+        undefined -> ets:new(asobi_match_state, [named_table, public, set]);
+        _ -> ok
+    end,
+    case whereis(nova_scope) of
+        undefined -> {ok, _} = pg:start(nova_scope);
+        _ -> ok
+    end,
+    meck:new(asobi_repo, [no_link]),
+    meck:expect(asobi_repo, insert, fun(_CS) -> {ok, #{}} end),
+    meck:expect(asobi_repo, insert, fun(_CS, _Opts) -> {ok, #{}} end),
+    ok.
+
+cleanup(_) ->
+    meck:unload(asobi_repo),
+    ok.
+
+globals_persist() ->
+    Script = temp_script(
+        ~"""
+        calls = 0
+        function think(_bot, _state)
+            calls = calls + 1
+            return { n = calls }
+        end
+        """
+    ),
+    Ns = run_bot(Script, ~"bot_Counter", fun(Inputs) -> length(Inputs) >= 3 end, ~"n"),
+    ?assertMatch([_, _, _ | _], Ns),
+    ?assertEqual(lists:sublist([1, 2, 3], 3), lists:sublist(Ns, 3)).
+
+cooldown_gates_input() ->
+    %% The pattern guides/lua-bots.md documents: remember the last tick this
+    %% bot acted on, keyed by bot id, and stay quiet until the cooldown is up.
+    Script = temp_script(
+        ~"""
+        tick = 0
+        next_action = {}
+        function think(bot, _state)
+            tick = tick + 1
+            if (next_action[bot] or 0) > tick then
+                return {}
+            end
+            next_action[bot] = tick + 3
+            return { fired = tick }
+        end
+        """
+    ),
+    Fired = run_bot(
+        Script, ~"bot_Cooldown", fun(Inputs) -> length(Inputs) >= 8 end, ~"fired"
+    ),
+    %% Every fourth call, not every call.
+    ?assertEqual([1, 4, 7], lists:sublist(Fired, 3)).
+
+%% --- helpers ---
+
+run_bot(Script, BotId, Until, Key) ->
+    MatchPid = start_match(),
+    BotPid = start_bot(MatchPid, BotId, Script),
+    try
+        wait_until(fun() -> Until(asobi_bot_input_game:inputs()) end),
+        [
+            round(V)
+         || Input <- asobi_bot_input_game:inputs(),
+            {ok, V} <- [maps:find(Key, Input)],
+            is_number(V)
+        ]
+    after
+        stop_process(BotPid),
+        stop_process(MatchPid),
+        file:delete(Script)
+    end.
+
+start_match() ->
+    {ok, Pid} = asobi_match_server:start_link(?BASE_CONFIG),
+    unlink(Pid),
+    Pid.
+
+start_bot(MatchPid, BotId, Script) ->
+    {ok, Pid} = asobi_bot:start_link(MatchPid, BotId, Script),
+    unlink(Pid),
+    Pid.
+
+temp_script(Code) ->
+    Name = "bot_state_" ++ integer_to_list(erlang:unique_integer([positive])) ++ ".lua",
+    Path = filename:join([filename:basedir(user_cache, "asobi_lua_tests"), Name]),
+    ok = filelib:ensure_dir(Path),
+    ok = file:write_file(Path, Code),
+    Path.
+
+stop_process(Pid) ->
+    case is_process_alive(Pid) of
+        true ->
+            Ref = monitor(process, Pid),
+            exit(Pid, shutdown),
+            receive
+                {'DOWN', Ref, process, Pid, _} -> ok
+            after 5000 -> ok
+            end;
+        false ->
+            ok
+    end.
+
+wait_until(Fun) ->
+    wait_until(Fun, 200).
+
+wait_until(_Fun, 0) ->
+    error(condition_never_held);
+wait_until(Fun, N) ->
+    case Fun() of
+        true ->
+            ok;
+        false ->
+            timer:sleep(25),
+            wait_until(Fun, N - 1)
+    end.

--- a/test/asobi_bot_state_tests.erl
+++ b/test/asobi_bot_state_tests.erl
@@ -17,12 +17,17 @@
 bot_state_test_() ->
     {foreach, fun setup/0, fun cleanup/1, [
         {"a bot script's globals survive across think calls", fun globals_persist/0},
-        {"a per-bot cooldown gates input as the guide describes", fun cooldown_gates_input/0}
+        {"a per-bot cooldown gates input as the guide describes", fun cooldown_gates_input/0},
+        {"a bare `return` keeps state and falls back only on the input",
+            fun bare_return_keeps_state/0},
+        {"a state past the ceiling is reloaded and its globals are gone",
+            fun oversized_state_reloads/0},
+        {"a self-referencing table costs the tick, not the bot", fun cyclic_result_survives/0},
+        {"a returned function never reaches the match script", fun callable_input_dropped/0}
     ]}.
 
 setup() ->
-    _ = asobi_bot_input_game:log(),
-    true = ets:delete_all_objects(asobi_bot_input_log),
+    ok = asobi_bot_input_game:reset(),
     case ets:whereis(asobi_match_state) of
         undefined -> ets:new(asobi_match_state, [named_table, public, set]);
         _ -> ok
@@ -51,8 +56,7 @@ globals_persist() ->
         """
     ),
     Ns = run_bot(Script, ~"bot_Counter", fun(Inputs) -> length(Inputs) >= 3 end, ~"n"),
-    ?assertMatch([_, _, _ | _], Ns),
-    ?assertEqual(lists:sublist([1, 2, 3], 3), lists:sublist(Ns, 3)).
+    ?assertEqual([1, 2, 3], lists:sublist(Ns, 3)).
 
 cooldown_gates_input() ->
     %% The pattern guides/lua-bots.md documents: remember the last tick this
@@ -76,6 +80,97 @@ cooldown_gates_input() ->
     ),
     %% Every fourth call, not every call.
     ?assertEqual([1, 4, 7], lists:sublist(Fired, 3)).
+
+bare_return_keeps_state() ->
+    %% `return {}` is one value and takes the ordinary path; only a bare `return`
+    %% yields none. Without the {ok, [], _} clause the odd call's increment is
+    %% rolled back and `calls` never reaches an even number.
+    Script = temp_script(
+        ~"""
+        calls = 0
+        function think(_bot, _state)
+            calls = calls + 1
+            if calls % 2 == 1 then return end
+            return { n = calls }
+        end
+        """
+    ),
+    Ns = run_bot(Script, ~"bot_Bare", fun(Inputs) -> length(Inputs) >= 7 end, ~"n"),
+    ?assertEqual([2, 4, 6], lists:sublist(Ns, 3)).
+
+oversized_state_reloads() ->
+    %% Luerl collects garbage, not what a script keeps live, so a hoarding script
+    %% grows without bound and the collector gives up on it. Past the ceiling the
+    %% script is reloaded, which is observable as `calls` restarting from 1.
+    application:set_env(asobi, max_bot_state_words, 6000),
+    Script = temp_script(
+        ~"""
+        calls = 0
+        hoard = {}
+        function think(_bot, _state)
+            calls = calls + 1
+            for i = 1, 50 do
+                hoard[#hoard + 1] = { i, i, i, i }
+            end
+            return { n = calls }
+        end
+        """
+    ),
+    try
+        Ns = run_bot(Script, ~"bot_Hoarder", fun(Inputs) -> length(Inputs) >= 8 end, ~"n"),
+        ?assert(lists:max(Ns) < length(Ns))
+    after
+        application:unset_env(asobi, max_bot_state_words)
+    end.
+
+cyclic_result_survives() ->
+    %% luerl:decode/2 raises on a table that references itself. Uncaught that
+    %% kills a `temporary` child and the match loses the bot for good, so the
+    %% bot must stay alive and keep sending.
+    Script = temp_script(
+        ~"""
+        calls = 0
+        function think(_bot, _state)
+            calls = calls + 1
+            local t = { n = calls }
+            t.self = t
+            return t
+        end
+        """
+    ),
+    MatchPid = start_match(),
+    BotPid = start_bot(MatchPid, ~"bot_Cyclic", Script),
+    try
+        wait_until(fun() -> length(asobi_bot_input_game:inputs()) >= 3 end),
+        ?assert(is_process_alive(BotPid))
+    after
+        stop_process(BotPid),
+        stop_process(MatchPid),
+        file:delete(Script)
+    end.
+
+callable_input_dropped() ->
+    %% An input crosses into the match script's own Luerl state, so it carries
+    %% only what a client could have sent.
+    Script = temp_script(
+        ~"""
+        function think(_bot, _state)
+            return { shoot = true, aim = { x = 1 }, evil = function() return 1 end }
+        end
+        """
+    ),
+    MatchPid = start_match(),
+    BotPid = start_bot(MatchPid, ~"bot_Callable", Script),
+    try
+        wait_until(fun() -> asobi_bot_input_game:inputs() =/= [] end),
+        [Input | _] = asobi_bot_input_game:inputs(),
+        %% The nested table survives - a bot may send what a player can.
+        ?assertEqual([~"aim", ~"shoot"], lists:sort(maps:keys(Input)))
+    after
+        stop_process(BotPid),
+        stop_process(MatchPid),
+        file:delete(Script)
+    end.
 
 %% --- helpers ---
 


### PR DESCRIPTION
## What was wrong

`asobi_bot` called the operator's Lua `think(bot_id, state)` and threw away the Luerl state it got back, so every tick re-entered the script exactly as it was loaded. A bot script could not remember anything between calls.

That made `guides/lua-bots.md` wrong where it told authors to key per-bot state off `bot_id` in a module-level table, and it is what a forum poster hit trying to make a bot wait four seconds between commands. Their client-side guard fired every tick because the value it compared against had already reset. Working around it server-side was the only thing that could have worked.

Reproduced before fixing, and the regression tests fail on `main` with the exact symptom:

```
globals_persist:      expected [1,2,3]  got [1,1,1]
cooldown_gates_input: expected [1,4,7]  got [1,1,1]
```

## What changed

**The state is threaded across ticks** (`b1cef15`), so a bot script's globals persist the way a match script's do. On failure the pre-call state is carried forward, so a bot that fails every tick cannot grow the state it is failing on; a `think` that returns no values keeps its state and only the input falls back.

**And then bounded** (`2971a17`). Persisting removed the only limit a bot's Lua memory had: `luerl:gc/1` reclaims garbage, not what a script keeps live, and its mark phase is quadratic in the live set, so a hoarding script drives the adaptive collector past its abandon threshold and it switches off for that state. Measured 139 MB per bot after 400 ticks, with a mean tick of 104 ms against a 100 ms loop. `collect_state/1` now returns the size it was already measuring, and a bot past `max_bot_state_words` (10 MB, configurable) reloads its script. A bot is the one Lua bridge where that is affordable: nothing a player can see lives in its state.

Also hardened on the same path:

- `decode_result/2` gains a try/catch. `luerl:decode/2` raises on a self-referencing table, and an uncaught raise kills a `temporary` child, so the match lost the bot for the rest of its life.
- `format_status/1`, so a crash report does not format a multi-MB state (measured 10 MB of log, 1.4 s).
- The think-error log bounds the reason it echoes, since a script chooses what it raises with. Its throttle moves out of `persistent_term`, whose keys were per bot id and therefore never reused.
- An input reaching the match script drops funs, pids, ports and refs. Nested tables are kept, since a bot may send the shaped input a player can.

## Docs

`guides/lua-bots.md` gains **Timing and cooldowns** (count your own `think` calls, or count a tick counter the match broadcasts) and **What a bot may keep**. It also now says that `think` runs on a fixed 100 ms loop independent of `tick_rate`, that a bare `return` runs the default AI rather than declining, and that a failed call is rolled back whole so a deterministic failure repeats forever.

ADR 0005, `asobi_telemetry` and `guides/observability.md` pick up `kind => bot`, with `bot_id` explicitly not a label. The trust model notes that the state copy sits outside the callback budget.

## Review

Ran the full gate. The architecture guardian accepted the design and independently reproduced the bug; the security reviewer raised the memory ceiling as a merge blocker, which is what `2971a17` addresses; the code reviewer found the `{ok, [], _}` clause untested.

Six regression tests, each verified to fail when its own fix is neutralised.

`fmt` / `xref` / `dialyzer` / `eqwalize` clean, full `eunit` 2406 passing, `asobi_lua_SUITE` 8/8. DB-backed CT suites were not run locally: Docker is not reachable from this machine.

## Behaviour changes for anyone already running bots

- A bot script's globals now persist between `think` calls.
- A script holding more than 10 MB of Lua state is reloaded and its globals reset.
- The think-error log carries its message under `event` rather than `msg`. The string is unchanged, so a grep still matches.