### PR TITLE
feat(world): dispatch on_zone_loaded/2 and on_zone_unloaded/2

### DIFF
--- a/guides/large-worlds.md
+++ b/guides/large-worlds.md
@@ -202,18 +202,49 @@ see [Clustering](clustering.md#what-is-per-node).
 ## Zone lifecycle callbacks
 
 A world script can react to zones loading and unloading. Both callbacks are
-optional.
+optional. They run in the world VM, not the zone's, so they see the world's
+state and share the world's 200 ms callback budget.
+
+`on_zone_loaded` is the seam for lazy loading: a zone created on demand has no
+zone_state of its own, and this is where it gets one. The table it returns is
+the `zone_state` argument the zone's own `zone_tick` is handed, from that
+zone's very first tick - so this is where a zone learns its coordinates, its
+biome, or anything else that is a function of where it is.
 
 ```lua
 function on_zone_loaded(cx, cy, state)
-    local zone_state = { biome = "plains" }
+    local zone_state = { biome = "plains", cx = cx, cy = cy }
     return zone_state, state
+end
+
+function zone_tick(entities, zone_state)
+    -- zone_state.biome is "plains" on the first tick after a lazy load
+    return entities, zone_state
 end
 
 function on_zone_unloaded(cx, cy, state)
     return state
 end
 ```
+
+When it runs, and when it does not:
+
+- Only for a zone loaded on demand. A zone pre-spawned at world start already
+  carries the zone_state `generate_world` built for it.
+- Only when there is nothing to restore. In a `persistent` world a zone that
+  has a snapshot loads it, and the hook does not run - restoring and seeding
+  the same zone would throw away what it was holding.
+- Returning an empty table means "no seed", and the zone starts with a
+  `zone_state` of `nil` exactly as it did before. That keeps the usual
+  `if zone_state == nil then` initialisation guard working.
+- The zone does not tick until the callback answers, so a zone never runs with
+  the blank state the callback exists to fill in. A callback that does not
+  answer within a second is given up on, the zone starts blank, and asobi logs
+  `zone_seed_timeout`.
+
+`on_zone_unloaded` runs when the zone process for those coordinates is gone -
+reaped for idleness, or crashed. It does not run when the whole world shuts
+down: the world is going away with it.
 
 In Erlang:
 

--- a/guides/world-server.md
+++ b/guides/world-server.md
@@ -219,7 +219,7 @@ end
 | `spawn_templates(config)` | no | See [Spawn templates](#spawn-templates) |
 | `phases(config)` | no | See [Phases](phases.md) |
 | `on_phase_started(name, state)` / `on_phase_ended(name, state)` | no | Phase transitions |
-| `on_zone_loaded(cx, cy, state)` / `on_zone_unloaded(cx, cy, state)` | no | See [Large worlds](large-worlds.md) |
+| `on_zone_loaded(cx, cy, state)` / `on_zone_unloaded(cx, cy, state)` | no | Seeds a lazily-loaded zone's `zone_state`. See [Large worlds](large-worlds.md#zone-lifecycle-callbacks) |
 | `terrain_provider(config)` | no | See [Large worlds](large-worlds.md) |
 | `on_world_recovered(snapshot, state)` | no | The world process restarted and a snapshot was recovered |
 

--- a/src/lua/asobi_lua_world.erl
+++ b/src/lua/asobi_lua_world.erl
@@ -958,14 +958,29 @@ terrain_provider(_) ->
 on_zone_loaded({CX, CY}, #{lua_state := LuaSt, game_state := GS} = State) ->
     case asobi_lua_loader:call(on_zone_loaded, [CX, CY, GS], LuaSt, ?ZONE_LIFECYCLE_TIMEOUT) of
         {ok, [ZS, GS1 | _], LuaSt1} ->
-            ZoneState = decode_to_map(ZS, LuaSt1),
+            ZoneState = seed_zone_state(decode_to_map(ZS, LuaSt1)),
             {ok, ZoneState, State#{lua_state => LuaSt1, game_state => GS1}};
         {ok, [ZS | _], LuaSt1} ->
-            ZoneState = decode_to_map(ZS, LuaSt1),
+            ZoneState = seed_zone_state(decode_to_map(ZS, LuaSt1)),
             {ok, ZoneState, State#{lua_state => LuaSt1}};
         {error, _} ->
             {ok, #{}, State}
     end.
+
+%% The table the world script returns is what the ZONE script should find in
+%% its own `game_state` - that is the whole point of the hook, and a zone
+%% script has no other way to read it. `init_zone_state/2` builds the zone VM's
+%% game_state out of the `game_state` key of the zone_state it is handed
+%% (restore_game_state/2, the snapshot-restore path), so the seed rides in
+%% under the same key rather than as loose top-level keys the zone VM would
+%% never look at.
+%%
+%% An empty table is no seed at all, and stays one: wrapping it would hand the
+%% zone a `game_state` of `{}` and defeat the `if game_state == nil` guard
+%% every zone script opens with.
+-spec seed_zone_state(map()) -> map().
+seed_zone_state(ZoneState) when map_size(ZoneState) =:= 0 -> #{};
+seed_zone_state(ZoneState) -> #{~"game_state" => ZoneState}.
 
 -spec on_zone_unloaded({integer(), integer()}, map()) -> {ok, map()}.
 on_zone_unloaded({CX, CY}, #{lua_state := LuaSt, game_state := GS} = State) ->

--- a/src/world/asobi_world.erl
+++ b/src/world/asobi_world.erl
@@ -295,11 +295,31 @@ not only the ones that changed.
 -callback terrain_provider(Config :: map()) ->
     {Module :: module(), ProviderArgs :: map()} | none.
 
--doc "Optional: a zone was lazily loaded.".
+-doc """
+Optional: a zone was lazily loaded. `ZoneState` becomes that zone's
+`zone_state`, before its first tick and before `init_zone_state/2` builds any
+per-zone runtime from it.
+
+Runs in the world server, against the world's game state - so for a Lua game it
+runs in the world VM, on the world's budget.
+
+Only for a zone created on demand, and only when it has nothing to restore: a
+pre-spawned zone already carries what `generate_world/2` built for it, and a
+persistent zone with a snapshot has already loaded it. Seeding either would
+discard state the game did not ask to lose.
+
+The zone declines to tick until this answers, so it never runs against the
+blank `zone_state` this callback exists to fill in. See
+`guides/large-worlds.md`.
+""".
 -callback on_zone_loaded(Coords :: {integer(), integer()}, GameState :: term()) ->
     {ok, ZoneState :: map(), GameState1 :: term()}.
 
--doc "Optional: a zone was unloaded.".
+-doc """
+Optional: the zone process for these coords is gone - reaped for idleness, or
+crashed. Not called on world teardown, where the world's own state is going
+away too.
+""".
 -callback on_zone_unloaded(Coords :: {integer(), integer()}, GameState :: term()) ->
     {ok, GameState1 :: term()}.
 

--- a/src/world/asobi_world_server.erl
+++ b/src/world/asobi_world_server.erl
@@ -27,6 +27,7 @@ transient matches use `asobi_match_server` instead.
 -export_type([listing/0]).
 -export([spawn_at/3, spawn_at/4]).
 -export([zone_created/3]).
+-export([zone_loaded/3, zone_unloaded/2]).
 -export([reconnect/2]).
 -export([resync/3]).
 -export([start_vote/2, cast_vote/4, use_veto/3]).
@@ -125,6 +126,28 @@ already covered those coords (widgrensit/asobi#275).
 -spec zone_created(pid(), {integer(), integer()}, pid()) -> ok.
 zone_created(Pid, Coords, ZonePid) when is_pid(ZonePid) ->
     gen_statem:cast(Pid, {zone_created, Coords, ZonePid}).
+
+-doc """
+A lazily-created zone asking for the zone_state `c:asobi_world:on_zone_loaded/2`
+builds for its coords, answered with `asobi_zone:zone_state_loaded/2`.
+
+Cast rather than call in both directions: the world server calls into a zone it
+has just had created (`asobi_zone:sync/1` on the join path), so a blocking call
+the other way deadlocks. See `asobi_zone`'s seed_request/1.
+""".
+-spec zone_loaded(pid(), {integer(), integer()}, pid()) -> ok.
+zone_loaded(Pid, Coords, ZonePid) when is_pid(ZonePid) ->
+    gen_statem:cast(Pid, {zone_loaded, Coords, ZonePid}).
+
+-doc """
+The zone process for these coords is gone - reaped, parked, stopped with the
+world, or crashed - so `c:asobi_world:on_zone_unloaded/2` can update the world's
+game state. Sent by `asobi_zone_manager` as it cleans the coords up, which is
+the one place that sees an orderly stop and a crash alike.
+""".
+-spec zone_unloaded(pid(), {integer(), integer()}) -> ok.
+zone_unloaded(Pid, Coords) ->
+    gen_statem:cast(Pid, {zone_unloaded, Coords}).
 
 -spec move_player(pid(), binary(), {number(), number()}) -> ok.
 move_player(Pid, PlayerId, NewPos) ->
@@ -321,6 +344,16 @@ loading(cast, {move_player, _PlayerId, _NewPos, _Entity}, _State) ->
     {keep_state_and_data, [postpone]};
 loading(cast, {zone_created, _Coords, _ZonePid}, _State) ->
     {keep_state_and_data, [postpone]};
+%% Postponed rather than dropped: the zone that sent this is not ticking until
+%% it gets an answer, and dropping it would cost it the whole seed deadline.
+%% Loading is bounded by generate_world/2, so the wait is short.
+loading(cast, {zone_loaded, _Coords, _ZonePid}, _State) ->
+    {keep_state_and_data, [postpone]};
+%% Not postponed: a zone that came and went before the world finished loading
+%% has nothing for the game state to reconcile, and postponing would deliver an
+%% unload for a zone the game was never told had loaded.
+loading(cast, {zone_unloaded, _Coords}, _State) ->
+    keep_state_and_data;
 %% A world script broadcasting during generate_world/init reaches the world
 %% server while it is still loading. Without this clause that is a
 %% function_clause and the world dies before it ever runs.
@@ -363,6 +396,28 @@ running(cast, {zone_created, {ZX, ZY} = Coords, ZonePid}, #{player_zones := Play
 %% it. loading/3 postpones this same cast unguarded, so a malformed one is
 %% buffered and only detonates on entry to running.
 running(cast, {zone_created, _Coords, _ZonePid}, _State) ->
+    keep_state_and_data;
+running(
+    cast,
+    {zone_loaded, {ZX, ZY} = Coords, ZonePid},
+    #{game_module := Mod, game_state := GS} = State
+) when is_integer(ZX), is_integer(ZY), is_pid(ZonePid) ->
+    {ZoneState, GS1} = call_on_zone_loaded(Mod, Coords, GS, State),
+    asobi_zone:zone_state_loaded(ZonePid, ZoneState),
+    {keep_state, State#{game_state => GS1}};
+%% Still answered. A zone waiting on a seed it will never get stops ticking for
+%% the whole deadline, so a payload that misses the guards costs a second of
+%% that zone's life rather than nothing.
+running(cast, {zone_loaded, _Coords, ZonePid}, _State) when is_pid(ZonePid) ->
+    asobi_zone:zone_state_loaded(ZonePid, #{}),
+    keep_state_and_data;
+running(cast, {zone_loaded, _Coords, _ZonePid}, _State) ->
+    keep_state_and_data;
+running(
+    cast, {zone_unloaded, {ZX, ZY} = Coords}, #{game_module := Mod, game_state := GS} = State
+) when is_integer(ZX), is_integer(ZY) ->
+    {keep_state, State#{game_state => call_on_zone_unloaded(Mod, Coords, GS)}};
+running(cast, {zone_unloaded, _Coords}, _State) ->
     keep_state_and_data;
 %% Guards narrow both cast arguments rather than trusting the sender. The ws
 %% handler validates the frame before it gets here, so this is defence in depth,
@@ -1826,6 +1881,55 @@ resolve_siblings(#{instance_sup := InstanceSup}) ->
     TickerPid = asobi_world_instance:get_child(InstanceSup, asobi_world_ticker),
     ZoneManagerPid = asobi_world_instance:get_child(InstanceSup, asobi_zone_manager),
     {ZoneSupPid, TickerPid, ZoneManagerPid}.
+
+%% --- Internal: Zone lifecycle ---
+
+%% Both hooks run the game module in this process, so a game module that raises
+%% would take the world server with it - and this instance is one_for_all, so
+%% that is every zone, the ticker and the manager, for one bad coords. A lazy
+%% load is triggered by whichever player happened to walk that way, so the blast
+%% radius would be arbitrary. Caught, logged, and the zone starts blank.
+-spec call_on_zone_loaded(module(), {integer(), integer()}, term(), map()) -> {map(), term()}.
+call_on_zone_loaded(Mod, Coords, GS, State) ->
+    case erlang:function_exported(Mod, on_zone_loaded, 2) of
+        false ->
+            {#{}, GS};
+        true ->
+            try Mod:on_zone_loaded(Coords, GS) of
+                {ok, ZoneState, GS1} when is_map(ZoneState) ->
+                    {ZoneState, GS1};
+                Other ->
+                    log_zone_hook_error(on_zone_loaded, Coords, {bad_return, Other}, State),
+                    {#{}, GS}
+            catch
+                Class:Reason:Stack ->
+                    log_zone_hook_error(on_zone_loaded, Coords, {Class, Reason, Stack}, State),
+                    {#{}, GS}
+            end
+    end.
+
+-spec call_on_zone_unloaded(module(), {integer(), integer()}, term()) -> term().
+call_on_zone_unloaded(Mod, Coords, GS) ->
+    case erlang:function_exported(Mod, on_zone_unloaded, 2) of
+        false ->
+            GS;
+        true ->
+            try Mod:on_zone_unloaded(Coords, GS) of
+                {ok, GS1} -> GS1;
+                _Other -> GS
+            catch
+                _Class:_Reason -> GS
+            end
+    end.
+
+log_zone_hook_error(Hook, Coords, Reason, State) ->
+    ?LOG_ERROR(#{
+        event => zone_lifecycle_hook_failed,
+        world_id => maps:get(world_id, State, undefined),
+        hook => Hook,
+        coords => Coords,
+        reason => Reason
+    }).
 
 %% --- Internal: Phases ---
 

--- a/src/world/asobi_zone.erl
+++ b/src/world/asobi_zone.erl
@@ -8,6 +8,7 @@ via `asobi_spatial`. Zones are created and reaped lazily as players move.
 -behaviour(gen_server).
 
 -export([start_link/1, reap/1]).
+-export([zone_state_loaded/2]).
 -export([tick/2, player_input/3, player_input/4, add_entity/3, remove_entity/2]).
 -export([spawn_entity/3, spawn_entity/4, spawn_entities/2, despawn_entity/2]).
 -export([subscribe/2, unsubscribe/2, resync/2]).
@@ -63,6 +64,13 @@ via `asobi_spatial`. Zones are created and reaped lazily as players move.
 %% the manager is saturated - in which case the NPC waits in this zone for a
 %% later tick rather than the zone stalling behind a 5s gen_server default.
 -define(ENSURE_ZONE_TIMEOUT, 1_000).
+%% How long a lazily-created zone waits for the world's `on_zone_loaded/2`
+%% answer before giving up and starting blank. The callback itself is budgeted
+%% at 200 ms in the world VM (asobi_lua_world's ?ZONE_LIFECYCLE_TIMEOUT); the
+%% rest is the world server's mailbox on a busy world. A zone that gives up
+%% logs and ticks - a world that stops opening zones because one script hung
+%% is a worse failure than one blank zone.
+-define(ZONE_SEED_DEADLINE, 1_000).
 %% How long a zone stays on the text wire before trying the binary one again, and
 %% the ceiling the doubling stops at. Read from the environment at zone start so a
 %% deployment whose games legitimately produce short-lived unencodable entities can
@@ -83,6 +91,17 @@ start_link(Config) ->
 -spec reap(pid()) -> ok.
 reap(Pid) ->
     gen_server:cast(Pid, reap).
+
+-doc """
+The world's answer to this zone's seed request: the zone_state
+`c:asobi_world:on_zone_loaded/2` built for these coords.
+
+Only `asobi_world_server` sends this, and only in reply to the cast
+`seed_request/1` makes. See there for why the round trip is asynchronous.
+""".
+-spec zone_state_loaded(pid(), map()) -> ok.
+zone_state_loaded(Pid, ZoneState) when is_map(ZoneState) ->
+    gen_server:cast(Pid, {zone_state_loaded, ZoneState}).
 
 -spec tick(pid(), non_neg_integer()) -> ok.
 tick(Pid, TickN) ->
@@ -304,6 +323,10 @@ init(Config) ->
             %% See touch_manager/1.
             zone_stamp_tab => maps:get(zone_stamp_tab, Config, undefined),
             terrain_store_pid => TerrainStorePid,
+            %% Set by asobi_zone_manager for a zone it started on demand, and
+            %% only then: a pre-warmed zone already carries the zone_state
+            %% generate_world/2 built for it. See seed_request/1.
+            zone_seed_hook => maps:get(zone_seed_hook, Config, false),
             zone_size => ZoneSize,
             grid_size => GridSize,
             rehome_margin => RehomeMargin,
@@ -418,9 +441,60 @@ init(Config) ->
 %% Build the zone's runtime state in the zone process (so a per-zone VM binds
 %% to self()), regardless of how the zone was created — pre-spawned, lazy, or
 %% recovered. Game modules without the callback keep their zone_state as-is.
+%%
+%% A lazily-created zone with nothing to restore asks the world for its
+%% zone_state first (seed_request/1) and finishes on the answer, so
+%% `init_zone_state` sees the seeded state rather than a blank map.
 -spec handle_continue(init_zone_state, map()) -> {noreply, map()}.
 handle_continue(init_zone_state, State0) ->
     State = maybe_restore_from_snapshot(State0),
+    case seed_request(State) of
+        {sent, State1} -> {noreply, State1};
+        none -> {noreply, build_zone_state(State)}
+    end.
+
+%% Ask the world server to run `c:asobi_world:on_zone_loaded/2` for these coords.
+%%
+%% The callback runs against the world's game state, which only the world server
+%% holds - for `asobi_lua_world` that is the world VM, and its 200 ms budget is
+%% documented as a world-VM budget. So the zone cannot run it itself, and it
+%% cannot *call* the world server either: the world server synchronously calls
+%% into a zone it has just had created (`asobi_zone:sync/1` on the join path),
+%% so a blocking call the other way deadlocks both for the length of two
+%% timeouts, on every join that opens a zone.
+%%
+%% The round trip is therefore two casts, and the zone declines to tick until
+%% the answer lands or `?ZONE_SEED_DEADLINE` passes. That is what "before the
+%% first tick" costs when the state has to come from another process.
+%%
+%% Only for a zone the manager started on demand (`zone_seed_hook`) that has
+%% nothing restored: a pre-warmed zone arrives with the zone_state
+%% `generate_world/2` built, and a persistent zone with a snapshot has already
+%% loaded it. Seeding either would overwrite state the game did not ask to lose.
+-spec seed_request(map()) -> {sent, map()} | none.
+seed_request(
+    #{
+        zone_seed_hook := true,
+        zone_state := ZoneState,
+        game_module := GameMod,
+        world_server_pid := WorldServerPid,
+        coords := Coords
+    } = State
+) when map_size(ZoneState) =:= 0, is_pid(WorldServerPid) ->
+    _ = code:ensure_loaded(GameMod),
+    case erlang:function_exported(GameMod, on_zone_loaded, 2) of
+        true ->
+            asobi_world_server:zone_loaded(WorldServerPid, Coords, self()),
+            TRef = erlang:send_after(?ZONE_SEED_DEADLINE, self(), zone_seed_deadline),
+            {sent, State#{zone_seed => TRef}};
+        false ->
+            none
+    end;
+seed_request(_State) ->
+    none.
+
+-spec build_zone_state(map()) -> map().
+build_zone_state(State) ->
     #{
         game_module := GameMod,
         world_id := WorldId,
@@ -443,7 +517,7 @@ handle_continue(init_zone_state, State0) ->
         border_tab => maps:get(border_tab, State, undefined)
     },
     ZoneState1 = call_optional(GameMod, init_zone_state, [ZoneConfig, ZoneState], ZoneState),
-    {noreply, State#{zone_state => ZoneState1}}.
+    State#{zone_state => ZoneState1}.
 
 %% Lazy zones (and idle-reaped ones) start with a blank zone_state. For a
 %% persistent world, recover the last snapshot here, in the zone process, so
@@ -565,6 +639,26 @@ handle_call(_Request, _From, State) ->
 
 -spec handle_cast(term(), map()) ->
     {noreply, map()} | {noreply, map(), hibernate} | {stop, normal, map()}.
+%% The world's answer to seed_request/1. `zone_seed` present is what says this
+%% zone asked and has not been answered - a second answer (a duplicated cast, or
+%% one arriving after the deadline already gave up) must not rebuild a zone_state
+%% the game has been mutating since, so it is dropped.
+handle_cast({zone_state_loaded, ZoneState}, #{zone_seed := TRef} = State) when
+    is_map(ZoneState)
+->
+    _ = erlang:cancel_timer(TRef),
+    State1 = maps:remove(zone_seed, State#{zone_state => ZoneState}),
+    {noreply, build_zone_state(State1)};
+handle_cast({zone_state_loaded, _ZoneState}, State) ->
+    {noreply, State};
+%% A zone that has not been seeded yet has no zone_state and, for a game with a
+%% per-zone VM, no VM either - init_zone_state has not run. Ticking it would run
+%% the game's spawner and handle_effects against exactly the blank state
+%% on_zone_loaded/2 exists to fill in, which is the bug (widgrensit/asobi#574),
+%% so drop the tick and stay active. The deadline below bounds this.
+handle_cast({tick, _TickN}, #{zone_seed := _} = State) ->
+    touch_manager(State),
+    {noreply, State};
 handle_cast(reap, #{entities := Entities, script_busy := true} = State) when
     map_size(Entities) =:= 0
 ->
@@ -756,6 +850,22 @@ handle_cast(_Msg, State) ->
     {noreply, State}.
 
 -spec handle_info(term(), map()) -> {noreply, map()} | {stop, term(), map()}.
+%% The world never answered seed_request/1 - it is overloaded, its script hung,
+%% or the game module's on_zone_loaded/2 crashed the callback out. Start blank
+%% and tick: a zone that never ticks is invisible to everyone in it, which is
+%% worse than a zone whose script has to cope with an empty zone_state. Loud,
+%% because a game relying on the seed will now be wrong.
+handle_info(zone_seed_deadline, #{zone_seed := _, coords := Coords} = State) ->
+    ?LOG_WARNING(#{
+        event => zone_seed_timeout,
+        world_id => maps:get(world_id, State, undefined),
+        coords => Coords,
+        timeout_ms => ?ZONE_SEED_DEADLINE,
+        msg => ~"on_zone_loaded/2 did not answer in time; the zone starts blank"
+    }),
+    {noreply, build_zone_state(maps:remove(zone_seed, State))};
+handle_info(zone_seed_deadline, State) ->
+    {noreply, State};
 handle_info({'DOWN', _Ref, process, DownPid, _Reason}, #{subscribers := Subs} = State) ->
     Subs1 = maps:filter(
         fun(_PlayerId, {Pid, _MonRef}) -> Pid =/= DownPid end,

--- a/src/world/asobi_zone_manager.erl
+++ b/src/world/asobi_zone_manager.erl
@@ -241,19 +241,27 @@ init(Opts) ->
     }}.
 
 -spec handle_call(term(), gen_server:from(), map()) -> {reply, term(), map()}.
-handle_call({ensure_zone, Coords}, _From, #{ets_tab := Tab} = State) ->
+%% Guarded like `revive_zone` below rather than trusting the payload: this
+%% manager is `transient` under a ONE_FOR_ALL supervisor, so a function_clause
+%% here takes the zone supervisor, the ticker, the world server and every zone
+%% with it. A caller that sends nonsense gets an error, not a dead world.
+handle_call({ensure_zone, {ZX, ZY} = Coords}, _From, #{ets_tab := Tab} = State) when
+    is_integer(ZX), is_integer(ZY)
+->
     case ets:lookup(Tab, Coords) of
         [{Coords, Pid}] ->
             touch(Coords, State),
             {reply, {ok, Pid, existing}, State};
         [] ->
-            case start_zone(Coords, State) of
+            case start_zone(Coords, lazy, State) of
                 {ok, Pid, State1} ->
                     {reply, {ok, Pid, created}, State1};
                 {error, Reason} ->
                     {reply, {error, Reason}, State}
             end
     end;
+handle_call({ensure_zone, _Coords}, _From, State) ->
+    {reply, {error, invalid_coords}, State};
 handle_call({revive_zone, {ZX, ZY} = Coords, DeadPid}, _From, #{ets_tab := Tab} = State) when
     is_integer(ZX), is_integer(ZY), is_pid(DeadPid)
 ->
@@ -261,7 +269,7 @@ handle_call({revive_zone, {ZX, ZY} = Coords, DeadPid}, _From, #{ets_tab := Tab} 
         [{Coords, DeadPid}] ->
             case await_zone_down(Coords, DeadPid, State) of
                 {ok, State1} ->
-                    case start_zone(Coords, State1) of
+                    case start_zone(Coords, lazy, State1) of
                         {ok, Pid, State2} -> {reply, {ok, Pid, created}, State2};
                         {error, Reason} -> {reply, {error, Reason}, State1}
                     end;
@@ -272,7 +280,7 @@ handle_call({revive_zone, {ZX, ZY} = Coords, DeadPid}, _From, #{ets_tab := Tab} 
             touch(Coords, State),
             {reply, {ok, Pid, existing}, State};
         [] ->
-            case start_zone(Coords, State) of
+            case start_zone(Coords, lazy, State) of
                 {ok, Pid, State1} -> {reply, {ok, Pid, created}, State1};
                 {error, Reason} -> {reply, {error, Reason}, State}
             end
@@ -375,8 +383,15 @@ terminate(_Reason, #{ets_tab := Tab, stamp_tab := StampTab}) ->
 
 %% --- Internal ---
 
+%% `Origin` is what tells the new zone whether to ask the world for a
+%% zone_state: `lazy` means nobody has built one for these coords, `prewarm`
+%% means generate_world/2 already did (set_initial_zone_states/2). See
+%% asobi_zone's seed_request/1 and widgrensit/asobi#574.
+-spec start_zone({integer(), integer()}, lazy | prewarm, map()) ->
+    {ok, pid(), map()} | {error, term()}.
 start_zone(
     Coords,
+    Origin,
     #{
         ets_tab := Tab,
         stamp_tab := StampTab,
@@ -394,7 +409,11 @@ start_zone(
         false ->
             %% Handed to the zone so it can stamp itself active without a cast
             %% at the manager - see stamp_active/2.
-            Config0 = BaseConfig#{coords => Coords, zone_stamp_tab => StampTab},
+            Config0 = BaseConfig#{
+                coords => Coords,
+                zone_stamp_tab => StampTab,
+                zone_seed_hook => Origin =:= lazy
+            },
             Config =
                 case maps:get(Coords, InitialStates, undefined) of
                     undefined -> Config0;
@@ -431,8 +450,11 @@ cleanup_zone(
     %% being there - a live-zone gauge built from opened minus closed would go
     %% negative otherwise.
     case ets:member(Tab, Coords) of
-        true -> asobi_telemetry:zone_closed(WorldId, Coords);
-        false -> ok
+        true ->
+            asobi_telemetry:zone_closed(WorldId, Coords),
+            notify_zone_unloaded(Coords, State);
+        false ->
+            ok
     end,
     %% The zone's own terminate/2 clears this too, but it does not run when the
     %% zone is killed rather than stopped - and a stale band row keeps a dead
@@ -535,6 +557,25 @@ reap_expired([Coords | Rest], Tab, State) ->
 touch(Coords, #{stamp_tab := StampTab}) ->
     stamp_active(StampTab, Coords).
 
+%% `c:asobi_world:on_zone_unloaded/2`, dispatched from here rather than from the
+%% zone's own terminate/2 because this is the one place that sees a reaped zone
+%% and a crashed one alike - terminate/2 does not run on a kill. Gated on the
+%% ETS row the same way the close telemetry is, so the double-call paths
+%% (a DOWN racing await_zone_down/3) deliver one unload, not two.
+%%
+%% Nothing fires on world teardown: the instance supervisor stops this manager
+%% before the zone supervisor, so the zones' DOWNs are never processed. A game
+%% that needs to persist on world end has on_world_recovered/2's counterpart in
+%% the world server's own terminate, not this.
+-spec notify_zone_unloaded({integer(), integer()}, map()) -> ok.
+notify_zone_unloaded(Coords, #{zone_config := ZoneConfig}) ->
+    case maps:get(world_server_pid, ZoneConfig, undefined) of
+        WSPid when is_pid(WSPid) -> asobi_world_server:zone_unloaded(WSPid, Coords);
+        _ -> ok
+    end;
+notify_zone_unloaded(_Coords, _State) ->
+    ok.
+
 %% The ticker owns its own active set rather than re-reading this manager's
 %% table every tick (widgrensit/asobi#560), so a zone has to be handed to it
 %% when it opens. Removal needs no counterpart: the ticker monitors what it is
@@ -578,7 +619,7 @@ prewarm_zones([Coords | Rest], #{ets_tab := Tab} = State) ->
             [{_, _}] ->
                 State;
             [] ->
-                case start_zone(Coords, State) of
+                case start_zone(Coords, prewarm, State) of
                     {ok, _Pid, S1} -> S1;
                     {error, _} -> State
                 end

--- a/test/asobi_lua_world_integration_tests.erl
+++ b/test/asobi_lua_world_integration_tests.erl
@@ -222,6 +222,42 @@ defined_callback_error_emits_game_error_test_() ->
         end
     end}.
 
+%% widgrensit/asobi#574: the whole chain, through the real world instance - a
+%% lazily-created zone asks the world server, the world VM runs
+%% `on_zone_loaded`, and what it returns is the `zone_state` the ZONE script
+%% is handed on its first tick. Asserting on the zone's Lua-visible state
+%% rather than on the bridge function is the point: the bridge was always
+%% callable, it was just never reached.
+lua_on_zone_loaded_seeds_a_lazy_zone_test_() ->
+    {timeout, 10, fun() ->
+        Config = (world_config(fixture("zone_seed_world.lua")))#{
+            grid_size => 3,
+            zone_size => 100,
+            lazy_zones => true
+        },
+        InstancePid = start_world(Config),
+        try
+            WorldPid = asobi_world_instance:get_child(InstancePid, asobi_world_server),
+            ZoneManagerPid = asobi_world_instance:get_child(InstancePid, asobi_zone_manager),
+            ok = asobi_world_server:join(WorldPid, ~"p1"),
+            {ok, ZonePid} = poll_until(
+                fun() -> asobi_zone_manager:get_zone(ZoneManagerPid, {1, 1}) end,
+                fun(R) -> R =/= not_loaded end,
+                2000
+            ),
+            Marker = poll_until(
+                fun() -> maps:get(~"marker", asobi_zone:get_entities(ZonePid), undefined) end,
+                fun(E) -> is_map(E) end,
+                2000
+            ),
+            ?assertMatch(#{biome := ~"plains"}, Marker),
+            ?assertEqual(1, maps:get(cx, Marker)),
+            ?assertEqual(1, maps:get(cy, Marker))
+        after
+            exit(InstancePid, shutdown)
+        end
+    end}.
+
 -spec poll_until(fun(() -> T), fun((T) -> boolean()), non_neg_integer()) -> T.
 poll_until(Get, _Done, TimeoutMs) when TimeoutMs =< 0 ->
     Get();

--- a/test/asobi_lua_world_integration_tests.erl
+++ b/test/asobi_lua_world_integration_tests.erl
@@ -237,7 +237,7 @@ lua_on_zone_loaded_seeds_a_lazy_zone_test_() ->
         },
         InstancePid = start_world(Config),
         try
-            WorldPid = asobi_world_instance:get_child(InstancePid, asobi_world_server),
+            WorldPid = child_pid(InstancePid, asobi_world_server),
             ZoneManagerPid = asobi_world_instance:get_child(InstancePid, asobi_zone_manager),
             ok = asobi_world_server:join(WorldPid, ~"p1"),
             {ok, ZonePid} = poll_until(
@@ -257,6 +257,14 @@ lua_on_zone_loaded_seeds_a_lazy_zone_test_() ->
             exit(InstancePid, shutdown)
         end
     end}.
+
+%% get_child/2 answers `undefined | pid()`; a test that is about to call the
+%% child has already failed if it is not there.
+-spec child_pid(pid(), atom()) -> pid().
+child_pid(InstancePid, Id) ->
+    case asobi_world_instance:get_child(InstancePid, Id) of
+        Pid when is_pid(Pid) -> Pid
+    end.
 
 -spec poll_until(fun(() -> T), fun((T) -> boolean()), non_neg_integer()) -> T.
 poll_until(Get, _Done, TimeoutMs) when TimeoutMs =< 0 ->

--- a/test/asobi_lua_world_tests.erl
+++ b/test/asobi_lua_world_tests.erl
@@ -604,8 +604,38 @@ on_zone_loaded_returns_zone_state_test() ->
     try
         {ok, S0} = asobi_lua_world:init(#{lua_script => Path}),
         {ok, ZoneState, _S1} = asobi_lua_world:on_zone_loaded({3, 4}, S0),
-        ?assertEqual(3, maps:get(~"cx", ZoneState)),
-        ?assertEqual(4, maps:get(~"cy", ZoneState))
+        %% Nested under `game_state`, which is the key init_zone_state/2 builds
+        %% the zone VM's game_state out of - a flat table would reach the zone
+        %% and then be invisible to its script.
+        Seed = maps:get(~"game_state", ZoneState),
+        ?assertEqual(3, maps:get(~"cx", Seed)),
+        ?assertEqual(4, maps:get(~"cy", Seed))
+    after
+        file:delete(Path)
+    end.
+
+%% A world script whose on_zone_loaded returns nothing must not hand the zone a
+%% game_state of {}: every zone script opens with `if game_state == nil`.
+on_zone_loaded_empty_return_is_no_seed_test() ->
+    Path = world_temp_script(
+        ~"""
+        match_size = 1
+        max_players = 1
+        game_type = "world"
+        function init(_) return {} end
+        function spawn_position(_, _) return { x = 0, y = 0 } end
+        function generate_world(_, _) return { ['0,0'] = {} } end
+        function zone_tick(e, z) return e, z end
+        function handle_input(_, _, e) return e end
+        function post_tick(_, s) return s end
+        function on_zone_loaded(_, _, s) return {}, s end
+        """
+    ),
+    try
+        {ok, S0} = asobi_lua_world:init(#{lua_script => Path}),
+        ?assertMatch({ok, #{}, _}, asobi_lua_world:on_zone_loaded({3, 4}, S0)),
+        {ok, ZoneState, _} = asobi_lua_world:on_zone_loaded({3, 4}, S0),
+        ?assertEqual(0, map_size(ZoneState))
     after
         file:delete(Path)
     end.

--- a/test/asobi_world_callbacks_tests.erl
+++ b/test/asobi_world_callbacks_tests.erl
@@ -1,7 +1,13 @@
 -module(asobi_world_callbacks_tests).
 -include_lib("eunit/include/eunit.hrl").
 
-%% Verify the new optional callbacks are defined in the behaviour
+%% Verify the new optional callbacks are defined in the behaviour.
+%%
+%% Membership in behaviour_info/1 only says the declaration exists - it says
+%% nothing about whether asobi ever calls it, which is how on_zone_loaded/2
+%% stayed dead through three of these (widgrensit/asobi#574). The dispatch is
+%% tested in asobi_zone_lifecycle_hooks_tests and, end to end through a Lua
+%% world, in asobi_lua_world_integration_tests.
 
 terrain_provider_callback_defined_test() ->
     Callbacks = asobi_world:behaviour_info(callbacks),

--- a/test/asobi_zone_lifecycle_hooks_tests.erl
+++ b/test/asobi_zone_lifecycle_hooks_tests.erl
@@ -1,0 +1,140 @@
+-module(asobi_zone_lifecycle_hooks_tests).
+-include_lib("eunit/include/eunit.hrl").
+
+%% widgrensit/asobi#574: on_zone_loaded/2 and on_zone_unloaded/2 were declared,
+%% bridged and documented, and never dispatched. These drive a real lazy zone
+%% load through asobi_world_instance and assert the hook ran AND that what it
+%% returned reached the zone's zone_state - the two things a behaviour_info/1
+%% membership assertion cannot tell apart from a dead callback.
+
+-define(GAME, asobi_zone_seed_game).
+-define(PROBE, asobi_zone_seed_probe).
+-define(BASE_CONFIG, #{
+    game_module => ?GAME,
+    grid_size => 3,
+    zone_size => 100,
+    tick_rate => 50,
+    max_players => 10,
+    view_radius => 0
+}).
+
+setup() ->
+    case whereis(nova_scope) of
+        undefined -> pg:start_link(nova_scope);
+        _ -> ok
+    end,
+    meck:new(asobi_repo, [no_link]),
+    meck:expect(asobi_repo, insert, fun(_CS) -> {ok, #{}} end),
+    meck:expect(asobi_repo, insert, fun(_CS, _Opts) -> {ok, #{}} end),
+    meck:new(asobi_presence, [non_strict, no_link]),
+    meck:expect(asobi_presence, send, fun(_PlayerId, _Msg) -> ok end),
+    ok.
+
+cleanup(_) ->
+    meck:unload(asobi_presence),
+    meck:unload(asobi_repo),
+    ok.
+
+start_world(Overrides) ->
+    unregister_probe(),
+    true = register(?PROBE, self()),
+    Config = maps:merge(?BASE_CONFIG, Overrides),
+    {ok, InstancePid} = asobi_world_instance:start_link(Config),
+    unlink(InstancePid),
+    timer:sleep(50),
+    #{
+        instance_pid => InstancePid,
+        world_pid => asobi_world_instance:get_child(InstancePid, asobi_world_server),
+        zone_mgr => asobi_world_instance:get_child(InstancePid, asobi_zone_manager)
+    }.
+
+stop_world(#{instance_pid := InstancePid}) ->
+    exit(InstancePid, shutdown),
+    timer:sleep(20),
+    unregister_probe(),
+    flush(),
+    ok.
+
+unregister_probe() ->
+    case whereis(?PROBE) of
+        undefined -> ok;
+        _ -> unregister(?PROBE)
+    end,
+    ok.
+
+flush() ->
+    receive
+        _ -> flush()
+    after 0 -> ok
+    end.
+
+await(Msg, Timeout) ->
+    receive
+        Msg -> ok
+    after Timeout -> timeout
+    end.
+
+zone_lifecycle_hooks_test_() ->
+    {setup, fun setup/0, fun cleanup/1, [
+        {"a lazily-created zone runs on_zone_loaded/2", fun lazy_zone_runs_on_zone_loaded/0},
+        {"what on_zone_loaded/2 returns is the zone's zone_state",
+            fun seed_reaches_the_zone_state/0},
+        {"a pre-warmed zone does not run on_zone_loaded/2", fun prewarmed_zone_is_not_seeded/0},
+        {"a stopped zone runs on_zone_unloaded/2", fun stopped_zone_runs_on_zone_unloaded/0},
+        {"a re-created zone is seeded again", fun recreated_zone_is_seeded_again/0}
+    ]}.
+
+lazy_zone_runs_on_zone_loaded() ->
+    Ctx = start_world(#{lazy_zones => true}),
+    #{world_pid := Pid} = Ctx,
+    ?assertEqual(ok, asobi_world_server:join(Pid, ~"p1")),
+    ?assertEqual(ok, await({on_zone_loaded, {1, 1}}, 1000)),
+    stop_world(Ctx).
+
+seed_reaches_the_zone_state() ->
+    Ctx = start_world(#{lazy_zones => true}),
+    #{world_pid := Pid, zone_mgr := Mgr} = Ctx,
+    ?assertEqual(ok, asobi_world_server:join(Pid, ~"p1")),
+    ?assertEqual(ok, await({on_zone_loaded, {1, 1}}, 1000)),
+    {ok, ZonePid} = asobi_zone_manager:get_zone(Mgr, {1, 1}),
+    ZoneState = zone_state(ZonePid),
+    ?assertEqual(~"plains", maps:get(biome, ZoneState)),
+    ?assertEqual({1, 1}, {maps:get(cx, ZoneState), maps:get(cy, ZoneState)}),
+    stop_world(Ctx).
+
+zone_state(ZonePid) ->
+    case sys:get_state(ZonePid) of
+        #{zone_state := ZS} when is_map(ZS) -> ZS
+    end.
+
+prewarmed_zone_is_not_seeded() ->
+    Ctx = start_world(#{lazy_zones => false}),
+    #{world_pid := Pid} = Ctx,
+    ?assertEqual(ok, asobi_world_server:join(Pid, ~"p1")),
+    ?assertEqual(timeout, await({on_zone_loaded, {1, 1}}, 300)),
+    stop_world(Ctx).
+
+stopped_zone_runs_on_zone_unloaded() ->
+    Ctx = start_world(#{lazy_zones => true}),
+    #{world_pid := Pid, zone_mgr := Mgr} = Ctx,
+    ?assertEqual(ok, asobi_world_server:join(Pid, ~"p1")),
+    ?assertEqual(ok, await({on_zone_loaded, {1, 1}}, 1000)),
+    {ok, ZonePid} = asobi_zone_manager:get_zone(Mgr, {1, 1}),
+    exit(ZonePid, kill),
+    ?assertEqual(ok, await({on_zone_unloaded, {1, 1}}, 1000)),
+    stop_world(Ctx).
+
+%% The manager marks every zone it starts on demand, not just the first, so a
+%% zone that was reaped and comes back is seeded rather than starting blank -
+%% which is the case #574 was actually about.
+recreated_zone_is_seeded_again() ->
+    Ctx = start_world(#{lazy_zones => true}),
+    #{world_pid := Pid, zone_mgr := Mgr} = Ctx,
+    ?assertEqual(ok, asobi_world_server:join(Pid, ~"p1")),
+    ?assertEqual(ok, await({on_zone_loaded, {1, 1}}, 1000)),
+    {ok, ZonePid} = asobi_zone_manager:get_zone(Mgr, {1, 1}),
+    exit(ZonePid, kill),
+    ?assertEqual(ok, await({on_zone_unloaded, {1, 1}}, 1000)),
+    ?assertMatch({ok, _, _}, asobi_zone_manager:ensure_zone(Mgr, {2, 2})),
+    ?assertEqual(ok, await({on_zone_loaded, {2, 2}}, 1000)),
+    stop_world(Ctx).

--- a/test/asobi_zone_seed_game.erl
+++ b/test/asobi_zone_seed_game.erl
@@ -1,0 +1,52 @@
+-module(asobi_zone_seed_game).
+-behaviour(asobi_world).
+
+%% A world game module that seeds every lazily-loaded zone from
+%% `on_zone_loaded/2` and reports both lifecycle hooks to whichever process
+%% registered itself as ?PROBE. Used by asobi_zone_lifecycle_hooks_tests.
+
+-export([init/1, join/2, leave/2, spawn_position/2]).
+-export([zone_tick/2, post_tick/2, on_zone_loaded/2, on_zone_unloaded/2]).
+
+-define(PROBE, asobi_zone_seed_probe).
+
+-spec init(map()) -> {ok, map()}.
+init(_Config) ->
+    {ok, #{loaded => [], unloaded => []}}.
+
+-spec join(binary(), map()) -> {ok, map()}.
+join(_PlayerId, State) ->
+    {ok, State}.
+
+-spec leave(binary(), map()) -> {ok, map()}.
+leave(_PlayerId, State) ->
+    {ok, State}.
+
+-spec spawn_position(binary(), map()) -> {ok, {number(), number()}}.
+spawn_position(_PlayerId, _State) ->
+    {ok, {100.0, 100.0}}.
+
+-spec zone_tick(map(), term()) -> {map(), term()}.
+zone_tick(Entities, ZoneState) ->
+    {Entities, ZoneState}.
+
+-spec post_tick(non_neg_integer(), map()) -> {ok, map()}.
+post_tick(_TickN, State) ->
+    {ok, State}.
+
+-spec on_zone_loaded({integer(), integer()}, map()) -> {ok, map(), map()}.
+on_zone_loaded({CX, CY} = Coords, #{loaded := Loaded} = State) ->
+    probe({on_zone_loaded, Coords}),
+    ZoneState = #{biome => ~"plains", cx => CX, cy => CY},
+    {ok, ZoneState, State#{loaded => [Coords | Loaded]}}.
+
+-spec on_zone_unloaded({integer(), integer()}, map()) -> {ok, map()}.
+on_zone_unloaded(Coords, #{unloaded := Unloaded} = State) ->
+    probe({on_zone_unloaded, Coords}),
+    {ok, State#{unloaded => [Coords | Unloaded]}}.
+
+probe(Msg) ->
+    case whereis(?PROBE) of
+        undefined -> ok;
+        Pid -> Pid ! Msg
+    end.

--- a/test/fixtures/lua/zone_seed_world.lua
+++ b/test/fixtures/lua/zone_seed_world.lua
@@ -1,0 +1,52 @@
+-- widgrensit/asobi#574: a lazily-loaded zone gets its zone_state from the
+-- world's on_zone_loaded, and the zone script sees it as its zone_state on
+-- the very first tick.
+match_size = 8
+max_players = 8
+game_type = "world"
+
+function init(_)
+    return {}
+end
+
+function spawn_position(_, _)
+    return { x = 100, y = 100 }
+end
+
+function generate_world(_, _)
+    return {}
+end
+
+function join(_, state)
+    return state
+end
+
+function leave(_, state)
+    return state
+end
+
+function on_zone_loaded(cx, cy, state)
+    return { biome = "plains", cx = cx, cy = cy }, state
+end
+
+function zone_tick(entities, zone_state)
+    if zone_state ~= nil and zone_state.biome ~= nil then
+        entities["marker"] = {
+            x = 0,
+            y = 0,
+            type = "marker",
+            biome = zone_state.biome,
+            cx = zone_state.cx,
+            cy = zone_state.cy,
+        }
+    end
+    return entities, zone_state
+end
+
+function handle_input(_, _, entities)
+    return entities
+end
+
+function post_tick(_, state)
+    return state
+end


### PR DESCRIPTION
Closes #574.

Both callbacks were declared, bridged into `asobi_lua_world`, documented in three guides, and never dispatched from `src/`. The tests did not catch it because they asserted membership in `asobi_world:behaviour_info(callbacks)` - a tautology over the declaration - and called the bridge function directly.

## What now happens

`on_zone_loaded/2` runs when `asobi_zone_manager` starts a zone **on demand** and that zone has **nothing to restore**:

- a pre-warmed zone already carries the zone_state `generate_world/2` built for it;
- a persistent zone with a snapshot has already loaded it, and seeding it would discard what it was holding.

`on_zone_unloaded/2` runs from the manager's `cleanup_zone/2` - the one place that sees a reaped zone and a crashed one alike, since `terminate/2` does not run on a kill. It does not fire on world teardown: the instance supervisor stops the manager before the zone supervisor, so the zones' DOWNs are never processed.

## Why it is a two-cast round trip

The callback runs against the world's game state, which only the world server holds - for `asobi_lua_world` that is the world VM, and the 200 ms budget in `guides/security-trust-model.md` is a world-VM budget. So the zone cannot run it itself.

It cannot *call* the world server either: the world server synchronously calls into a zone it has just had created (`asobi_zone:sync/1` in `bind_player_zone/4`), so a blocking call the other way deadlocks both for two timeouts on every join that opens a zone.

So it is two casts, and the zone declines to tick until the answer lands - a tick before the seed would run the spawner and `handle_effects` against exactly the blank `zone_state` the hook exists to fill in. `?ZONE_SEED_DEADLINE` (1s) bounds it: a zone that is never answered starts blank, logs `zone_seed_timeout`, and ticks. A zone that never ticks is worse than a blank one.

## The Lua shape

`init_zone_state/2` builds the zone VM's `game_state` out of the `game_state` key of the zone_state it is handed. A flat table from the world script would reach the zone and then be invisible to it, so the bridge nests the return under that key. An empty return is still no seed, so `if zone_state == nil` still fires on the zone's first tick.

## Tests

- `asobi_zone_lifecycle_hooks_tests` drives a real `asobi_world_instance`: the hook fires on a lazy load, what it returned is in the zone's `zone_state`, a pre-warmed zone is not seeded, a stopped zone reports unloaded, and a re-created zone is seeded again.
- `asobi_lua_world_integration_tests` runs the whole chain through a Lua world and asserts on what the **zone** script sees on its first tick, not on the bridge function.
- One eqwalizer-driven hardening on the way past: `handle_call({ensure_zone, ...})` is now guarded like `revive_zone` is, so a malformed coords answers `{error, invalid_coords}` instead of function_clausing a `transient` child of a `one_for_all` supervisor.

## Checks

`fmt --check`, `xref`, `dialyzer`, `elp eqwalize-all` (157 errors, unchanged from `origin/main`), `elp lint`, `ex_doc`, and the full `eunit` suite (2413 tests, 0 failures) all run locally.