### PR TITLE
feat(world): let a game stop a zone that still holds entities

### DIFF
--- a/guides/large-worlds.md
+++ b/guides/large-worlds.md
@@ -85,14 +85,52 @@ it and re-touches its own timer; only an empty zone stops. A join or crossing
 that finds its zone reaped between resolving the pid and placing the player
 transparently starts a replacement zone and places them there.
 
-Zone state is **not** snapshotted on the way out. Zone persistence exists in
-the zone process but no configuration path reaches it, so entities in a
-reaped zone are gone. Do not design a world that depends on a zone's contents
-surviving the players leaving it - write anything durable to your own tables
-from a callback.
+### Stopping a zone that still holds something
 
-`persistent = true` in a mode's config does one reachable thing today: it keeps
-an emptied world alive instead of finishing it.
+The default refusal is right when the only thing asking is an idle stamp, which
+can lag real occupancy. But it also means a zone that has ever been visited
+holds whatever the script spawned in it and is therefore never idle-reapable,
+so its Lua VM lives for as long as the world does. For a map whose zones
+contain scenery, `zone_idle_timeout` is dead by default.
+
+Two ways to stop one:
+
+```lua
+-- The zone decides, from its own tick.
+function zone_tick(entities, zone_state)
+    if nobody_is_watching() then
+        game.zone.park()
+    end
+    return entities, zone_state
+end
+```
+
+```lua
+-- Or let the reaper do it: an idle zone stops even holding entities.
+zone_park_on_idle = true
+```
+
+Both are the game saying it is safe, so both stop a populated zone - which the
+manager's own reap sweep still will not. Neither takes a zone out from under
+players: a zone with subscribers declines a park and logs it.
+
+What comes back depends on `persistent`:
+
+| | `persistent = true` | `persistent = false` |
+|---|---|---|
+| Entities | Restored from the zone's snapshot | Gone |
+| Spawner state, entity timers, tick | Restored | Gone |
+| `zone_state` | Restored | Restored, from memory, until the world ends |
+
+So a persistent world gets the zone back as it was. A non-persistent one gets
+back only "what was true here" - the `zone_state` your `on_zone_loaded` or
+`zone_tick` last left - and re-spawns the rest. That is enough for content that
+is a pure function of its coordinates; it is not enough for a damaged NPC or a
+half-looted container, and those need `persistent = true`.
+
+The in-memory `zone_state` set is capped at `max_active_zones` entries and
+dies with the world. Past the cap a parked zone comes back blank, and asobi
+logs `parked_zone_state_dropped`.
 
 ## Terrain data
 
@@ -268,7 +306,8 @@ In Erlang:
 | `view_radius` | `1` | Zone radius a player subscribes to. 0 means own zone only. |
 | `tick_rate` | `50` | Milliseconds per world tick. |
 | `max_players` | `500`, but `match_size` in a Lua script | Players per world. |
-| `persistent` | `false` | Keep an emptied world alive instead of finishing it. |
+| `persistent` | `false` | Snapshot zones to the database, and keep an emptied world alive instead of finishing it. |
+| `zone_park_on_idle` | `false` | Let the idle reaper stop a zone that still holds entities. |
 
 ## Scaling guidelines
 

--- a/guides/lua-api.md
+++ b/guides/lua-api.md
@@ -353,6 +353,7 @@ game.zone.spawn(template_id, x, y)                    -- true | false
 game.zone.spawn(template_id, x, y, overrides)         -- true | false
 game.zone.despawn(entity_id)                          -- true
 game.zone.apply(entity_id, event)                     -- true | false
+game.zone.park()                                      -- true
 game.terrain.get_chunk(cx, cy)                        -- { ok = data }
 game.terrain.preload(coords_list)                     -- true
 ```
@@ -368,6 +369,14 @@ only affect what `neighbours_radius`/`neighbours_rect` would have shown you.
 The owning zone runs the event through its own `handle_effects(effects,
 entities)` on its next tick. A script that calls `apply` without defining
 `handle_effects` gets a rate-limited error and dropped effects.
+
+`park` asks the zone to stop after this tick even though it still holds
+entities - the thing the idle reaper will not do on its own. `true` means
+"asked": it is a cast, like every `game.zone.*` call, because this runs inside
+the zone's own tick. It is declined outright while anyone is subscribed to the
+zone, and asobi logs when it is. What a parked zone gets back when it next
+loads depends on `persistent` - see
+[Large worlds](large-worlds.md#stopping-a-zone-that-still-holds-something).
 
 `terrain.preload` takes a list of tables carrying `cx`/`cy` (or `x`/`y`).
 Entries it cannot read are skipped rather than raising.

--- a/guides/world-server.md
+++ b/guides/world-server.md
@@ -396,6 +396,7 @@ version they are facts of the deployment rather than knobs.
 | `lazy_zones` | `grid_size > 100` | Spawn a zone on first use rather than pre-spawning the grid |
 | `max_active_zones` | 10,000 | See [Large worlds](large-worlds.md) for what happens at that ceiling |
 | `zone_idle_timeout` | 30,000 | Milliseconds an empty zone lingers before it is released |
+| `zone_park_on_idle` | `false` | Let that reaper stop a zone that still holds entities. See [Large worlds](large-worlds.md#stopping-a-zone-that-still-holds-something) |
 | `spatial_grid_cell_size` | unset | Cell side for the in-zone spatial index. Unset means no index is built |
 | `cold_tick_divisor` | 10 | Ticks between ticks of a zone with nothing to simulate; `1` ticks it every tick, `0` never ticks it - see [Performance tuning](performance-tuning.md) |
 | `border_band` | 0 | Fraction of `zone_size` published to neighbours - see [Seeing across a seam](#seeing-across-a-seam) |

--- a/src/asobi_game_modes.erl
+++ b/src/asobi_game_modes.erl
@@ -156,6 +156,7 @@ world_config_1(Mode, ModeConfig) ->
                         %% script asked for.
                         lazy_zones,
                         zone_idle_timeout,
+                        zone_park_on_idle,
                         max_active_zones,
                         spatial_grid_cell_size,
                         cold_tick_divisor,

--- a/src/lua/asobi_lua_api.erl
+++ b/src/lua/asobi_lua_api.erl
@@ -67,6 +67,7 @@ game.zone.spawn(template_id, x, y)              -- false if template_id is unkno
 game.zone.spawn(template_id, x, y, overrides)   -- false if template_id is unknown
 game.zone.despawn(entity_id)
 game.zone.apply(entity_id, event)               -- ask the owning neighbour zone to act; false if unseen
+game.zone.park()                                -- stop this zone after the tick, keeping what it holds
 
 -- Terrain (world mode only, requires terrain_store_pid in context)
 game.terrain.get_chunk(cx, cy)                   -- get compressed chunk data
@@ -218,6 +219,7 @@ core_surface(Ctx) ->
         {[~"game", ~"zone", ~"spawn"], zone_effect(Ctx), fun_zone_spawn(Ctx)},
         {[~"game", ~"zone", ~"despawn"], zone_effect(Ctx), fun_zone_despawn(Ctx)},
         {[~"game", ~"zone", ~"apply"], zone_effect(Ctx), fun_zone_apply(Ctx)},
+        {[~"game", ~"zone", ~"park"], zone_effect(Ctx), fun_zone_park(Ctx)},
         %% Terrain
         {[~"game", ~"terrain", ~"get_chunk"], none, fun_terrain_get_chunk(Ctx)},
         {[~"game", ~"terrain", ~"preload"], terrain_effect(Ctx), fun_terrain_preload(Ctx)}
@@ -1524,6 +1526,19 @@ fun_zone_despawn(#{zone_pid := ZonePid}) ->
     end;
 fun_zone_despawn(_) ->
     fun(_, St) -> error_result(~"zone.despawn not available (no zone context)", St) end.
+
+%% A cast, like every other game.zone.* call: this closure runs inside the zone
+%% process's own tick, so asking the zone a question synchronously would
+%% deadlock it. So `true` means "asked", not "stopped" - the zone finishes this
+%% tick first, and declines outright if anyone is still subscribed (it logs when
+%% it does).
+fun_zone_park(#{zone_pid := ZonePid}) ->
+    fun(_Args, St) ->
+        asobi_zone:park(ZonePid),
+        {[true], St}
+    end;
+fun_zone_park(_) ->
+    fun(_, St) -> error_result(~"zone.park not available (no zone context)", St) end.
 
 %% --- Terrain ---
 

--- a/src/lua/asobi_lua_config.erl
+++ b/src/lua/asobi_lua_config.erl
@@ -47,6 +47,7 @@ view_radius             = 0               -- optional, zone radius a player subs
 persistent              = false           -- optional, snapshot zones to DB across restarts
 lazy_zones              = true            -- optional, on-demand zone loading
 zone_idle_timeout       = 30000           -- optional, ms before idle zone is reaped
+zone_park_on_idle       = false           -- optional, let the reaper take a zone that still holds entities
 max_active_zones        = 10000           -- optional, cap on concurrent zones
 spatial_grid_cell_size  = 64              -- optional, cell size for spatial grid indexing
 cold_tick_divisor       = 10              -- optional, tick divisor for cold (idle) zones, 0 = never tick one
@@ -340,6 +341,7 @@ read_match_globals(ScriptPath, St) ->
     QuickPlay = read_global_bool_strict(~"quick_play", ScriptPath, St),
     LazyZones = read_global_bool(~"lazy_zones", St),
     ZoneIdleTimeout = read_global_int(~"zone_idle_timeout", St),
+    ZonePark = read_global_bool(~"zone_park_on_idle", St),
     MaxActiveZones = read_global_int(~"max_active_zones", St),
     SpatialGridCellSize = read_global_int(~"spatial_grid_cell_size", St),
     ColdTickDivisor = read_global_int(~"cold_tick_divisor", St),
@@ -363,7 +365,9 @@ read_match_globals(ScriptPath, St) ->
             Config2 = maybe_add_strategy(Config1, Strategy),
             Config2a = maybe_add_state_strategy(Config2, StateStrategy),
             Config3 = maybe_add_bots(Config2a, Bots, ScriptPath),
-            Config4 = maybe_add_zone_config(Config3, LazyZones, ZoneIdleTimeout, MaxActiveZones),
+            Config4 = maybe_add_zone_config(
+                Config3, LazyZones, ZoneIdleTimeout, MaxActiveZones, ZonePark
+            ),
             Config5 = maybe_add_int(Config4, spatial_grid_cell_size, SpatialGridCellSize),
             Config6 = maybe_add_non_neg_int(Config5, cold_tick_divisor, ColdTickDivisor),
             Config6a = maybe_add_fraction(Config6, border_band, BorderBand),
@@ -411,7 +415,7 @@ maybe_add_state_strategy(Config, ~"shared") ->
 maybe_add_state_strategy(Config, _) ->
     Config.
 
-maybe_add_zone_config(Config, LazyZones, ZoneIdleTimeout, MaxActiveZones) ->
+maybe_add_zone_config(Config, LazyZones, ZoneIdleTimeout, MaxActiveZones, ZonePark) ->
     Config1 =
         case LazyZones of
             true -> Config#{lazy_zones => true};
@@ -423,9 +427,15 @@ maybe_add_zone_config(Config, LazyZones, ZoneIdleTimeout, MaxActiveZones) ->
             ZIT when is_integer(ZIT), ZIT > 0 -> Config1#{zone_idle_timeout => ZIT};
             _ -> Config1
         end,
-    case MaxActiveZones of
-        MAZ when is_integer(MAZ), MAZ > 0 -> Config2#{max_active_zones => MAZ};
-        _ -> Config2
+    Config3 =
+        case MaxActiveZones of
+            MAZ when is_integer(MAZ), MAZ > 0 -> Config2#{max_active_zones => MAZ};
+            _ -> Config2
+        end,
+    case ZonePark of
+        true -> Config3#{zone_park_on_idle => true};
+        false -> Config3#{zone_park_on_idle => false};
+        undefined -> Config3
     end.
 
 maybe_add_int(Config, _Key, undefined) ->

--- a/src/world/asobi_world_server.erl
+++ b/src/world/asobi_world_server.erl
@@ -723,6 +723,10 @@ configure_zone_manager(
         world_server_pid => self(),
         spawn_templates => Templates,
         persistence => Persistence,
+        %% widgrensit/asobi#573: opt in to the idle reaper taking a zone that
+        %% still holds entities. Off by default, because for a world that did
+        %% not ask for it that is data loss.
+        park_on_idle => maps:get(zone_park_on_idle, Config, false),
         snapshot_interval => maps:get(snapshot_interval, Config, 600),
         %% Default 3, so at the 50ms tick_rate deltas go out every 150ms even
         %% though the sim runs at tick_rate; a mode sets `broadcast_interval` to

--- a/src/world/asobi_zone.erl
+++ b/src/world/asobi_zone.erl
@@ -7,7 +7,7 @@ via `asobi_spatial`. Zones are created and reaped lazily as players move.
 """.
 -behaviour(gen_server).
 
--export([start_link/1, reap/1]).
+-export([start_link/1, reap/1, park/1]).
 -export([zone_state_loaded/2]).
 -export([tick/2, player_input/3, player_input/4, add_entity/3, remove_entity/2]).
 -export([spawn_entity/3, spawn_entity/4, spawn_entities/2, despawn_entity/2]).
@@ -91,6 +91,28 @@ start_link(Config) ->
 -spec reap(pid()) -> ok.
 reap(Pid) ->
     gen_server:cast(Pid, reap).
+
+-doc """
+Stop this zone even though it still holds entities, because the game module
+says it is done with it.
+
+The distinction from `reap/1` is who is asking. `reap/1` is the manager acting
+on its own idle stamp, which can lag real occupancy, so a populated zone
+declines it - see handle_cast(reap, ...). This is the game module's own
+decision about its own zone, so a populated zone accepts it.
+
+What survives depends on the world. A `persistent` world snapshots everything
+the zone holds on the way out (terminate/2) and a later load brings it all
+back. A non-persistent world keeps the zone's `zone_state` in the manager and
+drops the entities - which is the trade the caller is making, and the reason
+this is not something asobi does on its own.
+
+Declined while anyone is subscribed: those players are watching this zone and
+would silently stop seeing it. Take them elsewhere first.
+""".
+-spec park(pid()) -> ok.
+park(Pid) ->
+    gen_server:cast(Pid, park).
 
 -doc """
 The world's answer to this zone's seed request: the zone_state
@@ -327,6 +349,9 @@ init(Config) ->
             %% only then: a pre-warmed zone already carries the zone_state
             %% generate_world/2 built for it. See seed_request/1.
             zone_seed_hook => maps:get(zone_seed_hook, Config, false),
+            %% `zone_park_on_idle`: let the idle reaper take this zone even
+            %% when it holds entities. Off by default - see the reap clauses.
+            park_on_idle => maps:get(park_on_idle, Config, false),
             zone_size => ZoneSize,
             grid_size => GridSize,
             rehome_margin => RehomeMargin,
@@ -447,7 +472,7 @@ init(Config) ->
 %% `init_zone_state` sees the seeded state rather than a blank map.
 -spec handle_continue(init_zone_state, map()) -> {noreply, map()}.
 handle_continue(init_zone_state, State0) ->
-    State = maybe_restore_from_snapshot(State0),
+    State = index_restored_entities(maybe_restore_from_snapshot(State0)),
     case seed_request(State) of
         {sent, State1} -> {noreply, State1};
         none -> {noreply, build_zone_state(State)}
@@ -526,6 +551,14 @@ build_zone_state(State) ->
 %% in the DB snapshot, so we load it whenever zone_state is blank. A pre-spawned
 %% zone arrives with a non-blank zone_state from Config and skips the DB.
 %% init_zone_state then rebuilds the runtime from the restored zone_state.
+%%
+%% The snapshot's entities are loaded here too (widgrensit/asobi#573). Until a
+%% zone could be stopped while it still held something, they were always empty
+%% on this path - the only zone that could stop was one holding nothing - and
+%% the world server's own restore_entities/4 covered the world-restart case.
+%% Now that `park/1` and `zone_park_on_idle` can stop a populated zone, the
+%% zone that next occupies these coords is the one that has to bring them back,
+%% or the snapshot is written and never read.
 -spec maybe_restore_from_snapshot(map()) -> map().
 maybe_restore_from_snapshot(
     #{
@@ -540,6 +573,9 @@ maybe_restore_from_snapshot(
         {ok, Snapshot} ->
             State#{
                 zone_state => maps:get(zone_state, Snapshot, #{}),
+                entities => restore_entities(
+                    maps:get(entities, Snapshot, #{}), maps:get(entities, State)
+                ),
                 spawner => restore_spawner(maps:get(spawner_state, Snapshot, #{}), Templates),
                 entity_timers => asobi_entity_timer:deserialise(
                     maps:get(entity_timers, Snapshot, #{})
@@ -573,6 +609,29 @@ safe_load_snapshot(WorldId, Coords) ->
     catch
         Class:Reason -> {error, {Class, Reason}}
     end.
+
+%% Whatever a zone starts life holding - the ETS crash backup, or the snapshot
+%% restored above - has to be in the spatial grid before the first tick.
+%% sync_spatial_grid/3 is a diff against the previous tick, so an entity that
+%% was there at start and never moves is never added by it: for a world with a
+%% `spatial_grid_cell_size`, restored scenery would be invisible to every
+%% game.spatial query for as long as it stayed still.
+-spec index_restored_entities(map()) -> map().
+index_restored_entities(#{spatial_grid := undefined} = State) ->
+    State;
+index_restored_entities(#{spatial_grid := Grid, entities := Entities} = State) ->
+    State#{spatial_grid => reindex_clamped(maps:to_list(Entities), Grid)}.
+
+%% The ETS crash backup is fresher than any DB row - it is written every 20
+%% ticks and only survives a stop that did NOT run terminate/2 - so anything it
+%% recovered wins outright.
+-spec restore_entities(term(), map()) -> map().
+restore_entities(_Snapshotted, Recovered) when map_size(Recovered) > 0 ->
+    Recovered;
+restore_entities(Snapshotted, _Recovered) when is_map(Snapshotted) ->
+    Snapshotted;
+restore_entities(_Snapshotted, Recovered) ->
+    Recovered.
 
 -spec restore_spawner(map(), map()) -> asobi_zone_spawner:state().
 restore_spawner(SpawnerState, Templates) when is_map(SpawnerState), map_size(SpawnerState) > 0 ->
@@ -685,6 +744,33 @@ handle_cast(reap, #{entities := Entities} = State) when map_size(Entities) =:= 0
     %% Graceful stop so terminate/2 writes a final snapshot. Transient restart
     %% means a normal stop is not respawned.
     {stop, normal, State};
+%% `zone_park_on_idle`. The default refusal below is right when the only thing
+%% asking is a stamp that can lag real occupancy - but it also means a zone
+%% that has ever been visited holds whatever the script spawned in it and is
+%% therefore never idle-reapable, so `zone_idle_timeout` is dead for any world
+%% whose zones contain scenery, and its Lua VM lives forever
+%% (widgrensit/asobi#573). A world that opts in says its zones can be stopped
+%% populated; a `persistent` world gets them all back from the snapshot, a
+%% non-persistent one gets its zone_state back and re-spawns the rest.
+%%
+%% Still not while anyone is subscribed, and still not mid-`script_busy`: those
+%% two refusals are about this zone being in use right now, which opting in
+%% does not change.
+handle_cast(reap, #{park_on_idle := true, subscribers := Subs} = State) when
+    map_size(Subs) =:= 0
+->
+    case maps:get(script_busy, State, false) of
+        false ->
+            {stop, normal, park_zone_state(State)};
+        true ->
+            touch_manager(State),
+            {noreply, State}
+    end;
+handle_cast(park, #{subscribers := Subs} = State) when map_size(Subs) > 0 ->
+    log_park_declined(State),
+    {noreply, State};
+handle_cast(park, State) ->
+    {stop, normal, park_zone_state(State)};
 handle_cast(reap, State) ->
     %% asobi#283: the manager decides to reap from its own last-active
     %% bookkeeping, which can lag real occupancy - release_zone backdates it
@@ -1705,6 +1791,7 @@ reject_log_key({WorldId, Coords}) -> {WorldId, Coords, input_rejected}.
 bad_batch_log_key({WorldId, Coords}) -> {WorldId, Coords, batch_contract}.
 unknown_outcome_log_key({WorldId, Coords}) -> {WorldId, Coords, unknown_outcome}.
 no_input_handler_log_key({WorldId, Coords}) -> {WorldId, Coords, no_input_handler}.
+park_declined_log_key({WorldId, Coords}) -> {WorldId, Coords, park_declined}.
 effect_log_key({WorldId, Coords}, Kind) -> {WorldId, Coords, Kind}.
 
 %% Same split as log_no_input_handler/2: the telemetry is unconditional and only
@@ -2684,6 +2771,53 @@ maybe_final_snapshot(#{persistence := true} = State) ->
 maybe_final_snapshot(_) ->
     ok.
 
+%% Hand this zone's zone_state to the manager so the zone that next occupies
+%% these coords starts from it instead of blank.
+%%
+%% Only for a non-persistent world. A persistent one writes the whole zone -
+%% entities, timers, spawner and all - to its snapshot in terminate/2, and a
+%% stashed zone_state would then be worse than nothing: the restore path
+%% (maybe_restore_from_snapshot/1) only runs for a zone whose zone_state is
+%% blank, so seeding one from here would suppress the snapshot load entirely.
+%%
+%% Sent before the stop rather than from terminate/2 so it is ordered ahead of
+%% the manager's DOWN for this zone: same sender, same destination, so the cast
+%% cannot overtake or be overtaken, and the coords cannot be re-created from a
+%% stale-empty parked set.
+-spec park_zone_state(map()) -> map().
+park_zone_state(#{persistence := true} = State) ->
+    State;
+park_zone_state(
+    #{
+        zone_manager_pid := ZMPid,
+        game_module := GameMod,
+        coords := Coords,
+        zone_state := ZoneState
+    } = State
+) when is_pid(ZMPid) ->
+    case call_optional(GameMod, dump_zone_state, [ZoneState], ZoneState) of
+        Dumped when is_map(Dumped), map_size(Dumped) > 0 ->
+            asobi_zone_manager:park_state(ZMPid, Coords, Dumped);
+        _ ->
+            ok
+    end,
+    State;
+park_zone_state(State) ->
+    State.
+
+log_park_declined(#{world_id := WorldId, coords := Coords}) ->
+    case asobi_script_log_limiter:allow(park_declined_log_key({WorldId, Coords})) of
+        {true, SuppressedSinceLast} ->
+            ?LOG_WARNING(#{
+                msg => ~"zone park declined: players are still subscribed to this zone",
+                world_id => WorldId,
+                coords => Coords,
+                suppressed_since_last => SuppressedSinceLast
+            });
+        false ->
+            ok
+    end.
+
 %% --- Zone State Backup/Recovery ---
 
 %% Every limiter key this zone can mint. forget/1 deletes an exact key, so a
@@ -2696,6 +2830,7 @@ forget_log_keys(WorldId, Coords) ->
     asobi_script_log_limiter:forget(bad_batch_log_key(Zone)),
     asobi_script_log_limiter:forget(unknown_outcome_log_key(Zone)),
     asobi_script_log_limiter:forget(no_input_handler_log_key(Zone)),
+    asobi_script_log_limiter:forget(park_declined_log_key(Zone)),
     asobi_script_log_limiter:forget(effect_log_key(Zone, effect_queue_full)),
     asobi_script_log_limiter:forget(effect_log_key(Zone, no_effect_handler)),
     asobi_script_log_limiter:forget(effect_log_key(Zone, bad_effects_return)),

--- a/src/world/asobi_zone_manager.erl
+++ b/src/world/asobi_zone_manager.erl
@@ -17,6 +17,7 @@ Hot-path lookups go through ETS directly, bypassing the gen_server.
 -export([stamp_active/2]).
 -export([get_active_zones/1, zone_terminated/3, pre_warm/1]).
 -export([register_zone/3, set_zone_config/2, set_initial_zone_states/2]).
+-export([park_state/3]).
 -export([init/1, handle_call/3, handle_cast/2, handle_info/2, terminate/2]).
 
 -include_lib("kernel/include/logger.hrl").
@@ -184,6 +185,27 @@ set_zone_config(Ref, Config) ->
     ok = gen_server:call(Ref, {set_zone_config, Config}).
 
 -doc """
+Hold a parked zone's `zone_state` for whichever zone next occupies these
+coords.
+
+For non-persistent worlds only - a persistent one has the whole zone in its
+snapshot, and `asobi_zone:park_zone_state/1` does not call this for it. This is
+the "somewhere to leave what was true here" a script otherwise has to build an
+extension for (widgrensit/asobi#573).
+
+Consumed on the next start for those coords and dropped, so a zone that comes
+back and is parked again re-stores; nothing accumulates for coords that are
+live. The set is capped (`max_parked_states`, defaulting to
+`max_active_zones`) because a large grid has far more coords than a node has
+memory - past the cap the state is dropped and logged rather than kept.
+""".
+-spec park_state(pid() | atom(), {integer(), integer()}, map()) -> ok.
+park_state(Ref, {X, Y} = Coords, ZoneState) when
+    is_integer(X), is_integer(Y), is_map(ZoneState)
+->
+    gen_server:cast(Ref, {park_state, Coords, ZoneState}).
+
+-doc """
 Provide per-coord initial zone_state. Used to thread per-zone state from
 `GameMod:generate_world/2` (e.g. lua_state for the asobi_lua_world bridge,
 or station/planet seeds for sc_game) through to each zone's init. Without
@@ -237,6 +259,10 @@ init(Opts) ->
         zone_size => maps:get(zone_size, Opts),
         zone_config => maps:get(zone_config, Opts, #{}),
         initial_zone_states => maps:get(initial_zone_states, Opts, #{}),
+        parked_states => #{},
+        max_parked_states => maps:get(
+            max_parked_states, Opts, maps:get(max_active_zones, Opts, ?DEFAULT_MAX_ACTIVE)
+        ),
         reap_ref => ReapRef
     }}.
 
@@ -329,6 +355,23 @@ handle_cast(
     Stale = erlang:monotonic_time(millisecond) - Timeout - 1,
     ets:insert(StampTab, {Coords, Stale}),
     {noreply, State};
+handle_cast(
+    {park_state, Coords, ZoneState},
+    #{parked_states := Parked, max_parked_states := Max, world_id := WorldId} = State
+) when is_map(ZoneState) ->
+    case map_size(Parked) >= Max andalso not is_map_key(Coords, Parked) of
+        true ->
+            ?LOG_WARNING(#{
+                event => parked_zone_state_dropped,
+                world_id => WorldId,
+                coords => Coords,
+                max_parked_states => Max,
+                msg => ~"parked zone_state set is full; this zone comes back blank"
+            }),
+            {noreply, State};
+        false ->
+            {noreply, State#{parked_states => Parked#{Coords => ZoneState}}}
+    end;
 handle_cast({zone_terminated, Coords, ZonePid}, #{ets_tab := Tab} = State) ->
     %% Only clean up if this coords still maps to the pid that terminated -
     %% a reaped zone's slot may already have been recreated.
@@ -400,6 +443,7 @@ start_zone(
         max_active_zones := MaxActive,
         zone_config := BaseConfig,
         initial_zone_states := InitialStates,
+        parked_states := Parked,
         world_id := WorldId
     } = State
 ) ->
@@ -414,8 +458,11 @@ start_zone(
                 zone_stamp_tab => StampTab,
                 zone_seed_hook => Origin =:= lazy
             },
+            %% A parked state wins over the world-generation one: it is what
+            %% these coords were last holding, and generate_world/2's is only
+            %% the state they started life with.
             Config =
-                case maps:get(Coords, InitialStates, undefined) of
+                case maps:get(Coords, Parked, maps:get(Coords, InitialStates, undefined)) of
                     undefined -> Config0;
                     ZS when is_map(ZS) -> Config0#{zone_state => ZS};
                     _ -> Config0
@@ -428,7 +475,11 @@ start_zone(
                     MonRef = monitor(process, Pid),
                     touch(Coords, State),
                     State1 = State#{
-                        zone_monitors => Monitors#{MonRef => Coords, Coords => MonRef}
+                        zone_monitors => Monitors#{MonRef => Coords, Coords => MonRef},
+                        %% Consumed, not kept: the live zone owns this state
+                        %% now, and holding a stale copy would resurrect it if
+                        %% the zone later died without parking.
+                        parked_states => maps:remove(Coords, Parked)
                     },
                     {ok, Pid, State1};
                 {error, _} = Err ->

--- a/test/asobi_lua_api_tests.erl
+++ b/test/asobi_lua_api_tests.erl
@@ -82,6 +82,8 @@ api_test_() ->
         {"game.zone.spawn with overrides and a typo'd template_id returns false",
             fun zone_spawn_unknown_template_with_overrides/0},
         {"game.zone.despawn calls zone", fun zone_despawn/0},
+        {"game.zone.park asks the zone to stop", fun zone_park/0},
+        {"game.zone.park errors without zone context", fun zone_park_no_zone/0},
         {"game.spatial.query_radius zone-based", fun spatial_zone_query_radius/0},
         {"game.spatial.query_rect zone-based", fun spatial_zone_query_rect/0},
         {"game.spatial.query_rect errors without zone", fun spatial_query_rect_no_zone/0},
@@ -201,6 +203,7 @@ setup() ->
     meck:expect(asobi_zone, spawn_entity, fun(_, _, _) -> ok end),
     meck:expect(asobi_zone, spawn_entity, fun(_, _, _, _) -> ok end),
     meck:expect(asobi_zone, despawn_entity, fun(_, _) -> ok end),
+    meck:expect(asobi_zone, park, fun(_) -> ok end),
     meck:expect(asobi_zone, query_radius, fun(_, _, _) ->
         [{~"e1", {5.0, 5.0}}, {~"e2", {3.0, 4.0}}]
     end),
@@ -688,6 +691,18 @@ zone_despawn() ->
     Code = "return game.zone.despawn('entity-123')",
     {ok, [true | _], _} = eval(Code, St),
     ?assert(meck:called(asobi_zone, despawn_entity, '_')).
+
+%% widgrensit/asobi#573. `true` means "asked": this runs inside the zone's own
+%% tick, so it is a cast like every other game.zone.* call.
+zone_park() ->
+    St = install_api_with_zone(),
+    {ok, [true | _], _} = eval("return game.zone.park()", St),
+    ?assert(meck:called(asobi_zone, park, '_')).
+
+zone_park_no_zone() ->
+    St = install_api_world(),
+    {ok, [Result | _], _} = eval("return game.zone.park().error", St),
+    ?assert(is_binary(Result)).
 
 %% widgrensit/asobi#544. The caller is zone (1,1) of a 5x5 grid of 100-unit
 %% zones; (2,1) touches it and publishes a pirate just past the seam.

--- a/test/asobi_zone_manager_tests.erl
+++ b/test/asobi_zone_manager_tests.erl
@@ -81,8 +81,49 @@ zone_manager_test_() ->
         {"a new zone is announced to the ticker", fun zone_open_announced_to_ticker/0},
         {"stamping a dead table does not crash the zone", fun stamp_on_dead_table/0},
         {"stamping without a table reports rather than pretends", fun stamp_without_table/0},
-        {"a junk stamp key is dropped, not fatal", fun junk_stamp_key_dropped/0}
+        {"a junk stamp key is dropped, not fatal", fun junk_stamp_key_dropped/0},
+        {"a parked zone_state seeds the next zone at those coords",
+            fun parked_state_seeds_next_zone/0},
+        {"a parked zone_state is consumed, not kept", fun parked_state_is_consumed/0},
+        {"a parked zone_state beyond the cap is dropped", fun parked_state_cap/0}
     ]}.
+
+%% widgrensit/asobi#573: for a non-persistent world this is the only place a
+%% zone can leave "what was true here" that outlives its process.
+parked_state_seeds_next_zone() ->
+    Ctx = #{mgr := Mgr} = start_manager(),
+    asobi_zone_manager:park_state(Mgr, {1, 2}, #{seeded => parked}),
+    {ok, ZonePid, created} = asobi_zone_manager:ensure_zone(Mgr, {1, 2}),
+    ?assertEqual(parked, maps:get(seeded, zone_zone_state(ZonePid))),
+    stop_manager(Ctx).
+
+parked_state_is_consumed() ->
+    Ctx = #{mgr := Mgr} = start_manager(),
+    asobi_zone_manager:park_state(Mgr, {1, 2}, #{seeded => parked}),
+    {ok, ZonePid, created} = asobi_zone_manager:ensure_zone(Mgr, {1, 2}),
+    gen_server:stop(ZonePid),
+    timer:sleep(20),
+    {ok, ZonePid2, created} = asobi_zone_manager:ensure_zone(Mgr, {1, 2}),
+    ?assertEqual(0, map_size(zone_zone_state(ZonePid2))),
+    stop_manager(Ctx).
+
+%% A 2000x2000 grid has four million coords and the node does not have four
+%% million zone_states of memory, so the set is capped.
+parked_state_cap() ->
+    Ctx = #{mgr := Mgr} = start_manager(#{max_parked_states => 1}),
+    asobi_zone_manager:park_state(Mgr, {1, 2}, #{seeded => kept}),
+    asobi_zone_manager:park_state(Mgr, {2, 2}, #{seeded => dropped}),
+    {ok, Kept, created} = asobi_zone_manager:ensure_zone(Mgr, {1, 2}),
+    {ok, Dropped, created} = asobi_zone_manager:ensure_zone(Mgr, {2, 2}),
+    ?assertEqual(kept, maps:get(seeded, zone_zone_state(Kept))),
+    ?assertEqual(0, map_size(zone_zone_state(Dropped))),
+    stop_manager(Ctx).
+
+-spec zone_zone_state(pid()) -> map().
+zone_zone_state(ZonePid) ->
+    case sys:get_state(ZonePid) of
+        #{zone_state := ZS} when is_map(ZS) -> ZS
+    end.
 
 %% --- #313: zone lifecycle telemetry ---
 %%

--- a/test/asobi_zone_park_tests.erl
+++ b/test/asobi_zone_park_tests.erl
@@ -1,0 +1,225 @@
+-module(asobi_zone_park_tests).
+-include_lib("eunit/include/eunit.hrl").
+
+%% widgrensit/asobi#573: a zone could only be stopped when it held nothing, so
+%% the snapshot that exists to preserve a populated zone never had anything to
+%% preserve. `park/1` is the game module's own decision to stop a zone that is
+%% still holding entities; `park_on_idle` lets the idle reaper make it too.
+
+setup() ->
+    case whereis(nova_scope) of
+        undefined -> pg:start_link(nova_scope);
+        _ -> ok
+    end,
+    ok.
+
+cleanup(_) ->
+    ok.
+
+start_zone(Overrides) ->
+    Config = maps:merge(
+        #{
+            world_id => ~"park_world",
+            coords => {2, 3},
+            ticker_pid => self(),
+            game_module => asobi_test_world_game,
+            zone_state => #{}
+        },
+        Overrides
+    ),
+    {ok, Pid} = asobi_zone:start_link(Config),
+    Pid.
+
+await_down(Pid, Timeout) ->
+    MonRef = monitor(process, Pid),
+    receive
+        {'DOWN', MonRef, process, Pid, _} -> ok
+    after Timeout ->
+        demonitor(MonRef, [flush]),
+        timeout
+    end.
+
+zone_park_test_() ->
+    {setup, fun setup/0, fun cleanup/1, [
+        {"a populated zone declines reap but accepts park", fun populated_zone_parks/0},
+        {"park is declined while a player is subscribed", fun park_declined_with_subscriber/0},
+        {"park_on_idle lets the reaper take a populated zone", fun park_on_idle_reaps_populated/0},
+        {"park_on_idle still declines a zone with subscribers",
+            fun park_on_idle_declines_subscribed/0},
+        {"park_on_idle still declines a busy zone", fun park_on_idle_declines_busy/0},
+        {"an empty zone is reaped as before", fun empty_zone_still_reaps/0},
+        {"a parked persistent zone snapshots the entities it held", fun park_snapshots_entities/0},
+        {"a parked persistent zone restores what it held", fun park_restores_entities/0},
+        {"a parked non-persistent zone leaves its zone_state with the manager",
+            fun park_stashes_zone_state/0},
+        {"a persistent zone does not stash - the snapshot owns it",
+            fun persistent_park_does_not_stash/0}
+    ]}.
+
+%% The half that was missing: the reap path already snapshotted everything a
+%% zone held, it just could never run for a zone that held anything.
+park_snapshots_entities() ->
+    meck:new(asobi_zone_snapshotter, [passthrough]),
+    Self = self(),
+    meck:expect(asobi_zone_snapshotter, load_snapshot, fun(_, _) -> {error, not_found} end),
+    meck:expect(asobi_zone_snapshotter, snapshot_sync, fun(Data) ->
+        Self ! {snapshot, Data},
+        ok
+    end),
+    try
+        Pid = start_zone(#{persistence => true}),
+        asobi_zone:add_entity(Pid, ~"rock1", #{x => 1.0, y => 1.0, type => ~"rock"}),
+        ok = asobi_zone:sync(Pid),
+        asobi_zone:park(Pid),
+        receive
+            {snapshot, Data} ->
+                ?assert(maps:is_key(~"rock1", maps:get(entities, Data)))
+        after 1000 ->
+            ?assert(false)
+        end,
+        ?assertEqual(ok, await_down(Pid, 1000))
+    after
+        meck:unload(asobi_zone_snapshotter)
+    end.
+
+park_restores_entities() ->
+    meck:new(asobi_zone_snapshotter, [passthrough]),
+    Self = self(),
+    meck:expect(asobi_zone_snapshotter, snapshot_sync, fun(Data) ->
+        Self ! {snapshot, Data},
+        ok
+    end),
+    meck:expect(asobi_zone_snapshotter, load_snapshot, fun(_, _) -> {error, not_found} end),
+    try
+        Pid = start_zone(#{persistence => true, game_module => asobi_zone_ctx_test_game}),
+        asobi_zone:add_entity(Pid, ~"rock1", #{x => 1.0, y => 1.0, type => ~"rock"}),
+        ok = asobi_zone:sync(Pid),
+        asobi_zone:park(Pid),
+        Snapshot =
+            receive
+                {snapshot, Data} -> Data
+            after 1000 -> #{}
+            end,
+        ?assertEqual(ok, await_down(Pid, 1000)),
+        meck:expect(asobi_zone_snapshotter, load_snapshot, fun(_, _) -> {ok, Snapshot} end),
+        Pid2 = start_zone(#{persistence => true, game_module => asobi_zone_ctx_test_game}),
+        ok = asobi_zone:sync(Pid2),
+        ?assert(maps:is_key(~"rock1", asobi_zone:get_entities(Pid2))),
+        gen_server:stop(Pid2)
+    after
+        meck:unload(asobi_zone_snapshotter)
+    end.
+
+%% Non-persistent worlds get the smaller half: no entities, but somewhere to
+%% leave "what was true here" that outlives the VM.
+park_stashes_zone_state() ->
+    Self = self(),
+    meck:new(asobi_zone_manager, [passthrough]),
+    meck:expect(asobi_zone_manager, park_state, fun(_Ref, Coords, ZoneState) ->
+        Self ! {parked, Coords, ZoneState},
+        ok
+    end),
+    try
+        Pid = start_zone(#{
+            game_module => asobi_zone_ctx_test_game, zone_manager_pid => self()
+        }),
+        asobi_zone:add_entity(Pid, ~"rock1", #{x => 1.0, y => 1.0, type => ~"rock"}),
+        ok = asobi_zone:sync(Pid),
+        asobi_zone:park(Pid),
+        receive
+            {parked, Coords, ZoneState} ->
+                ?assertEqual({2, 3}, Coords),
+                ?assertEqual(init_zone_state, maps:get(built_by, ZoneState))
+        after 1000 ->
+            ?assert(false)
+        end
+    after
+        meck:unload(asobi_zone_manager)
+    end.
+
+persistent_park_does_not_stash() ->
+    Self = self(),
+    meck:new(asobi_zone_manager, [passthrough]),
+    meck:expect(asobi_zone_manager, park_state, fun(_Ref, Coords, ZoneState) ->
+        Self ! {parked, Coords, ZoneState},
+        ok
+    end),
+    meck:new(asobi_zone_snapshotter, [passthrough]),
+    meck:expect(asobi_zone_snapshotter, load_snapshot, fun(_, _) -> {error, not_found} end),
+    meck:expect(asobi_zone_snapshotter, snapshot_sync, fun(_) -> ok end),
+    try
+        Pid = start_zone(#{
+            persistence => true,
+            game_module => asobi_zone_ctx_test_game,
+            zone_manager_pid => self()
+        }),
+        ok = asobi_zone:sync(Pid),
+        asobi_zone:park(Pid),
+        ?assertEqual(ok, await_down(Pid, 1000)),
+        receive
+            {parked, _, _} -> ?assert(false)
+        after 100 -> ok
+        end
+    after
+        meck:unload(asobi_zone_snapshotter),
+        meck:unload(asobi_zone_manager)
+    end.
+
+populated_zone_parks() ->
+    Pid = start_zone(#{}),
+    asobi_zone:add_entity(Pid, ~"npc1", #{x => 1.0, y => 1.0, type => ~"rock"}),
+    ok = asobi_zone:sync(Pid),
+    %% The manager's own reap is still declined: its idle stamp can lag real
+    %% occupancy, so it does not get to tear a populated zone down.
+    asobi_zone:reap(Pid),
+    ok = asobi_zone:sync(Pid),
+    ?assert(is_process_alive(Pid)),
+    asobi_zone:park(Pid),
+    ?assertEqual(ok, await_down(Pid, 1000)).
+
+park_declined_with_subscriber() ->
+    Pid = start_zone(#{}),
+    asobi_zone:add_entity(Pid, ~"npc1", #{x => 1.0, y => 1.0, type => ~"rock"}),
+    asobi_zone:subscribe(Pid, {~"p1", self()}),
+    ok = asobi_zone:sync(Pid),
+    asobi_zone:park(Pid),
+    ok = asobi_zone:sync(Pid),
+    ?assert(is_process_alive(Pid)),
+    gen_server:stop(Pid).
+
+park_on_idle_reaps_populated() ->
+    Pid = start_zone(#{park_on_idle => true}),
+    asobi_zone:add_entity(Pid, ~"npc1", #{x => 1.0, y => 1.0, type => ~"rock"}),
+    ok = asobi_zone:sync(Pid),
+    asobi_zone:reap(Pid),
+    ?assertEqual(ok, await_down(Pid, 1000)).
+
+park_on_idle_declines_subscribed() ->
+    Pid = start_zone(#{park_on_idle => true}),
+    asobi_zone:add_entity(Pid, ~"npc1", #{x => 1.0, y => 1.0, type => ~"rock"}),
+    asobi_zone:subscribe(Pid, {~"p1", self()}),
+    ok = asobi_zone:sync(Pid),
+    asobi_zone:reap(Pid),
+    ok = asobi_zone:sync(Pid),
+    ?assert(is_process_alive(Pid)),
+    gen_server:stop(Pid).
+
+park_on_idle_declines_busy() ->
+    Pid = start_zone(#{
+        park_on_idle => true,
+        game_module => asobi_zone_busy_game,
+        zone_state => #{busy => true}
+    }),
+    asobi_zone:add_entity(Pid, ~"npc1", #{x => 1.0, y => 1.0, type => ~"rock"}),
+    asobi_zone:tick(Pid, 1),
+    ok = asobi_zone:sync(Pid),
+    asobi_zone:reap(Pid),
+    ok = asobi_zone:sync(Pid),
+    ?assert(is_process_alive(Pid)),
+    gen_server:stop(Pid).
+
+empty_zone_still_reaps() ->
+    Pid = start_zone(#{}),
+    ok = asobi_zone:sync(Pid),
+    asobi_zone:reap(Pid),
+    ?assertEqual(ok, await_down(Pid, 1000)).


### PR DESCRIPTION
Closes #573.

`handle_cast(reap, ...)` accepted only on `map_size(Entities) =:= 0`, and the snapshot machinery wrote everything a zone held. The two halves never met: the only zone allowed to stop was the one whose snapshot had nothing in it.

## Who is asking

The manager's `reap` is a proposal from an idle stamp that can lag real occupancy, so a populated zone declines it. That refusal is correct and stays. What was missing is a way for the *game module* to say "this zone is done", which is a different question:

- **`asobi_zone:park/1`**, bound as **`game.zone.park()`** in the zone VM. A cast, like every `game.zone.*` call, because it runs inside the zone's own tick.
- **`zone_park_on_idle = true`**, which lets the idle reaper take a zone that still holds entities - so `zone_idle_timeout` means something for a world whose zones contain scenery, instead of being dead for any zone that has ever been visited.

Neither can take a zone out from under players: a zone with subscribers declines a park and logs it (rate-limited), and a `script_busy` zone still declines an idle reap, so a wave spawner is not reaped mid-countdown.

## The restore was only half there

`maybe_restore_from_snapshot/1` loaded `zone_state`, `spawner`, `entity_timers` and `tick` - but not `entities`. It never had to: the only zone that could stop held none, and the world server's `restore_entities/4` covered the world-restart case. With a populated zone now able to stop, the zone that next occupies those coords has to bring them back, or the snapshot is written and never read. The ETS crash backup still wins where it has anything, since it is fresher.

Whatever a zone starts life holding is also indexed into the spatial grid before its first tick. `sync_spatial_grid/3` is a diff against the previous tick, so an entity that was there at start and never moves was never added - restored scenery would have been invisible to every `game.spatial` query for as long as it stayed still. That applied to the existing ETS-recovery path too.

## Non-persistent worlds

The zone hands its dumped `zone_state` to the manager before stopping and the next zone at those coords starts from it - the "somewhere to leave what was true here" that games otherwise build a `gen_server` + named ETS extension for. Only for non-persistent worlds: a persistent one has the whole zone in its snapshot, and a stashed `zone_state` would actively suppress the snapshot load, since that path only runs for a blank `zone_state`.

Sent before the stop, not from `terminate/2`, so it is ordered ahead of the manager's `DOWN` for the same zone. Capped at `max_active_zones` entries, because a 2000x2000 grid has four million coords; past the cap the zone comes back blank and asobi logs `parked_zone_state_dropped`.

## Docs

`guides/large-worlds.md` had a "Zone state is **not** snapshotted on the way out / no configuration path reaches it" paragraph that stopped being true when #543 wired `persistence` through. It is replaced with what actually survives a park, per `persistent`.

## Tests

`asobi_zone_park_tests` (park accepted where reap is refused, declined with subscribers, `park_on_idle` for reap / subscribers / busy, snapshot-and-restore of a populated zone, the non-persistent stash, and no stash when persistent), plus manager tests for the parked set seeding / being consumed / respecting its cap, and two `asobi_lua_api_tests` for the binding.

## Checks

`fmt --check`, `xref`, `dialyzer`, `elp eqwalize-all` (156 errors, one fewer than `origin/main`'s 157), `elp lint`, `ex_doc`, and the full `eunit` suite (2421 tests, 0 failures).